### PR TITLE
fix(cli): use per-assistant runtimeUrl for managed health check org fetch

### DIFF
--- a/cli/src/lib/health-check.ts
+++ b/cli/src/lib/health-check.ts
@@ -28,7 +28,7 @@ export async function checkManagedHealth(
   let orgId: string;
   try {
     const { fetchOrganizationId } = await import("./platform-client.js");
-    orgId = await fetchOrganizationId(token);
+    orgId = await fetchOrganizationId(token, runtimeUrl);
   } catch (err) {
     return {
       status: "error (auth)",

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -75,16 +75,19 @@ interface OrganizationListResponse {
   results: { id: string; name: string }[];
 }
 
-export async function fetchOrganizationId(token: string): Promise<string> {
-  const platformUrl = getPlatformUrl();
-  const url = `${platformUrl}/v1/organizations/`;
+export async function fetchOrganizationId(
+  token: string,
+  platformUrl?: string,
+): Promise<string> {
+  const resolvedUrl = platformUrl || getPlatformUrl();
+  const url = `${resolvedUrl}/v1/organizations/`;
   const response = await fetch(url, {
     headers: { "X-Session-Token": token },
   });
 
   if (!response.ok) {
     throw new Error(
-      `Failed to fetch organizations from ${platformUrl} (${response.status}). Try logging in again.`,
+      `Failed to fetch organizations from ${resolvedUrl} (${response.status}). Try logging in again.`,
     );
   }
 


### PR DESCRIPTION
## Summary
- Updated `fetchOrganizationId` to accept an optional `platformUrl` parameter, falling back to the global `getPlatformUrl()` when not provided
- Updated `checkManagedHealth` to pass the assistant's `runtimeUrl` through to org fetch
- This fixes `vellum ps` showing 'error (auth)' for managed assistants on non-production platforms (e.g. dev-platform.vellum.ai)

Part of plan: platform-url-auth-fix.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
