### PR TITLE
Expose injection templates, identity config, and setup metadata in providers CLI

### DIFF
--- a/assistant/src/cli/commands/oauth/__tests__/providers-update.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/providers-update.test.ts
@@ -64,10 +64,6 @@ mock.module("../../../../oauth/seed-providers.js", () => ({
   seedAllProviders: () => {},
 }));
 
-mock.module("../../../../oauth/provider-behaviors.js", () => ({
-  getProviderBehavior: () => undefined,
-}));
-
 mock.module("../../../../inbound/public-ingress-urls.js", () => ({
   getOAuthCallbackUrl: () => null,
 }));
@@ -161,6 +157,18 @@ const sampleProviderRow = {
   dashboardUrl: null,
   clientIdPlaceholder: null,
   requiresClientSecret: 1,
+  loopbackPort: null,
+  injectionTemplates: null,
+  setupSkillId: null,
+  appType: null,
+  setupNotes: null,
+  identityUrl: null,
+  identityMethod: null,
+  identityHeaders: null,
+  identityBody: null,
+  identityResponsePaths: null,
+  identityFormat: null,
+  identityOkField: null,
   createdAt: Date.now(),
   updatedAt: Date.now(),
 };
@@ -307,6 +315,108 @@ describe("assistant oauth providers update", () => {
       displayName: "My API",
       defaultScopes: ["read", "write"],
       authUrl: "https://new.example.com/auth",
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Successful update with injection templates, identity config, and setup metadata
+  // -------------------------------------------------------------------------
+
+  test("successful update with injection templates and identity config passes new fields to updateProvider", async () => {
+    const injectionTemplates = [
+      {
+        hostPattern: "api.example.com",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
+    ];
+    const identityHeaders = { "X-Custom": "value" };
+    const identityBody = { query: "{ viewer { email } }" };
+    const setupNotes = ["Enable the API", "Add test users"];
+
+    mockGetProvider = () => ({ ...sampleProviderRow });
+    mockUpdateProvider = (_key, _params) => ({
+      ...sampleProviderRow,
+      loopbackPort: 17400,
+      injectionTemplates: JSON.stringify(injectionTemplates),
+      setupSkillId: "custom-setup-skill",
+      appType: "OAuth App",
+      setupNotes: JSON.stringify(setupNotes),
+      identityUrl: "https://api.example.com/me",
+      identityMethod: "POST",
+      identityHeaders: JSON.stringify(identityHeaders),
+      identityBody: JSON.stringify(identityBody),
+      identityResponsePaths: JSON.stringify(["email", "name"]),
+      identityFormat: "@{0}",
+      identityOkField: "ok",
+      updatedAt: Date.now(),
+    });
+
+    const { exitCode, stdout } = await runCommand([
+      "providers",
+      "update",
+      "custom-api",
+      "--loopback-port",
+      "17400",
+      "--injection-templates",
+      JSON.stringify(injectionTemplates),
+      "--setup-skill-id",
+      "custom-setup-skill",
+      "--app-type",
+      "OAuth App",
+      "--setup-notes",
+      JSON.stringify(setupNotes),
+      "--identity-url",
+      "https://api.example.com/me",
+      "--identity-method",
+      "POST",
+      "--identity-headers",
+      JSON.stringify(identityHeaders),
+      "--identity-body",
+      JSON.stringify(identityBody),
+      "--identity-response-paths",
+      "email,name",
+      "--identity-format",
+      "@{0}",
+      "--identity-ok-field",
+      "ok",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.providerKey).toBe("custom-api");
+
+    // Verify the new fields are present in the output (parsed from JSON strings)
+    expect(parsed.loopbackPort).toBe(17400);
+    expect(parsed.injectionTemplates).toEqual(injectionTemplates);
+    expect(parsed.setupSkillId).toBe("custom-setup-skill");
+    expect(parsed.appType).toBe("OAuth App");
+    expect(parsed.setupNotes).toEqual(setupNotes);
+    expect(parsed.identityUrl).toBe("https://api.example.com/me");
+    expect(parsed.identityMethod).toBe("POST");
+    expect(parsed.identityHeaders).toEqual(identityHeaders);
+    expect(parsed.identityBody).toEqual(identityBody);
+    expect(parsed.identityResponsePaths).toEqual(["email", "name"]);
+    expect(parsed.identityFormat).toBe("@{0}");
+    expect(parsed.identityOkField).toBe("ok");
+
+    // Verify updateProvider was called with the correct params
+    expect(mockUpdateProviderCalls).toHaveLength(1);
+    expect(mockUpdateProviderCalls[0].key).toBe("custom-api");
+    expect(mockUpdateProviderCalls[0].params).toEqual({
+      loopbackPort: 17400,
+      injectionTemplates,
+      setupSkillId: "custom-setup-skill",
+      appType: "OAuth App",
+      setupNotes,
+      identityUrl: "https://api.example.com/me",
+      identityMethod: "POST",
+      identityHeaders,
+      identityBody,
+      identityResponsePaths: ["email", "name"],
+      identityFormat: "@{0}",
+      identityOkField: "ok",
     });
   });
 });

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -14,7 +14,6 @@ import {
   registerProvider,
   updateProvider,
 } from "../../../oauth/oauth-store.js";
-import { getProviderBehavior } from "../../../oauth/provider-behaviors.js";
 import { SEEDED_PROVIDER_KEYS } from "../../../oauth/seed-providers.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
@@ -25,21 +24,19 @@ const LOOPBACK_CALLBACK_PATH = "/oauth/callback";
 
 /** Resolve the redirect URI for a provider based on its callback transport. */
 function resolveRedirectUri(
-  providerKey: string,
   callbackTransport: string | null,
+  loopbackPort: number | null,
 ): string | null {
   const transport = callbackTransport ?? "loopback";
   if (transport === "loopback") {
-    const behavior = getProviderBehavior(providerKey);
-    const port = behavior?.loopbackPort;
-    if (!port) {
+    if (!loopbackPort) {
       // No fixed port — loopback still works at runtime with an OS-assigned
       // port, but we can't predict the redirect URI ahead of time.  Return
       // a sentinel so callers know the transport is loopback-dynamic rather
       // than unsupported.
       return "http://localhost:<dynamic>/oauth/callback";
     }
-    return `http://localhost:${port}${LOOPBACK_CALLBACK_PATH}`;
+    return `http://localhost:${loopbackPort}${LOOPBACK_CALLBACK_PATH}`;
   }
   // Gateway transport — resolve from public ingress config.
   // Try the explicit publicBaseUrl first, then fall back to platform
@@ -69,7 +66,25 @@ function parseProviderRow(row: ReturnType<typeof getProvider>) {
     extraParams: row.extraParams ? JSON.parse(row.extraParams) : null,
     pingHeaders: row.pingHeaders ? JSON.parse(row.pingHeaders) : null,
     pingBody: row.pingBody ? JSON.parse(row.pingBody) : null,
-    redirectUri: resolveRedirectUri(row.providerKey, row.callbackTransport),
+    loopbackPort: row.loopbackPort ?? null,
+    injectionTemplates: row.injectionTemplates
+      ? JSON.parse(row.injectionTemplates)
+      : null,
+    setupSkillId: row.setupSkillId ?? null,
+    appType: row.appType ?? null,
+    setupNotes: row.setupNotes ? JSON.parse(row.setupNotes) : null,
+    identityUrl: row.identityUrl ?? null,
+    identityMethod: row.identityMethod ?? null,
+    identityHeaders: row.identityHeaders
+      ? JSON.parse(row.identityHeaders)
+      : null,
+    identityBody: row.identityBody ? JSON.parse(row.identityBody) : null,
+    identityResponsePaths: row.identityResponsePaths
+      ? JSON.parse(row.identityResponsePaths)
+      : null,
+    identityFormat: row.identityFormat ?? null,
+    identityOkField: row.identityOkField ?? null,
+    redirectUri: resolveRedirectUri(row.callbackTransport, row.loopbackPort),
     createdAt: new Date(row.createdAt).toISOString(),
     updatedAt: new Date(row.updatedAt).toISOString(),
   };
@@ -265,6 +280,54 @@ Examples:
       "--no-client-secret",
       "Mark this provider as not requiring a client secret (default: required)",
     )
+    .option(
+      "--loopback-port <port>",
+      "Fixed port for the local OAuth callback server (e.g. 17322). When set, the redirect URI is http://localhost:<port>/oauth/callback",
+    )
+    .option(
+      "--injection-templates <json>",
+      'JSON array of token injection templates — each with hostPattern, injectionType, headerName, valuePrefix (e.g. \'[{"hostPattern":"api.example.com","injectionType":"header","headerName":"Authorization","valuePrefix":"Bearer "}]\')',
+    )
+    .option(
+      "--setup-skill-id <id>",
+      'Skill ID that provides guided setup instructions for this provider (e.g. "google-oauth-applescript")',
+    )
+    .option(
+      "--app-type <type>",
+      'What the provider calls its OAuth apps (e.g. "OAuth App", "Desktop app", "Public integration")',
+    )
+    .option(
+      "--identity-url <url>",
+      "Identity verification endpoint URL — called after OAuth to identify the connected account",
+    )
+    .option(
+      "--identity-method <method>",
+      "HTTP method for the identity endpoint: GET (default) or POST",
+    )
+    .option(
+      "--identity-headers <json>",
+      'JSON object of extra headers for the identity request (e.g. \'{"Notion-Version":"2022-06-28"}\')',
+    )
+    .option(
+      "--identity-body <body>",
+      'JSON body to send with the identity request (e.g. \'{"query":"{ viewer { email } }"}\')',
+    )
+    .option(
+      "--identity-response-paths <paths>",
+      'Comma-separated dot-notation paths to extract identity from the response (e.g. "email,name,person.email")',
+    )
+    .option(
+      "--identity-format <template>",
+      'Format template for the extracted identity (e.g. "@{0}" to prefix with @). Uses {0}, {1}, etc. for extracted values',
+    )
+    .option(
+      "--identity-ok-field <field>",
+      'Dot-notation path to a boolean field that must be truthy for the response to be considered valid (e.g. "ok")',
+    )
+    .option(
+      "--setup-notes <json>",
+      'JSON array of setup instruction notes shown during guided setup (e.g. \'["Enable the Gmail API","Add test users"]\')',
+    )
     .addHelpText(
       "after",
       `
@@ -276,6 +339,10 @@ Run 'assistant oauth providers list' to see existing keys.
 On success, returns the full provider row including generated timestamps.
 After registering, create an OAuth app with 'assistant oauth apps create'
 and then connect with 'assistant oauth connect <provider-key>'.
+
+Token injection templates control how the OAuth access token is injected
+into outgoing HTTP requests matched by host pattern. Identity config
+defines how the assistant verifies the connected account after OAuth.
 
 Examples:
   $ assistant oauth providers register \\
@@ -293,7 +360,15 @@ Examples:
       --token-url https://example.com/token \\
       --ping-url https://example.com/graphql \\
       --ping-method POST \\
-      --ping-body '{"query":"{ viewer { id } }"}'`,
+      --ping-body '{"query":"{ viewer { id } }"}'
+  $ assistant oauth providers register \\
+      --provider-key my-api \\
+      --auth-url https://example.com/auth \\
+      --token-url https://example.com/token \\
+      --loopback-port 17400 \\
+      --injection-templates '[{"hostPattern":"api.example.com","injectionType":"header","headerName":"Authorization","valuePrefix":"Bearer "}]' \\
+      --identity-url https://api.example.com/me \\
+      --identity-response-paths email,name`,
     )
     .action(
       (
@@ -315,6 +390,18 @@ Examples:
           dashboardUrl?: string;
           clientIdPlaceholder?: string;
           clientSecret: boolean;
+          loopbackPort?: string;
+          injectionTemplates?: string;
+          setupSkillId?: string;
+          appType?: string;
+          identityUrl?: string;
+          identityMethod?: string;
+          identityHeaders?: string;
+          identityBody?: string;
+          identityResponsePaths?: string;
+          identityFormat?: string;
+          identityOkField?: string;
+          setupNotes?: string;
         },
         cmd: Command,
       ) => {
@@ -340,6 +427,30 @@ Examples:
             dashboardUrl: opts.dashboardUrl,
             clientIdPlaceholder: opts.clientIdPlaceholder,
             requiresClientSecret: opts.clientSecret ? 1 : 0,
+            loopbackPort: opts.loopbackPort
+              ? parseInt(opts.loopbackPort, 10)
+              : undefined,
+            injectionTemplates: opts.injectionTemplates
+              ? JSON.parse(opts.injectionTemplates)
+              : undefined,
+            setupSkillId: opts.setupSkillId,
+            appType: opts.appType,
+            identityUrl: opts.identityUrl,
+            identityMethod: opts.identityMethod,
+            identityHeaders: opts.identityHeaders
+              ? JSON.parse(opts.identityHeaders)
+              : undefined,
+            identityBody: opts.identityBody
+              ? JSON.parse(opts.identityBody)
+              : undefined,
+            identityResponsePaths: opts.identityResponsePaths
+              ? opts.identityResponsePaths.split(",")
+              : undefined,
+            identityFormat: opts.identityFormat,
+            identityOkField: opts.identityOkField,
+            setupNotes: opts.setupNotes
+              ? JSON.parse(opts.setupNotes)
+              : undefined,
           });
 
           writeOutput(cmd, parseProviderRow(row));
@@ -416,6 +527,54 @@ Examples:
       "--no-client-secret",
       "Mark this provider as not requiring a client secret (default: required)",
     )
+    .option(
+      "--loopback-port <port>",
+      "Fixed port for the local OAuth callback server (e.g. 17322). When set, the redirect URI is http://localhost:<port>/oauth/callback",
+    )
+    .option(
+      "--injection-templates <json>",
+      'JSON array of token injection templates — each with hostPattern, injectionType, headerName, valuePrefix (e.g. \'[{"hostPattern":"api.example.com","injectionType":"header","headerName":"Authorization","valuePrefix":"Bearer "}]\')',
+    )
+    .option(
+      "--setup-skill-id <id>",
+      'Skill ID that provides guided setup instructions for this provider (e.g. "google-oauth-applescript")',
+    )
+    .option(
+      "--app-type <type>",
+      'What the provider calls its OAuth apps (e.g. "OAuth App", "Desktop app", "Public integration")',
+    )
+    .option(
+      "--identity-url <url>",
+      "Identity verification endpoint URL — called after OAuth to identify the connected account",
+    )
+    .option(
+      "--identity-method <method>",
+      "HTTP method for the identity endpoint: GET (default) or POST",
+    )
+    .option(
+      "--identity-headers <json>",
+      'JSON object of extra headers for the identity request (e.g. \'{"Notion-Version":"2022-06-28"}\')',
+    )
+    .option(
+      "--identity-body <body>",
+      'JSON body to send with the identity request (e.g. \'{"query":"{ viewer { email } }"}\')',
+    )
+    .option(
+      "--identity-response-paths <paths>",
+      'Comma-separated dot-notation paths to extract identity from the response (e.g. "email,name,person.email")',
+    )
+    .option(
+      "--identity-format <template>",
+      'Format template for the extracted identity (e.g. "@{0}" to prefix with @). Uses {0}, {1}, etc. for extracted values',
+    )
+    .option(
+      "--identity-ok-field <field>",
+      'Dot-notation path to a boolean field that must be truthy for the response to be considered valid (e.g. "ok")',
+    )
+    .option(
+      "--setup-notes <json>",
+      'JSON array of setup instruction notes shown during guided setup (e.g. \'["Enable the Gmail API","Add test users"]\')',
+    )
     .addHelpText(
       "after",
       `
@@ -428,10 +587,19 @@ Built-in providers (e.g. "google", "slack") cannot be updated; they are
 managed by the system and reset on startup. To create a custom provider with
 different settings, use 'assistant oauth providers register'.
 
+Token injection templates control how the OAuth access token is injected
+into outgoing HTTP requests matched by host pattern. Identity config
+defines how the assistant verifies the connected account after OAuth.
+
 Examples:
   $ assistant oauth providers update custom-api --display-name "My Custom API"
   $ assistant oauth providers update custom-api --scopes read,write --auth-url https://new.example.com/auth
-  $ assistant oauth providers update custom-api --ping-url https://api.example.com/me --json`,
+  $ assistant oauth providers update custom-api --ping-url https://api.example.com/me --json
+  $ assistant oauth providers update custom-api \\
+      --identity-url https://api.example.com/me \\
+      --identity-response-paths email,name
+  $ assistant oauth providers update custom-api \\
+      --injection-templates '[{"hostPattern":"api.example.com","injectionType":"header","headerName":"Authorization","valuePrefix":"Bearer "}]'`,
     )
     .action(
       (
@@ -453,6 +621,18 @@ Examples:
           dashboardUrl?: string;
           clientIdPlaceholder?: string;
           clientSecret: boolean;
+          loopbackPort?: string;
+          injectionTemplates?: string;
+          setupSkillId?: string;
+          appType?: string;
+          identityUrl?: string;
+          identityMethod?: string;
+          identityHeaders?: string;
+          identityBody?: string;
+          identityResponsePaths?: string;
+          identityFormat?: string;
+          identityOkField?: string;
+          setupNotes?: string;
         },
         cmd: Command,
       ) => {
@@ -514,6 +694,31 @@ Examples:
           if (cmd.getOptionValueSource("clientSecret") === "cli") {
             params.requiresClientSecret = opts.clientSecret ? 1 : 0;
           }
+
+          if (opts.loopbackPort !== undefined)
+            params.loopbackPort = parseInt(opts.loopbackPort, 10);
+          if (opts.injectionTemplates !== undefined)
+            params.injectionTemplates = JSON.parse(opts.injectionTemplates);
+          if (opts.setupSkillId !== undefined)
+            params.setupSkillId = opts.setupSkillId;
+          if (opts.appType !== undefined) params.appType = opts.appType;
+          if (opts.identityUrl !== undefined)
+            params.identityUrl = opts.identityUrl;
+          if (opts.identityMethod !== undefined)
+            params.identityMethod = opts.identityMethod;
+          if (opts.identityHeaders !== undefined)
+            params.identityHeaders = JSON.parse(opts.identityHeaders);
+          if (opts.identityBody !== undefined)
+            params.identityBody = JSON.parse(opts.identityBody);
+          if (opts.identityResponsePaths !== undefined)
+            params.identityResponsePaths =
+              opts.identityResponsePaths.split(",");
+          if (opts.identityFormat !== undefined)
+            params.identityFormat = opts.identityFormat;
+          if (opts.identityOkField !== undefined)
+            params.identityOkField = opts.identityOkField;
+          if (opts.setupNotes !== undefined)
+            params.setupNotes = JSON.parse(opts.setupNotes);
 
           // Check if any fields were actually provided
           if (Object.keys(params).length === 0) {

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -255,6 +255,23 @@ export function registerProvider(params: {
   dashboardUrl?: string;
   clientIdPlaceholder?: string;
   requiresClientSecret?: number;
+  loopbackPort?: number;
+  injectionTemplates?: Array<{
+    hostPattern: string;
+    injectionType: string;
+    headerName: string;
+    valuePrefix: string;
+  }>;
+  setupSkillId?: string;
+  appType?: string;
+  setupNotes?: string[];
+  identityUrl?: string;
+  identityMethod?: string;
+  identityHeaders?: Record<string, string>;
+  identityBody?: unknown;
+  identityResponsePaths?: string[];
+  identityFormat?: string;
+  identityOkField?: string;
 }): OAuthProviderRow {
   const db = getDb();
   const now = Date.now();
@@ -286,18 +303,27 @@ export function registerProvider(params: {
     dashboardUrl: params.dashboardUrl ?? null,
     clientIdPlaceholder: params.clientIdPlaceholder ?? null,
     requiresClientSecret: params.requiresClientSecret ?? 1,
-    loopbackPort: null,
-    injectionTemplates: null,
-    setupSkillId: null,
-    appType: null,
-    setupNotes: null,
-    identityUrl: null,
-    identityMethod: null,
-    identityHeaders: null,
-    identityBody: null,
-    identityResponsePaths: null,
-    identityFormat: null,
-    identityOkField: null,
+    loopbackPort: params.loopbackPort ?? null,
+    injectionTemplates: params.injectionTemplates
+      ? JSON.stringify(params.injectionTemplates)
+      : null,
+    setupSkillId: params.setupSkillId ?? null,
+    appType: params.appType ?? null,
+    setupNotes: params.setupNotes ? JSON.stringify(params.setupNotes) : null,
+    identityUrl: params.identityUrl ?? null,
+    identityMethod: params.identityMethod ?? null,
+    identityHeaders: params.identityHeaders
+      ? JSON.stringify(params.identityHeaders)
+      : null,
+    identityBody:
+      params.identityBody !== undefined
+        ? JSON.stringify(params.identityBody)
+        : null,
+    identityResponsePaths: params.identityResponsePaths
+      ? JSON.stringify(params.identityResponsePaths)
+      : null,
+    identityFormat: params.identityFormat ?? null,
+    identityOkField: params.identityOkField ?? null,
     createdAt: now,
     updatedAt: now,
   };
@@ -337,6 +363,23 @@ export function updateProvider(
     dashboardUrl: string;
     clientIdPlaceholder: string;
     requiresClientSecret: boolean;
+    loopbackPort: number;
+    injectionTemplates: Array<{
+      hostPattern: string;
+      injectionType: string;
+      headerName: string;
+      valuePrefix: string;
+    }>;
+    setupSkillId: string;
+    appType: string;
+    setupNotes: string[];
+    identityUrl: string;
+    identityMethod: string;
+    identityHeaders: Record<string, string>;
+    identityBody: unknown;
+    identityResponsePaths: string[];
+    identityFormat: string;
+    identityOkField: string;
   }>,
 ): OAuthProviderRow | undefined {
   const existing = getProvider(providerKey);
@@ -372,6 +415,26 @@ export function updateProvider(
     set.clientIdPlaceholder = params.clientIdPlaceholder;
   if (params.requiresClientSecret !== undefined)
     set.requiresClientSecret = params.requiresClientSecret ? 1 : 0;
+  if (params.loopbackPort !== undefined) set.loopbackPort = params.loopbackPort;
+  if (params.injectionTemplates !== undefined)
+    set.injectionTemplates = JSON.stringify(params.injectionTemplates);
+  if (params.setupSkillId !== undefined) set.setupSkillId = params.setupSkillId;
+  if (params.appType !== undefined) set.appType = params.appType;
+  if (params.setupNotes !== undefined)
+    set.setupNotes = JSON.stringify(params.setupNotes);
+  if (params.identityUrl !== undefined) set.identityUrl = params.identityUrl;
+  if (params.identityMethod !== undefined)
+    set.identityMethod = params.identityMethod;
+  if (params.identityHeaders !== undefined)
+    set.identityHeaders = JSON.stringify(params.identityHeaders);
+  if (params.identityBody !== undefined)
+    set.identityBody = JSON.stringify(params.identityBody);
+  if (params.identityResponsePaths !== undefined)
+    set.identityResponsePaths = JSON.stringify(params.identityResponsePaths);
+  if (params.identityFormat !== undefined)
+    set.identityFormat = params.identityFormat;
+  if (params.identityOkField !== undefined)
+    set.identityOkField = params.identityOkField;
 
   db.update(oauthProviders)
     .set(set)


### PR DESCRIPTION
## Summary
- Update parseProviderRow() to include injection templates, identity config, and setup metadata
- Add CLI options for all new fields in providers register and update commands
- Update resolveRedirectUri to read loopbackPort from the DB row instead of provider behaviors
- Extend registerProvider() and updateProvider() in oauth-store.ts to accept all new fields
- Update providers-update test to cover the new fields
- Remove unused getProviderBehavior import from providers.ts

Part of plan: eliminate-provider-behaviors.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
