### PR TITLE
fix(macos): reconnect managed assistant after signing in from Settings

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -203,6 +203,9 @@ declare -a SAFE_LINE_PATTERNS=(
     # Only whitelist specific known key-name constants — a broad `*Key` pattern
     # would let real credentials like `let apiKey = "sk_live_..."` slip through.
     "(private[[:space:]]+)?(let|var)[[:space:]]+(archivedConversationsKey)[[:space:]]*[:=][[:space:]]*['\"][a-zA-Z][a-zA-Z0-9_]*['\"]"
+    # Swift static let feature-flag key constants — values are plain kebab-case
+    # flag names, not secrets.
+    "(private[[:space:]]+static[[:space:]]+)?(let|var)[[:space:]]+[a-zA-Z]*FeatureFlagKey[[:space:]]*[:=][[:space:]]*['\"][a-z][a-z0-9-]*['\"]"
 )
 
 matches_safe_line_pattern() {
@@ -220,7 +223,7 @@ matches_safe_line_pattern() {
             # Skip the guard for explicitly-allowlisted variable names that contain
             # sensitive substrings but are known UserDefaults/storage key constants.
             if printf '%s\n' "$text" | grep -iE "(let|var|val)[[:space:]]+[a-zA-Z0-9_]*[Kk]ey[[:space:]]*=" >/dev/null 2>&1; then
-                if ! printf '%s\n' "$text" | grep -E "(let|var|val)[[:space:]]+(archivedConversationsKey)[[:space:]]*[:=]" >/dev/null 2>&1; then
+                if ! printf '%s\n' "$text" | grep -E "(let|var|val)[[:space:]]+(archivedConversationsKey|[a-zA-Z]*FeatureFlagKey)[[:space:]]*[:=]" >/dev/null 2>&1; then
                     if printf '%s\n' "$text" | grep -iE "(let|var|val)[[:space:]]+[a-zA-Z0-9_]*(api|access|private|secret|client|encryption|encrypt|jwt|signing|sign|auth|hmac|master|symmetric|asymmetric|shared|session|verification|verify|decryption|decrypt|service|deploy|registry|webhook|database|db)[a-zA-Z0-9_]*[Kk]ey" >/dev/null 2>&1; then
                         continue
                     fi

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -76,6 +76,16 @@ extension AppDelegate {
         log.info("Configured remote assistant \(assistant.assistantId, privacy: .public)")
     }
 
+    // MARK: - Managed Reconnection
+
+    /// Re-establish the gateway connection for a managed assistant after the
+    /// user signs in from Settings. Resets `hasSetupDaemon` so the next call
+    /// to `setupGatewayConnectionManager()` runs the full setup again.
+    func reconnectManagedAssistant() {
+        hasSetupDaemon = false
+        setupGatewayConnectionManager()
+    }
+
     // MARK: - Gateway Connection Setup
 
     func setupGatewayConnectionManager() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -383,6 +383,12 @@ struct SettingsPanel: View {
                 // to skip the wait. Mirrors the reset in proceedToApp().
                 AppDelegate.shared?.localBootstrapDidComplete = false
                 AppDelegate.shared?.ensureLocalAssistantApiKey()
+
+                // For managed assistants, re-establish the connection now that
+                // the user has a valid session token.
+                if AppDelegate.shared?.isCurrentAssistantManaged ?? false {
+                    AppDelegate.shared?.reconnectManagedAssistant()
+                }
             })
         case .modelsAndServices:
             integrationsContent


### PR DESCRIPTION
## Summary
- Add managed assistant reconnection to the onSignIn closure in SettingsPanel
- After signing in from Settings > General, managed assistants now re-establish their connection
- Non-managed assistant sign-in flow remains unchanged
- Add `reconnectManagedAssistant()` method to AppDelegate that resets `hasSetupDaemon` and re-runs `setupGatewayConnectionManager()`
- Fix pre-commit hook false positive for FeatureFlagKey constants

Part of plan: managed-auth-gate-reconnect.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
