### PR TITLE
fix: remove GeometryReader pagination sentinel to fix main thread hang

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -621,10 +621,6 @@ struct MessageListView: View {
                         }
                         .padding(.vertical, VSpacing.sm)
                         .id("page-loading-indicator")
-                    } else if hasMoreMessages {
-                        Color.clear
-                            .frame(height: 1)
-                            .id("page-load-trigger")
                     }
 
                     let _ = recordScrollLoopEvent(.bodyEvaluation)
@@ -837,12 +833,13 @@ struct MessageListView: View {
                 // --- Pagination trigger ---
                 // Derive pagination from scroll offset instead of a
                 // GeometryReader+PreferenceKey sentinel inside the
-                // LazyVStack. contentOffsetY represents how far the
-                // content is scrolled — small values mean the top of
-                // the content (where older messages load) is near the
-                // viewport top, equivalent to the old sentinel minY.
+                // LazyVStack. The old sentinel reported minY in the
+                // ScrollView coordinate space (0 at viewport top,
+                // negative when scrolled past). contentOffsetY has
+                // inverted sign (0 at top, positive when scrolled
+                // down), so we negate to preserve the same semantics.
                 scrollCoordinator.handlePaginationSentinel(
-                    sentinelMinY: newState.contentOffsetY,
+                    sentinelMinY: -newState.contentOffsetY,
                     scrollViewportHeight: scrollCoordinator.currentScrollViewportHeight,
                     hasMoreMessages: hasMoreMessages,
                     isLoadingMoreMessages: isLoadingMoreMessages,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -622,20 +622,9 @@ struct MessageListView: View {
                         .padding(.vertical, VSpacing.sm)
                         .id("page-loading-indicator")
                     } else if hasMoreMessages {
-                        // Invisible sentinel: geometry-reported position gates
-                        // pagination on actual viewport entry rather than
-                        // LazyVStack prefetch (which fires several screens early).
                         Color.clear
                             .frame(height: 1)
                             .id("page-load-trigger")
-                            .background {
-                                GeometryReader { geo in
-                                    Color.clear.preference(
-                                        key: PaginationSentinelMinYKey.self,
-                                        value: geo.frame(in: .named("chatScrollView")).minY
-                                    )
-                                }
-                            }
                     }
 
                     let _ = recordScrollLoopEvent(.bodyEvaluation)
@@ -844,11 +833,16 @@ struct MessageListView: View {
                         animated: true
                     )
                 }
-            }
-            .scrollIndicators(scrollCoordinator.hideScrollIndicators ? .hidden : .automatic)
-            .onPreferenceChange(PaginationSentinelMinYKey.self) { sentinelMinY in
+
+                // --- Pagination trigger ---
+                // Derive pagination from scroll offset instead of a
+                // GeometryReader+PreferenceKey sentinel inside the
+                // LazyVStack. contentOffsetY represents how far the
+                // content is scrolled — small values mean the top of
+                // the content (where older messages load) is near the
+                // viewport top, equivalent to the old sentinel minY.
                 scrollCoordinator.handlePaginationSentinel(
-                    sentinelMinY: sentinelMinY,
+                    sentinelMinY: newState.contentOffsetY,
                     scrollViewportHeight: scrollCoordinator.currentScrollViewportHeight,
                     hasMoreMessages: hasMoreMessages,
                     isLoadingMoreMessages: isLoadingMoreMessages,
@@ -857,6 +851,7 @@ struct MessageListView: View {
                     loadPreviousMessagePage: loadPreviousMessagePage
                 )
             }
+            .scrollIndicators(scrollCoordinator.hideScrollIndicators ? .hidden : .automatic)
             .overlay(alignment: .bottom) {
                 if !isNearBottom {
                     Button(action: {
@@ -1259,15 +1254,6 @@ private struct MessageCellView: View, Equatable {
     }
 }
 
-/// Preference key that propagates the pagination sentinel's minY (in the
-/// `chatScrollView` coordinate space) so the geometry-based pagination
-/// trigger can evaluate whether the sentinel has entered the top band.
-private struct PaginationSentinelMinYKey: PreferenceKey {
-    static var defaultValue: CGFloat = .infinity
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = min(value, nextValue())
-    }
-}
 
 
 // MARK: - Cached Message Layout Metadata


### PR DESCRIPTION
## Summary
- Removes the `GeometryReader` + `PreferenceKey` pagination sentinel from inside the `LazyVStack` in `MessageListView`, which was causing a 22-second main thread hang due to SwiftUI layout thrashing
- Replaces it with scroll-offset-based pagination using the existing `onScrollGeometryChange` callback — `contentOffsetY` provides the same positional information as the old sentinel's `minY` with zero layout overhead
- Deletes the now-unused `PaginationSentinelMinYKey` preference key

## Implementation
The old approach used a `GeometryReader` inside a `LazyVStack` item to report its position via a `PreferenceKey`. Per Apple's WWDC guidance, `GeometryReader` inside lazy containers is a known performance anti-pattern — it breaks lazy evaluation by forcing frame calculations on demand, and preference propagation compounds the cost by triggering bottom-up recalculation through the entire view tree.

The new approach derives pagination triggers from `contentOffsetY` in the existing `onScrollGeometryChange` handler. When `contentOffsetY` is small, the user has scrolled near the top of the content where older messages load — this is equivalent to the old sentinel's `minY` being near zero. The `handlePaginationSentinel` function and `MessageListPaginationTriggerPolicy` are unchanged.

## Testing
- Open a conversation with many messages (enough to trigger pagination)
- Scroll up to load older messages — verify pagination still triggers correctly
- Verify no main thread hangs during normal scrolling and message streaming
- Existing `MessageListPaginationTriggerPolicyTests` should pass unchanged

## Original prompt
Fix the 22-second main thread hang in MessageListView by removing the GeometryReader + PreferenceKey pagination sentinel from inside the LazyVStack and replacing it with scroll-offset-based pagination derived from the existing onScrollGeometryChange callback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21748" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
