### PR TITLE
fix: decouple stop button visibility from isSending using isAssistantBusy

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -153,7 +153,7 @@ struct ChatContentView: View {
             InputBarView(
                 text: $viewModel.inputText,
                 isInputFocused: $isInputFocused,
-                isGenerating: (viewModel.isSending && !viewModel.hasPendingConfirmation) || viewModel.isThinking,
+                isGenerating: (viewModel.isAssistantBusy && !viewModel.hasPendingConfirmation) || viewModel.isThinking,
                 isCancelling: viewModel.isCancelling,
                 onSend: { viewModel.sendMessage() },
                 onStop: { viewModel.stopGenerating() },

--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -9,6 +9,7 @@ import VellumAssistantShared
 struct ChatEmptyStateView: View {
     @Binding var inputText: String
     let isSending: Bool
+    var isAssistantBusy: Bool = false
     let isRecording: Bool
     let suggestion: String?
     let pendingAttachments: [ChatAttachment]
@@ -121,6 +122,7 @@ struct ChatEmptyStateView: View {
         ComposerView(
             inputText: $inputText,
             isSending: isSending,
+            isAssistantBusy: isAssistantBusy,
             hasPendingConfirmation: false,
             isRecording: isRecording,
             suggestion: suggestion,
@@ -323,6 +325,7 @@ struct FlowLayout: Layout {
 struct ChatTemporaryChatEmptyStateView: View {
     @Binding var inputText: String
     let isSending: Bool
+    var isAssistantBusy: Bool = false
     let isRecording: Bool
     let suggestion: String?
     let pendingAttachments: [ChatAttachment]
@@ -365,6 +368,7 @@ struct ChatTemporaryChatEmptyStateView: View {
             ComposerView(
                 inputText: $inputText,
                 isSending: isSending,
+                isAssistantBusy: isAssistantBusy,
                 hasPendingConfirmation: false,
                 isRecording: isRecording,
                 suggestion: suggestion,

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -11,6 +11,7 @@ struct ChatView: View {
     let isThinking: Bool
     let isCompacting: Bool
     let isSending: Bool
+    let isAssistantBusy: Bool
     let suggestion: String?
     let pendingAttachments: [ChatAttachment]
     var isLoadingAttachment: Bool = false
@@ -178,6 +179,7 @@ struct ChatView: View {
                         ChatTemporaryChatEmptyStateView(
                             inputText: $inputText,
                             isSending: isSending,
+                            isAssistantBusy: isAssistantBusy,
                             isRecording: isRecording,
                             suggestion: suggestion,
                             pendingAttachments: pendingAttachments,
@@ -198,6 +200,7 @@ struct ChatView: View {
                         ChatEmptyStateView(
                             inputText: $inputText,
                             isSending: isSending,
+                            isAssistantBusy: isAssistantBusy,
                             isRecording: isRecording,
                             suggestion: suggestion,
                             pendingAttachments: pendingAttachments,
@@ -294,6 +297,7 @@ struct ChatView: View {
                         ComposerSection(
                             inputText: $inputText,
                             isSending: isSending,
+                            isAssistantBusy: isAssistantBusy,
                             hasPendingConfirmation: PendingConfirmationFocusSelector.activeRequestId(from: composerMessages) != nil,
                             onAllowPendingConfirmation: {
                                 if let requestId = PendingConfirmationFocusSelector.activeRequestId(from: composerMessages) {

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
@@ -4,6 +4,7 @@ import VellumAssistantShared
 struct ComposerSection: View {
     @Binding var inputText: String
     let isSending: Bool
+    var isAssistantBusy: Bool = false
     let hasPendingConfirmation: Bool
     var onAllowPendingConfirmation: (() -> Void)? = nil
     let isRecording: Bool
@@ -40,6 +41,7 @@ struct ComposerSection: View {
             ComposerView(
                 inputText: $inputText,
                 isSending: isSending,
+                isAssistantBusy: isAssistantBusy,
                 hasPendingConfirmation: hasPendingConfirmation,
                 onAllowPendingConfirmation: onAllowPendingConfirmation,
                 isRecording: isRecording,
@@ -59,7 +61,7 @@ struct ComposerSection: View {
                 recordingAmplitude: recordingAmplitude,
                 onDictateToggle: onDictateToggle,
                 onVoiceModeToggle: onVoiceModeToggle,
-                placeholderText: isSending ? "Working on it..." : "What would you like to do?",
+                placeholderText: isAssistantBusy ? "Working on it..." : "What would you like to do?",
                 conversationId: conversationId,
                 isInteractionEnabled: isInteractionEnabled
             )

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -38,6 +38,7 @@ struct ComposerView: View {
 
     @Binding var inputText: String
     let isSending: Bool
+    var isAssistantBusy: Bool = false
     let hasPendingConfirmation: Bool
     var onAllowPendingConfirmation: (() -> Void)? = nil
     let isRecording: Bool
@@ -388,7 +389,7 @@ struct ComposerView: View {
     private var composerActionBar: some View {
         HStack(spacing: VSpacing.xs) {
             // Left side
-            if isSending && !hasPendingConfirmation {
+            if isAssistantBusy && !hasPendingConfirmation {
                 Spacer()
             } else {
                 VButton(
@@ -405,7 +406,7 @@ struct ComposerView: View {
             }
 
             // Right side
-            if isSending && !hasPendingConfirmation {
+            if isAssistantBusy && !hasPendingConfirmation {
                 VButton(
                     label: "Stop generation",
                     iconOnly: VIcon.square.rawValue,

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -647,6 +647,7 @@ struct ActiveChatViewWrapper: View {
             isThinking: viewModel.isThinking,
             isCompacting: viewModel.isCompacting,
             isSending: viewModel.isSending,
+            isAssistantBusy: viewModel.isAssistantBusy,
             suggestion: viewModel.suggestion,
             pendingAttachments: viewModel.pendingAttachments,
             isLoadingAttachment: viewModel.isLoadingAttachment,

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
@@ -276,6 +276,7 @@ private struct ThreadWindowContentView: View {
             isThinking: viewModel.isThinking,
             isCompacting: viewModel.isCompacting,
             isSending: viewModel.isSending,
+            isAssistantBusy: viewModel.isAssistantBusy,
             suggestion: viewModel.suggestion,
             pendingAttachments: viewModel.pendingAttachments,
             isLoadingAttachment: viewModel.isLoadingAttachment,

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2060,6 +2060,21 @@ public final class ChatViewModel: ObservableObject {
     public func stopGenerating() {
         guard isAssistantBusy else { return }
 
+        // If the only reason we're "busy" is orphaned incomplete tool calls
+        // (daemon already sent messageComplete, clearing isSending and
+        // currentAssistantMessageId), complete them locally and return —
+        // there is nothing to cancel on the daemon side.
+        if !isSending && !isThinking && currentAssistantMessageId == nil && hasIncompleteToolCalls {
+            if let lastAssistant = messages.last(where: { $0.role == .assistant }),
+               let index = messages.firstIndex(where: { $0.id == lastAssistant.id }) {
+                for j in messages[index].toolCalls.indices where !messages[index].toolCalls[j].isComplete {
+                    messages[index].toolCalls[j].isComplete = true
+                    messages[index].toolCalls[j].completedAt = Date()
+                }
+            }
+            return
+        }
+
         pendingVoiceMessage = false
 
         // If we're still bootstrapping (no conversation yet), cancel locally:
@@ -2360,9 +2375,19 @@ public final class ChatViewModel: ObservableObject {
         // Remove this message from local state (it will be re-added by sendMessage)
         messages.remove(at: index)
 
-        // If the assistant is not busy, stopGenerating() will no-op and no
-        // cancel-completion event will fire. Dispatch immediately instead.
-        guard isAssistantBusy else {
+        // If the assistant is not busy (or only busy due to orphaned tool
+        // calls), complete any orphaned tool calls and dispatch immediately
+        // instead of going through the cancel flow.
+        if !isSending && !isThinking && currentAssistantMessageId == nil {
+            // Complete any orphaned incomplete tool calls first
+            if hasIncompleteToolCalls,
+               let lastAssistant = messages.last(where: { $0.role == .assistant }),
+               let idx = messages.firstIndex(where: { $0.id == lastAssistant.id }) {
+                for j in messages[idx].toolCalls.indices where !messages[idx].toolCalls[j].isComplete {
+                    messages[idx].toolCalls[j].isComplete = true
+                    messages[idx].toolCalls[j].completedAt = Date()
+                }
+            }
             inputText = text
             pendingAttachments = attachments
             pendingSkillInvocation = skillInvocation

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -257,12 +257,30 @@ public final class ChatViewModel: ObservableObject {
         set { messageManager.isThinking = newValue }
     }
     /// Whether the assistant is actively working on a response — covers sending,
-    /// extended-thinking, and any in-progress assistant message. Use this for UI
-    /// elements (stop button, placeholder text, paperclip hide) instead of
-    /// `isSending` alone, because the "thinking" activity phase sets
-    /// `isSending = false` to prevent the 60s watchdog from firing.
+    /// extended-thinking, any in-progress assistant message, and orphaned tool
+    /// calls that haven't received their `tool_result` event yet (e.g. tool
+    /// calls created during skill/app execution whose results are folded into
+    /// the parent tool's result rather than emitted individually).
+    ///
+    /// Use this for UI elements (stop button, placeholder text, paperclip hide)
+    /// instead of `isSending` alone, because:
+    /// 1. The "thinking" activity phase sets `isSending = false` to prevent
+    ///    the 60s watchdog from firing.
+    /// 2. `messageComplete` clears both `isSending` and `currentAssistantMessageId`
+    ///    simultaneously, but tool call chips may still be visually running.
     public var isAssistantBusy: Bool {
-        isSending || isThinking || currentAssistantMessageId != nil
+        isSending || isThinking || currentAssistantMessageId != nil || hasIncompleteToolCalls
+    }
+
+    /// Whether the most recent assistant message has any tool calls that
+    /// haven't been marked complete yet. This catches the case where
+    /// `messageComplete` fires (clearing `isSending` and `currentAssistantMessageId`)
+    /// but tool call chips are still visually running in the UI.
+    private var hasIncompleteToolCalls: Bool {
+        guard let lastAssistant = messages.last(where: { $0.role == .assistant }) else {
+            return false
+        }
+        return lastAssistant.toolCalls.contains(where: { !$0.isComplete })
     }
 
     public var isSending: Bool {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -256,6 +256,15 @@ public final class ChatViewModel: ObservableObject {
         get { messageManager.isThinking }
         set { messageManager.isThinking = newValue }
     }
+    /// Whether the assistant is actively working on a response — covers sending,
+    /// extended-thinking, and any in-progress assistant message. Use this for UI
+    /// elements (stop button, placeholder text, paperclip hide) instead of
+    /// `isSending` alone, because the "thinking" activity phase sets
+    /// `isSending = false` to prevent the 60s watchdog from firing.
+    public var isAssistantBusy: Bool {
+        isSending || isThinking || currentAssistantMessageId != nil
+    }
+
     public var isSending: Bool {
         get { messageManager.isSending }
         set {
@@ -2031,7 +2040,7 @@ public final class ChatViewModel: ObservableObject {
     }
 
     public func stopGenerating() {
-        guard isSending else { return }
+        guard isAssistantBusy else { return }
 
         pendingVoiceMessage = false
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2342,9 +2342,9 @@ public final class ChatViewModel: ObservableObject {
         // Remove this message from local state (it will be re-added by sendMessage)
         messages.remove(at: index)
 
-        // If nothing is actively sending, stopGenerating() will no-op and no
+        // If the assistant is not busy, stopGenerating() will no-op and no
         // cancel-completion event will fire. Dispatch immediately instead.
-        guard isSending else {
+        guard isAssistantBusy else {
             inputText = text
             pendingAttachments = attachments
             pendingSkillInvocation = skillInvocation


### PR DESCRIPTION
## Summary
Add a computed `isAssistantBusy` property to ChatViewModel that captures all active assistant states (`isSending || isThinking || currentAssistantMessageId != nil`). Use this for composer stop button visibility, placeholder text, and paperclip hide instead of `isSending` alone.

This fixes a regression from a57627d22 where the "thinking" activity phase sets `isSending = false` to prevent the 60s watchdog from firing, causing the stop button to disappear for the rest of the turn during streaming and tool execution.

## Changes
- Add `isAssistantBusy` computed property to ChatViewModel
- Update `stopGenerating()` guard to use `isAssistantBusy`
- Thread `isAssistantBusy` through PanelCoordinator → ChatView → ComposerSection → ComposerView
- Replace `isSending` with `isAssistantBusy` in composer UI logic (macOS)
- Update iOS `isGenerating` to use `isAssistantBusy` while preserving `isThinking` outside the `hasPendingConfirmation` guard

## Milestone PRs (merged into feature branch)
- #21733: fix: decouple stop button visibility from isSending using isAssistantBusy

## Project issue
Closes #21717

## Test plan
- [ ] Build macOS app successfully
- [ ] Stop button remains visible during extended thinking responses
- [ ] Stop button remains visible during tool execution after extended thinking
- [ ] Pressing stop during tool execution successfully cancels
- [ ] Watchdog does NOT fire during normal extended thinking
- [ ] Placeholder text shows "Working on it..." during all active phases
- [ ] iOS generating indicator shows during thinking regardless of pending confirmations
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
