### PR TITLE
Enable multifile app builder by default

### DIFF
--- a/assistant/src/__tests__/skill-feature-flags.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags.test.ts
@@ -19,6 +19,7 @@ afterEach(() => {
 const DECLARED_FLAG_ID = "contacts";
 const DECLARED_FLAG_KEY = DECLARED_FLAG_ID;
 const DECLARED_SKILL_ID = "contacts";
+const APP_BUILDER_MULTIFILE_FLAG_KEY = "app-builder-multifile";
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -157,6 +158,13 @@ describe("isAssistantFeatureFlagEnabled", () => {
     const config = makeConfig();
     // browser is declared in the registry with defaultEnabled: true
     expect(isAssistantFeatureFlagEnabled("browser", config)).toBe(true);
+  });
+
+  test("app-builder-multifile defaults to enabled when no override is set", () => {
+    const config = makeConfig();
+    expect(
+      isAssistantFeatureFlagEnabled(APP_BUILDER_MULTIFILE_FLAG_KEY, config),
+    ).toBe(true);
   });
 });
 

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -47,7 +47,7 @@
       "key": "app-builder-multifile",
       "label": "App Builder Multi-file",
       "description": "Enable multi-file TSX app creation with esbuild compilation instead of single-HTML apps",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "mobile-pairing",


### PR DESCRIPTION
## Summary
- enable the `app-builder-multifile` assistant feature flag by default in the unified registry
- add a resolver test to lock in the new default behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
