### PR TITLE
refactor: migrate ChatMessageManager to @Observable with CurrentValueSubject Combine bridges

### DIFF
--- a/clients/AGENTS.md
+++ b/clients/AGENTS.md
@@ -75,7 +75,7 @@ The following classes have been migrated from `ObservableObject` to `@Observable
 
 **macOS-only:** QuickInputTextModel, DevModeManager, RecordingHUDViewModel, NavigationHistory, AmbientAgent, DocumentManager, E2EStatusOverlayViewModel, WatchSession, SurfaceViewModel, SurfaceManager, AppListManager, TerminalSessionManager, MessageAudioPlayer, ContactsViewModel, OpenAIVoiceService, SkillsManager
 
-**Shared (macOS + iOS):** InlineVideoEmbedStateManager, ContactsStore, MemoryItemsStore, ChannelTrustStore, ChatErrorManager, ChatGreetingState, TaskProgressOverlayManager, ChatAttachmentManager
+**Shared (macOS + iOS):** InlineVideoEmbedStateManager, ContactsStore, MemoryItemsStore, ChannelTrustStore, ChatErrorManager, ChatGreetingState, TaskProgressOverlayManager, ChatAttachmentManager, ChatMessageManager
 
 </details>
 
@@ -90,8 +90,7 @@ These classes stay `ObservableObject` because they have deep Combine integration
 | `MainWindowState` | Bridges `@Observable` NavigationHistory via `withObservationTracking`; uses `objectWillChange` forwarding |
 | `VoiceModeManager` | Complex Combine pipelines (audio streams, state machine transitions) |
 | `ConversationManager` | Hub object subscribing to many child `objectWillChange` publishers; complex lifecycle |
-| `ChatViewModel` | Extensive Combine pipelines (SSE streaming, message coalescing, debounce); bridges `@Observable` ChatErrorManager, ChatGreetingState, and ChatAttachmentManager via `withObservationTracking` |
-| `ChatMessageManager` | Tightly coupled to ChatViewModel's Combine publish pipeline |
+| `ChatViewModel` | Extensive Combine pipelines (SSE streaming, message coalescing, debounce); bridges `@Observable` ChatErrorManager, ChatGreetingState, ChatAttachmentManager, and ChatMessageManager via `withObservationTracking` |
 | `GatewayConnectionManager` | Combine-based SSE event stream processing |
 | `RecordingManager` | Audio capture Combine pipelines |
 | `RecordingSourcePickerViewModel` | ScreenCaptureKit async sequences + Combine |

--- a/clients/ios/App/IOSConversationStore.swift
+++ b/clients/ios/App/IOSConversationStore.swift
@@ -939,7 +939,7 @@ class IOSConversationStore: ObservableObject {
         guard !observedForkAvailabilityConversationIds.contains(conversationLocalId) else { return }
         observedForkAvailabilityConversationIds.insert(conversationLocalId)
 
-        vm.messageManager.$messages
+        vm.messageManager.messagesPublisher
             .map { messages in
                 messages.last(where: { $0.daemonMessageId != nil && !$0.isStreaming && !$0.isHidden })?.daemonMessageId
             }
@@ -993,7 +993,7 @@ class IOSConversationStore: ObservableObject {
         // Find the conversation's default title; skip if already customized.
         guard conversations.first(where: { $0.id == conversationLocalId })?.title == "New Chat" else { return }
 
-        vm.messageManager.$messages
+        vm.messageManager.messagesPublisher
             .dropFirst()
             .compactMap { messages -> String? in
                 // Trigger once we have at least one user message and the first assistant
@@ -1029,7 +1029,7 @@ class IOSConversationStore: ObservableObject {
         guard !observedActivityConversationIds.contains(conversationLocalId) else { return }
         observedActivityConversationIds.insert(conversationLocalId)
 
-        vm.messageManager.$messages
+        vm.messageManager.messagesPublisher
             .dropFirst()
             .map(\.count)
             .removeDuplicates()

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -2183,9 +2183,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         let mgr = viewModel.messageManager
         // Combine the three relevant publishers into a single derived boolean.
         Publishers.CombineLatest3(
-            mgr.$isSending,
-            mgr.$isThinking,
-            mgr.$pendingQueuedCount
+            mgr.isSendingPublisher,
+            mgr.isThinkingPublisher,
+            mgr.pendingQueuedCountPublisher
         )
         .map { isSending, isThinking, pendingQueuedCount in
             isSending || isThinking || pendingQueuedCount > 0
@@ -2226,7 +2226,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             latestAssistantActivitySnapshots.removeValue(forKey: conversationId)
         }
 
-        assistantActivityCancellables[conversationId] = viewModel.messageManager.$messages
+        assistantActivityCancellables[conversationId] = viewModel.messageManager.messagesPublisher
             .map { [weak self] messages in
                 self?.latestAssistantActivitySnapshot(in: messages)
             }
@@ -2347,10 +2347,10 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         // WaitingForInput: hasPendingConfirmation (derived from messages).
         // Processing: isSending || isThinking || pendingQueuedCount > 0.
         Publishers.CombineLatest4(
-            msgMgr.$isSending,
-            msgMgr.$isThinking,
-            msgMgr.$pendingQueuedCount,
-            msgMgr.$messages
+            msgMgr.isSendingPublisher,
+            msgMgr.isThinkingPublisher,
+            msgMgr.pendingQueuedCountPublisher,
+            msgMgr.messagesPublisher
         )
         .combineLatest(
             errorSubject
@@ -2422,7 +2422,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         // Subscribe to the new active view model if one exists
         guard let viewModel = activeViewModel else { return }
 
-        activeViewModelCancellable = viewModel.messageManager.$messages
+        activeViewModelCancellable = viewModel.messageManager.messagesPublisher
             .map { $0.count }
             .removeDuplicates()
             .sink { [weak self] count in

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -126,14 +126,14 @@ final class VoiceModeManager: ObservableObject {
         chatViewModel.isVoiceModeActive = true
 
         // Monitor for permission requests during voice mode
-        messageCancellable = chatViewModel.messageManager.$messages
+        messageCancellable = chatViewModel.messageManager.messagesPublisher
             .sink { [weak self] messages in
                 self?.checkForConfirmations(in: messages)
             }
 
         // Pause the conversation timeout while the agent is executing tools,
         // preventing auto-deactivation during multi-step tool sequences.
-        isThinkingCancellable = chatViewModel.messageManager.$isThinking
+        isThinkingCancellable = chatViewModel.messageManager.isThinkingPublisher
             .removeDuplicates()
             .sink { [weak self] thinking in
                 guard let self, self.state == .idle else { return }

--- a/clients/shared/Features/Chat/ChatMessageManager.swift
+++ b/clients/shared/Features/Chat/ChatMessageManager.swift
@@ -11,38 +11,59 @@ import UIKit
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ChatMessageManager")
 
-/// Owns all message-list and send-state @Published properties that were previously
+/// Owns all message-list and send-state properties that were previously
 /// scattered across ChatViewModel.  ChatViewModel holds a reference to this object
 /// and forwards reads/writes via computed properties so every existing call site
 /// continues to compile without modification.
-@MainActor
-public final class ChatMessageManager: ObservableObject {
+@MainActor @Observable
+public final class ChatMessageManager {
 
     // MARK: - Message list
 
-    @Published public var messages: [ChatMessage] = []
+    public var messages: [ChatMessage] = []
 
     /// Active pending confirmation request ID, derived from `messages` via a
     /// Combine pipeline. Views read this O(1) cached value instead of scanning
     /// the message array each render cycle.
     ///
-    /// Not `@Published` — this value only changes when `messages` changes, and
-    /// `messages` is already `@Published`. A second `@Published` here would
-    /// emit a redundant `objectWillChange` in the same willSet call stack,
-    /// doubling SwiftUI invalidation during streaming.
-    ///
     /// - SeeAlso: [Improving your app's performance (Apple Developer)](https://developer.apple.com/documentation/swiftui/improving-your-app-s-performance)
     /// - SeeAlso: [WWDC23 — Demystify SwiftUI performance](https://developer.apple.com/videos/play/wwdc2023/10160/)
     public private(set) var activePendingRequestId: String?
 
-    private var activePendingRequestIdSub: AnyCancellable?
+    @ObservationIgnored private var activePendingRequestIdSub: AnyCancellable?
+
+    // MARK: - Combine bridges (CurrentValueSubject)
+
+    /// Combine bridge for `messages`, backed by a CurrentValueSubject for
+    /// immediate-value semantics on subscription.
+    @ObservationIgnored private let _messagesSubject = CurrentValueSubject<[ChatMessage], Never>([])
+    public var messagesPublisher: AnyPublisher<[ChatMessage], Never> { _messagesSubject.eraseToAnyPublisher() }
+
+    /// Combine bridge for `isSending`.
+    @ObservationIgnored private let _isSendingSubject = CurrentValueSubject<Bool, Never>(false)
+    public var isSendingPublisher: AnyPublisher<Bool, Never> { _isSendingSubject.eraseToAnyPublisher() }
+
+    /// Combine bridge for `isThinking`.
+    @ObservationIgnored private let _isThinkingSubject = CurrentValueSubject<Bool, Never>(false)
+    public var isThinkingPublisher: AnyPublisher<Bool, Never> { _isThinkingSubject.eraseToAnyPublisher() }
+
+    /// Combine bridge for `pendingQueuedCount`.
+    @ObservationIgnored private let _pendingQueuedCountSubject = CurrentValueSubject<Int, Never>(0)
+    public var pendingQueuedCountPublisher: AnyPublisher<Int, Never> { _pendingQueuedCountSubject.eraseToAnyPublisher() }
 
     init() {
+        // Start the withObservationTracking sync loops that keep the
+        // CurrentValueSubjects in sync with the @Observable properties.
+        syncMessagesPublisher()
+        syncIsSendingPublisher()
+        syncIsThinkingPublisher()
+        syncPendingQueuedCountPublisher()
+
         // Uses visibleMessages (all non-hidden) rather than paginatedMessages
         // because pending confirmations are always near the end of the list,
         // within the initial pagination window. The broader scope ensures the
         // model always knows the true pending state regardless of pagination.
-        activePendingRequestIdSub = $messages
+        activePendingRequestIdSub = messagesPublisher
             .map { messages in
                 PendingConfirmationFocusSelector.activeRequestId(
                     from: ChatVisibleMessageFilter.visibleMessages(from: messages)
@@ -54,66 +75,108 @@ public final class ChatMessageManager: ObservableObject {
             }
     }
 
+    // MARK: - Sync loops
+
+    private func syncMessagesPublisher() {
+        withObservationTracking {
+            _messagesSubject.send(self.messages)
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.syncMessagesPublisher()
+            }
+        }
+    }
+
+    private func syncIsSendingPublisher() {
+        withObservationTracking {
+            _isSendingSubject.send(self.isSending)
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.syncIsSendingPublisher()
+            }
+        }
+    }
+
+    private func syncIsThinkingPublisher() {
+        withObservationTracking {
+            _isThinkingSubject.send(self.isThinking)
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.syncIsThinkingPublisher()
+            }
+        }
+    }
+
+    private func syncPendingQueuedCountPublisher() {
+        withObservationTracking {
+            _pendingQueuedCountSubject.send(self.pendingQueuedCount)
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.syncPendingQueuedCountPublisher()
+            }
+        }
+    }
+
     // MARK: - Input / send state
 
-    @Published public var inputText: String = ""
-    @Published public var isThinking: Bool = false
-    @Published public var isSending: Bool = false
-    @Published public var assistantActivityPhase: String = "idle"
-    @Published public var assistantActivityAnchor: String = "global"
-    @Published public var assistantActivityReason: String?
-    @Published public var assistantStatusText: String?
-    @Published public var isCompacting: Bool = false
-    @Published public var pendingQueuedCount: Int = 0
-    @Published public var suggestion: String?
-    @Published public var isRecording: Bool = false
-    @Published public var recordingAmplitude: Float = 0
+    public var inputText: String = ""
+    public var isThinking: Bool = false
+    public var isSending: Bool = false
+    public var assistantActivityPhase: String = "idle"
+    public var assistantActivityAnchor: String = "global"
+    public var assistantActivityReason: String?
+    public var assistantStatusText: String?
+    public var isCompacting: Bool = false
+    public var pendingQueuedCount: Int = 0
+    public var suggestion: String?
+    public var isRecording: Bool = false
+    public var recordingAmplitude: Float = 0
 
     // MARK: - Workspace refinement
 
-    @Published public var isWorkspaceRefinementInFlight: Bool = false
+    public var isWorkspaceRefinementInFlight: Bool = false
     /// The user's sent text shown while a refinement is in progress.
-    @Published public var refinementMessagePreview: String?
+    public var refinementMessagePreview: String?
     /// The AI response as it streams during a refinement.
-    @Published public var refinementStreamingText: String?
+    public var refinementStreamingText: String?
     /// Tracks whether a cancel was initiated during a workspace refinement.
     /// Used by `messageComplete` to correctly suppress refinement side-effects
     /// even though `isWorkspaceRefinementInFlight` is cleared immediately for UI.
-    public var cancelledDuringRefinement: Bool = false
+    @ObservationIgnored public var cancelledDuringRefinement: Bool = false
     /// Text buffered during a workspace refinement (normally suppressed from chat).
     /// Surfaced to the user if the refinement completes without a surface update.
-    public var refinementTextBuffer: String = ""
-    public var refinementReceivedSurfaceUpdate: Bool = false
+    @ObservationIgnored public var refinementTextBuffer: String = ""
+    @ObservationIgnored public var refinementReceivedSurfaceUpdate: Bool = false
     /// When non-nil, displays a toast in the workspace with the AI's response
     /// after a refinement that produced no surface update.
-    @Published public var refinementFailureText: String?
-    public var refinementFailureDismissTask: Task<Void, Never>?
+    public var refinementFailureText: String?
+    @ObservationIgnored public var refinementFailureDismissTask: Task<Void, Never>?
     /// Coalesces refinement streaming text updates with a 50ms throttle,
     /// preventing republishing the entire accumulated buffer on every token.
-    public var refinementFlushTask: Task<Void, Never>?
+    @ObservationIgnored public var refinementFlushTask: Task<Void, Never>?
 
     // MARK: - Surface / undo
 
     /// Number of undo steps available for the active workspace surface.
-    @Published public var surfaceUndoCount: Int = 0
+    public var surfaceUndoCount: Int = 0
 
     // MARK: - Skill / subagent
 
-    @Published public var pendingSkillInvocation: SkillInvocationData?
-    @Published public var isWatchSessionActive: Bool = false
-    @Published public var activeSubagents: [SubagentInfo] = []
+    public var pendingSkillInvocation: SkillInvocationData?
+    public var isWatchSessionActive: Bool = false
+    public var activeSubagents: [SubagentInfo] = []
     /// Widget IDs dismissed by the user, persisted across view recreation.
-    @Published public var dismissedDocumentSurfaceIds: Set<String> = []
+    public var dismissedDocumentSurfaceIds: Set<String> = []
 
     // MARK: - Model / provider
 
     /// The currently active model ID, updated via `model_info` messages.
-    @Published public var selectedModel: String = "claude-opus-4-6"
+    public var selectedModel: String = "claude-opus-4-6"
     /// Set of provider keys with configured API keys, updated via `model_info` messages.
-    @Published public var configuredProviders: Set<String> = ["anthropic"]
+    public var configuredProviders: Set<String> = ["anthropic"]
     /// Full provider catalog from daemon, updated via `model_info` messages.
     /// Seeded with inline defaults so the UI has data before the first daemon fetch completes.
-    @Published public var providerCatalog: [ProviderCatalogEntry] = ProviderCatalogEntry.defaultCatalog
+    public var providerCatalog: [ProviderCatalogEntry] = ProviderCatalogEntry.defaultCatalog
 
 }
 

--- a/clients/shared/Features/Chat/ChatPaginationState.swift
+++ b/clients/shared/Features/Chat/ChatPaginationState.swift
@@ -68,7 +68,7 @@ public final class ChatPaginationState {
 
     // MARK: - Dependencies
 
-    /// The message manager whose `$messages` publisher drives `displayedMessages`.
+    /// The message manager whose `messagesPublisher` drives `displayedMessages`.
     private let messageManager: ChatMessageManager
 
     /// Callback invoked when `loadPreviousMessagePage` needs to fetch an older
@@ -81,8 +81,8 @@ public final class ChatPaginationState {
     /// Set after init to avoid capturing `self` before ChatViewModel is fully initialized.
     var conversationIdProvider: () -> String? = { nil }
 
-    /// Combine subscription for the throttled $messages -> displayedMessages sync.
-    private var messagesSyncSub: AnyCancellable?
+    /// Combine subscription for the throttled messagesPublisher -> displayedMessages sync.
+    @ObservationIgnored private var messagesSyncSub: AnyCancellable?
 
     // MARK: - Init
 
@@ -97,13 +97,12 @@ public final class ChatPaginationState {
         //
         // Two correctness/perf fixes applied here:
         // 1. Use the delivered `newMessages` value directly rather than reading
-        //    `self.messages` inside the sink. @Published fires during willSet, so
-        //    the stored property still holds the OLD value when the subscriber runs
-        //    — reading it caused displayedMessages to lag one mutation behind.
+        //    `self.messages` inside the sink. The CurrentValueSubject bridge
+        //    delivers the latest value at the point of emission.
         // 2. Throttle to 50ms so displayedMessages (and any SwiftUI views observing
         //    it) only refresh at most every 50ms, matching the coalesced publish
         //    window used for the rest of the view model.
-        messagesSyncSub = messageManager.$messages
+        messagesSyncSub = messageManager.messagesPublisher
             .throttle(for: .milliseconds(50), scheduler: RunLoop.main, latest: true)
             .sink { [weak self] newMessages in
                 self?.displayedMessages = ChatVisibleMessageFilter.visibleMessages(from: newMessages)

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -185,6 +185,50 @@ public final class ChatViewModel: ObservableObject, MessageSendCoordinatorDelega
         objectWillChange.send()
     }
 
+    // MARK: - @Observable → ObservableObject bridge for ChatMessageManager
+
+    /// Recursively observe all tracked properties on the @Observable
+    /// ChatMessageManager and forward changes into ChatViewModel's
+    /// ObservableObject objectWillChange via the coalesced publish path.
+    private func observeMessageManager() {
+        withObservationTracking {
+            _ = messageManager.messages
+            _ = messageManager.inputText
+            _ = messageManager.isThinking
+            _ = messageManager.isSending
+            _ = messageManager.assistantActivityPhase
+            _ = messageManager.assistantActivityAnchor
+            _ = messageManager.assistantActivityReason
+            _ = messageManager.assistantStatusText
+            _ = messageManager.isCompacting
+            _ = messageManager.pendingQueuedCount
+            _ = messageManager.suggestion
+            _ = messageManager.isRecording
+            _ = messageManager.recordingAmplitude
+            _ = messageManager.isWorkspaceRefinementInFlight
+            _ = messageManager.refinementMessagePreview
+            _ = messageManager.refinementStreamingText
+            _ = messageManager.refinementFailureText
+            _ = messageManager.surfaceUndoCount
+            _ = messageManager.pendingSkillInvocation
+            _ = messageManager.isWatchSessionActive
+            _ = messageManager.activeSubagents
+            _ = messageManager.dismissedDocumentSurfaceIds
+            _ = messageManager.selectedModel
+            _ = messageManager.configuredProviders
+            _ = messageManager.providerCatalog
+            _ = messageManager.activePendingRequestId
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.scheduleCoalescedPublish()
+                #if DEBUG
+                self?.trackPublish(source: "messageManager")
+                #endif
+                self?.observeMessageManager() // re-arm
+            }
+        }
+    }
+
     // MARK: - @Observable → ObservableObject bridge for ChatErrorManager
 
     /// Recursively observe all tracked properties on the @Observable
@@ -1082,8 +1126,8 @@ public final class ChatViewModel: ObservableObject, MessageSendCoordinatorDelega
         }
         // Hard-delete the stripped messages so ChatMessage objects are freed entirely.
         messages.removeSubrange(0..<trimEnd)
-        // displayedMessages is updated automatically via the messageManager.$messages
-        // publisher subscription set up in init.
+        // displayedMessages is updated automatically via the messageManager.messagesPublisher
+        // Combine bridge subscription set up in ChatPaginationState init.
         // After deleting the oldest messages, advance the history cursor to the oldest
         // retained message and mark that older pages are available from the daemon so
         // the user can paginate back to re-fetch the trimmed messages.
@@ -1183,14 +1227,11 @@ public final class ChatViewModel: ObservableObject, MessageSendCoordinatorDelega
         // into a single objectWillChange per 50ms window. Views still
         // update promptly, but the SwiftUI diffing cost drops dramatically.
 
-        messageManager.objectWillChange
-            .sink { [weak self] _ in
-                self?.scheduleCoalescedPublish()
-                #if DEBUG
-                self?.trackPublish(source: "messageManager")
-                #endif
-            }
-            .store(in: &cancellables)
+        // ChatMessageManager is @Observable — bridge its changes into
+        // ChatViewModel's ObservableObject objectWillChange via
+        // withObservationTracking so views that read message state through
+        // ChatViewModel's computed forwarding properties still update.
+        observeMessageManager()
         // ChatAttachmentManager is @Observable — bridge its changes into
         // ChatViewModel's ObservableObject objectWillChange via
         // withObservationTracking so views that read attachment state through


### PR DESCRIPTION
## Summary
- Migrate ChatMessageManager from ObservableObject to @Observable
- Add CurrentValueSubject Combine bridges for messages, isSending, isThinking, pendingQueuedCount
- Update ConversationManager subscribers to use new publisher properties
- Update ChatPaginationState to use messagesPublisher instead of $messages
- Add withObservationTracking bridge in ChatViewModel for coalesced publish
- Update VoiceModeManager and IOSConversationStore to use new publisher properties
- Update clients/AGENTS.md migrated class list

Part of plan: chatvm-observable-migration.md (PR 10 of 13)

## Test plan
- [ ] Verify macOS and iOS targets build
- [ ] Verify existing tests in ChatViewModelTests.swift, ChatViewModelForkCommandTests.swift pass
- [ ] Verify chat message sending/receiving works
- [ ] Verify busy state indicators work in conversation sidebar
- [ ] Verify voice mode confirmations still trigger
- [ ] Verify pagination (load more messages) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21851" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
