### PR TITLE
fix(macos): seed platform URL from lockfile before managed assistant reauth

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
@@ -163,6 +163,14 @@ struct ReauthView: View {
         authManager.errorMessage = nil
         defer { isActivatingManagedAssistant = false }
 
+        // Seed AuthService with the platform URL from the existing lockfile entry
+        // so that organization resolution hits the correct platform (e.g. dev-platform
+        // vs production) before the daemon is connected.
+        if let managedAssistant = LockfileAssistant.loadAll().first(where: { $0.isManaged }),
+           let runtimeUrl = managedAssistant.runtimeUrl, !runtimeUrl.isEmpty {
+            AuthService.shared.configuredBaseURL = runtimeUrl
+        }
+
         do {
             let activation = try await ManagedAssistantConnectionCoordinator().activateManagedAssistantAfterReauth()
             didComplete = true


### PR DESCRIPTION
## Summary
- Before managed assistant reauth, loads the existing lockfile entry's `runtimeUrl` and seeds `AuthService.shared.configuredBaseURL`
- This ensures organization resolution during reauth hits the correct platform (e.g. `dev-platform.vellum.ai`) instead of falling back to the hardcoded production URL
- No-op when no managed assistant exists in the lockfile

Part of plan: platform-url-auth-fix.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
