### PR TITLE
Replace per-provider identityVerifier functions with a generic data-driven verifier

### DIFF
--- a/assistant/src/oauth/__tests__/identity-verifier.test.ts
+++ b/assistant/src/oauth/__tests__/identity-verifier.test.ts
@@ -7,19 +7,21 @@ import {
   test,
 } from "bun:test";
 
-import type { OAuthProviderRow } from "../oauth-store.js";
 import { verifyIdentity } from "../identity-verifier.js";
+import type { OAuthProviderRow } from "../oauth-store.js";
 
 // ---------------------------------------------------------------------------
 // Mock fetch
 // ---------------------------------------------------------------------------
 
 const originalFetch = globalThis.fetch;
-let mockFetch: ReturnType<typeof mock<typeof fetch>>;
+let mockFetch: ReturnType<typeof mock<any>>;
 
 beforeEach(() => {
-  mockFetch = mock<typeof fetch>();
-  globalThis.fetch = mockFetch;
+  mockFetch = mock(() =>
+    Promise.resolve(new Response("{}", { status: 200 })),
+  );
+  globalThis.fetch = mockFetch as unknown as typeof fetch;
 });
 
 afterEach(() => {
@@ -34,8 +36,9 @@ function makeProviderRow(
   overrides: Partial<OAuthProviderRow> & { providerKey: string },
 ): OAuthProviderRow {
   const now = Date.now();
+  const { providerKey, ...rest } = overrides;
   return {
-    providerKey: overrides.providerKey,
+    providerKey,
     authUrl: "https://example.com/auth",
     tokenUrl: "https://example.com/token",
     tokenEndpointAuthMethod: null,
@@ -69,7 +72,7 @@ function makeProviderRow(
     identityOkField: null,
     createdAt: now,
     updatedAt: now,
-    ...overrides,
+    ...rest,
   };
 }
 

--- a/assistant/src/oauth/__tests__/identity-verifier.test.ts
+++ b/assistant/src/oauth/__tests__/identity-verifier.test.ts
@@ -1,0 +1,474 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import type { OAuthProviderRow } from "../oauth-store.js";
+import { verifyIdentity } from "../identity-verifier.js";
+
+// ---------------------------------------------------------------------------
+// Mock fetch
+// ---------------------------------------------------------------------------
+
+const originalFetch = globalThis.fetch;
+let mockFetch: ReturnType<typeof mock<typeof fetch>>;
+
+beforeEach(() => {
+  mockFetch = mock<typeof fetch>();
+  globalThis.fetch = mockFetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// ---------------------------------------------------------------------------
+// Helper: build a minimal OAuthProviderRow with identity fields
+// ---------------------------------------------------------------------------
+
+function makeProviderRow(
+  overrides: Partial<OAuthProviderRow> & { providerKey: string },
+): OAuthProviderRow {
+  const now = Date.now();
+  return {
+    providerKey: overrides.providerKey,
+    authUrl: "https://example.com/auth",
+    tokenUrl: "https://example.com/token",
+    tokenEndpointAuthMethod: null,
+    userinfoUrl: null,
+    baseUrl: null,
+    defaultScopes: "[]",
+    scopePolicy: "{}",
+    extraParams: null,
+    callbackTransport: null,
+    pingUrl: null,
+    pingMethod: null,
+    pingHeaders: null,
+    pingBody: null,
+    managedServiceConfigKey: null,
+    displayName: null,
+    description: null,
+    dashboardUrl: null,
+    clientIdPlaceholder: null,
+    requiresClientSecret: 1,
+    loopbackPort: null,
+    injectionTemplates: null,
+    setupSkillId: null,
+    appType: null,
+    setupNotes: null,
+    identityUrl: null,
+    identityMethod: null,
+    identityHeaders: null,
+    identityBody: null,
+    identityResponsePaths: null,
+    identityFormat: null,
+    identityOkField: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("verifyIdentity", () => {
+  // -----------------------------------------------------------------------
+  // Missing identity URL
+  // -----------------------------------------------------------------------
+  test("returns undefined when identityUrl is null", async () => {
+    const row = makeProviderRow({ providerKey: "custom" });
+    const result = await verifyIdentity(row, "token-abc");
+    expect(result).toBeUndefined();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  // -----------------------------------------------------------------------
+  // Google: simple GET, extract email
+  // -----------------------------------------------------------------------
+  describe("Google pattern", () => {
+    const googleRow = makeProviderRow({
+      providerKey: "google",
+      identityUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
+      identityResponsePaths: JSON.stringify(["email"]),
+    });
+
+    test("extracts email from response", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ email: "user@gmail.com", name: "Test User" }),
+      );
+
+      const result = await verifyIdentity(googleRow, "google-token");
+
+      expect(result).toBe("user@gmail.com");
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe("https://www.googleapis.com/oauth2/v2/userinfo");
+      expect((init as RequestInit).method).toBe("GET");
+      const headers = (init as RequestInit).headers as Record<string, string>;
+      expect(headers["Authorization"]).toBe("Bearer google-token");
+    });
+
+    test("returns undefined when email is missing", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ name: "Test User" }));
+      const result = await verifyIdentity(googleRow, "google-token");
+      expect(result).toBeUndefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Slack: GET with ok check + format template
+  // -----------------------------------------------------------------------
+  describe("Slack pattern", () => {
+    const slackRow = makeProviderRow({
+      providerKey: "slack",
+      identityUrl: "https://slack.com/api/auth.test",
+      identityOkField: "ok",
+      identityResponsePaths: JSON.stringify(["user", "team"]),
+      identityFormat: "@${user} (${team})",
+    });
+
+    test("returns formatted string when all fields present", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ ok: true, user: "alice", team: "acme-corp" }),
+      );
+
+      const result = await verifyIdentity(slackRow, "slack-token");
+      expect(result).toBe("@alice (acme-corp)");
+    });
+
+    test("returns @user when team is missing (fallback)", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ ok: true, user: "alice" }),
+      );
+
+      const result = await verifyIdentity(slackRow, "slack-token");
+      expect(result).toBe("@alice");
+    });
+
+    test("returns undefined when ok is false", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ ok: false, user: "alice", team: "acme-corp" }),
+      );
+
+      const result = await verifyIdentity(slackRow, "slack-token");
+      expect(result).toBeUndefined();
+    });
+
+    test("returns undefined when ok field is missing", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ user: "alice", team: "acme-corp" }),
+      );
+
+      const result = await verifyIdentity(slackRow, "slack-token");
+      expect(result).toBeUndefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // HubSpot: URL-interpolated token, no Authorization header
+  // -----------------------------------------------------------------------
+  describe("HubSpot pattern", () => {
+    const hubspotRow = makeProviderRow({
+      providerKey: "hubspot",
+      identityUrl:
+        "https://api.hubapi.com/oauth/v1/access-tokens/${accessToken}",
+      identityResponsePaths: JSON.stringify(["user", "hub_domain"]),
+    });
+
+    test("interpolates token in URL and skips Authorization header", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({
+          user: "admin@hubspot.com",
+          hub_domain: "mycompany.hubspot.com",
+        }),
+      );
+
+      const result = await verifyIdentity(hubspotRow, "hs-token-123");
+
+      expect(result).toBe("admin@hubspot.com");
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe(
+        "https://api.hubapi.com/oauth/v1/access-tokens/hs-token-123",
+      );
+      const headers = (init as RequestInit).headers as Record<string, string>;
+      // Should NOT have Authorization header since token is in URL
+      expect(headers["Authorization"]).toBeUndefined();
+    });
+
+    test("falls back to hub_domain when user is missing", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ hub_domain: "mycompany.hubspot.com" }),
+      );
+
+      const result = await verifyIdentity(hubspotRow, "hs-token-123");
+      expect(result).toBe("mycompany.hubspot.com");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Linear: POST with JSON body, GraphQL response
+  // -----------------------------------------------------------------------
+  describe("Linear pattern", () => {
+    const linearRow = makeProviderRow({
+      providerKey: "linear",
+      identityUrl: "https://api.linear.app/graphql",
+      identityMethod: "POST",
+      identityHeaders: JSON.stringify({ "Content-Type": "application/json" }),
+      identityBody: JSON.stringify({
+        query: "{ viewer { email name } }",
+      }),
+      identityResponsePaths: JSON.stringify([
+        "data.viewer.email",
+        "data.viewer.name",
+      ]),
+    });
+
+    test("extracts email from nested GraphQL response", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({
+          data: { viewer: { email: "dev@linear.app", name: "Dev User" } },
+        }),
+      );
+
+      const result = await verifyIdentity(linearRow, "linear-token");
+
+      expect(result).toBe("dev@linear.app");
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe("https://api.linear.app/graphql");
+      expect((init as RequestInit).method).toBe("POST");
+      const headers = (init as RequestInit).headers as Record<string, string>;
+      expect(headers["Authorization"]).toBe("Bearer linear-token");
+      expect(headers["Content-Type"]).toBe("application/json");
+      expect((init as RequestInit).body).toBe(
+        JSON.stringify({ query: "{ viewer { email name } }" }),
+      );
+    });
+
+    test("falls back to name when email is missing", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({
+          data: { viewer: { name: "Dev User" } },
+        }),
+      );
+
+      const result = await verifyIdentity(linearRow, "linear-token");
+      expect(result).toBe("Dev User");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Todoist: POST with form body
+  // -----------------------------------------------------------------------
+  describe("Todoist pattern", () => {
+    const todoistRow = makeProviderRow({
+      providerKey: "todoist",
+      identityUrl: "https://api.todoist.com/sync/v9/sync",
+      identityMethod: "POST",
+      identityHeaders: JSON.stringify({
+        "Content-Type": "application/x-www-form-urlencoded",
+      }),
+      identityBody: JSON.stringify(
+        "sync_token=*&resource_types=[%22user%22]",
+      ),
+      identityResponsePaths: JSON.stringify(["user.full_name", "user.email"]),
+    });
+
+    test("extracts full_name from nested response", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({
+          user: { full_name: "Jane Doe", email: "jane@example.com" },
+        }),
+      );
+
+      const result = await verifyIdentity(todoistRow, "todoist-token");
+
+      expect(result).toBe("Jane Doe");
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      const [, init] = mockFetch.mock.calls[0];
+      expect((init as RequestInit).method).toBe("POST");
+      // Body should be the form-encoded string
+      expect((init as RequestInit).body).toBe(
+        "sync_token=*&resource_types=[%22user%22]",
+      );
+    });
+
+    test("falls back to email when full_name is missing", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ user: { email: "jane@example.com" } }),
+      );
+
+      const result = await verifyIdentity(todoistRow, "todoist-token");
+      expect(result).toBe("jane@example.com");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Twitter: format template with nested path
+  // -----------------------------------------------------------------------
+  describe("Twitter pattern", () => {
+    const twitterRow = makeProviderRow({
+      providerKey: "twitter",
+      identityUrl: "https://api.x.com/2/users/me",
+      identityResponsePaths: JSON.stringify(["data.username"]),
+      identityFormat: "@${data.username}",
+    });
+
+    test("returns formatted @username", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ data: { username: "elonmusk" } }),
+      );
+
+      const result = await verifyIdentity(twitterRow, "twitter-token");
+      expect(result).toBe("@elonmusk");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // GitHub: format template with simple path
+  // -----------------------------------------------------------------------
+  describe("GitHub pattern", () => {
+    const githubRow = makeProviderRow({
+      providerKey: "github",
+      identityUrl: "https://api.github.com/user",
+      identityResponsePaths: JSON.stringify(["login"]),
+      identityFormat: "@${login}",
+    });
+
+    test("returns formatted @login", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ login: "octocat" }));
+
+      const result = await verifyIdentity(githubRow, "gh-token");
+      expect(result).toBe("@octocat");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Notion: custom headers, multiple fallback paths
+  // -----------------------------------------------------------------------
+  describe("Notion pattern", () => {
+    const notionRow = makeProviderRow({
+      providerKey: "notion",
+      identityUrl: "https://api.notion.com/v1/users/me",
+      identityHeaders: JSON.stringify({ "Notion-Version": "2022-06-28" }),
+      identityResponsePaths: JSON.stringify(["name", "person.email"]),
+    });
+
+    test("returns name when present", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ name: "Test Bot", person: { email: "user@notion.so" } }),
+      );
+
+      const result = await verifyIdentity(notionRow, "notion-token");
+      expect(result).toBe("Test Bot");
+
+      const [, init] = mockFetch.mock.calls[0];
+      const headers = (init as RequestInit).headers as Record<string, string>;
+      expect(headers["Notion-Version"]).toBe("2022-06-28");
+      expect(headers["Authorization"]).toBe("Bearer notion-token");
+    });
+
+    test("falls back to person.email when name is missing", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ person: { email: "user@notion.so" } }),
+      );
+
+      const result = await verifyIdentity(notionRow, "notion-token");
+      expect(result).toBe("user@notion.so");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Error handling
+  // -----------------------------------------------------------------------
+  describe("error handling", () => {
+    const googleRow = makeProviderRow({
+      providerKey: "google",
+      identityUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
+      identityResponsePaths: JSON.stringify(["email"]),
+    });
+
+    test("returns undefined on fetch failure", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+      const result = await verifyIdentity(googleRow, "token");
+      expect(result).toBeUndefined();
+    });
+
+    test("returns undefined on non-OK response", async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response("Unauthorized", { status: 401 }),
+      );
+
+      const result = await verifyIdentity(googleRow, "token");
+      expect(result).toBeUndefined();
+    });
+
+    test("returns undefined on invalid JSON response", async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response("not json", {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      const result = await verifyIdentity(googleRow, "token");
+      expect(result).toBeUndefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Dropbox: POST with no explicit body
+  // -----------------------------------------------------------------------
+  describe("Dropbox pattern", () => {
+    const dropboxRow = makeProviderRow({
+      providerKey: "dropbox",
+      identityUrl:
+        "https://api.dropboxapi.com/2/users/get_current_account",
+      identityMethod: "POST",
+      identityResponsePaths: JSON.stringify(["name.display_name", "email"]),
+    });
+
+    test("extracts nested display_name", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({
+          name: { display_name: "Jane Doe" },
+          email: "jane@dropbox.com",
+        }),
+      );
+
+      const result = await verifyIdentity(dropboxRow, "dbx-token");
+      expect(result).toBe("Jane Doe");
+
+      const [, init] = mockFetch.mock.calls[0];
+      expect((init as RequestInit).method).toBe("POST");
+    });
+
+    test("falls back to email when name is missing", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ email: "jane@dropbox.com" }),
+      );
+
+      const result = await verifyIdentity(dropboxRow, "dbx-token");
+      expect(result).toBe("jane@dropbox.com");
+    });
+  });
+});

--- a/assistant/src/oauth/connect-orchestrator.ts
+++ b/assistant/src/oauth/connect-orchestrator.ts
@@ -28,6 +28,7 @@ import type {
   OAuthProviderBehavior,
   OAuthScopePolicy,
 } from "./connect-types.js";
+import { verifyIdentity } from "./identity-verifier.js";
 import { getProvider } from "./oauth-store.js";
 import { getProviderBehavior } from "./provider-behaviors.js";
 import { resolveScopes } from "./scope-policy.js";
@@ -44,7 +45,6 @@ const log = getLogger("oauth-connect-orchestrator");
  * Returns an empty object when no behavior is registered.
  */
 function resolveBehavior(providerKey: string): {
-  identityVerifier?: OAuthProviderBehavior["identityVerifier"];
   setup?: OAuthProviderBehavior["setup"];
   setupSkillId?: string;
   postConnectHookId?: string;
@@ -53,7 +53,6 @@ function resolveBehavior(providerKey: string): {
   const behavior = getProviderBehavior(providerKey);
   if (!behavior) return {};
   return {
-    identityVerifier: behavior.identityVerifier,
     setup: behavior.setup,
     setupSkillId: behavior.setupSkillId,
     postConnectHookId: behavior.postConnectHookId,
@@ -274,19 +273,12 @@ export async function orchestrateOAuthConnect(
       prepared.completion
         .then(async (result) => {
           try {
-            let parsedAccountIdentifier: string | undefined;
-
             // Parse account identifier from the provider's identity endpoint.
             // Best-effort — format varies by provider and may fail.
-            if (behavior.identityVerifier) {
-              try {
-                parsedAccountIdentifier = await behavior.identityVerifier(
-                  result.tokens.accessToken,
-                );
-              } catch {
-                // Non-fatal
-              }
-            }
+            const parsedAccountIdentifier = await verifyIdentity(
+              providerRow,
+              result.tokens.accessToken,
+            );
 
             const stored = await storeOAuth2Tokens({
               ...storageParams,
@@ -395,19 +387,15 @@ export async function orchestrateOAuthConnect(
 
     // Parse account identifier from the provider's identity endpoint.
     // Best-effort — format varies by provider and may fail.
-    let parsedAccountIdentifier: string | undefined;
-    if (behavior.identityVerifier) {
-      try {
-        parsedAccountIdentifier = await behavior.identityVerifier(
-          tokens.accessToken,
-        );
-        log.info(
-          { service: options.service, parsedAccountIdentifier },
-          "orchestrateOAuthConnect: identity verified",
-        );
-      } catch {
-        // Non-fatal
-      }
+    const parsedAccountIdentifier = await verifyIdentity(
+      providerRow,
+      tokens.accessToken,
+    );
+    if (parsedAccountIdentifier) {
+      log.info(
+        { service: options.service, parsedAccountIdentifier },
+        "orchestrateOAuthConnect: identity verified",
+      );
     }
 
     const { accountInfo } = await storeOAuth2Tokens({

--- a/assistant/src/oauth/identity-verifier.ts
+++ b/assistant/src/oauth/identity-verifier.ts
@@ -1,0 +1,179 @@
+/**
+ * Generic, data-driven identity verifier for OAuth providers.
+ *
+ * Replaces per-provider hand-coded `identityVerifier` functions with a
+ * single function that interprets the declarative identity configuration
+ * stored in the `oauth_providers` DB table (identityUrl, identityMethod,
+ * identityHeaders, identityBody, identityResponsePaths, identityFormat,
+ * identityOkField).
+ */
+
+import type { OAuthProviderRow } from "./oauth-store.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Traverse a nested object by a dot-separated path (e.g. "data.viewer.email"). */
+function getNestedValue(obj: unknown, dotPath: string): unknown {
+  const parts = dotPath.split(".");
+  let current: unknown = obj;
+  for (const part of parts) {
+    if (current == null || typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}
+
+/** Safely parse a JSON string, returning a fallback on failure or null/undefined input. */
+function safeJsonParse<T>(value: string | null | undefined, fallback: T): T {
+  if (value == null) return fallback;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Verify the user's identity after a successful OAuth token exchange.
+ *
+ * Returns a human-readable account identifier (e.g. email, @username, or
+ * a formatted string like "@user (team)") or `undefined` when:
+ * - the provider has no identity URL configured
+ * - the identity request fails or returns a non-OK status
+ * - the response cannot be parsed into an identifier
+ *
+ * This function is intentionally non-throwing — identity verification is
+ * always best-effort.
+ */
+export async function verifyIdentity(
+  providerRow: OAuthProviderRow,
+  accessToken: string,
+): Promise<string | undefined> {
+  const { identityUrl: rawUrl } = providerRow;
+  if (!rawUrl) return undefined;
+
+  try {
+    // Interpolate ${accessToken} in the URL (HubSpot pattern)
+    const urlContainsToken = rawUrl.includes("${accessToken}");
+    const url = rawUrl.replace("${accessToken}", accessToken);
+
+    // Build headers
+    const parsedHeaders = safeJsonParse<Record<string, string>>(
+      providerRow.identityHeaders,
+      {},
+    );
+    const headers: Record<string, string> = {
+      ...parsedHeaders,
+    };
+    // Only add the Authorization header if the token is not embedded in the URL
+    if (!urlContainsToken) {
+      headers["Authorization"] = `Bearer ${accessToken}`;
+    }
+
+    // Build request init
+    const method = providerRow.identityMethod ?? "GET";
+    const init: RequestInit = { method, headers };
+
+    // Add body if present
+    if (providerRow.identityBody != null) {
+      const bodyValue = safeJsonParse<unknown>(
+        providerRow.identityBody,
+        providerRow.identityBody,
+      );
+      if (typeof bodyValue === "string") {
+        init.body = bodyValue;
+      } else {
+        init.body = JSON.stringify(bodyValue);
+      }
+    }
+
+    // Make the request
+    const resp = await fetch(url, init);
+    if (!resp.ok) return undefined;
+
+    const body: unknown = await resp.json();
+
+    // Check OK field (Slack pattern: body.ok must be truthy)
+    if (providerRow.identityOkField) {
+      const okValue = (body as Record<string, unknown>)[
+        providerRow.identityOkField
+      ];
+      if (!okValue) return undefined;
+    }
+
+    // Parse response paths
+    const responsePaths = safeJsonParse<string[]>(
+      providerRow.identityResponsePaths,
+      [],
+    );
+    if (responsePaths.length === 0) return undefined;
+
+    const { identityFormat } = providerRow;
+
+    // Simple mode: no format template — return the first non-null path value
+    if (!identityFormat) {
+      for (const path of responsePaths) {
+        const value = getNestedValue(body, path);
+        if (value != null) return String(value);
+      }
+      return undefined;
+    }
+
+    // Format mode: build a lookup map from all paths, then interpolate
+    const pathValues = new Map<string, string | undefined>();
+    for (const path of responsePaths) {
+      const value = getNestedValue(body, path);
+      pathValues.set(path, value != null ? String(value) : undefined);
+    }
+
+    // Replace ${path} tokens in the format string
+    let result = identityFormat;
+    let allResolved = true;
+    for (const [path, value] of pathValues) {
+      if (value != null) {
+        result = result.replace(`\${${path}}`, value);
+      } else {
+        allResolved = false;
+      }
+    }
+
+    if (allResolved) return result;
+
+    // Fallback: if some tokens couldn't be resolved, try cleaning up
+    // the format string by removing unresolved tokens and their surrounding
+    // punctuation (parentheses, spaces).
+    // First, try removing unresolved tokens with their surrounding parens/space
+    // e.g. "@${user} (${team})" with missing team -> "@user"
+    let cleaned = identityFormat;
+    for (const [path, value] of pathValues) {
+      if (value != null) {
+        cleaned = cleaned.replace(`\${${path}}`, value);
+      } else {
+        // Remove patterns like " (${path})" or " ${path}" or "(${path})"
+        cleaned = cleaned.replace(
+          new RegExp(`\\s*\\(?\\$\\{${path.replace(/\./g, "\\.")}\\}\\)?`, "g"),
+          "",
+        );
+      }
+    }
+
+    cleaned = cleaned.trim();
+    if (cleaned) return cleaned;
+
+    // Last resort: return the first non-null path value
+    for (const value of pathValues.values()) {
+      if (value != null) return value;
+    }
+
+    return undefined;
+  } catch {
+    // Non-fatal — identity verification is best-effort
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Summary
- Create generic verifyIdentity() function that interprets declarative identity config from the DB (URL, method, headers, body, response paths, format template)
- Replace hand-coded identityVerifier calls in connect-orchestrator with the new generic function
- Add comprehensive tests covering Google, Slack, HubSpot, Linear, Todoist patterns

Part of plan: eliminate-provider-behaviors.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21662" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
