### PR TITLE
fix: make inline table widget fill available width

### DIFF
--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -216,7 +216,7 @@ public struct InlineTableWidget: View {
             horizontalScrollableTable
         } else {
             tableContent
-                .frame(width: minimumTableWidth, alignment: .leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 


### PR DESCRIPTION
## Summary
- Changed `InlineTableWidget` from `.frame(width: minimumTableWidth)` to `.frame(maxWidth: .infinity)` so tables fill the full chat bubble width instead of shrink-wrapping to content

## Test plan
- [ ] Ask assistant to generate a table — it should fill the full bubble width
- [ ] Tables with many columns that overflow should still scroll horizontally (existing behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21827" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
