### PR TITLE
fix: add bounds validation and oauth_app test for resolveCredentialPath

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -745,6 +745,32 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
     expect(parsed.id).toBe("app-upsert-1");
   });
 
+  test("upsert passes oauth_app/ prefixed credential path through unchanged", async () => {
+    const { exitCode, stdout } = await runCli([
+      "apps",
+      "upsert",
+      "--provider",
+      "google",
+      "--client-id",
+      "abc",
+      "--client-secret-credential-path",
+      "oauth_app/some-id/client_secret",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(mockUpsertAppCalls).toHaveLength(1);
+    // oauth_app/ prefixed path should be passed through as-is
+    expect(mockUpsertAppCalls[0]).toEqual({
+      provider: "google",
+      clientId: "abc",
+      clientSecretOpts: {
+        clientSecretCredentialPath: "oauth_app/some-id/client_secret",
+      },
+    });
+    const parsed = JSON.parse(stdout);
+    expect(parsed.id).toBe("app-upsert-1");
+  });
+
   test("upsert with invalid credential path returns error when no secret found", async () => {
     // Override upsertApp to throw when given an unresolvable credential path
     mockUpsertAppImpl = async (_provider, _clientId, clientSecretOpts) => {

--- a/assistant/src/cli/commands/oauth/apps.ts
+++ b/assistant/src/cli/commands/oauth/apps.ts
@@ -27,7 +27,7 @@ function resolveCredentialPath(input: string): string {
   }
 
   const lastColon = input.lastIndexOf(":");
-  if (lastColon === -1) {
+  if (lastColon < 1 || lastColon === input.length - 1) {
     return input;
   }
 


### PR DESCRIPTION
## Summary
Fixes two gaps from plan review:
- Add bounds validation on colon index in `resolveCredentialPath` to prevent malformed paths from inputs like `:foo` or `foo:`
- Add explicit test for `oauth_app/` prefix backward compatibility

Part of plan: unify-credential-path-format.md (review fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21660" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
