### PR TITLE
Expose allowedHosts to apps via window.vellum JS bridge

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -151,6 +151,20 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
     }
 
     func makeNSView(context: Context) -> NSView {
+        // Serialize allowedHosts to a JSON string for injection into the JS bridge.
+        // Escape backslashes, single quotes, and newlines to prevent XSS when
+        // embedded inside a JS single-quoted string.
+        let hostsJSON: String = {
+            guard let data = try? JSONSerialization.data(withJSONObject: allowedHosts, options: []),
+                  let raw = String(data: data, encoding: .utf8) else {
+                return "[]"
+            }
+            return raw
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "'", with: "\\'")
+                .replacingOccurrences(of: "\n", with: "\\n")
+        }()
+
         // Console forwarding: capture JS console.log/error/warn and route to os.Logger.
         var jsSource = """
             (function() {
@@ -216,7 +230,8 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
                 _resolveConfirm: function(confirmId, result) {
                     var p = window.vellum._confirmPending[confirmId];
                     if (p) { delete window.vellum._confirmPending[confirmId]; p(result); }
-                }
+                },
+                hosts: JSON.parse('\(hostsJSON)')
             };
             """
 


### PR DESCRIPTION
## Summary
- Add `window.vellum.hosts` property to the JS bridge, exposing the effective allowed hosts array
- Properly escape JSON serialization to prevent XSS
- Returns `[]` when no allowed hosts are configured

Part of plan: webview-host-allowlist.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21726" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
