### PR TITLE
fix: guard installingSkillId race condition on concurrent installs

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -40,7 +40,8 @@ final class SkillsManager {
         skillsStore.$isLoadingSkillFiles.sink { [weak self] in self?.isLoadingSkillFiles = $0 }.store(in: &cancellables)
         skillsStore.$skillFilesError.sink { [weak self] in self?.skillFilesError = $0 }.store(in: &cancellables)
         skillsStore.$installResult.sink { [weak self] result in
-            guard let self, result != nil else { return }
+            guard let self, let result else { return }
+            guard result.slug == self.installingSkillId else { return }
             self.installingSkillId = nil
         }.store(in: &cancellables)
     }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skills-catalog-ui.md.

**Gap:** installingSkillId race condition on concurrent installs
**What was expected:** Each install spinner tracks independently
**What was found:** installingSkillId cleared on any install result without checking slug match
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
