### PR TITLE
fix(macos): check pending managed switch before bootstrap

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -538,6 +538,19 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             SoundManager.shared.play(.appOpen)
         }
 
+        // On cold-start reauth (non-first-launch), check for a pending managed
+        // assistant switch BEFORE bootstrapping credentials. This avoids
+        // provisioning against the wrong assistant only to immediately switch.
+        if !isFirstLaunch,
+           let pendingId = UserDefaults.standard.string(forKey: "pendingManagedSwitchAssistantId"),
+           !pendingId.isEmpty {
+            UserDefaults.standard.removeObject(forKey: "pendingManagedSwitchAssistantId")
+            if let assistant = LockfileAssistant.loadByName(pendingId) {
+                performSwitchAssistant(to: assistant)
+                return
+            }
+        }
+
         // Ensure actor credentials are present. On first launch this performs
         // initial bootstrap; on subsequent launches it schedules proactive
         // refresh when the access token nears expiry.
@@ -618,18 +631,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 } else {
                     // Can't sync traits (no daemon), but still clean up onboarding state.
                     self.onboardingState = nil
-                }
-            }
-
-            // Check for a pending managed assistant switch (set by performSwitchAssistant
-            // when the user was logged out). Now that the user has authenticated and all
-            // essential setup has completed, perform the switch.
-            if let pendingId = UserDefaults.standard.string(forKey: "pendingManagedSwitchAssistantId"),
-               !pendingId.isEmpty {
-                UserDefaults.standard.removeObject(forKey: "pendingManagedSwitchAssistantId")
-                if let assistant = LockfileAssistant.loadByName(pendingId) {
-                    performSwitchAssistant(to: assistant)
-                    return
                 }
             }
 


### PR DESCRIPTION
## Summary
- Move pending managed switch check in cold-start path to before ensureActorCredentials/ensureLocalAssistantApiKey
- Prevents starting credential provisioning against the wrong assistant before switching
- Warm reauth path (hasSetupApp == true) unchanged

Addresses feedback on #21809
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21812" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
