### PR TITLE
docs: codify credential_store prompt requirement in skills AGENTS.md

### DIFF
--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -18,7 +18,7 @@
 - **API interactions use Vellum's outbound proxy**
   - Outbound network traffic from the bash tool is automatically intercepted by an outbound proxy in a manner that's transparent to the assistant
   - Update proxy settings so the bash tool can inject correct auth headers for approved domains
-  - Avoid instructions that tell the assistant to find and use secrets directly
+  - **Never instruct the assistant to ask for secrets in chat.** API keys, tokens, passwords, and webhook secrets must be collected via `credential_store prompt`, which provides a secure UI — the value never enters the conversation. Non-secret values (e.g., Client IDs, Account SIDs, usernames) can be collected conversationally. See existing skills (e.g., `twilio-setup`, `slack-app-setup`) for the pattern.
 
 - **Write portable instructions**
   - Avoid referring to tools by specific names (prefer "Take a browser screenshot" over "Use browser_screen_grab")


### PR DESCRIPTION
## Summary
- Replaces vague 'avoid instructions that tell the assistant to find and use secrets directly' with an explicit rule
- Specifies that secrets must be collected via `credential_store prompt`, not in chat
- Distinguishes secrets from non-secret config values (Client IDs, usernames)
- References `twilio-setup` and `slack-app-setup` as example patterns

Part of plan: no-secrets-in-chat.md (PR 3 of 4)

Part of JARVIS-367
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21819" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
