### PR TITLE
Fix: handle platform dict-format feature flag response in FeatureFlagClient

### DIFF
--- a/clients/shared/Network/FeatureFlagClient.swift
+++ b/clients/shared/Network/FeatureFlagClient.swift
@@ -50,6 +50,11 @@ private struct FeatureFlagsResponse<Flag: Decodable>: Decodable {
     let flags: [Flag]
 }
 
+/// Wrapper for the platform's dict-format response: `{ "flags": { "key": bool } }`.
+private struct PlatformFeatureFlagsResponse: Decodable {
+    let flags: [String: Bool]
+}
+
 public enum FeatureFlagError: Error, LocalizedError {
     case requestFailed(Int)
 
@@ -76,8 +81,15 @@ public struct FeatureFlagClient: FeatureFlagClientProtocol {
             log.error("getFeatureFlags failed (HTTP \(response.statusCode))")
             throw FeatureFlagError.requestFailed(response.statusCode)
         }
-        let decoded = try JSONDecoder().decode(FeatureFlagsResponse<AssistantFeatureFlag>.self, from: response.data)
-        return decoded.flags
+        // Try gateway array format first: { "flags": [{ key, enabled, ... }] }
+        if let decoded = try? JSONDecoder().decode(FeatureFlagsResponse<AssistantFeatureFlag>.self, from: response.data) {
+            return decoded.flags
+        }
+        // Fall back to platform dict format: { "flags": { "key": bool } }
+        let platform = try JSONDecoder().decode(PlatformFeatureFlagsResponse.self, from: response.data)
+        return platform.flags.map { key, enabled in
+            AssistantFeatureFlag(key: key, enabled: enabled)
+        }
     }
 
     public func setFeatureFlag(key: String, enabled: Bool) async throws {


### PR DESCRIPTION
## Summary
- Add PlatformFeatureFlagsResponse struct to decode the platform's dict-format response
- Modify getFeatureFlags() to try gateway array format first, falling back to platform dict format
- Enables feature flags to load correctly when connected to cloud-hosted assistants

Part of plan: fix-cloud-feature-flags.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
