### PR TITLE
fix: restore AppleScript Google BYO OAuth flow

### DIFF
--- a/.private/UNREVIEWED_PRS.md
+++ b/.private/UNREVIEWED_PRS.md
@@ -1,0 +1,1 @@
+https://github.com/vellum-ai/vellum-assistant/pull/21754

--- a/skills/google-oauth-app-setup/SKILL.md
+++ b/skills/google-oauth-app-setup/SKILL.md
@@ -152,9 +152,9 @@ Open: `https://console.cloud.google.com/auth/audience?project=PROJECT_ID`
 
 Open: `https://console.cloud.google.com/auth/scopes?project=PROJECT_ID`
 
+On macOS desktop, before proceeding, copy the comma-separated scope string below to the user's clipboard using `pbcopy`.
+
 > I've opened **Data Access**.
->
-> Before the user pastes anything on macOS desktop, copy the comma-separated scope string below to their clipboard with `pbcopy`, then have them:
 >
 > 1. Click **Add or Remove Scopes** → scroll to **"Manually add scopes"** → paste the comma-separated scopes below → click **Update**
 > 2. Back on the main page, scroll down and click **Save**

--- a/skills/google-oauth-app-setup/SKILL.md
+++ b/skills/google-oauth-app-setup/SKILL.md
@@ -20,6 +20,32 @@ The included `vellum-oauth-integrations` skill handles the generic parts of the 
 - **Credential type (Path A):** Desktop app
 - **Credential type (Path B):** Web application (callback through public gateway)
 
+## Path A: macOS Desktop App
+
+On the macOS desktop app, this is a collaborative Google Chrome flow. For every `Open:` URL in this file:
+
+- Use `host_bash` plus `osascript` to activate Google Chrome and navigate the user's existing browser window to that URL
+- Wait for the user to confirm they are done before moving to the next step
+- Never use `browser_*`, CDP, the browser skill, or `computer_use_*` for Google Cloud Console or Google OAuth pages
+- If Chrome is unavailable or AppleScript navigation fails, tell the user the URL and continue manually; do not switch to browser automation
+
+Use this exact pattern:
+
+```
+host_bash:
+  command: |
+    osascript -e '
+    tell application "Google Chrome"
+      activate
+      if (count of windows) = 0 then
+        make new window
+      end if
+      set URL of active tab of front window to "TARGET_URL"
+    end tell'
+```
+
+Replace `TARGET_URL` with the actual URL for that step. The point of Path A is to keep the flow in the user's real Chrome profile and avoid automated-browser rejections.
+
 ## Google-Specific Flow
 
 The flow has 9 steps total, takes about 3-5 minutes.
@@ -128,6 +154,8 @@ Open: `https://console.cloud.google.com/auth/scopes?project=PROJECT_ID`
 
 > I've opened **Data Access**.
 >
+> Before the user pastes anything on macOS desktop, copy the comma-separated scope string below to their clipboard with `pbcopy`, then have them:
+>
 > 1. Click **Add or Remove Scopes** → scroll to **"Manually add scopes"** → paste the comma-separated scopes below → click **Update**
 > 2. Back on the main page, scroll down and click **Save**
 
@@ -169,7 +197,16 @@ A modal should appear with the **Client ID** and **Client Secret**. Tell the use
 
 ### Steps 7–9: Store Credentials, Authorize, and Verify
 
-Follow the `vellum-oauth-integrations` workflow to collect credentials, register the OAuth app, connect, and verify.
+Follow the `vellum-oauth-integrations` workflow to collect credentials, register the OAuth app, and verify the connection.
+
+Google-specific override for macOS desktop app:
+
+1. Before app registration, check the provider mode and set it to `your-own` if needed with `assistant oauth mode google --set your-own`.
+2. Register the OAuth app normally via `assistant oauth apps upsert`.
+3. For authorization, do **not** use `assistant oauth connect google --open-browser`.
+4. Instead, run `assistant oauth connect google` without `--open-browser` so the command returns the authorization URL.
+5. Open that returned authorization URL in Google Chrome using the same `host_bash` + `osascript` pattern as every other `Open:` step in this skill.
+6. Never use browser automation or computer-use for the Google consent screen.
 
 > I'll start the Google authorization flow now.
 >

--- a/skills/vellum-oauth-integrations/references/CONNECTING_ACCOUNTS.md
+++ b/skills/vellum-oauth-integrations/references/CONNECTING_ACCOUNTS.md
@@ -33,6 +33,8 @@ assistant oauth connect <provider-key> --open-browser
 
 **Tip:** You can optionally specify scopes using the `--scopes` flag. This is useful if you know ahead of time what your user is trying to accomplish and want to request the bare minimum scopes needed to accomplish the task at hand.
 
+If the provider-specific setup skill gives its own browser handoff instructions, follow those instead of `--open-browser`. Google bring-your-own setup on the macOS desktop app is one example: request the auth URL without `--open-browser`, then open it using the provider skill's AppleScript/browser handoff rules.
+
 This will open a new web browser tab where the user can log in to the third-party provider. Upon success, they should be redirected to a confirmation page and told that it's safe to close the browser tab and come back here.
 
 ## Verification


### PR DESCRIPTION
## Summary
- restore explicit macOS AppleScript + Google Chrome navigation rules for the BYO Google OAuth setup skill
- forbid browser/CDP/computer-use automation for Google Cloud and consent pages in that flow
- document that provider-specific browser handoff rules override the generic `--open-browser` guidance

## Testing
- git diff --check
- not run: runtime tests (skill/reference-only change)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21754" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
