### PR TITLE
fix: strip unresolved placeholder fields from IDENTITY.md in system prompt

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -232,7 +232,15 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   const userIsTemplate = isTemplateContent(user, "USER.md");
 
   if (identity && !identityIsTemplate) {
-    dynamicParts.push(identity);
+    // Strip placeholder lines (e.g. "- **Name:** _(not yet chosen)_") so
+    // the model doesn't treat unresolved fields as prompts to ask the user.
+    const cleanedIdentity = identity
+      .split("\n")
+      .filter((line) => !/_\(not yet (?:chosen|established)\)_/.test(line))
+      .join("\n");
+    if (cleanedIdentity.trim()) {
+      dynamicParts.push(cleanedIdentity);
+    }
   }
   if (soul) dynamicParts.push(soul);
   if (options?.userPersona) dynamicParts.push(options.userPersona);


### PR DESCRIPTION
## Summary
- Strip lines with placeholder values (`_(not yet chosen)_`, `_(not yet established)_`) from IDENTITY.md before including in the system prompt
- Prevents the model from treating unresolved template fields as prompts to interrogate the user about personality/nature when onboarding was partial

## Test plan
- [ ] Fresh install, set name only (skip personality), open new conversation — model should greet normally without asking about personality
- [ ] Full onboarding (all fields set) — no change in behavior
- [ ] Unmodified template — still skipped entirely (existing `isTemplateContent` check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
