### PR TITLE
Replace all getProviderBehavior calls with DB-backed provider row reads

### DIFF
--- a/assistant/src/__tests__/credential-vault-unit.test.ts
+++ b/assistant/src/__tests__/credential-vault-unit.test.ts
@@ -1056,6 +1056,7 @@ describe("credential_store tool — oauth2_connect error paths", () => {
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: JSON.stringify(["https://mail.google.com/"]),
+      requiresClientSecret: 1,
     }));
 
     const result = await credentialStoreTool.execute(
@@ -1092,6 +1093,7 @@ describe("credential_store tool — oauth2_connect error paths", () => {
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: JSON.stringify(["https://mail.google.com/"]),
+      requiresClientSecret: 1,
     }));
 
     const result = await credentialStoreTool.execute(

--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -8,7 +8,6 @@ import {
   getMostRecentAppByProvider,
   getProvider,
 } from "../../../oauth/oauth-store.js";
-import { getProviderBehavior } from "../../../oauth/provider-behaviors.js";
 import { renderOAuthCompletionPage } from "../../../security/oauth-completion-page.js";
 import { openInBrowser } from "../../../util/browser.js";
 import { getSecureKeyViaDaemon } from "../../lib/daemon-credential-client.js";
@@ -342,14 +341,7 @@ Examples:
 
             // d. Check if client_secret is required but missing
             if (clientSecret === undefined) {
-              const behavior = getProviderBehavior(provider);
-
-              const requiresSecret =
-                behavior?.setup?.requiresClientSecret ??
-                !!(
-                  providerRow?.tokenEndpointAuthMethod ||
-                  providerRow?.extraParams
-                );
+              const requiresSecret = !!providerRow?.requiresClientSecret;
 
               if (requiresSecret) {
                 writeError(

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -14,7 +14,6 @@ import {
   registerProvider,
   updateProvider,
 } from "../../../oauth/oauth-store.js";
-import { getProviderBehavior } from "../../../oauth/provider-behaviors.js";
 import { SEEDED_PROVIDER_KEYS } from "../../../oauth/seed-providers.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
@@ -25,13 +24,12 @@ const LOOPBACK_CALLBACK_PATH = "/oauth/callback";
 
 /** Resolve the redirect URI for a provider based on its callback transport. */
 function resolveRedirectUri(
-  providerKey: string,
   callbackTransport: string | null,
+  loopbackPort: number | null,
 ): string | null {
   const transport = callbackTransport ?? "loopback";
   if (transport === "loopback") {
-    const behavior = getProviderBehavior(providerKey);
-    const port = behavior?.loopbackPort;
+    const port = loopbackPort;
     if (!port) {
       // No fixed port — loopback still works at runtime with an OS-assigned
       // port, but we can't predict the redirect URI ahead of time.  Return
@@ -69,7 +67,7 @@ function parseProviderRow(row: ReturnType<typeof getProvider>) {
     extraParams: row.extraParams ? JSON.parse(row.extraParams) : null,
     pingHeaders: row.pingHeaders ? JSON.parse(row.pingHeaders) : null,
     pingBody: row.pingBody ? JSON.parse(row.pingBody) : null,
-    redirectUri: resolveRedirectUri(row.providerKey, row.callbackTransport),
+    redirectUri: resolveRedirectUri(row.callbackTransport, row.loopbackPort),
     createdAt: new Date(row.createdAt).toISOString(),
     updatedAt: new Date(row.updatedAt).toISOString(),
   };

--- a/assistant/src/oauth/connect-orchestrator.ts
+++ b/assistant/src/oauth/connect-orchestrator.ts
@@ -25,12 +25,10 @@ import { prepareOAuth2Flow, startOAuth2Flow } from "../security/oauth2.js";
 import { getLogger } from "../util/logger.js";
 import type {
   OAuthConnectResult,
-  OAuthProviderBehavior,
   OAuthScopePolicy,
 } from "./connect-types.js";
 import { verifyIdentity } from "./identity-verifier.js";
 import { getProvider } from "./oauth-store.js";
-import { getProviderBehavior } from "./provider-behaviors.js";
 import { resolveScopes } from "./scope-policy.js";
 import { storeOAuth2Tokens } from "./token-persistence.js";
 
@@ -39,26 +37,6 @@ const log = getLogger("oauth-connect-orchestrator");
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/**
- * Look up the code-side behavioral fields for a provider.
- * Returns an empty object when no behavior is registered.
- */
-function resolveBehavior(providerKey: string): {
-  setup?: OAuthProviderBehavior["setup"];
-  setupSkillId?: string;
-  postConnectHookId?: string;
-  loopbackPort?: number;
-} {
-  const behavior = getProviderBehavior(providerKey);
-  if (!behavior) return {};
-  return {
-    setup: behavior.setup,
-    setupSkillId: behavior.setupSkillId,
-    postConnectHookId: behavior.postConnectHookId,
-    loopbackPort: behavior.loopbackPort,
-  };
-}
 
 /** Safely parse a JSON string, returning a fallback on failure or null/undefined input. */
 function safeJsonParse<T>(value: string | null | undefined, fallback: T): T {
@@ -138,9 +116,6 @@ export async function orchestrateOAuthConnect(
     };
   }
 
-  // Behavioral/code-side fields come from the behavior registry
-  const behavior = resolveBehavior(options.service);
-
   // Deserialize JSON fields from the DB row
   const dbDefaultScopes = safeJsonParse<string[]>(
     providerRow.defaultScopes,
@@ -170,7 +145,7 @@ export async function orchestrateOAuthConnect(
   const callbackTransport =
     (providerRow.callbackTransport as "loopback" | "gateway" | null) ??
     "loopback";
-  const loopbackPort = behavior.loopbackPort;
+  const loopbackPort = providerRow.loopbackPort ?? undefined;
 
   // Resolve scopes via the scope policy engine
   const scopeProfile = {

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -30,7 +30,6 @@ import {
   getMostRecentAppByProvider,
   getProvider,
 } from "../../oauth/oauth-store.js";
-import { getProviderBehavior } from "../../oauth/provider-behaviors.js";
 import {
   check,
   classifyRisk,
@@ -204,11 +203,8 @@ async function handleOAuthConnectStart(body: {
     );
   }
 
-  const behavior = getProviderBehavior(service);
   const providerRow = getProvider(service);
-  const requiresSecret =
-    behavior?.setup?.requiresClientSecret ??
-    !!(providerRow?.tokenEndpointAuthMethod || providerRow?.extraParams);
+  const requiresSecret = !!providerRow?.requiresClientSecret;
   if (requiresSecret && !clientSecret) {
     return httpError(
       "BAD_REQUEST",

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -11,11 +11,8 @@ import {
   getAppByProviderAndClientId,
   getMostRecentAppByProvider,
   getProvider,
+  listProviders,
 } from "../../oauth/oauth-store.js";
-import {
-  getProviderBehavior,
-  PROVIDER_BEHAVIORS,
-} from "../../oauth/provider-behaviors.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
 import { buildAssistantEvent } from "../../runtime/assistant-event.js";
@@ -828,8 +825,6 @@ class CredentialStoreTool implements Tool {
             isError: true,
           };
 
-        // Code-side behavioral fields (identityVerifier, setup, etc.)
-        const behavior = getProviderBehavior(service);
         // Protocol-level config from the DB (authUrl, tokenUrl, scopes, etc.)
         const providerRow = getProvider(service);
 
@@ -877,10 +872,9 @@ class CredentialStoreTool implements Tool {
         // agent to collect it from the user rather than letting it improvise
         // browser-automation workarounds that inevitably fail.
         const requiresSecret =
-          behavior?.setup?.requiresClientSecret ??
-          !!(providerRow.tokenEndpointAuthMethod || providerRow.extraParams);
+          !!providerRow.requiresClientSecret;
         if (requiresSecret && !clientSecret) {
-          const skillId = behavior?.setupSkillId;
+          const skillId = providerRow?.setupSkillId;
           const skillHint = skillId
             ? `\n\nLoad the "${skillId}" skill for provider-specific instructions on obtaining the client secret.`
             : '\n\nUse credential_store with action "prompt" to securely collect the client_secret from the user before calling oauth2_connect again.';
@@ -968,15 +962,12 @@ class CredentialStoreTool implements Tool {
         }
         const descProviderRow = getProvider(descService);
         if (!descProviderRow) {
+          const availableServices = listProviders().map((p) => p.providerKey);
           return {
-            content: `No well-known OAuth config found for "${descService}". Available services: ${Object.keys(
-              PROVIDER_BEHAVIORS,
-            ).join(", ")}`,
+            content: `No well-known OAuth config found for "${descService}". Available services: ${availableServices.join(", ")}`,
             isError: false,
           };
         }
-
-        const descBehavior = getProviderBehavior(descService);
 
         // Compute the redirect URI based on callback transport
         let redirectUri: string;
@@ -985,7 +976,7 @@ class CredentialStoreTool implements Tool {
             | "loopback"
             | "gateway"
             | null) ?? "gateway";
-        const loopbackPort = descBehavior?.loopbackPort;
+        const loopbackPort = descProviderRow.loopbackPort;
         if (transport === "loopback" && loopbackPort) {
           redirectUri = `http://localhost:${loopbackPort}/oauth/callback`;
         } else if (transport === "loopback") {
@@ -1005,13 +996,7 @@ class CredentialStoreTool implements Tool {
           }
         }
 
-        // Prefer explicit setup metadata, fall back to heuristic
-        const requiresClientSecret =
-          descBehavior?.setup?.requiresClientSecret ??
-          !!(
-            descProviderRow.tokenEndpointAuthMethod ||
-            descProviderRow.extraParams
-          );
+        const requiresClientSecret = !!descProviderRow.requiresClientSecret;
 
         const descDefaultScopes: string[] = descProviderRow.defaultScopes
           ? JSON.parse(descProviderRow.defaultScopes)
@@ -1026,7 +1011,17 @@ class CredentialStoreTool implements Tool {
           redirectUri,
           requiresClientSecret,
         };
-        if (descBehavior?.setup) info.setup = descBehavior.setup;
+        if (descProviderRow.displayName && descProviderRow.dashboardUrl && descProviderRow.appType) {
+          info.setup = {
+            displayName: descProviderRow.displayName,
+            dashboardUrl: descProviderRow.dashboardUrl,
+            appType: descProviderRow.appType,
+            requiresClientSecret: !!descProviderRow.requiresClientSecret,
+            ...(descProviderRow.setupNotes
+              ? { notes: JSON.parse(descProviderRow.setupNotes) }
+              : {}),
+          };
+        }
         if (descProviderRow.extraParams) {
           try {
             info.extraParams = JSON.parse(descProviderRow.extraParams);


### PR DESCRIPTION
## Summary
- Remove resolveBehavior() from connect-orchestrator, read directly from provider row
- Replace all getProviderBehavior/PROVIDER_BEHAVIORS imports in vault.ts, connect.ts, providers.ts, settings-routes.ts
- All consumers now read loopbackPort, setupSkillId, requiresClientSecret, etc. from the DB

Part of plan: eliminate-provider-behaviors.md (PR 4 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
