### PR TITLE
fix(macos): preserve pending managed switch target on auth error

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -372,8 +372,9 @@ extension AppDelegate {
                 case .conversationError(let msg):
                     if msg.code == .authenticationRequired && self.isCurrentAssistantManaged {
                         log.info("Received authenticationRequired error for managed assistant — showing reauth screen")
-                        // Store current assistant as pending so we reconnect after reauth
-                        if let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") {
+                        // Only set pending if not already set (preserve user's intended switch target)
+                        if UserDefaults.standard.string(forKey: "pendingManagedSwitchAssistantId") == nil,
+                           let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") {
                             UserDefaults.standard.set(assistantId, forKey: "pendingManagedSwitchAssistantId")
                         }
                         self.showAuthWindow()


### PR DESCRIPTION
## Summary
- Only set pendingManagedSwitchAssistantId in the authenticationRequired handler if not already set
- Preserves user's intended switch target when an auth error arrives during a pending switch

Addresses feedback on #21799
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
