### PR TITLE
fix: prevent assistant disconnect on non-managed logout/login

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -174,6 +174,18 @@ extension AppDelegate {
                 await authManager.logoutWithToast { [weak self] msg, style in
                     self?.mainWindow?.windowState.showToast(message: msg, style: style)
                 }
+
+                // Restore connectedAssistantId immediately — authManager.logout()
+                // clears it from UserDefaults, but clearDaemonCredentials() needs
+                // it to resolve the gateway connection via GatewayHTTPClient.
+                // Without it, all DELETE requests fail with "No connected assistant",
+                // triggering the fallback that disconnects and stops the assistant.
+                // Do NOT restore connectedOrganizationId: the org ID may belong
+                // to a different environment (e.g. dev vs prod). Letting bootstrap
+                // re-resolve it on the next login ensures it matches the session.
+                if let connectedAssistantId {
+                    UserDefaults.standard.set(connectedAssistantId, forKey: "connectedAssistantId")
+                }
             } else {
                 // Managed: user is redirected to the reauth screen regardless of
                 // HTTP outcome, so we don't toast. Log the error for diagnostics —
@@ -235,21 +247,11 @@ extension AppDelegate {
             if !wasManaged {
                 // Self-hosted (local or remote): clear auth state but keep the
                 // app running. The user can sign in again from Settings > General.
-
-                // Restore connectedAssistantId — authManager.logout() clears it
-                // from UserDefaults, but the app stays running in this path and
-                // the assistant process is still active.
-                // Do NOT restore connectedOrganizationId: the org ID may belong
-                // to a different environment (e.g. dev vs prod). Letting bootstrap
-                // re-resolve it on the next login ensures it matches the session.
-                if let connectedAssistantId {
-                    UserDefaults.standard.set(connectedAssistantId, forKey: "connectedAssistantId")
-                }
-
-                actorTokenBootstrapTask?.cancel()
-                actorTokenBootstrapTask = nil
-                ActorTokenManager.deleteToken()
-                hasSetupDaemon = false
+                // connectedAssistantId was already restored above (before
+                // clearDaemonCredentials). Preserve the actor token and gateway
+                // connection — the actor token authenticates to the local gateway
+                // (device-scoped, not user-scoped) and is independent of the
+                // platform auth session.
 
                 AvatarAppearanceManager.shared.reloadAvatar()
             } else {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1225,6 +1225,15 @@ struct MainWindowView: View {
                     Task {
                         await authManager.loginWithToast(showToast: { msg, style in
                             windowState.showToast(message: msg, style: style)
+                        }, onSuccess: {
+                            // Re-bootstrap actor credentials and local assistant API key
+                            // so the app can authenticate to the local assistant again.
+                            // Mirrors the pattern in SettingsPanel and proceedToApp().
+                            if !(AppDelegate.shared?.isCurrentAssistantManaged ?? false) {
+                                AppDelegate.shared?.ensureActorCredentials()
+                            }
+                            AppDelegate.shared?.localBootstrapDidComplete = false
+                            AppDelegate.shared?.ensureLocalAssistantApiKey()
                         })
                     }
                 },


### PR DESCRIPTION
## Summary
- Restore `connectedAssistantId` in UserDefaults immediately after `authManager.logout()` but before `clearDaemonCredentials()` runs, so the gateway DELETE requests can resolve the connection instead of failing with "No connected assistant" and triggering the fallback that kills the assistant process
- Preserve the actor token and gateway connection during non-managed logout — the actor token is device-scoped and independent of the platform auth session
- Add credential re-bootstrap (`ensureActorCredentials` + `ensureLocalAssistantApiKey`) to the drawer menu's Log In handler, mirroring what the Settings panel already does

## Test plan
- [ ] Log out from a non-managed local assistant via the drawer menu
- [ ] Verify the assistant stays connected (not "unreachable")
- [ ] Log back in from the drawer menu
- [ ] Verify credentials are re-provisioned and the assistant remains healthy
- [ ] Verify managed assistant logout still works correctly (full teardown)

## Original prompt
fix: restore connectedAssistantId before clearDaemonCredentials during non-managed logout

During non-managed logout, authManager.logout() clears connectedAssistantId from UserDefaults. clearDaemonCredentials() runs afterward and needs that ID to resolve the gateway connection via GatewayHTTPClient. Without it, all DELETE requests fail with "No connected assistant", triggering the fallback that disconnects and stops the assistant process. On re-login, the assistant is dead and credential bootstrap fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21688" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
