### PR TITLE
fix: disable detail navigation for available catalog skills

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -225,7 +225,6 @@ struct AgentPanelContent: View {
                         if skill.isAvailable {
                             AvailableSkillItemRow(
                                 skill: skill,
-                                onSelect: { selectedInstalledSkillId = skill.id },
                                 onInstall: { skillsManager.installSkill(slug: skill.id) },
                                 isInstalling: skillsManager.installingSkillId == skill.id
                             )
@@ -334,11 +333,8 @@ struct SkillItemRow: View {
 
 struct AvailableSkillItemRow: View {
     let skill: SkillInfo
-    let onSelect: () -> Void
     let onInstall: () -> Void
     var isInstalling: Bool = false
-
-    @State private var isHovered = false
 
     var body: some View {
         HStack(alignment: .center, spacing: VSpacing.lg) {
@@ -375,7 +371,6 @@ struct AvailableSkillItemRow: View {
             }
         }
         .padding(VSpacing.lg)
-        .background(isHovered ? VColor.surfaceBase : Color.clear)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
         .overlay(
             RoundedRectangle(cornerRadius: VRadius.xl)
@@ -384,10 +379,5 @@ struct AvailableSkillItemRow: View {
                     style: StrokeStyle(lineWidth: 2, dash: [6, 4])
                 )
         )
-        .contentShape(RoundedRectangle(cornerRadius: VRadius.xl))
-        .onHover { isHovered = $0 }
-        .animation(VAnimation.fast, value: isHovered)
-        .onTapGesture { onSelect() }
-        .pointerCursor()
     }
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skills-catalog-ui.md.

**Gap:** Available skill row opens SkillDetailView which 404s for catalog skills
**What was expected:** Tapping available skill should not navigate to broken detail view
**What was found:** onSelect set selectedInstalledSkillId for catalog skills that have no files on disk
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
