### PR TITLE
feat: make inline table fill available width and add hover copy button

### DIFF
--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -15,6 +15,7 @@ public struct InlineSurfaceRouter: View {
 
     @State private var selectionPayload: [String: AnyCodable]?
     @State private var clickedActionLabel: String?
+    @State private var isCardHovered = false
 
     public init(
         surface: InlineSurfaceData,
@@ -125,6 +126,11 @@ public struct InlineSurfaceRouter: View {
                 }
                 .buttonStyle(.plain)
                 .padding(VSpacing.sm)
+            } else if isTableSurface, case .table(let tableData) = surface.data {
+                VCopyButton(text: Self.tableAsMarkdown(tableData), size: .compact)
+                    .opacity(isCardHovered ? 1 : 0)
+                    .animation(VAnimation.fast, value: isCardHovered)
+                    .padding(VSpacing.sm)
             } else if isDocumentPreview {
                 if case .documentPreview(let data) = surface.data {
                     Button {
@@ -147,6 +153,9 @@ public struct InlineSurfaceRouter: View {
                 }
             }
         }
+        #if os(macOS)
+        .onHover { isCardHovered = $0 }
+        #endif
         // Dynamic page/document previews stay compact; tables can grow to the chat bubble max width.
         .frame(maxWidth: isAppCreated ? 400 : (isDynamicPreview || isDocumentPreview ? 350 : standardWidgetMaxWidth), alignment: .leading)
         }
@@ -388,5 +397,18 @@ public struct InlineSurfaceRouter: View {
         case .destructive: return VColor.systemNegativeStrong
         case .secondary: return VColor.borderBase.opacity(0.5)
         }
+    }
+
+    /// Builds a markdown table string from TableSurfaceData for clipboard copy.
+    static func tableAsMarkdown(_ data: TableSurfaceData) -> String {
+        let headers = data.columns.map(\.label)
+        let headerLine = "| " + headers.joined(separator: " | ") + " |"
+        let separatorLine = "| " + headers.map { _ in "---" }.joined(separator: " | ") + " |"
+        let rowLines = data.rows.map { row in
+            "| " + data.columns.map { col in
+                row.cells[col.id]?.text ?? ""
+            }.joined(separator: " | ") + " |"
+        }
+        return ([headerLine, separatorLine] + rowLines).joined(separator: "\n")
     }
 }

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTableWidget.swift
@@ -195,6 +195,7 @@ public struct InlineTableWidget: View {
                     .padding(.top, VSpacing.xs)
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .onAppear {
             selectedIds = Set(data.rows.filter(\.selected).map(\.id))
             if hasSelection {


### PR DESCRIPTION
## Summary
- Make `InlineTableWidget` fill full chat bubble width instead of shrink-wrapping to content
- Add hover-revealed copy button on table cards that copies as markdown format (pastes natively into Notion)

## Test plan
- [ ] Ask assistant to generate a table — fills full bubble width
- [ ] Hover over table — copy button appears at top-right of card
- [ ] Copy and paste into Notion — renders as a proper table
- [ ] Tables with many columns still scroll horizontally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21828" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
