### PR TITLE
fix: default VCard padding to 16px, remove padding variants

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -346,7 +346,7 @@ struct SkillItemRow: View {
     }
 
     var body: some View {
-        VCard(padding: VSpacing.lg, action: onSelect) {
+        VCard(action: onSelect) {
             HStack(alignment: .center, spacing: VSpacing.lg) {
                 if let emoji = skill.emoji, !emoji.isEmpty {
                     Text(emoji)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -11,7 +11,7 @@ struct MemoryItemRow: View {
     }
 
     var body: some View {
-        VCard(padding: VSpacing.lg, action: onSelect) {
+        VCard(action: onSelect) {
             HStack(alignment: .center, spacing: VSpacing.lg) {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     HStack(alignment: .center, spacing: VSpacing.sm) {

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -36,7 +36,7 @@ struct ImproveExperienceStepView: View {
         VStack(spacing: VSpacing.md) {
             VStack(spacing: VSpacing.md) {
                 // Privacy toggles card
-                VCard(padding: VSpacing.lg) {
+                VCard {
                     VStack(spacing: VSpacing.lg) {
                         // Usage analytics toggle
                         VToggle(
@@ -59,7 +59,7 @@ struct ImproveExperienceStepView: View {
                 }
 
                 // ToS consent checkbox
-                VCard(padding: VSpacing.lg) {
+                VCard {
                     HStack(spacing: VSpacing.md) {
                         VCheckbox(isOn: $tosAccepted)
                         tosConsentText

--- a/clients/shared/DesignSystem/Components/Display/VCard.swift
+++ b/clients/shared/DesignSystem/Components/Display/VCard.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 public struct VCard<Content: View>: View {
-    public var padding: CGFloat = VSpacing.xl
+    public var padding: CGFloat = VSpacing.lg
     public var isActive: Bool = false
     public var action: (() -> Void)?
     @ViewBuilder public let content: () -> Content
@@ -9,7 +9,7 @@ public struct VCard<Content: View>: View {
     @State private var isHovered = false
 
     public init(
-        padding: CGFloat = VSpacing.xl,
+        padding: CGFloat = VSpacing.lg,
         isActive: Bool = false,
         action: (() -> Void)? = nil,
         @ViewBuilder content: @escaping () -> Content

--- a/clients/shared/DesignSystem/Gallery/Sections/DisplayGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/DisplayGallerySection.swift
@@ -4,7 +4,6 @@ import SwiftUI
 struct DisplayGallerySection: View {
     var filter: String?
 
-    @State private var cardPadding: CGFloat = 24
     @State private var waveformAmplitude: Float = 0.5
     @State private var waveformActive: Bool = true
 
@@ -14,54 +13,14 @@ struct DisplayGallerySection: View {
                 // MARK: - VCard
                 GallerySectionHeader(
                     title: "VCard",
-                    description: "Container with surface background, border, and configurable padding.",
+                    description: "Container with surface background, border, and 16pt padding.",
                     useInsteadOf: "Manual padding + background + cornerRadius"
                 )
 
                 VCard {
-                    VStack(alignment: .leading, spacing: VSpacing.xl) {
-                        HStack {
-                            Text("Padding: \(Int(cardPadding))pt")
-                                .font(VFont.labelDefault)
-                                .foregroundStyle(VColor.contentSecondary)
-                            Slider(value: $cardPadding, in: 0...48, step: 4)
-                                .frame(maxWidth: 200)
-                        }
-
-                        Divider().background(VColor.borderBase)
-
-                        VCard(padding: cardPadding) {
-                            Text("Card content with \(Int(cardPadding))pt padding")
-                                .font(VFont.bodyMediumLighter)
-                                .foregroundStyle(VColor.contentDefault)
-                        }
-                    }
-                }
-
-                // Padding variants
-                Text("Padding Variants")
-                    .font(VFont.bodySmallEmphasised)
-                    .foregroundStyle(VColor.contentSecondary)
-
-                HStack(spacing: VSpacing.lg) {
-                    ForEach([
-                        ("xs", VSpacing.xs),
-                        ("sm", VSpacing.sm),
-                        ("md", VSpacing.md),
-                        ("lg", VSpacing.lg),
-                        ("xl", VSpacing.xl)
-                    ], id: \.0) { name, padding in
-                        VCard(padding: padding) {
-                            VStack(spacing: VSpacing.xs) {
-                                Text(name)
-                                    .font(VFont.labelDefault)
-                                    .foregroundStyle(VColor.contentDefault)
-                                Text("\(Int(padding))pt")
-                                    .font(VFont.labelDefault)
-                                    .foregroundStyle(VColor.contentTertiary)
-                            }
-                        }
-                    }
+                    Text("Default card with 16pt padding")
+                        .font(VFont.bodyMediumLighter)
+                        .foregroundStyle(VColor.contentDefault)
                 }
 
                 // Action variants (tappable cards with hover highlight)

--- a/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
@@ -78,7 +78,7 @@ struct NavigationGallerySection: View {
                     description: "Compact pill-style segmented control for inline use in toolbars and headers."
                 )
 
-                VCard(padding: VSpacing.lg) {
+                VCard {
                     VStack(alignment: .leading, spacing: VSpacing.md) {
                         Divider().background(VColor.borderBase)
 


### PR DESCRIPTION
## Summary
- Change VCard default padding from 24pt to 16pt
- Remove redundant `padding: VSpacing.lg` from callers (now the default)
- Remove padding variants showcase from gallery

## Test plan
- [ ] Verify cards across the app have consistent 16pt padding
- [ ] Component gallery → Display → VCard shows default and action variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
