### PR TITLE
Fix wrapper program bypass for assistant and git subcommand risk classification

### DIFF
--- a/assistant/src/__tests__/cli-command-risk-guard.test.ts
+++ b/assistant/src/__tests__/cli-command-risk-guard.test.ts
@@ -187,3 +187,43 @@ describe("CLI command risk guard: elevated assistant subcommands", () => {
     }
   });
 });
+
+describe("CLI command risk guard: wrapper program propagation", () => {
+  test("env assistant oauth token is High risk", async () => {
+    const risk = await classifyRisk("bash", {
+      command: "env assistant oauth token",
+    });
+    expect(risk).toBe(RiskLevel.High);
+  });
+
+  test("nice assistant credentials reveal is High risk", async () => {
+    const risk = await classifyRisk("bash", {
+      command: "nice assistant credentials reveal",
+    });
+    expect(risk).toBe(RiskLevel.High);
+  });
+
+  test("timeout 30 assistant oauth request is Medium risk", async () => {
+    const risk = await classifyRisk("bash", {
+      command: "timeout 30 assistant oauth request",
+    });
+    expect(risk).toBe(RiskLevel.Medium);
+  });
+
+  test("env assistant config is Low risk", async () => {
+    const risk = await classifyRisk("bash", {
+      command: "env assistant config",
+    });
+    expectLowRisk("env assistant config", risk);
+  });
+
+  test("env git push is Medium risk (not Low)", async () => {
+    const risk = await classifyRisk("bash", { command: "env git push" });
+    expect(risk).toBe(RiskLevel.Medium);
+  });
+
+  test("env git status is Low risk", async () => {
+    const risk = await classifyRisk("bash", { command: "env git status" });
+    expectLowRisk("env git status", risk);
+  });
+});

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -328,6 +328,28 @@ function getWrappedProgram(seg: {
   return undefined;
 }
 
+/**
+ * Like `getWrappedProgram`, but also returns the remaining args after the
+ * wrapped program name. This allows callers to propagate subcommand-aware
+ * classification (e.g. `env assistant oauth token` → classify `oauth token`).
+ */
+function getWrappedProgramWithArgs(seg: {
+  program: string;
+  args: string[];
+}): { program: string; args: string[] } | undefined {
+  const isEnv = seg.program === "env";
+  for (let i = 0; i < seg.args.length; i++) {
+    const arg = seg.args[i];
+    if (arg.startsWith("-")) {
+      if (isEnv && ENV_VALUE_FLAGS.has(arg)) i++;
+      continue;
+    }
+    if (isEnv && arg.includes("=")) continue;
+    return { program: arg, args: seg.args.slice(i + 1) };
+  }
+  return undefined;
+}
+
 function getStringField(
   input: Record<string, unknown>,
   ...keys: string[]
@@ -760,6 +782,34 @@ async function classifyRiskUncached(
         if (wrapped === "curl" || wrapped === "wget") {
           maxRisk = RiskLevel.Medium;
           continue;
+        }
+        // Propagate subcommand-aware classification for wrapped git/assistant
+        if (wrapped === "git") {
+          const wrappedWithArgs = getWrappedProgramWithArgs(seg);
+          if (wrappedWithArgs) {
+            const subcommand = firstPositionalArg(
+              wrappedWithArgs.args,
+              GIT_VALUE_FLAGS,
+            );
+            if (subcommand && LOW_RISK_GIT_SUBCOMMANDS.has(subcommand)) {
+              continue;
+            }
+            maxRisk = RiskLevel.Medium;
+            continue;
+          }
+        }
+        if (wrapped === "assistant") {
+          const wrappedWithArgs = getWrappedProgramWithArgs(seg);
+          if (wrappedWithArgs) {
+            const assistantRisk = classifyAssistantSubcommand(
+              wrappedWithArgs.args,
+            );
+            if (assistantRisk === RiskLevel.High) return RiskLevel.High;
+            if (assistantRisk === RiskLevel.Medium) {
+              maxRisk = RiskLevel.Medium;
+            }
+            continue;
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
- Add `getWrappedProgramWithArgs` helper to extract both the wrapped program name and its remaining args from wrapper invocations
- Propagate subcommand-aware classification for `git` and `assistant` through wrapper programs (`env`, `nice`, `nohup`, `timeout`, etc.)
- Add test coverage for wrapped invocations of sensitive assistant and git subcommands

Part of plan: wrapper-subcommand-risk.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21685" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
