### PR TITLE
Add settings UI to manage per-app allowed hosts

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -55,6 +55,16 @@ extension AppDelegate {
     func setupSurfaceManager() {
         // Surface event handling is now in startDaemonEventSubscription() via subscribe().
 
+        // Sync global app allowed hosts from settings into SurfaceManager.
+        let settingsStore = services.settingsStore
+        surfaceManager.globalAppAllowedHosts = settingsStore.globalAppAllowedHosts
+        settingsStore.$globalAppAllowedHosts
+            .receive(on: RunLoop.main)
+            .sink { [weak self] hosts in
+                self?.surfaceManager.globalAppAllowedHosts = hosts
+            }
+            .store(in: &surfaceManagerCancellables)
+
         // Wire SurfaceManager action callback to SurfaceActionClient
         surfaceManager.onAction = { conversationId, surfaceId, actionId, data in
             let codableData: [String: AnyCodable]? = data?.mapValues { AnyCodable($0) }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -41,6 +41,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var hostCuOverlayCleanupTask: Task<Void, Never>?
     /// Combine subscriptions for host CU overlay state observation.
     var hostCuOverlayCancellables = Set<AnyCancellable>()
+    var surfaceManagerCancellables = Set<AnyCancellable>()
     /// In-flight CU tasks keyed by request ID, for cancel support.
     var inFlightCuTasks: [String: Task<Void, Never>] = [:]
     var isStartingSession = false

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -7,7 +7,9 @@ struct SettingsAppearanceTab: View {
 
     @ObservedObject var store: SettingsStore
     @State private var newAllowlistDomain = ""
+    @State private var newAppAllowlistDomain = ""
     @State private var isVideoDomainsExpanded: Bool = false
+    @State private var isAppHostsExpanded: Bool = false
     @State private var isRecordingGlobalHotkey = false
     @State private var isRecordingQuickInputHotkey = false
     @State private var isRecordingSidebarToggle = false
@@ -496,6 +498,55 @@ struct SettingsAppearanceTab: View {
                     }
                 }
             }
+
+            // APP HOST ALLOWLIST section
+            SettingsCard(title: "App Host Allowlist", subtitle: "Allow sandboxed apps to connect to these hosts. Apps may also declare their own allowed hosts in their manifest.") {
+                VDisclosureSection(
+                    title: "Global Allowed Hosts",
+                    isExpanded: $isAppHostsExpanded
+                ) {
+                    VStack(alignment: .leading, spacing: VSpacing.sm) {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            Text("Add Domain")
+                                .font(VFont.labelDefault)
+                                .foregroundStyle(VColor.contentTertiary)
+
+                            HStack(spacing: VSpacing.sm) {
+                                VTextField(
+                                    placeholder: "Add domain (e.g. api.example.com)",
+                                    text: $newAppAllowlistDomain,
+                                    onSubmit: { addAppAllowlistDomain() }
+                                )
+
+                                VButton(label: "Add", style: .primary, isDisabled: newAppAllowlistDomain.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
+                                    addAppAllowlistDomain()
+                                }
+                            }
+                        }
+
+                        ForEach(store.globalAppAllowedHosts, id: \.self) { domain in
+                            HStack {
+                                Text(domain)
+                                    .font(VFont.bodyMediumLighter)
+                                    .foregroundStyle(VColor.contentDefault)
+                                    .textSelection(.enabled)
+                                Spacer()
+                                VButton(label: "Remove domain", iconOnly: VIcon.trash.rawValue, style: .danger) {
+                                    var domains = store.globalAppAllowedHosts
+                                    domains.removeAll { $0 == domain }
+                                    store.setGlobalAppAllowedHosts(domains)
+                                }
+                            }
+                            .padding(.horizontal, VSpacing.md)
+                            .padding(.vertical, VSpacing.sm)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: VRadius.lg)
+                                    .strokeBorder(VColor.borderBase, lineWidth: 1)
+                            )
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -508,6 +559,15 @@ struct SettingsAppearanceTab: View {
         domains.append(domain)
         store.setMediaEmbedVideoAllowlistDomains(domains)
         newAllowlistDomain = ""
+    }
+
+    private func addAppAllowlistDomain() {
+        let domain = newAppAllowlistDomain.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !domain.isEmpty else { return }
+        var domains = store.globalAppAllowedHosts
+        domains.append(domain)
+        store.setGlobalAppAllowedHosts(domains)
+        newAppAllowlistDomain = ""
     }
 
     // MARK: - Timezone Helpers

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -92,6 +92,10 @@ public final class SettingsStore: ObservableObject {
     @Published var mediaEmbedVideoAllowlistDomains: [String]
     @Published var userTimezone: String?
 
+    // MARK: - App Host Allowlist
+
+    @Published var globalAppAllowedHosts: [String]
+
     // MARK: - Permissions Settings
 
     @Published var dangerouslySkipPermissions: Bool
@@ -437,6 +441,9 @@ public final class SettingsStore: ObservableObject {
         self.mediaEmbedVideoAllowlistDomains = mediaSettings.domains
         self.userTimezone = Self.loadUserTimezone(config: emptyConfig)
 
+        // Load global app allowed hosts from UserDefaults
+        self.globalAppAllowedHosts = UserDefaults.standard.stringArray(forKey: "app_global_allowed_hosts") ?? []
+
         // Permissions default to false until daemon provides config
         self.dangerouslySkipPermissions = false
 
@@ -487,6 +494,12 @@ public final class SettingsStore: ObservableObject {
             .dropFirst()
             .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
             .sink { value in UserDefaults.standard.set(value, forKey: "collectUsageData") }
+            .store(in: &cancellables)
+
+        $globalAppAllowedHosts
+            .dropFirst()
+            .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
+            .sink { value in UserDefaults.standard.set(value, forKey: "app_global_allowed_hosts") }
             .store(in: &cancellables)
 
         // Persist shortcut changes immediately so the hotkey re-registers without delay
@@ -2939,6 +2952,12 @@ public final class SettingsStore: ObservableObject {
                 log.error("Failed to patch config for video allowlist domains")
             }
         }
+    }
+
+    /// Replaces the global app allowed hosts list, normalizing the input and
+    /// persisting via the Combine sink to UserDefaults.
+    func setGlobalAppAllowedHosts(_ domains: [String]) {
+        globalAppAllowedHosts = AppHostAllowlist.normalizeDomains(domains)
     }
 
     /// Writes the current `mediaEmbedsEnabled` and `mediaEmbedsEnabledSince` to

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -79,6 +79,9 @@ final class SurfaceManager {
 
     @ObservationIgnored private var closeObservers: [String: Any] = [:]
 
+    /// Global allowed hosts from settings, merged with per-app manifest hosts.
+    @ObservationIgnored var globalAppAllowedHosts: [String] = []
+
     @ObservationIgnored private let panelWidth: CGFloat = 380
     @ObservationIgnored private let panelMargin: CGFloat = 20
     @ObservationIgnored private let panelSpacing: CGFloat = 10
@@ -140,10 +143,14 @@ final class SurfaceManager {
         let appId = surfaceAppIds[surface.id]
         let isSandboxed = message.conversationId == "shared-app"
 
-        // Look up allowed hosts from bundle metadata for sandboxed apps.
+        // Look up allowed hosts from bundle metadata for sandboxed apps,
+        // merged with the global allowed hosts from settings.
         let allowedHosts: [String]
         if isSandboxed, let appId, let metadata = BundleSandbox.metadata(for: appId) {
-            allowedHosts = metadata.allowedHosts
+            let merged = Set(metadata.allowedHosts).union(globalAppAllowedHosts)
+            allowedHosts = Array(merged).sorted()
+        } else if isSandboxed, !globalAppAllowedHosts.isEmpty {
+            allowedHosts = globalAppAllowedHosts
         } else {
             allowedHosts = []
         }


### PR DESCRIPTION
## Summary
- Add `globalAppAllowedHosts` to `SettingsStore` with UserDefaults persistence and domain normalization
- Add domain list UI in settings (add/remove pattern matching media embed allowlist)
- Merge global allowed hosts with per-app manifest hosts in `SurfaceManager`

Part of plan: webview-host-allowlist.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
