### PR TITLE
fix: simplify credential_store prompt instruction in messaging SKILL.md

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -65,7 +65,7 @@ When the user asks to "connect my email", "set up email", "manage my email", or 
      - **confirmLabel:** "Get Started"
      - **cancelLabel:** "Not Now"
    - If the user confirms, briefly acknowledge (e.g., "Setting up Gmail now...") and proceed with the setup guide. If they decline, acknowledge and let them know they can set it up later.
-3. **If the user provides a client_id directly in chat:** Call `credential_store` with `action: "oauth2_connect"`, `service: "google"`, and `client_id: "<their value>"`. If a client_secret is also needed, collect it via `credential_store` with `action: "prompt"`, `service: "google"`, `field: "client_secret"` — never accept it pasted in chat. Everything else is auto-filled.
+3. **If the user provides a client_id directly in chat:** Call `credential_store` with `action: "oauth2_connect"`, `service: "google"`, and `client_id: "<their value>"`. If a `client_secret` is also needed, collect it securely via `credential_store` with `action: "prompt"` — never accept it pasted in chat. Everything else is auto-filled.
 
 ### Slack
 


### PR DESCRIPTION
## Summary
Fixes integration gap: the previous credential_store prompt instruction specified service: "google" and field: "client_secret", but oauth2_connect uses service: "gmail" and looks up secrets via the oauth-store DB, not the credential vault directly. Simplified to just instruct secure collection without prescribing incorrect params.

Part of JARVIS-367
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21824" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
