### PR TITLE
fix: clear pending managed switch key in reconnectManagedAssistant

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -82,6 +82,7 @@ extension AppDelegate {
     /// user signs in from Settings. Resets `hasSetupDaemon` so the next call
     /// to `setupGatewayConnectionManager()` runs the full setup again.
     func reconnectManagedAssistant() {
+        UserDefaults.standard.removeObject(forKey: "pendingManagedSwitchAssistantId")
         hasSetupDaemon = false
         setupGatewayConnectionManager()
     }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for managed-auth-gate-reconnect.md.

**Gap:** Stale pendingManagedSwitchAssistantId never cleared outside proceedToApp
**What was expected:** Pending key should be cleared in all sign-in paths
**What was found:** Only cleared in proceedToApp, not in reconnectManagedAssistant
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
