### PR TITLE
fix(cli): add optional platformUrl param to all platform-client helpers

### DIFF
--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -110,8 +110,12 @@ interface AllauthSessionResponse {
   };
 }
 
-export async function fetchCurrentUser(token: string): Promise<PlatformUser> {
-  const url = `${getPlatformUrl()}/_allauth/app/v1/auth/session`;
+export async function fetchCurrentUser(
+  token: string,
+  platformUrl?: string,
+): Promise<PlatformUser> {
+  const resolvedUrl = platformUrl || getPlatformUrl();
+  const url = `${resolvedUrl}/_allauth/app/v1/auth/session`;
   const response = await fetch(url, {
     headers: { "X-Session-Token": token },
   });
@@ -141,9 +145,10 @@ export async function rollbackPlatformAssistant(
   token: string,
   orgId: string,
   version?: string,
+  platformUrl?: string,
 ): Promise<{ detail: string; version: string | null }> {
-  const platformUrl = getPlatformUrl();
-  const response = await fetch(`${platformUrl}/v1/assistants/rollback/`, {
+  const resolvedUrl = platformUrl || getPlatformUrl();
+  const response = await fetch(`${resolvedUrl}/v1/assistants/rollback/`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -185,9 +190,10 @@ export async function platformInitiateExport(
   token: string,
   orgId: string,
   description?: string,
+  platformUrl?: string,
 ): Promise<{ jobId: string; status: string }> {
-  const platformUrl = getPlatformUrl();
-  const response = await fetch(`${platformUrl}/v1/migrations/export/`, {
+  const resolvedUrl = platformUrl || getPlatformUrl();
+  const response = await fetch(`${resolvedUrl}/v1/migrations/export/`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -218,10 +224,11 @@ export async function platformPollExportStatus(
   jobId: string,
   token: string,
   orgId: string,
+  platformUrl?: string,
 ): Promise<{ status: string; downloadUrl?: string; error?: string }> {
-  const platformUrl = getPlatformUrl();
+  const resolvedUrl = platformUrl || getPlatformUrl();
   const response = await fetch(
-    `${platformUrl}/v1/migrations/export/${jobId}/status/`,
+    `${resolvedUrl}/v1/migrations/export/${jobId}/status/`,
     {
       headers: {
         "X-Session-Token": token,
@@ -272,10 +279,11 @@ export async function platformImportPreflight(
   bundleData: Uint8Array<ArrayBuffer>,
   token: string,
   orgId: string,
+  platformUrl?: string,
 ): Promise<{ statusCode: number; body: Record<string, unknown> }> {
-  const platformUrl = getPlatformUrl();
+  const resolvedUrl = platformUrl || getPlatformUrl();
   const response = await fetch(
-    `${platformUrl}/v1/migrations/import-preflight/`,
+    `${resolvedUrl}/v1/migrations/import-preflight/`,
     {
       method: "POST",
       headers: {
@@ -299,9 +307,10 @@ export async function platformImportBundle(
   bundleData: Uint8Array<ArrayBuffer>,
   token: string,
   orgId: string,
+  platformUrl?: string,
 ): Promise<{ statusCode: number; body: Record<string, unknown> }> {
-  const platformUrl = getPlatformUrl();
-  const response = await fetch(`${platformUrl}/v1/migrations/import/`, {
+  const resolvedUrl = platformUrl || getPlatformUrl();
+  const response = await fetch(`${resolvedUrl}/v1/migrations/import/`, {
     method: "POST",
     headers: {
       "Content-Type": "application/octet-stream",


### PR DESCRIPTION
## Summary
- Added optional `platformUrl` parameter to all platform API helper functions in `platform-client.ts`
- Each function now resolves the URL with `platformUrl || getPlatformUrl()`, matching the pattern from `fetchOrganizationId`
- This enables CLI commands to pass per-assistant URLs for non-production platform assistants

Fixes gap from plan review: platform-url-auth-fix.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21790" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
