### PR TITLE
fix(cli): thread per-assistant runtimeUrl through all CLI platform commands

### DIFF
--- a/cli/src/commands/backup.ts
+++ b/cli/src/commands/backup.ts
@@ -66,7 +66,7 @@ export async function backup(): Promise<void> {
   const cloud =
     entry.cloud || (entry.project ? "gcp" : entry.sshUser ? "custom" : "local");
   if (cloud === "vellum") {
-    await backupPlatform(name, outputArg);
+    await backupPlatform(name, outputArg, entry.runtimeUrl);
     return;
   }
 
@@ -184,7 +184,11 @@ export async function backup(): Promise<void> {
 // Platform (Vellum-hosted) backup via Django async migration export
 // ---------------------------------------------------------------------------
 
-async function backupPlatform(name: string, outputArg?: string): Promise<void> {
+async function backupPlatform(
+  name: string,
+  outputArg?: string,
+  runtimeUrl?: string,
+): Promise<void> {
   // Step 1 — Authenticate
   const token = readPlatformToken();
   if (!token) {
@@ -194,7 +198,7 @@ async function backupPlatform(name: string, outputArg?: string): Promise<void> {
 
   let orgId: string;
   try {
-    orgId = await fetchOrganizationId(token);
+    orgId = await fetchOrganizationId(token, runtimeUrl);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     if (msg.includes("401") || msg.includes("403")) {
@@ -207,7 +211,12 @@ async function backupPlatform(name: string, outputArg?: string): Promise<void> {
   // Step 2 — Initiate export job
   let jobId: string;
   try {
-    const result = await platformInitiateExport(token, orgId, "CLI backup");
+    const result = await platformInitiateExport(
+      token,
+      orgId,
+      "CLI backup",
+      runtimeUrl,
+    );
     jobId = result.jobId;
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -235,7 +244,7 @@ async function backupPlatform(name: string, outputArg?: string): Promise<void> {
   while (Date.now() < deadline) {
     let status: { status: string; downloadUrl?: string; error?: string };
     try {
-      status = await platformPollExportStatus(jobId, token, orgId);
+      status = await platformPollExportStatus(jobId, token, orgId, runtimeUrl);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       // Let non-transient errors (e.g. 404 "job not found") propagate immediately

--- a/cli/src/commands/restore.ts
+++ b/cli/src/commands/restore.ts
@@ -179,7 +179,7 @@ async function restorePlatform(
 
   let orgId: string;
   try {
-    orgId = await fetchOrganizationId(token);
+    orgId = await fetchOrganizationId(token, entry.runtimeUrl);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     if (msg.includes("401") || msg.includes("403")) {
@@ -206,6 +206,7 @@ async function restorePlatform(
         new Uint8Array(bundleData),
         token,
         orgId,
+        entry.runtimeUrl,
       );
     } catch (err) {
       if (err instanceof Error && err.name === "TimeoutError") {
@@ -315,7 +316,12 @@ async function restorePlatform(
     );
 
     try {
-      await rollbackPlatformAssistant(token, orgId, opts.version);
+      await rollbackPlatformAssistant(
+        token,
+        orgId,
+        opts.version,
+        entry.runtimeUrl,
+      );
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (msg.includes("401") || msg.includes("403")) {
@@ -340,6 +346,7 @@ async function restorePlatform(
       new Uint8Array(bundleData),
       token,
       orgId,
+      entry.runtimeUrl,
     );
   } catch (err) {
     if (err instanceof Error && err.name === "TimeoutError") {

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -197,7 +197,10 @@ async function retireCustom(entry: AssistantEntry): Promise<void> {
   console.log(`\u2705 Custom instance retired.`);
 }
 
-async function retireVellum(assistantId: string): Promise<void> {
+async function retireVellum(
+  assistantId: string,
+  runtimeUrl?: string,
+): Promise<void> {
   console.log("\u{1F5D1}\ufe0f  Retiring platform-hosted instance...\n");
 
   const token = readPlatformToken();
@@ -208,9 +211,10 @@ async function retireVellum(assistantId: string): Promise<void> {
     process.exit(1);
   }
 
-  const orgId = await fetchOrganizationId(token);
+  const orgId = await fetchOrganizationId(token, runtimeUrl);
 
-  const url = `${getPlatformUrl()}/v1/assistants/${encodeURIComponent(assistantId)}/retire/`;
+  const platformUrl = runtimeUrl || getPlatformUrl();
+  const url = `${platformUrl}/v1/assistants/${encodeURIComponent(assistantId)}/retire/`;
   const response = await fetch(url, {
     method: "DELETE",
     headers: {
@@ -343,7 +347,7 @@ async function retireInner(): Promise<void> {
   } else if (cloud === "custom") {
     await retireCustom(entry);
   } else if (cloud === "vellum") {
-    await retireVellum(entry.assistantId);
+    await retireVellum(entry.assistantId, entry.runtimeUrl);
   } else {
     console.error(`Error: Unknown cloud type '${cloud}'.`);
     process.exit(1);

--- a/cli/src/commands/rollback.ts
+++ b/cli/src/commands/rollback.ts
@@ -185,7 +185,7 @@ async function rollbackPlatformViaEndpoint(
 
   let orgId: string;
   try {
-    orgId = await fetchOrganizationId(token);
+    orgId = await fetchOrganizationId(token, entry.runtimeUrl);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     if (msg.includes("401") || msg.includes("403")) {
@@ -206,7 +206,12 @@ async function rollbackPlatformViaEndpoint(
 
   let result: { detail: string; version: string | null };
   try {
-    result = await rollbackPlatformAssistant(token, orgId, version);
+    result = await rollbackPlatformAssistant(
+      token,
+      orgId,
+      version,
+      entry.runtimeUrl,
+    );
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
 

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -729,9 +729,9 @@ async function upgradePlatform(
     process.exit(1);
   }
 
-  const orgId = await fetchOrganizationId(token);
+  const orgId = await fetchOrganizationId(token, entry.runtimeUrl);
 
-  const url = `${getPlatformUrl()}/v1/assistants/upgrade/`;
+  const url = `${entry.runtimeUrl || getPlatformUrl()}/v1/assistants/upgrade/`;
   const body: { assistant_id?: string; version?: string } = {
     assistant_id: entry.assistantId,
   };

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -141,9 +141,10 @@ export async function rollbackPlatformAssistant(
   token: string,
   orgId: string,
   version?: string,
+  platformUrl?: string,
 ): Promise<{ detail: string; version: string | null }> {
-  const platformUrl = getPlatformUrl();
-  const response = await fetch(`${platformUrl}/v1/assistants/rollback/`, {
+  const resolvedUrl = platformUrl || getPlatformUrl();
+  const response = await fetch(`${resolvedUrl}/v1/assistants/rollback/`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -185,9 +186,10 @@ export async function platformInitiateExport(
   token: string,
   orgId: string,
   description?: string,
+  platformUrl?: string,
 ): Promise<{ jobId: string; status: string }> {
-  const platformUrl = getPlatformUrl();
-  const response = await fetch(`${platformUrl}/v1/migrations/export/`, {
+  const resolvedUrl = platformUrl || getPlatformUrl();
+  const response = await fetch(`${resolvedUrl}/v1/migrations/export/`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -218,10 +220,11 @@ export async function platformPollExportStatus(
   jobId: string,
   token: string,
   orgId: string,
+  platformUrl?: string,
 ): Promise<{ status: string; downloadUrl?: string; error?: string }> {
-  const platformUrl = getPlatformUrl();
+  const resolvedUrl = platformUrl || getPlatformUrl();
   const response = await fetch(
-    `${platformUrl}/v1/migrations/export/${jobId}/status/`,
+    `${resolvedUrl}/v1/migrations/export/${jobId}/status/`,
     {
       headers: {
         "X-Session-Token": token,
@@ -272,10 +275,11 @@ export async function platformImportPreflight(
   bundleData: Uint8Array<ArrayBuffer>,
   token: string,
   orgId: string,
+  platformUrl?: string,
 ): Promise<{ statusCode: number; body: Record<string, unknown> }> {
-  const platformUrl = getPlatformUrl();
+  const resolvedUrl = platformUrl || getPlatformUrl();
   const response = await fetch(
-    `${platformUrl}/v1/migrations/import-preflight/`,
+    `${resolvedUrl}/v1/migrations/import-preflight/`,
     {
       method: "POST",
       headers: {
@@ -299,9 +303,10 @@ export async function platformImportBundle(
   bundleData: Uint8Array<ArrayBuffer>,
   token: string,
   orgId: string,
+  platformUrl?: string,
 ): Promise<{ statusCode: number; body: Record<string, unknown> }> {
-  const platformUrl = getPlatformUrl();
-  const response = await fetch(`${platformUrl}/v1/migrations/import/`, {
+  const resolvedUrl = platformUrl || getPlatformUrl();
+  const response = await fetch(`${resolvedUrl}/v1/migrations/import/`, {
     method: "POST",
     headers: {
       "Content-Type": "application/octet-stream",


### PR DESCRIPTION
## Summary
- Updated `backup`, `retire`, `upgrade`, `rollback`, and `restore` commands to pass the assistant's `runtimeUrl` to `fetchOrganizationId` and other platform API helpers
- Added optional `platformUrl` parameter to `rollbackPlatformAssistant`, `platformInitiateExport`, `platformPollExportStatus`, `platformImportPreflight`, and `platformImportBundle` in platform-client.ts
- Replaced direct `getPlatformUrl()` calls with the per-assistant URL where applicable
- This ensures all CLI commands work correctly with non-production platform assistants (e.g. dev-platform.vellum.ai)

Fixes gap from plan review: platform-url-auth-fix.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
