### PR TITLE
refactor: rename VSidebarRow to VNavItem

### DIFF
--- a/clients/AGENTS.md
+++ b/clients/AGENTS.md
@@ -412,7 +412,7 @@ All UI icons use **vendored Lucide PDF assets** rendered through the `VIcon` enu
 
 ### Naming Convention: `V` Prefix
 All design system types — structs, enums, and view modifiers — **must** use the `V` prefix to distinguish them from native SwiftUI types and feature-level views:
-- **Views and controls:** `VButton`, `VCard`, `VTextField`, `VSidebarRow`, `VLoadingIndicator`
+- **Views and controls:** `VButton`, `VCard`, `VTextField`, `VNavItem`, `VLoadingIndicator`
 - **Tokens:** `VColor`, `VFont`, `VSpacing`, `VRadius`, `VShadow`, `VAnimation`, `VIcon`
 - **View modifiers:** `.vCard()`, `.vTooltip()`, `.vShimmer()`, `.vPanelBackground()`
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -183,7 +183,7 @@ struct AgentPanelContent: View {
     }
 
     private func categorySidebarRow(icon: String, label: String, category: SkillCategory?) -> some View {
-        VSidebarRow(
+        VNavItem(
             icon: icon,
             label: label,
             isActive: selectedCategory == category,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -164,7 +164,7 @@ struct MemoriesPanel: View {
     }
 
     private func kindFilterRow(icon: String, label: String, kind: MemoryKind?) -> some View {
-        VSidebarRow(
+        VNavItem(
             icon: icon,
             label: label,
             isActive: selectedKind == kind,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarPrimaryRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarPrimaryRow.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import VellumAssistantShared
 
 /// Unified sidebar row used by both nav items and pinned apps.
-/// Delegates to the shared `VSidebarRow` for layout and styling.
+/// Delegates to the shared `VNavItem` for layout and styling.
 struct SidebarPrimaryRow: View {
     let icon: String
     let label: String
@@ -13,7 +13,7 @@ struct SidebarPrimaryRow: View {
 
     var body: some View {
         if let trailingIcon {
-            VSidebarRow(
+            VNavItem(
                 icon: icon,
                 label: label,
                 isActive: isActive,
@@ -22,7 +22,7 @@ struct SidebarPrimaryRow: View {
                 action: action
             )
         } else {
-            VSidebarRow(
+            VNavItem(
                 icon: icon,
                 label: label,
                 isActive: isActive,

--- a/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
@@ -61,7 +61,7 @@ public struct VMenu<Content: View>: View {
 public enum VMenuItemSize {
     /// Compact menu item — 13pt DM Sans, matching sidebar conversation rows.
     case compact
-    /// Regular menu item — delegates to `VSidebarRow` (14pt `VFont.bodyMediumDefault`).
+    /// Regular menu item — delegates to `VNavItem` (14pt `VFont.bodyMediumDefault`).
     case regular
 
     fileprivate var font: Font { self == .compact ? VFont.menuCompact : VFont.bodyMediumDefault }
@@ -72,13 +72,13 @@ public enum VMenuItemSize {
 /// A tappable menu row with optional leading icon, active state, and trailing content.
 ///
 /// Defaults to `.compact` size (13pt) to match sidebar conversation rows. Use `.regular`
-/// for 14pt rows that match `VSidebarRow`.
+/// for 14pt rows that match `VNavItem`.
 ///
 /// Usage:
 /// ```swift
 /// VMenuItem(icon: VIcon.settings.rawValue, label: "Settings") { openSettings() }
 ///
-/// // Regular size (14pt, same as VSidebarRow):
+/// // Regular size (14pt, same as VNavItem):
 /// VMenuItem(icon: VIcon.settings.rawValue, label: "Settings", size: .regular) { openSettings() }
 ///
 /// // With trailing content:
@@ -125,7 +125,7 @@ public struct VMenuItem<Trailing: View>: View {
 
     public var body: some View {
         if size == .regular {
-            VSidebarRow(
+            VNavItem(
                 icon: icon,
                 label: label,
                 isActive: isActive,

--- a/clients/shared/DesignSystem/Core/Navigation/VNavItem.swift
+++ b/clients/shared/DesignSystem/Core/Navigation/VNavItem.swift
@@ -7,16 +7,16 @@ import SwiftUI
 ///
 /// Usage:
 /// ```swift
-/// VSidebarRow(icon: VIcon.brain.rawValue, label: "Intelligence", isActive: true) {
+/// VNavItem(icon: VIcon.brain.rawValue, label: "Intelligence", isActive: true) {
 ///     showPanel(.intelligence)
 /// }
 ///
 /// // With trailing content:
-/// VSidebarRow(label: "Identity", isActive: true, action: { }) {
+/// VNavItem(label: "Identity", isActive: true, action: { }) {
 ///     Text("5").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
 /// }
 /// ```
-public struct VSidebarRow<Trailing: View>: View {
+public struct VNavItem<Trailing: View>: View {
     public let icon: String?
     public let label: String
     public var isActive: Bool
@@ -97,7 +97,7 @@ public struct VSidebarRow<Trailing: View>: View {
 
 // MARK: - Convenience initializers
 
-public extension VSidebarRow where Trailing == EmptyView {
+public extension VNavItem where Trailing == EmptyView {
     /// Simple row with no trailing content.
     init(
         icon: String? = nil,
@@ -112,7 +112,7 @@ public extension VSidebarRow where Trailing == EmptyView {
     }
 }
 
-public extension VSidebarRow where Trailing == VSidebarRowTrailingIcon {
+public extension VNavItem where Trailing == VNavItemTrailingIcon {
     /// Row with a trailing icon and optional rotation (used by the main sidebar for disclosure arrows).
     init(
         icon: String? = nil,
@@ -125,7 +125,7 @@ public extension VSidebarRow where Trailing == VSidebarRowTrailingIcon {
     ) {
         let active = isActive
         self.init(icon: icon, label: label, isActive: isActive, isExpanded: isExpanded, action: action) {
-            VSidebarRowTrailingIcon(
+            VNavItemTrailingIcon(
                 icon: trailingIcon,
                 rotation: trailingIconRotation,
                 isActive: active
@@ -135,7 +135,7 @@ public extension VSidebarRow where Trailing == VSidebarRowTrailingIcon {
 }
 
 /// Trailing icon view extracted so the convenience init can reference a concrete type.
-public struct VSidebarRowTrailingIcon: View {
+public struct VNavItemTrailingIcon: View {
     let icon: String
     var rotation: Angle = .zero
     var isActive: Bool = false

--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -130,7 +130,7 @@ enum ComponentGalleryCategory: String, CaseIterable, Identifiable {
         case .navigation:
             return [
                 GalleryComponent("vSegmentedControl", "VTabs", keywords: ["segmented control", "tabs"], description: "Segmented control with underline, pill, or compact pill styles for switching between views."),
-                GalleryComponent("vSidebarRow", "VSidebarRow", keywords: ["sidebar row", "navigation row"], description: "Sidebar navigation row with icon, label, hover/active states, trailing disclosure icon, and collapsed mode."),
+                GalleryComponent("vNavItem", "VNavItem", keywords: ["sidebar row", "navigation row"], description: "Sidebar navigation row with icon, label, hover/active states, trailing disclosure icon, and collapsed mode."),
                 GalleryComponent("vLink", "VLink", keywords: ["link", "url", "external link", "hyperlink"], description: "Styled external link that opens a URL in the default browser. Applies pointer cursor, single-line truncation, and caption font by default."),
                 GalleryComponent("vThemeToggle", "VThemeToggle", keywords: ["theme toggle", "dark mode", "light mode"], description: "Three-way theme toggle (System / Light / Dark). Reads and writes themePreference in UserDefaults."),
                 GalleryComponent("vMenu", "VMenu", keywords: ["menu", "popover", "dropdown", "drawer", "overflow"], description: "Reusable popover container with section headers, dividers, action items, and custom rows. Use instead of manual drawer chrome."),
@@ -269,7 +269,7 @@ struct ComponentGalleryView: View {
         let isCategoryExpanded = isSearching || expandedCategories.contains(category)
 
         VStack(spacing: 0) {
-            VSidebarRow(
+            VNavItem(
                 icon: category.vIcon.rawValue,
                 label: category.rawValue,
                 trailingIcon: VIcon.chevronRight.rawValue,
@@ -305,7 +305,7 @@ struct ComponentGalleryView: View {
     private func sidebarRow(label: String, page: GalleryPage) -> some View {
         let isSelected = selectedPage == page
 
-        return VSidebarRow(
+        return VNavItem(
             label: label,
             isActive: isSelected
         ) {

--- a/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
@@ -97,13 +97,13 @@ struct NavigationGallerySection: View {
 
             }
 
-            if filter == nil || filter == "vSidebarRow" {
+            if filter == nil || filter == "vNavItem" {
                 if filter == nil {
                     Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
                 }
-                // MARK: - VSidebarRow
+                // MARK: - VNavItem
                 GallerySectionHeader(
-                    title: "VSidebarRow",
+                    title: "VNavItem",
                     description: "Sidebar navigation row with icon, label, hover/active states, and optional trailing icon. Used by the main app sidebar and the component gallery."
                 )
 
@@ -111,13 +111,13 @@ struct NavigationGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.sm) {
                         Text("States").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
 
-                        VSidebarRow(icon: VIcon.brain.rawValue, label: "Intelligence", isActive: sidebarRowActive == "Intelligence") {
+                        VNavItem(icon: VIcon.brain.rawValue, label: "Intelligence", isActive: sidebarRowActive == "Intelligence") {
                             sidebarRowActive = "Intelligence"
                         }
-                        VSidebarRow(icon: VIcon.bookOpen.rawValue, label: "Library", isActive: sidebarRowActive == "Library") {
+                        VNavItem(icon: VIcon.bookOpen.rawValue, label: "Library", isActive: sidebarRowActive == "Library") {
                             sidebarRowActive = "Library"
                         }
-                        VSidebarRow(icon: VIcon.settings.rawValue, label: "Settings", isActive: sidebarRowActive == "Settings") {
+                        VNavItem(icon: VIcon.settings.rawValue, label: "Settings", isActive: sidebarRowActive == "Settings") {
                             sidebarRowActive = "Settings"
                         }
                     }
@@ -127,9 +127,9 @@ struct NavigationGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.sm) {
                         Text("Without Icon").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
 
-                        VSidebarRow(label: "Overview", isActive: false) {}
-                        VSidebarRow(label: "VButton", isActive: true) {}
-                        VSidebarRow(label: "VSplitButton", isActive: false) {}
+                        VNavItem(label: "Overview", isActive: false) {}
+                        VNavItem(label: "VButton", isActive: true) {}
+                        VNavItem(label: "VSplitButton", isActive: false) {}
                     }
                 }
 
@@ -137,7 +137,7 @@ struct NavigationGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.sm) {
                         Text("Trailing Icon (Disclosure)").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
 
-                        VSidebarRow(
+                        VNavItem(
                             icon: VIcon.layers.rawValue,
                             label: "Display",
                             trailingIcon: VIcon.chevronRight.rawValue,
@@ -149,9 +149,9 @@ struct NavigationGallerySection: View {
                         }
 
                         if sidebarDisclosureExpanded {
-                            VSidebarRow(label: "VCard", isActive: false) {}
+                            VNavItem(label: "VCard", isActive: false) {}
                                 .padding(.leading, VSpacing.md)
-                            VSidebarRow(label: "VEmptyState", isActive: false) {}
+                            VNavItem(label: "VEmptyState", isActive: false) {}
                                 .padding(.leading, VSpacing.md)
                         }
                     }
@@ -161,17 +161,17 @@ struct NavigationGallerySection: View {
                     VStack(alignment: .leading, spacing: VSpacing.sm) {
                         Text("Trailing Content").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
 
-                        VSidebarRow(label: "All", isActive: true, action: {}) {
+                        VNavItem(label: "All", isActive: true, action: {}) {
                             Text("42")
                                 .font(VFont.labelDefault)
                                 .foregroundStyle(VColor.contentTertiary)
                         }
-                        VSidebarRow(label: "Identity", action: {}) {
+                        VNavItem(label: "Identity", action: {}) {
                             Text("12")
                                 .font(VFont.labelDefault)
                                 .foregroundStyle(VColor.contentTertiary)
                         }
-                        VSidebarRow(label: "Preference", action: {}) {
+                        VNavItem(label: "Preference", action: {}) {
                             Text("8")
                                 .font(VFont.labelDefault)
                                 .foregroundStyle(VColor.contentTertiary)
@@ -184,9 +184,9 @@ struct NavigationGallerySection: View {
                         Text("Collapsed Mode").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
 
                         HStack(spacing: VSpacing.md) {
-                            VSidebarRow(icon: VIcon.brain.rawValue, label: "Intelligence", isExpanded: false) {}
-                            VSidebarRow(icon: VIcon.bookOpen.rawValue, label: "Library", isActive: true, isExpanded: false) {}
-                            VSidebarRow(icon: VIcon.settings.rawValue, label: "Settings", isExpanded: false) {}
+                            VNavItem(icon: VIcon.brain.rawValue, label: "Intelligence", isExpanded: false) {}
+                            VNavItem(icon: VIcon.bookOpen.rawValue, label: "Library", isActive: true, isExpanded: false) {}
+                            VNavItem(icon: VIcon.settings.rawValue, label: "Settings", isExpanded: false) {}
                         }
                         .frame(maxWidth: 200)
                     }
@@ -387,7 +387,7 @@ extension NavigationGallerySection {
     static func componentPage(_ id: String) -> some View {
         switch id {
         case "vSegmentedControl": NavigationGallerySection(filter: "vSegmentedControl")
-        case "vSidebarRow": NavigationGallerySection(filter: "vSidebarRow")
+        case "vNavItem": NavigationGallerySection(filter: "vNavItem")
         case "vLink": NavigationGallerySection(filter: "vLink")
         case "vThemeToggle": NavigationGallerySection(filter: "vThemeToggle")
         case "vMenu": NavigationGallerySection(filter: "vMenu")


### PR DESCRIPTION
## Summary
- Rename `VSidebarRow` → `VNavItem` across all usage sites, gallery, and docs
- No behavioral changes

## Test plan
- [ ] Build passes
- [ ] Component gallery → Navigation → VNavItem renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21735" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
