### PR TITLE
refactor: migrate ChatAttachmentManager to @Observable with Combine bridges

### DIFF
--- a/clients/AGENTS.md
+++ b/clients/AGENTS.md
@@ -75,7 +75,7 @@ The following classes have been migrated from `ObservableObject` to `@Observable
 
 **macOS-only:** QuickInputTextModel, DevModeManager, RecordingHUDViewModel, NavigationHistory, AmbientAgent, DocumentManager, E2EStatusOverlayViewModel, WatchSession, SurfaceViewModel, SurfaceManager, AppListManager, TerminalSessionManager, MessageAudioPlayer, ContactsViewModel, OpenAIVoiceService, SkillsManager
 
-**Shared (macOS + iOS):** InlineVideoEmbedStateManager, ContactsStore, MemoryItemsStore, ChannelTrustStore, ChatErrorManager, ChatGreetingState, TaskProgressOverlayManager
+**Shared (macOS + iOS):** InlineVideoEmbedStateManager, ContactsStore, MemoryItemsStore, ChannelTrustStore, ChatErrorManager, ChatGreetingState, TaskProgressOverlayManager, ChatAttachmentManager
 
 </details>
 
@@ -90,7 +90,7 @@ These classes stay `ObservableObject` because they have deep Combine integration
 | `MainWindowState` | Bridges `@Observable` NavigationHistory via `withObservationTracking`; uses `objectWillChange` forwarding |
 | `VoiceModeManager` | Complex Combine pipelines (audio streams, state machine transitions) |
 | `ConversationManager` | Hub object subscribing to many child `objectWillChange` publishers; complex lifecycle |
-| `ChatViewModel` | Extensive Combine pipelines (SSE streaming, message coalescing, debounce); bridges `@Observable` ChatErrorManager and ChatGreetingState via `withObservationTracking` |
+| `ChatViewModel` | Extensive Combine pipelines (SSE streaming, message coalescing, debounce); bridges `@Observable` ChatErrorManager, ChatGreetingState, and ChatAttachmentManager via `withObservationTracking` |
 | `ChatMessageManager` | Tightly coupled to ChatViewModel's Combine publish pipeline |
 | `GatewayConnectionManager` | Combine-based SSE event stream processing |
 | `RecordingManager` | Audio capture Combine pipelines |

--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -628,7 +628,7 @@ extension AppDelegate {
         if let imageData {
             viewModel.addAttachment(imageData: imageData, filename: "Screenshot.jpg")
             viewModel.inputText = message
-            quickInputAttachmentCancellable = viewModel.attachmentManager.$isLoadingAttachment
+            quickInputAttachmentCancellable = viewModel.attachmentManager.isLoadingAttachmentPublisher
                 .filter { !$0 }
                 .first()
                 .sink { [weak self] _ in

--- a/clients/shared/Features/Chat/ChatAttachmentManager.swift
+++ b/clients/shared/Features/Chat/ChatAttachmentManager.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import os
 import UniformTypeIdentifiers
@@ -41,15 +42,30 @@ private actor AsyncSemaphore {
 /// computed properties so every existing call site continues to compile without
 /// modification.
 @MainActor
-public final class ChatAttachmentManager: ObservableObject {
+@Observable
+public final class ChatAttachmentManager {
 
-    @Published public var pendingAttachments: [ChatAttachment] = []
+    public var pendingAttachments: [ChatAttachment] = []
     /// True while at least one attachment is being loaded in the background.
     /// The send button checks this so a user can't send before async load finishes.
-    @Published public var isLoadingAttachment: Bool = false
+    public var isLoadingAttachment: Bool = false {
+        didSet {
+            isLoadingAttachmentSubject.send(isLoadingAttachment)
+        }
+    }
+
+    // MARK: - Combine compatibility
+
+    /// Combine bridge for `isLoadingAttachment`, consumed by
+    /// `AppDelegate+InputMonitors` to wait for attachment loading before sending.
+    private let isLoadingAttachmentSubject = CurrentValueSubject<Bool, Never>(false)
+    public var isLoadingAttachmentPublisher: AnyPublisher<Bool, Never> {
+        isLoadingAttachmentSubject.eraseToAnyPublisher()
+    }
 
     // Counts in-flight background loads; isLoadingAttachment is true when > 0.
-    private var loadingCount: Int = 0 {
+    // Not observed by views — only drives `isLoadingAttachment` via didSet.
+    @ObservationIgnored private var loadingCount: Int = 0 {
         didSet { isLoadingAttachment = loadingCount > 0 }
     }
 
@@ -82,7 +98,7 @@ public final class ChatAttachmentManager: ObservableObject {
     // MARK: - Error callback
 
     /// Called when an operation fails, so ChatViewModel can surface the error.
-    public var onError: ((String) -> Void)?
+    @ObservationIgnored public var onError: ((String) -> Void)?
 
     // MARK: - Error type
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -276,6 +276,26 @@ public final class ChatViewModel: ObservableObject, MessageSendCoordinatorDelega
         }
     }
 
+    // MARK: - @Observable → ObservableObject bridge for ChatAttachmentManager
+
+    /// Recursively observe all tracked properties on the @Observable
+    /// ChatAttachmentManager and forward changes into ChatViewModel's
+    /// ObservableObject objectWillChange via the coalesced publish path.
+    private func observeAttachmentManager() {
+        withObservationTracking {
+            _ = attachmentManager.pendingAttachments
+            _ = attachmentManager.isLoadingAttachment
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.scheduleCoalescedPublish()
+                #if DEBUG
+                self?.trackPublish(source: "attachmentManager")
+                #endif
+                self?.observeAttachmentManager() // re-arm
+            }
+        }
+    }
+
     // MARK: - Debug publish-rate counters
 
     private static let stallLog = OSLog(subsystem: "com.vellum.assistant", category: "LayoutStall")
@@ -1166,14 +1186,11 @@ public final class ChatViewModel: ObservableObject, MessageSendCoordinatorDelega
                 #endif
             }
             .store(in: &cancellables)
-        attachmentManager.objectWillChange
-            .sink { [weak self] _ in
-                self?.scheduleCoalescedPublish()
-                #if DEBUG
-                self?.trackPublish(source: "attachmentManager")
-                #endif
-            }
-            .store(in: &cancellables)
+        // ChatAttachmentManager is @Observable — bridge its changes into
+        // ChatViewModel's ObservableObject objectWillChange via
+        // withObservationTracking so views that read attachment state through
+        // ChatViewModel's computed forwarding properties still update.
+        observeAttachmentManager()
         // ChatErrorManager is @Observable — bridge its changes into
         // ChatViewModel's ObservableObject objectWillChange via
         // withObservationTracking so views that read error state through


### PR DESCRIPTION
## Summary
- Migrate ChatAttachmentManager from ObservableObject to @Observable
- Remove @Published from pendingAttachments and isLoadingAttachment
- Add withObservationTracking bridge in ChatViewModel for coalesced publish
- Add CurrentValueSubject Combine wrapper for isLoadingAttachment (consumed by AppDelegate+InputMonitors)
- Update AppDelegate+InputMonitors to use isLoadingAttachmentPublisher instead of $isLoadingAttachment
- Update clients/AGENTS.md migrated class list

Part of plan: chatvm-observable-migration.md (PR 11 of 13)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21849" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
