### PR TITLE
fix(macos): handle authenticationRequired errors by showing reauth screen

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -368,6 +368,16 @@ extension AppDelegate {
                     self.secretPromptManager.showPrompt(msg)
                     SoundManager.shared.play(.needsInput)
 
+                case .conversationError(let msg):
+                    if msg.code == .authenticationRequired && self.isCurrentAssistantManaged {
+                        log.info("Received authenticationRequired error for managed assistant — showing reauth screen")
+                        // Store current assistant as pending so we reconnect after reauth
+                        if let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") {
+                            UserDefaults.standard.set(assistantId, forKey: "pendingManagedSwitchAssistantId")
+                        }
+                        self.showAuthWindow()
+                    }
+
                 default:
                     break
                 }


### PR DESCRIPTION
## Summary
- Handle .conversationError(.authenticationRequired) in the SSE event subscription
- For managed assistants, show the reauth screen and set pending switch for auto-reconnect
- Non-managed assistant errors are unaffected

Part of plan: managed-auth-gate-reconnect.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
