### PR TITLE
Fix: fall back to bundled registry when feature flag HTTP fetch fails

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -825,7 +825,21 @@ struct SettingsDeveloperTab: View {
         do {
             assistantFlags = try await featureFlagClient.getFeatureFlags()
         } catch {
-            assistantFlagsError = error.localizedDescription
+            // Fall back to the bundled registry + local persisted overrides
+            if let registry = loadFeatureFlagRegistry() {
+                let resolved = AssistantFeatureFlagResolver.resolvedFlags(registry: registry)
+                assistantFlags = registry.assistantScopeFlags().map { def in
+                    AssistantFeatureFlag(
+                        key: def.key,
+                        enabled: resolved[def.key] ?? def.defaultEnabled,
+                        defaultEnabled: def.defaultEnabled,
+                        description: def.description,
+                        label: def.label
+                    )
+                }
+            } else {
+                assistantFlagsError = error.localizedDescription
+            }
         }
         isLoadingAssistantFlags = false
     }


### PR DESCRIPTION
## Summary
- Add local-registry fallback in SettingsDeveloperTab.loadAssistantFlags()
- When gateway/platform HTTP fetch fails, populate assistant flags from bundled registry + persisted overrides
- Error banner only shown if even the local registry cannot be loaded

Part of plan: fix-cloud-feature-flags.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21739" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
