### PR TITLE
fix: pass conversationType explicitly in iOS ConversationListClientProtocol calls

### DIFF
--- a/clients/ios/App/IOSConversationStore.swift
+++ b/clients/ios/App/IOSConversationStore.swift
@@ -515,7 +515,7 @@ class IOSConversationStore: ObservableObject {
             guard let self else { return }
             // Fetch foreground and background conversations in parallel so
             // background conversations don't consume pagination slots.
-            async let foregroundResult = conversationListClient.fetchConversationList(offset: 0, limit: Self.conversationPageSize)
+            async let foregroundResult = conversationListClient.fetchConversationList(offset: 0, limit: Self.conversationPageSize, conversationType: nil)
             async let backgroundResult = conversationListClient.fetchConversationList(offset: 0, limit: Self.conversationPageSize, conversationType: "background")
             let foreground = await foregroundResult
             let background = await backgroundResult
@@ -783,7 +783,7 @@ class IOSConversationStore: ObservableObject {
         let capturedOffset = conversationListOffset
         Task { [weak self] in
             guard let self else { return }
-            if let response = await conversationListClient.fetchConversationList(offset: nextOffset, limit: Self.conversationPageSize) {
+            if let response = await conversationListClient.fetchConversationList(offset: nextOffset, limit: Self.conversationPageSize, conversationType: nil) {
                 guard capturedGeneration == self.conversationListGeneration else { return }
                 self.handleConversationListResponse(response)
             } else {


### PR DESCRIPTION
## Summary
- Two calls to `fetchConversationList` in `IOSConversationStore.swift` were missing the `conversationType` argument. The property is typed as `any ConversationListClientProtocol`, so Swift doesn't pick up default parameter values from the concrete `ConversationListClient` — the parameter must be passed explicitly.
- Passes `nil` at both call sites (lines 518, 786) to restore the previous behavior.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23612652351/job/68772117605
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21767" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
