### PR TITLE
Fix --set=value bypass in assistant oauth mode risk classification

### DIFF
--- a/assistant/src/__tests__/cli-command-risk-guard.test.ts
+++ b/assistant/src/__tests__/cli-command-risk-guard.test.ts
@@ -133,6 +133,13 @@ describe("CLI command risk guard: elevated assistant subcommands", () => {
     expect(risk).toBe(RiskLevel.High);
   });
 
+  test("assistant oauth mode --set=value is High risk (equals syntax)", async () => {
+    const risk = await classifyRisk("bash", {
+      command: "assistant oauth mode google --set=managed",
+    });
+    expect(risk).toBe(RiskLevel.High);
+  });
+
   test("assistant oauth mode without --set is Low risk (read-only)", async () => {
     const risk = await classifyRisk("bash", {
       command: "assistant oauth mode",

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -211,8 +211,10 @@ function classifyAssistantSubcommand(args: string[]): RiskLevel {
     const oauthSub = firstPositionalArg(args.slice(args.indexOf(sub) + 1));
     if (oauthSub === "token") return RiskLevel.High;
     if (oauthSub === "mode") {
-      // `oauth mode --set` is high risk; bare `oauth mode` (read) is low
-      if (args.includes("--set")) return RiskLevel.High;
+      // `oauth mode --set` is high risk; bare `oauth mode` (read) is low.
+      // Match both `--set value` (two tokens) and `--set=value` (one token).
+      if (args.some((a) => a === "--set" || a.startsWith("--set=")))
+        return RiskLevel.High;
       return RiskLevel.Low;
     }
     if (oauthSub === "request") return RiskLevel.Medium;


### PR DESCRIPTION
## Summary
- Fix `args.includes("--set")` not matching `--set=managed` (single token) — use `args.some()` with a `startsWith` check to catch both `--set value` and `--set=value` syntax
- Add test case for the `--set=value` form to prevent regression
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21683" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
