### PR TITLE
fix: scroll to last user message on conversation switch

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator+ScrollBehavior.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator+ScrollBehavior.swift
@@ -197,6 +197,7 @@ extension MessageListScrollCoordinator {
         isSending: Bool,
         assistantActivityPhase: String,
         containerWidth: CGFloat,
+        messages: [ChatMessage],
         isNearBottom: inout Bool,
         highlightedMessageId: Binding<UUID?>,
         resizeScrollTask: inout Task<Void, Never>?,
@@ -229,13 +230,21 @@ extension MessageListScrollCoordinator {
         if isSending {
             hasReceivedScrollEvent = true
         }
-        // Scroll to bottom for the new conversation. All positioning is
-        // imperative via ScrollPosition to avoid conflicts with push-to-top.
+        // Scroll to the last user message (push-to-top pattern) so the
+        // user's most recent message is at the viewport top. For short
+        // conversations that fit on screen, content stays top-aligned
+        // naturally. Falls back to bottom edge for conversations with
+        // no user messages (e.g. assistant-initiated).
         scrollRestoreTask?.cancel()
         if anchorMessageId.wrappedValue == nil {
-            scrollToEdge?(.bottom)
+            if let lastUserMsg = messages.last(where: { $0.role == .user }) {
+                performScrollTo(lastUserMsg.id, anchor: .top)
+            } else {
+                scrollToEdge?(.bottom)
+            }
         }
-        restoreScrollToBottom(
+        restoreScrollToLastUserMessage(
+            messages: messages,
             conversationId: newConversationId,
             anchorMessageId: anchorMessageId
         )
@@ -431,6 +440,33 @@ extension MessageListScrollCoordinator {
             {
                 os_signpost(.event, log: PerfSignposts.log, name: "scrollRestoreStage", "stage=fallback")
                 self.requestBottomPin(reason: .initialRestore, conversationId: conversationId)
+            }
+            self.scrollRestoreTask = nil
+        }
+    }
+
+    /// Delayed fallback that scrolls to the last user message after
+    /// LazyVStack has had time to materialize content. Mirrors
+    /// `restoreScrollToBottom` but uses the push-to-top anchor.
+    func restoreScrollToLastUserMessage(
+        messages: [ChatMessage],
+        conversationId: UUID?,
+        anchorMessageId: Binding<UUID?>
+    ) {
+        scrollRestoreTask?.cancel()
+
+        scrollRestoreTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            guard !Task.isCancelled, let self else { return }
+            if anchorMessageId.wrappedValue == nil
+                && !self.hasReceivedScrollEvent
+            {
+                os_signpost(.event, log: PerfSignposts.log, name: "scrollRestoreStage", "stage=lastUserMsg")
+                if let lastUserMsg = messages.last(where: { $0.role == .user }) {
+                    self.performScrollTo(lastUserMsg.id, anchor: .top)
+                } else {
+                    self.requestBottomPin(reason: .initialRestore, conversationId: conversationId)
+                }
             }
             self.scrollRestoreTask = nil
         }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -735,7 +735,6 @@ struct MessageListView: View {
             .plainTextCopy()
             .coordinateSpace(name: "chatScrollView")
             .scrollDisabled(messages.isEmpty && !isSending)
-            .defaultScrollAnchor(.bottom)
             .scrollPosition($scrollPosition)
             .environment(\.suppressAutoScroll, { [self] in
                 scrollCoordinator.handleSuppressAutoScroll(
@@ -966,6 +965,7 @@ struct MessageListView: View {
                     isSending: isSending,
                     assistantActivityPhase: assistantActivityPhase,
                     containerWidth: containerWidth,
+                    messages: messages,
                     isNearBottom: &isNearBottom,
                     highlightedMessageId: $highlightedMessageId,
                     resizeScrollTask: &resizeScrollTask,


### PR DESCRIPTION
## Summary
- Removes `.defaultScrollAnchor(.bottom)` which incorrectly pushed short conversations to the bottom of the viewport
- On conversation switch, scrolls to the last user message with `.top` anchor (push-to-top pattern), matching the existing behavior when sending a new message
- Short conversations that fit on one screen now display naturally from the top
- Falls back to `scrollToEdge(.bottom)` for conversations with no user messages

## Implementation
- `conversationSwitched()` now accepts `messages` parameter to find the last user message
- New `restoreScrollToLastUserMessage()` fallback mirrors `restoreScrollToBottom()` but uses the push-to-top anchor after a 100ms delay for LazyVStack materialization

## Testing
- Switch to a short conversation (fits on screen) — should display from top, not pushed to bottom
- Switch to a long conversation — should land with last user message at the top of the viewport
- Send a new message — push-to-top should still work as before
- Switch to an assistant-initiated conversation (no user messages) — should show from top/bottom naturally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
