### PR TITLE
fix: improve VSplitButton dropdown hit-testing reliability

### DIFF
--- a/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
@@ -81,7 +81,7 @@ public struct VSplitButton<MenuContent: View>: View {
                 Menu {
                     menuContent()
                 } label: {
-                    Color.clear
+                    Color.white.opacity(0.001)
                         .frame(width: dropdownWidth, height: zoneHeight)
                         .contentShape(Rectangle())
                 }
@@ -90,7 +90,6 @@ public struct VSplitButton<MenuContent: View>: View {
                 .accessibilityLabel("\(label) options")
             }
             .frame(width: dropdownWidth, height: zoneHeight)
-            .clipped()
             .onHover { hovering in
                 isDropdownHovered = isDisabled ? false : hovering
             }

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -464,6 +464,7 @@ public struct ToolConfirmationBubble: View {
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.md)
                         .strokeBorder(VColor.primaryBase, lineWidth: isPrimaryAllowKeyboardSelected ? 2 : 0)
+                        .allowsHitTesting(false)
                 )
 
             VButton(label: "Deny", style: .danger, size: .compact) {


### PR DESCRIPTION
Three targeted fixes for the VSplitButton dropdown not responding to clicks:

1. Replace Color.clear with Color.white.opacity(0.001) in Menu label — fixes inconsistent hit-testing with AppKit NSPopUpButton backing
2. Add .allowsHitTesting(false) to keyboard selection overlay in ToolConfirmationBubble — prevents overlay from intercepting taps
3. Remove .clipped() from dropdown ZStack — eliminates unnecessary clip boundary that can interfere with Menu hit region

Closes #21770
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
