### PR TITLE
fix: reconnect managed assistant after service card sign-in

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
@@ -114,7 +114,11 @@ struct ImageGenerationServiceCard: View {
                 isDisabled: authManager.isSubmitting
             ) {
                 Task {
-                    await authManager.loginWithToast(showToast: showToast)
+                    await authManager.loginWithToast(showToast: showToast, onSuccess: {
+                        if AppDelegate.shared?.isCurrentAssistantManaged ?? false {
+                            AppDelegate.shared?.reconnectManagedAssistant()
+                        }
+                    })
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -294,7 +294,11 @@ struct InferenceServiceCard: View {
                 isDisabled: authManager.isSubmitting
             ) {
                 Task {
-                    await authManager.loginWithToast(showToast: showToast)
+                    await authManager.loginWithToast(showToast: showToast, onSuccess: {
+                        if AppDelegate.shared?.isCurrentAssistantManaged ?? false {
+                            AppDelegate.shared?.reconnectManagedAssistant()
+                        }
+                    })
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
@@ -177,7 +177,11 @@ struct WebSearchServiceCard: View {
                 isDisabled: authManager.isSubmitting
             ) {
                 Task {
-                    await authManager.loginWithToast(showToast: showToast)
+                    await authManager.loginWithToast(showToast: showToast, onSuccess: {
+                        if AppDelegate.shared?.isCurrentAssistantManaged ?? false {
+                            AppDelegate.shared?.reconnectManagedAssistant()
+                        }
+                    })
                 }
             }
         }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for managed-auth-gate-reconnect.md.

**Gap:** Service card sign-in does not trigger managed assistant reconnection
**What was expected:** All sign-in paths should reconnect managed assistants
**What was found:** InferenceServiceCard, ImageGenerationServiceCard, and WebSearchServiceCard loginWithToast calls were missing reconnection
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
