### PR TITLE
feat: make user-created custom skills clearly identifiable with "Custom" tag

### DIFF
--- a/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
@@ -36,7 +36,7 @@ public struct VSkillTypePill: View {
             switch self {
             case .core: return VColor.contentDefault
             case .installed: return VColor.systemPositiveStrong
-            case .created: return VColor.funBlue
+            case .created: return VColor.contentDefault
             case .extra: return VColor.contentTertiary
             case .available: return VColor.funTeal
             case .custom(_, _, let fg, _): return fg

--- a/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// A pill badge indicating the type/source of a skill (Core, Installed, Created).
+/// A pill badge indicating the type/source of a skill (Core, Installed, Custom).
 public struct VSkillTypePill: View {
     public enum SkillType {
         case core
@@ -14,7 +14,7 @@ public struct VSkillTypePill: View {
             switch self {
             case .core: return "Core"
             case .installed: return "Installed"
-            case .created: return "Created"
+            case .created: return "Custom"
             case .extra: return "Extra"
             case .available: return "Available"
             case .custom(let label, _, _, _): return label
@@ -25,7 +25,7 @@ public struct VSkillTypePill: View {
             switch self {
             case .core: return .package
             case .installed: return .circleCheck
-            case .created: return .sparkles
+            case .created: return .user
             case .extra: return .puzzle
             case .available: return .arrowDownToLine
             case .custom(_, let icon, _, _): return .resolve(icon)
@@ -36,7 +36,7 @@ public struct VSkillTypePill: View {
             switch self {
             case .core: return VColor.contentDefault
             case .installed: return VColor.systemPositiveStrong
-            case .created: return VColor.contentSecondary
+            case .created: return VColor.funPurple
             case .extra: return VColor.contentTertiary
             case .available: return VColor.funTeal
             case .custom(_, _, let fg, _): return fg
@@ -47,7 +47,7 @@ public struct VSkillTypePill: View {
             switch self {
             case .core: return VColor.surfaceBase
             case .installed: return VColor.systemPositiveWeak
-            case .created: return VColor.surfaceBase
+            case .created: return VColor.funPurple.opacity(0.12)
             case .extra: return VColor.surfaceOverlay
             case .available: return VColor.funTeal.opacity(0.12)
             case .custom(_, _, _, let bg): return bg

--- a/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
@@ -36,7 +36,7 @@ public struct VSkillTypePill: View {
             switch self {
             case .core: return VColor.contentDefault
             case .installed: return VColor.systemPositiveStrong
-            case .created: return VColor.funPurple
+            case .created: return VColor.funBlue
             case .extra: return VColor.contentTertiary
             case .available: return VColor.funTeal
             case .custom(_, _, let fg, _): return fg
@@ -47,7 +47,7 @@ public struct VSkillTypePill: View {
             switch self {
             case .core: return VColor.surfaceBase
             case .installed: return VColor.systemPositiveWeak
-            case .created: return VColor.funPurple.opacity(0.12)
+            case .created: return VColor.funBlue.opacity(0.12)
             case .extra: return VColor.surfaceOverlay
             case .available: return VColor.funTeal.opacity(0.12)
             case .custom(_, _, _, let bg): return bg


### PR DESCRIPTION
## Summary
- Renamed the skill type pill label from "Created" to "Custom" for user-created (workspace) skills — "Custom" is the most universally understood label
- Changed the icon from sparkles to user icon for clearer identification
- Applied a distinctive purple color scheme (`funPurple`) instead of the previous muted `contentSecondary`/`surfaceBase` so custom skills visually stand out

## Original prompt
--safe https://linear.app/vellum/issue/LUM-425/skills-tab-make-user-created-custom-skills-clearly-identifiable add tag to every installed skill that is user created, use the best tag to describe it "Custom" or "User-built" or anything that will be most common to identify it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
