### PR TITLE
fix: replace containerRelativeFrame with frame to restore vertical scrolling

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
@@ -111,7 +111,7 @@ struct HighlightedTextView: View {
                     )
                     .frame(maxWidth: .infinity)
                 }
-                .containerRelativeFrame([.vertical], alignment: .topLeading) { length, _ in length }
+                .frame(maxWidth: .infinity, alignment: .topLeading)
             }
             .background(Self.editorBackground)
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/JSONTreeView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/JSONTreeView.swift
@@ -237,7 +237,7 @@ struct JSONTreeView: View {
                 )
             }
             .padding(VSpacing.md)
-            .containerRelativeFrame([.vertical], alignment: .topLeading) { length, _ in length }
+            .frame(maxWidth: .infinity, alignment: .topLeading)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }

--- a/clients/shared/DesignSystem/Components/Display/VCodeView.swift
+++ b/clients/shared/DesignSystem/Components/Display/VCodeView.swift
@@ -125,7 +125,7 @@ public struct VCodeView: View {
                 )
                 .frame(maxWidth: .infinity)
             }
-            .containerRelativeFrame([.vertical], alignment: .topLeading) { length, _ in length }
+            .frame(maxWidth: .infinity, alignment: .topLeading)
         }
         .background(Self.editorBackground)
     }


### PR DESCRIPTION
## Summary
- Fixes broken vertical scrolling in VCodeView, HighlightedTextView, and JSONTreeView introduced by PR #21752
- `containerRelativeFrame([.vertical])` sets an **exact** viewport-height frame, capping content to the viewport and preventing scroll. The old code used `frame(minHeight:)` which set a **minimum** allowing content to grow.
- Replaces with `frame(maxWidth: .infinity, alignment: .topLeading)` which allows natural content sizing

## Testing
- Open a code block taller than the viewport — verify it scrolls vertically
- Open a short code block — verify it renders correctly (top-aligned)
- Check JSON tree inspector with deep nested content — verify vertical scroll works
- Check editable code view in workspace panel — verify vertical scroll works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
