### PR TITLE
Fix: cancel morphTimer in deinit and pauseAnimations

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AnimatedAvatarView.swift
@@ -202,6 +202,7 @@ class AvatarLayerView: NSView {
         blinkTask?.cancel()
         twitchTask?.cancel()
         postEntryTask?.cancel()
+        morphTimer?.cancel()
         for observer in notificationObservers {
             NotificationCenter.default.removeObserver(observer)
         }
@@ -624,6 +625,7 @@ class AvatarLayerView: NSView {
         blinkTask?.cancel()
         twitchTask?.cancel()
         postEntryTask?.cancel()
+        morphTimer?.cancel()
         if configBreathingEnabled {
             let pausedTime = bodyLayer.convertTime(CACurrentMediaTime(), from: nil)
             bodyLayer.speed = 0


### PR DESCRIPTION
## Summary
- Cancel `morphTimer` in `deinit` alongside `blinkTask`, `twitchTask`, and `postEntryTask` for consistency
- Cancel `morphTimer` in `pauseAnimations()` to stop the 150ms morph cycle when the window loses focus

## Original prompt
Address review feedback from PR #21707: morphTimer was not being cancelled in deinit or pauseAnimations, unlike all other async tasks.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21710" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
