### PR TITLE
Accept `service:field` shorthand in `--client-secret-credential-path`

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -579,6 +579,9 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
   });
 
   test("upsert with --client-secret-credential-path passes path to upsertApp", async () => {
+    // "custom/path" has no colon and no credential/ or oauth_app/ prefix.
+    // resolveCredentialPath passes it through unchanged since it doesn't
+    // match the service:field shorthand pattern.
     const { exitCode, stdout } = await runCli([
       "apps",
       "upsert",
@@ -665,9 +668,8 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
     });
   });
 
-  test("upsert passes non-prefixed credential path through unchanged", async () => {
-    // Short-form resolution (splitting on last colon) has been removed.
-    // Non-prefixed paths are now passed through as-is.
+  test("upsert resolves service:field shorthand to full credential path", async () => {
+    // The service:field shorthand is resolved to credential/{service}/{field}
     const { exitCode, stdout } = await runCli([
       "apps",
       "upsert",
@@ -685,7 +687,32 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
       provider: "google",
       clientId: "abc",
       clientSecretOpts: {
-        clientSecretCredentialPath: "google:client_secret",
+        clientSecretCredentialPath: "credential/google/client_secret",
+      },
+    });
+    const parsed = JSON.parse(stdout);
+    expect(parsed.id).toBe("app-upsert-1");
+  });
+
+  test("upsert resolves slack:client_secret shorthand to full credential path", async () => {
+    const { exitCode, stdout } = await runCli([
+      "apps",
+      "upsert",
+      "--provider",
+      "slack",
+      "--client-id",
+      "slack-abc",
+      "--client-secret-credential-path",
+      "slack:client_secret",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(mockUpsertAppCalls).toHaveLength(1);
+    expect(mockUpsertAppCalls[0]).toEqual({
+      provider: "slack",
+      clientId: "slack-abc",
+      clientSecretOpts: {
+        clientSecretCredentialPath: "credential/slack/client_secret",
       },
     });
     const parsed = JSON.parse(stdout);

--- a/assistant/src/cli/commands/oauth/apps.ts
+++ b/assistant/src/cli/commands/oauth/apps.ts
@@ -8,8 +8,33 @@ import {
   listApps,
   upsertApp,
 } from "../../../oauth/oauth-store.js";
+import { credentialKey } from "../../../security/credential-key.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
+
+/**
+ * Resolve a credential path input to its full internal format.
+ *
+ * - If `input` already starts with `credential/` or `oauth_app/`, return as-is
+ *   (backwards compatibility for full paths).
+ * - Otherwise, split on the **last** colon to extract `service` and `field`,
+ *   then return `credential/{service}/{field}`.
+ * - If there is no colon, return as-is (unknown format, pass through).
+ */
+function resolveCredentialPath(input: string): string {
+  if (input.startsWith("credential/") || input.startsWith("oauth_app/")) {
+    return input;
+  }
+
+  const lastColon = input.lastIndexOf(":");
+  if (lastColon === -1) {
+    return input;
+  }
+
+  const service = input.slice(0, lastColon);
+  const field = input.slice(lastColon + 1);
+  return credentialKey(service, field);
+}
 
 const log = getCliLogger("cli");
 
@@ -218,13 +243,14 @@ You can supply the client secret directly via --client-secret, or reference an
 existing credential in the store via --client-secret-credential-path. These two
 options are mutually exclusive — providing both is an error.
 
-The --client-secret-credential-path must be a full credential path
-(e.g. "credential/google/client_secret").
+The --client-secret-credential-path accepts a credential reference in
+\`service:field\` format (e.g. \`google:client_secret\`). Full paths like
+\`credential/google/client_secret\` are also accepted.
 
 Examples:
   $ assistant oauth apps upsert --provider google --client-id abc123
   $ assistant oauth apps upsert --provider slack --client-id def456 --client-secret s3cret
-  $ assistant oauth apps upsert --provider slack --client-id def456 --client-secret-credential-path "credential/slack/client_secret"
+  $ assistant oauth apps upsert --provider slack --client-id def456 --client-secret-credential-path "slack:client_secret"
   $ assistant oauth apps upsert --provider google --client-id abc123 --json`,
     )
     .action(
@@ -248,10 +274,13 @@ Examples:
             return;
           }
 
+          const resolvedPath = opts.clientSecretCredentialPath
+            ? resolveCredentialPath(opts.clientSecretCredentialPath)
+            : undefined;
           const clientSecretOpts = opts.clientSecret
             ? { clientSecretValue: opts.clientSecret }
-            : opts.clientSecretCredentialPath
-              ? { clientSecretCredentialPath: opts.clientSecretCredentialPath }
+            : resolvedPath
+              ? { clientSecretCredentialPath: resolvedPath }
               : undefined;
           const row = await upsertApp(
             opts.provider,


### PR DESCRIPTION
## Summary
- Add `resolveCredentialPath` helper that expands `service:field` shorthand to `credential/service/field` internal format
- Preserve backwards compat for full paths (`credential/...` and `oauth_app/...`)
- Update help text and tests

Part of plan: unify-credential-path-format.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
