### PR TITLE
fix(macos): use connectedAssistantId to resolve managed assistant for platform URL seeding

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
@@ -166,7 +166,9 @@ struct ReauthView: View {
         // Seed AuthService with the platform URL from the existing lockfile entry
         // so that organization resolution hits the correct platform (e.g. dev-platform
         // vs production) before the daemon is connected.
-        if let managedAssistant = LockfileAssistant.loadAll().first(where: { $0.isManaged }),
+        if let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
+           let managedAssistant = LockfileAssistant.loadByName(connectedId),
+           managedAssistant.isManaged,
            let runtimeUrl = managedAssistant.runtimeUrl, !runtimeUrl.isEmpty {
             AuthService.shared.configuredBaseURL = runtimeUrl
         }


### PR DESCRIPTION
## Summary
- Changed ReauthView's platform URL seeding to use `connectedAssistantId` from UserDefaults to find the correct managed assistant, instead of `LockfileAssistant.loadAll().first(where: { $0.isManaged })`
- Prevents seeding the wrong platform URL when multiple managed assistants exist (e.g. one on prod, one on dev)
- Matches the pattern used in AppDelegate+ConnectionSetup.swift which resolves via `loadAssistantFromLockfile()`

Addresses feedback on #21788
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
