### PR TITLE
fix: replace GeometryReader with containerRelativeFrame to fix layout hangs

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
@@ -93,29 +93,27 @@ struct HighlightedTextView: View {
                 )
             }
 
-            GeometryReader { geometry in
-                ScrollView([.vertical]) {
-                    HStack(alignment: .top, spacing: 0) {
-                        lineNumberGutter(lineCount: lineCount, width: gutterWidth)
+            ScrollView([.vertical]) {
+                HStack(alignment: .top, spacing: 0) {
+                    lineNumberGutter(lineCount: lineCount, width: gutterWidth)
 
-                        CodeTextView(
-                            text: $text,
-                            onTextChange: onTextChange,
-                            onEscape: {
-                                if isSearchVisible {
-                                    dismissSearch()
-                                } else {
-                                    isActivelyEditing = false
-                                }
-                            },
-                            onCommandF: { isSearchVisible = true }
-                        )
-                        .frame(minWidth: geometry.size.width - gutterWidth)
-                    }
-                    .frame(minHeight: geometry.size.height, alignment: .topLeading)
+                    CodeTextView(
+                        text: $text,
+                        onTextChange: onTextChange,
+                        onEscape: {
+                            if isSearchVisible {
+                                dismissSearch()
+                            } else {
+                                isActivelyEditing = false
+                            }
+                        },
+                        onCommandF: { isSearchVisible = true }
+                    )
+                    .frame(maxWidth: .infinity)
                 }
-                .background(Self.editorBackground)
+                .containerRelativeFrame([.vertical], alignment: .topLeading) { length, _ in length }
             }
+            .background(Self.editorBackground)
         }
         .onKeyPress(.escape) {
             if isSearchVisible {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/JSONTreeView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/JSONTreeView.swift
@@ -237,7 +237,7 @@ struct JSONTreeView: View {
                 )
             }
             .padding(VSpacing.md)
-            .containerRelativeFrame([.horizontal, .vertical], alignment: .topLeading) { length, _ in length }
+            .containerRelativeFrame([.vertical], alignment: .topLeading) { length, _ in length }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/JSONTreeView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/JSONTreeView.swift
@@ -227,21 +227,17 @@ struct JSONTreeView: View {
 
     @ViewBuilder
     private func treeContent(_ node: JSONNode) -> some View {
-        VStack(alignment: .leading, spacing: 0) {
-            GeometryReader { proxy in
-                ScrollView([.vertical, .horizontal]) {
-                    LazyVStack(alignment: .leading, spacing: 0) {
-                        JSONNodeRow(
-                            node: node,
-                            key: nil,
-                            depth: 0,
-                            expandedPaths: $expandedPaths
-                        )
-                    }
-                    .padding(VSpacing.md)
-                    .frame(minWidth: proxy.size.width, minHeight: proxy.size.height, alignment: .topLeading)
-                }
+        ScrollView([.vertical, .horizontal]) {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                JSONNodeRow(
+                    node: node,
+                    key: nil,
+                    depth: 0,
+                    expandedPaths: $expandedPaths
+                )
             }
+            .padding(VSpacing.md)
+            .containerRelativeFrame([.horizontal, .vertical], alignment: .topLeading) { length, _ in length }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }

--- a/clients/shared/DesignSystem/Components/Display/VCodeView.swift
+++ b/clients/shared/DesignSystem/Components/Display/VCodeView.swift
@@ -109,27 +109,25 @@ public struct VCodeView: View {
         let lineCount = cachedLineCount
         let gutterWidth = gutterWidth(for: lineCount)
 
-        return GeometryReader { geometry in
-            ScrollView([.vertical]) {
-                HStack(alignment: .top, spacing: 0) {
-                    lineNumberGutter(lineCount: lineCount, width: gutterWidth)
+        return ScrollView([.vertical]) {
+            HStack(alignment: .top, spacing: 0) {
+                lineNumberGutter(lineCount: lineCount, width: gutterWidth)
 
-                    VCodeTextView(
-                        text: text,
-                        highlighter: highlighter,
-                        highlightVersion: highlightVersion,
-                        searchQuery: searchQuery,
-                        currentMatchIndex: currentMatchIndex,
-                        matchRanges: isSearchVisible
-                            ? Self.findMatchRanges(in: text, query: searchQuery) : [],
-                        onContentClick: onContentClick
-                    )
-                    .frame(minWidth: geometry.size.width - gutterWidth)
-                }
-                .frame(minHeight: geometry.size.height, alignment: .topLeading)
+                VCodeTextView(
+                    text: text,
+                    highlighter: highlighter,
+                    highlightVersion: highlightVersion,
+                    searchQuery: searchQuery,
+                    currentMatchIndex: currentMatchIndex,
+                    matchRanges: isSearchVisible
+                        ? Self.findMatchRanges(in: text, query: searchQuery) : [],
+                    onContentClick: onContentClick
+                )
+                .frame(maxWidth: .infinity)
             }
-            .background(Self.editorBackground)
+            .containerRelativeFrame([.vertical], alignment: .topLeading) { length, _ in length }
         }
+        .background(Self.editorBackground)
     }
 
     // MARK: - Colors


### PR DESCRIPTION
## Summary
- Removes `GeometryReader` wrapping `ScrollView` + `LazyVStack` patterns in 3 files that caused 73-second main thread hangs during chat message rendering
- Replaces with `containerRelativeFrame` (macOS 14+) for content sizing — Apple's recommended alternative that doesn't participate in the layout feedback cycle
- Directly addresses a second hang report where the stack trace showed `GeometryReaderLayout.placeSubviews` → deep `StackLayout.sizeThatFits` chains inside `ScrollViewLayoutComputer`

## Implementation
The anti-pattern in all 3 files was identical: `GeometryReader { proxy in ScrollView { content.frame(minWidth: proxy.size.width, minHeight: proxy.size.height) } }`. This creates a layout feedback loop where geometry changes trigger frame constraint updates which trigger content remeasurement which triggers geometry changes.

**VCodeView** (most critical — renders code blocks inside chat messages): `GeometryReader` → `containerRelativeFrame([.vertical])` + `frame(maxWidth: .infinity)`

**HighlightedTextView**: Same pattern as VCodeView

**JSONTreeView**: Same pattern, also removed unnecessary wrapping `VStack`

## Testing
- Open a conversation and send a message that triggers a code block response — verify no hang
- Check code blocks render with correct width/height (fill available space)
- Check JSON tree inspector fills its panel correctly
- Resize the window/panels — verify content adapts

## Deferred
- WorkspacePanel GeometryReader cleanup (blocked by pre-commit hook false positive on pre-existing UserDefaults key)
- MessageListView file split refactor (PR 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
