### PR TITLE
Add allowedHosts field to BundleMetadata and manifest types

### DIFF
--- a/clients/macos/vellum-assistant/Features/Sharing/BundleSandbox.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/BundleSandbox.swift
@@ -27,12 +27,66 @@ enum BundleSandbox {
         let createdAt: String
         let createdBy: String
         let capabilities: [String]
+        let allowedHosts: [String]
         let trustTier: String
         let signerKeyId: String?
         let signerDisplayName: String?
         let signerAccount: String?
         let bundleSizeBytes: Int
         let installedAt: String
+
+        init(
+            uuid: String,
+            name: String,
+            description: String?,
+            icon: String?,
+            entry: String,
+            createdAt: String,
+            createdBy: String,
+            capabilities: [String],
+            allowedHosts: [String] = [],
+            trustTier: String,
+            signerKeyId: String?,
+            signerDisplayName: String?,
+            signerAccount: String?,
+            bundleSizeBytes: Int,
+            installedAt: String
+        ) {
+            self.uuid = uuid
+            self.name = name
+            self.description = description
+            self.icon = icon
+            self.entry = entry
+            self.createdAt = createdAt
+            self.createdBy = createdBy
+            self.capabilities = capabilities
+            self.allowedHosts = allowedHosts
+            self.trustTier = trustTier
+            self.signerKeyId = signerKeyId
+            self.signerDisplayName = signerDisplayName
+            self.signerAccount = signerAccount
+            self.bundleSizeBytes = bundleSizeBytes
+            self.installedAt = installedAt
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            uuid = try container.decode(String.self, forKey: .uuid)
+            name = try container.decode(String.self, forKey: .name)
+            description = try container.decodeIfPresent(String.self, forKey: .description)
+            icon = try container.decodeIfPresent(String.self, forKey: .icon)
+            entry = try container.decode(String.self, forKey: .entry)
+            createdAt = try container.decode(String.self, forKey: .createdAt)
+            createdBy = try container.decode(String.self, forKey: .createdBy)
+            capabilities = try container.decode([String].self, forKey: .capabilities)
+            allowedHosts = try container.decodeIfPresent([String].self, forKey: .allowedHosts) ?? []
+            trustTier = try container.decode(String.self, forKey: .trustTier)
+            signerKeyId = try container.decodeIfPresent(String.self, forKey: .signerKeyId)
+            signerDisplayName = try container.decodeIfPresent(String.self, forKey: .signerDisplayName)
+            signerAccount = try container.decodeIfPresent(String.self, forKey: .signerAccount)
+            bundleSizeBytes = try container.decode(Int.self, forKey: .bundleSizeBytes)
+            installedAt = try container.decode(String.self, forKey: .installedAt)
+        }
     }
 
     /// Unpacks a `.vellum` zip file into the sandbox and writes metadata.
@@ -90,6 +144,7 @@ enum BundleSandbox {
             createdAt: manifest.created_at,
             createdBy: manifest.created_by,
             capabilities: manifest.capabilities,
+            allowedHosts: manifest.allowed_hosts,
             trustTier: signatureResult.trustTier,
             signerKeyId: signatureResult.signerKeyId,
             signerDisplayName: signatureResult.signerDisplayName,

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -607,10 +607,11 @@ public struct BundleAppResponseManifest: Codable, Sendable {
     public let created_by: String
     public let entry: String
     public let capabilities: [String]
+    public let allowed_hosts: [String]
     public let version: String?
     public let content_id: String?
 
-    public init(format_version: Int, name: String, description: String? = nil, icon: String? = nil, created_at: String, created_by: String, entry: String, capabilities: [String], version: String? = nil, content_id: String? = nil) {
+    public init(format_version: Int, name: String, description: String? = nil, icon: String? = nil, created_at: String, created_by: String, entry: String, capabilities: [String], allowed_hosts: [String] = [], version: String? = nil, content_id: String? = nil) {
         self.format_version = format_version
         self.name = name
         self.description = description
@@ -619,8 +620,24 @@ public struct BundleAppResponseManifest: Codable, Sendable {
         self.created_by = created_by
         self.entry = entry
         self.capabilities = capabilities
+        self.allowed_hosts = allowed_hosts
         self.version = version
         self.content_id = content_id
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        format_version = try container.decode(Int.self, forKey: .format_version)
+        name = try container.decode(String.self, forKey: .name)
+        description = try container.decodeIfPresent(String.self, forKey: .description)
+        icon = try container.decodeIfPresent(String.self, forKey: .icon)
+        created_at = try container.decode(String.self, forKey: .created_at)
+        created_by = try container.decode(String.self, forKey: .created_by)
+        entry = try container.decode(String.self, forKey: .entry)
+        capabilities = try container.decode([String].self, forKey: .capabilities)
+        allowed_hosts = try container.decodeIfPresent([String].self, forKey: .allowed_hosts) ?? []
+        version = try container.decodeIfPresent(String.self, forKey: .version)
+        content_id = try container.decodeIfPresent(String.self, forKey: .content_id)
     }
 }
 
@@ -2873,8 +2890,9 @@ public struct OpenBundleResponseManifest: Codable, Sendable {
     public let created_by: String
     public let entry: String
     public let capabilities: [String]
+    public let allowed_hosts: [String]
 
-    public init(format_version: Int, name: String, description: String? = nil, icon: String? = nil, created_at: String, created_by: String, entry: String, capabilities: [String]) {
+    public init(format_version: Int, name: String, description: String? = nil, icon: String? = nil, created_at: String, created_by: String, entry: String, capabilities: [String], allowed_hosts: [String] = []) {
         self.format_version = format_version
         self.name = name
         self.description = description
@@ -2883,6 +2901,20 @@ public struct OpenBundleResponseManifest: Codable, Sendable {
         self.created_by = created_by
         self.entry = entry
         self.capabilities = capabilities
+        self.allowed_hosts = allowed_hosts
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        format_version = try container.decode(Int.self, forKey: .format_version)
+        name = try container.decode(String.self, forKey: .name)
+        description = try container.decodeIfPresent(String.self, forKey: .description)
+        icon = try container.decodeIfPresent(String.self, forKey: .icon)
+        created_at = try container.decode(String.self, forKey: .created_at)
+        created_by = try container.decode(String.self, forKey: .created_by)
+        entry = try container.decode(String.self, forKey: .entry)
+        capabilities = try container.decode([String].self, forKey: .capabilities)
+        allowed_hosts = try container.decodeIfPresent([String].self, forKey: .allowed_hosts) ?? []
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `allowedHosts: [String]` to `BundleMetadata` with backward-compatible decoding (defaults to `[]`)
- Add `allowed_hosts` field to manifest response types (`BundleAppResponseManifest`, `OpenBundleResponseManifest`)
- Thread `allowedHosts` through the `install()` method

Part of plan: webview-host-allowlist.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
