### PR TITLE
M1: Data Foundation — Schema, API, Server Creation Paths

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.0.0
 info:
   title: Vellum Assistant API
-  version: 0.5.11
+  version: 0.5.12
   description: Auto-generated OpenAPI specification for the Vellum Assistant runtime HTTP server.
 servers:
   - url: http://127.0.0.1:7821
@@ -3176,6 +3176,93 @@ paths:
                 - conversationId
                 - startTime
                 - endTime
+              additionalProperties: false
+  /v1/groups:
+    get:
+      operationId: groups_get
+      summary: List groups
+      description: Return all conversation groups.
+      tags:
+        - groups
+      responses:
+        "200":
+          description: Successful response
+    post:
+      operationId: groups_post
+      summary: Create group
+      description: Create a new custom conversation group. Server assigns sort_position.
+      tags:
+        - groups
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: Group name
+              required:
+                - name
+              additionalProperties: false
+  /v1/groups/{groupId}:
+    delete:
+      operationId: groups_by_groupId_delete
+      summary: Delete group
+      description: Delete a custom conversation group.
+      tags:
+        - groups
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          schema:
+            type: string
+    patch:
+      operationId: groups_by_groupId_patch
+      summary: Update group
+      description: Update a conversation group's name or sort position.
+      tags:
+        - groups
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/groups/reorder:
+    post:
+      operationId: groups_reorder_post
+      summary: Reorder groups
+      description: Batch-update sort positions for conversation groups.
+      tags:
+        - groups
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                updates:
+                  type: array
+                  items: {}
+                  description: Array of { groupId, sortPosition } objects
+              required:
+                - updates
               additionalProperties: false
   /v1/guardian-actions/decision:
     post:

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -173,6 +173,7 @@ export class HeartbeatService {
       const conversation = bootstrapConversation({
         conversationType: "background",
         source: "heartbeat",
+        groupId: "system:background",
         origin: "heartbeat",
         systemHint: "Heartbeat",
       });

--- a/assistant/src/memory/conversation-bootstrap.ts
+++ b/assistant/src/memory/conversation-bootstrap.ts
@@ -11,6 +11,7 @@ export interface BootstrapConversationOptions {
   origin: TitleOrigin;
   systemHint: string;
   scheduleJobId?: string;
+  groupId?: string;
 }
 
 export function bootstrapConversation(opts: BootstrapConversationOptions) {
@@ -19,6 +20,7 @@ export function bootstrapConversation(opts: BootstrapConversationOptions) {
     ...(opts.conversationType && { conversationType: opts.conversationType }),
     ...(opts.source && { source: opts.source }),
     ...(opts.scheduleJobId && { scheduleJobId: opts.scheduleJobId }),
+    ...(opts.groupId && { groupId: opts.groupId }),
   });
   queueGenerateConversationTitle({
     conversationId: conversation.id,

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -41,6 +41,7 @@ import {
   updateMetaFile,
 } from "./conversation-disk-view.js";
 import { ensureDisplayOrderMigration } from "./conversation-display-order-migration.js";
+import { ensureGroupMigration } from "./conversation-group-migration.js";
 import { getDb, rawAll, rawExec, rawGet, rawRun } from "./db.js";
 import { indexMessageNow } from "./indexer.js";
 import { enqueueMemoryJob } from "./jobs-store.js";
@@ -244,6 +245,7 @@ export function createConversation(
         conversationType?: "standard" | "private" | "background";
         source?: string;
         scheduleJobId?: string;
+        groupId?: string;
       },
 ) {
   const db = getDb();
@@ -254,9 +256,16 @@ export function createConversation(
       : (titleOrOpts ?? {});
   const conversationType = opts.conversationType ?? "standard";
   const source = opts.source ?? "user";
+  const groupId = opts.groupId;
   const id = uuid();
   const memoryScopeId =
     conversationType === "private" ? `private:${id}` : "default";
+
+  // Ensure group_id column exists before INSERT that may include group_id.
+  if (groupId) {
+    ensureGroupMigration();
+  }
+
   const conversation = {
     id,
     title: opts.title ?? null,
@@ -298,6 +307,12 @@ export function createConversation(
       }
       throw err;
     }
+  }
+
+  // group_id is NOT in the Drizzle schema (raw-query-only pattern, matching
+  // display_order and is_pinned). Set it via raw SQL after the Drizzle insert.
+  if (groupId) {
+    rawRun("UPDATE conversations SET group_id = ? WHERE id = ?", groupId, id);
   }
 
   initConversationDir({ ...conversation, originChannel: null });
@@ -342,6 +357,20 @@ export function getConversationType(
 export function getConversationMemoryScopeId(conversationId: string): string {
   const conv = getConversation(conversationId);
   return conv?.memoryScopeId ?? "default";
+}
+
+/**
+ * Fetch group_id for a conversation via raw SQL. group_id is NOT in the
+ * Drizzle schema (raw-query-only pattern), so ConversationRow doesn't
+ * include it. This helper is used by forkConversation to inherit group_id.
+ */
+export function getConversationGroupId(conversationId: string): string | null {
+  ensureGroupMigration();
+  const row = rawGet<{ group_id: string | null }>(
+    "SELECT group_id FROM conversations WHERE id = ?",
+    conversationId,
+  );
+  return row?.group_id ?? null;
 }
 
 export function forkConversation(params: {
@@ -407,10 +436,14 @@ export function forkConversation(params: {
   // (linkAttachmentToMessage, relinkAttachments, seedForkedConversationAttention)
   // use the same underlying bun:sqlite connection, so their writes participate
   // in this transaction automatically.
+  // Inherit group_id from parent via raw SQL helper (group_id is not in Drizzle schema)
+  const parentGroupId = getConversationGroupId(conversationId);
+
   const forkedConversation = db.transaction(() => {
     const fc = createConversation({
       title: forkTitle,
       conversationType: "standard",
+      groupId: parentGroupId ?? undefined,
     });
 
     db.update(conversations)
@@ -1670,18 +1703,45 @@ export function batchSetDisplayOrders(
     id: string;
     displayOrder: number | null;
     isPinned: boolean;
+    groupId?: string | null;
   }>,
 ): void {
   ensureDisplayOrderMigration();
+  ensureGroupMigration();
   rawExec("BEGIN");
   try {
     for (const update of updates) {
-      rawRun(
-        "UPDATE conversations SET display_order = ?, is_pinned = ? WHERE id = ?",
-        update.displayOrder,
-        update.isPinned ? 1 : 0,
-        update.id,
-      );
+      if (update.groupId !== undefined) {
+        // New client: groupId is authoritative
+        // Derive is_pinned from groupId
+        rawRun(
+          "UPDATE conversations SET display_order = ?, is_pinned = ?, group_id = ? WHERE id = ?",
+          update.displayOrder,
+          update.groupId === "system:pinned" ? 1 : 0,
+          update.groupId,
+          update.id,
+        );
+      } else {
+        // Old client: no groupId in payload
+        // isPinned true -> set group_id = system:pinned
+        // isPinned false -> clear group_id ONLY IF currently system:pinned
+        //                   otherwise preserve existing group_id
+        if (update.isPinned) {
+          rawRun(
+            "UPDATE conversations SET display_order = ?, is_pinned = 1, group_id = 'system:pinned' WHERE id = ?",
+            update.displayOrder,
+            update.id,
+          );
+        } else {
+          rawRun(
+            `UPDATE conversations SET display_order = ?, is_pinned = 0,
+             group_id = CASE WHEN group_id = 'system:pinned' THEN NULL ELSE group_id END
+             WHERE id = ?`,
+            update.displayOrder,
+            update.id,
+          );
+        }
+      }
     }
     rawExec("COMMIT");
   } catch (err) {
@@ -1692,21 +1752,30 @@ export function batchSetDisplayOrders(
 
 export function getDisplayMetaForConversations(
   conversationIds: string[],
-): Map<string, { displayOrder: number | null; isPinned: boolean }> {
+): Map<
+  string,
+  { displayOrder: number | null; isPinned: boolean; groupId: string | null }
+> {
   ensureDisplayOrderMigration();
+  ensureGroupMigration();
   const result = new Map<
     string,
-    { displayOrder: number | null; isPinned: boolean }
+    { displayOrder: number | null; isPinned: boolean; groupId: string | null }
   >();
   if (conversationIds.length === 0) return result;
   for (const id of conversationIds) {
     const row = rawGet<{
       display_order: number | null;
       is_pinned: number | null;
-    }>("SELECT display_order, is_pinned FROM conversations WHERE id = ?", id);
+      group_id: string | null;
+    }>(
+      "SELECT display_order, is_pinned, group_id FROM conversations WHERE id = ?",
+      id,
+    );
     result.set(id, {
       displayOrder: row?.display_order ?? null,
       isPinned: (row?.is_pinned ?? 0) === 1,
+      groupId: row?.group_id ?? null,
     });
   }
   return result;

--- a/assistant/src/memory/conversation-group-migration.ts
+++ b/assistant/src/memory/conversation-group-migration.ts
@@ -1,0 +1,117 @@
+/**
+ * Runtime migration for the conversation_groups table and group_id column
+ * on the conversations table. Follows the same lazy-initialization pattern
+ * as conversation-display-order-migration.ts.
+ *
+ * group_id is display/organizational metadata, consistent with how
+ * display_order and is_pinned are handled via runtime migration rather
+ * than the formal migrations/ pipeline.
+ */
+
+import { getLogger } from "../util/logger.js";
+import { ensureDisplayOrderMigration } from "./conversation-display-order-migration.js";
+import { rawExec, rawRun } from "./db.js";
+
+const log = getLogger("conversation-store");
+
+function isDuplicateColumnError(err: unknown): boolean {
+  return err instanceof Error && /duplicate column name:/i.test(err.message);
+}
+
+let migrated = false;
+
+export function ensureGroupMigration(): void {
+  if (migrated) return;
+
+  // 1. Create groups table if not exists
+  rawExec(`
+    CREATE TABLE IF NOT EXISTS conversation_groups (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      sort_position REAL NOT NULL DEFAULT 0,
+      is_system_group BOOLEAN NOT NULL DEFAULT FALSE,
+      created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+      updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+    )
+  `);
+
+  // 2. Add group_id column if not exists
+  // Match existing error-handling pattern from conversation-display-order-migration.ts:
+  // only swallow duplicate-column errors, log+throw everything else.
+  try {
+    rawRun(
+      "ALTER TABLE conversations ADD COLUMN group_id TEXT REFERENCES conversation_groups(id) ON DELETE SET NULL",
+    );
+  } catch (err) {
+    if (!isDuplicateColumnError(err)) {
+      log.error({ err }, "Failed to add group_id column");
+      throw err;
+    }
+  }
+
+  // 3. Seed system groups (three: pinned, scheduled, background)
+  rawExec(`
+    INSERT OR IGNORE INTO conversation_groups (id, name, sort_position, is_system_group)
+    VALUES
+      ('system:pinned', 'Pinned', 0, TRUE),
+      ('system:scheduled', 'Scheduled', 1, TRUE),
+      ('system:background', 'Background', 2, TRUE)
+  `);
+
+  // 4. One-time backfill (guard: only if not already done)
+  ensureDisplayOrderMigration(); // ensure is_pinned column exists first
+
+  // Canonical classification rules (full decision tree with precedence):
+  //
+  //   1. Pinned:     is_pinned = TRUE
+  //                  → system:pinned (always wins, checked first)
+  //
+  //   2. Scheduled:  source IN ('schedule', 'reminder') OR schedule_job_id IS NOT NULL
+  //                  → system:scheduled (checked second)
+  //
+  //   3. Background: (conversation_type = 'background' AND COALESCE(source, '') != 'notification')
+  //                  OR source IN ('heartbeat', 'task')
+  //                  AND COALESCE(source, '') NOT IN ('schedule', 'reminder')  ← safety + NULL handling
+  //                  AND schedule_job_id IS NULL                               ← safety: prevents overlap with step 2
+  //                  → system:background
+  //
+  //   4. Else:       ungrouped (group_id = NULL)
+  //
+  // Each backfill step uses AND group_id IS NULL to avoid reassignment.
+  // The exclusion guards in step 3 are belt-and-suspenders — step 2's
+  // group_id IS NULL guard already prevents overlap, but the explicit
+  // exclusions make the SQL self-documenting and migration-order-independent.
+  // COALESCE handles NULL source values (legacy rows).
+
+  // Step A: Pinned -> system:pinned (runs first, always wins)
+  rawExec(`
+    UPDATE conversations SET group_id = 'system:pinned'
+    WHERE is_pinned = 1 AND group_id IS NULL
+  `);
+
+  // Step B: Scheduled -> system:scheduled (schedule/reminder source or has schedule_job_id)
+  rawExec(`
+    UPDATE conversations SET group_id = 'system:scheduled'
+    WHERE (source IN ('schedule', 'reminder') OR schedule_job_id IS NOT NULL)
+    AND group_id IS NULL
+  `);
+
+  // Step C: Background -> system:background (background type, heartbeat, or task — excluding notifications)
+  // Explicit exclusion of schedule sources + schedule_job_id as a safety net.
+  // Step B already catches those via group_id IS NULL guard, but the explicit exclusion
+  // makes the SQL self-documenting and protects against future migration ordering changes.
+  // Note: source can be NULL for legacy rows. NULL != 'notification' evaluates to NULL (not TRUE)
+  // in SQL, so use COALESCE to treat NULL source as empty string for the exclusion checks.
+  rawExec(`
+    UPDATE conversations SET group_id = 'system:background'
+    WHERE (
+      (conversation_type = 'background' AND COALESCE(source, '') != 'notification')
+      OR source IN ('heartbeat', 'task')
+    )
+    AND COALESCE(source, '') NOT IN ('schedule', 'reminder')
+    AND schedule_job_id IS NULL
+    AND group_id IS NULL
+  `);
+
+  migrated = true;
+}

--- a/assistant/src/memory/conversation-queries.ts
+++ b/assistant/src/memory/conversation-queries.ts
@@ -4,6 +4,7 @@ import { getLogger } from "../util/logger.js";
 import type { ConversationRow } from "./conversation-crud.js";
 import { parseConversation } from "./conversation-crud.js";
 import { ensureDisplayOrderMigration } from "./conversation-display-order-migration.js";
+import { ensureGroupMigration } from "./conversation-group-migration.js";
 import { getDb, rawAll } from "./db.js";
 import { conversations, messages } from "./schema.js";
 
@@ -30,6 +31,7 @@ export function listConversations(
   offset = 0,
 ): ConversationRow[] {
   ensureDisplayOrderMigration();
+  ensureGroupMigration();
   const db = getDb();
   const where = backgroundOnly
     ? sql`${conversations.conversationType} = 'background'`

--- a/assistant/src/memory/group-crud.ts
+++ b/assistant/src/memory/group-crud.ts
@@ -1,0 +1,180 @@
+/**
+ * CRUD operations for conversation groups.
+ *
+ * All functions call ensureGroupMigration() before any DB access
+ * to guarantee the conversation_groups table exists.
+ */
+
+import { v4 as uuid } from "uuid";
+
+import { ensureGroupMigration } from "./conversation-group-migration.js";
+import { rawAll, rawGet, rawRun } from "./db.js";
+
+export interface ConversationGroupRow {
+  id: string;
+  name: string;
+  sortPosition: number;
+  isSystemGroup: boolean;
+  createdAt?: number;
+  updatedAt?: number;
+}
+
+// ---------------------------------------------------------------------------
+// List
+// ---------------------------------------------------------------------------
+
+export function listGroups(): ConversationGroupRow[] {
+  ensureGroupMigration();
+  const rows = rawAll<{
+    id: string;
+    name: string;
+    sort_position: number;
+    is_system_group: number;
+    created_at: number;
+    updated_at: number;
+  }>(
+    "SELECT id, name, sort_position, is_system_group, created_at, updated_at FROM conversation_groups ORDER BY sort_position ASC",
+  );
+  return rows.map((r) => ({
+    id: r.id,
+    name: r.name,
+    sortPosition: r.sort_position,
+    isSystemGroup: r.is_system_group === 1,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Get
+// ---------------------------------------------------------------------------
+
+export function getGroup(groupId: string): ConversationGroupRow | null {
+  ensureGroupMigration();
+  const row = rawGet<{
+    id: string;
+    name: string;
+    sort_position: number;
+    is_system_group: number;
+    created_at: number;
+    updated_at: number;
+  }>(
+    "SELECT id, name, sort_position, is_system_group, created_at, updated_at FROM conversation_groups WHERE id = ?",
+    groupId,
+  );
+  if (!row) return null;
+  return {
+    id: row.id,
+    name: row.name,
+    sortPosition: row.sort_position,
+    isSystemGroup: row.is_system_group === 1,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Create
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a custom group. Server assigns sort_position as max(custom) + 1.
+ * System groups occupy positions 0 (pinned), 1 (scheduled), 2 (background).
+ * First custom group gets position 3. Fallback ?? 2 ensures 2 + 1 = 3 when
+ * no custom groups exist.
+ */
+export function createGroup(name: string): ConversationGroupRow {
+  ensureGroupMigration();
+  const maxPos =
+    rawGet<{ max: number | null }>(
+      "SELECT MAX(sort_position) as max FROM conversation_groups WHERE is_system_group = 0",
+    )?.max ?? 2;
+  const sortPosition = maxPos + 1;
+  const id = uuid();
+  const now = Math.floor(Date.now() / 1000);
+  rawRun(
+    "INSERT INTO conversation_groups (id, name, sort_position, is_system_group, created_at, updated_at) VALUES (?, ?, ?, 0, ?, ?)",
+    id,
+    name,
+    sortPosition,
+    now,
+    now,
+  );
+  return {
+    id,
+    name,
+    sortPosition,
+    isSystemGroup: false,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Update
+// ---------------------------------------------------------------------------
+
+export function updateGroup(
+  groupId: string,
+  updates: { name?: string; sortPosition?: number },
+): ConversationGroupRow | null {
+  ensureGroupMigration();
+  const existing = getGroup(groupId);
+  if (!existing) return null;
+
+  const fields: string[] = [];
+  const values: (string | number)[] = [];
+
+  if (updates.name !== undefined) {
+    fields.push("name = ?");
+    values.push(updates.name);
+  }
+  if (updates.sortPosition !== undefined) {
+    fields.push("sort_position = ?");
+    values.push(updates.sortPosition);
+  }
+
+  if (fields.length === 0) return existing;
+
+  fields.push("updated_at = ?");
+  const now = Math.floor(Date.now() / 1000);
+  values.push(now);
+  values.push(groupId);
+
+  rawRun(
+    `UPDATE conversation_groups SET ${fields.join(", ")} WHERE id = ?`,
+    ...values,
+  );
+
+  return getGroup(groupId);
+}
+
+// ---------------------------------------------------------------------------
+// Delete
+// ---------------------------------------------------------------------------
+
+export function deleteGroup(groupId: string): boolean {
+  ensureGroupMigration();
+  rawRun("DELETE FROM conversation_groups WHERE id = ?", groupId);
+  // ON DELETE SET NULL will clear group_id on conversations
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Reorder
+// ---------------------------------------------------------------------------
+
+export function reorderGroups(
+  updates: Array<{ groupId: string; sortPosition: number }>,
+): void {
+  ensureGroupMigration();
+  const now = Math.floor(Date.now() / 1000);
+  for (const update of updates) {
+    rawRun(
+      "UPDATE conversation_groups SET sort_position = ?, updated_at = ? WHERE id = ?",
+      update.sortPosition,
+      now,
+      update.groupId,
+    );
+  }
+}

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -362,6 +362,13 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "conversations/wipe", scopes: ["chat.write"] },
   { endpoint: "conversations/reorder", scopes: ["chat.write"] },
 
+  // Conversation groups
+  { endpoint: "groups:GET", scopes: ["chat.read"] },
+  { endpoint: "groups:POST", scopes: ["chat.write"] },
+  { endpoint: "groups:PATCH", scopes: ["chat.write"] },
+  { endpoint: "groups:DELETE", scopes: ["chat.write"] },
+  { endpoint: "groups/reorder", scopes: ["chat.write"] },
+
   // Conversation search
   { endpoint: "conversations/search", scopes: ["chat.read"] },
 

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -55,6 +55,7 @@ import {
 } from "../memory/conversation-queries.js";
 import type { ExternalConversationBinding } from "../memory/external-conversation-store.js";
 import * as externalConversationStore from "../memory/external-conversation-store.js";
+import { listGroups } from "../memory/group-crud.js";
 import {
   consumeCallback,
   consumeCallbackError,
@@ -139,6 +140,7 @@ import { diagnosticsRouteDefinitions } from "./routes/diagnostics-routes.js";
 import { documentRouteDefinitions } from "./routes/documents-routes.js";
 import { eventsRouteDefinitions } from "./routes/events-routes.js";
 import { globalSearchRouteDefinitions } from "./routes/global-search-routes.js";
+import { groupRouteDefinitions } from "./routes/group-routes.js";
 import { guardianActionRouteDefinitions } from "./routes/guardian-action-routes.js";
 import { handleGuardianBootstrap } from "./routes/guardian-bootstrap-routes.js";
 import { handleGuardianRefresh } from "./routes/guardian-refresh-routes.js";
@@ -818,7 +820,11 @@ export class RuntimeHttpServer {
     conversation: ConversationRow;
     binding?: ExternalConversationBinding | null;
     attentionState?: AttentionState;
-    displayMeta?: { displayOrder: number | null; isPinned: boolean };
+    displayMeta?: {
+      displayOrder: number | null;
+      isPinned: boolean;
+      groupId: string | null;
+    };
     parentCache: Map<string, ConversationRow | null>;
   }) {
     const { conversation, binding, attentionState, displayMeta, parentCache } =
@@ -860,6 +866,7 @@ export class RuntimeHttpServer {
               displayOrder: displayMeta.displayOrder,
             }
           : {}),
+      groupId: displayMeta?.groupId ?? null,
       ...(forkParent ? { forkParent } : {}),
     };
   }
@@ -1041,7 +1048,7 @@ export class RuntimeHttpServer {
           const attentionStates =
             getAttentionStateByConversationIds(conversationIds);
           const parentCache = new Map<string, ConversationRow | null>();
-          return Response.json({
+          const response: Record<string, unknown> = {
             conversations: rows.map((conversation) =>
               this.serializeConversationSummary({
                 conversation,
@@ -1052,7 +1059,18 @@ export class RuntimeHttpServer {
               }),
             ),
             hasMore: offset + rows.length < totalCount,
-          });
+          };
+          // Include groups array on first page only
+          if (offset === 0) {
+            const groups = listGroups();
+            response.groups = groups.map((g) => ({
+              id: g.id,
+              name: g.name,
+              sortPosition: g.sortPosition,
+              isSystemGroup: g.isSystemGroup,
+            }));
+          }
+          return Response.json(response);
         },
       },
       ...conversationAttentionRouteDefinitions(),
@@ -1060,6 +1078,8 @@ export class RuntimeHttpServer {
       ...(conversationManagementDeps
         ? conversationManagementRouteDefinitions(conversationManagementDeps)
         : []),
+
+      ...groupRouteDefinitions(),
 
       {
         endpoint: "conversations/seen",

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -528,6 +528,7 @@ export function conversationManagementRouteDefinitions(
             conversationId: string;
             displayOrder?: number;
             isPinned?: boolean;
+            groupId?: string | null;
           }>;
         };
         if (!Array.isArray(body.updates)) {
@@ -538,6 +539,7 @@ export function conversationManagementRouteDefinitions(
             id: u.conversationId,
             displayOrder: u.displayOrder ?? null,
             isPinned: u.isPinned ?? false,
+            groupId: u.groupId,
           })),
         );
         return Response.json({ ok: true });

--- a/assistant/src/runtime/routes/group-routes.ts
+++ b/assistant/src/runtime/routes/group-routes.ts
@@ -1,0 +1,180 @@
+/**
+ * Route handlers for conversation group management.
+ *
+ * GET    /v1/groups              — list all groups
+ * POST   /v1/groups              — create a custom group
+ * PATCH  /v1/groups/:groupId     — update a group
+ * DELETE /v1/groups/:groupId     — delete a group
+ * POST   /v1/groups/reorder      — reorder groups
+ */
+
+import { z } from "zod";
+
+import {
+  createGroup,
+  deleteGroup,
+  getGroup,
+  listGroups,
+  reorderGroups,
+  updateGroup,
+} from "../../memory/group-crud.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+
+function serializeGroup(group: ReturnType<typeof getGroup>) {
+  if (!group) return null;
+  return {
+    id: group.id,
+    name: group.name,
+    sortPosition: group.sortPosition,
+    isSystemGroup: group.isSystemGroup,
+  };
+}
+
+export function groupRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "groups",
+      method: "GET",
+      policyKey: "groups",
+      summary: "List groups",
+      description: "Return all conversation groups.",
+      tags: ["groups"],
+      handler: () => {
+        const groups = listGroups();
+        return Response.json({
+          groups: groups.map(serializeGroup),
+        });
+      },
+    },
+    {
+      endpoint: "groups",
+      method: "POST",
+      policyKey: "groups",
+      summary: "Create group",
+      description:
+        "Create a new custom conversation group. Server assigns sort_position.",
+      tags: ["groups"],
+      requestBody: z.object({
+        name: z.string().describe("Group name"),
+      }),
+      handler: async ({ req }) => {
+        const body = (await req.json()) as { name?: string };
+        if (!body.name || typeof body.name !== "string") {
+          return httpError("BAD_REQUEST", "Missing or invalid name", 400);
+        }
+        const group = createGroup(body.name);
+        return Response.json(serializeGroup(group), { status: 201 });
+      },
+    },
+    {
+      endpoint: "groups/:groupId",
+      method: "PATCH",
+      policyKey: "groups",
+      summary: "Update group",
+      description: "Update a conversation group's name or sort position.",
+      tags: ["groups"],
+      handler: async ({ req, params }) => {
+        const groupId = params.groupId;
+        const existing = getGroup(groupId);
+        if (!existing) {
+          return httpError("NOT_FOUND", "Group not found", 404);
+        }
+        // System groups are immutable
+        if (existing.isSystemGroup) {
+          return httpError(
+            "FORBIDDEN",
+            "System groups cannot be modified",
+            403,
+          );
+        }
+        const body = (await req.json()) as {
+          name?: string;
+          sortPosition?: number;
+        };
+        // Custom group sort_position must be >= 3
+        if (body.sortPosition !== undefined && body.sortPosition < 3) {
+          return httpError(
+            "BAD_REQUEST",
+            "Custom group sort_position must be >= 3",
+            400,
+          );
+        }
+        const updated = updateGroup(groupId, {
+          name: body.name,
+          sortPosition: body.sortPosition,
+        });
+        if (!updated) {
+          return httpError("NOT_FOUND", "Group not found", 404);
+        }
+        return Response.json(serializeGroup(updated));
+      },
+    },
+    {
+      endpoint: "groups/:groupId",
+      method: "DELETE",
+      policyKey: "groups",
+      summary: "Delete group",
+      description: "Delete a custom conversation group.",
+      tags: ["groups"],
+      handler: ({ params }) => {
+        const groupId = params.groupId;
+        const existing = getGroup(groupId);
+        if (!existing) {
+          return httpError("NOT_FOUND", "Group not found", 404);
+        }
+        // System groups cannot be deleted
+        if (existing.isSystemGroup) {
+          return httpError("FORBIDDEN", "System groups cannot be deleted", 403);
+        }
+        deleteGroup(groupId);
+        return new Response(null, { status: 204 });
+      },
+    },
+    {
+      endpoint: "groups/reorder",
+      method: "POST",
+      policyKey: "groups/reorder",
+      summary: "Reorder groups",
+      description: "Batch-update sort positions for conversation groups.",
+      tags: ["groups"],
+      requestBody: z.object({
+        updates: z
+          .array(z.unknown())
+          .describe("Array of { groupId, sortPosition } objects"),
+      }),
+      handler: async ({ req }) => {
+        const body = (await req.json()) as {
+          updates?: Array<{
+            groupId: string;
+            sortPosition: number;
+          }>;
+        };
+        if (!Array.isArray(body.updates)) {
+          return httpError("BAD_REQUEST", "Missing updates array", 400);
+        }
+        // Validate: no system group reordering, no sort_position < 3 for custom groups
+        for (const update of body.updates) {
+          const group = getGroup(update.groupId);
+          if (!group) continue;
+          if (group.isSystemGroup) {
+            return httpError(
+              "FORBIDDEN",
+              `Cannot reorder system group: ${update.groupId}`,
+              403,
+            );
+          }
+          if (update.sortPosition < 3) {
+            return httpError(
+              "BAD_REQUEST",
+              `Custom group sort_position must be >= 3 (got ${update.sortPosition} for ${update.groupId})`,
+              400,
+            );
+          }
+        }
+        reorderGroups(body.updates);
+        return Response.json({ ok: true });
+      },
+    },
+  ];
+}

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -229,6 +229,7 @@ async function handleRunScheduleNow(
       );
       const fallbackConversation = bootstrapConversation({
         source: "schedule",
+        groupId: "system:scheduled",
         origin: "schedule",
         systemHint: `Schedule (manual): ${schedule.name}`,
       });
@@ -241,6 +242,7 @@ async function handleRunScheduleNow(
   // Regular message-based schedule
   const conversation = bootstrapConversation({
     source: "schedule",
+    groupId: "system:scheduled",
     origin: "schedule",
     systemHint: `Schedule (manual): ${schedule.name}`,
   });

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -188,7 +188,12 @@ async function runScheduleOnce(
         );
         const { runTask } = await import("../tasks/task-runner.js");
         const result = await runTask(
-          { taskId, workingDir: process.cwd(), source: "schedule", scheduleJobId: job.id },
+          {
+            taskId,
+            workingDir: process.cwd(),
+            source: "schedule",
+            scheduleJobId: job.id,
+          },
           processMessage as (
             conversationId: string,
             message: string,
@@ -237,6 +242,7 @@ async function runScheduleOnce(
         const fallbackConversation = bootstrapConversation({
           source: "schedule",
           scheduleJobId: job.id,
+          groupId: "system:scheduled",
           origin: "schedule",
           systemHint: `Schedule: ${job.name}`,
         });
@@ -255,6 +261,7 @@ async function runScheduleOnce(
     const conversation = bootstrapConversation({
       source: "schedule",
       scheduleJobId: job.id,
+      groupId: "system:scheduled",
       origin: "schedule",
       systemHint: isOneShot ? `Reminder: ${job.name}` : `Schedule: ${job.name}`,
     });

--- a/assistant/src/tasks/task-runner.ts
+++ b/assistant/src/tasks/task-runner.ts
@@ -64,8 +64,10 @@ export async function runTask(
     // Scheduled section; non-schedule tasks use "background" to stay out of
     // the main conversation list.
     conversationType: opts.source === "schedule" ? undefined : "background",
-    source: opts.source,
+    source: opts.source === "schedule" ? "schedule" : "task",
     scheduleJobId: opts.scheduleJobId,
+    groupId:
+      opts.source === "schedule" ? "system:scheduled" : "system:background",
     origin: "task",
     systemHint: `Task: ${task.title}`,
   });

--- a/clients/ios/App/IOSConversationStore.swift
+++ b/clients/ios/App/IOSConversationStore.swift
@@ -25,6 +25,8 @@ struct IOSConversation: Identifiable {
     var scheduleJobId: String?
     /// The parent conversation/message this conversation forked from, if any.
     var forkParent: ConversationForkParent?
+    /// The conversation group this conversation belongs to, if any.
+    var groupId: String?
     var hasUnseenLatestAssistantMessage: Bool
     var latestAssistantMessageAt: Date?
     var lastSeenAssistantMessageAt: Date?
@@ -36,7 +38,7 @@ struct IOSConversation: Identifiable {
         return title.hasPrefix("Schedule: ") || title.hasPrefix("Schedule (manual): ") || title.hasPrefix("Reminder: ")
     }
 
-    init(id: UUID = UUID(), title: String = "New Chat", createdAt: Date = Date(), lastActivityAt: Date? = nil, conversationId: String? = nil, isArchived: Bool = false, isPinned: Bool = false, displayOrder: Int? = nil, isPrivate: Bool = false, scheduleJobId: String? = nil, forkParent: ConversationForkParent? = nil, hasUnseenLatestAssistantMessage: Bool = false, latestAssistantMessageAt: Date? = nil, lastSeenAssistantMessageAt: Date? = nil) {
+    init(id: UUID = UUID(), title: String = "New Chat", createdAt: Date = Date(), lastActivityAt: Date? = nil, conversationId: String? = nil, isArchived: Bool = false, isPinned: Bool = false, displayOrder: Int? = nil, isPrivate: Bool = false, scheduleJobId: String? = nil, forkParent: ConversationForkParent? = nil, groupId: String? = nil, hasUnseenLatestAssistantMessage: Bool = false, latestAssistantMessageAt: Date? = nil, lastSeenAssistantMessageAt: Date? = nil) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
@@ -48,6 +50,7 @@ struct IOSConversation: Identifiable {
         self.isPrivate = isPrivate
         self.scheduleJobId = scheduleJobId
         self.forkParent = forkParent
+        self.groupId = groupId
         self.hasUnseenLatestAssistantMessage = hasUnseenLatestAssistantMessage
         self.latestAssistantMessageAt = latestAssistantMessageAt
         self.lastSeenAssistantMessageAt = lastSeenAssistantMessageAt
@@ -233,6 +236,7 @@ class IOSConversationStore: ObservableObject {
     ) {
         conversation.isPinned = item.isPinned ?? false
         conversation.displayOrder = item.displayOrder.map { Int($0) }
+        conversation.groupId = item.groupId
         conversation.hasUnseenLatestAssistantMessage =
             item.assistantAttention?.hasUnseenLatestAssistantMessage ?? false
         conversation.latestAssistantMessageAt = assistantTimestamp(

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationGroup.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationGroup.swift
@@ -1,0 +1,34 @@
+import Foundation
+import VellumAssistantShared
+
+/// Represents a conversation group for organizing conversations in the sidebar.
+struct ConversationGroup: Identifiable, Hashable, Codable, Sendable {
+    let id: String
+    var name: String
+    var sortPosition: Double
+    var isSystemGroup: Bool
+
+    static let pinned = ConversationGroup(
+        id: "system:pinned", name: "Pinned", sortPosition: 0, isSystemGroup: true
+    )
+    static let scheduled = ConversationGroup(
+        id: "system:scheduled", name: "Scheduled", sortPosition: 1, isSystemGroup: true
+    )
+    static let background = ConversationGroup(
+        id: "system:background", name: "Background", sortPosition: 2, isSystemGroup: true
+    )
+
+    init(id: String, name: String, sortPosition: Double, isSystemGroup: Bool) {
+        self.id = id
+        self.name = name
+        self.sortPosition = sortPosition
+        self.isSystemGroup = isSystemGroup
+    }
+
+    init(from response: ConversationGroupResponse) {
+        self.id = response.id
+        self.name = response.name
+        self.sortPosition = response.sortPosition
+        self.isSystemGroup = response.isSystemGroup
+    }
+}

--- a/clients/shared/Network/ConversationDetailClient.swift
+++ b/clients/shared/Network/ConversationDetailClient.swift
@@ -46,6 +46,7 @@ public struct ConversationDetailClient: ConversationDetailClientProtocol {
             assistantAttention: conversation.assistantAttention,
             displayOrder: conversation.displayOrder,
             isPinned: conversation.isPinned,
+            groupId: conversation.groupId,
             forkParent: conversation.forkParent
         )
     }

--- a/clients/shared/Network/ConversationForkClient.swift
+++ b/clients/shared/Network/ConversationForkClient.swift
@@ -52,6 +52,7 @@ public struct ConversationForkClient: ConversationForkClientProtocol {
             assistantAttention: conversation.assistantAttention,
             displayOrder: conversation.displayOrder,
             isPinned: conversation.isPinned,
+            groupId: conversation.groupId,
             forkParent: conversation.forkParent
         )
     }

--- a/clients/shared/Network/ConversationListClient.swift
+++ b/clients/shared/Network/ConversationListClient.swift
@@ -51,13 +51,15 @@ public struct ConversationListClient: ConversationListClientProtocol {
                     assistantAttention: $0.assistantAttention,
                     displayOrder: $0.displayOrder,
                     isPinned: $0.isPinned,
+                    groupId: $0.groupId,
                     forkParent: $0.forkParent
                 )
             }
             return ConversationListResponse(
                 type: "conversation_list_response",
                 conversations: items,
-                hasMore: decoded.hasMore
+                hasMore: decoded.hasMore,
+                groups: decoded.groups
             )
         } catch {
             log.error("fetchConversationList error: \(error.localizedDescription)")
@@ -194,6 +196,14 @@ public struct ConversationListClient: ConversationListClientProtocol {
                     if let order = u.displayOrder {
                         entry["displayOrder"] = order
                     }
+
+                    #if os(macOS)
+                    // macOS always sends groupId key: JSON null for ungrouped, string for grouped.
+                    // This lets the server distinguish "explicitly ungrouped" (null) from "old client" (key absent).
+                    entry["groupId"] = u.groupId as Any
+                    #endif
+                    // iOS: key is omitted entirely -- server treats as old client, preserves existing group_id.
+
                     return entry
                 }
             ]
@@ -209,6 +219,110 @@ public struct ConversationListClient: ConversationListClientProtocol {
             return true
         } catch {
             log.error("reorderConversations error: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    // MARK: - Group Management
+
+    public func fetchGroups() async -> [ConversationGroupResponse]? {
+        do {
+            let response = try await GatewayHTTPClient.get(
+                path: "assistants/{assistantId}/groups",
+                timeout: 15
+            )
+            guard response.isSuccess else {
+                log.error("fetchGroups failed (HTTP \(response.statusCode))")
+                return nil
+            }
+            struct GroupsResponse: Decodable {
+                let groups: [ConversationGroupResponse]
+            }
+            let decoded = try JSONDecoder().decode(GroupsResponse.self, from: response.data)
+            return decoded.groups
+        } catch {
+            log.error("fetchGroups error: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    public func createGroup(name: String) async -> ConversationGroupResponse? {
+        do {
+            let response = try await GatewayHTTPClient.post(
+                path: "assistants/{assistantId}/groups",
+                json: ["name": name],
+                timeout: 10
+            )
+            guard response.isSuccess || response.statusCode == 201 else {
+                log.error("createGroup failed (HTTP \(response.statusCode))")
+                return nil
+            }
+            return try JSONDecoder().decode(ConversationGroupResponse.self, from: response.data)
+        } catch {
+            log.error("createGroup error: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    public func updateGroup(groupId: String, name: String?, sortPosition: Double?) async -> Bool {
+        do {
+            var body: [String: Any] = [:]
+            if let name { body["name"] = name }
+            if let sortPosition { body["sortPosition"] = sortPosition }
+
+            let response = try await GatewayHTTPClient.patch(
+                path: "assistants/{assistantId}/groups/\(groupId)",
+                json: body,
+                timeout: 10
+            )
+            guard response.isSuccess else {
+                log.error("updateGroup failed (HTTP \(response.statusCode))")
+                return false
+            }
+            return true
+        } catch {
+            log.error("updateGroup error: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    public func deleteGroup(groupId: String) async -> Bool {
+        do {
+            let response = try await GatewayHTTPClient.delete(
+                path: "assistants/{assistantId}/groups/\(groupId)",
+                timeout: 10
+            )
+            guard response.isSuccess || response.statusCode == 204 else {
+                log.error("deleteGroup failed (HTTP \(response.statusCode))")
+                return false
+            }
+            return true
+        } catch {
+            log.error("deleteGroup error: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    public func reorderGroups(updates: [(groupId: String, sortPosition: Double)]) async -> Bool {
+        do {
+            let body: [String: Any] = [
+                "updates": updates.map { [
+                    "groupId": $0.groupId,
+                    "sortPosition": $0.sortPosition
+                ] as [String: Any] }
+            ]
+            let response = try await GatewayHTTPClient.post(
+                path: "assistants/{assistantId}/groups/reorder",
+                json: body,
+                timeout: 10
+            )
+            guard response.isSuccess else {
+                log.error("reorderGroups failed (HTTP \(response.statusCode))")
+                return false
+            }
+            return true
+        } catch {
+            log.error("reorderGroups error: \(error.localizedDescription)")
             return false
         }
     }
@@ -266,10 +380,12 @@ private struct HTTPConversationsListResponse: Decodable {
         let assistantAttention: AssistantAttention?
         let displayOrder: Double?
         let isPinned: Bool?
+        let groupId: String?
         let forkParent: ConversationForkParent?
     }
     let conversations: [Conversation]
     let hasMore: Bool?
+    let groups: [ConversationGroupResponse]?
 }
 
 /// The HTTP search endpoint omits the `type` discriminator, so we decode

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -3153,11 +3153,13 @@ public struct ReorderConversationsRequestUpdate: Codable, Sendable {
     public let conversationId: String
     public let displayOrder: Double?
     public let isPinned: Bool
+    public let groupId: String?
 
-    public init(conversationId: String, displayOrder: Double?, isPinned: Bool) {
+    public init(conversationId: String, displayOrder: Double?, isPinned: Bool, groupId: String? = nil) {
         self.conversationId = conversationId
         self.displayOrder = displayOrder
         self.isPinned = isPinned
+        self.groupId = groupId
     }
 }
 
@@ -3434,11 +3436,14 @@ public struct ConversationListResponse: Codable, Sendable {
     public let conversations: [ConversationListResponseItem]
     /// Whether more conversations exist beyond the returned page.
     public let hasMore: Bool?
+    /// Available conversation groups. Sent with the first page only.
+    public let groups: [ConversationGroupResponse]?
 
-    public init(type: String, conversations: [ConversationListResponseItem], hasMore: Bool? = nil) {
+    public init(type: String, conversations: [ConversationListResponseItem], hasMore: Bool? = nil, groups: [ConversationGroupResponse]? = nil) {
         self.type = type
         self.conversations = conversations
         self.hasMore = hasMore
+        self.groups = groups
     }
 }
 
@@ -3458,9 +3463,10 @@ public struct ConversationListResponseItem: Codable, Sendable {
     public let assistantAttention: AssistantAttention?
     public let displayOrder: Double?
     public let isPinned: Bool?
+    public let groupId: String?
     public let forkParent: ConversationForkParent?
 
-    public init(id: String, title: String, createdAt: Int? = nil, updatedAt: Int, conversationType: String? = nil, source: String? = nil, scheduleJobId: String? = nil, channelBinding: ChannelBinding? = nil, conversationOriginChannel: String? = nil, conversationOriginInterface: String? = nil, assistantAttention: AssistantAttention? = nil, displayOrder: Double? = nil, isPinned: Bool? = nil, forkParent: ConversationForkParent? = nil) {
+    public init(id: String, title: String, createdAt: Int? = nil, updatedAt: Int, conversationType: String? = nil, source: String? = nil, scheduleJobId: String? = nil, channelBinding: ChannelBinding? = nil, conversationOriginChannel: String? = nil, conversationOriginInterface: String? = nil, assistantAttention: AssistantAttention? = nil, displayOrder: Double? = nil, isPinned: Bool? = nil, groupId: String? = nil, forkParent: ConversationForkParent? = nil) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
@@ -3474,7 +3480,22 @@ public struct ConversationListResponseItem: Codable, Sendable {
         self.assistantAttention = assistantAttention
         self.displayOrder = displayOrder
         self.isPinned = isPinned
+        self.groupId = groupId
         self.forkParent = forkParent
+    }
+}
+
+public struct ConversationGroupResponse: Codable, Sendable {
+    public let id: String
+    public let name: String
+    public let sortPosition: Double
+    public let isSystemGroup: Bool
+
+    public init(id: String, name: String, sortPosition: Double, isSystemGroup: Bool) {
+        self.id = id
+        self.name = name
+        self.sortPosition = sortPosition
+        self.isSystemGroup = isSystemGroup
     }
 }
 

--- a/clients/shared/Network/NetworkResponseTypes.swift
+++ b/clients/shared/Network/NetworkResponseTypes.swift
@@ -29,6 +29,7 @@ public struct ConversationsListResponse: Decodable {
         public let assistantAttention: AssistantAttention?
         public let displayOrder: Double?
         public let isPinned: Bool?
+        public let groupId: String?
         public let forkParent: ConversationForkParent?
     }
     public let conversations: [Conversation]


### PR DESCRIPTION
## Summary
- Implements the data layer for conversation groups (M1 of #21830)
- Creates daemon migration, group CRUD, API endpoints, server-side group assignment at conversation creation time, backward-compat guards, and iOS/macOS client type updates
- No client behavior changes — old clients work identically

## Changes

### Daemon (new files)
- `conversation-group-migration.ts` — Lazy runtime migration: creates `conversation_groups` table, adds `group_id` column, seeds 3 system groups (pinned/scheduled/background), backfills existing conversations with precedence rules (pinned > scheduled > background > ungrouped)
- `group-crud.ts` — CRUD operations for conversation groups with `ensureGroupMigration()` guard
- `group-routes.ts` — REST endpoints: list, create, update, delete, reorder with system group immutability guards and custom sort_position >= 3 enforcement

### Daemon (modified)
- `conversation-crud.ts` — `createConversation()` accepts optional `groupId`, sets via raw SQL after Drizzle insert; `forkConversation()` inherits group_id from parent via `getConversationGroupId()` helper; `batchSetDisplayOrders()` backward-compat logic (groupId present = authoritative, absent + pin = system:pinned, absent + unpin = clear only if currently pinned); `getDisplayMetaForConversations()` returns groupId
- `conversation-queries.ts` — `listConversations()` calls `ensureGroupMigration()`
- `conversation-bootstrap.ts` — Passes groupId through to `createConversation()`
- `http-server.ts` — Serializes groupId in conversation summary, includes groups array on first page of list response, registers group routes
- `route-policy.ts` — Policy entries for all group endpoints
- `conversation-management-routes.ts` — Reorder handler accepts groupId
- `scheduler.ts` — Passes `groupId: "system:scheduled"` to all conversation creation paths
- `schedule-routes.ts` — Manual schedule runs pass `groupId: "system:scheduled"`
- `task-runner.ts` — Schedule tasks get "system:scheduled", non-schedule tasks get "system:background" with explicit `source: "task"` provenance
- `heartbeat-service.ts` — Passes `groupId: "system:background"`

### Swift clients (shared)
- `GeneratedAPITypes.swift` — Added `groupId` to `ConversationListResponseItem` and `ReorderConversationsRequestUpdate`, added `ConversationGroupResponse` struct, added `groups` to `ConversationListResponse`
- `NetworkResponseTypes.swift` — Added `groupId` to `ConversationsListResponse.Conversation`
- `ConversationListClient.swift` — Group API methods (fetch, create, update, delete, reorder), tri-state groupId serialization with `#if os(macOS)`, updated decode DTOs
- `ConversationForkClient.swift`, `ConversationDetailClient.swift` — Pass groupId through

### macOS (new file)
- `ConversationGroup.swift` — Model with static `pinned`/`scheduled`/`background` constants

### iOS
- `IOSConversationStore.swift` — Added `groupId` to `IOSConversation`, populated from server response, omitted from reorder payloads

## Key design decisions
- `group_id` is raw-query-only (NOT in Drizzle schema), matching `display_order`/`is_pinned` pattern
- Old clients without groupId preserve existing group_id (backward-compat)
- System groups are immutable via API (403 on PATCH/DELETE/reorder)
- Custom group sort_position >= 3 (system groups at 0, 1, 2)
- Fork inherits group_id server-side, not from client

## Test plan
- [ ] Existing macOS/iOS clients work identically
- [ ] Old clients pin/unpin correctly without groupId
- [ ] System groups immutable via API
- [ ] Server-created conversations get correct group assignments
- [ ] Fork inherits group_id from parent
- [ ] Route policy guard test passes
- [ ] Boundary guard test passes

Closes #21831

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21845" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
