### PR TITLE
fix: use maxTableViewportWidth in estimatedFlexWidth (LUM-427 follow-up)

### DIFF
--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -499,13 +499,12 @@ public struct InlineTableWidget: View {
     }
 
     /// Estimate a flexible column's baseline width for drag start.
-    /// This uses the non-scroll card content width (540 - 2*16 = 508pt).
     private func estimatedFlexWidth() -> CGFloat {
         let checkboxWidth: CGFloat = hasSelection ? selectionColumnWidth : 0
         let fixedTotal = columnSpecs.compactMap { $0 }.reduce(0, +)
         let flexCount = columnSpecs.filter { $0 == nil }.count
         guard flexCount > 0 else { return minColumnWidth }
-        return max(minColumnWidth, (508 - checkboxWidth - fixedTotal) / CGFloat(flexCount))
+        return max(minColumnWidth, (maxTableViewportWidth - checkboxWidth - fixedTotal) / CGFloat(flexCount))
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary
- Replace hardcoded `508` in `estimatedFlexWidth()` with `maxTableViewportWidth` — the old value was stale after `chatBubbleMaxWidth` changed to 680pt, causing flex columns to jump on first resize drag
- Follow-up to #21570 addressing Devin review feedback

## Test plan
- [ ] Open a table widget with flex columns (no backend-specified widths)
- [ ] Drag a column resize handle — verify no initial width jump
- [ ] Verify column resizing works smoothly in both scroll and non-scroll modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
