### PR TITLE
fix: complete hasRenderableContent coverage for ChatMessage

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1628,6 +1628,9 @@ public struct ChatMessage: Identifiable, Equatable {
             || modelList != nil
             || commandList != nil
             || isError
+            || streamingCodePreview != nil
+            || skillInvocation != nil
+            || !attachmentWarnings.isEmpty
     }
 
     /// When true, heavyweight content (tool results, large text, inputFull/inputRawDict)

--- a/clients/shared/Tests/ChatVisibleMessageFilterTests.swift
+++ b/clients/shared/Tests/ChatVisibleMessageFilterTests.swift
@@ -81,6 +81,18 @@ final class ChatVisibleMessageFilterTests: XCTestCase {
         XCTAssertEqual(result.count, 1)
     }
 
+    func testMessageWithOnlyStreamingCodePreviewIsNotFilteredOut() {
+        // Messages created during app_create streaming have only streamingCodePreview set
+        // with empty text and no other content. They must pass the visibility filter.
+        var msg = ChatMessage(role: .assistant, text: "")
+        msg.streamingCodePreview = "<html><body>Hello</body></html>"
+
+        let result = ChatVisibleMessageFilter.visibleMessages(from: [msg])
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].streamingCodePreview, "<html><body>Hello</body></html>")
+    }
+
     func testEmptyArrayReturnsEmpty() {
         let result = ChatVisibleMessageFilter.visibleMessages(from: [])
         XCTAssertTrue(result.isEmpty)


### PR DESCRIPTION
## Summary
Addresses review feedback on PR #21694 — the `hasRenderableContent` computed property was missing checks for `streamingCodePreview`, `skillInvocation`, and `attachmentWarnings`, which could cause those message types to be incorrectly filtered from the visible message list.

## Changes
- Added `streamingCodePreview != nil` check — real bug fix (messages with only streaming HTML preview were hidden during app_create)
- Added `skillInvocation != nil` check — defensive (skill chips are renderable)
- Added `!attachmentWarnings.isEmpty` check — defensive (warning banners are renderable)
- Added test verifying messages with only `streamingCodePreview` pass the visibility filter

## Milestone PRs (merged into feature branch)
- #21704: fix: add missing fields to hasRenderableContent

## Project issue
Closes #21700

## Test plan
- [ ] Verify `app_create` streaming HTML preview is visible during generation
- [ ] Verify skill invocation messages remain visible
- [ ] Verify attachment warning messages remain visible
- [ ] Verify phantom empty messages are still filtered (no regression)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21706" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
