### PR TITLE
fix: use registry key instead of raw platform key for AssistantFeatureFlag

### DIFF
--- a/clients/shared/Network/FeatureFlagClient.swift
+++ b/clients/shared/Network/FeatureFlagClient.swift
@@ -102,7 +102,7 @@ public struct FeatureFlagClient: FeatureFlagClientProtocol {
             }()
             let def = registryByKey[registryKey]
             return AssistantFeatureFlag(
-                key: key,
+                key: registryKey,
                 enabled: enabled,
                 defaultEnabled: def?.defaultEnabled,
                 description: def?.description,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-cloud-feature-flags.md.

**Gap:** Platform-format keys break flag toggling and downstream key lookups
**What was expected:** Returned AssistantFeatureFlag should use normalized registry key (e.g. 'browser')
**What was found:** Raw LaunchDarkly key (e.g. 'feature_flags.browser.enabled') was used, breaking PATCH, lookups, and notifications
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21742" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
