### PR TITLE
feat: add "create custom skill" info banner to Skills tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -94,6 +94,14 @@ extension MainWindowView {
                     vm?.pendingSkillInvocation = nil
                     windowState.selection = nil
                 },
+                onCreateSkill: {
+                    conversationManager.openConversation(
+                        message: "I'd like to create a new custom skill. What kind of skill would you like to build?",
+                        forceNew: true,
+                        autoSend: false
+                    )
+                    windowState.selection = nil
+                },
                 connectionManager: connectionManager,
                 eventStreamClient: eventStreamClient,
                 store: settingsStore,
@@ -480,6 +488,14 @@ extension MainWindowView {
                         )
                     }
                     vm?.pendingSkillInvocation = nil
+                    windowState.dismissOverlay()
+                },
+                onCreateSkill: {
+                    conversationManager.openConversation(
+                        message: "I'd like to create a new custom skill. What kind of skill would you like to build?",
+                        forceNew: true,
+                        autoSend: false
+                    )
                     windowState.dismissOverlay()
                 },
                 connectionManager: connectionManager,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -7,6 +7,7 @@ import VellumAssistantShared
 /// (e.g. inside IntelligencePanel).
 struct AgentPanelContent: View {
     var onInvokeSkill: ((SkillInfo) -> Void)?
+    var onCreateSkill: (() -> Void)?
     var onSkillsChanged: (() -> Void)?
     let connectionManager: GatewayConnectionManager
 
@@ -17,8 +18,9 @@ struct AgentPanelContent: View {
     @State private var globalSkillSearchQuery = ""
     @State private var showAllSkills = false
 
-    init(onInvokeSkill: ((SkillInfo) -> Void)? = nil, onSkillsChanged: (() -> Void)? = nil, connectionManager: GatewayConnectionManager) {
+    init(onInvokeSkill: ((SkillInfo) -> Void)? = nil, onCreateSkill: (() -> Void)? = nil, onSkillsChanged: (() -> Void)? = nil, connectionManager: GatewayConnectionManager) {
         self.onInvokeSkill = onInvokeSkill
+        self.onCreateSkill = onCreateSkill
         self.onSkillsChanged = onSkillsChanged
         self.connectionManager = connectionManager
         _skillsManager = State(wrappedValue: SkillsManager(connectionManager: connectionManager))
@@ -38,6 +40,28 @@ struct AgentPanelContent: View {
         VStack(alignment: .leading, spacing: 0) {
             if !isShowingDetail {
                 filterBar
+            }
+            if !isShowingDetail {
+                HStack(spacing: VSpacing.sm) {
+                    VIconView(.sparkles, size: 14)
+                        .foregroundStyle(VColor.primaryBase)
+                    Text("You can create custom skills by describing what you want in chat.")
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(VColor.contentDefault)
+                    Spacer()
+                    VButton(label: "Create a Skill", style: .outlined, size: .compact) {
+                        onCreateSkill?()
+                    }
+                }
+                .padding(.horizontal, VSpacing.md)
+                .padding(.vertical, VSpacing.sm)
+                .background(VColor.primaryBase.opacity(0.10))
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .stroke(VColor.primaryBase.opacity(0.18), lineWidth: 1)
+                )
+                .padding(.top, VSpacing.sm)
             }
             HStack(alignment: .top, spacing: VSpacing.xxl) {
                 if !isShowingDetail {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -6,6 +6,7 @@ import VellumAssistantShared
 struct IntelligencePanel: View {
     var onClose: () -> Void
     var onInvokeSkill: ((SkillInfo) -> Void)?
+    var onCreateSkill: (() -> Void)?
     let connectionManager: GatewayConnectionManager
     let eventStreamClient: EventStreamClient?
     var store: SettingsStore?
@@ -21,9 +22,10 @@ struct IntelligencePanel: View {
     private static let contactsFeatureFlagKey = "contacts"
     private static let emailFeatureFlagKey = "email-channel"
 
-    init(onClose: @escaping () -> Void, onInvokeSkill: ((SkillInfo) -> Void)? = nil, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient? = nil, store: SettingsStore? = nil, conversationManager: ConversationManager? = nil, showToast: ((String, ToastInfo.Style) -> Void)? = nil, initialTab: String? = nil, pendingMemoryId: Binding<String?> = .constant(nil)) {
+    init(onClose: @escaping () -> Void, onInvokeSkill: ((SkillInfo) -> Void)? = nil, onCreateSkill: (() -> Void)? = nil, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient? = nil, store: SettingsStore? = nil, conversationManager: ConversationManager? = nil, showToast: ((String, ToastInfo.Style) -> Void)? = nil, initialTab: String? = nil, pendingMemoryId: Binding<String?> = .constant(nil)) {
         self.onClose = onClose
         self.onInvokeSkill = onInvokeSkill
+        self.onCreateSkill = onCreateSkill
         self.connectionManager = connectionManager
         self.eventStreamClient = eventStreamClient
         self.store = store
@@ -138,6 +140,7 @@ struct IntelligencePanel: View {
         case .installedSkills:
             AgentPanelContent(
                 onInvokeSkill: onInvokeSkill,
+                onCreateSkill: onCreateSkill,
                 connectionManager: connectionManager
             )
             .padding(.top, VSpacing.sm)


### PR DESCRIPTION
## Summary
- Add info banner to Skills tab with descriptive text and a "Create a Skill" button
- Clicking the button opens a new conversation with a pre-filled prompt about creating a custom skill
- Banner uses the design system's info color scheme and only appears in the list view (not detail view)

Part of plan: skills-create-banner.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21715" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
