### PR TITLE
fix(macos): require login before switching to a managed assistant

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -414,6 +414,14 @@ extension AppDelegate {
     /// 4. Reconfigure transport and reconnect
     /// 5. Resume credential bootstrap
     func performSwitchAssistant(to assistant: LockfileAssistant) {
+        // If switching to a managed assistant while logged out, prompt login first.
+        if assistant.isManaged && !authManager.isAuthenticated {
+            // Persist the target so we can switch after login completes.
+            UserDefaults.standard.set(assistant.assistantId, forKey: "pendingManagedSwitchAssistantId")
+            showAuthWindow()
+            return
+        }
+
         // 1. Clear assistant-scoped runtime state while the assistant is still
         // running so forceStop can deliver a recording_status message.
         recordingManager.forceStop()


### PR DESCRIPTION
## Summary
- Add auth check at top of performSwitchAssistant() for managed assistants
- When logged out and switching to managed assistant, persist target ID and show auth window
- Non-managed and already-authenticated flows are unaffected

Part of plan: managed-auth-gate-reconnect.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21795" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
