### PR TITLE
fix: match skills card description style to memory card

### DIFF
--- a/clients/ios/Views/Intelligence/InstalledSkillsView.swift
+++ b/clients/ios/Views/Intelligence/InstalledSkillsView.swift
@@ -98,8 +98,8 @@ struct InstalledSkillsView: View {
 
                 if !skill.description.isEmpty {
                     Text(skill.description)
-                        .font(VFont.labelDefault)
-                        .foregroundStyle(VColor.contentTertiary)
+                        .font(VFont.bodyMediumLighter)
+                        .foregroundStyle(VColor.contentSecondary)
                         .lineLimit(2)
                 }
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -311,7 +311,7 @@ struct SkillItemRow: View {
 
                     Text(skill.description)
                         .font(VFont.bodyMediumDefault)
-                        .foregroundStyle(VColor.contentTertiary)
+                        .foregroundStyle(VColor.contentSecondary)
                         .lineLimit(1)
                         .truncationMode(.tail)
                 }


### PR DESCRIPTION
## Summary
- Updated iOS skills list description from `VFont.labelDefault` + `contentTertiary` to `VFont.bodyMediumLighter` + `contentSecondary` to match memory list styling
- Updated macOS skills list description (AgentPanel, 2 places) from `contentTertiary` to `contentSecondary` to match memory row styling

## Original prompt
make sure in skills card description font color and size is the same as for memory card description

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21675" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
