### PR TITLE
fix(macos): resume pending managed assistant switch after reauth

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -476,6 +476,18 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         authWindow?.close()
         authWindow = nil
 
+        // Check for a pending managed assistant switch (set by performSwitchAssistant
+        // when the user was logged out). Now that the user has authenticated, complete
+        // the switch.
+        if let pendingId = UserDefaults.standard.string(forKey: "pendingManagedSwitchAssistantId"),
+           !pendingId.isEmpty {
+            UserDefaults.standard.removeObject(forKey: "pendingManagedSwitchAssistantId")
+            if let assistant = LockfileAssistant.loadByName(pendingId) {
+                performSwitchAssistant(to: assistant)
+                return
+            }
+        }
+
         if !isFirstLaunch && isBootstrapping {
             log.warning("Stale bootstrap state detected on non-first-launch — resetting to complete")
             transitionBootstrap(to: .complete)


### PR DESCRIPTION
## Summary
- Add pending managed switch completion in proceedToApp()
- After reauth, automatically switch to the managed assistant the user originally selected
- Cleans up the pendingManagedSwitchAssistantId key regardless of success

Part of plan: managed-auth-gate-reconnect.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21798" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
