### PR TITLE
fix(macos): restore URL-seeding fallback when connectedAssistantId is absent

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
@@ -171,6 +171,9 @@ struct ReauthView: View {
            managedAssistant.isManaged,
            let runtimeUrl = managedAssistant.runtimeUrl, !runtimeUrl.isEmpty {
             AuthService.shared.configuredBaseURL = runtimeUrl
+        } else if let managedAssistant = LockfileAssistant.loadAll().first(where: { $0.isManaged }),
+                  let runtimeUrl = managedAssistant.runtimeUrl, !runtimeUrl.isEmpty {
+            AuthService.shared.configuredBaseURL = runtimeUrl
         }
 
         do {


### PR DESCRIPTION
## Summary
After managed logout, connectedAssistantId is cleared from UserDefaults. The ReauthView URL seeding now falls back to scanning the lockfile for any managed assistant, restoring correct behavior for dev/staging environments.

Addresses feedback on #21792
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21808" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
