### PR TITLE
feat: add installStatus field to GET /skills with optional catalog inclusion

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5533,7 +5533,7 @@ paths:
     get:
       operationId: skills_get
       summary: List all skills
-      description: Return all installed skills.
+      description: Return all installed skills. Pass ?include=catalog to also include available catalog skills.
       tags:
         - skills
       responses:
@@ -5546,11 +5546,82 @@ paths:
                 properties:
                   skills:
                     type: array
-                    items: {}
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        description:
+                          type: string
+                        emoji:
+                          type: string
+                        homepage:
+                          type: string
+                        source:
+                          type: string
+                          enum:
+                            - bundled
+                            - managed
+                            - workspace
+                            - clawhub
+                            - extra
+                            - catalog
+                        state:
+                          type: string
+                          enum:
+                            - enabled
+                            - disabled
+                        installStatus:
+                          type: string
+                          enum:
+                            - bundled
+                            - installed
+                            - available
+                        updateAvailable:
+                          type: boolean
+                        provenance:
+                          type: object
+                          properties:
+                            kind:
+                              type: string
+                              enum:
+                                - first-party
+                                - third-party
+                                - local
+                            provider:
+                              type: string
+                            originId:
+                              type: string
+                            sourceUrl:
+                              type: string
+                          required:
+                            - kind
+                          additionalProperties: false
+                      required:
+                        - id
+                        - name
+                        - description
+                        - source
+                        - state
+                        - installStatus
+                        - updateAvailable
+                        - provenance
+                      additionalProperties: false
                     description: Skill objects
                 required:
                   - skills
                 additionalProperties: false
+      parameters:
+        - name: include
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - catalog
+          description: Optional inclusion flag. Use 'catalog' to merge available Vellum catalog skills into the response.
     post:
       operationId: skills_post
       summary: Create skill

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -25,6 +25,7 @@ import {
   userMessage,
 } from "../../providers/provider-send-message.js";
 import { isTextMimeType as isTextMime } from "../../runtime/routes/workspace-utils.js";
+import { getCatalog } from "../../skills/catalog-cache.js";
 import { filterByQuery } from "../../skills/catalog-search.js";
 import {
   clawhubCheckUpdates,
@@ -233,8 +234,9 @@ export interface SkillListItem {
   description: string;
   emoji?: string;
   homepage?: string;
-  source: "bundled" | "managed" | "workspace" | "clawhub" | "extra";
+  source: "bundled" | "managed" | "workspace" | "clawhub" | "extra" | "catalog";
   state: "enabled" | "disabled";
+  installStatus: "bundled" | "installed" | "available";
   updateAvailable: boolean;
   provenance: SkillProvenance;
 }
@@ -260,6 +262,9 @@ export function listSkills(_ctx: SkillOperationContext): SkillListItem[] {
     homepage: r.summary.homepage,
     source: r.summary.source,
     state: r.state,
+    installStatus: (r.summary.source === "bundled"
+      ? "bundled"
+      : "installed") as SkillListItem["installStatus"],
     updateAvailable: false,
     provenance: resolveProvenance(r.summary),
   }));
@@ -274,6 +279,54 @@ export function listSkills(_ctx: SkillOperationContext): SkillListItem[] {
   });
 
   return items;
+}
+
+/**
+ * List installed skills merged with available catalog skills.
+ * Installed skills take precedence when deduplicating by ID.
+ */
+export async function listSkillsWithCatalog(
+  ctx: SkillOperationContext,
+): Promise<SkillListItem[]> {
+  const installed = listSkills(ctx);
+  const installedIds = new Set(installed.map((s) => s.id));
+
+  let catalogSkills: import("../../skills/catalog-install.js").CatalogSkill[];
+  try {
+    catalogSkills = await getCatalog();
+  } catch {
+    // If catalog fetch fails, return installed-only
+    return installed;
+  }
+
+  // All entries from the Vellum platform API are first-party.
+  // Create SkillListItems for catalog skills not already installed.
+  const available: SkillListItem[] = catalogSkills
+    .filter((cs) => !installedIds.has(cs.id))
+    .map((cs) => ({
+      id: cs.id,
+      name: cs.metadata?.vellum?.["display-name"] ?? cs.name,
+      description: cs.description,
+      emoji: cs.emoji,
+      homepage: undefined,
+      source: "catalog" as const,
+      state: "disabled" as const,
+      installStatus: "available" as const,
+      updateAvailable: false,
+      provenance: { kind: "first-party" as const, provider: "Vellum" },
+    }));
+
+  const merged = [...installed, ...available];
+
+  // Sort using the same provenance sort + alphabetical
+  merged.sort((a, b) => {
+    const rankDiff =
+      provenanceSortRank(a.provenance) - provenanceSortRank(b.provenance);
+    if (rankDiff !== 0) return rankDiff;
+    return a.name.localeCompare(b.name);
+  });
+
+  return merged;
 }
 
 /** Look up a single skill by ID from the resolved catalog, returning its SkillListItem. */
@@ -295,6 +348,7 @@ function findSkillById(
     homepage: r.summary.homepage,
     source: r.summary.source,
     state: r.state,
+    installStatus: r.summary.source === "bundled" ? "bundled" : "installed",
     updateAvailable: false,
     provenance: resolveProvenance(r.summary),
   };

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -23,6 +23,7 @@ import {
   inspectSkill,
   installSkill,
   listSkills,
+  listSkillsWithCatalog,
   searchSkills,
   uninstallSkill,
   updateSkill,
@@ -47,13 +48,53 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
       method: "GET",
       policyKey: "skills",
       summary: "List all skills",
-      description: "Return all installed skills.",
+      description:
+        "Return all installed skills. Pass ?include=catalog to also include available catalog skills.",
       tags: ["skills"],
+      queryParams: [
+        {
+          name: "include",
+          schema: { type: "string", enum: ["catalog"] },
+          description:
+            "Optional inclusion flag. Use 'catalog' to merge available Vellum catalog skills into the response.",
+        },
+      ],
       responseBody: z.object({
-        skills: z.array(z.unknown()).describe("Skill objects"),
+        skills: z
+          .array(
+            z.object({
+              id: z.string(),
+              name: z.string(),
+              description: z.string(),
+              emoji: z.string().optional(),
+              homepage: z.string().optional(),
+              source: z.enum([
+                "bundled",
+                "managed",
+                "workspace",
+                "clawhub",
+                "extra",
+                "catalog",
+              ]),
+              state: z.enum(["enabled", "disabled"]),
+              installStatus: z.enum(["bundled", "installed", "available"]),
+              updateAvailable: z.boolean(),
+              provenance: z.object({
+                kind: z.enum(["first-party", "third-party", "local"]),
+                provider: z.string().optional(),
+                originId: z.string().optional(),
+                sourceUrl: z.string().optional(),
+              }),
+            }),
+          )
+          .describe("Skill objects"),
       }),
-      handler: () => {
-        const skills = listSkills(ctx());
+      handler: async ({ url }) => {
+        const include = url.searchParams.get("include");
+        const skills =
+          include === "catalog"
+            ? await listSkillsWithCatalog(ctx())
+            : listSkills(ctx());
         return Response.json({ skills });
       },
     },


### PR DESCRIPTION
## Summary
- Add `installStatus` field (`bundled` | `installed` | `available`) to `SkillListItem` and populate it in `listSkills()`
- Add `listSkillsWithCatalog()` that merges installed skills with the Vellum catalog, using the cached fetcher from PR 2
- Add `?include=catalog` query param to `GET /skills` route to optionally include available catalog skills
- Default behavior (no param) unchanged — backward compatible

Part of plan: skills-catalog-ui.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
