### PR TITLE
fix: filter catalog skills from iOS InstalledSkillsView

### DIFF
--- a/clients/ios/Views/Intelligence/InstalledSkillsView.swift
+++ b/clients/ios/Views/Intelligence/InstalledSkillsView.swift
@@ -7,11 +7,15 @@ struct InstalledSkillsView: View {
     @State private var skillToUninstall: SkillInfo?
     @State private var showUninstallConfirmation = false
 
+    private var installedSkills: [SkillInfo] {
+        skillsStore.skills.filter { $0.isInstalled }
+    }
+
     var body: some View {
         Group {
-            if skillsStore.isLoading && skillsStore.skills.isEmpty {
+            if skillsStore.isLoading && installedSkills.isEmpty {
                 loadingState
-            } else if skillsStore.skills.isEmpty {
+            } else if installedSkills.isEmpty {
                 emptyState
             } else {
                 skillsList
@@ -39,7 +43,7 @@ struct InstalledSkillsView: View {
 
     private var skillsList: some View {
         List {
-            ForEach(skillsStore.skills) { skill in
+            ForEach(installedSkills) { skill in
                 NavigationLink {
                     SkillDetailView(skill: skill, skillsStore: skillsStore)
                 } label: {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skills-catalog-ui.md.

**Gap:** iOS InstalledSkillsView shows catalog available skills with broken swipe actions
**What was expected:** iOS should only show installed/bundled skills
**What was found:** No filtering on isInstalled, catalog skills appeared with inappropriate actions
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
