### PR TITLE
fix: improve VSplitButton dropdown hit-testing reliability

### DIFF
--- a/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
@@ -81,7 +81,7 @@ public struct VSplitButton<MenuContent: View>: View {
                 Menu {
                     menuContent()
                 } label: {
-                    Color.clear
+                    Color.white.opacity(0.001)
                         .frame(width: dropdownWidth, height: zoneHeight)
                         .contentShape(Rectangle())
                 }
@@ -90,7 +90,6 @@ public struct VSplitButton<MenuContent: View>: View {
                 .accessibilityLabel("\(label) options")
             }
             .frame(width: dropdownWidth, height: zoneHeight)
-            .clipped()
             .onHover { hovering in
                 isDropdownHovered = isDisabled ? false : hovering
             }

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -464,6 +464,7 @@ public struct ToolConfirmationBubble: View {
                 .overlay(
                     RoundedRectangle(cornerRadius: VRadius.md)
                         .strokeBorder(VColor.primaryBase, lineWidth: isPrimaryAllowKeyboardSelected ? 2 : 0)
+                        .allowsHitTesting(false)
                 )
 
             VButton(label: "Deny", style: .danger, size: .compact) {

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -474,6 +474,7 @@ public struct ToolConfirmationBubble: View {
             .overlay(
                 RoundedRectangle(cornerRadius: VRadius.md)
                     .strokeBorder(VColor.systemNegativeStrong, lineWidth: keyboardModel?.selectedAction == .dontAllow ? 2 : 0)
+                    .allowsHitTesting(false)
             )
         }
     }


### PR DESCRIPTION
## Summary
Fix intermittent failure of the VSplitButton dropdown/arrow button not responding to clicks. Three independent, targeted hit-testing fixes address different failure modes without any visual changes.

## Changes
- Replace `Color.clear` with `Color.white.opacity(0.001)` in VSplitButton Menu label — fixes inconsistent hit-testing with AppKit's NSPopUpButton backing view
- Add `.allowsHitTesting(false)` to keyboard selection overlay in ToolConfirmationBubble — prevents overlay from intercepting taps meant for the dropdown Menu
- Remove `.clipped()` from dropdown ZStack in VSplitButton — eliminates unnecessary clip boundary that can interfere with Menu's AppKit hosting hit region

## Milestone PRs (merged into feature branch)
- #21772: fix: improve VSplitButton dropdown hit-testing reliability

## Project issue
Closes #21769

## Test plan
- [ ] Open a conversation that triggers tool confirmations (e.g., bash commands)
- [ ] Verify the "Allow" split button dropdown opens on click
- [ ] Verify all dropdown menu items (Allow once, Allow for 10 minutes, Always allow) work
- [ ] Verify keyboard navigation (Tab/Enter) still works for the confirmation buttons
- [ ] Verify visual appearance is unchanged across all VSplitButton styles in the gallery
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
