### PR TITLE
feat: Skills tab shows Installed/All filter pills with install action for catalog skills

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -15,6 +15,7 @@ struct AgentPanelContent: View {
     @State private var skillToDelete: SkillInfo?
     @State private var selectedCategory: SkillCategory?
     @State private var globalSkillSearchQuery = ""
+    @State private var showAllSkills = false
 
     init(onInvokeSkill: ((SkillInfo) -> Void)? = nil, onSkillsChanged: (() -> Void)? = nil, connectionManager: GatewayConnectionManager) {
         self.onInvokeSkill = onInvokeSkill
@@ -89,7 +90,22 @@ struct AgentPanelContent: View {
     private var filterBar: some View {
         HStack(spacing: VSpacing.sm) {
             VSearchBar(placeholder: "Search Skills", text: $globalSkillSearchQuery)
+            filterPill(label: "Installed", isActive: !showAllSkills) {
+                withAnimation(VAnimation.fast) { showAllSkills = false }
+            }
+            filterPill(label: "All", isActive: showAllSkills) {
+                withAnimation(VAnimation.fast) { showAllSkills = true }
+            }
         }
+    }
+
+    private func filterPill(label: String, isActive: Bool, action: @escaping () -> Void) -> some View {
+        VButton(
+            label: label,
+            style: isActive ? .primary : .ghost,
+            size: .pill,
+            action: action
+        )
     }
 
     // MARK: - Category Sidebar
@@ -129,7 +145,10 @@ struct AgentPanelContent: View {
     // MARK: - Filtering
 
     private var userSkills: [SkillInfo] {
-        skillsManager.skills
+        if showAllSkills {
+            return skillsManager.skills
+        }
+        return skillsManager.skills.filter { $0.isInstalled }
     }
 
     /// Skills filtered by search query only.
@@ -154,9 +173,10 @@ struct AgentPanelContent: View {
             filtered = base
         }
         return filtered.sorted { a, b in
-            let aInstalled = (a.source == "managed" || a.source == "clawhub")
-            let bInstalled = (b.source == "managed" || b.source == "clawhub")
-            if aInstalled != bInstalled { return aInstalled }
+            if a.isInstalled != b.isInstalled { return a.isInstalled }
+            let aManaged = (a.source == "managed" || a.source == "clawhub")
+            let bManaged = (b.source == "managed" || b.source == "clawhub")
+            if a.isInstalled && b.isInstalled && aManaged != bManaged { return aManaged }
             return a.name.localizedCaseInsensitiveCompare(b.name) == .orderedAscending
         }
     }
@@ -188,27 +208,40 @@ struct AgentPanelContent: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if filteredSkills.isEmpty {
             VEmptyState(
-                title: selectedCategory == nil ? "No Skills Installed" : "No \(selectedCategory!.displayName) Skills",
-                subtitle: selectedCategory == nil
-                    ? "Ask your assistant in chat to search for and install new skills."
-                    : "Try selecting a different category or clearing the filter.",
-                icon: VIcon.zap.rawValue
+                title: showAllSkills
+                    ? "No Skills Available"
+                    : (selectedCategory == nil ? "No Skills Installed" : "No \(selectedCategory!.displayName) Skills"),
+                subtitle: showAllSkills
+                    ? "Check your connection to the Vellum catalog."
+                    : (selectedCategory == nil
+                        ? "Ask your assistant in chat to search for and install new skills."
+                        : "Try selecting a different category or clearing the filter."),
+                icon: showAllSkills ? VIcon.cloudOff.rawValue : VIcon.zap.rawValue
             )
         } else {
             ScrollView {
                 LazyVStack(spacing: VSpacing.sm) {
                     ForEach(filteredSkills) { skill in
-                        SkillItemRow(
-                            skill: skill,
-                            onSelect: {
-                                withAnimation(VAnimation.fast) {
-                                    selectedInstalledSkillId = skill.id
+                        if skill.isAvailable {
+                            AvailableSkillItemRow(
+                                skill: skill,
+                                onSelect: { selectedInstalledSkillId = skill.id },
+                                onInstall: { skillsManager.installSkill(slug: skill.id) },
+                                isInstalling: skillsManager.installingSkillId == skill.id
+                            )
+                        } else {
+                            SkillItemRow(
+                                skill: skill,
+                                onSelect: {
+                                    withAnimation(VAnimation.fast) {
+                                        selectedInstalledSkillId = skill.id
+                                    }
+                                },
+                                onDelete: {
+                                    skillToDelete = skill
                                 }
-                            },
-                            onDelete: {
-                                skillToDelete = skill
-                            }
-                        )
+                            )
+                        }
                     }
                 }
                 .background { OverlayScrollerStyle() }
@@ -227,6 +260,8 @@ struct AgentPanelContent: View {
             return "Created"
         case "extra":
             return "Extra"
+        case "catalog":
+            return "Available"
         default:
             return source.replacingOccurrences(of: "-", with: " ").capitalized
         }
@@ -292,5 +327,67 @@ struct SkillItemRow: View {
             Button("Remove", role: .destructive, action: onDelete)
         }
         .accessibilityElement(children: .combine)
+    }
+}
+
+// MARK: - Available Skill Item Row
+
+struct AvailableSkillItemRow: View {
+    let skill: SkillInfo
+    let onSelect: () -> Void
+    let onInstall: () -> Void
+    var isInstalling: Bool = false
+
+    @State private var isHovered = false
+
+    var body: some View {
+        HStack(alignment: .center, spacing: VSpacing.lg) {
+            if let emoji = skill.emoji, !emoji.isEmpty {
+                Text(emoji)
+                    .font(.system(size: 32))
+                    .opacity(0.5)
+            }
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                HStack(alignment: .center, spacing: VSpacing.sm) {
+                    Text(skill.name)
+                        .font(VFont.titleSmall)
+                        .foregroundStyle(VColor.contentSecondary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    VSkillTypePill(source: skill.source)
+                    Spacer()
+                }
+                Text(skill.description)
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            if isInstalling {
+                VLoadingIndicator()
+            } else {
+                VButton(
+                    label: "Install",
+                    style: .outlined,
+                    size: .compact,
+                    action: onInstall
+                )
+            }
+        }
+        .padding(VSpacing.lg)
+        .background(isHovered ? VColor.surfaceBase : Color.clear)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.xl)
+                .strokeBorder(
+                    VColor.borderDisabled,
+                    style: StrokeStyle(lineWidth: 2, dash: [6, 4])
+                )
+        )
+        .contentShape(RoundedRectangle(cornerRadius: VRadius.xl))
+        .onHover { isHovered = $0 }
+        .animation(VAnimation.fast, value: isHovered)
+        .onTapGesture { onSelect() }
+        .pointerCursor()
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -17,6 +17,7 @@ final class SkillsManager {
     var selectedSkillFiles: SkillDetailFilesHTTPResponse?
     var isLoadingSkillFiles = false
     var skillFilesError: String?
+    var installingSkillId: String?
 
     @ObservationIgnored private var cancellables = Set<AnyCancellable>()
 
@@ -38,6 +39,10 @@ final class SkillsManager {
         skillsStore.$selectedSkillFiles.sink { [weak self] in self?.selectedSkillFiles = $0 }.store(in: &cancellables)
         skillsStore.$isLoadingSkillFiles.sink { [weak self] in self?.isLoadingSkillFiles = $0 }.store(in: &cancellables)
         skillsStore.$skillFilesError.sink { [weak self] in self?.skillFilesError = $0 }.store(in: &cancellables)
+        skillsStore.$installResult.sink { [weak self] result in
+            guard let self, result != nil else { return }
+            self.installingSkillId = nil
+        }.store(in: &cancellables)
     }
 
     // MARK: - Delegated Operations
@@ -52,6 +57,11 @@ final class SkillsManager {
 
     func uninstallSkill(id: String) {
         skillsStore.uninstallSkill(id: id)
+    }
+
+    func installSkill(slug: String) {
+        installingSkillId = slug
+        skillsStore.installSkill(slug: slug)
     }
 
     func fetchSkillFiles(skillId: String) {


### PR DESCRIPTION
## Summary
- Add Installed/All filter pills to the Skills tab search bar for toggling between installed and all-including-catalog views
- Create `AvailableSkillItemRow` with dashed border, muted emoji, secondary title color, teal Available badge, and outlined Install button
- Wire Install button to `SkillsStore.installSkill()` with inline loading state
- Update sorting to place available skills after installed, category counts respect active filter

Part of plan: skills-catalog-ui.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
