### PR TITLE
refactor: simplify MessagingProvider connection type to optional OAuthConnection

### DIFF
--- a/assistant/src/__tests__/messaging-send-tool.test.ts
+++ b/assistant/src/__tests__/messaging-send-tool.test.ts
@@ -24,16 +24,16 @@ const provider: MessagingProvider = {
   getHistory: async () => [],
   search: async () => ({ total: 0, messages: [], hasMore: false }),
   sendMessage: (
-    connectionOrToken: OAuthConnection | string,
+    connection: OAuthConnection | undefined,
     conversationId: string,
     text: string,
     options?: SendOptions,
-  ) => sendMessageMock(connectionOrToken, conversationId, text, options),
+  ) => sendMessageMock(connection, conversationId, text, options),
 };
 
 mock.module("../config/bundled-skills/messaging/tools/shared.js", () => ({
   resolveProvider: () => provider,
-  getProviderConnection: () => "provider-token",
+  getProviderConnection: () => undefined,
   ok: (content: string) => ({ content, isError: false }),
   err: (content: string) => ({ content, isError: true }),
   extractHeader: () => "",
@@ -65,7 +65,7 @@ describe("messaging-send tool", () => {
 
     expect(result.isError).toBe(false);
     expect(sendMessageMock).toHaveBeenCalledWith(
-      "provider-token",
+      undefined,
       "+15550004444",
       "test message",
       {
@@ -95,7 +95,7 @@ describe("messaging-send tool", () => {
 
     expect(result.isError).toBe(false);
     expect(sendMessageMock).toHaveBeenCalledWith(
-      "provider-token",
+      undefined,
       "conv-1",
       "reply text",
       {

--- a/assistant/src/__tests__/slack-messaging-token-resolution.test.ts
+++ b/assistant/src/__tests__/slack-messaging-token-resolution.test.ts
@@ -139,7 +139,7 @@ describe("Slack messaging token resolution", () => {
   // ── slackProvider.resolveConnection() ───────────────────────────────────
 
   describe("slackProvider.resolveConnection()", () => {
-    test("returns bot token string when Socket Mode credentials exist", async () => {
+    test("returns undefined when Socket Mode credentials exist (token cached internally)", async () => {
       getSecureKeyAsyncMock.mockImplementation(async (key: string) =>
         key === "credential/slack_channel/bot_token"
           ? "xoxb-socket-token"
@@ -147,17 +147,17 @@ describe("Slack messaging token resolution", () => {
       );
 
       const result = await slackProvider.resolveConnection!();
-      expect(result).toBe("xoxb-socket-token");
+      expect(result).toBeUndefined();
     });
 
-    test("returns bot token string even without a slack_channel connection row (token-only resilience)", async () => {
+    test("returns undefined even without a slack_channel connection row (token-only resilience)", async () => {
       getSecureKeyAsyncMock.mockImplementation(async (key: string) =>
         key === "credential/slack_channel/bot_token" ? "xoxb-token-only" : null,
       );
-      // No connection row — resolveConnection should still return the token
+      // No connection row — resolveConnection should still return undefined (token cached internally)
 
       const result = await slackProvider.resolveConnection!();
-      expect(result).toBe("xoxb-token-only");
+      expect(result).toBeUndefined();
     });
 
     test("returns OAuthConnection when only OAuth slack credentials exist (backwards compat)", async () => {
@@ -189,13 +189,13 @@ describe("Slack messaging token resolution", () => {
   // ── getProviderConnection() integration ─────────────────────────────────
 
   describe("getProviderConnection()", () => {
-    test("returns bot token string for Slack when Socket Mode credentials exist", async () => {
+    test("returns undefined for Slack when Socket Mode credentials exist (token cached internally)", async () => {
       getSecureKeyAsyncMock.mockImplementation(async (key: string) =>
         key === "credential/slack_channel/bot_token" ? "xoxb-conn-token" : null,
       );
 
       const result = await getProviderConnection(slackProvider);
-      expect(result).toBe("xoxb-conn-token");
+      expect(result).toBeUndefined();
     });
 
     test("returns OAuthConnection for Slack when only OAuth credentials exist (backwards compat)", async () => {
@@ -220,9 +220,9 @@ describe("Slack messaging token resolution", () => {
       );
     });
 
-    test('Telegram still returns "" (no resolveConnection, uses isConnected path — regression check)', async () => {
+    test("Telegram returns undefined (no resolveConnection, uses isConnected path — regression check)", async () => {
       // Telegram has isConnected but no resolveConnection.
-      // When isConnected returns true, getProviderConnection returns ""
+      // When isConnected returns true, getProviderConnection returns undefined
       getSecureKeyAsyncMock.mockImplementation(async (key: string) => {
         if (key === "credential/telegram/bot_token") return "bot-token";
         if (key === "credential/telegram/webhook_secret") return "secret";
@@ -233,7 +233,7 @@ describe("Slack messaging token resolution", () => {
       );
 
       const result = await getProviderConnection(telegramBotMessagingProvider);
-      expect(result).toBe("");
+      expect(result).toBeUndefined();
     });
 
     test("Gmail still calls resolveOAuthConnection (no resolveConnection, no isConnected — regression check)", async () => {

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
@@ -9,7 +9,6 @@ import {
   listMessages,
 } from "../../../../messaging/providers/gmail/client.js";
 import { buildMultipartMime } from "../../../../messaging/providers/gmail/mime-builder.js";
-import type { OAuthConnection } from "../../../../oauth/connection.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -57,7 +56,11 @@ export async function run(
 
     // Gmail: create a draft instead of sending directly
     if (provider.id === "gmail") {
-      const gmailConn = conn as OAuthConnection;
+      if (!conn)
+        return err(
+          "Gmail requires an OAuth connection — is the account connected?",
+        );
+      const gmailConn = conn;
       // Reply mode: thread_id provided - create a threaded draft with reply-all recipients
       if (threadId) {
         // Fetch thread messages to extract recipients and threading headers

--- a/assistant/src/config/bundled-skills/messaging/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/shared.ts
@@ -126,17 +126,16 @@ export async function resolveProvider(
 }
 
 /**
- * Resolve an OAuthConnection (or empty string for non-OAuth providers)
- * for the given messaging provider.
+ * Resolve an OAuthConnection for the given messaging provider.
  *
- * Non-OAuth providers (e.g. Telegram) use isConnected() and don't need
- * tokens - they receive an empty string which the string overload handles.
+ * Returns undefined for providers that manage credentials internally
+ * (e.g. Telegram bot tokens, Slack Socket Mode bot tokens).
  */
 export async function getProviderConnection(
   provider: MessagingProvider,
   account?: string,
-): Promise<OAuthConnection | string> {
+): Promise<OAuthConnection | undefined> {
   if (provider.resolveConnection) return provider.resolveConnection(account);
-  if (await provider.isConnected?.()) return "";
+  if (await provider.isConnected?.()) return undefined;
   return resolveOAuthConnection(provider.credentialService, { account });
 }

--- a/assistant/src/messaging/provider.ts
+++ b/assistant/src/messaging/provider.ts
@@ -30,25 +30,23 @@ export interface MessagingProvider {
 
   // ── Universal operations (every platform must implement) ──────────
 
-  testConnection(
-    connectionOrToken: OAuthConnection | string,
-  ): Promise<ConnectionInfo>;
+  testConnection(connection?: OAuthConnection): Promise<ConnectionInfo>;
   listConversations(
-    connectionOrToken: OAuthConnection | string,
+    connection: OAuthConnection | undefined,
     options?: ListOptions,
   ): Promise<Conversation[]>;
   getHistory(
-    connectionOrToken: OAuthConnection | string,
+    connection: OAuthConnection | undefined,
     conversationId: string,
     options?: HistoryOptions,
   ): Promise<Message[]>;
   search(
-    connectionOrToken: OAuthConnection | string,
+    connection: OAuthConnection | undefined,
     query: string,
     options?: SearchOptions,
   ): Promise<SearchResult>;
   sendMessage(
-    connectionOrToken: OAuthConnection | string,
+    connection: OAuthConnection | undefined,
     conversationId: string,
     text: string,
     options?: SendOptions,
@@ -57,26 +55,26 @@ export interface MessagingProvider {
   // ── Optional operations (platforms implement what they support) ───
 
   getThreadReplies?(
-    connectionOrToken: OAuthConnection | string,
+    connection: OAuthConnection | undefined,
     conversationId: string,
     threadId: string,
     options?: HistoryOptions,
   ): Promise<Message[]>;
   markRead?(
-    connectionOrToken: OAuthConnection | string,
+    connection: OAuthConnection | undefined,
     conversationId: string,
     messageId?: string,
   ): Promise<void>;
 
   /** Scan messages and group by sender for bulk cleanup (e.g. newsletter decluttering). */
   senderDigest?(
-    connectionOrToken: OAuthConnection | string,
+    connection: OAuthConnection | undefined,
     query: string,
     options?: { maxMessages?: number; maxSenders?: number; pageToken?: string },
   ): Promise<SenderDigestResult>;
   /** Archive messages matching a search query. */
   archiveByQuery?(
-    connectionOrToken: OAuthConnection | string,
+    connection: OAuthConnection | undefined,
     query: string,
   ): Promise<ArchiveResult>;
 
@@ -95,8 +93,11 @@ export interface MessagingProvider {
    * than the OAuth provider key). When present, getProviderConnection() calls
    * this instead of resolveOAuthConnection(), giving the provider full control
    * over credential lookup including fallback strategies.
+   *
+   * Returns an OAuthConnection if the provider uses OAuth, or undefined if
+   * the provider manages credentials internally (e.g. raw bot tokens).
    */
-  resolveConnection?(account?: string): Promise<OAuthConnection | string>;
+  resolveConnection?(account?: string): Promise<OAuthConnection | undefined>;
 
   /** Platform-specific capabilities for tool routing (e.g. 'reactions', 'threads', 'labels'). */
   capabilities: Set<string>;

--- a/assistant/src/messaging/providers/gmail/adapter.ts
+++ b/assistant/src/messaging/providers/gmail/adapter.ts
@@ -24,6 +24,17 @@ import type {
 import * as gmail from "./client.js";
 import type { GmailMessage, GmailMessagePart } from "./types.js";
 
+function requireConnection(
+  connection: OAuthConnection | undefined,
+): OAuthConnection {
+  if (!connection) {
+    throw new Error(
+      "Gmail requires an OAuth connection — is the account connected?",
+    );
+  }
+  return connection;
+}
+
 function extractHeader(msg: GmailMessage, name: string): string {
   const lower = name.toLowerCase();
   return (
@@ -95,11 +106,9 @@ export const gmailMessagingProvider: MessagingProvider = {
     "unsubscribe",
   ]),
 
-  async testConnection(
-    connectionOrToken: OAuthConnection | string,
-  ): Promise<ConnectionInfo> {
-    const connection = connectionOrToken as OAuthConnection;
-    const profile = await gmail.getProfile(connection);
+  async testConnection(connection?: OAuthConnection): Promise<ConnectionInfo> {
+    const conn = requireConnection(connection);
+    const profile = await gmail.getProfile(conn);
     return {
       connected: true,
       user: profile.emailAddress,
@@ -112,12 +121,12 @@ export const gmailMessagingProvider: MessagingProvider = {
   },
 
   async listConversations(
-    connectionOrToken: OAuthConnection | string,
+    connection: OAuthConnection | undefined,
     _options?: ListOptions,
   ): Promise<Conversation[]> {
-    const connection = connectionOrToken as OAuthConnection;
+    const conn = requireConnection(connection);
     // Gmail "conversations" are modeled as labels with unread counts
-    const labels = await gmail.listLabels(connection);
+    const labels = await gmail.listLabels(conn);
     const conversations: Conversation[] = [];
 
     for (const label of labels) {
@@ -156,15 +165,15 @@ export const gmailMessagingProvider: MessagingProvider = {
   },
 
   async getHistory(
-    connectionOrToken: OAuthConnection | string,
+    connection: OAuthConnection | undefined,
     conversationId: string,
     options?: HistoryOptions,
   ): Promise<Message[]> {
-    const connection = connectionOrToken as OAuthConnection;
+    const conn = requireConnection(connection);
     // conversationId is a label ID — list messages in that label
     const limit = options?.limit ?? 50;
     const listResult = await gmail.listMessages(
-      connection,
+      conn,
       undefined,
       limit,
       undefined,
@@ -174,7 +183,7 @@ export const gmailMessagingProvider: MessagingProvider = {
     if (!listResult.messages?.length) return [];
 
     const messages = await gmail.batchGetMessages(
-      connection,
+      conn,
       listResult.messages.map((m) => m.id),
       "full",
     );
@@ -183,20 +192,20 @@ export const gmailMessagingProvider: MessagingProvider = {
   },
 
   async search(
-    connectionOrToken: OAuthConnection | string,
+    connection: OAuthConnection | undefined,
     query: string,
     options?: SearchOptions,
   ): Promise<SearchResult> {
-    const connection = connectionOrToken as OAuthConnection;
+    const conn = requireConnection(connection);
     const count = options?.count ?? 20;
-    const listResult = await gmail.listMessages(connection, query, count);
+    const listResult = await gmail.listMessages(conn, query, count);
 
     if (!listResult.messages?.length) {
       return { total: 0, messages: [], hasMore: false };
     }
 
     const messages = await gmail.batchGetMessages(
-      connection,
+      conn,
       listResult.messages.map((m) => m.id),
       "full",
     );
@@ -210,17 +219,17 @@ export const gmailMessagingProvider: MessagingProvider = {
   },
 
   async sendMessage(
-    connectionOrToken: OAuthConnection | string,
+    connection: OAuthConnection | undefined,
     conversationId: string,
     text: string,
     options?: SendOptions,
   ): Promise<SendResult> {
-    const connection = connectionOrToken as OAuthConnection;
+    const conn = requireConnection(connection);
     // conversationId is the recipient email for Gmail
     const to = conversationId;
     const subject = options?.subject ?? "";
     const msg = await gmail.sendMessage(
-      connection,
+      conn,
       to,
       subject,
       text,
@@ -236,16 +245,16 @@ export const gmailMessagingProvider: MessagingProvider = {
   },
 
   async getThreadReplies(
-    connectionOrToken: OAuthConnection | string,
+    connection: OAuthConnection | undefined,
     _conversationId: string,
     threadId: string,
     options?: HistoryOptions,
   ): Promise<Message[]> {
-    const connection = connectionOrToken as OAuthConnection;
+    const conn = requireConnection(connection);
     // Get all messages in a Gmail thread
     const limit = options?.limit ?? 50;
     const listResult = await gmail.listMessages(
-      connection,
+      conn,
       `thread:${threadId}`,
       limit,
     );
@@ -253,7 +262,7 @@ export const gmailMessagingProvider: MessagingProvider = {
     if (!listResult.messages?.length) return [];
 
     const messages = await gmail.batchGetMessages(
-      connection,
+      conn,
       listResult.messages.map((m) => m.id),
       "full",
     );
@@ -262,23 +271,23 @@ export const gmailMessagingProvider: MessagingProvider = {
   },
 
   async markRead(
-    connectionOrToken: OAuthConnection | string,
+    connection: OAuthConnection | undefined,
     _conversationId: string,
     messageId?: string,
   ): Promise<void> {
-    const connection = connectionOrToken as OAuthConnection;
+    const conn = requireConnection(connection);
     if (!messageId) return;
-    await gmail.modifyMessage(connection, messageId, {
+    await gmail.modifyMessage(conn, messageId, {
       removeLabelIds: ["UNREAD"],
     });
   },
 
   async senderDigest(
-    connectionOrToken: OAuthConnection | string,
+    connection: OAuthConnection | undefined,
     query: string,
     options?: { maxMessages?: number; maxSenders?: number; pageToken?: string },
   ): Promise<SenderDigestResult> {
-    const connection = connectionOrToken as OAuthConnection;
+    const conn = requireConnection(connection);
     const maxMessages = Math.min(options?.maxMessages ?? 5000, 5000);
     const maxSenders = options?.maxSenders ?? 30;
     const maxIdsPerSender = 5000;
@@ -298,7 +307,7 @@ export const gmailMessagingProvider: MessagingProvider = {
       }
       const pageSize = Math.min(100, maxMessages - allMessageIds.length);
       const listResp = await gmail.listMessages(
-        connection,
+        conn,
         query,
         pageSize,
         pageToken,
@@ -308,7 +317,7 @@ export const gmailMessagingProvider: MessagingProvider = {
       allMessageIds.push(...ids);
       fetchPromises.push(
         gmail.batchGetMessages(
-          connection,
+          conn,
           ids,
           "metadata",
           metadataHeaders,
@@ -423,10 +432,10 @@ export const gmailMessagingProvider: MessagingProvider = {
   },
 
   async archiveByQuery(
-    connectionOrToken: OAuthConnection | string,
+    connection: OAuthConnection | undefined,
     query: string,
   ): Promise<ArchiveResult> {
-    const connection = connectionOrToken as OAuthConnection;
+    const conn = requireConnection(connection);
     const maxMessages = 5000;
     const batchModifyLimit = 1000;
 
@@ -436,7 +445,7 @@ export const gmailMessagingProvider: MessagingProvider = {
 
     while (allMessageIds.length < maxMessages) {
       const listResp = await gmail.listMessages(
-        connection,
+        conn,
         query,
         Math.min(500, maxMessages - allMessageIds.length),
         pageToken,
@@ -458,7 +467,7 @@ export const gmailMessagingProvider: MessagingProvider = {
 
     for (let i = 0; i < allMessageIds.length; i += batchModifyLimit) {
       const chunk = allMessageIds.slice(i, i + batchModifyLimit);
-      await gmail.batchModifyMessages(connection, chunk, {
+      await gmail.batchModifyMessages(conn, chunk, {
         removeLabelIds: ["INBOX"],
       });
     }

--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -32,8 +32,30 @@ import type {
 // Cache user display names to avoid repeated API calls within a session
 const userNameCache = new Map<string, string>();
 
+/**
+ * Cached auth resolved during resolveConnection().
+ *
+ * For Socket Mode this holds a raw bot token string; for OAuth it holds the
+ * OAuthConnection. The Slack client functions accept both via their own
+ * OAuthConnection | string union, so we can pass this value through directly.
+ */
+let _cachedSlackAuth: OAuthConnection | string | null = null;
+
+/**
+ * Get the Slack auth value to pass to Slack client functions.
+ * Prefers the explicit connection from the caller; falls back to the cached
+ * value set during resolveConnection().
+ */
+function getSlackAuth(connection?: OAuthConnection): OAuthConnection | string {
+  if (connection) return connection;
+  if (_cachedSlackAuth) return _cachedSlackAuth;
+  throw new Error(
+    "Slack: no connection or cached token available. Was resolveConnection() called?",
+  );
+}
+
 async function resolveUserName(
-  connectionOrToken: OAuthConnection | string,
+  auth: OAuthConnection | string,
   userId: string,
 ): Promise<string> {
   if (!userId) return "unknown";
@@ -41,7 +63,7 @@ async function resolveUserName(
   if (cached) return cached;
 
   try {
-    const resp = await slack.userInfo(connectionOrToken, userId);
+    const resp = await slack.userInfo(auth, userId);
     const name =
       resp.user.profile?.display_name ||
       resp.user.profile?.real_name ||
@@ -128,21 +150,27 @@ export const slackProvider: MessagingProvider = {
     return isProviderConnected("slack");
   },
 
-  async resolveConnection(account?: string): Promise<OAuthConnection | string> {
-    // Socket Mode: return raw bot token if available.
+  async resolveConnection(
+    account?: string,
+  ): Promise<OAuthConnection | undefined> {
+    // Socket Mode: cache the raw bot token for use in adapter methods.
     // Token presence is sufficient — no connection row required.
     const botToken = await getSecureKeyAsync(
       credentialKey("slack_channel", "bot_token"),
     );
-    if (botToken) return botToken;
+    if (botToken) {
+      _cachedSlackAuth = botToken;
+      return undefined;
+    }
     // Preserve existing OAuth path for backwards compat.
-    return resolveOAuthConnection("slack", { account });
+    const conn = await resolveOAuthConnection("slack", { account });
+    _cachedSlackAuth = conn;
+    return conn;
   },
 
-  async testConnection(
-    connectionOrToken: OAuthConnection | string,
-  ): Promise<ConnectionInfo> {
-    const resp = await slack.authTest(connectionOrToken);
+  async testConnection(connection?: OAuthConnection): Promise<ConnectionInfo> {
+    const auth = getSlackAuth(connection);
+    const resp = await slack.authTest(auth);
     return {
       connected: true,
       user: resp.user,
@@ -152,9 +180,10 @@ export const slackProvider: MessagingProvider = {
   },
 
   async listConversations(
-    connectionOrToken: OAuthConnection | string,
+    connection: OAuthConnection | undefined,
     options?: ListOptions,
   ): Promise<Conversation[]> {
+    const auth = getSlackAuth(connection);
     const typeMap: Record<string, string> = {
       channel: "public_channel,private_channel",
       dm: "im",
@@ -174,7 +203,7 @@ export const slackProvider: MessagingProvider = {
     // Paginate through all results
     do {
       const resp = await slack.listConversations(
-        connectionOrToken,
+        auth,
         types,
         options?.excludeArchived ?? true,
         options?.limit ?? 200,
@@ -191,7 +220,7 @@ export const slackProvider: MessagingProvider = {
     for (const conv of conversations) {
       if (conv.type === "dm" && conv.metadata?.dmUserId) {
         conv.name = await resolveUserName(
-          connectionOrToken,
+          auth,
           conv.metadata.dmUserId as string,
         );
       }
@@ -201,12 +230,13 @@ export const slackProvider: MessagingProvider = {
   },
 
   async getHistory(
-    connectionOrToken: OAuthConnection | string,
+    connection: OAuthConnection | undefined,
     conversationId: string,
     options?: HistoryOptions,
   ): Promise<Message[]> {
+    const auth = getSlackAuth(connection);
     const resp = await slack.conversationHistory(
-      connectionOrToken,
+      auth,
       conversationId,
       options?.limit ?? 50,
       options?.before,
@@ -215,7 +245,7 @@ export const slackProvider: MessagingProvider = {
 
     const messages: Message[] = [];
     for (const msg of resp.messages) {
-      const name = await resolveUserName(connectionOrToken, msg.user ?? "");
+      const name = await resolveUserName(auth, msg.user ?? "");
       messages.push(mapMessage(msg, conversationId, name));
     }
 
@@ -223,15 +253,12 @@ export const slackProvider: MessagingProvider = {
   },
 
   async search(
-    connectionOrToken: OAuthConnection | string,
+    connection: OAuthConnection | undefined,
     query: string,
     options?: SearchOptions,
   ): Promise<SearchResult> {
-    const resp = await slack.searchMessages(
-      connectionOrToken,
-      query,
-      options?.count ?? 20,
-    );
+    const auth = getSlackAuth(connection);
+    const resp = await slack.searchMessages(auth, query, options?.count ?? 20);
     return {
       total: resp.messages.total,
       messages: resp.messages.matches.map(mapSearchMatch),
@@ -240,13 +267,14 @@ export const slackProvider: MessagingProvider = {
   },
 
   async sendMessage(
-    connectionOrToken: OAuthConnection | string,
+    connection: OAuthConnection | undefined,
     conversationId: string,
     text: string,
     options?: SendOptions,
   ): Promise<SendResult> {
+    const auth = getSlackAuth(connection);
     const resp = await slack.postMessage(
-      connectionOrToken,
+      auth,
       conversationId,
       text,
       options?.threadId,
@@ -259,32 +287,34 @@ export const slackProvider: MessagingProvider = {
   },
 
   async getThreadReplies(
-    connectionOrToken: OAuthConnection | string,
+    connection: OAuthConnection | undefined,
     conversationId: string,
     threadId: string,
     options?: HistoryOptions,
   ): Promise<Message[]> {
+    const auth = getSlackAuth(connection);
     const resp = await slack.conversationReplies(
-      connectionOrToken,
+      auth,
       conversationId,
       threadId,
       options?.limit ?? 50,
     );
     const messages: Message[] = [];
     for (const msg of resp.messages) {
-      const name = await resolveUserName(connectionOrToken, msg.user ?? "");
+      const name = await resolveUserName(auth, msg.user ?? "");
       messages.push(mapMessage(msg, conversationId, name));
     }
     return messages;
   },
 
   async markRead(
-    connectionOrToken: OAuthConnection | string,
+    connection: OAuthConnection | undefined,
     conversationId: string,
     messageId?: string,
   ): Promise<void> {
+    const auth = getSlackAuth(connection);
     // Slack's conversations.mark requires a timestamp — use the provided one or "now"
     const ts = messageId ?? String(Date.now() / 1000);
-    await slack.conversationMark(connectionOrToken, conversationId, ts);
+    await slack.conversationMark(auth, conversationId, ts);
   },
 };

--- a/assistant/src/messaging/providers/telegram-bot/adapter.ts
+++ b/assistant/src/messaging/providers/telegram-bot/adapter.ts
@@ -6,7 +6,7 @@
  * with OAuth tokens, Telegram delivery is proxied through the gateway which
  * owns the bot token and handles Telegram API retries.
  *
- * The `connectionOrToken` parameter in MessagingProvider methods is unused
+ * The `connection` parameter in MessagingProvider methods is unused
  * for Telegram because delivery is authenticated via the gateway's bearer
  * token, not a per-user OAuth token.
  */
@@ -76,9 +76,7 @@ export const telegramBotMessagingProvider: MessagingProvider = {
     return !!webhookSecret;
   },
 
-  async testConnection(
-    _connectionOrToken: OAuthConnection | string,
-  ): Promise<ConnectionInfo> {
+  async testConnection(_connection?: OAuthConnection): Promise<ConnectionInfo> {
     const botToken = await getBotToken();
     if (!botToken) {
       return {
@@ -123,7 +121,7 @@ export const telegramBotMessagingProvider: MessagingProvider = {
   },
 
   async sendMessage(
-    _connectionOrToken: OAuthConnection | string,
+    _connection: OAuthConnection | undefined,
     conversationId: string,
     text: string,
     _options?: SendOptions,
@@ -161,7 +159,7 @@ export const telegramBotMessagingProvider: MessagingProvider = {
   // interact with chats where users have initiated contact or the bot
   // has been added to a group.
   async listConversations(
-    _connectionOrToken: OAuthConnection | string,
+    _connection?: OAuthConnection,
     _options?: ListOptions,
   ): Promise<Conversation[]> {
     return [];
@@ -169,7 +167,7 @@ export const telegramBotMessagingProvider: MessagingProvider = {
 
   // Telegram Bot API does not provide message history retrieval.
   async getHistory(
-    _connectionOrToken: OAuthConnection | string,
+    _connection: OAuthConnection | undefined,
     _conversationId: string,
     _options?: HistoryOptions,
   ): Promise<Message[]> {
@@ -178,7 +176,7 @@ export const telegramBotMessagingProvider: MessagingProvider = {
 
   // Telegram Bot API does not support message search.
   async search(
-    _connectionOrToken: OAuthConnection | string,
+    _connection: OAuthConnection | undefined,
     _query: string,
     _options?: SearchOptions,
   ): Promise<SearchResult> {

--- a/assistant/src/messaging/providers/whatsapp/adapter.ts
+++ b/assistant/src/messaging/providers/whatsapp/adapter.ts
@@ -5,7 +5,7 @@
  * endpoint. Delivery is proxied through the gateway which owns the Meta Cloud API
  * credentials (phone_number_id + access_token).
  *
- * The `connectionOrToken` parameter in MessagingProvider methods is unused
+ * The `connection` parameter in MessagingProvider methods is unused
  * for WhatsApp because delivery is authenticated via the gateway's bearer
  * token, not a per-user OAuth token.
  */
@@ -66,9 +66,7 @@ export const whatsappMessagingProvider: MessagingProvider = {
     return hasWhatsAppCredentials();
   },
 
-  async testConnection(
-    _connectionOrToken: OAuthConnection | string,
-  ): Promise<ConnectionInfo> {
+  async testConnection(_connection?: OAuthConnection): Promise<ConnectionInfo> {
     if (!(await hasWhatsAppCredentials())) {
       return {
         connected: false,
@@ -96,7 +94,7 @@ export const whatsappMessagingProvider: MessagingProvider = {
   },
 
   async sendMessage(
-    _connectionOrToken: OAuthConnection | string,
+    _connection: OAuthConnection | undefined,
     conversationId: string,
     text: string,
     options?: SendOptions,
@@ -140,7 +138,7 @@ export const whatsappMessagingProvider: MessagingProvider = {
 
   // WhatsApp does not support listing conversations via this provider.
   async listConversations(
-    _connectionOrToken: OAuthConnection | string,
+    _connection?: OAuthConnection,
     _options?: ListOptions,
   ): Promise<Conversation[]> {
     return [];
@@ -148,7 +146,7 @@ export const whatsappMessagingProvider: MessagingProvider = {
 
   // WhatsApp does not provide message history retrieval via the gateway.
   async getHistory(
-    _connectionOrToken: OAuthConnection | string,
+    _connection: OAuthConnection | undefined,
     _conversationId: string,
     _options?: HistoryOptions,
   ): Promise<Message[]> {
@@ -157,7 +155,7 @@ export const whatsappMessagingProvider: MessagingProvider = {
 
   // WhatsApp does not support message search.
   async search(
-    _connectionOrToken: OAuthConnection | string,
+    _connection: OAuthConnection | undefined,
     _query: string,
     _options?: SearchOptions,
   ): Promise<SearchResult> {

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -72,6 +72,7 @@ export async function resolveOAuthConnection(
         accountInfo: account ?? null,
         client,
         connectionId,
+        baseUrl: provider?.baseUrl ?? undefined,
       });
     }
   }

--- a/assistant/src/oauth/platform-connection.test.ts
+++ b/assistant/src/oauth/platform-connection.test.ts
@@ -93,7 +93,7 @@ describe("PlatformOAuthConnection", () => {
     expect(result.body).toEqual(upstreamBody);
   });
 
-  test("forwards baseUrl when provided", async () => {
+  test("forwards per-request baseUrl when provided", async () => {
     const client = makeMockClient(
       mock(async (_url: string | URL | Request, init?: RequestInit) => {
         const parsed = JSON.parse(init?.body as string);
@@ -116,7 +116,57 @@ describe("PlatformOAuthConnection", () => {
     });
   });
 
-  test("omits baseUrl from envelope when not provided", async () => {
+  test("falls back to connection-level baseUrl when per-request baseUrl is absent", async () => {
+    const client = makeMockClient(
+      mock(async (_url: string | URL | Request, init?: RequestInit) => {
+        const parsed = JSON.parse(init?.body as string);
+        expect(parsed.request.baseUrl).toBe(
+          "https://gmail.googleapis.com/gmail/v1/users/me",
+        );
+
+        return new Response(
+          JSON.stringify({ status: 200, headers: {}, body: null }),
+          { status: 200 },
+        );
+      }) as unknown as typeof globalThis.fetch,
+    );
+
+    const conn = new PlatformOAuthConnection({
+      ...DEFAULT_OPTIONS,
+      client,
+      baseUrl: "https://gmail.googleapis.com/gmail/v1/users/me",
+    });
+    await conn.request({ method: "GET", path: "/messages" });
+  });
+
+  test("per-request baseUrl overrides connection-level baseUrl", async () => {
+    const client = makeMockClient(
+      mock(async (_url: string | URL | Request, init?: RequestInit) => {
+        const parsed = JSON.parse(init?.body as string);
+        expect(parsed.request.baseUrl).toBe(
+          "https://www.googleapis.com/calendar/v3",
+        );
+
+        return new Response(
+          JSON.stringify({ status: 200, headers: {}, body: {} }),
+          { status: 200 },
+        );
+      }) as unknown as typeof globalThis.fetch,
+    );
+
+    const conn = new PlatformOAuthConnection({
+      ...DEFAULT_OPTIONS,
+      client,
+      baseUrl: "https://gmail.googleapis.com/gmail/v1/users/me",
+    });
+    await conn.request({
+      method: "GET",
+      path: "/calendars/primary/events",
+      baseUrl: "https://www.googleapis.com/calendar/v3",
+    });
+  });
+
+  test("omits baseUrl from envelope when neither connection nor request provides one", async () => {
     const client = makeMockClient(
       mock(async (_url: string | URL | Request, init?: RequestInit) => {
         const parsed = JSON.parse(init?.body as string);

--- a/assistant/src/oauth/platform-connection.ts
+++ b/assistant/src/oauth/platform-connection.ts
@@ -28,6 +28,9 @@ export interface PlatformOAuthConnectionOptions {
   client: VellumPlatformClient;
   /** Platform-side connection ID used in the proxy URL path. */
   connectionId: string;
+  /** Provider API base URL (e.g. "https://gmail.googleapis.com/gmail/v1/users/me").
+   *  Sent to the proxy so it can construct the full upstream URL. */
+  baseUrl?: string;
 }
 
 export class PlatformOAuthConnection implements OAuthConnection {
@@ -38,6 +41,7 @@ export class PlatformOAuthConnection implements OAuthConnection {
 
   private readonly client: VellumPlatformClient;
   private readonly connectionId: string;
+  private readonly baseUrl: string | undefined;
 
   constructor(options: PlatformOAuthConnectionOptions) {
     if (!options.connectionId) {
@@ -53,6 +57,7 @@ export class PlatformOAuthConnection implements OAuthConnection {
     this.accountInfo = options.accountInfo;
     this.client = options.client;
     this.connectionId = options.connectionId;
+    this.baseUrl = options.baseUrl;
   }
 
   async request(req: OAuthConnectionRequest): Promise<OAuthConnectionResponse> {
@@ -65,7 +70,9 @@ export class PlatformOAuthConnection implements OAuthConnection {
         query: req.query ?? {},
         headers: req.headers ?? {},
         body: req.body ?? null,
-        ...(req.baseUrl ? { baseUrl: req.baseUrl } : {}),
+        ...((req.baseUrl ?? this.baseUrl)
+          ? { baseUrl: req.baseUrl ?? this.baseUrl }
+          : {}),
       },
     };
 


### PR DESCRIPTION
## Summary

- Replace `connectionOrToken: OAuthConnection | string` with `connection?: OAuthConnection` across the `MessagingProvider` interface — the string variant was never genuinely passed through the interface by external callers
- Remove all `as OAuthConnection` casts in the Gmail adapter (replaced with a type-safe `requireConnection()` guard) and add internal auth caching in the Slack adapter for Socket Mode bot tokens
- Add connection-level `baseUrl` support to `PlatformOAuthConnection` so managed OAuth providers can specify a default API base URL

## Original prompt

all changes except for assistant/src/config/bundled-skills/gmail/SKILL.md and skills/vellum-oauth-integrations/SKILL.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21672" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
