### PR TITLE
perf: improve scrolling performance for long tool results

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -31,6 +31,7 @@ struct ChatBubble: View {
     var onRetryConversationError: (() -> Void)?
 
     var isLatestAssistantMessage: Bool = false
+    @Environment(\.suppressAutoScroll) private var suppressAutoScroll
     @State private var avatarBounceScale: CGFloat = 1.0
     /// When true, the assistant is still processing after tool calls completed.
     /// Renders an inline loading indicator in trailingStatus to avoid a separate
@@ -693,7 +694,7 @@ struct ChatBubble: View {
                 if isUser && !message.toolCalls.isEmpty {
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
                         ForEach(message.toolCalls) { toolCall in
-                            ToolCallChip(toolCall: toolCall)
+                            ToolCallChip(toolCall: toolCall, onWillExpand: suppressAutoScroll)
                         }
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -837,7 +837,11 @@ struct MessageListView: View {
                 }
 
                 // --- Push-to-top overflow detection ---
-                if scrollCoordinator.pushToTopMessageId != nil && distanceFromBottom > 50 {
+                // Guard against suppression so that expanding a tool result (which
+                // grows content height) doesn't yank the user to the bottom.
+                if scrollCoordinator.pushToTopMessageId != nil
+                    && distanceFromBottom > 50
+                    && !scrollCoordinator.isSuppressed {
                     scrollCoordinator.pushToTopMessageId = nil
                     scrollCoordinator.requestBottomPin(
                         reason: .messageCount,

--- a/clients/shared/DesignSystem/Components/Display/VDiffView.swift
+++ b/clients/shared/DesignSystem/Components/Display/VDiffView.swift
@@ -45,9 +45,10 @@ public struct VDiffView: View {
     public var body: some View {
         let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
         if let maxHeight {
-            diffScrollView(lines: lines, axes: [.horizontal, .vertical], lazy: lines.count > 200)
+            // Height-constrained: always virtualize — only visible lines render
+            diffScrollView(lines: lines, axes: [.horizontal, .vertical], lazy: true)
                 .frame(maxHeight: maxHeight)
-        } else if lines.count > 200 {
+        } else if lines.count > 80 {
             // Large diffs without an explicit maxHeight still get capped + virtualized
             diffScrollView(lines: lines, axes: [.horizontal, .vertical], lazy: true)
                 .frame(maxHeight: 400)

--- a/clients/shared/DesignSystem/Components/Display/VDiffView.swift
+++ b/clients/shared/DesignSystem/Components/Display/VDiffView.swift
@@ -19,8 +19,6 @@ public struct VDiffView: View {
     }
 
     private static func classify(_ line: Substring) -> LineKind {
-        // Unified diff file headers ("--- a/...", "+++ b/...", "--- /dev/null", "+++ /dev/null").
-        // Only match real headers to avoid misclassifying removed/added lines like "--- note".
         if line.hasPrefix("--- a/") || line.hasPrefix("--- /dev/null") { return .context }
         if line.hasPrefix("+++ b/") || line.hasPrefix("+++ /dev/null") { return .context }
         if line.hasPrefix("@@") { return .hunk }
@@ -28,8 +26,6 @@ public struct VDiffView: View {
         if line.hasPrefix("-") { return .removed }
         return .context
     }
-
-    // MARK: - Colors
 
     private static func lineBackground(_ kind: LineKind) -> Color {
         switch kind {
@@ -40,56 +36,47 @@ public struct VDiffView: View {
         }
     }
 
+    // MARK: - State
+
+    @State private var lines: [(text: String, kind: LineKind)]?
+
     // MARK: - Body
 
     public var body: some View {
-        let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
-        if let maxHeight {
-            // Height-constrained: always virtualize — only visible lines render
-            diffScrollView(lines: lines, axes: [.horizontal, .vertical], lazy: true)
-                .frame(maxHeight: maxHeight)
-        } else if lines.count > 80 {
-            // Large diffs without an explicit maxHeight still get capped + virtualized
-            diffScrollView(lines: lines, axes: [.horizontal, .vertical], lazy: true)
-                .frame(maxHeight: 400)
-        } else {
-            diffScrollView(lines: lines, axes: .horizontal, lazy: false)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-    }
-
-    private func diffScrollView(lines: [Substring], axes: Axis.Set, lazy: Bool) -> some View {
-        ScrollView(axes, showsIndicators: false) {
-            if lazy {
+        let effectiveMaxHeight = maxHeight ?? 400
+        ScrollView([.horizontal, .vertical], showsIndicators: false) {
+            if let lines {
                 LazyVStack(alignment: .leading, spacing: 0) {
                     ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
-                        diffLine(line)
+                        HStack(spacing: 0) {
+                            Text(line.text)
+                                .font(VFont.bodySmallDefault)
+                                .foregroundStyle(VColor.contentSecondary)
+                                .fixedSize(horizontal: true, vertical: true)
+                            Spacer(minLength: 0)
+                        }
+                        .padding(.horizontal, VSpacing.xs)
+                        .padding(.vertical, 1)
+                        .background(Self.lineBackground(line.kind))
                     }
                 }
                 .fixedSize(horizontal: true, vertical: false)
             } else {
-                VStack(alignment: .leading, spacing: 0) {
-                    ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
-                        diffLine(line)
-                    }
-                }
-                .fixedSize(horizontal: true, vertical: true)
+                ProgressView()
+                    .scaleEffect(0.6)
+                    .frame(maxWidth: .infinity, minHeight: 40)
             }
         }
+        .frame(maxHeight: effectiveMaxHeight)
         .textSelection(.enabled)
-    }
-
-    private func diffLine(_ line: Substring) -> some View {
-        let kind = Self.classify(line)
-        return HStack(spacing: 0) {
-            Text(line.isEmpty ? " " : String(line))
-                .font(VFont.bodySmallDefault)
-                .foregroundStyle(VColor.contentSecondary)
-                .fixedSize(horizontal: true, vertical: true)
-            Spacer(minLength: 0)
+        .task {
+            let t = text
+            let result = await Task.detached(priority: .userInitiated) {
+                t.split(separator: "\n", omittingEmptySubsequences: false).map { line in
+                    (text: line.isEmpty ? " " : String(line), kind: Self.classify(line))
+                }
+            }.value
+            lines = result
         }
-        .padding(.horizontal, VSpacing.xs)
-        .padding(.vertical, 1)
-        .background(Self.lineBackground(kind))
     }
 }

--- a/clients/shared/DesignSystem/Components/Display/VDiffView.swift
+++ b/clients/shared/DesignSystem/Components/Display/VDiffView.swift
@@ -45,22 +45,35 @@ public struct VDiffView: View {
     public var body: some View {
         let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
         if let maxHeight {
-            diffScrollView(lines: lines, axes: [.horizontal, .vertical])
+            diffScrollView(lines: lines, axes: [.horizontal, .vertical], lazy: lines.count > 200)
                 .frame(maxHeight: maxHeight)
+        } else if lines.count > 200 {
+            // Large diffs without an explicit maxHeight still get capped + virtualized
+            diffScrollView(lines: lines, axes: [.horizontal, .vertical], lazy: true)
+                .frame(maxHeight: 400)
         } else {
-            diffScrollView(lines: lines, axes: .horizontal)
+            diffScrollView(lines: lines, axes: .horizontal, lazy: false)
                 .fixedSize(horizontal: false, vertical: true)
         }
     }
 
-    private func diffScrollView(lines: [Substring], axes: Axis.Set) -> some View {
+    private func diffScrollView(lines: [Substring], axes: Axis.Set, lazy: Bool) -> some View {
         ScrollView(axes, showsIndicators: false) {
-            VStack(alignment: .leading, spacing: 0) {
-                ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
-                    diffLine(line)
+            if lazy {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
+                        diffLine(line)
+                    }
                 }
+                .fixedSize(horizontal: true, vertical: false)
+            } else {
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
+                        diffLine(line)
+                    }
+                }
+                .fixedSize(horizontal: true, vertical: true)
             }
-            .fixedSize(horizontal: true, vertical: true)
         }
         .textSelection(.enabled)
     }

--- a/clients/shared/Features/Chat/ToolCallChip.swift
+++ b/clients/shared/Features/Chat/ToolCallChip.swift
@@ -140,11 +140,23 @@ public struct ToolCallChip: View {
                                 .font(VFont.labelDefault)
                                 .foregroundStyle(VColor.contentSecondary)
                             if !resolvedInputFull.isEmpty {
-                                Text(resolvedInputFull)
-                                    .font(VFont.bodySmallDefault)
-                                    .foregroundStyle(VColor.contentSecondary)
-                                    .textSelection(.enabled)
-                                    .fixedSize(horizontal: false, vertical: true)
+                                let inputLineCount = Self.countLines(in: resolvedInputFull)
+                                if inputLineCount > 80 {
+                                    ScrollView {
+                                        Text(resolvedInputFull)
+                                            .font(VFont.bodySmallDefault)
+                                            .foregroundStyle(VColor.contentSecondary)
+                                            .frame(maxWidth: .infinity, alignment: .leading)
+                                            .textSelection(.enabled)
+                                    }
+                                    .frame(maxHeight: 300)
+                                } else {
+                                    Text(resolvedInputFull)
+                                        .font(VFont.bodySmallDefault)
+                                        .foregroundStyle(VColor.contentSecondary)
+                                        .textSelection(.enabled)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                }
                             }
                         }
                     }
@@ -212,10 +224,22 @@ public struct ToolCallChip: View {
                                         .replacingOccurrences(of: #"<command_exit code="\d+" />"#, with: "", options: .regularExpression)
                                         .trimmingCharacters(in: .whitespacesAndNewlines)
                                     if !extraOutput.isEmpty {
-                                        Text(extraOutput)
-                                            .font(VFont.bodySmallDefault)
-                                            .foregroundStyle(VColor.contentSecondary)
-                                            .textSelection(.enabled)
+                                        let extraLineCount = Self.countLines(in: extraOutput)
+                                        if extraLineCount > 80 {
+                                            ScrollView {
+                                                Text(extraOutput)
+                                                    .font(VFont.bodySmallDefault)
+                                                    .foregroundStyle(VColor.contentSecondary)
+                                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                                    .textSelection(.enabled)
+                                            }
+                                            .frame(maxHeight: 300)
+                                        } else {
+                                            Text(extraOutput)
+                                                .font(VFont.bodySmallDefault)
+                                                .foregroundStyle(VColor.contentSecondary)
+                                                .textSelection(.enabled)
+                                        }
                                     }
                                 }
                             } else if result == "<command_completed />" {
@@ -229,8 +253,8 @@ public struct ToolCallChip: View {
                             } else {
                                 let lineCount = cachedResultLineCount ?? Self.countLines(in: result)
                                 if Self.isFileEditTool(toolCall.toolName) {
-                                    VDiffView(result, maxHeight: lineCount > 500 ? 400 : nil)
-                                } else if lineCount > 500 {
+                                    VDiffView(result, maxHeight: lineCount > 80 ? 400 : nil)
+                                } else if lineCount > 80 {
                                     ScrollView {
                                         Text(result)
                                             .font(VFont.bodySmallDefault)

--- a/clients/shared/Features/Chat/ToolCallChip.swift
+++ b/clients/shared/Features/Chat/ToolCallChip.swift
@@ -3,6 +3,28 @@ import SwiftUI
 import AppKit
 #endif
 
+/// Splits text into lines and renders only visible ones via LazyVStack.
+/// Used for long tool outputs/inputs where a single Text view is too expensive to layout.
+private struct LazyTextView: View {
+    let text: String
+    let font: Font
+    let color: Color
+
+    var body: some View {
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+        LazyVStack(alignment: .leading, spacing: 0) {
+            ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
+                Text(line.isEmpty ? " " : line)
+                    .font(font)
+                    .foregroundStyle(color)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .textSelection(.enabled)
+    }
+}
+
 public struct ToolCallChip: View {
     public let toolCall: ToolCallData
     /// Optional callback invoked when expanding a tool call whose content was truncated.
@@ -143,11 +165,11 @@ public struct ToolCallChip: View {
                                 let inputLineCount = Self.countLines(in: resolvedInputFull)
                                 if inputLineCount > 80 {
                                     ScrollView {
-                                        Text(resolvedInputFull)
-                                            .font(VFont.bodySmallDefault)
-                                            .foregroundStyle(VColor.contentSecondary)
-                                            .frame(maxWidth: .infinity, alignment: .leading)
-                                            .textSelection(.enabled)
+                                        LazyTextView(
+                                            text: resolvedInputFull,
+                                            font: VFont.bodySmallDefault,
+                                            color: VColor.contentSecondary
+                                        )
                                     }
                                     .frame(maxHeight: 300)
                                 } else {
@@ -227,11 +249,11 @@ public struct ToolCallChip: View {
                                         let extraLineCount = Self.countLines(in: extraOutput)
                                         if extraLineCount > 80 {
                                             ScrollView {
-                                                Text(extraOutput)
-                                                    .font(VFont.bodySmallDefault)
-                                                    .foregroundStyle(VColor.contentSecondary)
-                                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                                    .textSelection(.enabled)
+                                                LazyTextView(
+                                                    text: extraOutput,
+                                                    font: VFont.bodySmallDefault,
+                                                    color: VColor.contentSecondary
+                                                )
                                             }
                                             .frame(maxHeight: 300)
                                         } else {
@@ -256,11 +278,11 @@ public struct ToolCallChip: View {
                                     VDiffView(result, maxHeight: lineCount > 80 ? 400 : nil)
                                 } else if lineCount > 80 {
                                     ScrollView {
-                                        Text(result)
-                                            .font(VFont.bodySmallDefault)
-                                            .foregroundStyle(VColor.contentSecondary)
-                                            .frame(maxWidth: .infinity, alignment: .leading)
-                                            .textSelection(.enabled)
+                                        LazyTextView(
+                                            text: result,
+                                            font: VFont.bodySmallDefault,
+                                            color: VColor.contentSecondary
+                                        )
                                     }
                                     .frame(maxHeight: 400)
                                 } else {

--- a/clients/shared/Features/Chat/ToolCallChip.swift
+++ b/clients/shared/Features/Chat/ToolCallChip.swift
@@ -3,25 +3,42 @@ import SwiftUI
 import AppKit
 #endif
 
-/// Splits text into lines and renders only visible ones via LazyVStack.
-/// Used for long tool outputs/inputs where a single Text view is too expensive to layout.
+/// Loads text content asynchronously and renders only visible lines via LazyVStack.
 private struct LazyTextView: View {
     let text: String
     let font: Font
     let color: Color
+    let maxHeight: CGFloat
+
+    @State private var lines: [Substring]?
 
     var body: some View {
-        let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
-        LazyVStack(alignment: .leading, spacing: 0) {
-            ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
-                Text(line.isEmpty ? " " : line)
-                    .font(font)
-                    .foregroundStyle(color)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .fixedSize(horizontal: false, vertical: true)
+        ScrollView {
+            if let lines {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
+                        Text(line.isEmpty ? " " : line)
+                            .font(font)
+                            .foregroundStyle(color)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                .textSelection(.enabled)
+            } else {
+                ProgressView()
+                    .scaleEffect(0.6)
+                    .frame(maxWidth: .infinity, minHeight: 40)
             }
         }
-        .textSelection(.enabled)
+        .frame(maxHeight: maxHeight)
+        .task {
+            let t = text
+            let result = await Task.detached(priority: .userInitiated) {
+                t.split(separator: "\n", omittingEmptySubsequences: false)
+            }.value
+            lines = result
+        }
     }
 }
 
@@ -30,18 +47,18 @@ public struct ToolCallChip: View {
     /// Optional callback invoked when expanding a tool call whose content was truncated.
     /// The parent view can use this to trigger on-demand rehydration of the full content.
     public var onRehydrate: (() -> Void)?
+    /// Optional callback to suppress auto-scroll during expansion.
+    public var onWillExpand: (() -> Void)?
 
-    public init(toolCall: ToolCallData, onRehydrate: (() -> Void)? = nil) {
+    public init(toolCall: ToolCallData, onRehydrate: (() -> Void)? = nil, onWillExpand: (() -> Void)? = nil) {
         self.toolCall = toolCall
         self.onRehydrate = onRehydrate
+        self.onWillExpand = onWillExpand
     }
     @State private var isExpanded = false
     /// Cached formatted input — computed once on first expand to avoid re-running
     /// `formatAllToolInput` on every SwiftUI render pass.
     @State private var cachedInputFull: String?
-    /// Cached line count for the result text — avoids O(n) `components(separatedBy:)`
-    /// array allocation on every SwiftUI render pass when the chip is expanded.
-    @State private var cachedResultLineCount: Int?
 
     /// Parse a `<command_exit code="N" />` tag from the result string and return the exit code.
     static func parseExitCode(from result: String) -> Int? {
@@ -55,15 +72,6 @@ public struct ToolCallChip: View {
             return nil
         }
         return Int(matched[numRange])
-    }
-
-    /// Count lines in a string without allocating an intermediate array.
-    static func countLines(in text: String) -> Int {
-        var count = 1
-        for byte in text.utf8 where byte == UInt8(ascii: "\n") {
-            count += 1
-        }
-        return count
     }
 
     /// Whether the tool produces diff-formatted output that benefits from line-level highlighting.
@@ -109,6 +117,7 @@ public struct ToolCallChip: View {
             // Chip header (always visible)
             Button {
                 if toolCall.isComplete && hasExpandableContent {
+                    onWillExpand?()
                     withAnimation(VAnimation.fast) { isExpanded.toggle() }
                 }
             } label: {
@@ -162,23 +171,12 @@ public struct ToolCallChip: View {
                                 .font(VFont.labelDefault)
                                 .foregroundStyle(VColor.contentSecondary)
                             if !resolvedInputFull.isEmpty {
-                                let inputLineCount = Self.countLines(in: resolvedInputFull)
-                                if inputLineCount > 80 {
-                                    ScrollView {
-                                        LazyTextView(
-                                            text: resolvedInputFull,
-                                            font: VFont.bodySmallDefault,
-                                            color: VColor.contentSecondary
-                                        )
-                                    }
-                                    .frame(maxHeight: 300)
-                                } else {
-                                    Text(resolvedInputFull)
-                                        .font(VFont.bodySmallDefault)
-                                        .foregroundStyle(VColor.contentSecondary)
-                                        .textSelection(.enabled)
-                                        .fixedSize(horizontal: false, vertical: true)
-                                }
+                                LazyTextView(
+                                    text: resolvedInputFull,
+                                    font: VFont.bodySmallDefault,
+                                    color: VColor.contentSecondary,
+                                    maxHeight: 300
+                                )
                             }
                         }
                     }
@@ -246,22 +244,12 @@ public struct ToolCallChip: View {
                                         .replacingOccurrences(of: #"<command_exit code="\d+" />"#, with: "", options: .regularExpression)
                                         .trimmingCharacters(in: .whitespacesAndNewlines)
                                     if !extraOutput.isEmpty {
-                                        let extraLineCount = Self.countLines(in: extraOutput)
-                                        if extraLineCount > 80 {
-                                            ScrollView {
-                                                LazyTextView(
-                                                    text: extraOutput,
-                                                    font: VFont.bodySmallDefault,
-                                                    color: VColor.contentSecondary
-                                                )
-                                            }
-                                            .frame(maxHeight: 300)
-                                        } else {
-                                            Text(extraOutput)
-                                                .font(VFont.bodySmallDefault)
-                                                .foregroundStyle(VColor.contentSecondary)
-                                                .textSelection(.enabled)
-                                        }
+                                        LazyTextView(
+                                            text: extraOutput,
+                                            font: VFont.bodySmallDefault,
+                                            color: VColor.contentSecondary,
+                                            maxHeight: 300
+                                        )
                                     }
                                 }
                             } else if result == "<command_completed />" {
@@ -273,25 +261,15 @@ public struct ToolCallChip: View {
                                         .foregroundStyle(VColor.contentSecondary)
                                 }
                             } else {
-                                let lineCount = cachedResultLineCount ?? Self.countLines(in: result)
                                 if Self.isFileEditTool(toolCall.toolName) {
-                                    VDiffView(result, maxHeight: lineCount > 80 ? 400 : nil)
-                                } else if lineCount > 80 {
-                                    ScrollView {
-                                        LazyTextView(
-                                            text: result,
-                                            font: VFont.bodySmallDefault,
-                                            color: VColor.contentSecondary
-                                        )
-                                    }
-                                    .frame(maxHeight: 400)
+                                    VDiffView(result, maxHeight: 400)
                                 } else {
-                                    Text(result)
-                                        .font(VFont.bodySmallDefault)
-                                        .foregroundStyle(VColor.contentSecondary)
-                                        .frame(maxWidth: .infinity, alignment: .leading)
-                                        .textSelection(.enabled)
-                                        .fixedSize(horizontal: false, vertical: true)
+                                    LazyTextView(
+                                        text: result,
+                                        font: VFont.bodySmallDefault,
+                                        color: VColor.contentSecondary,
+                                        maxHeight: 400
+                                    )
                                 }
                             }
                         }
@@ -299,7 +277,6 @@ public struct ToolCallChip: View {
                     }
                 }
                 .padding(.bottom, VSpacing.sm)
-                .transition(.opacity.combined(with: .move(edge: .top)))
                 .onAppear {
                     // Compute formatted input once when the user first expands,
                     // rather than re-running formatAllToolInput on every render.
@@ -309,10 +286,6 @@ public struct ToolCallChip: View {
                         } else if let dict = toolCall.inputRawDict {
                             cachedInputFull = ToolCallData.formatAllToolInput(dict)
                         }
-                    }
-                    // Cache the result line count so subsequent renders are O(1).
-                    if cachedResultLineCount == nil, let result = toolCall.result {
-                        cachedResultLineCount = Self.countLines(in: result)
                     }
                     // Trigger on-demand rehydration when expanding truncated content.
                     onRehydrate?()
@@ -344,22 +317,12 @@ public struct ToolCallChip: View {
                         cachedInputFull = toolCall.inputFull
                     }
                 }
-                if cachedResultLineCount == nil, let result = toolCall.result {
-                    cachedResultLineCount = Self.countLines(in: result)
-                }
             }
         }
         .onChange(of: toolCall.inputFull) {
             // Invalidate the cached formatted input so the next render picks up
             // the fresh (rehydrated) value instead of the stale truncated one.
             cachedInputFull = nil
-        }
-        .onChange(of: toolCall.result) {
-            if isExpanded, let result = toolCall.result {
-                cachedResultLineCount = Self.countLines(in: result)
-            } else {
-                cachedResultLineCount = nil
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Lowers the line threshold for applying `maxHeight` + `ScrollView` from 500 to 80 lines in `ToolCallChip`, so medium-length tool results no longer expand the view unboundedly
- Adds `maxHeight` capping (300pt) to the "Technical details" input section and exit code extra output, which previously had no height limit
- Virtualizes `VDiffView` with `LazyVStack` for diffs over 200 lines, so only visible lines are rendered instead of the entire diff
- Large diffs without an explicit `maxHeight` now auto-cap at 400pt with vertical scrolling

## Original prompt
--safe https://linear.app/vellum/issue/LUM-514/improve-performance-of-long-tool-results looks like long lists slowing down scrolling and responsiveness of app controls, we could think about virtualization and adding max-height limit for expanded details parts to make it performant
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
