### PR TITLE
fix: replace GeometryReader with onGeometryChange in WorkspacePanel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -370,14 +370,10 @@ private struct WorkspaceTreeSidebar: View {
                         }
                         .padding(.vertical, VSpacing.xs)
                     }
-                    .background {
-                        GeometryReader { geo in
-                            Color.clear
-                                .onAppear { viewportWidth = geo.size.width }
-                                .onChange(of: geo.size.width) { _, newWidth in
-                                    viewportWidth = newWidth
-                                }
-                        }
+                    .onGeometryChange(for: CGFloat.self) { proxy in
+                        proxy.size.width
+                    } action: { newWidth in
+                        viewportWidth = newWidth
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Replaces `GeometryReader` in `.background` with `onGeometryChange` (macOS 15+) for viewport width observation in WorkspacePanel's file tree
- `GeometryReader` participates in the layout cycle and can contribute to layout thrashing; `onGeometryChange` is a one-way observation that doesn't

## Testing
- Open the workspace file tree panel
- Resize the window/panel — verify tree rows still fill the available width
- Verify file tree renders correctly with no visual changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21757" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
