### PR TITLE
fix: align ToolConfirmationBubble hit regions with visual layout on macOS 26

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -200,19 +200,23 @@ public struct ToolConfirmationBubble: View {
     private var pendingContent: some View {
         let actions = topLevelActions
         VStack(alignment: .leading, spacing: VSpacing.sm) {
-            // Adaptive layout: horizontal when wide, vertical when narrow
-            if useCompactConfirmationLayout {
+            // Adaptive layout: horizontal when wide, vertical when narrow.
+            // Uses AnyLayout to preserve child view identity across layout
+            // switches, preventing stale hit regions on macOS 26.
+            let adaptiveLayout = useCompactConfirmationLayout
+                ? AnyLayout(VStackLayout(alignment: .leading, spacing: VSpacing.sm))
+                : AnyLayout(HStackLayout(alignment: .top, spacing: VSpacing.sm))
+
+            adaptiveLayout {
                 confirmationDescription
-                HStack {
-                    Spacer()
-                    confirmationActions
-                }
-            } else {
-                HStack(alignment: .top, spacing: VSpacing.sm) {
-                    confirmationDescription
+                if useCompactConfirmationLayout {
+                    Spacer(minLength: 0)
+                } else {
                     Spacer(minLength: VSpacing.md)
-                    confirmationActions
                 }
+                confirmationActions
+                    .frame(maxWidth: useCompactConfirmationLayout ? .infinity : nil,
+                           alignment: .trailing)
             }
 
             // First-time educational banner for command confirmations
@@ -236,7 +240,7 @@ public struct ToolConfirmationBubble: View {
                             .font(VFont.labelDefault)
                             .foregroundStyle(VColor.contentDefault)
                     }
-                    .offset(x: -1)
+                    .padding(.leading, -1)
                 }
                 .buttonStyle(.plain)
 
@@ -268,7 +272,9 @@ public struct ToolConfirmationBubble: View {
         .onGeometryChange(for: Bool.self) { proxy in
             proxy.size.width < 450
         } action: { isCompact in
-            useCompactConfirmationLayout = isCompact
+            withAnimation(.none) {
+                useCompactConfirmationLayout = isCompact
+            }
         }
         .onAppear {
             if isKeyboardActive {

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -205,15 +205,12 @@ public struct ToolConfirmationBubble: View {
             // switches, preventing stale hit regions on macOS 26.
             let adaptiveLayout = useCompactConfirmationLayout
                 ? AnyLayout(VStackLayout(alignment: .leading, spacing: VSpacing.sm))
-                : AnyLayout(HStackLayout(alignment: .top, spacing: VSpacing.sm))
+                : AnyLayout(HStackLayout(alignment: .top, spacing: VSpacing.md))
 
             adaptiveLayout {
                 confirmationDescription
-                if useCompactConfirmationLayout {
-                    Spacer(minLength: 0)
-                } else {
-                    Spacer(minLength: VSpacing.md)
-                }
+                    .frame(maxWidth: useCompactConfirmationLayout ? nil : .infinity,
+                           alignment: .leading)
                 confirmationActions
                     .frame(maxWidth: useCompactConfirmationLayout ? .infinity : nil,
                            alignment: .trailing)


### PR DESCRIPTION
## Summary
Three targeted fixes for hitbox misalignment on macOS 26.2 (Tahoe) during window resize:

1. Wrap `onGeometryChange` layout-mode state update in `withAnimation(.none)` to force synchronous layout invalidation and hit-region recalculation
2. Replace `if/else` layout branch with `AnyLayout` to preserve child view identity across compact/wide layout switches, preventing tree destruction and stale hit regions
3. Replace `.offset(x: -1)` with `.padding(.leading, -1)` on "Show details" button to align hit region with visual position

## Test plan
- [ ] Resize the window past the 450px compact breakpoint and verify Allow/Deny buttons remain clickable
- [ ] Verify "Show details" toggle button is clickable on first click (no offset mismatch)
- [ ] Verify visual layout is pixel-identical: wide mode has description left + actions right, compact mode has description on top + right-aligned actions below

Closes #21779

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21780" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
