### PR TITLE
fix: restore .defaultScrollAnchor(.bottom) to fix conversation switch scroll

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -735,6 +735,7 @@ struct MessageListView: View {
             .plainTextCopy()
             .coordinateSpace(name: "chatScrollView")
             .scrollDisabled(messages.isEmpty && !isSending)
+            .defaultScrollAnchor(.bottom)
             .scrollPosition($scrollPosition)
             .environment(\.suppressAutoScroll, { [self] in
                 scrollCoordinator.handleSuppressAutoScroll(


### PR DESCRIPTION
## Summary
- Restores `.defaultScrollAnchor(.bottom)` on the MessageListView ScrollView, fixing a bug where switching to a long conversation lands in the middle instead of at the bottom
- This was incorrectly removed in PR #21539 (push-to-top implementation) based on the incorrect belief that it conflicts with programmatic `scrollTo()` calls

## Why this was removed and why that was wrong
PR #21539 removed `.defaultScrollAnchor(.bottom)` stating it "eliminates the conflict between the declarative anchor and push-to-top programmatic scrolls." Per Apple's documentation, `defaultScrollAnchor` only applies to **initial layout** — it does NOT re-trigger during content updates or streaming, and does NOT conflict with programmatic `scrollTo(id:, anchor:)` calls.

## Why this fixes the bug
When `conversationId` changes, the existing code calls `scrollToEdge(.bottom)` imperatively. But this fires before the new conversation's messages materialize in the LazyVStack. Without `.defaultScrollAnchor(.bottom)`, SwiftUI has no instruction for where to anchor the new content, so it falls back to the stale `ScrollPosition` state from the previous conversation — landing in the middle.

## Testing
- Switch between conversations, including long ones with many messages — should always start at the bottom
- Send a message — push-to-top should still work (user message scrolls to top of viewport)
- During streaming — should auto-follow at the bottom
- Scroll up manually, then switch conversations — new conversation should start at bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
