### PR TITLE
Fix credential_store to use prompt: for secure client secret input

### DIFF
--- a/skills/vellum-oauth-integrations/references/CONFIGURING_APPLICATIONS.md
+++ b/skills/vellum-oauth-integrations/references/CONFIGURING_APPLICATIONS.md
@@ -41,10 +41,12 @@ Prompt the user to enter the Client ID conversationally through chat. This is sa
 Securely collect the Client Secret using:
 
 ```
-credential_store store:
+credential_store prompt:
   service: "<provider-key>"
   field: "client_secret"
-  value: "<the-client-secret-value>"
+  label: "OAuth Client Secret"
+  description: "Copy the Client Secret from the app credentials page and paste it here."
+  placeholder: "..."
 ```
 
 Do NOT collect the client secret conversationally.


### PR DESCRIPTION
## Summary

- Changed `credential_store store:` to `credential_store prompt:` in the OAuth integrations skill's CONFIGURING_APPLICATIONS.md
- The `store:` form contradicts the "Do NOT collect the client secret conversationally" instruction since it requires the value to already be known. The `prompt:` form presents a secure UI input, matching the established pattern across all other skills (notion-oauth-app-setup, vercel-token-setup, etc.)

## Original prompt

the first one
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21652" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
