### PR TITLE
fix: clear selected skill when filter toggle hides it

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -70,6 +70,12 @@ struct AgentPanelContent: View {
                 selectedInstalledSkillId = nil
             }
         }
+        .onChange(of: showAllSkills) {
+            if let selectedId = selectedInstalledSkillId,
+               !filteredSkills.contains(where: { $0.id == selectedId }) {
+                selectedInstalledSkillId = nil
+            }
+        }
         .sheet(item: $skillToDelete) { skill in
             SkillDeleteConfirmView(
                 skillName: skill.name,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skills-catalog-ui.md.

**Gap:** selectedInstalledSkillId not cleared on filter toggle
**What was expected:** Switching from All to Installed clears selection if selected skill is catalog-only
**What was found:** No onChange(of: showAllSkills) handler existed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
