### PR TITLE
fix: reconnect managed assistant after OAuth service card sign-in

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/OAuthProviderServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/OAuthProviderServiceCard.swift
@@ -162,6 +162,9 @@ struct OAuthProviderServiceCard: View {
             ) {
                 Task {
                     await authManager.loginWithToast(showToast: showToast, onSuccess: {
+                        if AppDelegate.shared?.isCurrentAssistantManaged ?? false {
+                            AppDelegate.shared?.reconnectManagedAssistant()
+                        }
                         Task { await store.fetchManagedOAuthConnections(providerKey: providerKey, userId: currentUserId) }
                     })
                 }


### PR DESCRIPTION
## Summary
Fixes gap: OAuthProviderServiceCard loginWithToast missing reconnectManagedAssistant() call.
Mirrors the pattern already applied to InferenceServiceCard, ImageGenerationServiceCard, and WebSearchServiceCard.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
