### PR TITLE
fix: CLI help text for --identity-format documents correct ${path} syntax

### DIFF
--- a/assistant/src/cli/commands/oauth/__tests__/providers-update.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/providers-update.test.ts
@@ -348,7 +348,7 @@ describe("assistant oauth providers update", () => {
       identityHeaders: JSON.stringify(identityHeaders),
       identityBody: JSON.stringify(identityBody),
       identityResponsePaths: JSON.stringify(["email", "name"]),
-      identityFormat: "@{0}",
+      identityFormat: "@${email}",
       identityOkField: "ok",
       updatedAt: Date.now(),
     });
@@ -378,7 +378,7 @@ describe("assistant oauth providers update", () => {
       "--identity-response-paths",
       "email,name",
       "--identity-format",
-      "@{0}",
+      "@${email}",
       "--identity-ok-field",
       "ok",
       "--json",
@@ -398,7 +398,7 @@ describe("assistant oauth providers update", () => {
     expect(parsed.identityHeaders).toEqual(identityHeaders);
     expect(parsed.identityBody).toEqual(identityBody);
     expect(parsed.identityResponsePaths).toEqual(["email", "name"]);
-    expect(parsed.identityFormat).toBe("@{0}");
+    expect(parsed.identityFormat).toBe("@${email}");
     expect(parsed.identityOkField).toBe("ok");
 
     // Verify updateProvider was called with the correct params
@@ -415,7 +415,7 @@ describe("assistant oauth providers update", () => {
       identityHeaders,
       identityBody,
       identityResponsePaths: ["email", "name"],
-      identityFormat: "@{0}",
+      identityFormat: "@${email}",
       identityOkField: "ok",
     });
   });

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -318,7 +318,7 @@ Examples:
     )
     .option(
       "--identity-format <template>",
-      'Format template for the extracted identity (e.g. "@{0}" to prefix with @). Uses {0}, {1}, etc. for extracted values',
+      'Format template for the extracted identity using ${pathName} tokens from --identity-response-paths (e.g. "@${login}" or "@${user} (${team})")',
     )
     .option(
       "--identity-ok-field <field>",
@@ -565,7 +565,7 @@ Examples:
     )
     .option(
       "--identity-format <template>",
-      'Format template for the extracted identity (e.g. "@{0}" to prefix with @). Uses {0}, {1}, etc. for extracted values',
+      'Format template for the extracted identity using ${pathName} tokens from --identity-response-paths (e.g. "@${login}" or "@${user} (${team})")',
     )
     .option(
       "--identity-ok-field <field>",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for eliminate-provider-behaviors.md.

**Gap:** CLI help text documents {0} syntax but implementation uses ${path} syntax
**What was expected:** Help text should document the correct ${path} syntax
**What was found:** Help text said {0}, {1}, etc. but verifier uses ${pathName} tokens
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21670" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
