### PR TITLE
fix: Respect -- option terminator in assistant --help risk bypass

### DIFF
--- a/assistant/src/__tests__/cli-command-risk-guard.test.ts
+++ b/assistant/src/__tests__/cli-command-risk-guard.test.ts
@@ -191,6 +191,13 @@ describe("CLI command risk guard: elevated assistant subcommands", () => {
     }
   });
 
+  test("--help after -- option terminator does not downgrade risk", async () => {
+    const risk = await classifyRisk("bash", {
+      command: "assistant oauth token -- --help",
+    });
+    expect(risk).toBe(RiskLevel.High);
+  });
+
   test("non-sensitive oauth subcommands remain Low risk", async () => {
     const lowRiskOauthCommands = [
       "assistant oauth apps",

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -205,7 +205,11 @@ const LOW_RISK_GIT_SUBCOMMANDS = new Set([
  */
 function classifyAssistantSubcommand(args: string[]): RiskLevel {
   // `--help` on any subcommand is read-only, always Low risk.
-  if (args.some((a) => a === "--help" || a === "-h")) return RiskLevel.Low;
+  // Only check args before `--` (option terminator) — after `--`, tokens
+  // are positional arguments, not flags.
+  const ddIndex = args.indexOf("--");
+  const flagArgs = ddIndex === -1 ? args : args.slice(0, ddIndex);
+  if (flagArgs.some((a) => a === "--help" || a === "-h")) return RiskLevel.Low;
 
   const sub = firstPositionalArg(args);
   if (!sub) return RiskLevel.Low;


### PR DESCRIPTION
## Summary
- Only check for `--help`/`-h` flags before `--` (option terminator) in `classifyAssistantSubcommand` — after `--`, tokens are positional arguments, not flags
- Add test verifying `assistant oauth token -- --help` remains High risk

## Original prompt
Fix the `--help`/`-h` early return in `classifyAssistantSubcommand` to only check for help flags before a `--` option terminator. `assistant oauth token -- --help` should still classify as High risk.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21702" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
