### PR TITLE
feat: send vak_ platform API keys via Authorization: Bearer

### DIFF
--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -1,6 +1,7 @@
 import {
   clearPlatformToken,
   fetchCurrentUser,
+  fetchOrganizationId,
   readPlatformToken,
   savePlatformToken,
 } from "../lib/platform-client";
@@ -44,9 +45,17 @@ export async function login(): Promise<void> {
   console.log("Validating token...");
 
   try {
-    const user = await fetchCurrentUser(token);
-    savePlatformToken(token);
-    console.log(`✅ Logged in as ${user.email}`);
+    if (token.startsWith("vak_")) {
+      // Platform API keys can't use the allauth session endpoint.
+      // Validate by fetching the organization instead.
+      await fetchOrganizationId(token);
+      savePlatformToken(token);
+      console.log("✅ Logged in with platform API key");
+    } else {
+      const user = await fetchCurrentUser(token);
+      savePlatformToken(token);
+      console.log(`✅ Logged in as ${user.email}`);
+    }
   } catch (error) {
     console.error(
       `❌ Login failed: ${error instanceof Error ? error.message : error}`,
@@ -86,12 +95,18 @@ export async function whoami(): Promise<void> {
   }
 
   try {
-    const user = await fetchCurrentUser(token);
-    console.log(`Email: ${user.email}`);
-    if (user.display) {
-      console.log(`Name:  ${user.display}`);
+    if (token.startsWith("vak_")) {
+      const orgId = await fetchOrganizationId(token);
+      console.log("Authenticated with platform API key");
+      console.log(`Organization: ${orgId}`);
+    } else {
+      const user = await fetchCurrentUser(token);
+      console.log(`Email: ${user.email}`);
+      if (user.display) {
+        console.log(`Name:  ${user.display}`);
+      }
+      console.log(`ID:    ${user.id}`);
     }
-    console.log(`ID:    ${user.id}`);
   } catch (error) {
     console.error(`Error: ${error instanceof Error ? error.message : error}`);
     process.exit(1);

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -10,6 +10,7 @@ import {
 } from "../lib/assistant-config";
 import type { AssistantEntry } from "../lib/assistant-config";
 import {
+  authHeaders,
   fetchOrganizationId,
   getPlatformUrl,
   readPlatformToken,
@@ -214,7 +215,7 @@ async function retireVellum(assistantId: string): Promise<void> {
   const response = await fetch(url, {
     method: "DELETE",
     headers: {
-      "X-Session-Token": token,
+      ...authHeaders(token),
       "Vellum-Organization-Id": orgId,
     },
   });

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -20,6 +20,7 @@ import {
 } from "../lib/docker";
 import { resolveImageRefs } from "../lib/platform-releases";
 import {
+  authHeaders,
   fetchOrganizationId,
   getPlatformUrl,
   readPlatformToken,
@@ -743,7 +744,7 @@ async function upgradePlatform(
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "X-Session-Token": token,
+      ...authHeaders(token),
       "Vellum-Organization-Id": orgId,
     },
     body: JSON.stringify(body),

--- a/cli/src/lib/health-check.ts
+++ b/cli/src/lib/health-check.ts
@@ -1,3 +1,5 @@
+import { authHeaders } from "./platform-client";
+
 export const HEALTH_CHECK_TIMEOUT_MS = 1500;
 
 interface HealthResponse {
@@ -45,7 +47,7 @@ export async function checkManagedHealth(
     );
 
     const headers: Record<string, string> = {
-      "X-Session-Token": token,
+      ...authHeaders(token),
       "Vellum-Organization-Id": orgId,
     };
 

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -65,6 +65,22 @@ export function clearPlatformToken(): void {
   }
 }
 
+const VAK_PREFIX = "vak_";
+
+/**
+ * Returns the appropriate auth header for the given platform token.
+ *
+ * - `vak_`-prefixed tokens are long-lived platform API keys and use
+ *   `Authorization: Bearer`.
+ * - All other tokens are allauth session tokens and use `X-Session-Token`.
+ */
+export function authHeaders(token: string): Record<string, string> {
+  if (token.startsWith(VAK_PREFIX)) {
+    return { Authorization: `Bearer ${token}` };
+  }
+  return { "X-Session-Token": token };
+}
+
 export interface PlatformUser {
   id: string;
   email: string;
@@ -79,7 +95,7 @@ export async function fetchOrganizationId(token: string): Promise<string> {
   const platformUrl = getPlatformUrl();
   const url = `${platformUrl}/v1/organizations/`;
   const response = await fetch(url, {
-    headers: { "X-Session-Token": token },
+    headers: { ...authHeaders(token) },
   });
 
   if (!response.ok) {
@@ -110,7 +126,7 @@ interface AllauthSessionResponse {
 export async function fetchCurrentUser(token: string): Promise<PlatformUser> {
   const url = `${getPlatformUrl()}/_allauth/app/v1/auth/session`;
   const response = await fetch(url, {
-    headers: { "X-Session-Token": token },
+    headers: { ...authHeaders(token) },
   });
 
   if (!response.ok) {
@@ -144,7 +160,7 @@ export async function rollbackPlatformAssistant(
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "X-Session-Token": token,
+      ...authHeaders(token),
       "Vellum-Organization-Id": orgId,
     },
     body: JSON.stringify(version ? { version } : {}),
@@ -188,7 +204,7 @@ export async function platformInitiateExport(
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "X-Session-Token": token,
+      ...authHeaders(token),
       "Vellum-Organization-Id": orgId,
     },
     body: JSON.stringify({ description: description ?? "CLI backup" }),
@@ -221,7 +237,7 @@ export async function platformPollExportStatus(
     `${platformUrl}/v1/migrations/export/${jobId}/status/`,
     {
       headers: {
-        "X-Session-Token": token,
+        ...authHeaders(token),
         "Vellum-Organization-Id": orgId,
       },
     },
@@ -277,7 +293,7 @@ export async function platformImportPreflight(
       method: "POST",
       headers: {
         "Content-Type": "application/octet-stream",
-        "X-Session-Token": token,
+        ...authHeaders(token),
         "Vellum-Organization-Id": orgId,
       },
       body: new Blob([bundleData]),
@@ -302,7 +318,7 @@ export async function platformImportBundle(
     method: "POST",
     headers: {
       "Content-Type": "application/octet-stream",
-      "X-Session-Token": token,
+      ...authHeaders(token),
       "Vellum-Organization-Id": orgId,
     },
     body: new Blob([bundleData]),


### PR DESCRIPTION
## Summary
- Adds `authHeaders()` helper to `platform-client.ts` that routes tokens to the correct HTTP header based on prefix
- `vak_`-prefixed tokens (long-lived platform API keys) → `Authorization: Bearer vak_...`
- All other tokens (allauth session tokens) → `X-Session-Token: ...` (unchanged behavior)
- All platform API call sites across `platform-client.ts`, `upgrade.ts`, `retire.ts`, and `health-check.ts` now use this helper

## Why
For E2E tests of cloud-hosted assistants, we need a long-lived credential stored as the platform token. `VellumAPIKey` (`vak_` prefix) is that credential, but Django's `VellumAPIKeyAuthentication` only checks `Authorization: Bearer` — not `X-Session-Token`. Rather than adding non-standard auth logic to the server, the client sends the token via the correct header.

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Existing session token flow unchanged (non-`vak_` tokens still use `X-Session-Token`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21814" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
