### PR TITLE
fix: use uniquingKeysWith to prevent crash on duplicate registry keys

### DIFF
--- a/clients/shared/Network/FeatureFlagClient.swift
+++ b/clients/shared/Network/FeatureFlagClient.swift
@@ -91,7 +91,7 @@ public struct FeatureFlagClient: FeatureFlagClientProtocol {
         // enrich each flag with defaultEnabled, description, and label.
         let registryByKey: [String: FeatureFlagDefinition] = {
             guard let registry = loadFeatureFlagRegistry() else { return [:] }
-            return Dictionary(uniqueKeysWithValues: registry.assistantScopeFlags().map { ($0.key, $0) })
+            return Dictionary(registry.assistantScopeFlags().map { ($0.key, $0) }, uniquingKeysWith: { _, latest in latest })
         }()
         return platform.flags.map { key, enabled in
             // Platform keys use LaunchDarkly format like "feature_flags.browser.enabled".


### PR DESCRIPTION
## Summary
- Replace Dictionary(uniqueKeysWithValues:) with Dictionary(_:uniquingKeysWith:) in FeatureFlagClient.swift
- Prevents fatal preconditionFailure if registry ever contains duplicate assistant-scope flag keys
- Addresses feedback from Devin on #21740
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
