### PR TITLE
fix: add missing service/field params to messaging SKILL.md credential_store prompt

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -65,7 +65,7 @@ When the user asks to "connect my email", "set up email", "manage my email", or 
      - **confirmLabel:** "Get Started"
      - **cancelLabel:** "Not Now"
    - If the user confirms, briefly acknowledge (e.g., "Setting up Gmail now...") and proceed with the setup guide. If they decline, acknowledge and let them know they can set it up later.
-3. **If the user provides a client_id directly in chat:** Call `credential_store` with `action: "oauth2_connect"`, `service: "google"`, and `client_id: "<their value>"`. If a client_secret is also needed, collect it via `credential_store` with `action: "prompt"` — never accept it pasted in chat. Everything else is auto-filled.
+3. **If the user provides a client_id directly in chat:** Call `credential_store` with `action: "oauth2_connect"`, `service: "google"`, and `client_id: "<their value>"`. If a client_secret is also needed, collect it via `credential_store` with `action: "prompt"`, `service: "google"`, `field: "client_secret"` — never accept it pasted in chat. Everything else is auto-filled.
 
 ### Slack
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for no-secrets-in-chat.md.

**Gap:** Missing required parameters for credential_store prompt action
**What was expected:** credential_store prompt instruction should include service and field
**What was found:** The instruction omitted required service and field parameters
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21822" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
