### PR TITLE
Add subcommand-aware risk classification for assistant CLI

### DIFF
--- a/assistant/src/__tests__/cli-command-risk-guard.test.ts
+++ b/assistant/src/__tests__/cli-command-risk-guard.test.ts
@@ -1,7 +1,8 @@
-// Guard test: assistant CLI commands must always classify as Low risk.
+// Guard test: assistant CLI commands must classify at the expected risk level.
 //
-// The assistant uses its own CLI tools during normal operation. If these
-// commands require user approval, it blocks autonomous assistant workflows.
+// The assistant uses its own CLI tools during normal operation. Most commands
+// should be Low risk so they don't block autonomous workflows. Certain
+// sensitive subcommands are intentionally elevated to Medium or High.
 // See #18982 / #18998 for the regression that motivated this guard.
 
 import { mkdtempSync } from "node:fs";
@@ -60,10 +61,10 @@ function expectLowRisk(command: string, actual: RiskLevel): void {
   if (actual !== RiskLevel.Low) {
     throw new Error(
       `"${command}" classified as ${actual} instead of Low. ` +
-        `assistant CLI commands must always be Low risk — the assistant ` +
+        `assistant CLI commands must be Low risk by default — the assistant ` +
         `uses its own CLI during normal operation. If you need risk ` +
-        `escalation for specific subcommands, add them to an allowlist ` +
-        `in this guard test with justification.`,
+        `escalation for specific subcommands, add them to the elevated ` +
+        `risk tests in this guard test with justification.`,
     );
   }
   expect(actual).toBe(RiskLevel.Low);
@@ -86,6 +87,9 @@ describe("CLI command risk guard: assistant commands", () => {
 
   test("all assistant CLI subcommands classify as Low risk", async () => {
     for (const subcommand of ASSISTANT_SUBCOMMANDS) {
+      // Subcommands with elevated children are tested separately below.
+      // The bare top-level subcommand (e.g. `assistant oauth`) is still
+      // expected to be Low.
       const command = `assistant ${subcommand}`;
       const risk = await classifyRisk("bash", { command });
       expectLowRisk(command, risk);
@@ -105,6 +109,72 @@ describe("CLI command risk guard: assistant commands", () => {
     ];
 
     for (const command of flagCommands) {
+      const risk = await classifyRisk("bash", { command });
+      expectLowRisk(command, risk);
+    }
+  });
+});
+
+// Sensitive subcommands that are intentionally elevated above Low risk.
+// Each entry documents why the elevation is necessary.
+
+describe("CLI command risk guard: elevated assistant subcommands", () => {
+  test("assistant oauth token is High risk (exposes raw tokens)", async () => {
+    const risk = await classifyRisk("bash", {
+      command: "assistant oauth token",
+    });
+    expect(risk).toBe(RiskLevel.High);
+  });
+
+  test("assistant oauth mode --set is High risk (changes auth mode)", async () => {
+    const risk = await classifyRisk("bash", {
+      command: "assistant oauth mode --set managed",
+    });
+    expect(risk).toBe(RiskLevel.High);
+  });
+
+  test("assistant oauth mode without --set is Low risk (read-only)", async () => {
+    const risk = await classifyRisk("bash", {
+      command: "assistant oauth mode",
+    });
+    expect(risk).toBe(RiskLevel.Low);
+  });
+
+  test("assistant credentials reveal is High risk (exposes secrets)", async () => {
+    const risk = await classifyRisk("bash", {
+      command: "assistant credentials reveal",
+    });
+    expect(risk).toBe(RiskLevel.High);
+  });
+
+  test("assistant oauth request is Medium risk (initiates OAuth flow)", async () => {
+    const risk = await classifyRisk("bash", {
+      command: "assistant oauth request",
+    });
+    expect(risk).toBe(RiskLevel.Medium);
+  });
+
+  test("non-sensitive oauth subcommands remain Low risk", async () => {
+    const lowRiskOauthCommands = [
+      "assistant oauth apps",
+      "assistant oauth apps list",
+      "assistant oauth providers",
+      "assistant oauth status",
+    ];
+
+    for (const command of lowRiskOauthCommands) {
+      const risk = await classifyRisk("bash", { command });
+      expectLowRisk(command, risk);
+    }
+  });
+
+  test("non-sensitive credentials subcommands remain Low risk", async () => {
+    const lowRiskCredCommands = [
+      "assistant credentials",
+      "assistant credentials list",
+    ];
+
+    for (const command of lowRiskCredCommands) {
       const risk = await classifyRisk("bash", { command });
       expectLowRisk(command, risk);
     }

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -146,7 +146,6 @@ const LOW_RISK_PROGRAMS = new Set([
   "tree",
   "du",
   "df",
-  "assistant",
 ]);
 
 // High-risk shell programs / patterns
@@ -199,6 +198,35 @@ const LOW_RISK_GIT_SUBCOMMANDS = new Set([
   "cat-file",
   "reflog",
 ]);
+
+/**
+ * Classify risk for `assistant` CLI subcommands. Multi-word subcommands
+ * (e.g. `assistant oauth token`) are matched by walking the positional args.
+ */
+function classifyAssistantSubcommand(args: string[]): RiskLevel {
+  const sub = firstPositionalArg(args);
+  if (!sub) return RiskLevel.Low;
+
+  if (sub === "oauth") {
+    const oauthSub = firstPositionalArg(args.slice(args.indexOf(sub) + 1));
+    if (oauthSub === "token") return RiskLevel.High;
+    if (oauthSub === "mode") {
+      // `oauth mode --set` is high risk; bare `oauth mode` (read) is low
+      if (args.includes("--set")) return RiskLevel.High;
+      return RiskLevel.Low;
+    }
+    if (oauthSub === "request") return RiskLevel.Medium;
+    return RiskLevel.Low;
+  }
+
+  if (sub === "credentials") {
+    const credSub = firstPositionalArg(args.slice(args.indexOf(sub) + 1));
+    if (credSub === "reveal") return RiskLevel.High;
+    return RiskLevel.Low;
+  }
+
+  return RiskLevel.Low;
+}
 
 // Commands that wrap another program — the real program appears as the first
 // non-flag argument.  When one of these is the segment program we look through
@@ -741,6 +769,15 @@ async function classifyRiskUncached(
         }
         // Non-read-only git commands are medium
         maxRisk = RiskLevel.Medium;
+        continue;
+      }
+
+      if (prog === "assistant") {
+        const assistantRisk = classifyAssistantSubcommand(seg.args);
+        if (assistantRisk === RiskLevel.High) return RiskLevel.High;
+        if (assistantRisk === RiskLevel.Medium) {
+          maxRisk = RiskLevel.Medium;
+        }
         continue;
       }
 


### PR DESCRIPTION
## Summary
- Remove `assistant` from the blanket `LOW_RISK_PROGRAMS` set and add subcommand-aware risk classification following the existing `git` subcommand pattern
- High risk: `oauth token`, `oauth mode --set`, `credentials reveal` — these expose raw tokens/secrets or change auth modes
- Medium risk: `oauth request` — initiates an OAuth flow requiring user awareness
- Update guard tests to cover both the elevated subcommands and verify non-sensitive subcommands remain Low risk

## Original prompt
Add subcommand-aware risk classification for the `assistant` CLI in `assistant/src/permissions/checker.ts`, following the existing pattern used for `git` subcommands. Elevate `oauth token`, `oauth mode --set`, and `credentials reveal` to High risk; `oauth request` to Medium risk; everything else stays Low.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21680" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
