### PR TITLE
feat: replace archive button with overflow menu on conversation threads

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
@@ -34,7 +34,6 @@ final class SharingState {
 final class SidebarInteractionState {
     var isHoveredConversation: UUID?
     var isHoveredApp: String?
-    var conversationPendingDeletion: UUID?
     var renamingConversationId: UUID?
     var renameText: String = ""
     var showAllConversations: Bool = false
@@ -45,9 +44,8 @@ final class SidebarInteractionState {
     var showAllApps: Bool = false
     var showPreferencesDrawer: Bool = false
 
-    /// Updates conversation hover state and clears stale pending-deletion when hover
-    /// moves to a different conversation. Centralises the invariant so callers don't
-    /// need to coordinate.
+    /// Updates conversation hover state. Centralises the invariant so callers
+    /// don't need to coordinate.
     ///
     /// During an active drag, hover updates are suppressed to avoid triggering
     /// icon-swap animations and unnecessary re-renders across sibling rows.
@@ -66,18 +64,10 @@ final class SidebarInteractionState {
         }
 
         if hovering {
-            // Moving to a new conversation clears pending archive of the old one
-            if let pending = conversationPendingDeletion, pending != conversationId {
-                conversationPendingDeletion = nil
-            }
             isHoveredConversation = conversationId
         } else {
             if isHoveredConversation == conversationId {
                 isHoveredConversation = nil
-            }
-            // Leaving a pending-deletion conversation clears the confirmation
-            if conversationPendingDeletion == conversationId {
-                conversationPendingDeletion = nil
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -351,7 +351,6 @@ extension MainWindowView {
                             Spacer()
                         }
                         .padding(.leading, VSpacing.xs + SidebarLayoutMetrics.iconSlotSize + VSpacing.xs - VSpacing.sm)
-                        .padding(.top, VSpacing.sm)
                         .padding(.bottom, VSpacing.xs)
                     }
 
@@ -491,7 +490,6 @@ extension MainWindowView {
                                 Spacer()
                             }
                             .padding(.leading, VSpacing.xs + SidebarLayoutMetrics.iconSlotSize + VSpacing.xs - VSpacing.sm)
-                            .padding(.top, VSpacing.sm)
                             .padding(.bottom, VSpacing.xs)
                         }
                     }
@@ -527,7 +525,6 @@ extension MainWindowView {
                                 Spacer()
                             }
                             .padding(.leading, VSpacing.xs + SidebarLayoutMetrics.iconSlotSize + VSpacing.xs - VSpacing.sm)
-                            .padding(.top, VSpacing.sm)
                             .padding(.bottom, VSpacing.xs)
                         }
                     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -177,7 +177,6 @@ extension MainWindowView {
             isSelected: isConversationSelected(conversation),
             interactionState: conversationManager.interactionState(for: conversation.id),
             isHovered: sidebar.isHoveredConversation == conversation.id,
-            isPendingDeletion: sidebar.conversationPendingDeletion == conversation.id,
             selectConversation: { selectConversation(conversation) },
             onSelect: onSelect,
             onTogglePin: {
@@ -190,11 +189,6 @@ extension MainWindowView {
                 }
             },
             onArchive: { conversationManager.archiveConversation(id: conversation.id) },
-            onBeginArchive: { sidebar.conversationPendingDeletion = conversation.id },
-            onConfirmArchive: {
-                conversationManager.archiveConversation(id: conversation.id)
-                sidebar.conversationPendingDeletion = nil
-            },
             onStartRename: {
                 sidebar.renamingConversationId = conversation.id
                 sidebar.renameText = conversation.title

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
@@ -32,7 +32,6 @@ struct ConversationSwitcherDrawer: View {
                         isSelected: isConversationSelected(conversation),
                         interactionState: conversationManager.interactionState(for: conversation.id),
                         isHovered: sidebar.isHoveredConversation == conversation.id,
-                        isPendingDeletion: sidebar.conversationPendingDeletion == conversation.id,
                         selectConversation: { selectConversation(conversation) },
                         onSelect: onDismiss,
                         onTogglePin: {
@@ -45,11 +44,6 @@ struct ConversationSwitcherDrawer: View {
                             }
                         },
                         onArchive: { conversationManager.archiveConversation(id: conversation.id) },
-                        onBeginArchive: { sidebar.conversationPendingDeletion = conversation.id },
-                        onConfirmArchive: {
-                            conversationManager.archiveConversation(id: conversation.id)
-                            sidebar.conversationPendingDeletion = nil
-                        },
                         onStartRename: {
                             sidebar.renamingConversationId = conversation.id
                             sidebar.renameText = conversation.title
@@ -83,7 +77,6 @@ struct ConversationSwitcherDrawer: View {
             if sidebar.isHoveredConversation != nil {
                 sidebar.isHoveredConversation = nil
             }
-            sidebar.conversationPendingDeletion = nil
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -179,6 +179,7 @@ struct SidebarConversationItem: View, Equatable {
         .overlay(alignment: .trailing) {
             if isHovered || isMenuOpen {
                 Button {
+                    guard !isMenuOpen else { return }
                     isMenuOpen = true
                     let appearance = NSApp.keyWindow?.effectiveAppearance
                     VMenuPanel.show(

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -11,15 +11,12 @@ struct SidebarConversationItem: View, Equatable {
     let isSelected: Bool
     let interactionState: ConversationInteractionState
     let isHovered: Bool
-    let isPendingDeletion: Bool
 
     // Action closures — not compared in Equatable
     var selectConversation: () -> Void
     var onSelect: (() -> Void)? = nil
     var onTogglePin: () -> Void
     var onArchive: () -> Void
-    var onBeginArchive: () -> Void
-    var onConfirmArchive: () -> Void
     var onStartRename: () -> Void
     var onMarkUnread: () -> Void
     var onHoverChange: (Bool) -> Void
@@ -31,15 +28,45 @@ struct SidebarConversationItem: View, Equatable {
         lhs.conversation == rhs.conversation &&
         lhs.isSelected == rhs.isSelected &&
         lhs.interactionState == rhs.interactionState &&
-        lhs.isHovered == rhs.isHovered &&
-        lhs.isPendingDeletion == rhs.isPendingDeletion
+        lhs.isHovered == rhs.isHovered
     }
 
-    private var hasTrailingIcon: Bool { isHovered || isPendingDeletion }
+    @State private var isMenuOpen: Bool = false
+    private var hasTrailingIcon: Bool { isHovered || isMenuOpen }
     private var canMarkUnread: Bool {
         !conversation.hasUnseenLatestAssistantMessage &&
             conversation.conversationId != nil &&
             conversation.latestAssistantMessageAt != nil
+    }
+
+    @ViewBuilder
+    private var contextMenuContent: some View {
+        VMenuItem(icon: conversation.isPinned ? VIcon.pinOff.rawValue : VIcon.pin.rawValue, label: conversation.isPinned ? "Unpin" : "Pin") {
+            onTogglePin()
+        }
+        VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename") {
+            onStartRename()
+        }
+        VMenuItem(icon: VIcon.archive.rawValue, label: "Archive") {
+            onArchive()
+        }
+        VMenuItem(icon: VIcon.circle.rawValue, label: "Mark as unread") {
+            onMarkUnread()
+        }
+        .disabled(!canMarkUnread)
+
+        if let onOpenInNewWindow {
+            VMenuItem(icon: VIcon.externalLink.rawValue, label: "Open in New Window") {
+                onOpenInNewWindow()
+            }
+        }
+
+        VMenuDivider()
+
+        VMenuItem(icon: VIcon.messageCircle.rawValue, label: "Share Feedback") {
+            onShowFeedback?()
+        }
+        .disabled(onShowFeedback == nil)
     }
 
     var body: some View {
@@ -121,13 +148,13 @@ struct SidebarConversationItem: View, Equatable {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.leading, VSpacing.xs)
-            .padding(.trailing, isPendingDeletion ? SidebarLayoutMetrics.archiveConfirmTrailingPadding : hasTrailingIcon ? SidebarLayoutMetrics.archiveIconTrailingPadding : VSpacing.sm)
+            .padding(.trailing, hasTrailingIcon ? SidebarLayoutMetrics.trailingIconPadding : VSpacing.sm)
             .padding(.vertical, SidebarLayoutMetrics.rowVerticalPadding)
             .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)
             .background {
                 if isSelected {
                     VColor.surfaceActive
-                } else if isHovered {
+                } else if isHovered || isMenuOpen {
                     VColor.surfaceBase
                 } else if conversation.kind == .private {
                     VColor.primaryBase.opacity(0.04)
@@ -149,56 +176,35 @@ struct SidebarConversationItem: View, Equatable {
             selectConversation()
         }
         .overlay(alignment: .trailing) {
-            if isPendingDeletion {
-                VButton(label: "Confirm", style: .dangerOutline, size: .pill) {
-                    onConfirmArchive()
-                }
-                .fixedSize()
-                .padding(.trailing, VSpacing.xs)
-                .accessibilityLabel("Confirm archive \(conversation.title)")
-            } else if isHovered {
+            if isHovered || isMenuOpen {
                 Button {
-                    onBeginArchive()
+                    isMenuOpen = true
+                    let appearance = NSApp.keyWindow?.effectiveAppearance
+                    VMenuPanel.show(
+                        at: NSEvent.mouseLocation,
+                        sourceAppearance: appearance
+                    ) {
+                        VMenu(width: 200) {
+                            contextMenuContent
+                        }
+                    } onDismiss: {
+                        isMenuOpen = false
+                    }
                 } label: {
-                    VIconView(.archive, size: 13)
+                    VIconView(.ellipsis, size: 13)
                         .foregroundStyle(VColor.contentSecondary)
                         .frame(width: 20, height: 20)
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .nativeTooltip("Archive")
+                .nativeTooltip("More options")
                 .padding(.trailing, VSpacing.xs)
-                .accessibilityLabel("Archive \(conversation.title)")
+                .accessibilityLabel("More options for \(conversation.title)")
             }
         }
         .padding(.horizontal, 0)
         .vContextMenu(width: 200) {
-            VMenuItem(icon: conversation.isPinned ? VIcon.pinOff.rawValue : VIcon.pin.rawValue, label: conversation.isPinned ? "Unpin" : "Pin") {
-                onTogglePin()
-            }
-            VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename") {
-                onStartRename()
-            }
-            VMenuItem(icon: VIcon.archive.rawValue, label: "Archive") {
-                onArchive()
-            }
-            VMenuItem(icon: VIcon.circle.rawValue, label: "Mark as unread") {
-                onMarkUnread()
-            }
-            .disabled(!canMarkUnread)
-
-            if let onOpenInNewWindow {
-                VMenuItem(icon: VIcon.externalLink.rawValue, label: "Open in New Window") {
-                    onOpenInNewWindow()
-                }
-            }
-
-            VMenuDivider()
-
-            VMenuItem(icon: VIcon.messageCircle.rawValue, label: "Share Feedback") {
-                onShowFeedback?()
-            }
-            .disabled(onShowFeedback == nil)
+            contextMenuContent
         }
         .pointerCursor { hovering in
             onHoverChange(hovering)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -32,7 +32,6 @@ struct SidebarConversationItem: View, Equatable {
     }
 
     @State private var isMenuOpen: Bool = false
-    @State private var overflowButtonFrame: CGRect = .zero
     private var hasTrailingIcon: Bool { isHovered || isMenuOpen }
     private var canMarkUnread: Bool {
         !conversation.hasUnseenLatestAssistantMessage &&
@@ -182,20 +181,8 @@ struct SidebarConversationItem: View, Equatable {
                 Button {
                     isMenuOpen = true
                     let appearance = NSApp.keyWindow?.effectiveAppearance
-                    let screenPoint: CGPoint
-                    if let window = NSApp.keyWindow {
-                        // Convert button's bottom-center from SwiftUI global (window flipped)
-                        // to window coordinates, then to screen coordinates.
-                        let windowPoint = CGPoint(
-                            x: overflowButtonFrame.midX,
-                            y: overflowButtonFrame.maxY
-                        )
-                        screenPoint = window.convertPoint(toScreen: windowPoint)
-                    } else {
-                        screenPoint = NSEvent.mouseLocation
-                    }
                     VMenuPanel.show(
-                        at: screenPoint,
+                        at: NSEvent.mouseLocation,
                         sourceAppearance: appearance
                     ) {
                         VMenu(width: 200) {
@@ -211,15 +198,6 @@ struct SidebarConversationItem: View, Equatable {
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .overlay {
-                    GeometryReader { geo in
-                        Color.clear
-                            .onAppear { overflowButtonFrame = geo.frame(in: .global) }
-                            .onChange(of: geo.frame(in: .global)) { _, newFrame in
-                                overflowButtonFrame = newFrame
-                            }
-                    }
-                }
                 .nativeTooltip("More options")
                 .padding(.trailing, VSpacing.xs)
                 .accessibilityLabel("More options for \(conversation.title)")

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -32,6 +32,7 @@ struct SidebarConversationItem: View, Equatable {
     }
 
     @State private var isMenuOpen: Bool = false
+    @State private var overflowButtonFrame: CGRect = .zero
     private var hasTrailingIcon: Bool { isHovered || isMenuOpen }
     private var canMarkUnread: Bool {
         !conversation.hasUnseenLatestAssistantMessage &&
@@ -165,6 +166,7 @@ struct SidebarConversationItem: View, Equatable {
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .contentShape(Rectangle())
             .animation(VAnimation.fast, value: isHovered)
+            .animation(VAnimation.fast, value: isMenuOpen)
         }
         .onTapGesture {
             selectConversation()
@@ -180,8 +182,20 @@ struct SidebarConversationItem: View, Equatable {
                 Button {
                     isMenuOpen = true
                     let appearance = NSApp.keyWindow?.effectiveAppearance
+                    let screenPoint: CGPoint
+                    if let window = NSApp.keyWindow {
+                        // Convert button's bottom-center from SwiftUI global (window flipped)
+                        // to window coordinates, then to screen coordinates.
+                        let windowPoint = CGPoint(
+                            x: overflowButtonFrame.midX,
+                            y: overflowButtonFrame.maxY
+                        )
+                        screenPoint = window.convertPoint(toScreen: windowPoint)
+                    } else {
+                        screenPoint = NSEvent.mouseLocation
+                    }
                     VMenuPanel.show(
-                        at: NSEvent.mouseLocation,
+                        at: screenPoint,
                         sourceAppearance: appearance
                     ) {
                         VMenu(width: 200) {
@@ -197,6 +211,15 @@ struct SidebarConversationItem: View, Equatable {
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
+                .overlay {
+                    GeometryReader { geo in
+                        Color.clear
+                            .onAppear { overflowButtonFrame = geo.frame(in: .global) }
+                            .onChange(of: geo.frame(in: .global)) { _, newFrame in
+                                overflowButtonFrame = newFrame
+                            }
+                    }
+                }
                 .nativeTooltip("More options")
                 .padding(.trailing, VSpacing.xs)
                 .accessibilityLabel("More options for \(conversation.title)")

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarLayoutMetrics.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarLayoutMetrics.swift
@@ -37,14 +37,11 @@ enum SidebarLayoutMetrics {
     /// Gap below the "Scheduled" label before the first scheduled row.
     static let scheduledHeaderBottomGap: CGFloat = VSpacing.xs  // 4pt
 
-    // MARK: - Archive Confirm
+    // MARK: - Trailing Icon
 
-    /// Trailing padding reserved for the "Confirm" pill button overlay during archive flow.
-    static let archiveConfirmTrailingPadding: CGFloat = 72
-
-    /// Trailing padding reserved for the archive icon overlay on hover
+    /// Trailing padding reserved for the overflow menu icon overlay on hover
     /// (20pt icon + 4pt trailing padding on the overlay + 8pt gap).
-    static let archiveIconTrailingPadding: CGFloat = 32
+    static let trailingIconPadding: CGFloat = 32
 
     // MARK: - Section Divider
 


### PR DESCRIPTION
## Summary
Replaces the archive icon button that appears on hover over sidebar conversation rows with an ellipsis ("...") overflow menu button. Clicking it shows the same VMenu as right-clicking the row (Pin/Unpin, Rename, Archive, Mark as unread, Open in New Window, Share Feedback). The pin icon remains unchanged.

## Changes
- Replaced archive icon button with ellipsis (`VIcon.ellipsis`) overflow menu button in `SidebarConversationItem`
- Extracted context menu items into shared `@ViewBuilder contextMenuContent` property (used by both right-click and overflow button)
- Added `isMenuOpen` state to keep row highlighted and button visible while the menu panel is open
- Removed dead code: `onBeginArchive`, `onConfirmArchive`, `isPendingDeletion`, `conversationPendingDeletion`, and the "Confirm" archive overlay
- Renamed `archiveIconTrailingPadding` → `trailingIconPadding`

## Milestone PRs (merged into feature branch)
- #21727: feat: replace archive button with overflow menu on conversation threads

## Project issue
Closes #21723

Closes LUM-436

## Test plan
- [ ] Hover over a conversation row — ellipsis ("...") button appears on the right
- [ ] Click ellipsis button — overflow menu appears with all context menu items
- [ ] Move mouse from row to the menu — row stays highlighted, button stays visible
- [ ] Select a menu item (Pin, Rename, Archive, etc.) — action executes correctly
- [ ] Right-click a conversation row — same context menu appears as before
- [ ] Pin icon button still works on hover (left side of row)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21736" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
