### PR TITLE
feat: Swift SkillsClient passes include=catalog param and adds Available pill variant

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -690,7 +690,7 @@ extension AppDelegate {
     func refreshSkillsCache() {
         refreshSkillsTask?.cancel()
         refreshSkillsTask = Task {
-            let response = await SkillsClient().fetchSkillsList()
+            let response = await SkillsClient().fetchSkillsList(includeCatalog: false)
             guard let response else { return }
             self.cachedSkills = response.skills
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -359,7 +359,7 @@ struct IdentityPanel: View {
 
     private func fetchSkills() {
         Task {
-            let response = await SkillsClient().fetchSkillsList()
+            let response = await SkillsClient().fetchSkillsList(includeCatalog: false)
             if let response {
                 skills = response.skills.filter { $0.state == "enabled" }
             }

--- a/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
@@ -7,6 +7,7 @@ public struct VSkillTypePill: View {
         case installed
         case created
         case extra
+        case available
         case custom(label: String, icon: String, foreground: Color, background: Color)
 
         var label: String {
@@ -15,6 +16,7 @@ public struct VSkillTypePill: View {
             case .installed: return "Installed"
             case .created: return "Created"
             case .extra: return "Extra"
+            case .available: return "Available"
             case .custom(let label, _, _, _): return label
             }
         }
@@ -25,6 +27,7 @@ public struct VSkillTypePill: View {
             case .installed: return .circleCheck
             case .created: return .sparkles
             case .extra: return .puzzle
+            case .available: return .arrowDownToLine
             case .custom(_, let icon, _, _): return .resolve(icon)
             }
         }
@@ -35,6 +38,7 @@ public struct VSkillTypePill: View {
             case .installed: return VColor.systemPositiveStrong
             case .created: return VColor.contentSecondary
             case .extra: return VColor.contentTertiary
+            case .available: return VColor.funTeal
             case .custom(_, _, let fg, _): return fg
             }
         }
@@ -45,6 +49,7 @@ public struct VSkillTypePill: View {
             case .installed: return VColor.systemPositiveWeak
             case .created: return VColor.surfaceBase
             case .extra: return VColor.surfaceOverlay
+            case .available: return VColor.funTeal.opacity(0.12)
             case .custom(_, _, _, let bg): return bg
             }
         }
@@ -67,6 +72,8 @@ public struct VSkillTypePill: View {
             self.type = .created
         case "extra":
             self.type = .extra
+        case "catalog":
+            self.type = .available
         default:
             self.type = .custom(
                 label: source.replacingOccurrences(of: "-", with: " ").capitalized,

--- a/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
@@ -461,6 +461,7 @@ struct FeedbackGallerySection: View {
                         VSkillTypePill(type: .installed)
                         VSkillTypePill(type: .created)
                         VSkillTypePill(type: .extra)
+                        VSkillTypePill(type: .available)
                     }
                 }
             }

--- a/clients/shared/Features/Skills/SkillsStore.swift
+++ b/clients/shared/Features/Skills/SkillsStore.swift
@@ -118,7 +118,7 @@ public final class SkillsStore: ObservableObject {
         isLoading = true
 
         Task {
-            let response = await skillsClient.fetchSkillsList()
+            let response = await skillsClient.fetchSkillsList(includeCatalog: true)
             if let response {
                 skills = response.skills
             }

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -912,8 +912,17 @@ extension SkillsListResponseSkill: Identifiable {}
 extension SkillsListResponseSkill {
     /// Returns a copy with a different `state`, preserving all other fields including `id`.
     public func withState(_ newState: String) -> Self {
-        Self(id: id, name: name, description: description, emoji: emoji, homepage: homepage, source: source, state: newState, installedVersion: installedVersion, latestVersion: latestVersion, updateAvailable: updateAvailable, clawhub: clawhub, provenance: provenance)
+        Self(id: id, name: name, description: description, emoji: emoji, homepage: homepage, source: source, state: newState, installStatus: installStatus, installedVersion: installedVersion, latestVersion: latestVersion, updateAvailable: updateAvailable, clawhub: clawhub, provenance: provenance)
     }
+
+    /// Whether the skill is available from the catalog but not yet installed.
+    public var isAvailable: Bool { installStatus == "available" }
+
+    /// Whether the skill is a bundled (core) skill.
+    public var isBundled: Bool { installStatus == "bundled" }
+
+    /// Whether the skill is currently installed (explicitly installed or bundled).
+    public var isInstalled: Bool { installStatus == "installed" || installStatus == "bundled" }
 }
 
 /// Response containing the list of available skills.

--- a/clients/shared/Network/SkillsClient.swift
+++ b/clients/shared/Network/SkillsClient.swift
@@ -9,7 +9,7 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 /// updating, searching, inspecting, drafting, and creating skills.
 @MainActor
 public protocol SkillsClientProtocol {
-    func fetchSkillsList() async -> SkillsListResponseMessage?
+    func fetchSkillsList(includeCatalog: Bool) async -> SkillsListResponseMessage?
     func enableSkill(name: String) async -> SkillsOperationResponseMessage?
     func disableSkill(name: String) async -> SkillsOperationResponseMessage?
     func configureSkill(name: String, env: [String: String]?, apiKey: String?, config: [String: AnyCodable]?) async -> SkillsOperationResponseMessage?
@@ -41,10 +41,11 @@ public struct SkillsClient: SkillsClientProtocol {
         value.addingPercentEncoding(withAllowedCharacters: pathComponentAllowed) ?? value
     }
 
-    public func fetchSkillsList() async -> SkillsListResponseMessage? {
+    public func fetchSkillsList(includeCatalog: Bool) async -> SkillsListResponseMessage? {
         do {
+            let params: [String: String]? = includeCatalog ? ["include": "catalog"] : nil
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/skills", timeout: 10
+                path: "assistants/{assistantId}/skills", params: params, timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchSkillsList failed (HTTP \(response.statusCode))")


### PR DESCRIPTION
## Summary
- Update `SkillsClient.fetchSkillsList()` to accept `includeCatalog` param, passing `?include=catalog` to the daemon
- `SkillsStore.fetchSkills()` now always requests catalog skills for the full picture
- Add `isAvailable`, `isBundled`, `isInstalled` computed properties on `SkillInfo`
- Add teal `.available` variant to `VSkillTypePill` for catalog-source skills
- Fix `withState()` to preserve `installStatus` field
- Update Gallery entry for VSkillTypePill to include new Available pill

Part of plan: skills-catalog-ui.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
