### PR TITLE
Clean up OAuth skill docs

### DIFF
--- a/skills/vellum-oauth-integrations/SKILL.md
+++ b/skills/vellum-oauth-integrations/SKILL.md
@@ -16,14 +16,9 @@ Integrating with a third-party software via OAuth is typically used to perform a
 
 ## The Assistant OAuth CLI
 
-You are provided with a rich CLI for performing all necessary oauth-related actions. Lean on it and its help documentation heavily. 
+You are provided with the `assistant oauth` CLI for performing all necessary oauth-related actions.
 
-```bash
-assistant oauth --help
-```
-
-**Important: **When in doubt how a command works or how to do something, read the references at the bottom and use `--help` with the CLI.
-
+**Important:** When in doubt how a command works or how to do something, read the references at the bottom. Never guess at how the CLI works. Read references and use the `--help` flag for any command you're about to run.
 
 ## Viewing Available OAuth Providers
 


### PR DESCRIPTION
## Summary
- Simplified the OAuth CLI introduction to be more direct
- Strengthened guidance to always read references and use `--help` instead of guessing at CLI usage
- Fixed minor markdown formatting (bold tag)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21681" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
