### PR TITLE
test: add regression test verifying full-chunk flush

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -2916,4 +2916,42 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.messages[0].isStreaming,
                        "Message should no longer be streaming after error")
     }
+
+    // MARK: - Full-Chunk Flush Regression
+
+    func testFlushStreamingBufferAppendsFullChunkNotSubdivisions() {
+        // Regression test: flushStreamingBuffer must append the entire
+        // streamingDeltaBuffer in a single appendTextToCurrentMessage call,
+        // producing one contiguous text segment — NOT artificial 3-char
+        // subdivisions from the removed typewriter drip queue.
+
+        // Simulate several assistantTextDelta events that accumulate in
+        // the buffer without any intermediate flush (e.g., rapid deltas
+        // arriving within the throttle window).
+        let deltas = ["Here ", "is ", "a ", "longer ", "piece ", "of ", "markdown: ", "**bold** and `code`."]
+        for delta in deltas {
+            // Directly buffer like the delta handler does, bypassing the
+            // scheduled flush timer so nothing drains mid-test.
+            viewModel.streamingDeltaBuffer += delta
+        }
+
+        // Ensure an assistant message exists for the flush to target.
+        let msg = ChatMessage(role: .assistant, text: "", isStreaming: true)
+        viewModel.currentAssistantMessageId = msg.id
+        viewModel.messages.append(msg)
+
+        // Act: flush the entire buffer in one shot.
+        viewModel.flushStreamingBuffer()
+
+        // Assert: the message should contain exactly one text segment with
+        // the full concatenated buffer — no 3-char splits.
+        let expectedText = deltas.joined()
+        XCTAssertEqual(viewModel.messages.count, 1)
+        XCTAssertEqual(viewModel.messages[0].textSegments.count, 1,
+                       "Flush should produce exactly one text segment, not multiple subdivisions")
+        XCTAssertEqual(viewModel.messages[0].textSegments.first, expectedText,
+                       "The single text segment should contain all buffered text")
+        XCTAssertTrue(viewModel.streamingDeltaBuffer.isEmpty,
+                      "Buffer should be empty after flush")
+    }
 }


### PR DESCRIPTION
## Summary
Adds a regression test (`testFlushStreamingBufferAppendsFullChunkNotSubdivisions`) that verifies `flushStreamingBuffer()` appends the entire buffered text in a single `appendTextToCurrentMessage` call, producing exactly one text segment — not artificial 3-char subdivisions from the removed typewriter drip queue.

## Test plan
- [ ] Verify the new test passes in Xcode (macOS test target)
- [ ] Confirm no existing tests are broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21705" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
