### PR TITLE
fix(macos): seed platform URL from lockfile on startup before daemon connects

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -84,6 +84,13 @@ extension AppDelegate {
 
         let assistant = loadAssistantFromLockfile()
 
+        // Seed AuthService with the platform URL from the lockfile so that any
+        // platform API calls before the daemon connects (e.g. organization
+        // resolution during managed bootstrap) use the correct URL.
+        if let assistant, assistant.isManaged, let runtimeUrl = assistant.runtimeUrl, !runtimeUrl.isEmpty {
+            AuthService.shared.configuredBaseURL = runtimeUrl
+        }
+
         configureDaemonTransport(for: assistant)
 
         // Set recovery credentials for automatic 401 re-bootstrap


### PR DESCRIPTION
## Summary
- In `setupGatewayConnectionManager()`, after loading the assistant from the lockfile, seeds `AuthService.shared.configuredBaseURL` with the managed assistant's `runtimeUrl`
- This ensures platform API calls before daemon connection (e.g. organization resolution) use the correct platform URL
- Only applies to managed assistants; local and remote assistants are unaffected

Part of plan: platform-url-auth-fix.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
