### PR TITLE
feat: replace archive button with overflow menu on conversation threads

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
@@ -34,7 +34,6 @@ final class SharingState {
 final class SidebarInteractionState {
     var isHoveredConversation: UUID?
     var isHoveredApp: String?
-    var conversationPendingDeletion: UUID?
     var renamingConversationId: UUID?
     var renameText: String = ""
     var showAllConversations: Bool = false
@@ -45,9 +44,8 @@ final class SidebarInteractionState {
     var showAllApps: Bool = false
     var showPreferencesDrawer: Bool = false
 
-    /// Updates conversation hover state and clears stale pending-deletion when hover
-    /// moves to a different conversation. Centralises the invariant so callers don't
-    /// need to coordinate.
+    /// Updates conversation hover state. Centralises the invariant so callers
+    /// don't need to coordinate.
     ///
     /// During an active drag, hover updates are suppressed to avoid triggering
     /// icon-swap animations and unnecessary re-renders across sibling rows.
@@ -66,18 +64,10 @@ final class SidebarInteractionState {
         }
 
         if hovering {
-            // Moving to a new conversation clears pending archive of the old one
-            if let pending = conversationPendingDeletion, pending != conversationId {
-                conversationPendingDeletion = nil
-            }
             isHoveredConversation = conversationId
         } else {
             if isHoveredConversation == conversationId {
                 isHoveredConversation = nil
-            }
-            // Leaving a pending-deletion conversation clears the confirmation
-            if conversationPendingDeletion == conversationId {
-                conversationPendingDeletion = nil
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -177,7 +177,6 @@ extension MainWindowView {
             isSelected: isConversationSelected(conversation),
             interactionState: conversationManager.interactionState(for: conversation.id),
             isHovered: sidebar.isHoveredConversation == conversation.id,
-            isPendingDeletion: sidebar.conversationPendingDeletion == conversation.id,
             selectConversation: { selectConversation(conversation) },
             onSelect: onSelect,
             onTogglePin: {
@@ -190,11 +189,6 @@ extension MainWindowView {
                 }
             },
             onArchive: { conversationManager.archiveConversation(id: conversation.id) },
-            onBeginArchive: { sidebar.conversationPendingDeletion = conversation.id },
-            onConfirmArchive: {
-                conversationManager.archiveConversation(id: conversation.id)
-                sidebar.conversationPendingDeletion = nil
-            },
             onStartRename: {
                 sidebar.renamingConversationId = conversation.id
                 sidebar.renameText = conversation.title

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
@@ -32,7 +32,6 @@ struct ConversationSwitcherDrawer: View {
                         isSelected: isConversationSelected(conversation),
                         interactionState: conversationManager.interactionState(for: conversation.id),
                         isHovered: sidebar.isHoveredConversation == conversation.id,
-                        isPendingDeletion: sidebar.conversationPendingDeletion == conversation.id,
                         selectConversation: { selectConversation(conversation) },
                         onSelect: onDismiss,
                         onTogglePin: {
@@ -45,11 +44,6 @@ struct ConversationSwitcherDrawer: View {
                             }
                         },
                         onArchive: { conversationManager.archiveConversation(id: conversation.id) },
-                        onBeginArchive: { sidebar.conversationPendingDeletion = conversation.id },
-                        onConfirmArchive: {
-                            conversationManager.archiveConversation(id: conversation.id)
-                            sidebar.conversationPendingDeletion = nil
-                        },
                         onStartRename: {
                             sidebar.renamingConversationId = conversation.id
                             sidebar.renameText = conversation.title
@@ -83,7 +77,6 @@ struct ConversationSwitcherDrawer: View {
             if sidebar.isHoveredConversation != nil {
                 sidebar.isHoveredConversation = nil
             }
-            sidebar.conversationPendingDeletion = nil
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -148,7 +148,7 @@ struct SidebarConversationItem: View, Equatable {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.leading, VSpacing.xs)
-            .padding(.trailing, hasTrailingIcon ? SidebarLayoutMetrics.archiveIconTrailingPadding : VSpacing.sm)
+            .padding(.trailing, hasTrailingIcon ? SidebarLayoutMetrics.trailingIconPadding : VSpacing.sm)
             .padding(.vertical, SidebarLayoutMetrics.rowVerticalPadding)
             .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)
             .background {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -11,15 +11,12 @@ struct SidebarConversationItem: View, Equatable {
     let isSelected: Bool
     let interactionState: ConversationInteractionState
     let isHovered: Bool
-    let isPendingDeletion: Bool
 
     // Action closures — not compared in Equatable
     var selectConversation: () -> Void
     var onSelect: (() -> Void)? = nil
     var onTogglePin: () -> Void
     var onArchive: () -> Void
-    var onBeginArchive: () -> Void
-    var onConfirmArchive: () -> Void
     var onStartRename: () -> Void
     var onMarkUnread: () -> Void
     var onHoverChange: (Bool) -> Void
@@ -31,11 +28,11 @@ struct SidebarConversationItem: View, Equatable {
         lhs.conversation == rhs.conversation &&
         lhs.isSelected == rhs.isSelected &&
         lhs.interactionState == rhs.interactionState &&
-        lhs.isHovered == rhs.isHovered &&
-        lhs.isPendingDeletion == rhs.isPendingDeletion
+        lhs.isHovered == rhs.isHovered
     }
 
-    private var hasTrailingIcon: Bool { isHovered || isPendingDeletion }
+    @State private var isMenuOpen: Bool = false
+    private var hasTrailingIcon: Bool { isHovered || isMenuOpen }
     private var canMarkUnread: Bool {
         !conversation.hasUnseenLatestAssistantMessage &&
             conversation.conversationId != nil &&
@@ -151,7 +148,7 @@ struct SidebarConversationItem: View, Equatable {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.leading, VSpacing.xs)
-            .padding(.trailing, isPendingDeletion ? SidebarLayoutMetrics.archiveConfirmTrailingPadding : hasTrailingIcon ? SidebarLayoutMetrics.archiveIconTrailingPadding : VSpacing.sm)
+            .padding(.trailing, hasTrailingIcon ? SidebarLayoutMetrics.archiveIconTrailingPadding : VSpacing.sm)
             .padding(.vertical, SidebarLayoutMetrics.rowVerticalPadding)
             .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)
             .background {
@@ -179,15 +176,9 @@ struct SidebarConversationItem: View, Equatable {
             selectConversation()
         }
         .overlay(alignment: .trailing) {
-            if isPendingDeletion {
-                VButton(label: "Confirm", style: .dangerOutline, size: .pill) {
-                    onConfirmArchive()
-                }
-                .fixedSize()
-                .padding(.trailing, VSpacing.xs)
-                .accessibilityLabel("Confirm archive \(conversation.title)")
-            } else if isHovered {
+            if isHovered || isMenuOpen {
                 Button {
+                    isMenuOpen = true
                     let appearance = NSApp.keyWindow?.effectiveAppearance
                     VMenuPanel.show(
                         at: NSEvent.mouseLocation,
@@ -196,7 +187,9 @@ struct SidebarConversationItem: View, Equatable {
                         VMenu(width: 200) {
                             contextMenuContent
                         }
-                    } onDismiss: {}
+                    } onDismiss: {
+                        isMenuOpen = false
+                    }
                 } label: {
                     VIconView(.ellipsis, size: 13)
                         .foregroundStyle(VColor.contentSecondary)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -154,7 +154,7 @@ struct SidebarConversationItem: View, Equatable {
             .background {
                 if isSelected {
                     VColor.surfaceActive
-                } else if isHovered {
+                } else if isHovered || isMenuOpen {
                     VColor.surfaceBase
                 } else if conversation.kind == .private {
                     VColor.primaryBase.opacity(0.04)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -42,6 +42,36 @@ struct SidebarConversationItem: View, Equatable {
             conversation.latestAssistantMessageAt != nil
     }
 
+    @ViewBuilder
+    private var contextMenuContent: some View {
+        VMenuItem(icon: conversation.isPinned ? VIcon.pinOff.rawValue : VIcon.pin.rawValue, label: conversation.isPinned ? "Unpin" : "Pin") {
+            onTogglePin()
+        }
+        VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename") {
+            onStartRename()
+        }
+        VMenuItem(icon: VIcon.archive.rawValue, label: "Archive") {
+            onArchive()
+        }
+        VMenuItem(icon: VIcon.circle.rawValue, label: "Mark as unread") {
+            onMarkUnread()
+        }
+        .disabled(!canMarkUnread)
+
+        if let onOpenInNewWindow {
+            VMenuItem(icon: VIcon.externalLink.rawValue, label: "Open in New Window") {
+                onOpenInNewWindow()
+            }
+        }
+
+        VMenuDivider()
+
+        VMenuItem(icon: VIcon.messageCircle.rawValue, label: "Share Feedback") {
+            onShowFeedback?()
+        }
+        .disabled(onShowFeedback == nil)
+    }
+
     var body: some View {
         // Always reserve 20pt leading slot so text never shifts.
         // Use a tap gesture instead of Button so .onDrag can coexist —
@@ -158,47 +188,30 @@ struct SidebarConversationItem: View, Equatable {
                 .accessibilityLabel("Confirm archive \(conversation.title)")
             } else if isHovered {
                 Button {
-                    onBeginArchive()
+                    let appearance = NSApp.keyWindow?.effectiveAppearance
+                    VMenuPanel.show(
+                        at: NSEvent.mouseLocation,
+                        sourceAppearance: appearance
+                    ) {
+                        VMenu(width: 200) {
+                            contextMenuContent
+                        }
+                    } onDismiss: {}
                 } label: {
-                    VIconView(.archive, size: 13)
+                    VIconView(.ellipsis, size: 13)
                         .foregroundStyle(VColor.contentSecondary)
                         .frame(width: 20, height: 20)
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .nativeTooltip("Archive")
+                .nativeTooltip("More options")
                 .padding(.trailing, VSpacing.xs)
-                .accessibilityLabel("Archive \(conversation.title)")
+                .accessibilityLabel("More options for \(conversation.title)")
             }
         }
         .padding(.horizontal, 0)
         .vContextMenu(width: 200) {
-            VMenuItem(icon: conversation.isPinned ? VIcon.pinOff.rawValue : VIcon.pin.rawValue, label: conversation.isPinned ? "Unpin" : "Pin") {
-                onTogglePin()
-            }
-            VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename") {
-                onStartRename()
-            }
-            VMenuItem(icon: VIcon.archive.rawValue, label: "Archive") {
-                onArchive()
-            }
-            VMenuItem(icon: VIcon.circle.rawValue, label: "Mark as unread") {
-                onMarkUnread()
-            }
-            .disabled(!canMarkUnread)
-
-            if let onOpenInNewWindow {
-                VMenuItem(icon: VIcon.externalLink.rawValue, label: "Open in New Window") {
-                    onOpenInNewWindow()
-                }
-            }
-
-            VMenuDivider()
-
-            VMenuItem(icon: VIcon.messageCircle.rawValue, label: "Share Feedback") {
-                onShowFeedback?()
-            }
-            .disabled(onShowFeedback == nil)
+            contextMenuContent
         }
         .pointerCursor { hovering in
             onHoverChange(hovering)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarLayoutMetrics.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarLayoutMetrics.swift
@@ -39,9 +39,9 @@ enum SidebarLayoutMetrics {
 
     // MARK: - Trailing Icon
 
-    /// Trailing padding reserved for the archive icon overlay on hover
+    /// Trailing padding reserved for the overflow menu icon overlay on hover
     /// (20pt icon + 4pt trailing padding on the overlay + 8pt gap).
-    static let archiveIconTrailingPadding: CGFloat = 32
+    static let trailingIconPadding: CGFloat = 32
 
     // MARK: - Section Divider
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarLayoutMetrics.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarLayoutMetrics.swift
@@ -37,10 +37,7 @@ enum SidebarLayoutMetrics {
     /// Gap below the "Scheduled" label before the first scheduled row.
     static let scheduledHeaderBottomGap: CGFloat = VSpacing.xs  // 4pt
 
-    // MARK: - Archive Confirm
-
-    /// Trailing padding reserved for the "Confirm" pill button overlay during archive flow.
-    static let archiveConfirmTrailingPadding: CGFloat = 72
+    // MARK: - Trailing Icon
 
     /// Trailing padding reserved for the archive icon overlay on hover
     /// (20pt icon + 4pt trailing padding on the overlay + 8pt gap).


### PR DESCRIPTION
Replaces the archive icon on sidebar conversation rows with an ellipsis overflow menu that shows the same options as the right-click context menu.

Part of #21723
Part of LUM-436
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
