### PR TITLE
fix: replace raw Color.white with Color.clear in VSplitButton

### DIFF
--- a/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
@@ -81,7 +81,7 @@ public struct VSplitButton<MenuContent: View>: View {
                 Menu {
                     menuContent()
                 } label: {
-                    Color.white.opacity(0.001)
+                    Color.clear
                         .frame(width: dropdownWidth, height: zoneHeight)
                         .contentShape(Rectangle())
                 }


### PR DESCRIPTION
## Summary
- Replace `Color.white.opacity(0.001)` with `Color.clear` in `VSplitButton.swift` to fix design token guard violation
- The `.contentShape(Rectangle())` modifier already ensures hit testing works with `Color.clear`

## Original prompt
Fix the design token violation in shared/DesignSystem/Core/Buttons/VSplitButton.swift:84 where `Color.white.opacity(0.001)` is used instead of a design token. Replace it with the appropriate design token equivalent.