### PR TITLE
Pass allowedHosts from bundle metadata through to webview sandbox

### DIFF
--- a/clients/macos/vellum-assistant/Features/Sharing/BundleSandbox.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/BundleSandbox.swift
@@ -172,6 +172,13 @@ enum BundleSandbox {
         return (uuid: uuid, directory: targetDir)
     }
 
+    /// Loads the persisted metadata for a given bundle UUID, if available.
+    static func metadata(for uuid: String) -> BundleMetadata? {
+        let metaPath = sharedAppsDirectory.appendingPathComponent("\(uuid)-meta.json")
+        guard let data = try? Data(contentsOf: metaPath) else { return nil }
+        return try? JSONDecoder().decode(BundleMetadata.self, from: data)
+    }
+
     /// Loads the persisted icon image for a given bundle UUID, if available.
     static func iconImage(for uuid: String) -> NSImage? {
         let iconPath = sharedAppsDirectory.appendingPathComponent("\(uuid)-icon.png")

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -101,6 +101,8 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
     var onLinkOpen: ((String, [String: Any]?) -> Void)?
     /// When true, blocks all network requests to external origins and restricts navigation.
     let sandboxMode: Bool
+    /// Hosts that sandboxed apps are allowed to reach (e.g. API endpoints declared in the bundle manifest).
+    let allowedHosts: [String]
     let topContentInset: CGFloat
     let bottomContentInset: CGFloat
     /// Corner radius applied at the AppKit layer to clip WKWebView content.
@@ -118,6 +120,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         onSnapshotCaptured: ((String) -> Void)? = nil,
         onLinkOpen: ((String, [String: Any]?) -> Void)? = nil,
         sandboxMode: Bool = false,
+        allowedHosts: [String] = [],
         topContentInset: CGFloat = 0,
         bottomContentInset: CGFloat = 0,
         cornerRadius: CGFloat = 0,
@@ -132,6 +135,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         self.onSnapshotCaptured = onSnapshotCaptured
         self.onLinkOpen = onLinkOpen
         self.sandboxMode = sandboxMode
+        self.allowedHosts = allowedHosts
         self.topContentInset = topContentInset
         self.bottomContentInset = bottomContentInset
         self.cornerRadius = cornerRadius
@@ -139,7 +143,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
     }
 
     func makeCoordinator() -> Coordinator {
-        let coordinator = Coordinator(onAction: onAction, onDataRequest: onDataRequest, onPageChanged: onPageChanged, onSnapshotCaptured: onSnapshotCaptured, onLinkOpen: onLinkOpen, currentHTML: data.html, sandboxMode: sandboxMode)
+        let coordinator = Coordinator(onAction: onAction, onDataRequest: onDataRequest, onPageChanged: onPageChanged, onSnapshotCaptured: onSnapshotCaptured, onLinkOpen: onLinkOpen, currentHTML: data.html, sandboxMode: sandboxMode, allowedHosts: allowedHosts)
         coordinator.surfaceId = data.appId ?? "ephemeral"
         coordinator.appId = appId
         coordinator.loadStartTime = CFAbsoluteTimeGetCurrent()
@@ -624,6 +628,8 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         /// The page currently displayed in a multi-page app (e.g. "settings.html").
         var currentPage: String = "index.html"
         let sandboxMode: Bool
+        /// Hosts that sandboxed apps are allowed to reach (declared in bundle manifest).
+        let allowedHosts: [String]
         weak var webView: WKWebView?
         var lastTopInset: Int = 0
         var lastBottomInset: Int = 0
@@ -661,7 +667,8 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             onSnapshotCaptured: ((String) -> Void)?,
             onLinkOpen: ((String, [String: Any]?) -> Void)? = nil,
             currentHTML: String,
-            sandboxMode: Bool = false
+            sandboxMode: Bool = false,
+            allowedHosts: [String] = []
         ) {
             self.onAction = onAction
             self.onDataRequest = onDataRequest
@@ -670,6 +677,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             self.onLinkOpen = onLinkOpen
             self.currentHTML = currentHTML
             self.sandboxMode = sandboxMode
+            self.allowedHosts = allowedHosts
         }
 
         func userContentController(

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -79,7 +79,8 @@ struct SurfaceContainerView: View {
                     onDataRequest: viewModel.onDataRequest,
                     onCoordinatorReady: viewModel.onCoordinatorReady,
                     onLinkOpen: viewModel.onLinkOpen,
-                    sandboxMode: viewModel.sandboxMode
+                    sandboxMode: viewModel.sandboxMode,
+                    allowedHosts: viewModel.allowedHosts
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             case .fileUpload(let data):

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -18,6 +18,7 @@ final class SurfaceViewModel {
     @ObservationIgnored let onCoordinatorReady: ((DynamicPageSurfaceView.Coordinator) -> Void)?
     @ObservationIgnored let onLinkOpen: ((String, [String: Any]?) -> Void)?
     @ObservationIgnored let sandboxMode: Bool
+    @ObservationIgnored let allowedHosts: [String]
 
     init(
         surface: Surface,
@@ -27,7 +28,8 @@ final class SurfaceViewModel {
         onDataRequest: ((String, String, String?, [String: Any]?) -> Void)? = nil,
         onCoordinatorReady: ((DynamicPageSurfaceView.Coordinator) -> Void)? = nil,
         onLinkOpen: ((String, [String: Any]?) -> Void)? = nil,
-        sandboxMode: Bool = false
+        sandboxMode: Bool = false,
+        allowedHosts: [String] = []
     ) {
         self.surface = surface
         self.onAction = onAction
@@ -37,6 +39,7 @@ final class SurfaceViewModel {
         self.onCoordinatorReady = onCoordinatorReady
         self.onLinkOpen = onLinkOpen
         self.sandboxMode = sandboxMode
+        self.allowedHosts = allowedHosts
     }
 }
 
@@ -137,6 +140,14 @@ final class SurfaceManager {
         let appId = surfaceAppIds[surface.id]
         let isSandboxed = message.conversationId == "shared-app"
 
+        // Look up allowed hosts from bundle metadata for sandboxed apps.
+        let allowedHosts: [String]
+        if isSandboxed, let appId, let metadata = BundleSandbox.metadata(for: appId) {
+            allowedHosts = metadata.allowedHosts
+        } else {
+            allowedHosts = []
+        }
+
         let viewModel = SurfaceViewModel(
             surface: surface,
             onAction: { [weak self] actionId, data in
@@ -164,7 +175,8 @@ final class SurfaceManager {
             onLinkOpen: { [weak self] url, metadata in
                 self?.onLinkOpen?(url, metadata)
             },
-            sandboxMode: isSandboxed
+            sandboxMode: isSandboxed,
+            allowedHosts: allowedHosts
         )
         viewModels[surface.id] = viewModel
 


### PR DESCRIPTION
## Summary
- Add `allowedHosts: [String]` to `SurfaceViewModel`, `DynamicPageSurfaceView`, and its `Coordinator`
- Look up `BundleMetadata.allowedHosts` in `SurfaceManager` for sandboxed apps and pass it through
- Add `BundleSandbox.metadata(for:)` static method for loading persisted bundle metadata by UUID
- No behavioral changes — data threading only, enforcement comes in PR 4

Part of plan: webview-host-allowlist.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21718" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
