### PR TITLE
fix: replace raw Color.white with Color.clear in VSplitButton

### DIFF
--- a/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
@@ -81,7 +81,7 @@ public struct VSplitButton<MenuContent: View>: View {
                 Menu {
                     menuContent()
                 } label: {
-                    Color.white.opacity(0.001)
+                    Color.clear
                         .frame(width: dropdownWidth, height: zoneHeight)
                         .contentShape(Rectangle())
                 }


### PR DESCRIPTION
## Summary
- Replace `Color.white.opacity(0.001)` with `Color.clear` in VSplitButton's menu hit target — the `.contentShape(Rectangle())` already handles hit testing, so the near-invisible white tint is unnecessary and violates the design system rule against raw color values.

## Original prompt
address this build issue on main: shared/DesignSystem/Core/Buttons/VSplitButton.swift:84: Color.white.opacity(0.001)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21820" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
