### PR TITLE
Add oauth connect/disconnect as Medium risk; --help bypass as Low risk

### DIFF
--- a/assistant/src/__tests__/cli-command-risk-guard.test.ts
+++ b/assistant/src/__tests__/cli-command-risk-guard.test.ts
@@ -161,6 +161,36 @@ describe("CLI command risk guard: elevated assistant subcommands", () => {
     expect(risk).toBe(RiskLevel.Medium);
   });
 
+  test("assistant oauth connect is Medium risk (modifies OAuth connections)", async () => {
+    const risk = await classifyRisk("bash", {
+      command: "assistant oauth connect",
+    });
+    expect(risk).toBe(RiskLevel.Medium);
+  });
+
+  test("assistant oauth disconnect is Medium risk (removes OAuth connections)", async () => {
+    const risk = await classifyRisk("bash", {
+      command: "assistant oauth disconnect",
+    });
+    expect(risk).toBe(RiskLevel.Medium);
+  });
+
+  test("--help on elevated subcommands is Low risk (read-only)", async () => {
+    const helpCommands = [
+      "assistant oauth token --help",
+      "assistant oauth mode --set --help",
+      "assistant credentials reveal --help",
+      "assistant oauth request --help",
+      "assistant oauth connect --help",
+      "assistant oauth disconnect -h",
+    ];
+
+    for (const command of helpCommands) {
+      const risk = await classifyRisk("bash", { command });
+      expectLowRisk(command, risk);
+    }
+  });
+
   test("non-sensitive oauth subcommands remain Low risk", async () => {
     const lowRiskOauthCommands = [
       "assistant oauth apps",

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -204,6 +204,9 @@ const LOW_RISK_GIT_SUBCOMMANDS = new Set([
  * (e.g. `assistant oauth token`) are matched by walking the positional args.
  */
 function classifyAssistantSubcommand(args: string[]): RiskLevel {
+  // `--help` on any subcommand is read-only, always Low risk.
+  if (args.some((a) => a === "--help" || a === "-h")) return RiskLevel.Low;
+
   const sub = firstPositionalArg(args);
   if (!sub) return RiskLevel.Low;
 
@@ -218,6 +221,8 @@ function classifyAssistantSubcommand(args: string[]): RiskLevel {
       return RiskLevel.Low;
     }
     if (oauthSub === "request") return RiskLevel.Medium;
+    if (oauthSub === "connect" || oauthSub === "disconnect")
+      return RiskLevel.Medium;
     return RiskLevel.Low;
   }
 


### PR DESCRIPTION
## Summary
- Elevate `assistant oauth connect` and `assistant oauth disconnect` to Medium risk (prompts user, can be trust-ruled)
- Add early return for `--help` / `-h` flags so help queries on elevated subcommands remain Low risk (no prompt)
- Add test coverage for both new Medium-risk subcommands and the --help bypass across all elevated commands

## Original prompt
Add `assistant oauth connect` and `assistant oauth disconnect` to the medium risk category. If the assistant is just using the `--help` flag for any of these medium or high risk commands on `assistant ...` it should be considered low risk.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21693" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
