### PR TITLE
refactor: remove typewriter drip queue — flush streaming text as full chunks at 50ms intervals

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -2795,4 +2795,125 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.currentAssistantMessageId,
                      "Stale flush should reset currentAssistantMessageId to nil")
     }
+
+    // MARK: - Buffered Text Before Finalize Invariant
+
+    func testMessageCompleteFlushesBufferedText() {
+        // Buffered text in streamingDeltaBuffer must appear in the final
+        // message when messageComplete arrives.
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Hello ")))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "world")))
+        // Don't manually flush — messageComplete should flush internally.
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage()))
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        XCTAssertEqual(viewModel.messages[0].text, "Hello world",
+                       "messageComplete should flush all buffered text")
+        XCTAssertFalse(viewModel.messages[0].isStreaming,
+                       "Message should no longer be streaming after messageComplete")
+    }
+
+    func testToolUseStartFlushesBufferedTextBeforeChip() {
+        // Buffered text must be flushed before the tool call chip so that
+        // text appears before the chip in contentOrder.
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Searching...")))
+        // Don't manually flush — toolUseStart should flush internally.
+        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(
+            type: "tool_use_start",
+            toolName: "bash",
+            input: ["command": AnyCodable("ls")],
+            conversationId: nil
+        )))
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        let msg = viewModel.messages[0]
+        XCTAssertEqual(msg.textSegments, ["Searching..."],
+                       "Buffered text should be flushed before tool call chip")
+        XCTAssertEqual(msg.toolCalls.count, 1)
+        // Text must come before tool call in content order.
+        XCTAssertEqual(msg.contentOrder, [.text(0), .toolCall(0)],
+                       "Text should appear before tool call in contentOrder")
+    }
+
+    func testToolUsePreviewStartFlushesBufferedTextBeforeChip() {
+        // Buffered text must be flushed before the preview chip so that
+        // text appears before the chip in contentOrder.
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Let me check...")))
+        // Don't manually flush — toolUsePreviewStart should flush internally.
+        viewModel.handleServerMessage(.toolUsePreviewStart(ToolUsePreviewStartMessage(
+            type: "tool_use_preview_start",
+            toolUseId: "tu-1",
+            toolName: "bash",
+            conversationId: nil
+        )))
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        let msg = viewModel.messages[0]
+        XCTAssertEqual(msg.textSegments, ["Let me check..."],
+                       "Buffered text should be flushed before preview chip")
+        XCTAssertEqual(msg.toolCalls.count, 1)
+        XCTAssertEqual(msg.contentOrder, [.text(0), .toolCall(0)],
+                       "Text should appear before preview chip in contentOrder")
+    }
+
+    func testUiSurfaceShowFlushesBufferedTextBeforeSurface() {
+        // Buffered text must be flushed before the inline surface so that
+        // text appears before the surface in contentOrder.
+        viewModel.conversationId = "sess-surface"
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Here is the result:")))
+        // Don't manually flush — uiSurfaceShow should flush internally.
+        let surfaceMsg = UiSurfaceShowMessage(
+            conversationId: "sess-surface",
+            surfaceId: "surface-flush-test",
+            surfaceType: "card",
+            title: "Test Card",
+            data: AnyCodable(["title": "Test Card", "body": "Card body"]),
+            actions: nil,
+            display: "inline",
+            messageId: nil
+        )
+        viewModel.handleServerMessage(.uiSurfaceShow(surfaceMsg))
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        let msg = viewModel.messages[0]
+        XCTAssertEqual(msg.textSegments, ["Here is the result:"],
+                       "Buffered text should be flushed before inline surface")
+        XCTAssertEqual(msg.inlineSurfaces.count, 1)
+        // Text must come before surface in content order.
+        XCTAssertTrue(msg.contentOrder.contains(.text(0)),
+                      "Content order should include text segment")
+        XCTAssertTrue(msg.contentOrder.contains(.surface(0)),
+                      "Content order should include surface")
+        guard let textIdx = msg.contentOrder.firstIndex(of: .text(0)),
+              let surfIdx = msg.contentOrder.firstIndex(of: .surface(0)) else {
+            XCTFail("Expected both text and surface in contentOrder")
+            return
+        }
+        XCTAssertTrue(textIdx < surfIdx,
+                      "Text should appear before surface in contentOrder")
+    }
+
+    func testConversationErrorPreservesBufferedText() {
+        // Buffered text must be preserved in the assistant message when an
+        // error arrives mid-stream.
+        viewModel.conversationId = "sess-err"
+        viewModel.isSending = true
+        viewModel.isThinking = true
+
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Partial response")))
+        // Don't manually flush — conversationError should flush internally.
+        let errorMsg = ConversationErrorMessage(
+            conversationId: "sess-err",
+            code: .conversationProcessingFailed,
+            userMessage: "Something went wrong",
+            retryable: true
+        )
+        viewModel.handleServerMessage(.conversationError(errorMsg))
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        XCTAssertEqual(viewModel.messages[0].text, "Partial response",
+                       "Buffered text should be preserved when error arrives mid-stream")
+        XCTAssertFalse(viewModel.messages[0].isStreaming,
+                       "Message should no longer be streaming after error")
+    }
 }

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -374,43 +374,18 @@ extension ChatViewModel {
         streamingFlushTask?.cancel()
         streamingFlushTask = nil
         streamingDeltaBuffer = ""
-        typewriterDripTask?.cancel()
-        typewriterDripTask = nil
-        typewriterQueue = ""
     }
 
     /// Flush any buffered streaming text into the messages array.
-    /// Called on a timer and also eagerly on `messageComplete`.
-    ///
-    /// When `immediate` is false (the normal streaming path), this
-    /// transfers buffered text into a typewriter drip queue that emits
-    /// characters a few at a time. When `immediate` is true (e.g.
-    /// messageComplete), all remaining text is flushed at once so the
-    /// final message is never incomplete.
-    func flushStreamingBuffer(immediate: Bool = false) {
-        // Always clear the task reference so scheduleStreamingFlush() can
-        // schedule a new flush even if the buffer was empty this time.
+    /// Called on a timer and also eagerly on `messageComplete`,
+    /// `toolUseStart`, `uiSurfaceShow`, etc.
+    func flushStreamingBuffer() {
         streamingFlushTask?.cancel()
         streamingFlushTask = nil
-        guard !streamingDeltaBuffer.isEmpty else {
-            // If immediate, also drain any remaining typewriter queue.
-            if immediate { drainTypewriterBuffer() }
-            return
-        }
+        guard !streamingDeltaBuffer.isEmpty else { return }
         let buffered = streamingDeltaBuffer
         streamingDeltaBuffer = ""
-
-        if immediate {
-            // Dump everything at once (message complete, cancel, etc.)
-            typewriterDripTask?.cancel()
-            typewriterDripTask = nil
-            appendTextToCurrentMessage(buffered)
-            drainTypewriterBuffer()
-        } else {
-            // Feed into the typewriter drip queue.
-            typewriterQueue += buffered
-            startTypewriterDripIfNeeded()
-        }
+        appendTextToCurrentMessage(buffered)
     }
 
     /// Append a chunk of text to the current assistant message.
@@ -440,32 +415,6 @@ extension ChatViewModel {
             currentAssistantMessageId = msg.id
             messages.append(msg)
             lastContentWasToolCall = false
-        }
-    }
-
-    /// Start the typewriter drip loop if it isn't already running.
-    private func startTypewriterDripIfNeeded() {
-        guard typewriterDripTask == nil else { return }
-        typewriterDripTask = Task { @MainActor [weak self] in
-            while let self, !Task.isCancelled, !self.typewriterQueue.isEmpty {
-                let count = min(Self.typewriterCharsPerTick, self.typewriterQueue.count)
-                let endIndex = self.typewriterQueue.index(self.typewriterQueue.startIndex, offsetBy: count)
-                let chunk = String(self.typewriterQueue[..<endIndex])
-                self.typewriterQueue = String(self.typewriterQueue[endIndex...])
-                self.appendTextToCurrentMessage(chunk)
-                try? await Task.sleep(nanoseconds: UInt64(Self.typewriterTickInterval * 1_000_000_000))
-            }
-            self?.typewriterDripTask = nil
-        }
-    }
-
-    /// Immediately flush all remaining typewriter queue text.
-    private func drainTypewriterBuffer() {
-        typewriterDripTask?.cancel()
-        typewriterDripTask = nil
-        if !typewriterQueue.isEmpty {
-            appendTextToCurrentMessage(typewriterQueue)
-            typewriterQueue = ""
         }
     }
 
@@ -624,7 +573,7 @@ extension ChatViewModel {
         case .messageComplete(let complete):
             guard belongsToConversation(complete.conversationId) else { return }
             // Flush any buffered streaming text before finalizing the message.
-            flushStreamingBuffer(immediate: true)
+            flushStreamingBuffer()
             flushPartialOutputBuffer()
             // Backfill the daemon's persisted message ID so fork, inspect,
             // TTS, and other daemon-anchored actions work without a history reload.
@@ -955,7 +904,7 @@ extension ChatViewModel {
             // created by the preceding assistant_text_delta so it doesn't remain
             // stuck in streaming state or cause subsequent deltas to append to it.
             if msg.runStillActive != true {
-                flushStreamingBuffer(immediate: true)
+                flushStreamingBuffer()
                 flushPartialOutputBuffer()
                 if let existingId = currentAssistantMessageId,
                    let index = messages.firstIndex(where: { $0.id == existingId }) {
@@ -981,7 +930,7 @@ extension ChatViewModel {
             isThinking = false
             // Flush buffered text so it lands on the current assistant message
             // before we clear the ID and hand off to the next queued turn.
-            flushStreamingBuffer(immediate: true)
+            flushStreamingBuffer()
             flushPartialOutputBuffer()
             // Must run before currentAssistantMessageId is cleared so attachments land on the right message
             ingestAssistantAttachments(handoff.attachments)
@@ -1040,7 +989,7 @@ extension ChatViewModel {
             let savedTurnUserText = currentTurnUserText
             // Flush any buffered text so already-received tokens are preserved
             // in the assistant message before we clear the turn state.
-            flushStreamingBuffer(immediate: true)
+            flushStreamingBuffer()
             flushPartialOutputBuffer()
             // Mark current assistant message as no longer streaming
             if let existingId = currentAssistantMessageId,
@@ -1159,7 +1108,7 @@ extension ChatViewModel {
         case .confirmationRequest(let msg):
             guard !isLoadingHistory else { return }
             // Flush buffered text before inserting the confirmation message.
-            flushStreamingBuffer(immediate: true)
+            flushStreamingBuffer()
             flushPartialOutputBuffer()
             // Route using conversationId when available (daemon >= v1.x includes
             // the conversationId). Fall back to the timestamp-based heuristic
@@ -1220,7 +1169,7 @@ extension ChatViewModel {
                 break
             }
             // Flush buffered text so it lands before the tool call in content order.
-            flushStreamingBuffer(immediate: true)
+            flushStreamingBuffer()
             flushPartialOutputBuffer()
             // If a chip with the same toolUseId already exists (e.g. toolUseStart
             // arrived before this preview), ignore the late preview.
@@ -1264,7 +1213,7 @@ extension ChatViewModel {
             guard !isLoadingHistory else { return }
             guard !isWorkspaceRefinementInFlight else { return }
             // Flush buffered text so it lands before the tool call in content order.
-            flushStreamingBuffer(immediate: true)
+            flushStreamingBuffer()
             flushPartialOutputBuffer()
             lastToolUseReceivedAt = Date()
             // Suppress ToolCallChip for ui_show — the inline surface widget replaces it.
@@ -1497,6 +1446,10 @@ extension ChatViewModel {
             guard msg.display == nil || msg.display == "inline" || msg.display == "panel" else { break }
             guard let surface = Surface.from(msg) else { break }
 
+            // Flush buffered text so it lands before the surface in content order.
+            flushStreamingBuffer()
+            flushPartialOutputBuffer()
+
             // Show floating overlay for task_progress cards (macOS only)
             #if os(macOS)
             if case .card(let cardData) = surface.data,
@@ -1687,7 +1640,7 @@ extension ChatViewModel {
             // `messages` before we try to finalize it below. This mirrors
             // the `messageComplete` path and preserves partial assistant
             // text for the user to see alongside the error.
-            flushStreamingBuffer(immediate: true)
+            flushStreamingBuffer()
             if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
                 messages[index].isStreaming = false

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -678,21 +678,10 @@ public final class ChatViewModel: ObservableObject {
     /// view-graph invalidation frequency during streaming.
     static let streamingFlushInterval: TimeInterval = 0.05 // 50 ms
 
-    /// Number of characters to emit per typewriter tick. Small batches
-    /// (2-4 chars) feel letter-by-letter while keeping CPU overhead low.
-    static let typewriterCharsPerTick: Int = 3
-
-    /// Interval between typewriter ticks when dripping characters.
-    static let typewriterTickInterval: TimeInterval = 0.012 // 12 ms
-
     /// Buffered text that has not yet been flushed to `messages`.
     var streamingDeltaBuffer: String = ""
     /// Scheduled flush work item; cancelled and re-created on each delta.
     var streamingFlushTask: Task<Void, Never>?
-    /// Typewriter drip task that emits characters one-by-one from the buffer.
-    var typewriterDripTask: Task<Void, Never>?
-    /// Accumulated text waiting to be dripped out character by character.
-    var typewriterQueue: String = ""
 
     // MARK: - Partial Output Coalescing
 
@@ -2161,7 +2150,7 @@ public final class ChatViewModel: ObservableObject {
 
         // Flush any buffered streaming text so already-received tokens are
         // visible before we set isCancelling (which suppresses future deltas).
-        flushStreamingBuffer(immediate: true)
+        flushStreamingBuffer()
 
         // Set cancelling flag so late-arriving deltas are suppressed.
         // isSending stays true until the daemon acknowledges the cancel
@@ -3292,7 +3281,6 @@ public final class ChatViewModel: ObservableObject {
         subManagerPublishTask?.cancel()
         messageLoopTask?.cancel()
         streamingFlushTask?.cancel()
-        typewriterDripTask?.cancel()
         partialOutputFlushTask?.cancel()
         cancelTimeoutTask?.cancel()
         loadMoreTimeoutTask?.cancel()


### PR DESCRIPTION
## Summary
- Remove typewriter drip queue (3 chars/12ms) that caused 83 model mutations/sec, COW array copies, and markdown mis-parses on transient 3-char boundaries
- Simplify flushStreamingBuffer to always flush directly at 50ms intervals — no immediate parameter, no typewriter queue
- Add flushStreamingBuffer to uiSurfaceShow handler to fix content ordering (buffered text was landing after inline surfaces)
- Add regression tests for buffered-text-before-finalize invariant across messageComplete, toolUseStart, toolUsePreviewStart, uiSurfaceShow, and error paths

Part of plan: view-layer-typewriter.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)