### PR TITLE
feat: typewriter-style letter-by-letter streaming text

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -444,18 +444,18 @@ private extension View {
     }
 }
 
-// MARK: - Streaming Fade
+// MARK: - Streaming Typewriter
 
 private extension View {
     /// Conditionally applies `StreamingFadeRenderer` during streaming.
-    /// New characters fade from 0 → 1 opacity over 150ms as SwiftUI
+    /// Characters appear one by one (typewriter style) as SwiftUI
     /// interpolates the renderer's animatable `elapsedCount`.
     @ViewBuilder
     func streamingFade(isStreaming: Bool, characterCount: Int) -> some View {
         if isStreaming {
             self
                 .textRenderer(StreamingFadeRenderer(elapsedCount: Double(characterCount)))
-                .animation(.easeIn(duration: 0.15), value: characterCount)
+                .animation(.linear(duration: 0.22), value: characterCount)
         } else {
             self
         }

--- a/clients/macos/vellum-assistant/Features/Chat/StreamingFadeRenderer.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/StreamingFadeRenderer.swift
@@ -1,22 +1,16 @@
 import SwiftUI
 
-/// Per-glyph opacity fade-in renderer for streaming text.
+/// Per-glyph renderer for streaming text.
 ///
-/// Run slices below `elapsedCount` render at full opacity; slices at
-/// the boundary transition from 0 → 1 as SwiftUI interpolates the
-/// animatable data between flush updates. Slices beyond the boundary
-/// are invisible (mid-animation, not yet reached).
-///
-/// Apply with `.animation(.easeIn(duration: 0.15), value: characterCount)`
-/// so SwiftUI interpolates `elapsedCount` from the previous character count
-/// to the new one, producing a smooth fade-in for each streaming delta.
+/// With the typewriter drip at the data layer, characters arrive a few
+/// at a time. This renderer simply draws all laid-out run slices.
+/// The `elapsedCount` / `animatableData` conformance is retained so
+/// SwiftUI can still drive layout animations when character count changes.
 ///
 /// References:
 /// - https://developer.apple.com/documentation/swiftui/textrenderer
 /// - WWDC 2024: "Create custom visual effects with SwiftUI"
 struct StreamingFadeRenderer: TextRenderer {
-    /// The number of run slices that should be fully visible.
-    /// SwiftUI animates this value between updates.
     var elapsedCount: Double
 
     var animatableData: Double {
@@ -25,14 +19,9 @@ struct StreamingFadeRenderer: TextRenderer {
     }
 
     func draw(layout: Text.Layout, in ctx: inout GraphicsContext) {
-        for (index, slice) in layout.flattenedRunSlices.enumerated() {
-            let progress = min(1, max(0, elapsedCount - Double(index)))
-            if progress >= 1 {
-                ctx.draw(slice)
-            } else if progress > 0 {
-                var copy = ctx
-                copy.opacity = progress
-                copy.draw(slice)
+        for line in layout {
+            for run in line {
+                ctx.draw(run)
             }
         }
     }

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -374,39 +374,64 @@ extension ChatViewModel {
         streamingFlushTask?.cancel()
         streamingFlushTask = nil
         streamingDeltaBuffer = ""
+        typewriterDripTask?.cancel()
+        typewriterDripTask = nil
+        typewriterQueue = ""
     }
 
     /// Flush any buffered streaming text into the messages array.
     /// Called on a timer and also eagerly on `messageComplete`.
-    func flushStreamingBuffer() {
+    ///
+    /// When `immediate` is false (the normal streaming path), this
+    /// transfers buffered text into a typewriter drip queue that emits
+    /// characters a few at a time. When `immediate` is true (e.g.
+    /// messageComplete), all remaining text is flushed at once so the
+    /// final message is never incomplete.
+    func flushStreamingBuffer(immediate: Bool = false) {
         // Always clear the task reference so scheduleStreamingFlush() can
         // schedule a new flush even if the buffer was empty this time.
         streamingFlushTask?.cancel()
         streamingFlushTask = nil
-        guard !streamingDeltaBuffer.isEmpty else { return }
+        guard !streamingDeltaBuffer.isEmpty else {
+            // If immediate, also drain any remaining typewriter queue.
+            if immediate { drainTypewriterBuffer() }
+            return
+        }
         let buffered = streamingDeltaBuffer
         streamingDeltaBuffer = ""
 
+        if immediate {
+            // Dump everything at once (message complete, cancel, etc.)
+            typewriterDripTask?.cancel()
+            typewriterDripTask = nil
+            appendTextToCurrentMessage(buffered)
+            drainTypewriterBuffer()
+        } else {
+            // Feed into the typewriter drip queue.
+            typewriterQueue += buffered
+            startTypewriterDripIfNeeded()
+        }
+    }
+
+    /// Append a chunk of text to the current assistant message.
+    private func appendTextToCurrentMessage(_ text: String) {
+        guard !text.isEmpty else { return }
         if let existingId = currentAssistantMessageId,
            let index = messages.firstIndex(where: { $0.id == existingId }) {
             if lastContentWasToolCall || messages[index].textSegments.isEmpty {
                 let segIdx = messages[index].textSegments.count
-                messages[index].textSegments.append(buffered)
+                messages[index].textSegments.append(text)
                 messages[index].contentOrder.append(.text(segIdx))
                 lastContentWasToolCall = false
             } else {
-                messages[index].textSegments[messages[index].textSegments.count - 1] += buffered
+                messages[index].textSegments[messages[index].textSegments.count - 1] += text
             }
         } else if currentAssistantMessageId != nil {
-            // Message ID is set but message not found — stale reference after
-            // history replacement or reconnect. Discard the buffer to avoid
-            // creating an orphan message.
-            log.warning("Stale currentAssistantMessageId \(self.currentAssistantMessageId!.uuidString) — discarding \(buffered.count) buffered chars")
+            log.warning("Stale currentAssistantMessageId \(self.currentAssistantMessageId!.uuidString) — discarding \(text.count) buffered chars")
             currentAssistantMessageId = nil
             return
         } else {
-            // No existing assistant message — create a new one (first text delta)
-            var msg = ChatMessage(role: .assistant, text: buffered, isStreaming: true)
+            var msg = ChatMessage(role: .assistant, text: text, isStreaming: true)
             if currentTurnUserText == "/models" {
                 msg.modelList = ModelListData()
             } else if currentTurnUserText == "/commands" {
@@ -415,6 +440,32 @@ extension ChatViewModel {
             currentAssistantMessageId = msg.id
             messages.append(msg)
             lastContentWasToolCall = false
+        }
+    }
+
+    /// Start the typewriter drip loop if it isn't already running.
+    private func startTypewriterDripIfNeeded() {
+        guard typewriterDripTask == nil else { return }
+        typewriterDripTask = Task { @MainActor [weak self] in
+            while let self, !Task.isCancelled, !self.typewriterQueue.isEmpty {
+                let count = min(Self.typewriterCharsPerTick, self.typewriterQueue.count)
+                let endIndex = self.typewriterQueue.index(self.typewriterQueue.startIndex, offsetBy: count)
+                let chunk = String(self.typewriterQueue[..<endIndex])
+                self.typewriterQueue = String(self.typewriterQueue[endIndex...])
+                self.appendTextToCurrentMessage(chunk)
+                try? await Task.sleep(nanoseconds: UInt64(Self.typewriterTickInterval * 1_000_000_000))
+            }
+            self?.typewriterDripTask = nil
+        }
+    }
+
+    /// Immediately flush all remaining typewriter queue text.
+    private func drainTypewriterBuffer() {
+        typewriterDripTask?.cancel()
+        typewriterDripTask = nil
+        if !typewriterQueue.isEmpty {
+            appendTextToCurrentMessage(typewriterQueue)
+            typewriterQueue = ""
         }
     }
 
@@ -573,7 +624,7 @@ extension ChatViewModel {
         case .messageComplete(let complete):
             guard belongsToConversation(complete.conversationId) else { return }
             // Flush any buffered streaming text before finalizing the message.
-            flushStreamingBuffer()
+            flushStreamingBuffer(immediate: true)
             flushPartialOutputBuffer()
             // Backfill the daemon's persisted message ID so fork, inspect,
             // TTS, and other daemon-anchored actions work without a history reload.
@@ -904,7 +955,7 @@ extension ChatViewModel {
             // created by the preceding assistant_text_delta so it doesn't remain
             // stuck in streaming state or cause subsequent deltas to append to it.
             if msg.runStillActive != true {
-                flushStreamingBuffer()
+                flushStreamingBuffer(immediate: true)
                 flushPartialOutputBuffer()
                 if let existingId = currentAssistantMessageId,
                    let index = messages.firstIndex(where: { $0.id == existingId }) {
@@ -930,7 +981,7 @@ extension ChatViewModel {
             isThinking = false
             // Flush buffered text so it lands on the current assistant message
             // before we clear the ID and hand off to the next queued turn.
-            flushStreamingBuffer()
+            flushStreamingBuffer(immediate: true)
             flushPartialOutputBuffer()
             // Must run before currentAssistantMessageId is cleared so attachments land on the right message
             ingestAssistantAttachments(handoff.attachments)
@@ -989,7 +1040,7 @@ extension ChatViewModel {
             let savedTurnUserText = currentTurnUserText
             // Flush any buffered text so already-received tokens are preserved
             // in the assistant message before we clear the turn state.
-            flushStreamingBuffer()
+            flushStreamingBuffer(immediate: true)
             flushPartialOutputBuffer()
             // Mark current assistant message as no longer streaming
             if let existingId = currentAssistantMessageId,
@@ -1108,7 +1159,7 @@ extension ChatViewModel {
         case .confirmationRequest(let msg):
             guard !isLoadingHistory else { return }
             // Flush buffered text before inserting the confirmation message.
-            flushStreamingBuffer()
+            flushStreamingBuffer(immediate: true)
             flushPartialOutputBuffer()
             // Route using conversationId when available (daemon >= v1.x includes
             // the conversationId). Fall back to the timestamp-based heuristic
@@ -1169,7 +1220,7 @@ extension ChatViewModel {
                 break
             }
             // Flush buffered text so it lands before the tool call in content order.
-            flushStreamingBuffer()
+            flushStreamingBuffer(immediate: true)
             flushPartialOutputBuffer()
             // If a chip with the same toolUseId already exists (e.g. toolUseStart
             // arrived before this preview), ignore the late preview.
@@ -1213,7 +1264,7 @@ extension ChatViewModel {
             guard !isLoadingHistory else { return }
             guard !isWorkspaceRefinementInFlight else { return }
             // Flush buffered text so it lands before the tool call in content order.
-            flushStreamingBuffer()
+            flushStreamingBuffer(immediate: true)
             flushPartialOutputBuffer()
             lastToolUseReceivedAt = Date()
             // Suppress ToolCallChip for ui_show — the inline surface widget replaces it.
@@ -1636,7 +1687,7 @@ extension ChatViewModel {
             // `messages` before we try to finalize it below. This mirrors
             // the `messageComplete` path and preserves partial assistant
             // text for the user to see alongside the error.
-            flushStreamingBuffer()
+            flushStreamingBuffer(immediate: true)
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
                 messages[index].isStreaming = false

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -678,10 +678,21 @@ public final class ChatViewModel: ObservableObject {
     /// view-graph invalidation frequency during streaming.
     static let streamingFlushInterval: TimeInterval = 0.05 // 50 ms
 
+    /// Number of characters to emit per typewriter tick. Small batches
+    /// (2-4 chars) feel letter-by-letter while keeping CPU overhead low.
+    static let typewriterCharsPerTick: Int = 3
+
+    /// Interval between typewriter ticks when dripping characters.
+    static let typewriterTickInterval: TimeInterval = 0.012 // 12 ms
+
     /// Buffered text that has not yet been flushed to `messages`.
     var streamingDeltaBuffer: String = ""
     /// Scheduled flush work item; cancelled and re-created on each delta.
     var streamingFlushTask: Task<Void, Never>?
+    /// Typewriter drip task that emits characters one-by-one from the buffer.
+    var typewriterDripTask: Task<Void, Never>?
+    /// Accumulated text waiting to be dripped out character by character.
+    var typewriterQueue: String = ""
 
     // MARK: - Partial Output Coalescing
 
@@ -2150,7 +2161,7 @@ public final class ChatViewModel: ObservableObject {
 
         // Flush any buffered streaming text so already-received tokens are
         // visible before we set isCancelling (which suppresses future deltas).
-        flushStreamingBuffer()
+        flushStreamingBuffer(immediate: true)
 
         // Set cancelling flag so late-arriving deltas are suppressed.
         // isSending stays true until the daemon acknowledges the cancel
@@ -3281,6 +3292,7 @@ public final class ChatViewModel: ObservableObject {
         subManagerPublishTask?.cancel()
         messageLoopTask?.cancel()
         streamingFlushTask?.cancel()
+        typewriterDripTask?.cancel()
         partialOutputFlushTask?.cancel()
         cancelTimeoutTask?.cancel()
         loadMoreTimeoutTask?.cancel()


### PR DESCRIPTION
## Summary
- Replaces chunk-at-once streaming text display with a typewriter drip queue that emits ~3 characters every 12ms for smooth left-to-right letter-by-letter reveal (like Claude Desktop)
- On messageComplete, cancel, error, or tool calls the queue drains immediately so messages are never left incomplete
- Simplified `StreamingFadeRenderer` to pass-through draw (no opacity/fade effects) since the typewriter effect is now at the data layer

## Test plan
- [ ] Send a message and verify streaming text appears letter-by-letter, not in chunks
- [ ] Cancel a streaming message and verify all buffered text appears immediately
- [ ] Verify tool call messages still render correctly (text flushes before tool chip)
- [ ] Verify completed/non-streaming messages render instantly with no animation artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21673" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
