### PR TITLE
feat: add cached Vellum catalog fetching to daemon skill handler

### DIFF
--- a/assistant/src/__tests__/catalog-cache.test.ts
+++ b/assistant/src/__tests__/catalog-cache.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for the catalog cache (catalog-cache.ts).
+ *
+ * Validates TTL-based caching, re-fetch after expiry, stale-cache fallback
+ * on fetch failure, and explicit cache invalidation.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import type { CatalogSkill } from "../skills/catalog-install.js";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be defined before importing the module under test
+// ---------------------------------------------------------------------------
+
+// Suppress logger output
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+let mockRepoSkillsDir: string | undefined = undefined;
+let mockFetchCatalogResult: CatalogSkill[] = [];
+let mockFetchCatalogError: Error | null = null;
+let fetchCatalogCallCount = 0;
+let readLocalCatalogCallCount = 0;
+
+mock.module("../skills/catalog-install.js", () => ({
+  getRepoSkillsDir: () => mockRepoSkillsDir,
+  readLocalCatalog: (_dir: string) => {
+    readLocalCatalogCallCount++;
+    return mockFetchCatalogResult;
+  },
+  fetchCatalog: async () => {
+    fetchCatalogCallCount++;
+    if (mockFetchCatalogError) {
+      throw mockFetchCatalogError;
+    }
+    return mockFetchCatalogResult;
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import { getCatalog, invalidateCatalogCache } from "../skills/catalog-cache.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const sampleCatalog: CatalogSkill[] = [
+  { id: "web-search", name: "Web Search", description: "Search the web" },
+  { id: "browser", name: "Browser", description: "Browse the web" },
+];
+
+const updatedCatalog: CatalogSkill[] = [
+  { id: "web-search", name: "Web Search v2", description: "Updated search" },
+];
+
+function resetState(): void {
+  invalidateCatalogCache();
+  mockRepoSkillsDir = undefined;
+  mockFetchCatalogResult = [];
+  mockFetchCatalogError = null;
+  fetchCatalogCallCount = 0;
+  readLocalCatalogCallCount = 0;
+}
+
+afterEach(resetState);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("getCatalog", () => {
+  test("returns cached value within TTL without re-fetching", async () => {
+    mockFetchCatalogResult = sampleCatalog;
+
+    const first = await getCatalog();
+    expect(first).toEqual(sampleCatalog);
+    expect(fetchCatalogCallCount).toBe(1);
+
+    // Second call should use cache
+    const second = await getCatalog();
+    expect(second).toEqual(sampleCatalog);
+    expect(fetchCatalogCallCount).toBe(1); // no additional fetch
+  });
+
+  test("re-fetches after TTL expires", async () => {
+    mockFetchCatalogResult = sampleCatalog;
+
+    const first = await getCatalog();
+    expect(first).toEqual(sampleCatalog);
+    expect(fetchCatalogCallCount).toBe(1);
+
+    // Simulate TTL expiry by manipulating Date.now
+    const originalNow = Date.now;
+    Date.now = () => originalNow() + 5 * 60 * 1000 + 1;
+
+    try {
+      mockFetchCatalogResult = updatedCatalog;
+      const second = await getCatalog();
+      expect(second).toEqual(updatedCatalog);
+      expect(fetchCatalogCallCount).toBe(2);
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+
+  test("falls back to stale cache on fetch failure", async () => {
+    mockFetchCatalogResult = sampleCatalog;
+
+    // Populate cache
+    const first = await getCatalog();
+    expect(first).toEqual(sampleCatalog);
+
+    // Expire cache and make fetch fail
+    const originalNow = Date.now;
+    Date.now = () => originalNow() + 5 * 60 * 1000 + 1;
+
+    try {
+      mockFetchCatalogError = new Error("Network timeout");
+      const fallback = await getCatalog();
+      expect(fallback).toEqual(sampleCatalog); // stale cache
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+
+  test("returns empty array on fetch failure with no stale cache", async () => {
+    mockFetchCatalogError = new Error("Network timeout");
+
+    const result = await getCatalog();
+    expect(result).toEqual([]);
+  });
+
+  test("invalidateCatalogCache forces re-fetch", async () => {
+    mockFetchCatalogResult = sampleCatalog;
+
+    await getCatalog();
+    expect(fetchCatalogCallCount).toBe(1);
+
+    invalidateCatalogCache();
+
+    mockFetchCatalogResult = updatedCatalog;
+    const refreshed = await getCatalog();
+    expect(refreshed).toEqual(updatedCatalog);
+    expect(fetchCatalogCallCount).toBe(2);
+  });
+
+  test("uses local catalog when repoSkillsDir is set", async () => {
+    mockRepoSkillsDir = "/mock/repo/skills";
+    mockFetchCatalogResult = sampleCatalog;
+
+    const result = await getCatalog();
+    expect(result).toEqual(sampleCatalog);
+    expect(readLocalCatalogCallCount).toBe(1);
+    expect(fetchCatalogCallCount).toBe(0); // no remote fetch
+  });
+});

--- a/assistant/src/skills/catalog-cache.ts
+++ b/assistant/src/skills/catalog-cache.ts
@@ -1,0 +1,44 @@
+import { getLogger } from "../util/logger.js";
+import type { CatalogSkill } from "./catalog-install.js";
+import {
+  fetchCatalog,
+  getRepoSkillsDir,
+  readLocalCatalog,
+} from "./catalog-install.js";
+
+const log = getLogger("catalog-cache");
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+let cachedCatalog: CatalogSkill[] | null = null;
+let cacheTimestamp = 0;
+
+/** Resolve the Vellum catalog with in-memory caching. */
+export async function getCatalog(): Promise<CatalogSkill[]> {
+  if (cachedCatalog && Date.now() - cacheTimestamp < CACHE_TTL_MS) {
+    return cachedCatalog;
+  }
+  const repoSkillsDir = getRepoSkillsDir();
+  let catalog: CatalogSkill[];
+  if (repoSkillsDir) {
+    catalog = readLocalCatalog(repoSkillsDir);
+  } else {
+    try {
+      catalog = await fetchCatalog();
+    } catch (err) {
+      log.warn(
+        { err },
+        "Failed to fetch Vellum catalog, using stale cache or empty",
+      );
+      return cachedCatalog ?? [];
+    }
+  }
+  cachedCatalog = catalog;
+  cacheTimestamp = Date.now();
+  return catalog;
+}
+
+/** Invalidate the cache (for testing or forced refresh). */
+export function invalidateCatalogCache(): void {
+  cachedCatalog = null;
+  cacheTimestamp = 0;
+}


### PR DESCRIPTION
## Summary
- Add `assistant/src/skills/catalog-cache.ts` with `getCatalog()` that wraps Platform API fetching with a 5-minute TTL in-memory cache
- Falls back to stale cache on fetch failure (never throws)
- Uses local catalog in dev mode (VELLUM_DEV), remote Platform API otherwise
- Add unit tests covering caching, TTL expiry, failure fallback, and cache invalidation

Part of plan: skills-catalog-ui.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
