### PR TITLE
revert: remove band-aid typewriter flush from uiSurfaceShow

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1496,12 +1496,6 @@ extension ChatViewModel {
             guard belongsToConversation(msg.conversationId) else { return }
             guard msg.display == nil || msg.display == "inline" || msg.display == "panel" else { break }
             guard let surface = Surface.from(msg) else { break }
-            // Flush any in-flight typewriter drip so the surface (e.g. a
-            // credential form) doesn't share a message with a tight 12ms
-            // mutation loop. Without this, every typewriter tick rebuilds
-            // the form view, starving the main thread.
-            flushStreamingBuffer(immediate: true)
-            flushPartialOutputBuffer()
 
             // Show floating overlay for task_progress cards (macOS only)
             #if os(macOS)


### PR DESCRIPTION
## Summary
- Reverts the band-aid fix from #21679 that flushed the typewriter buffer on uiSurfaceShow
- The root cause is that the typewriter drip queue mutates @Published messages at 83Hz, causing full view hierarchy rebuilds — this needs an architectural fix, not per-event-type flushes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21682" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
