### PR TITLE
fix: reconnect managed assistant after drawer menu sign-in

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1236,6 +1236,12 @@ struct MainWindowView: View {
                             }
                             AppDelegate.shared?.localBootstrapDidComplete = false
                             AppDelegate.shared?.ensureLocalAssistantApiKey()
+
+                            // For managed assistants, re-establish the connection now that
+                            // the user has a valid session token.
+                            if AppDelegate.shared?.isCurrentAssistantManaged ?? false {
+                                AppDelegate.shared?.reconnectManagedAssistant()
+                            }
                         })
                     }
                 },


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for managed-auth-gate-reconnect.md.

**Gap:** Drawer menu sign-in does not reconnect managed assistant
**What was expected:** All sign-in paths should reconnect managed assistants
**What was found:** MainWindowView's login callback was missing reconnectManagedAssistant() call
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21800" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
