### PR TITLE
chore: untrack .private/UNREVIEWED_PRS.md

### DIFF
--- a/.private/UNREVIEWED_PRS.md
+++ b/.private/UNREVIEWED_PRS.md
@@ -1,1 +1,0 @@
-https://github.com/vellum-ai/vellum-assistant/pull/21754


### PR DESCRIPTION
## Summary
- `.private/UNREVIEWED_PRS.md` was committed before `.private/` was added to `.gitignore`, so changes kept showing up as staged
- Removes the file from the git index (`git rm --cached`) so `.gitignore` takes effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21766" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
