### PR TITLE
fix: enrich platform dict-format flags with bundled registry metadata

### DIFF
--- a/clients/shared/Network/FeatureFlagClient.swift
+++ b/clients/shared/Network/FeatureFlagClient.swift
@@ -87,8 +87,27 @@ public struct FeatureFlagClient: FeatureFlagClientProtocol {
         }
         // Fall back to platform dict format: { "flags": { "key": bool } }
         let platform = try JSONDecoder().decode(PlatformFeatureFlagsResponse.self, from: response.data)
+        // Build a lookup from registry keys to their definitions so we can
+        // enrich each flag with defaultEnabled, description, and label.
+        let registryByKey: [String: FeatureFlagDefinition] = {
+            guard let registry = loadFeatureFlagRegistry() else { return [:] }
+            return Dictionary(uniqueKeysWithValues: registry.assistantScopeFlags().map { ($0.key, $0) })
+        }()
         return platform.flags.map { key, enabled in
-            AssistantFeatureFlag(key: key, enabled: enabled)
+            // Platform keys use LaunchDarkly format like "feature_flags.browser.enabled".
+            // Extract the middle segment(s) to match the registry's kebab-case key.
+            let registryKey: String = {
+                let stripped = key.hasPrefix("feature_flags.") ? String(key.dropFirst("feature_flags.".count)) : key
+                return stripped.hasSuffix(".enabled") ? String(stripped.dropLast(".enabled".count)) : stripped
+            }()
+            let def = registryByKey[registryKey]
+            return AssistantFeatureFlag(
+                key: key,
+                enabled: enabled,
+                defaultEnabled: def?.defaultEnabled,
+                description: def?.description,
+                label: def?.label
+            )
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-cloud-feature-flags.md.

**Gap:** Platform dict-format flags lack defaultEnabled, description, and label
**What was expected:** Flags decoded from the platform dict format should have correct metadata from the bundled registry
**What was found:** AssistantFeatureFlag was constructed with only key and enabled, causing misleading default badges in the settings UI
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
