### PR TITLE
fix: flush typewriter buffer before inline surface show to prevent credential form hangs

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1496,6 +1496,12 @@ extension ChatViewModel {
             guard belongsToConversation(msg.conversationId) else { return }
             guard msg.display == nil || msg.display == "inline" || msg.display == "panel" else { break }
             guard let surface = Surface.from(msg) else { break }
+            // Flush any in-flight typewriter drip so the surface (e.g. a
+            // credential form) doesn't share a message with a tight 12ms
+            // mutation loop. Without this, every typewriter tick rebuilds
+            // the form view, starving the main thread.
+            flushStreamingBuffer(immediate: true)
+            flushPartialOutputBuffer()
 
             // Show floating overlay for task_progress cards (macOS only)
             #if os(macOS)


### PR DESCRIPTION
## Summary
- Flush the typewriter drip queue immediately when a `ui_surface_show` event arrives, before appending the surface to the current assistant message
- The typewriter feature (3 chars every 12ms = ~83 updates/sec) mutates `messages[]` on each tick. When a credential form surface is embedded in the same message, every tick triggers a full re-render of the form view — starving the main thread and causing the app to hang or become unresponsive during credential entry
- This matches the existing pattern used by `messageComplete`, `toolUseStart`, `confirmationRequest`, and `error` handlers, all of which flush immediately before inserting content that shouldn't coexist with an active typewriter loop
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21679" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
