### PR TITLE
fix: split conversation list pagination so background conversations don't consume foreground slots

### DIFF
--- a/assistant/src/memory/conversation-queries.ts
+++ b/assistant/src/memory/conversation-queries.ts
@@ -26,13 +26,13 @@ function buildFtsMatchQuery(text: string): string | null {
 
 export function listConversations(
   limit?: number,
-  includeBackground = false,
+  backgroundOnly = false,
   offset = 0,
 ): ConversationRow[] {
   ensureDisplayOrderMigration();
   const db = getDb();
-  const where = includeBackground
-    ? undefined
+  const where = backgroundOnly
+    ? sql`${conversations.conversationType} = 'background'`
     : sql`${conversations.conversationType} NOT IN ('background', 'private')`;
   const query = db
     .select()
@@ -44,10 +44,10 @@ export function listConversations(
   return query.all().map(parseConversation);
 }
 
-export function countConversations(includeBackground = false): number {
+export function countConversations(backgroundOnly = false): number {
   const db = getDb();
-  const where = includeBackground
-    ? undefined
+  const where = backgroundOnly
+    ? sql`${conversations.conversationType} = 'background'`
     : sql`${conversations.conversationType} NOT IN ('background', 'private')`;
   const [{ total }] = db
     .select({ total: count() })

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -27,13 +27,11 @@ import {
   handleVoiceWebhook,
 } from "../calls/twilio-routes.js";
 import { parseChannelId } from "../channels/types.js";
-import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import {
   getGatewayInternalBaseUrl,
   hasUngatedHttpAuthDisabled,
   isHttpAuthDisabled,
 } from "../config/env.js";
-import { getConfig } from "../config/loader.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import { PairingStore } from "../daemon/pairing-store.js";
 import {
@@ -1030,17 +1028,11 @@ export class RuntimeHttpServer {
         handler: ({ url }) => {
           const limit = Number(url.searchParams.get("limit") ?? 50);
           const offset = Number(url.searchParams.get("offset") ?? 0);
-          const includeBackground = isAssistantFeatureFlagEnabled(
-            "show-background-conversations",
-            getConfig(),
-          );
-          const conversations = listConversations(
-            limit,
-            includeBackground,
-            offset,
-          );
-          const totalCount = countConversations(includeBackground);
-          const conversationIds = conversations.map((c) => c.id);
+          const backgroundOnly =
+            url.searchParams.get("conversationType") === "background";
+          const rows = listConversations(limit, backgroundOnly, offset);
+          const totalCount = countConversations(backgroundOnly);
+          const conversationIds = rows.map((c) => c.id);
           const displayMeta = getDisplayMetaForConversations(conversationIds);
           const bindings =
             externalConversationStore.getBindingsForConversations(
@@ -1050,7 +1042,7 @@ export class RuntimeHttpServer {
             getAttentionStateByConversationIds(conversationIds);
           const parentCache = new Map<string, ConversationRow | null>();
           return Response.json({
-            conversations: conversations.map((conversation) =>
+            conversations: rows.map((conversation) =>
               this.serializeConversationSummary({
                 conversation,
                 binding: bindings.get(conversation.id),
@@ -1059,7 +1051,7 @@ export class RuntimeHttpServer {
                 parentCache,
               }),
             ),
-            hasMore: offset + conversations.length < totalCount,
+            hasMore: offset + rows.length < totalCount,
           });
         },
       },

--- a/clients/ios/App/IOSConversationStore.swift
+++ b/clients/ios/App/IOSConversationStore.swift
@@ -513,10 +513,22 @@ class IOSConversationStore: ObservableObject {
         let currentGeneration = conversationListGeneration
         Task { [weak self] in
             guard let self else { return }
-            if let response = await conversationListClient.fetchConversationList(offset: 0, limit: Self.conversationPageSize) {
+            // Fetch foreground and background conversations in parallel so
+            // background conversations don't consume pagination slots.
+            async let foregroundResult = conversationListClient.fetchConversationList(offset: 0, limit: Self.conversationPageSize)
+            async let backgroundResult = conversationListClient.fetchConversationList(offset: 0, limit: Self.conversationPageSize, conversationType: "background")
+            let foreground = await foregroundResult
+            let background = await backgroundResult
+
+            if let foreground {
                 guard currentGeneration == self.conversationListGeneration else { return }
+                let merged = ConversationListResponse(
+                    type: foreground.type,
+                    conversations: foreground.conversations + (background?.conversations ?? []),
+                    hasMore: foreground.hasMore
+                )
                 self.expectedConversationListGeneration = currentGeneration
-                self.handleConversationListResponse(response)
+                self.handleConversationListResponse(merged)
             } else {
                 guard currentGeneration == self.conversationListGeneration else { return }
                 self.isLoadingInitialConversations = false

--- a/clients/ios/Tests/ConversationLifecycleIOSTests.swift
+++ b/clients/ios/Tests/ConversationLifecycleIOSTests.swift
@@ -854,7 +854,7 @@ private final class MockConversationListClient: ConversationListClientProtocol {
     private(set) var sentSeenSignals: [ConversationSeenSignal] = []
     private(set) var reorderRequests: [[ReorderConversationsRequestUpdate]] = []
 
-    func fetchConversationList(offset: Int, limit: Int) async -> ConversationListResponse? { nil }
+    func fetchConversationList(offset: Int, limit: Int, conversationType: String?) async -> ConversationListResponse? { nil }
     func switchConversation(conversationId: String) async -> Bool { true }
     func renameConversation(conversationId: String, name: String) async -> Bool { true }
     func clearAllConversations() async -> Bool { true }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -17,12 +17,15 @@ extension Notification.Name {
 private enum ImageActions {
 
     /// Copies the image to the system clipboard.
-    /// Prefers full-resolution data decoded from `base64Data` when available,
-    /// falling back to the provided (possibly thumbnail) NSImage.
-    static func copyToClipboard(_ image: NSImage, base64Data: String? = nil) {
-        // Prefer full-res from base64 data when available
+    /// Prefers full-resolution data decoded from `rawData` or `base64Data` when
+    /// available, falling back to the provided (possibly thumbnail) NSImage.
+    static func copyToClipboard(_ image: NSImage, base64Data: String? = nil, rawData: Data? = nil) {
+        // Prefer full-res from raw or base64 data when available
         let imageToWrite: NSImage
-        if let base64Data, !base64Data.isEmpty,
+        if let rawData, !rawData.isEmpty,
+           let fullRes = NSImage(data: rawData) {
+            imageToWrite = fullRes
+        } else if let base64Data, !base64Data.isEmpty,
            let decoded = Data(base64Encoded: base64Data), !decoded.isEmpty,
            let fullRes = NSImage(data: decoded) {
             imageToWrite = fullRes
@@ -34,19 +37,15 @@ private enum ImageActions {
     }
 
     /// Opens an NSSavePanel and writes the image to the chosen path.
-    /// Prefers `base64Data` (full resolution) when available, falling back to
-    /// PNG-encoding the in-memory NSImage.
-    static func saveImageAs(_ image: NSImage, filename: String, base64Data: String? = nil) {
+    /// Prefers `rawData` or `base64Data` (full resolution) when available,
+    /// falling back to PNG-encoding the in-memory NSImage.
+    static func saveImageAs(_ image: NSImage, filename: String, base64Data: String? = nil, rawData: Data? = nil) {
         let sanitized = (filename as NSString).lastPathComponent
         let fallbackName = sanitized.isEmpty ? "image.png" : sanitized
 
-        // Use non-emptiness as a lightweight proxy for valid base64 data to
-        // decide the suggested filename. Full decode is deferred to the
-        // background write block to avoid blocking the main thread for large
-        // payloads (multi-MB screenshots).
-        let hasBase64 = base64Data.map { !$0.isEmpty } ?? false
+        let hasFullData = (rawData != nil && !rawData!.isEmpty) || (base64Data.map { !$0.isEmpty } ?? false)
         let suggestedName: String
-        if hasBase64 {
+        if hasFullData {
             suggestedName = fallbackName
         } else {
             suggestedName = (fallbackName as NSString).deletingPathExtension + ".png"
@@ -61,7 +60,9 @@ private enum ImageActions {
             // tiffRepresentation is not thread-safe (see ChatAttachmentManager.swift)
             // so PNG encoding must happen here, not in a background queue.
             let dataToWrite: Data?
-            if let base64Data, !base64Data.isEmpty,
+            if let rawData, !rawData.isEmpty {
+                dataToWrite = rawData
+            } else if let base64Data, !base64Data.isEmpty,
                let decoded = Data(base64Encoded: base64Data), !decoded.isEmpty {
                 dataToWrite = decoded
             } else if let tiff = image.tiffRepresentation,
@@ -89,15 +90,18 @@ private enum ImageActions {
     }
 
     /// Writes the image to a temporary file and returns the file URL.
-    /// Prefers `base64Data` (full resolution), falling back to PNG-encoding the NSImage.
-    /// Returns nil if the image could not be written.
-    static func writeTempFile(_ image: NSImage, filename: String, base64Data: String? = nil) -> URL? {
+    /// Prefers `rawData`, then `base64Data` (full resolution), falling back to
+    /// PNG-encoding the NSImage. Returns nil if the image could not be written.
+    static func writeTempFile(_ image: NSImage, filename: String, base64Data: String? = nil, rawData: Data? = nil) -> URL? {
         let tempDir = FileManager.default.temporaryDirectory
         let sanitized = (filename as NSString).lastPathComponent
         let fallbackName = sanitized.isEmpty ? "image.png" : sanitized
 
         var usedPNGFallback = false
         let fileData: Data? = {
+            if let rawData, !rawData.isEmpty {
+                return rawData
+            }
             if let base64Data, !base64Data.isEmpty,
                let decoded = Data(base64Encoded: base64Data), !decoded.isEmpty {
                 return decoded
@@ -128,8 +132,8 @@ private enum ImageActions {
     }
 
     /// Writes the image to a temporary file and opens it in the default app (Preview).
-    static func openInPreview(_ image: NSImage, filename: String, base64Data: String? = nil) {
-        guard let fileURL = writeTempFile(image, filename: filename, base64Data: base64Data) else { return }
+    static func openInPreview(_ image: NSImage, filename: String, base64Data: String? = nil, rawData: Data? = nil) {
+        guard let fileURL = writeTempFile(image, filename: filename, base64Data: base64Data, rawData: rawData) else { return }
         NSWorkspace.shared.open(fileURL)
     }
 
@@ -183,28 +187,64 @@ private enum ImageActions {
         return services
     }
 
+    /// Fetches full-res image data for a lazy-loaded attachment, falling back to nil on error.
+    private static func fetchLazyData(attachmentId: String?) async -> Data? {
+        guard let attachmentId, !attachmentId.isEmpty else { return nil }
+        return try? await AttachmentContentClient.fetchContent(attachmentId: attachmentId)
+    }
+
     /// Builds a SwiftUI context menu with Copy, Save As, and Open in Preview actions.
+    /// When `lazyAttachmentId` is provided and `base64Data` is nil, actions will
+    /// fetch full-res data from the server on demand.
     @available(macOS, deprecated: 13.0)
     @ViewBuilder
     static func contextMenuItems(
         image: NSImage,
         filename: String,
-        base64Data: String? = nil
+        base64Data: String? = nil,
+        lazyAttachmentId: String? = nil
     ) -> some View {
         Button {
-            copyToClipboard(image, base64Data: base64Data)
+            if base64Data != nil {
+                copyToClipboard(image, base64Data: base64Data)
+            } else if let lazyAttachmentId {
+                Task {
+                    let data = await fetchLazyData(attachmentId: lazyAttachmentId)
+                    copyToClipboard(image, rawData: data)
+                }
+            } else {
+                copyToClipboard(image)
+            }
         } label: {
             Label { Text("Copy Image") } icon: { VIconView(.copy, size: 12) }
         }
 
         Button {
-            saveImageAs(image, filename: filename, base64Data: base64Data)
+            if base64Data != nil {
+                saveImageAs(image, filename: filename, base64Data: base64Data)
+            } else if let lazyAttachmentId {
+                Task {
+                    let data = await fetchLazyData(attachmentId: lazyAttachmentId)
+                    saveImageAs(image, filename: filename, rawData: data)
+                }
+            } else {
+                saveImageAs(image, filename: filename)
+            }
         } label: {
             Label { Text("Save Image As\u{2026}") } icon: { VIconView(.arrowDownToLine, size: 12) }
         }
 
         Button {
-            openInPreview(image, filename: filename, base64Data: base64Data)
+            if base64Data != nil {
+                openInPreview(image, filename: filename, base64Data: base64Data)
+            } else if let lazyAttachmentId {
+                Task {
+                    let data = await fetchLazyData(attachmentId: lazyAttachmentId)
+                    openInPreview(image, filename: filename, rawData: data)
+                }
+            } else {
+                openInPreview(image, filename: filename)
+            }
         } label: {
             Label { Text("Open in Preview") } icon: { VIconView(.eye, size: 12) }
         }
@@ -221,15 +261,27 @@ private enum ImageActions {
             Menu {
                 ForEach(Array(services.enumerated()), id: \.offset) { _, service in
                     Button {
-                        // Write temp file at action time (not during render).
-                        // Try full-res first, fall back to thumbnail, fall back to
-                        // the probe file so the Share action is never a silent no-op.
-                        let shareURL = writeTempFile(image, filename: filename, base64Data: base64Data)
-                            ?? writeTempFile(image, filename: filename)
-                        let probeExt = (filename as NSString).pathExtension.lowercased()
-                        let fallback = FileManager.default.temporaryDirectory
-                            .appendingPathComponent("vellum-share-probe.\(probeExt.isEmpty ? "png" : probeExt)")
-                        service.perform(withItems: [shareURL ?? fallback])
+                        if let lazyAttachmentId, base64Data == nil {
+                            Task {
+                                let data = await fetchLazyData(attachmentId: lazyAttachmentId)
+                                let shareURL = writeTempFile(image, filename: filename, rawData: data)
+                                    ?? writeTempFile(image, filename: filename)
+                                let probeExt = (filename as NSString).pathExtension.lowercased()
+                                let fallback = FileManager.default.temporaryDirectory
+                                    .appendingPathComponent("vellum-share-probe.\(probeExt.isEmpty ? "png" : probeExt)")
+                                service.perform(withItems: [shareURL ?? fallback])
+                            }
+                        } else {
+                            // Write temp file at action time (not during render).
+                            // Try full-res first, fall back to thumbnail, fall back to
+                            // the probe file so the Share action is never a silent no-op.
+                            let shareURL = writeTempFile(image, filename: filename, base64Data: base64Data)
+                                ?? writeTempFile(image, filename: filename)
+                            let probeExt = (filename as NSString).pathExtension.lowercased()
+                            let fallback = FileManager.default.temporaryDirectory
+                                .appendingPathComponent("vellum-share-probe.\(probeExt.isEmpty ? "png" : probeExt)")
+                            service.perform(withItems: [shareURL ?? fallback])
+                        }
                     } label: {
                         Label {
                             Text(service.title)
@@ -349,7 +401,8 @@ private struct AttachmentImageGrid<Fallback: View>: View {
                                 ImageActions.contextMenuItems(
                                     image: nsImage,
                                     filename: attachment.filename,
-                                    base64Data: attachment.data.isEmpty ? nil : attachment.data
+                                    base64Data: attachment.data.isEmpty ? nil : attachment.data,
+                                    lazyAttachmentId: attachment.isLazyLoad ? attachment.id : nil
                                 )
                             }
                             .onDrag {
@@ -490,11 +543,28 @@ extension ChatBubble {
 
     func attachmentImageGrid(_ images: [ChatAttachment]) -> some View {
         AttachmentImageGrid(imageAttachments: images, onTap: { attachment, image in
-            ImageActions.openInPreview(
-                image,
-                filename: attachment.filename,
-                base64Data: attachment.data.isEmpty ? nil : attachment.data
-            )
+            if attachment.isLazyLoad, !attachment.id.isEmpty {
+                // Full image data was cleared to save memory — fetch from server
+                Task {
+                    do {
+                        let data = try await AttachmentContentClient.fetchContent(attachmentId: attachment.id)
+                        ImageActions.openInPreview(
+                            image,
+                            filename: attachment.filename,
+                            rawData: data
+                        )
+                    } catch {
+                        // Fetch failed — open with thumbnail
+                        ImageActions.openInPreview(image, filename: attachment.filename)
+                    }
+                }
+            } else {
+                ImageActions.openInPreview(
+                    image,
+                    filename: attachment.filename,
+                    base64Data: attachment.data.isEmpty ? nil : attachment.data
+                )
+            }
         }) { attachment in
             fileAttachmentChip(attachment)
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -350,8 +350,21 @@ final class ConversationRestorer {
             // per-request timeout) while still covering the daemon restart race.
             let maxAttempts = 2
             for attempt in 1...maxAttempts {
-                if let response = await conversationListClient.fetchConversationList(offset: 0, limit: 50) {
-                    self.handleConversationListResponse(response)
+                // Fetch foreground and background conversations in parallel so
+                // background conversations don't consume pagination slots from
+                // the main list.
+                async let foregroundResult = conversationListClient.fetchConversationList(offset: 0, limit: 50)
+                async let backgroundResult = conversationListClient.fetchConversationList(offset: 0, limit: 50, conversationType: "background")
+                let foreground = await foregroundResult
+                let background = await backgroundResult
+
+                if let foreground {
+                    let merged = ConversationListResponse(
+                        type: foreground.type,
+                        conversations: foreground.conversations + (background?.conversations ?? []),
+                        hasMore: foreground.hasMore
+                    )
+                    self.handleConversationListResponse(merged)
                     return
                 }
                 if attempt < maxAttempts {

--- a/clients/shared/Network/ConversationListClient.swift
+++ b/clients/shared/Network/ConversationListClient.swift
@@ -6,7 +6,7 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 /// Focused client for conversation list and management operations via the gateway.
 @MainActor
 public protocol ConversationListClientProtocol {
-    func fetchConversationList(offset: Int, limit: Int) async -> ConversationListResponse?
+    func fetchConversationList(offset: Int, limit: Int, conversationType: String?) async -> ConversationListResponse?
     func switchConversation(conversationId: String) async -> Bool
     func renameConversation(conversationId: String, name: String) async -> Bool
     func clearAllConversations() async -> Bool
@@ -22,13 +22,14 @@ public protocol ConversationListClientProtocol {
 public struct ConversationListClient: ConversationListClientProtocol {
     nonisolated public init() {}
 
-    public func fetchConversationList(offset: Int = 0, limit: Int = 50) async -> ConversationListResponse? {
+    public func fetchConversationList(offset: Int = 0, limit: Int = 50, conversationType: String? = nil) async -> ConversationListResponse? {
         do {
             var params: [String: String] = [
                 "limit": "\(limit)",
                 "offset": "\(offset)",
             ]
             if offset == 0 { params.removeValue(forKey: "offset") }
+            if let conversationType { params["conversationType"] = conversationType }
 
             let response = try await GatewayHTTPClient.get(
                 path: "assistants/{assistantId}/conversations", params: params, timeout: 15


### PR DESCRIPTION
## Summary
- Background conversations (heartbeats) were consuming all 50 pagination slots in the conversation list API, causing real user conversations to not appear in the sidebar
- The `GET /v1/conversations` endpoint now supports a `?conversationType=background` filter instead of relying on the `show-background-conversations` feature flag
- Both macOS and iOS clients now make two parallel requests on startup (foreground + background) and merge results, so each category gets its own 50-slot budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
