### PR TITLE
fix: always delete BOOTSTRAP.md after first conversation [JARVIS-242]

### DIFF
--- a/assistant/src/__tests__/onboarding-template-contract.test.ts
+++ b/assistant/src/__tests__/onboarding-template-contract.test.ts
@@ -57,8 +57,8 @@ describe("onboarding template contracts", () => {
     test("contains wrapping-up criteria with required conditions", () => {
       const lower = bootstrap.toLowerCase();
       expect(lower).toContain("wrapping up");
-      expect(lower).toContain("done with onboarding");
-      expect(lower).toContain("vibe");
+      expect(lower).toContain("delete");
+      expect(lower).toContain("bootstrap.md");
       expect(lower).toContain("two suggestions");
     });
 

--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -24,6 +24,7 @@ mock.module("../util/platform.js", () => ({
   getWorkspaceConfigPath: () => join(TEST_DIR, "config.json"),
   getWorkspaceSkillsDir: () => join(TEST_DIR, "skills"),
   getWorkspaceHooksDir: () => join(TEST_DIR, "hooks"),
+  getConversationsDir: () => join(TEST_DIR, "conversations"),
   getWorkspacePromptPath: (file: string) => join(TEST_DIR, file),
   ensureDataDir: () => {},
   getPidPath: () => join(TEST_DIR, "vellum.pid"),
@@ -559,5 +560,43 @@ describe("ensurePromptFiles", () => {
 
     const bootstrapPath = join(TEST_DIR, "BOOTSTRAP.md");
     expect(existsSync(bootstrapPath)).toBe(false);
+  });
+
+  test("auto-deletes stale BOOTSTRAP.md when prior conversations exist", () => {
+    // Simulate a non-first-run workspace: core files + BOOTSTRAP.md still present
+    writeFileSync(join(TEST_DIR, "IDENTITY.md"), "My identity");
+    writeFileSync(join(TEST_DIR, "SOUL.md"), "My soul");
+    writeFileSync(join(TEST_DIR, "USER.md"), "My user");
+    writeFileSync(join(TEST_DIR, "BOOTSTRAP.md"), "# Stale bootstrap");
+
+    // Create a conversations directory with at least one entry
+    const convDir = join(TEST_DIR, "conversations");
+    mkdirSync(convDir, { recursive: true });
+    writeFileSync(join(convDir, "conv-001.json"), "{}");
+
+    ensurePromptFiles();
+
+    expect(existsSync(join(TEST_DIR, "BOOTSTRAP.md"))).toBe(false);
+  });
+
+  test("keeps BOOTSTRAP.md on first run even if conversations dir exists", () => {
+    // First run: no core files exist, BOOTSTRAP.md should be created and kept
+    const convDir = join(TEST_DIR, "conversations");
+    mkdirSync(convDir, { recursive: true });
+    writeFileSync(join(convDir, "conv-001.json"), "{}");
+
+    ensurePromptFiles();
+
+    expect(existsSync(join(TEST_DIR, "BOOTSTRAP.md"))).toBe(true);
+  });
+
+  test("keeps BOOTSTRAP.md when no conversations exist yet", () => {
+    // Non-first-run but no conversations — user hasn't chatted yet
+    writeFileSync(join(TEST_DIR, "IDENTITY.md"), "My identity");
+    writeFileSync(join(TEST_DIR, "BOOTSTRAP.md"), "# Bootstrap");
+
+    ensurePromptFiles();
+
+    expect(existsSync(join(TEST_DIR, "BOOTSTRAP.md"))).toBe(true);
   });
 });

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -1,4 +1,11 @@
-import { copyFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  unlinkSync,
+} from "node:fs";
 import { join } from "node:path";
 
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
@@ -10,6 +17,7 @@ import { listConnections } from "../oauth/oauth-store.js";
 import { resolveBundledDir } from "../util/bundled-asset.js";
 import { getLogger } from "../util/logger.js";
 import {
+  getConversationsDir,
   getWorkspaceDir,
   getWorkspacePromptPath,
   isMacOS,
@@ -81,6 +89,24 @@ export function ensurePromptFiles(): void {
           "Failed to create BOOTSTRAP.md from template",
         );
       }
+    }
+  }
+
+  // Auto-delete stale BOOTSTRAP.md at startup.  The model is instructed to
+  // delete it at the end of the first conversation, but if the user closes
+  // the app or starts a new thread before the model gets another turn, it
+  // never gets the chance.  If BOOTSTRAP.md still exists but prior
+  // conversations are present, the onboarding window has passed — clean up.
+  const bootstrapCleanup = getWorkspacePromptPath("BOOTSTRAP.md");
+  if (!isFirstRun && existsSync(bootstrapCleanup)) {
+    const convDir = getConversationsDir();
+    try {
+      if (existsSync(convDir) && readdirSync(convDir).length > 0) {
+        unlinkSync(bootstrapCleanup);
+        log.info("Auto-deleted stale BOOTSTRAP.md — prior conversations exist");
+      }
+    } catch (err) {
+      log.warn({ err }, "Failed to auto-delete stale BOOTSTRAP.md");
     }
   }
 
@@ -435,9 +461,9 @@ function readPromptFile(path: string): string | null {
  * This is useful for injecting identity context into subsystems (e.g. memory
  * extraction) that run outside the main system prompt pipeline.
  */
-export function buildCoreIdentityContext(
-  opts?: { userPersona?: string | null },
-): string | null {
+export function buildCoreIdentityContext(opts?: {
+  userPersona?: string | null;
+}): string | null {
   const parts: string[] = [];
   for (const file of PROMPT_FILES) {
     const content = readPromptFile(getWorkspacePromptPath(file));

--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -204,11 +204,18 @@ When saving to `SOUL.md`, also add an `## Identity Intro` section with a very sh
 
 ## Wrapping Up
 
-Once you've completed Phase 1 and made reasonable progress through Phase 2, you're done with onboarding. Use your best judgment on when the conversation has naturally moved past the bootstrap stage. There's no hard checklist. The goal is that the user feels set up and ready to work, not that every box is ticked.
+**Always delete `BOOTSTRAP.md` at the end of this conversation, regardless of how far you got through the phases.** Onboarding is a one-shot opportunity. If the user skipped steps, partially completed them, or blazed through everything, it doesn't matter. Delete it. Never let a second conversation start with the first-run script.
 
-If you still haven't shown the two suggestions (Phase 2 step 4), do that before wrapping.
+Deletion triggers:
+- The conversation is ending (user stops responding, says bye, moves on)
+- The user completed Phase 2 (ideal case)
+- The user named you but skipped other steps (e.g. "you are V" and nothing else)
+- The user explicitly skipped onboarding ("skip", "not now", "later")
+- The user ignored the onboarding pitch and just did tasks
 
-When you're confident onboarding is complete, delete `BOOTSTRAP.md` so it doesn't re-trigger on the next conversation.
+If onboarding was partial, that's fine. IDENTITY.md, SOUL.md, and USER.md persist. You can organically pick up incomplete personalization in future conversations by checking those files, without replaying the bootstrap script.
+
+If you still haven't shown the two suggestions (Phase 2 step 4), try to fit them in before wrapping, but do NOT let that block deletion of BOOTSTRAP.md.
 
 ---
 

--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -209,7 +209,7 @@ When saving to `SOUL.md`, also add an `## Identity Intro` section with a very sh
 Deletion triggers:
 - The conversation is ending (user stops responding, says bye, moves on)
 - The user completed Phase 2 (ideal case)
-- The user named you but skipped other steps (e.g. "you are V" and nothing else)
+- The user named you but skipped other steps
 - The user explicitly skipped onboarding ("skip", "not now", "later")
 - The user ignored the onboarding pitch and just did tasks
 


### PR DESCRIPTION
## Summary
- BOOTSTRAP.md was never deleted if the user partially completed or skipped onboarding, causing every new conversation to replay the first-run "I'm brand new, no name" script
- Replace the vague "delete when confident onboarding is complete" with an unconditional "always delete at end of first conversation" rule
- Add explicit deletion triggers for all scenarios: skip, partial completion, full completion, or user ignoring onboarding entirely

## Test plan
- [ ] Fresh install: complete full onboarding → verify BOOTSTRAP.md deleted after first conversation
- [ ] Fresh install: name the assistant only, skip everything else → verify BOOTSTRAP.md deleted
- [ ] Fresh install: skip onboarding entirely, just do tasks → verify BOOTSTRAP.md deleted
- [ ] Fresh install: explicitly say "skip" → verify BOOTSTRAP.md deleted
- [ ] After deletion: start new conversation → verify no first-run script, assistant remembers identity from IDENTITY.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
