### PR TITLE
fix: use getNestedValue for identityOkField to support dot-notation paths

### DIFF
--- a/assistant/src/oauth/identity-verifier.ts
+++ b/assistant/src/oauth/identity-verifier.ts
@@ -101,9 +101,7 @@ export async function verifyIdentity(
 
     // Check OK field (Slack pattern: body.ok must be truthy)
     if (providerRow.identityOkField) {
-      const okValue = (body as Record<string, unknown>)[
-        providerRow.identityOkField
-      ];
+      const okValue = getNestedValue(body, providerRow.identityOkField);
       if (!okValue) return undefined;
     }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for eliminate-provider-behaviors.md.

**Gap:** identityOkField uses direct property access instead of dot-notation traversal
**What was expected:** Should use getNestedValue() helper for consistency with identityResponsePaths
**What was found:** Direct bracket notation that only works for top-level fields
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21669" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
