### PR TITLE
fix: include bundle UUID as appId in shared-app surface data

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift
@@ -162,7 +162,7 @@ extension AppDelegate {
                         surfaceId: surfaceId,
                         surfaceType: "dynamic_page",
                         title: manifest.name,
-                        data: AnyCodable(["html": html]),
+                        data: AnyCodable(["html": html, "appId": uuid]),
                         actions: nil,
                         display: "panel",
                         messageId: nil

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -413,7 +413,7 @@ struct AppsGridView: View {
             surfaceId: "shared-app-\(app.uuid)",
             surfaceType: "dynamic_page",
             title: app.name,
-            data: AnyCodable(["html": html]),
+            data: AnyCodable(["html": html, "appId": app.uuid]),
             actions: nil,
             display: "panel",
             messageId: nil

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -600,7 +600,7 @@ struct GeneratedPanel: View {
                 surfaceId: "shared-app-\(uuid)",
                 surfaceType: "dynamic_page",
                 title: item.name,
-                data: AnyCodable(["html": html]),
+                data: AnyCodable(["html": html, "appId": uuid]),
                 actions: nil,
                 display: "panel",
                 messageId: nil


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for webview-host-allowlist.md.

**Gap:** Per-app manifest `allowedHosts` were never loaded because shared-app surface messages didn't include `appId`. Added the bundle UUID to surface data in all three launch paths so `SurfaceManager` can look up `BundleMetadata.allowedHosts`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21732" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
