### PR TITLE
Update skill docs to use `service:field` credential path shorthand

### DIFF
--- a/skills/notion-oauth-setup/references/path-b-public-oauth.md
+++ b/skills/notion-oauth-setup/references/path-b-public-oauth.md
@@ -76,7 +76,7 @@ bash:
     assistant oauth apps upsert --provider notion --client-id $(cat <<'EOF'
     <client-id>
     EOF
-    ) --client-secret-credential-path "credential/notion/client_secret"
+    ) --client-secret-credential-path "notion:client_secret"
 ```
 
 ```

--- a/skills/vellum-oauth-integrations/references/CONFIGURING_APPLICATIONS.md
+++ b/skills/vellum-oauth-integrations/references/CONFIGURING_APPLICATIONS.md
@@ -53,7 +53,7 @@ Do NOT collect the client secret conversationally.
 Create the app using the CLI, subbing out values for `<provider-key>` and `<client-id>`:
 
 ```bash
-assistant oauth apps upsert --provider <provider-key> --client-id <client-id> --client-secret-credential-path "credential/<provider-key>/client_secret"
+assistant oauth apps upsert --provider <provider-key> --client-id <client-id> --client-secret-credential-path "<provider-key>:client_secret"
 ```
 
 ## Connecting Accounts


### PR DESCRIPTION
## Summary
- Update CONFIGURING_APPLICATIONS.md to use `<provider-key>:client_secret` format
- Update Notion path-b-public-oauth.md to use `notion:client_secret` format

Part of plan: unify-credential-path-format.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
