### PR TITLE
fix: content rule list regex, WSS support, and host normalization

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -148,9 +148,9 @@ final class SurfaceManager {
         let allowedHosts: [String]
         if isSandboxed, let appId, let metadata = BundleSandbox.metadata(for: appId) {
             let merged = Set(metadata.allowedHosts).union(globalAppAllowedHosts)
-            allowedHosts = Array(merged).sorted()
+            allowedHosts = AppHostAllowlist.normalizeDomains(Array(merged)).sorted()
         } else if isSandboxed, !globalAppAllowedHosts.isEmpty {
-            allowedHosts = globalAppAllowedHosts
+            allowedHosts = AppHostAllowlist.normalizeDomains(globalAppAllowedHosts)
         } else {
             allowedHosts = []
         }

--- a/clients/shared/Features/Surfaces/AppHostAllowlist.swift
+++ b/clients/shared/Features/Surfaces/AppHostAllowlist.swift
@@ -46,7 +46,7 @@ public enum AppHostAllowlist {
 
     /// Generates the WKContentRuleList JSON that blocks all requests except `vellumapp://`,
     /// `about:blank`, and the allowed hosts (each as an `ignore-previous-rules` entry with a
-    /// url-filter matching `^https://([^/]*\\.)?<escaped-host>/`).
+    /// url-filter matching `^(https|wss)://([^/]*\\.)?<escaped-host>(/|$)`).
     public static func contentRuleListJSON(allowedHosts: [String]) -> String {
         var rules: [[String: Any]] = []
 
@@ -72,7 +72,7 @@ public enum AppHostAllowlist {
         for host in allowedHosts {
             let escaped = NSRegularExpression.escapedPattern(for: host)
             rules.append([
-                "trigger": ["url-filter": "^https://([^/]*\\.)?\(escaped)/"],
+                "trigger": ["url-filter": "^(https|wss)://([^/]*\\.)?\(escaped)(/|$)"],
                 "action": ["type": "ignore-previous-rules"]
             ])
         }

--- a/clients/shared/Tests/AppHostAllowlistTests.swift
+++ b/clients/shared/Tests/AppHostAllowlistTests.swift
@@ -172,6 +172,19 @@ final class AppHostAllowlistTests: XCTestCase {
         XCTAssertEqual(rules.count, 5)
     }
 
+    func testContentRuleListJSON_hostPatternMatchesBareDomain() {
+        let json = AppHostAllowlist.contentRuleListJSON(allowedHosts: ["example.com"])
+        // The url-filter should use (/|$) to match bare-domain URLs without trailing slash
+        XCTAssertTrue(json.contains("(/|$)"), "Host pattern should use (/|$) to match bare-domain URLs")
+        XCTAssertFalse(json.contains("example\\\\.com/\""), "Host pattern should NOT require trailing slash")
+    }
+
+    func testContentRuleListJSON_hostPatternIncludesWss() {
+        let json = AppHostAllowlist.contentRuleListJSON(allowedHosts: ["example.com"])
+        // The url-filter should match both https and wss schemes
+        XCTAssertTrue(json.contains("(https|wss)"), "Host pattern should match both https and wss schemes")
+    }
+
     func testContentRuleListJSON_emptyHostsStillHasBaseRules() {
         let json = AppHostAllowlist.contentRuleListJSON(allowedHosts: [])
         let data = json.data(using: .utf8)!


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for webview-host-allowlist.md.

**Gap 1:** Content rule list url-filter now uses `(/|$)` instead of trailing `/` to match bare-domain URLs
**Gap 4:** Content rule list now includes WSS patterns alongside HTTPS for WebSocket support
**Gap 5:** Merged hosts are normalized via `AppHostAllowlist.normalizeDomains` in SurfaceManager
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21734" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
