### PR TITLE
fix: strip markdown backticks before pattern matching in skill secret guard test

### DIFF
--- a/assistant/src/__tests__/skill-secret-handling-guard.test.ts
+++ b/assistant/src/__tests__/skill-secret-handling-guard.test.ts
@@ -165,9 +165,13 @@ function findViolations(): Violation[] {
       if (inCredentialStoreBlock && CREDENTIAL_STORE_UI_FIELD.test(line))
         continue;
 
+      // Strip markdown backticks before pattern matching so that
+      // violations like `client_secret` are caught the same as bare words.
+      const stripped = line.replace(/`/g, "");
+
       // Check against violation patterns
       for (const pattern of VIOLATION_PATTERNS) {
-        if (pattern.test(line)) {
+        if (pattern.test(stripped)) {
           violations.push({
             file: filePath,
             line: lineNumber,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for no-secrets-in-chat.md.

**Gap:** Guard test regex patterns don't account for markdown backtick-wrapped secret words
**What was expected:** Guard should catch violations with backtick-wrapped secret words
**What was found:** Backticks between words break the regex whitespace matching

Part of JARVIS-367

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
