### PR TITLE
Add AppHostAllowlist model with domain normalization and matching

### DIFF
--- a/clients/shared/Features/Surfaces/AppHostAllowlist.swift
+++ b/clients/shared/Features/Surfaces/AppHostAllowlist.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// Static utility for managing per-app host allowlists used by sandboxed webview surfaces.
+/// Provides domain normalization, URL matching, and WKContentRuleList JSON generation.
+public enum AppHostAllowlist {
+
+    // MARK: - Domain Normalization
+
+    /// Normalizes a user-provided domain list: trims whitespace and newlines, lowercases,
+    /// strips URL schemes/paths/query strings/fragments, removes empty strings,
+    /// and deduplicates while preserving first-occurrence order.
+    public static func normalizeDomains(_ domains: [String]) -> [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        for domain in domains {
+            var normalized = domain.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            guard !normalized.isEmpty else { continue }
+            normalized = extractHost(from: normalized)
+            guard !normalized.isEmpty, !seen.contains(normalized) else { continue }
+            seen.insert(normalized)
+            result.append(normalized)
+        }
+        return result
+    }
+
+    // MARK: - URL Matching
+
+    /// Returns `true` if the URL is allowed by the given host list.
+    /// Only HTTPS and WSS schemes are permitted. Supports exact match and subdomain matching
+    /// (e.g. "example.com" matches "sub.example.com").
+    public static func isAllowed(_ url: URL, allowedHosts: [String]) -> Bool {
+        guard let scheme = url.scheme?.lowercased(),
+              scheme == "https" || scheme == "wss",
+              let host = url.host?.lowercased() else { return false }
+
+        for domain in allowedHosts {
+            let normalizedDomain = domain.lowercased()
+            if host == normalizedDomain || host.hasSuffix(".\(normalizedDomain)") {
+                return true
+            }
+        }
+        return false
+    }
+
+    // MARK: - Content Rule List
+
+    /// Generates the WKContentRuleList JSON that blocks all requests except `vellumapp://`,
+    /// `about:blank`, and the allowed hosts (each as an `ignore-previous-rules` entry with a
+    /// url-filter matching `^https://([^/]*\\.)?<escaped-host>/`).
+    public static func contentRuleListJSON(allowedHosts: [String]) -> String {
+        var rules: [[String: Any]] = []
+
+        // Block everything by default.
+        rules.append([
+            "trigger": ["url-filter": ".*"],
+            "action": ["type": "block"]
+        ])
+
+        // Allow vellumapp:// scheme.
+        rules.append([
+            "trigger": ["url-filter": "^vellumapp://.*"],
+            "action": ["type": "ignore-previous-rules"]
+        ])
+
+        // Allow about:blank.
+        rules.append([
+            "trigger": ["url-filter": "^about:blank$"],
+            "action": ["type": "ignore-previous-rules"]
+        ])
+
+        // Allow each host (exact + subdomain).
+        for host in allowedHosts {
+            let escaped = NSRegularExpression.escapedPattern(for: host)
+            rules.append([
+                "trigger": ["url-filter": "^https://([^/]*\\.)?\(escaped)/"],
+                "action": ["type": "ignore-previous-rules"]
+            ])
+        }
+
+        // Serialize to JSON.
+        // swiftlint:disable:next force_try
+        let data = try! JSONSerialization.data(withJSONObject: rules, options: [.prettyPrinted, .sortedKeys])
+        return String(data: data, encoding: .utf8)!
+    }
+
+    // MARK: - Private
+
+    /// Extracts just the host component from a string that may be a full URL.
+    private static func extractHost(from value: String) -> String {
+        if value.hasPrefix("http://") || value.hasPrefix("https://") {
+            if let components = URLComponents(string: value), let host = components.host, !host.isEmpty {
+                return host
+            }
+            return value
+        }
+
+        if let slashIndex = value.firstIndex(of: "/") {
+            let host = String(value[value.startIndex..<slashIndex])
+            return host.isEmpty ? value : host
+        }
+
+        return value
+    }
+}

--- a/clients/shared/Tests/AppHostAllowlistTests.swift
+++ b/clients/shared/Tests/AppHostAllowlistTests.swift
@@ -1,0 +1,182 @@
+import XCTest
+@testable import VellumAssistantShared
+
+final class AppHostAllowlistTests: XCTestCase {
+
+    // MARK: - normalizeDomains
+
+    func testNormalizeDomains_basicDomain() {
+        let result = AppHostAllowlist.normalizeDomains(["example.com"])
+        XCTAssertEqual(result, ["example.com"])
+    }
+
+    func testNormalizeDomains_trimsWhitespace() {
+        let result = AppHostAllowlist.normalizeDomains(["  example.com  ", "\texample.org\n"])
+        XCTAssertEqual(result, ["example.com", "example.org"])
+    }
+
+    func testNormalizeDomains_lowercases() {
+        let result = AppHostAllowlist.normalizeDomains(["Example.COM", "FOO.bar"])
+        XCTAssertEqual(result, ["example.com", "foo.bar"])
+    }
+
+    func testNormalizeDomains_stripsScheme() {
+        let result = AppHostAllowlist.normalizeDomains(["https://example.com", "http://foo.bar"])
+        XCTAssertEqual(result, ["example.com", "foo.bar"])
+    }
+
+    func testNormalizeDomains_stripsPath() {
+        let result = AppHostAllowlist.normalizeDomains(["example.com/path/to/page"])
+        XCTAssertEqual(result, ["example.com"])
+    }
+
+    func testNormalizeDomains_stripsSchemeAndPath() {
+        let result = AppHostAllowlist.normalizeDomains(["https://example.com/path?q=1#frag"])
+        XCTAssertEqual(result, ["example.com"])
+    }
+
+    func testNormalizeDomains_removesEmptyStrings() {
+        let result = AppHostAllowlist.normalizeDomains(["", "  ", "example.com", ""])
+        XCTAssertEqual(result, ["example.com"])
+    }
+
+    func testNormalizeDomains_deduplicates() {
+        let result = AppHostAllowlist.normalizeDomains(["example.com", "EXAMPLE.COM", "example.com"])
+        XCTAssertEqual(result, ["example.com"])
+    }
+
+    func testNormalizeDomains_preservesOrder() {
+        let result = AppHostAllowlist.normalizeDomains(["beta.com", "alpha.com", "gamma.com"])
+        XCTAssertEqual(result, ["beta.com", "alpha.com", "gamma.com"])
+    }
+
+    // MARK: - isAllowed — exact match
+
+    func testIsAllowed_exactMatch() {
+        let url = URL(string: "https://example.com/page")!
+        XCTAssertTrue(AppHostAllowlist.isAllowed(url, allowedHosts: ["example.com"]))
+    }
+
+    // MARK: - isAllowed — subdomain match
+
+    func testIsAllowed_subdomainMatch() {
+        let url = URL(string: "https://www.example.com/page")!
+        XCTAssertTrue(AppHostAllowlist.isAllowed(url, allowedHosts: ["example.com"]))
+    }
+
+    func testIsAllowed_deepSubdomainMatch() {
+        let url = URL(string: "https://a.b.c.example.com/page")!
+        XCTAssertTrue(AppHostAllowlist.isAllowed(url, allowedHosts: ["example.com"]))
+    }
+
+    // MARK: - isAllowed — non-matching domain
+
+    func testIsAllowed_nonMatchingDomain() {
+        let url = URL(string: "https://other.com/page")!
+        XCTAssertFalse(AppHostAllowlist.isAllowed(url, allowedHosts: ["example.com"]))
+    }
+
+    func testIsAllowed_partialMatchRejected() {
+        let url = URL(string: "https://notexample.com/page")!
+        XCTAssertFalse(AppHostAllowlist.isAllowed(url, allowedHosts: ["example.com"]))
+    }
+
+    // MARK: - isAllowed — scheme handling
+
+    func testIsAllowed_httpRejected() {
+        let url = URL(string: "http://example.com/page")!
+        XCTAssertFalse(AppHostAllowlist.isAllowed(url, allowedHosts: ["example.com"]))
+    }
+
+    func testIsAllowed_ftpRejected() {
+        let url = URL(string: "ftp://example.com/file")!
+        XCTAssertFalse(AppHostAllowlist.isAllowed(url, allowedHosts: ["example.com"]))
+    }
+
+    func testIsAllowed_httpsAllowed() {
+        let url = URL(string: "https://example.com")!
+        XCTAssertTrue(AppHostAllowlist.isAllowed(url, allowedHosts: ["example.com"]))
+    }
+
+    func testIsAllowed_wssAllowed() {
+        let url = URL(string: "wss://example.com/socket")!
+        XCTAssertTrue(AppHostAllowlist.isAllowed(url, allowedHosts: ["example.com"]))
+    }
+
+    func testIsAllowed_wsRejected() {
+        let url = URL(string: "ws://example.com/socket")!
+        XCTAssertFalse(AppHostAllowlist.isAllowed(url, allowedHosts: ["example.com"]))
+    }
+
+    // MARK: - isAllowed — edge cases
+
+    func testIsAllowed_emptyAllowlist() {
+        let url = URL(string: "https://example.com")!
+        XCTAssertFalse(AppHostAllowlist.isAllowed(url, allowedHosts: []))
+    }
+
+    func testIsAllowed_caseInsensitive() {
+        let url = URL(string: "https://WWW.Example.COM/page")!
+        XCTAssertTrue(AppHostAllowlist.isAllowed(url, allowedHosts: ["EXAMPLE.COM"]))
+    }
+
+    // MARK: - contentRuleListJSON
+
+    func testContentRuleListJSON_isValidJSON() {
+        let json = AppHostAllowlist.contentRuleListJSON(allowedHosts: ["example.com"])
+        let data = json.data(using: .utf8)!
+        let parsed = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+        XCTAssertNotNil(parsed, "Content rule list JSON should be valid JSON")
+    }
+
+    func testContentRuleListJSON_containsBlockAllRule() {
+        let json = AppHostAllowlist.contentRuleListJSON(allowedHosts: [])
+        XCTAssertTrue(json.contains("\"url-filter\" : \".*\""), "Should contain block-all trigger")
+        XCTAssertTrue(json.contains("\"type\" : \"block\""), "Should contain block action")
+    }
+
+    func testContentRuleListJSON_containsVellumAppBypass() {
+        let json = AppHostAllowlist.contentRuleListJSON(allowedHosts: [])
+        // JSONSerialization escapes forward slashes, so vellumapp:// becomes vellumapp:\/\/
+        XCTAssertTrue(json.contains("vellumapp:"), "Should contain vellumapp scheme bypass")
+    }
+
+    func testContentRuleListJSON_containsAboutBlankBypass() {
+        let json = AppHostAllowlist.contentRuleListJSON(allowedHosts: [])
+        XCTAssertTrue(json.contains("about:blank"), "Should contain about:blank bypass")
+    }
+
+    func testContentRuleListJSON_containsHostBypassRules() {
+        let json = AppHostAllowlist.contentRuleListJSON(allowedHosts: ["example.com", "foo.bar"])
+        // JSONSerialization double-escapes backslashes: example\.com becomes example\\.com in JSON
+        XCTAssertTrue(json.contains("example\\\\.com"), "Should contain escaped host pattern for example.com")
+        XCTAssertTrue(json.contains("foo\\\\.bar"), "Should contain escaped host pattern for foo.bar")
+    }
+
+    func testContentRuleListJSON_hostRulesUseIgnorePreviousRules() {
+        let json = AppHostAllowlist.contentRuleListJSON(allowedHosts: ["example.com"])
+        let data = json.data(using: .utf8)!
+        let rules = try! JSONSerialization.jsonObject(with: data) as! [[String: Any]]
+
+        // The last rule should be the host bypass rule with ignore-previous-rules action.
+        let lastRule = rules.last!
+        let action = lastRule["action"] as! [String: String]
+        XCTAssertEqual(action["type"], "ignore-previous-rules")
+    }
+
+    func testContentRuleListJSON_ruleCount() {
+        let json = AppHostAllowlist.contentRuleListJSON(allowedHosts: ["a.com", "b.com"])
+        let data = json.data(using: .utf8)!
+        let rules = try! JSONSerialization.jsonObject(with: data) as! [[String: Any]]
+        // 1 block-all + 1 vellumapp + 1 about:blank + 2 hosts = 5
+        XCTAssertEqual(rules.count, 5)
+    }
+
+    func testContentRuleListJSON_emptyHostsStillHasBaseRules() {
+        let json = AppHostAllowlist.contentRuleListJSON(allowedHosts: [])
+        let data = json.data(using: .utf8)!
+        let rules = try! JSONSerialization.jsonObject(with: data) as! [[String: Any]]
+        // 1 block-all + 1 vellumapp + 1 about:blank = 3
+        XCTAssertEqual(rules.count, 3)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `AppHostAllowlist` enum in `VellumAssistantShared` with domain normalization, URL matching (HTTPS + WSS), and WKContentRuleList JSON generation
- Add unit tests for all three functions

Part of plan: webview-host-allowlist.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
