### PR TITLE
fix: filter phantom empty messages causing duplicate timestamps

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1613,6 +1613,23 @@ public struct ChatMessage: Identifiable, Equatable {
     /// When true, this message was auto-sent by the client (e.g. bootstrap wake-up)
     /// and should not be shown to the user.
     public var isHidden: Bool = false
+    /// Whether this message has any content that would be rendered in the chat UI.
+    /// Phantom messages (empty text, no tool calls, no attachments, no special widgets)
+    /// can be created during streaming edge cases (e.g. API timeout/retry with massive
+    /// context) and should be excluded from the visible message list to prevent artifacts
+    /// like duplicate timestamp dividers.
+    public var hasRenderableContent: Bool {
+        !textSegments.isEmpty
+            || !toolCalls.isEmpty
+            || !attachments.isEmpty
+            || !inlineSurfaces.isEmpty
+            || confirmation != nil
+            || guardianDecision != nil
+            || modelList != nil
+            || commandList != nil
+            || isError
+    }
+
     /// When true, heavyweight content (tool results, large text, inputFull/inputRawDict)
     /// has been stripped from this message to reduce memory. The UI can use this flag
     /// to show a "load full content" affordance in a future milestone.

--- a/clients/shared/Features/Chat/ChatVisibleMessageFilter.swift
+++ b/clients/shared/Features/Chat/ChatVisibleMessageFilter.swift
@@ -6,9 +6,11 @@ import Foundation
 public enum ChatVisibleMessageFilter {
 
     /// Returns all messages that should be visible in the chat UI.
-    /// Excludes subagent notifications and hidden (automated) messages.
+    /// Excludes subagent notifications, hidden (automated) messages, and phantom
+    /// messages with no renderable content (which can arise from streaming edge
+    /// cases like API timeouts creating empty message shells).
     public static func visibleMessages(from messages: [ChatMessage]) -> [ChatMessage] {
-        messages.filter { !$0.isSubagentNotification && !$0.isHidden }
+        messages.filter { !$0.isSubagentNotification && !$0.isHidden && $0.hasRenderableContent }
     }
 
     /// Returns the paginated suffix of visible messages for a given `displayedMessageCount`.

--- a/clients/shared/Tests/ChatVisibleMessageFilterTests.swift
+++ b/clients/shared/Tests/ChatVisibleMessageFilterTests.swift
@@ -58,6 +58,29 @@ final class ChatVisibleMessageFilterTests: XCTestCase {
         XCTAssertEqual(result[1].text, "Why did the chicken cross the road?")
     }
 
+    func testPhantomEmptyMessagesAreFilteredOut() {
+        // Phantom messages with no renderable content (empty text, no tool calls,
+        // no attachments, no special widgets) should be excluded.
+        let phantom = ChatMessage(role: .assistant, text: "")
+        let visible = ChatMessage(role: .assistant, text: "Real response")
+
+        let result = ChatVisibleMessageFilter.visibleMessages(from: [phantom, visible])
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].text, "Real response")
+    }
+
+    func testMessagesWithToolCallsAreNotFilteredOut() {
+        var msg = ChatMessage(role: .assistant, text: "", toolCalls: [
+            ToolCallData(toolName: "Bash", inputSummary: "ls", inputFull: "", inputRawValue: "")
+        ])
+        msg.contentOrder = [.toolCall(0)]
+
+        let result = ChatVisibleMessageFilter.visibleMessages(from: [msg])
+
+        XCTAssertEqual(result.count, 1)
+    }
+
     func testEmptyArrayReturnsEmpty() {
         let result = ChatVisibleMessageFilter.visibleMessages(from: [])
         XCTAssertTrue(result.isEmpty)


### PR DESCRIPTION
## Summary
- Added `hasRenderableContent` computed property on `ChatMessage` that checks for any visible content (text, tool calls, attachments, inline surfaces, confirmation, guardian decision, model/command list, or error state)
- Updated `ChatVisibleMessageFilter.visibleMessages` to exclude messages without renderable content, closing the gap where phantom empty messages created during streaming could cause duplicate timestamp dividers
- Added tests for the new filtering behavior

## Original prompt
Add a `hasRenderableContent` computed property to `ChatMessage` that returns true if the message has non-empty text/textSegments, tool calls, attachments, inline surfaces, confirmation, modelList, commandList, guardianDecision, or isError. Then update `ChatVisibleMessageFilter` to also filter out messages where `!hasRenderableContent`, closing the gap where phantom empty messages created during streaming can appear in the visible message list and cause duplicate timestamp dividers.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
