### PR TITLE
fix: track visible message identity to prevent layout cache staleness crash

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator.swift
@@ -407,6 +407,7 @@ final class MessageListScrollCoordinator: ObservableObject {
         scrollTracking.lastKnownVisibleMessageCount = 0
         scrollTracking.lastKnownLastMessageStreaming = false
         scrollTracking.lastKnownIncompleteToolCallCount = 0
+        scrollTracking.lastKnownVisibleIdFingerprint = 0
         // Update the live conversation ID so closures read the new value.
         currentConversationId = newConversationId
         // Reset follow state for the new conversation.

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -64,6 +64,10 @@ extension EnvironmentValues {
     var lastKnownLastMessageStreaming: Bool = false
     /// Cached count of incomplete tool calls across visible messages.
     var lastKnownIncompleteToolCallCount: Int = 0
+    /// Lightweight identity fingerprint of visible message IDs. Catches
+    /// "same count, different IDs" scenarios where hasRenderableContent
+    /// changes cause different messages to pass the visibility filter.
+    var lastKnownVisibleIdFingerprint: Int = 0
 
     // MARK: - Scroll Geometry (non-reactive, updated every scroll tick)
 
@@ -209,6 +213,13 @@ struct MessageListView: View {
         let currentLastStreaming = visibleMessages.last?.isStreaming ?? false
         let currentIncompleteToolCalls = visibleMessages.last?.toolCalls.filter { !$0.isComplete }.count ?? 0
 
+        // O(n) hash of visible message IDs — catches "same count, different
+        // IDs" scenarios where hasRenderableContent changes cause different
+        // messages to pass the visibility filter without changing the count.
+        var idHasher = Hasher()
+        for msg in visibleMessages { idHasher.combine(msg.id) }
+        let currentIdFingerprint = idHasher.finalize()
+
         var changed = false
 
         if currentRawCount != scrollCoordinator.scrollTracking.lastKnownRawMessageCount {
@@ -225,6 +236,10 @@ struct MessageListView: View {
         }
         if currentIncompleteToolCalls != scrollCoordinator.scrollTracking.lastKnownIncompleteToolCallCount {
             scrollCoordinator.scrollTracking.lastKnownIncompleteToolCallCount = currentIncompleteToolCalls
+            changed = true
+        }
+        if currentIdFingerprint != scrollCoordinator.scrollTracking.lastKnownVisibleIdFingerprint {
+            scrollCoordinator.scrollTracking.lastKnownVisibleIdFingerprint = currentIdFingerprint
             changed = true
         }
 


### PR DESCRIPTION
## Summary
- Fixes a crash (DEBUG assertion failure) in `MessageListView.derivedState` where the layout cache returns stale IDs
- Root cause: `refreshMessageListVersionIfNeeded` tracked message **counts** but not **identity** — when `hasRenderableContent` changes cause different messages to pass the visibility filter without changing the count, the cache key matches but the cached IDs are wrong
- Adds an O(n) hash of visible message IDs as a fingerprint, bumping the version counter when identity changes

## What this does

**For users:** Fixes a crash that happens during normal chat usage — the app would suddenly quit mid-conversation, especially when the assistant is streaming responses with tool calls. After this fix, that crash stops happening.

**For development:** We cache the message list layout so we don't recompute it every frame. The cache was checking "are there still 4 messages?" to decide if it was still valid. But sometimes a message disappears and a new one appears — still 4 messages, but different ones. The cache said "still 4, reuse the old layout" and the old layout referenced a message that no longer exists. In debug builds that's an assertion crash; in release builds it would cause stale/wrong UI. The fix fingerprints *which* messages are visible, not just how many.

## The Bug
```
T0: visibleMessages = [A, B, C, D] (count: 4), cache stores IDs [A,B,C,D]
T1: msgD loses renderable content, msgE gains it
    visibleMessages = [A, B, C, E] (count: 4 — unchanged!)
    Version not bumped → cache hit → assertion: [A,B,C,D] != [A,B,C,E] → CRASH
```

## Testing
- In debug builds, the assertion at line 295 should no longer fire
- Normal chat usage — no behavioral changes expected
- Rapid message streaming with tool calls — verify no crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)