### PR TITLE
fix: pass conversationType explicitly in macOS ConversationListClientProtocol calls

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -791,7 +791,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         isLoadingMoreConversations = true
         Task { [weak self] in
             guard let self else { return }
-            if let response = await conversationListClient.fetchConversationList(offset: serverOffset, limit: 50) {
+            if let response = await conversationListClient.fetchConversationList(offset: serverOffset, limit: 50, conversationType: nil) {
                 self.appendConversations(from: response)
             } else {
                 self.isLoadingMoreConversations = false

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -353,7 +353,7 @@ final class ConversationRestorer {
                 // Fetch foreground and background conversations in parallel so
                 // background conversations don't consume pagination slots from
                 // the main list.
-                async let foregroundResult = conversationListClient.fetchConversationList(offset: 0, limit: 50)
+                async let foregroundResult = conversationListClient.fetchConversationList(offset: 0, limit: 50, conversationType: nil)
                 async let backgroundResult = conversationListClient.fetchConversationList(offset: 0, limit: 50, conversationType: "background")
                 let foreground = await foregroundResult
                 let background = await backgroundResult


### PR DESCRIPTION
## Summary
- Add missing `conversationType: nil` argument to `fetchConversationList` calls in `ConversationRestorer.swift` and `ConversationManager.swift`
- Fixes macOS build failure caused by #21767 updating the protocol signature but only fixing iOS call sites

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23612652359/job/68772150672
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
