### PR TITLE
refactor: extract shared catalog text-search helper to prevent CLI/daemon drift

### DIFF
--- a/assistant/src/__tests__/catalog-search.test.ts
+++ b/assistant/src/__tests__/catalog-search.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+
+import { filterByQuery } from "../skills/catalog-search.js";
+
+interface FakeSkill {
+  id: string;
+  name: string;
+  description: string;
+}
+
+const skills: FakeSkill[] = [
+  {
+    id: "weather",
+    name: "Weather Lookup",
+    description: "Get current weather for a city",
+  },
+  {
+    id: "search",
+    name: "Web Search",
+    description: "Search the web for information",
+  },
+  {
+    id: "deploy",
+    name: "Deploy Helper",
+    description: "Deploy apps to production",
+  },
+];
+
+const fields: ((s: FakeSkill) => string)[] = [
+  (s) => s.id,
+  (s) => s.name,
+  (s) => s.description,
+];
+
+describe("filterByQuery", () => {
+  test("case-insensitive matching", () => {
+    const result = filterByQuery(skills, "WEATHER", fields);
+    expect(result).toEqual([skills[0]]);
+  });
+
+  test("matches on any supplied field accessor", () => {
+    // Match on id
+    expect(filterByQuery(skills, "deploy", fields)).toEqual([skills[2]]);
+    // Match on name
+    expect(filterByQuery(skills, "Web Search", fields)).toEqual([skills[1]]);
+    // Match on description
+    expect(filterByQuery(skills, "production", fields)).toEqual([skills[2]]);
+  });
+
+  test("returns empty array for no matches", () => {
+    const result = filterByQuery(skills, "nonexistent", fields);
+    expect(result).toEqual([]);
+  });
+
+  test("returns all items for broad query", () => {
+    // All skills have "e" somewhere in their fields
+    const result = filterByQuery(skills, "e", fields);
+    expect(result).toHaveLength(3);
+    expect(result).toEqual(skills);
+  });
+});

--- a/assistant/src/cli/commands/skills.ts
+++ b/assistant/src/cli/commands/skills.ts
@@ -11,6 +11,7 @@ import {
   readLocalCatalog,
   uninstallSkillLocally,
 } from "../../skills/catalog-install.js";
+import { filterByQuery } from "../../skills/catalog-search.js";
 import type {
   AuditResponse,
   SkillsShSearchResult,
@@ -148,13 +149,11 @@ Examples:
           }
         }
 
-        const lowerQuery = query.toLowerCase();
-        const catalogMatches = catalog.filter(
-          (s) =>
-            s.id.toLowerCase().includes(lowerQuery) ||
-            s.name.toLowerCase().includes(lowerQuery) ||
-            s.description.toLowerCase().includes(lowerQuery),
-        );
+        const catalogMatches = filterByQuery(catalog, query, [
+          (s) => s.id,
+          (s) => s.name,
+          (s) => s.description,
+        ]);
 
         // ── Community registry search (non-fatal on failure) ─────────
         let registryResults: SkillsShSearchResult[] = [];

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -25,6 +25,7 @@ import {
   userMessage,
 } from "../../providers/provider-send-message.js";
 import { isTextMimeType as isTextMime } from "../../runtime/routes/workspace-utils.js";
+import { filterByQuery } from "../../skills/catalog-search.js";
 import {
   clawhubCheckUpdates,
   clawhubInspect,
@@ -662,13 +663,11 @@ export async function searchSkills(
   try {
     // Search the loaded skill catalog (bundled + installed) for matches
     const catalog = loadSkillCatalog();
-    const lowerQuery = query.toLowerCase();
-    const catalogMatches = catalog.filter(
-      (s) =>
-        s.id.toLowerCase().includes(lowerQuery) ||
-        s.displayName.toLowerCase().includes(lowerQuery) ||
-        s.description.toLowerCase().includes(lowerQuery),
-    );
+    const catalogMatches = filterByQuery(catalog, query, [
+      (s) => s.id,
+      (s) => s.displayName,
+      (s) => s.description,
+    ]);
 
     // Shape that matches ClawhubSearchResultItem so the client
     // (Swift ClawhubSkillItem) can decode results uniformly.

--- a/assistant/src/skills/catalog-search.ts
+++ b/assistant/src/skills/catalog-search.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared catalog text-search helper.
+ *
+ * Both the CLI `skills search` command and the daemon `searchSkills` handler
+ * need case-insensitive substring matching across multiple fields. This module
+ * provides a single generic implementation to prevent the two from drifting.
+ */
+
+export function filterByQuery<T>(
+  items: T[],
+  query: string,
+  fields: ((item: T) => string)[],
+): T[] {
+  const lower = query.toLowerCase();
+  return items.filter((item) =>
+    fields.some((fn) => fn(item).toLowerCase().includes(lower)),
+  );
+}


### PR DESCRIPTION
## Summary
- Extract `filterByQuery` generic helper to `assistant/src/skills/catalog-search.ts` to eliminate duplicated catalog text-search logic between CLI and daemon
- Update both CLI `skills search` and daemon `searchSkills` to use the shared helper
- Add unit tests for the shared helper

Part of plan: skills-catalog-ui.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
