### PR TITLE
refactor: extract surface refetch VM glue from ChatViewModel

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2004,22 +2004,13 @@ public final class ChatViewModel: ObservableObject {
 
     // MARK: - Surface Refetch
 
-    /// Lazily created manager that serializes surface content fetches.
-    private lazy var surfaceRefetchManager = SurfaceRefetchManager { [weak self] surfaceId, conversationId in
-        guard let self else { return nil }
-        return await self.surfaceClient.fetchSurfaceData(surfaceId: surfaceId, conversationId: conversationId)
-    }
-
-    /// In-flight refetch tasks, keyed by surface ID for cancellation.
-    private var refetchTasks: [String: Task<Void, Never>] = [:]
-
-    /// Re-fetch the full payload for a stripped surface and replace it in the message list.
-    public func refetchStrippedSurface(surfaceId: String, conversationId: String) {
-        guard refetchTasks[surfaceId] == nil else { return }
-        refetchTasks[surfaceId] = Task { @MainActor [weak self] in
-            defer { self?.refetchTasks.removeValue(forKey: surfaceId) }
+    private lazy var surfaceRefetchCoordinator = SurfaceRefetchCoordinator(
+        surfaceRefetchManager: SurfaceRefetchManager { [weak self] surfaceId, conversationId in
+            guard let self else { return nil }
+            return await self.surfaceClient.fetchSurfaceData(surfaceId: surfaceId, conversationId: conversationId)
+        },
+        applyResult: { [weak self] surfaceId, result in
             guard let self else { return }
-            let result = await self.surfaceRefetchManager.enqueue(surfaceId: surfaceId, conversationId: conversationId)
             for msgIndex in self.messages.indices {
                 if let surfIndex = self.messages[msgIndex].inlineSurfaces.firstIndex(where: { $0.id == surfaceId }) {
                     if let data = result.data {
@@ -2034,14 +2025,10 @@ public final class ChatViewModel: ObservableObject {
                 }
             }
         }
-    }
+    )
 
-    /// Cancel all in-flight surface refetch tasks and reset the manager's
-    /// failure counts so surfaces can be retried in the new conversation.
-    private func cancelRefetchTasks() {
-        for task in refetchTasks.values { task.cancel() }
-        refetchTasks.removeAll()
-        Task { await surfaceRefetchManager.resetFailureCounts() }
+    public func refetchStrippedSurface(surfaceId: String, conversationId: String) {
+        surfaceRefetchCoordinator.refetchStrippedSurface(surfaceId: surfaceId, conversationId: conversationId)
     }
 
     /// Cancel the queued user message without clearing `bootstrapCorrelationId`.
@@ -2974,7 +2961,7 @@ public final class ChatViewModel: ObservableObject {
         // or appending text to a stale currentAssistantMessageId.
         discardStreamingBuffer()
         discardPartialOutputBuffer()
-        cancelRefetchTasks()
+        surfaceRefetchCoordinator.cancelRefetchTasks()
         currentAssistantMessageId = nil
         currentAssistantHasText = false
         lastContentWasToolCall = false
@@ -3339,8 +3326,7 @@ public final class ChatViewModel: ObservableObject {
         partialOutputFlushTask?.cancel()
         cancelTimeoutTask?.cancel()
         loadMoreTimeoutTask?.cancel()
-        for task in refetchTasks.values { task.cancel() }
-        refetchTasks.removeAll()
+        // surfaceRefetchCoordinator is released with self; its deinit cancels tasks.
         // refinementFailureDismissTask and refinementFlushTask are accessed via
         // @MainActor computed properties (forwarded from ChatMessageManager), which
         // cannot be referenced from nonisolated deinit. Both tasks use [weak self],

--- a/clients/shared/Features/Chat/SurfaceRefetchCoordinator.swift
+++ b/clients/shared/Features/Chat/SurfaceRefetchCoordinator.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Thin @MainActor coordinator that wraps `SurfaceRefetchManager` and owns the
+/// per-surface task dictionary. Extracted from ChatViewModel to reduce VM size.
+/// This is NOT @Observable — it holds no view-facing state.
+@MainActor
+public final class SurfaceRefetchCoordinator {
+    /// Callback invoked on the main actor with the refetch result so the caller
+    /// can apply it to the message list.
+    public typealias ApplyResult = (String, SurfaceRefetchManager.RefetchResult) -> Void
+
+    private let surfaceRefetchManager: SurfaceRefetchManager
+    private let applyResult: ApplyResult
+
+    /// In-flight refetch tasks, keyed by surface ID for cancellation.
+    private var refetchTasks: [String: Task<Void, Never>] = [:]
+
+    public init(
+        surfaceRefetchManager: SurfaceRefetchManager,
+        applyResult: @escaping ApplyResult
+    ) {
+        self.surfaceRefetchManager = surfaceRefetchManager
+        self.applyResult = applyResult
+    }
+
+    deinit {
+        for task in refetchTasks.values { task.cancel() }
+    }
+
+    /// Re-fetch the full payload for a stripped surface. The result is applied
+    /// via the `applyResult` callback provided at init.
+    public func refetchStrippedSurface(surfaceId: String, conversationId: String) {
+        guard refetchTasks[surfaceId] == nil else { return }
+        refetchTasks[surfaceId] = Task { @MainActor [weak self] in
+            defer { self?.refetchTasks.removeValue(forKey: surfaceId) }
+            guard let self else { return }
+            let result = await self.surfaceRefetchManager.enqueue(
+                surfaceId: surfaceId,
+                conversationId: conversationId
+            )
+            self.applyResult(surfaceId, result)
+        }
+    }
+
+    /// Cancel all in-flight surface refetch tasks and reset the manager's
+    /// failure counts so surfaces can be retried in the new conversation.
+    public func cancelRefetchTasks() {
+        for task in refetchTasks.values { task.cancel() }
+        refetchTasks.removeAll()
+        Task { await surfaceRefetchManager.resetFailureCounts() }
+    }
+}


### PR DESCRIPTION
## Summary
- Extract refetchTasks dictionary, refetchStrippedSurface(), and cancelRefetchTasks() into new SurfaceRefetchCoordinator
- Thin @MainActor coordinator wrapping existing SurfaceRefetchManager actor
- No new abstraction layer — just extraction of existing VM-side glue

Part of plan: chatvm-observable-migration.md (PR 4 of 13)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21838" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
