### PR TITLE
Refactor avatar animations to use canonical names

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
@@ -64,6 +64,28 @@ private struct AvatarLayerRepresentable: NSViewRepresentable {
 }
 
 class AvatarLayerView: NSView {
+
+    // MARK: - Animation & Action Catalog
+    //
+    // Animations (canonical names — used as CAAnimation keys):
+    //   breathing — body scale pulse (inhale/exhale loop)
+    //   blink     — eye open/close cycle
+    //   twitch    — subtle body rotation wobble
+    //   poke      — squash-and-stretch spring on body
+    //   widen     — eye path widen/unwiden
+    //   entry     — water-drop bounce-in on body
+    //   reveal    — eye open during entry (sub-animation of entry action)
+    //   morph     — streaming body path wobble + squash/stretch/rotation
+    //              (morph.scaleX, morph.scaleY, morph.rotation)
+    //
+    // Actions (triggers that invoke one or more animations):
+    //   hover     → widen
+    //   poke      → poke (click)
+    //   entry     → entry + reveal, then after delay: breathing, blink, twitch
+    //   streaming → morph (pauses breathing while active)
+
+    // MARK: - Properties
+
     private var bodyLayer = CAShapeLayer()
     private var eyeLayers: [CAShapeLayer] = []
 
@@ -109,12 +131,12 @@ class AvatarLayerView: NSView {
     /// Cached current body shape and size for morph path generation.
     private var currentBodyShape: AvatarBodyShape?
     private var currentSize: CGFloat = 0
-    /// Pre-computed wobbled body paths for streaming animation.
+    /// Pre-computed wobbled body paths for morph animation.
     /// Index 0 is the original shape; remaining indices are wobble variants.
-    private var bodyWobblePaths: [CGPath] = []
-    /// Timer-driven path cycling for the wobble animation.
-    private var wobbleTimer: Task<Void, Never>?
-    private var wobbleFrameIndex: Int = 0
+    private var morphPaths: [CGPath] = []
+    /// Timer-driven path cycling for the morph animation.
+    private var morphTimer: Task<Void, Never>?
+    private var morphFrameIndex: Int = 0
 
     /// Notification observers for window key/resign-key events.
     private var notificationObservers: [NSObjectProtocol] = []
@@ -134,38 +156,16 @@ class AvatarLayerView: NSView {
     }
 
     /// Called from SwiftUI's `.onHover` via the representable bridge.
-    /// Animates eye paths between widened (hovered) and normal (not hovered).
+    /// Triggers the hover action: widen animation on hover-in, unwiden on hover-out.
     func updateHoverState(_ hovered: Bool) {
         guard hovered != isHovered else { return }
         isHovered = hovered
 
         if hovered {
             guard animationsActive else { isHovered = false; return }
-            guard !eyeLayers.isEmpty,
-                  eyeLayers.count == widenedEyePaths.count else { return }
-
-            for (i, eyeLayer) in eyeLayers.enumerated() {
-                let animation = CABasicAnimation(keyPath: "path")
-                animation.fromValue = eyeLayer.path
-                animation.toValue = widenedEyePaths[i]
-                animation.duration = 0.12
-                animation.timingFunction = CAMediaTimingFunction(name: .easeOut)
-                eyeLayer.path = widenedEyePaths[i]
-                eyeLayer.add(animation, forKey: "eyeWiden")
-            }
+            performWiden()
         } else {
-            guard !eyeLayers.isEmpty,
-                  eyeLayers.count == openEyePaths.count else { return }
-
-            for (i, eyeLayer) in eyeLayers.enumerated() {
-                let animation = CABasicAnimation(keyPath: "path")
-                animation.fromValue = eyeLayer.path
-                animation.toValue = openEyePaths[i]
-                animation.duration = 0.2
-                animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-                eyeLayer.path = openEyePaths[i]
-                eyeLayer.add(animation, forKey: "eyeWiden")
-            }
+            performUnwiden()
         }
     }
 
@@ -246,10 +246,10 @@ class AvatarLayerView: NSView {
         bodyLayer.anchorPoint = CGPoint(x: 0.5, y: 0.5)
         bodyLayer.position = CGPoint(x: frame.width / 2, y: frame.height / 2)
 
-        // Pre-compute wobbled body paths for streaming animation.
+        // Pre-compute morph paths for streaming animation.
         // Mirrors the eye blink approach: same EditablePath, same transform,
         // just control points perturbed — guarantees identical element count.
-        bodyWobblePaths.removeAll()
+        morphPaths.removeAll()
         if bodyViewBox.width > 0 && bodyViewBox.height > 0 {
             let wobbleAmount: CGFloat = 0.12  // ±12% radial scale
             for seed in 0..<16 {
@@ -257,7 +257,7 @@ class AvatarLayerView: NSView {
                 let wCGPath = wobbled.toCGPath()
                 var wTransform = bodyTransform
                 if let transformed = wCGPath.copy(using: &wTransform) {
-                    bodyWobblePaths.append(transformed)
+                    morphPaths.append(transformed)
                 }
             }
         }
@@ -409,53 +409,53 @@ class AvatarLayerView: NSView {
         bodyLayer.add(breathe, forKey: "breathing")
     }
 
-    // MARK: - Streaming Body Morph
+    // MARK: - Streaming (morph)
 
     func updateStreamingState(_ streaming: Bool) {
         guard streaming != isStreamingActive else { return }
         isStreamingActive = streaming
         if streaming {
-            startBodyMorph()
+            startMorph()
         } else {
-            stopBodyMorph()
+            stopMorph()
         }
     }
 
-    private func startBodyMorph() {
-        guard bodyWobblePaths.count >= 2 else { return }
+    private func startMorph() {
+        guard morphPaths.count >= 2 else { return }
 
         // Remove breathing — conflicts with morph.
         bodyLayer.removeAnimation(forKey: "breathing")
-        wobbleTimer?.cancel()
-        wobbleFrameIndex = 0
+        morphTimer?.cancel()
+        morphFrameIndex = 0
 
-        // Timer-driven path morphing: cycle through wobble paths using
+        // Timer-driven path morphing: cycle through morph paths using
         // CABasicAnimation for smooth interpolation between each pair.
         // This approach is proven to work (same as eye blink transitions).
-        wobbleTimer = Task { [weak self] in
+        morphTimer = Task { [weak self] in
             while !Task.isCancelled {
                 try? await Task.sleep(nanoseconds: 150_000_000) // 0.15s per frame
                 guard !Task.isCancelled, let self = self else { return }
                 await MainActor.run {
-                    guard self.isStreamingActive, self.bodyWobblePaths.count >= 2 else { return }
-                    let fromIndex = self.wobbleFrameIndex
-                    let toIndex = (fromIndex + 1) % self.bodyWobblePaths.count
-                    self.wobbleFrameIndex = toIndex
+                    guard self.isStreamingActive, self.morphPaths.count >= 2 else { return }
+                    let fromIndex = self.morphFrameIndex
+                    let toIndex = (fromIndex + 1) % self.morphPaths.count
+                    self.morphFrameIndex = toIndex
 
                     let anim = CABasicAnimation(keyPath: "path")
-                    anim.fromValue = self.bodyWobblePaths[fromIndex]
-                    anim.toValue = self.bodyWobblePaths[toIndex]
+                    anim.fromValue = self.morphPaths[fromIndex]
+                    anim.toValue = self.morphPaths[toIndex]
                     anim.duration = 0.3
                     anim.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
                     anim.fillMode = .forwards
                     anim.isRemovedOnCompletion = false
-                    self.bodyLayer.add(anim, forKey: "bodyMorph")
-                    self.bodyLayer.path = self.bodyWobblePaths[toIndex]
+                    self.bodyLayer.add(anim, forKey: "morph")
+                    self.bodyLayer.path = self.morphPaths[toIndex]
                 }
             }
         }
 
-        // Transform wobble layered on top for squash/stretch/rotation.
+        // Transform morph layered on top for squash/stretch/rotation.
         let scaleX = CAKeyframeAnimation(keyPath: "transform.scale.x")
         scaleX.values = [1.0, 1.04, 0.97, 1.02, 1.0]
         scaleX.keyTimes = [0, 0.25, 0.5, 0.75, 1.0] as [NSNumber]
@@ -477,20 +477,20 @@ class AvatarLayerView: NSView {
         rotation.repeatCount = .infinity
         rotation.timingFunctions = Array(repeating: CAMediaTimingFunction(name: .easeInEaseOut), count: 4)
 
-        bodyLayer.add(scaleX, forKey: "bodyMorph.scaleX")
-        bodyLayer.add(scaleY, forKey: "bodyMorph.scaleY")
-        bodyLayer.add(rotation, forKey: "bodyMorph.rotation")
+        bodyLayer.add(scaleX, forKey: "morph.scaleX")
+        bodyLayer.add(scaleY, forKey: "morph.scaleY")
+        bodyLayer.add(rotation, forKey: "morph.rotation")
     }
 
-    private func stopBodyMorph() {
-        wobbleTimer?.cancel()
-        wobbleTimer = nil
-        bodyLayer.removeAnimation(forKey: "bodyMorph")
-        bodyLayer.removeAnimation(forKey: "bodyMorph.scaleX")
-        bodyLayer.removeAnimation(forKey: "bodyMorph.scaleY")
-        bodyLayer.removeAnimation(forKey: "bodyMorph.rotation")
+    private func stopMorph() {
+        morphTimer?.cancel()
+        morphTimer = nil
+        bodyLayer.removeAnimation(forKey: "morph")
+        bodyLayer.removeAnimation(forKey: "morph.scaleX")
+        bodyLayer.removeAnimation(forKey: "morph.scaleY")
+        bodyLayer.removeAnimation(forKey: "morph.rotation")
         // Restore original path (index 0 is the unmodified shape)
-        if let original = bodyWobblePaths.first {
+        if let original = morphPaths.first {
             CATransaction.begin()
             CATransaction.setDisableActions(true)
             bodyLayer.path = original
@@ -539,7 +539,7 @@ class AvatarLayerView: NSView {
 
             // Trigger entry after a runloop tick so the view is laid out
             DispatchQueue.main.async { [weak self] in
-                self?.performEntryAnimation()
+                self?.performEntry()
             }
             return
         }
@@ -629,7 +629,7 @@ class AvatarLayerView: NSView {
         guard let rootLayer = layer else { return }
 
         // Play the character poke sound immediately on click, before starting the
-        // wobble animation. NSSound.play() is non-blocking so it won't delay the
+        // poke animation. NSSound.play() is non-blocking so it won't delay the
         // animation start — both fire in the same run-loop tick.
         SoundManager.shared.play(.characterPoke)
 
@@ -666,7 +666,7 @@ class AvatarLayerView: NSView {
         rootLayer.add(animation, forKey: "poke")
     }
 
-    private func performEntryAnimation() {
+    private func performEntry() {
         guard let rootLayer = layer else { return }
         entrySetupPending = false
 
@@ -714,7 +714,7 @@ class AvatarLayerView: NSView {
             anim.fillMode = .backwards  // Show closed eyes until beginTime
             anim.isRemovedOnCompletion = true
             anim.timingFunction = CAMediaTimingFunction(name: .easeOut)
-            eyeLayer.add(anim, forKey: "eyeReveal")
+            eyeLayer.add(anim, forKey: "reveal")
         }
 
         // --- Start other animations after a comfortable pause post-entry ---
@@ -772,6 +772,36 @@ class AvatarLayerView: NSView {
             }
             animation.isRemovedOnCompletion = true
             eyeLayer.add(animation, forKey: "blink")
+        }
+    }
+
+    private func performWiden() {
+        guard !eyeLayers.isEmpty,
+              eyeLayers.count == widenedEyePaths.count else { return }
+
+        for (i, eyeLayer) in eyeLayers.enumerated() {
+            let animation = CABasicAnimation(keyPath: "path")
+            animation.fromValue = eyeLayer.path
+            animation.toValue = widenedEyePaths[i]
+            animation.duration = 0.12
+            animation.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            eyeLayer.path = widenedEyePaths[i]
+            eyeLayer.add(animation, forKey: "widen")
+        }
+    }
+
+    private func performUnwiden() {
+        guard !eyeLayers.isEmpty,
+              eyeLayers.count == openEyePaths.count else { return }
+
+        for (i, eyeLayer) in eyeLayers.enumerated() {
+            let animation = CABasicAnimation(keyPath: "path")
+            animation.fromValue = eyeLayer.path
+            animation.toValue = openEyePaths[i]
+            animation.duration = 0.2
+            animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            eyeLayer.path = openEyePaths[i]
+            eyeLayer.add(animation, forKey: "widen")
         }
     }
 }


### PR DESCRIPTION
## Summary
- Added animation & action catalog MARK section documenting all 8 canonical animation names and 4 action triggers
- Renamed animation keys and methods for consistency: `bodyMorph` → `morph`, `eyeWiden` → `widen`, `eyeReveal` → `reveal`, `performEntryAnimation` → `performEntry`, `startBodyMorph`/`stopBodyMorph` → `startMorph`/`stopMorph`
- Extracted `performWiden()`/`performUnwiden()` from inline `updateHoverState()` logic, renamed `bodyWobblePaths`/`wobbleTimer`/`wobbleFrameIndex` → `morphPaths`/`morphTimer`/`morphFrameIndex`

## Original prompt
Refactor AnimatedAvatarView.swift to use canonical animation and action names. Each animation should have a canonical name (e.g. "breathing", "blink", "twitch"), and actions are triggers that invoke one or more animations (e.g. "hover" triggers "widen").
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
