### PR TITLE
WebView host allowlist for sandboxed apps

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift
@@ -162,7 +162,7 @@ extension AppDelegate {
                         surfaceId: surfaceId,
                         surfaceType: "dynamic_page",
                         title: manifest.name,
-                        data: AnyCodable(["html": html]),
+                        data: AnyCodable(["html": html, "appId": uuid]),
                         actions: nil,
                         display: "panel",
                         messageId: nil

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -55,6 +55,16 @@ extension AppDelegate {
     func setupSurfaceManager() {
         // Surface event handling is now in startDaemonEventSubscription() via subscribe().
 
+        // Sync global app allowed hosts from settings into SurfaceManager.
+        let settingsStore = services.settingsStore
+        surfaceManager.globalAppAllowedHosts = settingsStore.globalAppAllowedHosts
+        settingsStore.$globalAppAllowedHosts
+            .receive(on: RunLoop.main)
+            .sink { [weak self] hosts in
+                self?.surfaceManager.globalAppAllowedHosts = hosts
+            }
+            .store(in: &surfaceManagerCancellables)
+
         // Wire SurfaceManager action callback to SurfaceActionClient
         surfaceManager.onAction = { conversationId, surfaceId, actionId, data in
             let codableData: [String: AnyCodable]? = data?.mapValues { AnyCodable($0) }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -41,6 +41,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var hostCuOverlayCleanupTask: Task<Void, Never>?
     /// Combine subscriptions for host CU overlay state observation.
     var hostCuOverlayCancellables = Set<AnyCancellable>()
+    var surfaceManagerCancellables = Set<AnyCancellable>()
     /// In-flight CU tasks keyed by request ID, for cancel support.
     var inFlightCuTasks: [String: Task<Void, Never>] = [:]
     var isStartingSession = false

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -143,7 +143,9 @@ extension MainWindowView {
                 },
                 onLinkOpen: { url, metadata in
                     surfaceManager.onLinkOpen?(url, metadata)
-                }
+                },
+                sandboxMode: surface.conversationId == "shared-app",
+                allowedHosts: Self.computeAllowedHosts(for: surface, surfaceManager: surfaceManager)
             )
         } else {
             VStack {
@@ -156,6 +158,26 @@ extension MainWindowView {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(VColor.surfaceOverlay)
         }
+    }
+
+    // MARK: - Sandbox Helpers
+
+    /// Computes the merged allowed hosts for a surface by looking up the bundle
+    /// manifest and merging with the global allowed hosts from settings.
+    /// Mirrors the logic in `SurfaceManager.showSurface()` so that workspace-routed
+    /// shared-app surfaces get the same sandbox enforcement as floating panels.
+    static func computeAllowedHosts(for surface: Surface, surfaceManager: SurfaceManager) -> [String] {
+        let isSandboxed = surface.conversationId == "shared-app"
+        guard isSandboxed else { return [] }
+        if case .dynamicPage(let dpData) = surface.data,
+           let appId = dpData.appId,
+           let metadata = BundleSandbox.metadata(for: appId) {
+            let merged = Set(metadata.allowedHosts).union(surfaceManager.globalAppAllowedHosts)
+            return AppHostAllowlist.normalizeDomains(Array(merged)).sorted()
+        } else if !surfaceManager.globalAppAllowedHosts.isEmpty {
+            return AppHostAllowlist.normalizeDomains(surfaceManager.globalAppAllowedHosts)
+        }
+        return []
     }
 
     // MARK: - Split-Width Helpers
@@ -989,6 +1011,8 @@ struct DynamicWorkspaceWrapper: View {
                         onLinkOpen: { url, metadata in
                             surfaceManager.onLinkOpen?(url, metadata)
                         },
+                        sandboxMode: surface.conversationId == "shared-app",
+                        allowedHosts: MainWindowView.computeAllowedHosts(for: surface, surfaceManager: surfaceManager),
                         topContentInset: 0,
                         bottomContentInset: 0,
                         cornerRadius: webViewCornerRadius,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -413,7 +413,7 @@ struct AppsGridView: View {
             surfaceId: "shared-app-\(app.uuid)",
             surfaceType: "dynamic_page",
             title: app.name,
-            data: AnyCodable(["html": html]),
+            data: AnyCodable(["html": html, "appId": app.uuid]),
             actions: nil,
             display: "panel",
             messageId: nil

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -600,7 +600,7 @@ struct GeneratedPanel: View {
                 surfaceId: "shared-app-\(uuid)",
                 surfaceType: "dynamic_page",
                 title: item.name,
-                data: AnyCodable(["html": html]),
+                data: AnyCodable(["html": html, "appId": uuid]),
                 actions: nil,
                 display: "panel",
                 messageId: nil

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -7,7 +7,9 @@ struct SettingsAppearanceTab: View {
 
     @ObservedObject var store: SettingsStore
     @State private var newAllowlistDomain = ""
+    @State private var newAppAllowlistDomain = ""
     @State private var isVideoDomainsExpanded: Bool = false
+    @State private var isAppHostsExpanded: Bool = false
     @State private var isRecordingGlobalHotkey = false
     @State private var isRecordingQuickInputHotkey = false
     @State private var isRecordingSidebarToggle = false
@@ -496,6 +498,55 @@ struct SettingsAppearanceTab: View {
                     }
                 }
             }
+
+            // APP HOST ALLOWLIST section
+            SettingsCard(title: "App Host Allowlist", subtitle: "Allow sandboxed apps to connect to these hosts. Apps may also declare their own allowed hosts in their manifest.") {
+                VDisclosureSection(
+                    title: "Global Allowed Hosts",
+                    isExpanded: $isAppHostsExpanded
+                ) {
+                    VStack(alignment: .leading, spacing: VSpacing.sm) {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            Text("Add Domain")
+                                .font(VFont.labelDefault)
+                                .foregroundStyle(VColor.contentTertiary)
+
+                            HStack(spacing: VSpacing.sm) {
+                                VTextField(
+                                    placeholder: "Add domain (e.g. api.example.com)",
+                                    text: $newAppAllowlistDomain,
+                                    onSubmit: { addAppAllowlistDomain() }
+                                )
+
+                                VButton(label: "Add", style: .primary, isDisabled: newAppAllowlistDomain.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
+                                    addAppAllowlistDomain()
+                                }
+                            }
+                        }
+
+                        ForEach(store.globalAppAllowedHosts, id: \.self) { domain in
+                            HStack {
+                                Text(domain)
+                                    .font(VFont.bodyMediumLighter)
+                                    .foregroundStyle(VColor.contentDefault)
+                                    .textSelection(.enabled)
+                                Spacer()
+                                VButton(label: "Remove domain", iconOnly: VIcon.trash.rawValue, style: .danger) {
+                                    var domains = store.globalAppAllowedHosts
+                                    domains.removeAll { $0 == domain }
+                                    store.setGlobalAppAllowedHosts(domains)
+                                }
+                            }
+                            .padding(.horizontal, VSpacing.md)
+                            .padding(.vertical, VSpacing.sm)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: VRadius.lg)
+                                    .strokeBorder(VColor.borderBase, lineWidth: 1)
+                            )
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -508,6 +559,15 @@ struct SettingsAppearanceTab: View {
         domains.append(domain)
         store.setMediaEmbedVideoAllowlistDomains(domains)
         newAllowlistDomain = ""
+    }
+
+    private func addAppAllowlistDomain() {
+        let domain = newAppAllowlistDomain.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !domain.isEmpty else { return }
+        var domains = store.globalAppAllowedHosts
+        domains.append(domain)
+        store.setGlobalAppAllowedHosts(domains)
+        newAppAllowlistDomain = ""
     }
 
     // MARK: - Timezone Helpers

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -92,6 +92,10 @@ public final class SettingsStore: ObservableObject {
     @Published var mediaEmbedVideoAllowlistDomains: [String]
     @Published var userTimezone: String?
 
+    // MARK: - App Host Allowlist
+
+    @Published var globalAppAllowedHosts: [String]
+
     // MARK: - Permissions Settings
 
     @Published var dangerouslySkipPermissions: Bool
@@ -437,6 +441,9 @@ public final class SettingsStore: ObservableObject {
         self.mediaEmbedVideoAllowlistDomains = mediaSettings.domains
         self.userTimezone = Self.loadUserTimezone(config: emptyConfig)
 
+        // Load global app allowed hosts from UserDefaults
+        self.globalAppAllowedHosts = UserDefaults.standard.stringArray(forKey: "app_global_allowed_hosts") ?? []
+
         // Permissions default to false until daemon provides config
         self.dangerouslySkipPermissions = false
 
@@ -487,6 +494,12 @@ public final class SettingsStore: ObservableObject {
             .dropFirst()
             .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
             .sink { value in UserDefaults.standard.set(value, forKey: "collectUsageData") }
+            .store(in: &cancellables)
+
+        $globalAppAllowedHosts
+            .dropFirst()
+            .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
+            .sink { value in UserDefaults.standard.set(value, forKey: "app_global_allowed_hosts") }
             .store(in: &cancellables)
 
         // Persist shortcut changes immediately so the hotkey re-registers without delay
@@ -2939,6 +2952,12 @@ public final class SettingsStore: ObservableObject {
                 log.error("Failed to patch config for video allowlist domains")
             }
         }
+    }
+
+    /// Replaces the global app allowed hosts list, normalizing the input and
+    /// persisting via the Combine sink to UserDefaults.
+    func setGlobalAppAllowedHosts(_ domains: [String]) {
+        globalAppAllowedHosts = AppHostAllowlist.normalizeDomains(domains)
     }
 
     /// Writes the current `mediaEmbedsEnabled` and `mediaEmbedsEnabledSince` to

--- a/clients/macos/vellum-assistant/Features/Sharing/BundleSandbox.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/BundleSandbox.swift
@@ -172,6 +172,13 @@ enum BundleSandbox {
         return (uuid: uuid, directory: targetDir)
     }
 
+    /// Loads the persisted metadata for a given bundle UUID, if available.
+    static func metadata(for uuid: String) -> BundleMetadata? {
+        let metaPath = sharedAppsDirectory.appendingPathComponent("\(uuid)-meta.json")
+        guard let data = try? Data(contentsOf: metaPath) else { return nil }
+        return try? JSONDecoder().decode(BundleMetadata.self, from: data)
+    }
+
     /// Loads the persisted icon image for a given bundle UUID, if available.
     static func iconImage(for uuid: String) -> NSImage? {
         let iconPath = sharedAppsDirectory.appendingPathComponent("\(uuid)-icon.png")

--- a/clients/macos/vellum-assistant/Features/Sharing/BundleSandbox.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/BundleSandbox.swift
@@ -27,12 +27,66 @@ enum BundleSandbox {
         let createdAt: String
         let createdBy: String
         let capabilities: [String]
+        let allowedHosts: [String]
         let trustTier: String
         let signerKeyId: String?
         let signerDisplayName: String?
         let signerAccount: String?
         let bundleSizeBytes: Int
         let installedAt: String
+
+        init(
+            uuid: String,
+            name: String,
+            description: String?,
+            icon: String?,
+            entry: String,
+            createdAt: String,
+            createdBy: String,
+            capabilities: [String],
+            allowedHosts: [String] = [],
+            trustTier: String,
+            signerKeyId: String?,
+            signerDisplayName: String?,
+            signerAccount: String?,
+            bundleSizeBytes: Int,
+            installedAt: String
+        ) {
+            self.uuid = uuid
+            self.name = name
+            self.description = description
+            self.icon = icon
+            self.entry = entry
+            self.createdAt = createdAt
+            self.createdBy = createdBy
+            self.capabilities = capabilities
+            self.allowedHosts = allowedHosts
+            self.trustTier = trustTier
+            self.signerKeyId = signerKeyId
+            self.signerDisplayName = signerDisplayName
+            self.signerAccount = signerAccount
+            self.bundleSizeBytes = bundleSizeBytes
+            self.installedAt = installedAt
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            uuid = try container.decode(String.self, forKey: .uuid)
+            name = try container.decode(String.self, forKey: .name)
+            description = try container.decodeIfPresent(String.self, forKey: .description)
+            icon = try container.decodeIfPresent(String.self, forKey: .icon)
+            entry = try container.decode(String.self, forKey: .entry)
+            createdAt = try container.decode(String.self, forKey: .createdAt)
+            createdBy = try container.decode(String.self, forKey: .createdBy)
+            capabilities = try container.decode([String].self, forKey: .capabilities)
+            allowedHosts = try container.decodeIfPresent([String].self, forKey: .allowedHosts) ?? []
+            trustTier = try container.decode(String.self, forKey: .trustTier)
+            signerKeyId = try container.decodeIfPresent(String.self, forKey: .signerKeyId)
+            signerDisplayName = try container.decodeIfPresent(String.self, forKey: .signerDisplayName)
+            signerAccount = try container.decodeIfPresent(String.self, forKey: .signerAccount)
+            bundleSizeBytes = try container.decode(Int.self, forKey: .bundleSizeBytes)
+            installedAt = try container.decode(String.self, forKey: .installedAt)
+        }
     }
 
     /// Unpacks a `.vellum` zip file into the sandbox and writes metadata.
@@ -90,6 +144,7 @@ enum BundleSandbox {
             createdAt: manifest.created_at,
             createdBy: manifest.created_by,
             capabilities: manifest.capabilities,
+            allowedHosts: manifest.allowed_hosts,
             trustTier: signatureResult.trustTier,
             signerKeyId: signatureResult.signerKeyId,
             signerDisplayName: signatureResult.signerDisplayName,

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -151,6 +151,20 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
     }
 
     func makeNSView(context: Context) -> NSView {
+        // Serialize allowedHosts to a JSON string for injection into the JS bridge.
+        // Escape backslashes, single quotes, and newlines to prevent XSS when
+        // embedded inside a JS single-quoted string.
+        let hostsJSON: String = {
+            guard let data = try? JSONSerialization.data(withJSONObject: allowedHosts, options: []),
+                  let raw = String(data: data, encoding: .utf8) else {
+                return "[]"
+            }
+            return raw
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "'", with: "\\'")
+                .replacingOccurrences(of: "\n", with: "\\n")
+        }()
+
         // Console forwarding: capture JS console.log/error/warn and route to os.Logger.
         var jsSource = """
             (function() {
@@ -216,7 +230,8 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
                 _resolveConfirm: function(confirmId, result) {
                     var p = window.vellum._confirmPending[confirmId];
                     if (p) { delete window.vellum._confirmPending[confirmId]; p(result); }
-                }
+                },
+                hosts: JSON.parse('\(hostsJSON)')
             };
             """
 

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -344,22 +344,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         // When sandbox mode is enabled, compile a content rule list that blocks
         // all network requests except those to the vellumapp:// scheme.
         if sandboxMode {
-            let ruleJSON = """
-            [
-                {
-                    "trigger": { "url-filter": ".*" },
-                    "action": { "type": "block" }
-                },
-                {
-                    "trigger": { "url-filter": "^vellumapp://.*" },
-                    "action": { "type": "ignore-previous-rules" }
-                },
-                {
-                    "trigger": { "url-filter": "^about:blank$" },
-                    "action": { "type": "ignore-previous-rules" }
-                }
-            ]
-            """
+            let ruleJSON = AppHostAllowlist.contentRuleListJSON(allowedHosts: allowedHosts)
             WKContentRuleListStore.default().compileContentRuleList(
                 forIdentifier: "sandbox-block-external",
                 encodedContentRuleList: ruleJSON
@@ -721,6 +706,13 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             // Handle openExternal requests from the JS bridge.
             if let type = body["type"] as? String, type == "open_external" {
                 if sandboxMode {
+                    // Allow URLs whose host matches the allowedHosts list.
+                    if let urlString = body["url"] as? String,
+                       let url = URL(string: urlString),
+                       AppHostAllowlist.isAllowed(url, allowedHosts: allowedHosts) {
+                        NSWorkspace.shared.open(url)
+                        return
+                    }
                     log.warning("open_external: blocked in sandbox mode")
                     return
                 }
@@ -744,10 +736,12 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
                     log.warning("open_link: invalid URL")
                     return
                 }
-                // Sandbox: only allow the Vellum branding domain.
+                // Sandbox: only allow the Vellum branding domain and allowedHosts.
                 if sandboxMode {
                     let host = url.host?.lowercased() ?? ""
-                    guard host == "vellum.ai" || host.hasSuffix(".vellum.ai") else {
+                    let isVellumDomain = host == "vellum.ai" || host.hasSuffix(".vellum.ai")
+                    let isAllowedHost = AppHostAllowlist.isAllowed(url, allowedHosts: allowedHosts)
+                    guard isVellumDomain || isAllowedHost else {
                         log.warning("open_link: blocked in sandbox mode (host=\(host, privacy: .public))")
                         return
                     }
@@ -1079,6 +1073,11 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
                     }
                     // Allow initial HTML load via https://*.vellum.local/
                     if scheme == "https" && (url.host?.hasSuffix(".vellum.local") == true) && navigationAction.navigationType == .other {
+                        decisionHandler(.allow)
+                        return
+                    }
+                    // Allow HTTPS/WSS requests to hosts in the allowlist.
+                    if (scheme == "https" || scheme == "wss") && AppHostAllowlist.isAllowed(url, allowedHosts: allowedHosts) {
                         decisionHandler(.allow)
                         return
                     }

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -101,6 +101,8 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
     var onLinkOpen: ((String, [String: Any]?) -> Void)?
     /// When true, blocks all network requests to external origins and restricts navigation.
     let sandboxMode: Bool
+    /// Hosts that sandboxed apps are allowed to reach (e.g. API endpoints declared in the bundle manifest).
+    let allowedHosts: [String]
     let topContentInset: CGFloat
     let bottomContentInset: CGFloat
     /// Corner radius applied at the AppKit layer to clip WKWebView content.
@@ -118,6 +120,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         onSnapshotCaptured: ((String) -> Void)? = nil,
         onLinkOpen: ((String, [String: Any]?) -> Void)? = nil,
         sandboxMode: Bool = false,
+        allowedHosts: [String] = [],
         topContentInset: CGFloat = 0,
         bottomContentInset: CGFloat = 0,
         cornerRadius: CGFloat = 0,
@@ -132,6 +135,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         self.onSnapshotCaptured = onSnapshotCaptured
         self.onLinkOpen = onLinkOpen
         self.sandboxMode = sandboxMode
+        self.allowedHosts = allowedHosts
         self.topContentInset = topContentInset
         self.bottomContentInset = bottomContentInset
         self.cornerRadius = cornerRadius
@@ -139,7 +143,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
     }
 
     func makeCoordinator() -> Coordinator {
-        let coordinator = Coordinator(onAction: onAction, onDataRequest: onDataRequest, onPageChanged: onPageChanged, onSnapshotCaptured: onSnapshotCaptured, onLinkOpen: onLinkOpen, currentHTML: data.html, sandboxMode: sandboxMode)
+        let coordinator = Coordinator(onAction: onAction, onDataRequest: onDataRequest, onPageChanged: onPageChanged, onSnapshotCaptured: onSnapshotCaptured, onLinkOpen: onLinkOpen, currentHTML: data.html, sandboxMode: sandboxMode, allowedHosts: allowedHosts)
         coordinator.surfaceId = data.appId ?? "ephemeral"
         coordinator.appId = appId
         coordinator.loadStartTime = CFAbsoluteTimeGetCurrent()
@@ -624,6 +628,8 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
         /// The page currently displayed in a multi-page app (e.g. "settings.html").
         var currentPage: String = "index.html"
         let sandboxMode: Bool
+        /// Hosts that sandboxed apps are allowed to reach (declared in bundle manifest).
+        let allowedHosts: [String]
         weak var webView: WKWebView?
         var lastTopInset: Int = 0
         var lastBottomInset: Int = 0
@@ -661,7 +667,8 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             onSnapshotCaptured: ((String) -> Void)?,
             onLinkOpen: ((String, [String: Any]?) -> Void)? = nil,
             currentHTML: String,
-            sandboxMode: Bool = false
+            sandboxMode: Bool = false,
+            allowedHosts: [String] = []
         ) {
             self.onAction = onAction
             self.onDataRequest = onDataRequest
@@ -670,6 +677,7 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
             self.onLinkOpen = onLinkOpen
             self.currentHTML = currentHTML
             self.sandboxMode = sandboxMode
+            self.allowedHosts = allowedHosts
         }
 
         func userContentController(

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceContainerView.swift
@@ -79,7 +79,8 @@ struct SurfaceContainerView: View {
                     onDataRequest: viewModel.onDataRequest,
                     onCoordinatorReady: viewModel.onCoordinatorReady,
                     onLinkOpen: viewModel.onLinkOpen,
-                    sandboxMode: viewModel.sandboxMode
+                    sandboxMode: viewModel.sandboxMode,
+                    allowedHosts: viewModel.allowedHosts
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             case .fileUpload(let data):

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -18,6 +18,7 @@ final class SurfaceViewModel {
     @ObservationIgnored let onCoordinatorReady: ((DynamicPageSurfaceView.Coordinator) -> Void)?
     @ObservationIgnored let onLinkOpen: ((String, [String: Any]?) -> Void)?
     @ObservationIgnored let sandboxMode: Bool
+    @ObservationIgnored let allowedHosts: [String]
 
     init(
         surface: Surface,
@@ -27,7 +28,8 @@ final class SurfaceViewModel {
         onDataRequest: ((String, String, String?, [String: Any]?) -> Void)? = nil,
         onCoordinatorReady: ((DynamicPageSurfaceView.Coordinator) -> Void)? = nil,
         onLinkOpen: ((String, [String: Any]?) -> Void)? = nil,
-        sandboxMode: Bool = false
+        sandboxMode: Bool = false,
+        allowedHosts: [String] = []
     ) {
         self.surface = surface
         self.onAction = onAction
@@ -37,6 +39,7 @@ final class SurfaceViewModel {
         self.onCoordinatorReady = onCoordinatorReady
         self.onLinkOpen = onLinkOpen
         self.sandboxMode = sandboxMode
+        self.allowedHosts = allowedHosts
     }
 }
 
@@ -137,6 +140,14 @@ final class SurfaceManager {
         let appId = surfaceAppIds[surface.id]
         let isSandboxed = message.conversationId == "shared-app"
 
+        // Look up allowed hosts from bundle metadata for sandboxed apps.
+        let allowedHosts: [String]
+        if isSandboxed, let appId, let metadata = BundleSandbox.metadata(for: appId) {
+            allowedHosts = metadata.allowedHosts
+        } else {
+            allowedHosts = []
+        }
+
         let viewModel = SurfaceViewModel(
             surface: surface,
             onAction: { [weak self] actionId, data in
@@ -164,7 +175,8 @@ final class SurfaceManager {
             onLinkOpen: { [weak self] url, metadata in
                 self?.onLinkOpen?(url, metadata)
             },
-            sandboxMode: isSandboxed
+            sandboxMode: isSandboxed,
+            allowedHosts: allowedHosts
         )
         viewModels[surface.id] = viewModel
 

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -148,9 +148,9 @@ final class SurfaceManager {
         let allowedHosts: [String]
         if isSandboxed, let appId, let metadata = BundleSandbox.metadata(for: appId) {
             let merged = Set(metadata.allowedHosts).union(globalAppAllowedHosts)
-            allowedHosts = Array(merged).sorted()
+            allowedHosts = AppHostAllowlist.normalizeDomains(Array(merged)).sorted()
         } else if isSandboxed, !globalAppAllowedHosts.isEmpty {
-            allowedHosts = globalAppAllowedHosts
+            allowedHosts = AppHostAllowlist.normalizeDomains(globalAppAllowedHosts)
         } else {
             allowedHosts = []
         }

--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -79,6 +79,9 @@ final class SurfaceManager {
 
     @ObservationIgnored private var closeObservers: [String: Any] = [:]
 
+    /// Global allowed hosts from settings, merged with per-app manifest hosts.
+    @ObservationIgnored var globalAppAllowedHosts: [String] = []
+
     @ObservationIgnored private let panelWidth: CGFloat = 380
     @ObservationIgnored private let panelMargin: CGFloat = 20
     @ObservationIgnored private let panelSpacing: CGFloat = 10
@@ -140,10 +143,14 @@ final class SurfaceManager {
         let appId = surfaceAppIds[surface.id]
         let isSandboxed = message.conversationId == "shared-app"
 
-        // Look up allowed hosts from bundle metadata for sandboxed apps.
+        // Look up allowed hosts from bundle metadata for sandboxed apps,
+        // merged with the global allowed hosts from settings.
         let allowedHosts: [String]
         if isSandboxed, let appId, let metadata = BundleSandbox.metadata(for: appId) {
-            allowedHosts = metadata.allowedHosts
+            let merged = Set(metadata.allowedHosts).union(globalAppAllowedHosts)
+            allowedHosts = Array(merged).sorted()
+        } else if isSandboxed, !globalAppAllowedHosts.isEmpty {
+            allowedHosts = globalAppAllowedHosts
         } else {
             allowedHosts = []
         }

--- a/clients/shared/Features/Surfaces/AppHostAllowlist.swift
+++ b/clients/shared/Features/Surfaces/AppHostAllowlist.swift
@@ -46,7 +46,7 @@ public enum AppHostAllowlist {
 
     /// Generates the WKContentRuleList JSON that blocks all requests except `vellumapp://`,
     /// `about:blank`, and the allowed hosts (each as an `ignore-previous-rules` entry with a
-    /// url-filter matching `^https://([^/]*\\.)?<escaped-host>/`).
+    /// url-filter matching `^(https|wss)://([^/]*\\.)?<escaped-host>(/|$)`).
     public static func contentRuleListJSON(allowedHosts: [String]) -> String {
         var rules: [[String: Any]] = []
 
@@ -72,7 +72,7 @@ public enum AppHostAllowlist {
         for host in allowedHosts {
             let escaped = NSRegularExpression.escapedPattern(for: host)
             rules.append([
-                "trigger": ["url-filter": "^https://([^/]*\\.)?\(escaped)/"],
+                "trigger": ["url-filter": "^(https|wss)://([^/]*\\.)?\(escaped)(/|$)"],
                 "action": ["type": "ignore-previous-rules"]
             ])
         }

--- a/clients/shared/Features/Surfaces/AppHostAllowlist.swift
+++ b/clients/shared/Features/Surfaces/AppHostAllowlist.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// Static utility for managing per-app host allowlists used by sandboxed webview surfaces.
+/// Provides domain normalization, URL matching, and WKContentRuleList JSON generation.
+public enum AppHostAllowlist {
+
+    // MARK: - Domain Normalization
+
+    /// Normalizes a user-provided domain list: trims whitespace and newlines, lowercases,
+    /// strips URL schemes/paths/query strings/fragments, removes empty strings,
+    /// and deduplicates while preserving first-occurrence order.
+    public static func normalizeDomains(_ domains: [String]) -> [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        for domain in domains {
+            var normalized = domain.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            guard !normalized.isEmpty else { continue }
+            normalized = extractHost(from: normalized)
+            guard !normalized.isEmpty, !seen.contains(normalized) else { continue }
+            seen.insert(normalized)
+            result.append(normalized)
+        }
+        return result
+    }
+
+    // MARK: - URL Matching
+
+    /// Returns `true` if the URL is allowed by the given host list.
+    /// Only HTTPS and WSS schemes are permitted. Supports exact match and subdomain matching
+    /// (e.g. "example.com" matches "sub.example.com").
+    public static func isAllowed(_ url: URL, allowedHosts: [String]) -> Bool {
+        guard let scheme = url.scheme?.lowercased(),
+              scheme == "https" || scheme == "wss",
+              let host = url.host?.lowercased() else { return false }
+
+        for domain in allowedHosts {
+            let normalizedDomain = domain.lowercased()
+            if host == normalizedDomain || host.hasSuffix(".\(normalizedDomain)") {
+                return true
+            }
+        }
+        return false
+    }
+
+    // MARK: - Content Rule List
+
+    /// Generates the WKContentRuleList JSON that blocks all requests except `vellumapp://`,
+    /// `about:blank`, and the allowed hosts (each as an `ignore-previous-rules` entry with a
+    /// url-filter matching `^https://([^/]*\\.)?<escaped-host>/`).
+    public static func contentRuleListJSON(allowedHosts: [String]) -> String {
+        var rules: [[String: Any]] = []
+
+        // Block everything by default.
+        rules.append([
+            "trigger": ["url-filter": ".*"],
+            "action": ["type": "block"]
+        ])
+
+        // Allow vellumapp:// scheme.
+        rules.append([
+            "trigger": ["url-filter": "^vellumapp://.*"],
+            "action": ["type": "ignore-previous-rules"]
+        ])
+
+        // Allow about:blank.
+        rules.append([
+            "trigger": ["url-filter": "^about:blank$"],
+            "action": ["type": "ignore-previous-rules"]
+        ])
+
+        // Allow each host (exact + subdomain).
+        for host in allowedHosts {
+            let escaped = NSRegularExpression.escapedPattern(for: host)
+            rules.append([
+                "trigger": ["url-filter": "^https://([^/]*\\.)?\(escaped)/"],
+                "action": ["type": "ignore-previous-rules"]
+            ])
+        }
+
+        // Serialize to JSON.
+        // swiftlint:disable:next force_try
+        let data = try! JSONSerialization.data(withJSONObject: rules, options: [.prettyPrinted, .sortedKeys])
+        return String(data: data, encoding: .utf8)!
+    }
+
+    // MARK: - Private
+
+    /// Extracts just the host component from a string that may be a full URL.
+    private static func extractHost(from value: String) -> String {
+        if value.hasPrefix("http://") || value.hasPrefix("https://") {
+            if let components = URLComponents(string: value), let host = components.host, !host.isEmpty {
+                return host
+            }
+            return value
+        }
+
+        if let slashIndex = value.firstIndex(of: "/") {
+            let host = String(value[value.startIndex..<slashIndex])
+            return host.isEmpty ? value : host
+        }
+
+        return value
+    }
+}

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -607,10 +607,11 @@ public struct BundleAppResponseManifest: Codable, Sendable {
     public let created_by: String
     public let entry: String
     public let capabilities: [String]
+    public let allowed_hosts: [String]
     public let version: String?
     public let content_id: String?
 
-    public init(format_version: Int, name: String, description: String? = nil, icon: String? = nil, created_at: String, created_by: String, entry: String, capabilities: [String], version: String? = nil, content_id: String? = nil) {
+    public init(format_version: Int, name: String, description: String? = nil, icon: String? = nil, created_at: String, created_by: String, entry: String, capabilities: [String], allowed_hosts: [String] = [], version: String? = nil, content_id: String? = nil) {
         self.format_version = format_version
         self.name = name
         self.description = description
@@ -619,8 +620,24 @@ public struct BundleAppResponseManifest: Codable, Sendable {
         self.created_by = created_by
         self.entry = entry
         self.capabilities = capabilities
+        self.allowed_hosts = allowed_hosts
         self.version = version
         self.content_id = content_id
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        format_version = try container.decode(Int.self, forKey: .format_version)
+        name = try container.decode(String.self, forKey: .name)
+        description = try container.decodeIfPresent(String.self, forKey: .description)
+        icon = try container.decodeIfPresent(String.self, forKey: .icon)
+        created_at = try container.decode(String.self, forKey: .created_at)
+        created_by = try container.decode(String.self, forKey: .created_by)
+        entry = try container.decode(String.self, forKey: .entry)
+        capabilities = try container.decode([String].self, forKey: .capabilities)
+        allowed_hosts = try container.decodeIfPresent([String].self, forKey: .allowed_hosts) ?? []
+        version = try container.decodeIfPresent(String.self, forKey: .version)
+        content_id = try container.decodeIfPresent(String.self, forKey: .content_id)
     }
 }
 
@@ -2873,8 +2890,9 @@ public struct OpenBundleResponseManifest: Codable, Sendable {
     public let created_by: String
     public let entry: String
     public let capabilities: [String]
+    public let allowed_hosts: [String]
 
-    public init(format_version: Int, name: String, description: String? = nil, icon: String? = nil, created_at: String, created_by: String, entry: String, capabilities: [String]) {
+    public init(format_version: Int, name: String, description: String? = nil, icon: String? = nil, created_at: String, created_by: String, entry: String, capabilities: [String], allowed_hosts: [String] = []) {
         self.format_version = format_version
         self.name = name
         self.description = description
@@ -2883,6 +2901,20 @@ public struct OpenBundleResponseManifest: Codable, Sendable {
         self.created_by = created_by
         self.entry = entry
         self.capabilities = capabilities
+        self.allowed_hosts = allowed_hosts
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        format_version = try container.decode(Int.self, forKey: .format_version)
+        name = try container.decode(String.self, forKey: .name)
+        description = try container.decodeIfPresent(String.self, forKey: .description)
+        icon = try container.decodeIfPresent(String.self, forKey: .icon)
+        created_at = try container.decode(String.self, forKey: .created_at)
+        created_by = try container.decode(String.self, forKey: .created_by)
+        entry = try container.decode(String.self, forKey: .entry)
+        capabilities = try container.decode([String].self, forKey: .capabilities)
+        allowed_hosts = try container.decodeIfPresent([String].self, forKey: .allowed_hosts) ?? []
     }
 }
 

--- a/clients/shared/Tests/AppHostAllowlistTests.swift
+++ b/clients/shared/Tests/AppHostAllowlistTests.swift
@@ -1,0 +1,182 @@
+import XCTest
+@testable import VellumAssistantShared
+
+final class AppHostAllowlistTests: XCTestCase {
+
+    // MARK: - normalizeDomains
+
+    func testNormalizeDomains_basicDomain() {
+        let result = AppHostAllowlist.normalizeDomains(["example.com"])
+        XCTAssertEqual(result, ["example.com"])
+    }
+
+    func testNormalizeDomains_trimsWhitespace() {
+        let result = AppHostAllowlist.normalizeDomains(["  example.com  ", "\texample.org\n"])
+        XCTAssertEqual(result, ["example.com", "example.org"])
+    }
+
+    func testNormalizeDomains_lowercases() {
+        let result = AppHostAllowlist.normalizeDomains(["Example.COM", "FOO.bar"])
+        XCTAssertEqual(result, ["example.com", "foo.bar"])
+    }
+
+    func testNormalizeDomains_stripsScheme() {
+        let result = AppHostAllowlist.normalizeDomains(["https://example.com", "http://foo.bar"])
+        XCTAssertEqual(result, ["example.com", "foo.bar"])
+    }
+
+    func testNormalizeDomains_stripsPath() {
+        let result = AppHostAllowlist.normalizeDomains(["example.com/path/to/page"])
+        XCTAssertEqual(result, ["example.com"])
+    }
+
+    func testNormalizeDomains_stripsSchemeAndPath() {
+        let result = AppHostAllowlist.normalizeDomains(["https://example.com/path?q=1#frag"])
+        XCTAssertEqual(result, ["example.com"])
+    }
+
+    func testNormalizeDomains_removesEmptyStrings() {
+        let result = AppHostAllowlist.normalizeDomains(["", "  ", "example.com", ""])
+        XCTAssertEqual(result, ["example.com"])
+    }
+
+    func testNormalizeDomains_deduplicates() {
+        let result = AppHostAllowlist.normalizeDomains(["example.com", "EXAMPLE.COM", "example.com"])
+        XCTAssertEqual(result, ["example.com"])
+    }
+
+    func testNormalizeDomains_preservesOrder() {
+        let result = AppHostAllowlist.normalizeDomains(["beta.com", "alpha.com", "gamma.com"])
+        XCTAssertEqual(result, ["beta.com", "alpha.com", "gamma.com"])
+    }
+
+    // MARK: - isAllowed — exact match
+
+    func testIsAllowed_exactMatch() {
+        let url = URL(string: "https://example.com/page")!
+        XCTAssertTrue(AppHostAllowlist.isAllowed(url, allowedHosts: ["example.com"]))
+    }
+
+    // MARK: - isAllowed — subdomain match
+
+    func testIsAllowed_subdomainMatch() {
+        let url = URL(string: "https://www.example.com/page")!
+        XCTAssertTrue(AppHostAllowlist.isAllowed(url, allowedHosts: ["example.com"]))
+    }
+
+    func testIsAllowed_deepSubdomainMatch() {
+        let url = URL(string: "https://a.b.c.example.com/page")!
+        XCTAssertTrue(AppHostAllowlist.isAllowed(url, allowedHosts: ["example.com"]))
+    }
+
+    // MARK: - isAllowed — non-matching domain
+
+    func testIsAllowed_nonMatchingDomain() {
+        let url = URL(string: "https://other.com/page")!
+        XCTAssertFalse(AppHostAllowlist.isAllowed(url, allowedHosts: ["example.com"]))
+    }
+
+    func testIsAllowed_partialMatchRejected() {
+        let url = URL(string: "https://notexample.com/page")!
+        XCTAssertFalse(AppHostAllowlist.isAllowed(url, allowedHosts: ["example.com"]))
+    }
+
+    // MARK: - isAllowed — scheme handling
+
+    func testIsAllowed_httpRejected() {
+        let url = URL(string: "http://example.com/page")!
+        XCTAssertFalse(AppHostAllowlist.isAllowed(url, allowedHosts: ["example.com"]))
+    }
+
+    func testIsAllowed_ftpRejected() {
+        let url = URL(string: "ftp://example.com/file")!
+        XCTAssertFalse(AppHostAllowlist.isAllowed(url, allowedHosts: ["example.com"]))
+    }
+
+    func testIsAllowed_httpsAllowed() {
+        let url = URL(string: "https://example.com")!
+        XCTAssertTrue(AppHostAllowlist.isAllowed(url, allowedHosts: ["example.com"]))
+    }
+
+    func testIsAllowed_wssAllowed() {
+        let url = URL(string: "wss://example.com/socket")!
+        XCTAssertTrue(AppHostAllowlist.isAllowed(url, allowedHosts: ["example.com"]))
+    }
+
+    func testIsAllowed_wsRejected() {
+        let url = URL(string: "ws://example.com/socket")!
+        XCTAssertFalse(AppHostAllowlist.isAllowed(url, allowedHosts: ["example.com"]))
+    }
+
+    // MARK: - isAllowed — edge cases
+
+    func testIsAllowed_emptyAllowlist() {
+        let url = URL(string: "https://example.com")!
+        XCTAssertFalse(AppHostAllowlist.isAllowed(url, allowedHosts: []))
+    }
+
+    func testIsAllowed_caseInsensitive() {
+        let url = URL(string: "https://WWW.Example.COM/page")!
+        XCTAssertTrue(AppHostAllowlist.isAllowed(url, allowedHosts: ["EXAMPLE.COM"]))
+    }
+
+    // MARK: - contentRuleListJSON
+
+    func testContentRuleListJSON_isValidJSON() {
+        let json = AppHostAllowlist.contentRuleListJSON(allowedHosts: ["example.com"])
+        let data = json.data(using: .utf8)!
+        let parsed = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+        XCTAssertNotNil(parsed, "Content rule list JSON should be valid JSON")
+    }
+
+    func testContentRuleListJSON_containsBlockAllRule() {
+        let json = AppHostAllowlist.contentRuleListJSON(allowedHosts: [])
+        XCTAssertTrue(json.contains("\"url-filter\" : \".*\""), "Should contain block-all trigger")
+        XCTAssertTrue(json.contains("\"type\" : \"block\""), "Should contain block action")
+    }
+
+    func testContentRuleListJSON_containsVellumAppBypass() {
+        let json = AppHostAllowlist.contentRuleListJSON(allowedHosts: [])
+        // JSONSerialization escapes forward slashes, so vellumapp:// becomes vellumapp:\/\/
+        XCTAssertTrue(json.contains("vellumapp:"), "Should contain vellumapp scheme bypass")
+    }
+
+    func testContentRuleListJSON_containsAboutBlankBypass() {
+        let json = AppHostAllowlist.contentRuleListJSON(allowedHosts: [])
+        XCTAssertTrue(json.contains("about:blank"), "Should contain about:blank bypass")
+    }
+
+    func testContentRuleListJSON_containsHostBypassRules() {
+        let json = AppHostAllowlist.contentRuleListJSON(allowedHosts: ["example.com", "foo.bar"])
+        // JSONSerialization double-escapes backslashes: example\.com becomes example\\.com in JSON
+        XCTAssertTrue(json.contains("example\\\\.com"), "Should contain escaped host pattern for example.com")
+        XCTAssertTrue(json.contains("foo\\\\.bar"), "Should contain escaped host pattern for foo.bar")
+    }
+
+    func testContentRuleListJSON_hostRulesUseIgnorePreviousRules() {
+        let json = AppHostAllowlist.contentRuleListJSON(allowedHosts: ["example.com"])
+        let data = json.data(using: .utf8)!
+        let rules = try! JSONSerialization.jsonObject(with: data) as! [[String: Any]]
+
+        // The last rule should be the host bypass rule with ignore-previous-rules action.
+        let lastRule = rules.last!
+        let action = lastRule["action"] as! [String: String]
+        XCTAssertEqual(action["type"], "ignore-previous-rules")
+    }
+
+    func testContentRuleListJSON_ruleCount() {
+        let json = AppHostAllowlist.contentRuleListJSON(allowedHosts: ["a.com", "b.com"])
+        let data = json.data(using: .utf8)!
+        let rules = try! JSONSerialization.jsonObject(with: data) as! [[String: Any]]
+        // 1 block-all + 1 vellumapp + 1 about:blank + 2 hosts = 5
+        XCTAssertEqual(rules.count, 5)
+    }
+
+    func testContentRuleListJSON_emptyHostsStillHasBaseRules() {
+        let json = AppHostAllowlist.contentRuleListJSON(allowedHosts: [])
+        let data = json.data(using: .utf8)!
+        let rules = try! JSONSerialization.jsonObject(with: data) as! [[String: Any]]
+        // 1 block-all + 1 vellumapp + 1 about:blank = 3
+        XCTAssertEqual(rules.count, 3)
+    }
+}

--- a/clients/shared/Tests/AppHostAllowlistTests.swift
+++ b/clients/shared/Tests/AppHostAllowlistTests.swift
@@ -172,6 +172,19 @@ final class AppHostAllowlistTests: XCTestCase {
         XCTAssertEqual(rules.count, 5)
     }
 
+    func testContentRuleListJSON_hostPatternMatchesBareDomain() {
+        let json = AppHostAllowlist.contentRuleListJSON(allowedHosts: ["example.com"])
+        // The url-filter should use (/|$) to match bare-domain URLs without trailing slash
+        XCTAssertTrue(json.contains("(/|$)"), "Host pattern should use (/|$) to match bare-domain URLs")
+        XCTAssertFalse(json.contains("example\\\\.com/\""), "Host pattern should NOT require trailing slash")
+    }
+
+    func testContentRuleListJSON_hostPatternIncludesWss() {
+        let json = AppHostAllowlist.contentRuleListJSON(allowedHosts: ["example.com"])
+        // The url-filter should match both https and wss schemes
+        XCTAssertTrue(json.contains("(https|wss)"), "Host pattern should match both https and wss schemes")
+    }
+
     func testContentRuleListJSON_emptyHostsStillHasBaseRules() {
         let json = AppHostAllowlist.contentRuleListJSON(allowedHosts: [])
         let data = json.data(using: .utf8)!


### PR DESCRIPTION
## Summary
Add per-app host whitelisting for sandboxed webview apps, enabling apps with more complex architectures (e.g., apps that talk to their own backend API, fetch data from third-party services, or load external assets). Hosts can be declared in the app manifest or configured globally in settings.

## PRs merged into feature branch
- #21713: Add AppHostAllowlist model with domain normalization and matching
- #21712: Add allowedHosts field to BundleMetadata and manifest types
- #21718: Pass allowedHosts from bundle metadata through to webview sandbox
- #21722: Enforce allowedHosts in sandbox content rules and navigation delegate
- #21728: Add settings UI to manage per-app allowed hosts
- #21726: Expose allowedHosts to apps via window.vellum JS bridge

### Fix PRs (from self-review)
- #21734: fix: content rule list regex, WSS support, and host normalization
- #21732: fix: include bundle UUID as appId in shared-app surface data

Part of plan: webview-host-allowlist.md