### PR TITLE
fix: use snake_case base_url in platform proxy payload to match DRF serializer

### DIFF
--- a/assistant/src/oauth/platform-connection.test.ts
+++ b/assistant/src/oauth/platform-connection.test.ts
@@ -97,7 +97,7 @@ describe("PlatformOAuthConnection", () => {
     const client = makeMockClient(
       mock(async (_url: string | URL | Request, init?: RequestInit) => {
         const parsed = JSON.parse(init?.body as string);
-        expect(parsed.request.baseUrl).toBe(
+        expect(parsed.request.base_url).toBe(
           "https://www.googleapis.com/calendar/v3",
         );
 
@@ -120,7 +120,7 @@ describe("PlatformOAuthConnection", () => {
     const client = makeMockClient(
       mock(async (_url: string | URL | Request, init?: RequestInit) => {
         const parsed = JSON.parse(init?.body as string);
-        expect(parsed.request.baseUrl).toBe(
+        expect(parsed.request.base_url).toBe(
           "https://gmail.googleapis.com/gmail/v1/users/me",
         );
 
@@ -143,7 +143,7 @@ describe("PlatformOAuthConnection", () => {
     const client = makeMockClient(
       mock(async (_url: string | URL | Request, init?: RequestInit) => {
         const parsed = JSON.parse(init?.body as string);
-        expect(parsed.request.baseUrl).toBe(
+        expect(parsed.request.base_url).toBe(
           "https://www.googleapis.com/calendar/v3",
         );
 
@@ -166,11 +166,11 @@ describe("PlatformOAuthConnection", () => {
     });
   });
 
-  test("omits baseUrl from envelope when neither connection nor request provides one", async () => {
+  test("omits base_url from envelope when neither connection nor request provides one", async () => {
     const client = makeMockClient(
       mock(async (_url: string | URL | Request, init?: RequestInit) => {
         const parsed = JSON.parse(init?.body as string);
-        expect("baseUrl" in parsed.request).toBe(false);
+        expect("base_url" in parsed.request).toBe(false);
 
         return new Response(
           JSON.stringify({ status: 200, headers: {}, body: null }),

--- a/assistant/src/oauth/platform-connection.ts
+++ b/assistant/src/oauth/platform-connection.ts
@@ -71,7 +71,7 @@ export class PlatformOAuthConnection implements OAuthConnection {
         headers: req.headers ?? {},
         body: req.body ?? null,
         ...((req.baseUrl ?? this.baseUrl)
-          ? { baseUrl: req.baseUrl ?? this.baseUrl }
+          ? { base_url: req.baseUrl ?? this.baseUrl }
           : {}),
       },
     };


### PR DESCRIPTION
## Summary
- Fixed camelCase/snake_case mismatch in `PlatformOAuthConnection.request()` — the proxy payload was sending `baseUrl` but the platform DRF serializer expects `base_url`
- This caused all Gmail API calls in managed OAuth mode to 404 because the proxy silently fell back to the wrong default base URL (`https://www.googleapis.com` instead of `https://gmail.googleapis.com/gmail/v1/users/me`)
- Updated tests to assert on `base_url` (snake_case) in the serialized proxy envelope

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21677" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
