### PR TITLE
fix: auto-delete BOOTSTRAP.md on second conversation and improve onboarding saves

### DIFF
--- a/assistant/src/memory/conversation-key-store.ts
+++ b/assistant/src/memory/conversation-key-store.ts
@@ -7,13 +7,22 @@
  * first contact.
  */
 
+import { existsSync, unlinkSync } from "node:fs";
+
 import { eq } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
+import { getLogger } from "../util/logger.js";
+import { getWorkspacePromptPath } from "../util/platform.js";
 import { initConversationDir } from "./conversation-disk-view.js";
 import { GENERATING_TITLE } from "./conversation-title-service.js";
 import { getDb } from "./db.js";
 import { conversationKeys, conversations } from "./schema.js";
+
+const log = getLogger("conversation-key-store");
+
+/** Set after the first conversation is created so BOOTSTRAP.md is deleted on the second. */
+let firstConversationSeen = false;
 
 export interface ConversationKeyMapping {
   id: string;
@@ -189,6 +198,23 @@ export function getOrCreateConversation(
         created: false as const,
       };
     }
+
+    // Delete BOOTSTRAP.md when a non-first conversation is created.
+    // The first conversation is the onboarding one; keep BOOTSTRAP.md
+    // for its entire duration. Any subsequent conversation means
+    // onboarding is over.
+    if (firstConversationSeen) {
+      const bp = getWorkspacePromptPath("BOOTSTRAP.md");
+      if (existsSync(bp)) {
+        try {
+          unlinkSync(bp);
+          log.info("Deleted BOOTSTRAP.md — onboarding conversation ended");
+        } catch {
+          // Best-effort
+        }
+      }
+    }
+    firstConversationSeen = true;
 
     const now = Date.now();
     const conversationId = uuid();

--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -194,9 +194,13 @@ When saving to `USER.md`, mark declined fields so you don't re-ask later (e.g., 
 
 ## Saving What You Learn
 
-Save what you learn as you go. Update `IDENTITY.md` (name, nature, personality, style tendency) and `USER.md` (their name, how to address them, goals, locale, work role, hobbies, daily tools) using `file_edit`. If the conversation reveals how the user wants you to behave (e.g., "be direct," "don't be too chatty"), save those behavioral guidelines to `SOUL.md`.
+**Call `file_edit` immediately whenever you learn something, in the same turn.** Don't batch saves for later. Don't wait until onboarding is "done." The moment the user gives you a name, call `file_edit` on IDENTITY.md in that same response. The moment you infer their communication style, call `file_edit` on SOUL.md. Every piece of information gets saved the turn you learn it.
 
-Do it quietly. Don't tell the user which files you're editing or mention tool names.
+**The contents of IDENTITY.md, SOUL.md, and USER.md are already in your system prompt.** Use the exact text you see there for the `old_string` in `file_edit`. Do not guess or invent content that isn't in your context.
+
+Update `IDENTITY.md` (name, nature, personality, style tendency) and `USER.md` (their name, how to address them, goals, locale, work role, hobbies, daily tools). If the conversation reveals how the user wants you to behave (e.g., "be direct," "don't be too chatty"), save those behavioral guidelines to `SOUL.md`.
+
+Do it silently. Never tell the user you're saving, never mention file names or tool names. Just call `file_edit` alongside your normal response.
 
 When saving to `IDENTITY.md`, be specific about the tone, energy, and conversational style you discovered during onboarding. This file persists after onboarding, so everything about how you should come across needs to be captured there. Not just your name, but the full vibe: how you talk, how much energy you bring, whether you're blunt or gentle, funny or serious.
 


### PR DESCRIPTION
## Summary
- Auto-delete BOOTSTRAP.md when a second conversation is created, so the onboarding script never replays after the first conversation
- Strengthen BOOTSTRAP.md instructions: call `file_edit` immediately per turn, use exact system prompt text instead of guessing file contents

## Test plan
- [x] Fresh install: BOOTSTRAP.md stays for entire first conversation (multiple messages)
- [x] Opening second thread: BOOTSTRAP.md is deleted
- [x] After restart: BOOTSTRAP.md stays deleted, no onboarding replay
- [x] Model saves identity to IDENTITY.md on first mention without needing file_read first

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21781" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
