### PR TITLE
fix: deduplicate conversation list merge to prevent double entries on platform assistants

### DIFF
--- a/clients/ios/App/IOSConversationStore.swift
+++ b/clients/ios/App/IOSConversationStore.swift
@@ -522,9 +522,17 @@ class IOSConversationStore: ObservableObject {
 
             if let foreground {
                 guard currentGeneration == self.conversationListGeneration else { return }
+                // Deduplicate by conversation ID so that daemons that don't
+                // yet support the conversationType query param (which return
+                // the same conversations for both requests) don't produce
+                // duplicate sidebar entries.
+                var seenIds = Set(foreground.conversations.map(\.id))
+                let uniqueBackground = (background?.conversations ?? []).filter {
+                    seenIds.insert($0.id).inserted
+                }
                 let merged = ConversationListResponse(
                     type: foreground.type,
-                    conversations: foreground.conversations + (background?.conversations ?? []),
+                    conversations: foreground.conversations + uniqueBackground,
                     hasMore: foreground.hasMore
                 )
                 self.expectedConversationListGeneration = currentGeneration

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -359,9 +359,17 @@ final class ConversationRestorer {
                 let background = await backgroundResult
 
                 if let foreground {
+                    // Deduplicate by conversation ID so that daemons that don't
+                    // yet support the conversationType query param (which return
+                    // the same conversations for both requests) don't produce
+                    // duplicate sidebar entries.
+                    var seenIds = Set(foreground.conversations.map(\.id))
+                    let uniqueBackground = (background?.conversations ?? []).filter {
+                        seenIds.insert($0.id).inserted
+                    }
                     let merged = ConversationListResponse(
                         type: foreground.type,
-                        conversations: foreground.conversations + (background?.conversations ?? []),
+                        conversations: foreground.conversations + uniqueBackground,
                         hasMore: foreground.hasMore
                     )
                     self.handleConversationListResponse(merged)


### PR DESCRIPTION
## Summary
- The conversation list split (#21765) makes two parallel requests (foreground + background) and concatenates the results
- Platform daemons that haven't been updated to support the `conversationType` query param return identical results for both requests, causing every conversation to appear twice in the sidebar
- Added deduplication by conversation ID at the merge point in both macOS (`ConversationRestorer.swift`) and iOS (`IOSConversationStore.swift`)

## Original prompt
create a PR with the above change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
