### PR TITLE
fix(macos): cancel prior event subscription before reconnecting

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -163,10 +163,12 @@ extension AppDelegate {
     /// Subscribe to the event stream and dispatch events to their handlers.
     /// Each event type is handled in a single switch statement.
     private func startEventSubscription() {
-        Task { @MainActor [weak self] in
+        eventSubscriptionTask?.cancel()
+        eventSubscriptionTask = Task { @MainActor [weak self] in
             guard let self else { return }
             let stream = self.eventStreamClient.subscribe()
             for await message in stream {
+                guard !Task.isCancelled else { break }
                 switch message {
                 case .notificationIntent(let msg):
                     self.deliverNotificationIntent(msg)

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -132,6 +132,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var refreshSkillsTask: Task<Void, Never>?
     var cachedApps: [AppItem] = []
     var refreshAppsTask: Task<Void, Never>?
+    /// The currently-active SSE event subscription task. Stored so it can be
+    /// cancelled before creating a new subscription (e.g. on reconnection or
+    /// assistant switch), preventing duplicate event processing.
+    var eventSubscriptionTask: Task<Void, Never>?
     /// Pending fallback notification tokens, keyed by conversationId.
     /// Used to avoid duplicate native alerts when notification_intent arrives.
     var pendingFallbackNotifications: [String: UUID] = [:]
@@ -664,6 +668,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         recordingManager.forceStop()
         recordingHUDWindow?.dismiss()
         e2eStatusOverlayWindow?.dismiss()
+        eventSubscriptionTask?.cancel()
         debugStateWriter.stop()
         RandomSoundTimer.shared.stop()
         SoundManager.shared.stop()


### PR DESCRIPTION
## Summary
- Store the event subscription Task so it can be cancelled on reconnection
- Cancel the old subscriber before creating a new one in startEventSubscription()
- Add Task.isCancelled check in the event loop for prompt exit
- Cancel subscription task on app termination for clean shutdown
- Prevents duplicate SSE event processing after reconnectManagedAssistant() or performSwitchAssistant()

Addresses feedback on #21797
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21811" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
