### PR TITLE
fix(macos): move pending managed switch after app setup

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -476,24 +476,23 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         authWindow?.close()
         authWindow = nil
 
-        // Check for a pending managed assistant switch (set by performSwitchAssistant
-        // when the user was logged out). Now that the user has authenticated, complete
-        // the switch.
-        if let pendingId = UserDefaults.standard.string(forKey: "pendingManagedSwitchAssistantId"),
-           !pendingId.isEmpty {
-            UserDefaults.standard.removeObject(forKey: "pendingManagedSwitchAssistantId")
-            if let assistant = LockfileAssistant.loadByName(pendingId) {
-                performSwitchAssistant(to: assistant)
-                return
-            }
-        }
-
         if !isFirstLaunch && isBootstrapping {
             log.warning("Stale bootstrap state detected on non-first-launch — resetting to complete")
             transitionBootstrap(to: .complete)
         }
 
         guard !hasSetupApp else {
+            // Check for a pending managed assistant switch (set by performSwitchAssistant
+            // when the user was logged out). Now that the user has re-authenticated and
+            // the app is already set up, complete the switch.
+            if let pendingId = UserDefaults.standard.string(forKey: "pendingManagedSwitchAssistantId"),
+               !pendingId.isEmpty {
+                UserDefaults.standard.removeObject(forKey: "pendingManagedSwitchAssistantId")
+                if let assistant = LockfileAssistant.loadByName(pendingId) {
+                    performSwitchAssistant(to: assistant)
+                    return
+                }
+            }
             showMainWindow()
             return
         }
@@ -617,6 +616,19 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                     self.onboardingState = nil
                 }
             }
+
+            // Check for a pending managed assistant switch (set by performSwitchAssistant
+            // when the user was logged out). Now that the user has authenticated and all
+            // essential setup has completed, perform the switch.
+            if let pendingId = UserDefaults.standard.string(forKey: "pendingManagedSwitchAssistantId"),
+               !pendingId.isEmpty {
+                UserDefaults.standard.removeObject(forKey: "pendingManagedSwitchAssistantId")
+                if let assistant = LockfileAssistant.loadByName(pendingId) {
+                    performSwitchAssistant(to: assistant)
+                    return
+                }
+            }
+
             showMainWindow()
             debugStateWriter.start(appDelegate: self)
         }


### PR DESCRIPTION
## Summary
- Move pendingManagedSwitchAssistantId check from before guard !hasSetupApp to after setup
- On cold start, all essential setup (voice, menus, hotkeys, auto-update) now runs before the switch
- On warm reauth (hasSetupApp == true), the check runs in the guard block before showMainWindow

Addresses feedback on #21798
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21809" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
