### PR TITLE
fix: add missing fields to hasRenderableContent

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1628,6 +1628,9 @@ public struct ChatMessage: Identifiable, Equatable {
             || modelList != nil
             || commandList != nil
             || isError
+            || streamingCodePreview != nil
+            || skillInvocation != nil
+            || !attachmentWarnings.isEmpty
     }
 
     /// When true, heavyweight content (tool results, large text, inputFull/inputRawDict)

--- a/clients/shared/Tests/ChatVisibleMessageFilterTests.swift
+++ b/clients/shared/Tests/ChatVisibleMessageFilterTests.swift
@@ -81,6 +81,18 @@ final class ChatVisibleMessageFilterTests: XCTestCase {
         XCTAssertEqual(result.count, 1)
     }
 
+    func testMessageWithOnlyStreamingCodePreviewIsNotFilteredOut() {
+        // Messages created during app_create streaming have only streamingCodePreview set
+        // with empty text and no other content. They must pass the visibility filter.
+        var msg = ChatMessage(role: .assistant, text: "")
+        msg.streamingCodePreview = "<html><body>Hello</body></html>"
+
+        let result = ChatVisibleMessageFilter.visibleMessages(from: [msg])
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].streamingCodePreview, "<html><body>Hello</body></html>")
+    }
+
     func testEmptyArrayReturnsEmpty() {
         let result = ChatVisibleMessageFilter.visibleMessages(from: [])
         XCTAssertTrue(result.isEmpty)


### PR DESCRIPTION
## Summary
- Added `streamingCodePreview`, `skillInvocation`, and `attachmentWarnings` checks to `ChatMessage.hasRenderableContent`
- Added test verifying messages with only `streamingCodePreview` pass the visibility filter

Closes #21701
Part of #21700
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21704" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
