### PR TITLE
M3: Sidebar Views — Collapsible Group Headers

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
@@ -39,12 +39,65 @@ final class SidebarInteractionState {
     var isHoveredApp: String?
     var renamingConversationId: UUID?
     var renameText: String = ""
-    var showAllConversations: Bool = false
-    var showAllScheduleConversations: Bool = false
-    var showAllBackgroundConversations: Bool = false
+    /// Set of group IDs whose sections are currently expanded.
+    /// Defaults to showing the pinned section expanded.
+    var expandedSections: Set<String> = {
+        // Migrate from old per-section booleans on first access.
+        let defaults = UserDefaults.standard
+        var initial: Set<String> = []
+
+        // If we have persisted expandedSections, use those.
+        if let saved = defaults.stringArray(forKey: "sidebar.expandedSections") {
+            initial = Set(saved)
+        } else {
+            // First-launch defaults: all system groups expanded.
+            initial = [
+                ConversationGroup.pinned.id,
+                ConversationGroup.scheduled.id,
+                ConversationGroup.background.id,
+            ]
+        }
+
+        // Clean up old keys (one-time migration).
+        for key in ["showAllConversations", "showAllScheduleConversations", "showAllBackgroundConversations"] {
+            defaults.removeObject(forKey: key)
+        }
+
+        return initial
+    }() {
+        didSet {
+            UserDefaults.standard.set(Array(expandedSections), forKey: "sidebar.expandedSections")
+        }
+    }
+
+    /// Set of group IDs where "Show more" has been toggled on.
+    var showAllInSection: Set<String> = []
+
+    /// Group ID currently targeted during a drag-and-drop operation.
+    var dropTargetSectionId: String?
+
     /// Set of schedule group keys (scheduleJobId values) that are currently expanded.
     var expandedScheduleGroups: Set<String> = []
     var showAllApps: Bool = false
+
+    /// Toggles the expand/collapse state of a section.
+    func toggleSection(_ groupId: String) {
+        if expandedSections.contains(groupId) {
+            expandedSections.remove(groupId)
+        } else {
+            expandedSections.insert(groupId)
+        }
+    }
+
+    /// Toggles the show-all/show-less state of a section.
+    func toggleShowAll(_ groupId: String) {
+        if showAllInSection.contains(groupId) {
+            showAllInSection.remove(groupId)
+        } else {
+            showAllInSection.insert(groupId)
+        }
+    }
+
     var showPreferencesDrawer: Bool = false
 
     /// Updates conversation hover state. Centralises the invariant so callers

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -2,6 +2,15 @@ import SwiftUI
 import UniformTypeIdentifiers
 import VellumAssistantShared
 
+// MARK: - Sidebar Group Entry
+
+/// Lightweight identifiable wrapper for ForEach over grouped conversations.
+private struct SidebarGroupEntry: Identifiable {
+    let id: String
+    let group: ConversationGroup?
+    let conversations: [ConversationModel]
+}
+
 // MARK: - Sidebar Content
 
 extension MainWindowView {
@@ -15,6 +24,13 @@ extension MainWindowView {
         }
         windowState.selection = .conversation(conversation.id)
         conversationManager.selectConversation(id: conversation.id)
+
+        // Auto-expand the section containing the selected conversation
+        // so it's always visible in the sidebar.
+        if let groupId = conversation.groupId,
+           !sidebar.expandedSections.contains(groupId) {
+            sidebar.expandedSections.insert(groupId)
+        }
     }
 
     func startNewConversation() {
@@ -29,83 +45,10 @@ extension MainWindowView {
         }
     }
 
+    /// All non-schedule/non-background conversations for the collapsed sidebar switcher.
+    /// Flat count regardless of custom group membership.
     var regularConversations: [ConversationModel] {
         conversationManager.visibleConversations.filter { !$0.isScheduleConversation && !$0.isBackgroundConversation }
-    }
-
-    var backgroundConversations: [ConversationModel] {
-        conversationManager.visibleConversations.filter { $0.isBackgroundConversation }
-    }
-
-    var scheduleConversations: [ConversationModel] {
-        conversationManager.visibleConversations.filter { $0.isScheduleConversation }
-    }
-
-    var displayedConversations: [ConversationModel] {
-        let all = regularConversations
-        return sidebar.showAllConversations ? all : Array(all.prefix(5))
-    }
-
-    var displayedScheduleConversations: [ConversationModel] {
-        let all = scheduleConversations
-        return sidebar.showAllScheduleConversations ? all : Array(all.prefix(3))
-    }
-
-    var displayedBackgroundConversations: [ConversationModel] {
-        let all = backgroundConversations
-        if sidebar.showAllBackgroundConversations { return all }
-        // Auto-expand if any hidden conversation has unread messages.
-        let visible = Array(all.prefix(3))
-        let hidden = all.dropFirst(3)
-        if hidden.contains(where: { $0.hasUnseenLatestAssistantMessage }) {
-            return all
-        }
-        return visible
-    }
-
-    /// Groups schedule conversations by their scheduleJobId.
-    /// Conversations without a scheduleJobId are placed in individual groups keyed by their conversation ID.
-    var scheduleConversationGroups: [(key: String, label: String, conversations: [ConversationModel])] {
-        var grouped: [String: [ConversationModel]] = [:]
-        var order: [String] = []
-        for conversation in scheduleConversations {
-            let key = conversation.scheduleJobId ?? conversation.conversationId ?? conversation.id.uuidString
-            if grouped[key] == nil {
-                order.append(key)
-            }
-            grouped[key, default: []].append(conversation)
-        }
-        return order.compactMap { key in
-            guard let conversations = grouped[key], let first = conversations.first else { return nil }
-            // Use the schedule title prefix (before the colon) as the group label,
-            // or fall back to the full title when there's no colon.
-            let label: String
-            if conversations.count > 1 {
-                let base = first.title
-                if let colonRange = base.range(of: ":") {
-                    label = String(base[base.startIndex..<colonRange.lowerBound])
-                } else {
-                    label = base
-                }
-            } else {
-                label = first.title
-            }
-            return (key: key, label: label, conversations: conversations)
-        }
-    }
-
-    var displayedScheduleGroups: [(key: String, label: String, conversations: [ConversationModel])] {
-        let all = scheduleConversationGroups
-        if sidebar.showAllScheduleConversations { return all }
-        // Auto-expand if any hidden group has unread conversations.
-        let visible = Array(all.prefix(3))
-        let hidden = all.dropFirst(3)
-        if hidden.contains(where: { group in
-            group.conversations.contains(where: { $0.hasUnseenLatestAssistantMessage })
-        }) {
-            return all
-        }
-        return visible
     }
 
     var displayedApps: [AppListManager.AppItem] {
@@ -213,6 +156,66 @@ extension MainWindowView {
         )
     }
 
+    // MARK: - Ungrouped Rows
+
+    /// Renders ungrouped conversations with drag-reorder support.
+    /// These appear without a collapsible header, matching the pre-groups layout.
+    @ViewBuilder
+    private func ungroupedConversationRows(_ conversations: [ConversationModel]) -> some View {
+        let displayed = sidebar.showAllInSection.contains("ungrouped")
+            ? conversations
+            : Array(conversations.prefix(5))
+
+        ForEach(displayed) { conversation in
+            makeSidebarRow(conversation: conversation)
+                .equatable()
+                .padding(.bottom, SidebarLayoutMetrics.listRowGap)
+                .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
+                    if sidebar.dropTargetConversationId == conversation.id {
+                        Rectangle()
+                            .fill(VColor.primaryBase)
+                            .frame(height: 2)
+                            .transition(.opacity)
+                    }
+                }
+                .dropDestination(for: String.self) { items, _ in
+                    sidebar.dropTargetConversationId = nil
+                    sidebar.draggingConversationId = nil
+                    guard let droppedId = items.first,
+                          let sourceUUID = UUID(uuidString: droppedId),
+                          sourceUUID != conversation.id else { return false }
+                    return conversationManager.moveConversation(sourceId: sourceUUID, targetId: conversation.id)
+                } isTargeted: { isTargeted in
+                    if isTargeted && conversation.id != sidebar.draggingConversationId {
+                        sidebar.dropTargetConversationId = conversation.id
+                        if let dragId = sidebar.draggingConversationId {
+                            let visible = conversationManager.visibleConversations
+                            let sIdx = visible.firstIndex(where: { $0.id == dragId }) ?? 0
+                            let tIdx = visible.firstIndex(where: { $0.id == conversation.id }) ?? 0
+                            sidebar.dropIndicatorAtBottom = sIdx < tIdx
+                        }
+                    } else if !isTargeted && sidebar.dropTargetConversationId == conversation.id {
+                        sidebar.dropTargetConversationId = nil
+                    }
+                }
+        }
+
+        if conversations.count > 5 {
+            HStack {
+                VButton(
+                    label: sidebar.showAllInSection.contains("ungrouped") ? "Show less" : "Show more",
+                    style: .ghost,
+                    size: .compact
+                ) {
+                    withAnimation(VAnimation.fast) { sidebar.toggleShowAll("ungrouped") }
+                }
+                Spacer()
+            }
+            .padding(.leading, VSpacing.xs + SidebarLayoutMetrics.iconSlotSize + VSpacing.xs - VSpacing.sm)
+            .padding(.bottom, VSpacing.xs)
+        }
+    }
+
     // MARK: - Pinned App Helpers
 
     /// A pinned app row — delegates layout to `SidebarPrimaryRow` for both
@@ -299,231 +302,51 @@ extension MainWindowView {
 
             ScrollView {
                 LazyVStack(spacing: 0) {
-                    if showDaemonLoading && displayedConversations.isEmpty {
+                    if showDaemonLoading && conversationManager.visibleConversations.isEmpty {
                         DaemonLoadingConversationsSkeleton()
                     }
 
-                    ForEach(displayedConversations) { conversation in
-                        makeSidebarRow(conversation: conversation)
-                            .equatable()
-                            .padding(.bottom, SidebarLayoutMetrics.listRowGap)
-                            .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
-                                if sidebar.dropTargetConversationId == conversation.id {
-                                    Rectangle()
-                                        .fill(VColor.primaryBase)
-                                        .frame(height: 2)
-                                        .transition(.opacity)
-                                }
-                            }
-                            .dropDestination(for: String.self) { items, _ in
-                                sidebar.dropTargetConversationId = nil
-                                sidebar.draggingConversationId = nil
-                                guard let droppedId = items.first,
-                                      let sourceUUID = UUID(uuidString: droppedId),
-                                      sourceUUID != conversation.id else { return false }
-                                return conversationManager.moveConversation(sourceId: sourceUUID, targetId: conversation.id)
-                            } isTargeted: { isTargeted in
-                                if isTargeted && conversation.id != sidebar.draggingConversationId {
-                                    sidebar.dropTargetConversationId = conversation.id
-                                    if let dragId = sidebar.draggingConversationId {
-                                        let visible = conversationManager.visibleConversations
-                                        let sIdx = visible.firstIndex(where: { $0.id == dragId }) ?? 0
-                                        let tIdx = visible.firstIndex(where: { $0.id == conversation.id }) ?? 0
-                                        sidebar.dropIndicatorAtBottom = sIdx < tIdx
-                                    }
-                                } else if !isTargeted && sidebar.dropTargetConversationId == conversation.id {
-                                    sidebar.dropTargetConversationId = nil
-                                }
-                            }
-                    }
-
-                    if regularConversations.count > 5 {
-                        HStack {
-                            VButton(
-                                label: sidebar.showAllConversations ? "Show less" : "Show more",
-                                style: .ghost,
-                                size: .compact
-                            ) {
-                                withAnimation(VAnimation.fast) { sidebar.showAllConversations.toggle() }
-                            }
-                            Spacer()
+                    let groupEntries = conversationManager.groupedConversations
+                        .map { entry in
+                            SidebarGroupEntry(
+                                id: entry.group?.id ?? "ungrouped",
+                                group: entry.group,
+                                conversations: entry.conversations
+                            )
                         }
-                        .padding(.leading, VSpacing.xs + SidebarLayoutMetrics.iconSlotSize + VSpacing.xs - VSpacing.sm)
-                        .padding(.bottom, VSpacing.xs)
-                    }
-
-                    if !scheduleConversations.isEmpty {
-                        // Scheduled conversations section
-                        HStack {
-                            Text("Scheduled")
-                                .font(VFont.labelDefault)
-                                .foregroundStyle(VColor.contentTertiary)
-                            Spacer()
-                        }
-                        .padding(.leading, SidebarLayoutMetrics.iconSlotSize)
-                        .padding(.trailing, VSpacing.md)
-                        .padding(.top, SidebarLayoutMetrics.scheduledHeaderTopGap)
-                        .padding(.bottom, SidebarLayoutMetrics.scheduledHeaderBottomGap)
-
-                        ForEach(displayedScheduleGroups, id: \.key) { group in
-                            if group.conversations.count == 1, let conversation = group.conversations.first {
-                                // Single-conversation group: render inline without a disclosure wrapper
-                                makeSidebarRow(conversation: conversation)
-                                    .equatable()
-                                    .padding(.bottom, SidebarLayoutMetrics.listRowGap)
-                                    .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
-                                        if sidebar.dropTargetConversationId == conversation.id {
-                                            Rectangle()
-                                                .fill(VColor.primaryBase)
-                                                .frame(height: 2)
-                                                .transition(.opacity)
-                                        }
-                                    }
-                                    .onDrop(of: [.plainText], delegate: ScheduleReorderDropDelegate(
-                                        targetConversation: conversation,
-                                        sidebar: sidebar,
-                                        conversationManager: conversationManager
-                                    ))
-                            } else {
-                                // Multi-conversation group: custom disclosure styled like a nav row
-                                let isGroupExpanded = sidebar.expandedScheduleGroups.contains(group.key)
-                                let hasUnread = !isGroupExpanded &&
-                                    group.conversations.contains(where: { $0.hasUnseenLatestAssistantMessage })
-
-                                // Header row — chevron in icon slot, label + count badge
-                                Button {
-                                    withAnimation(VAnimation.fast) {
-                                        if isGroupExpanded {
-                                            sidebar.expandedScheduleGroups.remove(group.key)
-                                        } else {
-                                            sidebar.expandedScheduleGroups.insert(group.key)
-                                        }
-                                    }
-                                } label: {
-                                    HStack(spacing: VSpacing.xs) {
-                                        HStack(spacing: 2) {
-                                            VIconView(.chevronRight, size: 10)
-                                                .foregroundStyle(VColor.contentTertiary)
-                                                .rotationEffect(.degrees(isGroupExpanded ? 90 : 0))
-                                                .animation(VAnimation.fast, value: isGroupExpanded)
-                                            if hasUnread {
-                                                Circle()
-                                                    .fill(VColor.systemNegativeStrong)
-                                                    .frame(width: 6, height: 6)
-                                                    .transition(.opacity)
-                                            }
-                                        }
-                                        .frame(height: SidebarLayoutMetrics.iconSlotSize)
-                                        Text(group.label)
-                                            .font(.system(size: 13))
-                                            .foregroundStyle(VColor.contentDefault)
-                                            .lineLimit(1)
-                                            .truncationMode(.tail)
-                                        Text("\(group.conversations.count)")
-                                            .font(.system(size: 10, weight: .medium))
-                                            .foregroundStyle(VColor.contentTertiary)
-                                            .padding(.horizontal, 6)
-                                            .padding(.vertical, 2)
-                                            .background(
-                                                Capsule()
-                                                    .fill(VColor.contentTertiary.opacity(0.12))
-                                            )
-                                        Spacer()
-                                    }
-                                    .padding(.leading, VSpacing.xs)
-                                    .padding(.trailing, VSpacing.sm)
-                                    .padding(.vertical, SidebarLayoutMetrics.rowVerticalPadding)
-                                    .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)
-                                    .contentShape(Rectangle())
-                                }
-                                .buttonStyle(.plain)
-                                .padding(.horizontal, VSpacing.sm)
-                                .pointerCursor()
-
-                                // Expanded child rows
-                                if isGroupExpanded {
-                                    ForEach(group.conversations) { conversation in
-                                        makeSidebarRow(conversation: conversation)
-                                            .equatable()
-                                            .padding(.bottom, SidebarLayoutMetrics.listRowGap)
-                                            .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
-                                                if sidebar.dropTargetConversationId == conversation.id {
-                                                    Rectangle()
-                                                        .fill(VColor.primaryBase)
-                                                        .frame(height: 2)
-                                                        .transition(.opacity)
-                                                }
-                                            }
-                                            .onDrop(of: [.plainText], delegate: ScheduleReorderDropDelegate(
-                                                targetConversation: conversation,
-                                                sidebar: sidebar,
-                                                conversationManager: conversationManager
-                                            ))
-                                    }
-                                }
-
-                                // Drop target on the group header so collapsed groups accept drops
-                                // (only from conversations within the same schedule group).
-                                if !isGroupExpanded {
-                                    Color.clear
-                                        .frame(height: 0)
-                                        .onDrop(of: [.plainText], delegate: ScheduleGroupHeaderDropDelegate(
-                                            group: group,
-                                            sidebar: sidebar,
-                                            conversationManager: conversationManager
-                                        ))
-                                }
-                            }
-                        }
-
-                        if scheduleConversationGroups.count > 3 {
-                            HStack {
-                                VButton(
-                                    label: sidebar.showAllScheduleConversations ? "Show less" : "Show more",
-                                    style: .ghost,
-                                    size: .compact
-                                ) {
-                                    withAnimation(VAnimation.fast) { sidebar.showAllScheduleConversations.toggle() }
-                                }
-                                Spacer()
-                            }
-                            .padding(.leading, VSpacing.xs + SidebarLayoutMetrics.iconSlotSize + VSpacing.xs - VSpacing.sm)
-                            .padding(.bottom, VSpacing.xs)
-                        }
-                    }
-
-                    if !backgroundConversations.isEmpty {
-                        // Background conversations section
-                        HStack {
-                            Text("Background")
-                                .font(VFont.labelDefault)
-                                .foregroundStyle(VColor.contentTertiary)
-                            Spacer()
-                        }
-                        .padding(.leading, SidebarLayoutMetrics.iconSlotSize)
-                        .padding(.trailing, VSpacing.md)
-                        .padding(.top, SidebarLayoutMetrics.scheduledHeaderTopGap)
-                        .padding(.bottom, SidebarLayoutMetrics.scheduledHeaderBottomGap)
-
-                        ForEach(displayedBackgroundConversations) { conversation in
-                            makeSidebarRow(conversation: conversation)
-                                .equatable()
-                                .padding(.bottom, SidebarLayoutMetrics.listRowGap)
-                        }
-
-                        if backgroundConversations.count > 3 {
-                            HStack {
-                                VButton(
-                                    label: sidebar.showAllBackgroundConversations ? "Show less" : "Show more",
-                                    style: .ghost,
-                                    size: .compact
-                                ) {
-                                    withAnimation(VAnimation.fast) { sidebar.showAllBackgroundConversations.toggle() }
-                                }
-                                Spacer()
-                            }
-                            .padding(.leading, VSpacing.xs + SidebarLayoutMetrics.iconSlotSize + VSpacing.xs - VSpacing.sm)
-                            .padding(.bottom, VSpacing.xs)
+                    ForEach(groupEntries) { entry in
+                        if let group = entry.group {
+                            SidebarSectionView(
+                                group: group,
+                                conversations: entry.conversations,
+                                isExpanded: sidebar.expandedSections.contains(group.id),
+                                showAll: sidebar.showAllInSection.contains(group.id),
+                                maxCollapsed: group.isSystemGroup ? 3 : 5,
+                                isDropTarget: sidebar.dropTargetSectionId == group.id,
+                                autoExpandOnUnread: group.id == ConversationGroup.scheduled.id,
+                                countMode: group.id == ConversationGroup.scheduled.id
+                                    ? .subGroups(grouper: { $0.scheduleJobId })
+                                    : .items,
+                                isRenaming: false,
+                                renamingName: .constant(""),
+                                onRename: nil,
+                                onCommitRename: nil,
+                                onDelete: nil,
+                                onToggleExpand: { sidebar.toggleSection(group.id) },
+                                onToggleShowAll: { sidebar.toggleShowAll(group.id) },
+                                makeRow: { makeSidebarRow(conversation: $0) },
+                                expandedScheduleGroups: group.id == ConversationGroup.scheduled.id
+                                    ? Binding(
+                                        get: { sidebar.expandedScheduleGroups },
+                                        set: { sidebar.expandedScheduleGroups = $0 }
+                                    )
+                                    : nil,
+                                sidebar: sidebar,
+                                conversationManager: conversationManager
+                            )
+                        } else {
+                            // Ungrouped -- no collapsible header, flat list with drag-reorder
+                            ungroupedConversationRows(entry.conversations)
                         }
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ScheduleDropDelegates.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ScheduleDropDelegates.swift
@@ -52,57 +52,6 @@ struct ScheduleReorderDropDelegate: DropDelegate {
     }
 }
 
-/// Drop delegate for the collapsed schedule group header.
-/// Targets the first conversation in the group; only accepts drops from the same schedule group.
-struct ScheduleGroupHeaderDropDelegate: DropDelegate {
-    let group: (key: String, label: String, conversations: [ConversationModel])
-    let sidebar: SidebarInteractionState
-    let conversationManager: ConversationManager
-
-    private var firstConversation: ConversationModel? { group.conversations.first }
-
-    func validateDrop(info: DropInfo) -> Bool {
-        guard let firstConversation = firstConversation,
-              let dragId = sidebar.draggingConversationId,
-              dragId != firstConversation.id,
-              let sourceConversation = conversationManager.visibleConversations.first(where: { $0.id == dragId }),
-              sourceConversation.isScheduleConversation,
-              sourceConversation.scheduleJobId == firstConversation.scheduleJobId
-        else { return false }
-        return true
-    }
-
-    func dropUpdated(info: DropInfo) -> DropProposal? {
-        return DropProposal(operation: .move)
-    }
-
-    func dropEntered(info: DropInfo) {
-        guard let firstConversation = firstConversation,
-              let dragId = sidebar.draggingConversationId,
-              dragId != firstConversation.id,
-              let sourceConversation = conversationManager.visibleConversations.first(where: { $0.id == dragId }),
-              sourceConversation.isScheduleConversation,
-              sourceConversation.scheduleJobId == firstConversation.scheduleJobId
-        else { return }
-
-        sidebar.dropTargetConversationId = firstConversation.id
-        sidebar.dropIndicatorAtBottom = false
-    }
-
-    func dropExited(info: DropInfo) {
-        if let firstConversation = firstConversation, sidebar.dropTargetConversationId == firstConversation.id {
-            sidebar.dropTargetConversationId = nil
-        }
-    }
-
-    func performDrop(info: DropInfo) -> Bool {
-        let sourceId = sidebar.draggingConversationId
-        sidebar.dropTargetConversationId = nil
-        sidebar.draggingConversationId = nil
-        guard let firstConversation = firstConversation,
-              let sourceId = sourceId,
-              sourceId != firstConversation.id
-        else { return false }
-        return conversationManager.moveConversation(sourceId: sourceId, targetId: firstConversation.id)
-    }
-}
+// ScheduleGroupHeaderDropDelegate has been replaced by ScheduleSubGroupHeaderDropDelegate
+// in SidebarSectionView.swift, which handles collapsed schedule sub-group drop targets
+// directly within the SidebarSectionView component.

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarLayoutMetrics.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarLayoutMetrics.swift
@@ -43,6 +43,14 @@ enum SidebarLayoutMetrics {
     /// (20pt icon + 4pt trailing padding on the overlay + 8pt gap).
     static let trailingIconPadding: CGFloat = 32
 
+    // MARK: - Section Header
+
+    /// Height of a collapsible section header row.
+    static let sectionHeaderHeight: CGFloat = 28
+
+    /// Size of the disclosure chevron in section headers.
+    static let sectionChevronSize: CGFloat = 10
+
     // MARK: - Section Divider
 
     /// Vertical padding above and below a section divider line.

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Collapsible header for a sidebar conversation group.
+///
+/// All interaction state is passed via callbacks/bindings -- no direct reference
+/// to SidebarInteractionState or ConversationManager. Matches the callback-based
+/// API style used by onToggleExpand.
+struct SidebarSectionHeader: View {
+    let group: ConversationGroup
+    let conversationCount: Int
+    let isExpanded: Bool
+    let isDropTarget: Bool
+    let unreadCount: Int
+    let isRenaming: Bool                       // M5: inline rename active
+    @Binding var renamingName: String           // M5: bound to rename text field
+    var onToggleExpand: () -> Void
+    var onRename: ((String) -> Void)?           // M5: enters rename mode (nil for system groups)
+    var onCommitRename: ((String) -> Void)?     // M5: commits the rename (nil for system groups)
+    var onDelete: (() -> Void)?                 // M5: nil for system groups
+
+    var body: some View {
+        HStack(spacing: SidebarLayoutMetrics.listRowGap) {
+            VIconView(.chevronRight, size: SidebarLayoutMetrics.sectionChevronSize)
+                .foregroundStyle(VColor.contentTertiary)
+                .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                .animation(VAnimation.fast, value: isExpanded)
+            Text(group.name)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Spacer()
+            if !isExpanded {
+                if unreadCount > 0 {
+                    Circle()
+                        .fill(VColor.systemNegativeStrong)
+                        .frame(width: 6, height: 6)
+                        .transition(.opacity)
+                }
+                if conversationCount > 0 {
+                    Text("\(conversationCount)")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+        }
+        .padding(.top, SidebarLayoutMetrics.sectionTitleTopGap)
+        .padding(.bottom, SidebarLayoutMetrics.sectionTitleBottomGap)
+        .contentShape(Rectangle())
+        .onTapGesture { withAnimation(VAnimation.fast) { onToggleExpand() } }
+        .background(isDropTarget ? Color.accentColor.opacity(0.15) : .clear)
+        .cornerRadius(4)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -1,0 +1,368 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// A schedule sub-group: conversations sharing the same scheduleJobId.
+struct ScheduleSubGroup {
+    let key: String
+    let label: String
+    let conversations: [ConversationModel]
+}
+
+/// Container wrapping a collapsible section header + conversation list.
+///
+/// Handles expand/collapse, show-more/less truncation, auto-expand on unread,
+/// and schedule sub-grouping (clusters by scheduleJobId when countMode is .subGroups).
+struct SidebarSectionView: View {
+    let group: ConversationGroup?
+    let conversations: [ConversationModel]
+    let isExpanded: Bool
+    let showAll: Bool
+    let maxCollapsed: Int
+    let isDropTarget: Bool
+    let autoExpandOnUnread: Bool
+    let countMode: CountMode
+
+    // Rename/delete plumbing -- passed through to SidebarSectionHeader.
+    // M3 passes inert defaults (isRenaming: false, renamingName: .constant(""),
+    // onRename: nil, onCommitRename: nil, onDelete: nil).
+    // M5 wires these to ConversationManager/SidebarInteractionState.
+    let isRenaming: Bool
+    @Binding var renamingName: String
+    var onRename: ((String) -> Void)?
+    var onCommitRename: ((String) -> Void)?
+    var onDelete: (() -> Void)?
+
+    var onToggleExpand: () -> Void
+    var onToggleShowAll: () -> Void
+    var makeRow: (ConversationModel) -> SidebarConversationItem
+
+    /// Schedule sub-group state -- managed by the parent's SidebarInteractionState.
+    /// Passed in so SidebarSectionView can render sub-group disclosure headers.
+    var expandedScheduleGroups: Binding<Set<String>>?
+    /// Drop delegate plumbing for schedule reorder.
+    var sidebar: SidebarInteractionState?
+    var conversationManager: ConversationManager?
+
+    enum CountMode {
+        case items
+        case subGroups(grouper: (ConversationModel) -> String?)
+    }
+
+    private var effectiveExpanded: Bool {
+        if autoExpandOnUnread && !isExpanded {
+            return conversations.contains(where: \.hasUnseenLatestAssistantMessage)
+        }
+        return isExpanded
+    }
+
+    private var unreadCount: Int {
+        conversations.filter(\.hasUnseenLatestAssistantMessage).count
+    }
+
+    private var displayCount: Int {
+        switch countMode {
+        case .items:
+            return conversations.count
+        case .subGroups(let grouper):
+            var seen = Set<String>()
+            for c in conversations {
+                if let key = grouper(c) {
+                    seen.insert(key)
+                } else {
+                    seen.insert(c.id.uuidString)
+                }
+            }
+            return seen.count
+        }
+    }
+
+    var body: some View {
+        if let group = group {
+            SidebarSectionHeader(
+                group: group,
+                conversationCount: displayCount,
+                isExpanded: effectiveExpanded,
+                isDropTarget: isDropTarget,
+                unreadCount: unreadCount,
+                isRenaming: isRenaming,
+                renamingName: $renamingName,
+                onToggleExpand: onToggleExpand,
+                onRename: onRename,
+                onCommitRename: onCommitRename,
+                onDelete: onDelete
+            )
+
+            if effectiveExpanded {
+                sectionContent
+            }
+        } else {
+            // Ungrouped -- no header, render conversations directly
+            sectionContent
+        }
+    }
+
+    @ViewBuilder
+    private var sectionContent: some View {
+        switch countMode {
+        case .subGroups(let grouper):
+            scheduleSubGroupContent(grouper: grouper)
+        case .items:
+            flatContent
+        }
+    }
+
+    @ViewBuilder
+    private var flatContent: some View {
+        let displayed = displayedConversations
+        ForEach(displayed) { conversation in
+            makeRow(conversation)
+                .equatable()
+                .padding(.bottom, SidebarLayoutMetrics.listRowGap)
+        }
+
+        showMoreLessButton
+    }
+
+    @ViewBuilder
+    private func scheduleSubGroupContent(grouper: (ConversationModel) -> String?) -> some View {
+        let subGroups = buildSubGroups(grouper: grouper)
+        let displayed = showAll ? subGroups : Array(subGroups.prefix(maxCollapsed))
+
+        ForEach(displayed, id: \.key) { subGroup in
+            if subGroup.conversations.count == 1, let conversation = subGroup.conversations.first {
+                // Single-conversation sub-group: render inline
+                scheduleRow(conversation)
+            } else {
+                // Multi-conversation sub-group: disclosure header
+                scheduleSubGroupDisclosure(subGroup)
+            }
+        }
+
+        if subGroups.count > maxCollapsed {
+            showMoreLessButtonForSchedule
+        }
+    }
+
+    @ViewBuilder
+    private func scheduleRow(_ conversation: ConversationModel) -> some View {
+        if let sidebar, let conversationManager {
+            makeRow(conversation)
+                .equatable()
+                .padding(.bottom, SidebarLayoutMetrics.listRowGap)
+                .onDrop(of: [.plainText], delegate: ScheduleReorderDropDelegate(
+                    targetConversation: conversation,
+                    sidebar: sidebar,
+                    conversationManager: conversationManager
+                ))
+        } else {
+            makeRow(conversation)
+                .equatable()
+                .padding(.bottom, SidebarLayoutMetrics.listRowGap)
+        }
+    }
+
+    @ViewBuilder
+    private func scheduleSubGroupDisclosure(_ subGroup: ScheduleSubGroup) -> some View {
+        let isSubGroupExpanded = expandedScheduleGroups?.wrappedValue.contains(subGroup.key) ?? false
+        let hasUnread = !isSubGroupExpanded &&
+            subGroup.conversations.contains(where: \.hasUnseenLatestAssistantMessage)
+
+        Button {
+            withAnimation(VAnimation.fast) {
+                if isSubGroupExpanded {
+                    expandedScheduleGroups?.wrappedValue.remove(subGroup.key)
+                } else {
+                    expandedScheduleGroups?.wrappedValue.insert(subGroup.key)
+                }
+            }
+        } label: {
+            HStack(spacing: VSpacing.xs) {
+                HStack(spacing: 2) {
+                    VIconView(.chevronRight, size: 10)
+                        .foregroundStyle(VColor.contentTertiary)
+                        .rotationEffect(.degrees(isSubGroupExpanded ? 90 : 0))
+                        .animation(VAnimation.fast, value: isSubGroupExpanded)
+                    if hasUnread {
+                        Circle()
+                            .fill(VColor.systemNegativeStrong)
+                            .frame(width: 6, height: 6)
+                            .transition(.opacity)
+                    }
+                }
+                .frame(height: SidebarLayoutMetrics.iconSlotSize)
+                Text(subGroup.label)
+                    .font(.system(size: 13))
+                    .foregroundStyle(VColor.contentDefault)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Text("\(subGroup.conversations.count)")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(VColor.contentTertiary)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(
+                        Capsule()
+                            .fill(VColor.contentTertiary.opacity(0.12))
+                    )
+                Spacer()
+            }
+            .padding(.leading, VSpacing.xs)
+            .padding(.trailing, VSpacing.sm)
+            .padding(.vertical, SidebarLayoutMetrics.rowVerticalPadding)
+            .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, VSpacing.sm)
+        .pointerCursor()
+
+        if isSubGroupExpanded {
+            ForEach(subGroup.conversations) { conversation in
+                scheduleRow(conversation)
+            }
+        }
+
+        // Drop target on collapsed sub-group header
+        if !isSubGroupExpanded, let sidebar, let conversationManager {
+            Color.clear
+                .frame(height: 0)
+                .onDrop(of: [.plainText], delegate: ScheduleSubGroupHeaderDropDelegate(
+                    subGroup: subGroup,
+                    sidebar: sidebar,
+                    conversationManager: conversationManager
+                ))
+        }
+    }
+
+    @ViewBuilder
+    private var showMoreLessButton: some View {
+        if conversations.count > maxCollapsed {
+            HStack {
+                VButton(
+                    label: showAll ? "Show less" : "Show more",
+                    style: .ghost,
+                    size: .compact
+                ) {
+                    withAnimation(VAnimation.fast) { onToggleShowAll() }
+                }
+                Spacer()
+            }
+            .padding(.leading, VSpacing.xs + SidebarLayoutMetrics.iconSlotSize + VSpacing.xs - VSpacing.sm)
+            .padding(.bottom, VSpacing.xs)
+        }
+    }
+
+    @ViewBuilder
+    private var showMoreLessButtonForSchedule: some View {
+        HStack {
+            VButton(
+                label: showAll ? "Show less" : "Show more",
+                style: .ghost,
+                size: .compact
+            ) {
+                withAnimation(VAnimation.fast) { onToggleShowAll() }
+            }
+            Spacer()
+        }
+        .padding(.leading, VSpacing.xs + SidebarLayoutMetrics.iconSlotSize + VSpacing.xs - VSpacing.sm)
+        .padding(.bottom, VSpacing.xs)
+    }
+
+    private var displayedConversations: [ConversationModel] {
+        if showAll { return conversations }
+        // Auto-expand if any hidden conversation has unread messages (for background section).
+        let visible = Array(conversations.prefix(maxCollapsed))
+        if autoExpandOnUnread {
+            let hidden = conversations.dropFirst(maxCollapsed)
+            if hidden.contains(where: \.hasUnseenLatestAssistantMessage) {
+                return conversations
+            }
+        }
+        return visible
+    }
+
+    // MARK: - Sub-group helpers
+
+    private func buildSubGroups(grouper: (ConversationModel) -> String?) -> [ScheduleSubGroup] {
+        var grouped: [String: [ConversationModel]] = [:]
+        var order: [String] = []
+        for conversation in conversations {
+            let key = grouper(conversation) ?? conversation.id.uuidString
+            if grouped[key] == nil {
+                order.append(key)
+            }
+            grouped[key, default: []].append(conversation)
+        }
+        return order.compactMap { key in
+            guard let conversations = grouped[key], let first = conversations.first else { return nil }
+            let label: String
+            if conversations.count > 1 {
+                let base = first.title
+                if let colonRange = base.range(of: ":") {
+                    label = String(base[base.startIndex..<colonRange.lowerBound])
+                } else {
+                    label = base
+                }
+            } else {
+                label = first.title
+            }
+            return ScheduleSubGroup(key: key, label: label, conversations: conversations)
+        }
+    }
+}
+
+/// Drop delegate for collapsed schedule sub-group headers within SidebarSectionView.
+/// Replaces the old ScheduleGroupHeaderDropDelegate that consumed the deleted
+/// scheduleConversationGroups tuple.
+struct ScheduleSubGroupHeaderDropDelegate: DropDelegate {
+    let subGroup: ScheduleSubGroup
+    let sidebar: SidebarInteractionState
+    let conversationManager: ConversationManager
+
+    private var firstConversation: ConversationModel? { subGroup.conversations.first }
+
+    func validateDrop(info: DropInfo) -> Bool {
+        guard let firstConversation = firstConversation,
+              let dragId = sidebar.draggingConversationId,
+              dragId != firstConversation.id,
+              let sourceConversation = conversationManager.visibleConversations.first(where: { $0.id == dragId }),
+              sourceConversation.isScheduleConversation,
+              sourceConversation.scheduleJobId == firstConversation.scheduleJobId
+        else { return false }
+        return true
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        return DropProposal(operation: .move)
+    }
+
+    func dropEntered(info: DropInfo) {
+        guard let firstConversation = firstConversation,
+              let dragId = sidebar.draggingConversationId,
+              dragId != firstConversation.id,
+              let sourceConversation = conversationManager.visibleConversations.first(where: { $0.id == dragId }),
+              sourceConversation.isScheduleConversation,
+              sourceConversation.scheduleJobId == firstConversation.scheduleJobId
+        else { return }
+
+        sidebar.dropTargetConversationId = firstConversation.id
+        sidebar.dropIndicatorAtBottom = false
+    }
+
+    func dropExited(info: DropInfo) {
+        if let firstConversation = firstConversation, sidebar.dropTargetConversationId == firstConversation.id {
+            sidebar.dropTargetConversationId = nil
+        }
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        let sourceId = sidebar.draggingConversationId
+        sidebar.dropTargetConversationId = nil
+        sidebar.draggingConversationId = nil
+        guard let firstConversation = firstConversation,
+              let sourceId = sourceId,
+              sourceId != firstConversation.id
+        else { return false }
+        return conversationManager.moveConversation(sourceId: sourceId, targetId: firstConversation.id)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -48,11 +48,21 @@ struct SidebarSectionView: View {
         case subGroups(grouper: (ConversationModel) -> String?)
     }
 
-    private var effectiveExpanded: Bool {
-        if autoExpandOnUnread && !isExpanded {
-            return conversations.contains(where: \.hasUnseenLatestAssistantMessage)
+    /// Auto-show-all when hidden items beyond the truncation cutoff have unread messages.
+    /// Works for both flat items and schedule sub-groups.
+    private var effectiveShowAll: Bool {
+        if showAll { return true }
+        switch countMode {
+        case .items:
+            let hidden = conversations.dropFirst(maxCollapsed)
+            return hidden.contains(where: \.hasUnseenLatestAssistantMessage)
+        case .subGroups(let grouper):
+            let subGroups = buildSubGroups(grouper: grouper)
+            let hidden = subGroups.dropFirst(maxCollapsed)
+            return hidden.contains(where: { subGroup in
+                subGroup.conversations.contains(where: \.hasUnseenLatestAssistantMessage)
+            })
         }
-        return isExpanded
     }
 
     private var unreadCount: Int {
@@ -81,7 +91,7 @@ struct SidebarSectionView: View {
             SidebarSectionHeader(
                 group: group,
                 conversationCount: displayCount,
-                isExpanded: effectiveExpanded,
+                isExpanded: isExpanded,
                 isDropTarget: isDropTarget,
                 unreadCount: unreadCount,
                 isRenaming: isRenaming,
@@ -92,7 +102,7 @@ struct SidebarSectionView: View {
                 onDelete: onDelete
             )
 
-            if effectiveExpanded {
+            if isExpanded {
                 sectionContent
             }
         } else {
@@ -126,7 +136,7 @@ struct SidebarSectionView: View {
     @ViewBuilder
     private func scheduleSubGroupContent(grouper: (ConversationModel) -> String?) -> some View {
         let subGroups = buildSubGroups(grouper: grouper)
-        let displayed = showAll ? subGroups : Array(subGroups.prefix(maxCollapsed))
+        let displayed = effectiveShowAll ? subGroups : Array(subGroups.prefix(maxCollapsed))
 
         ForEach(displayed, id: \.key) { subGroup in
             if subGroup.conversations.count == 1, let conversation = subGroup.conversations.first {
@@ -149,6 +159,14 @@ struct SidebarSectionView: View {
             makeRow(conversation)
                 .equatable()
                 .padding(.bottom, SidebarLayoutMetrics.listRowGap)
+                .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
+                    if sidebar.dropTargetConversationId == conversation.id {
+                        Rectangle()
+                            .fill(VColor.primaryBase)
+                            .frame(height: 2)
+                            .transition(.opacity)
+                    }
+                }
                 .onDrop(of: [.plainText], delegate: ScheduleReorderDropDelegate(
                     targetConversation: conversation,
                     sidebar: sidebar,
@@ -269,16 +287,8 @@ struct SidebarSectionView: View {
     }
 
     private var displayedConversations: [ConversationModel] {
-        if showAll { return conversations }
-        // Auto-expand if any hidden conversation has unread messages (for background section).
-        let visible = Array(conversations.prefix(maxCollapsed))
-        if autoExpandOnUnread {
-            let hidden = conversations.dropFirst(maxCollapsed)
-            if hidden.contains(where: \.hasUnseenLatestAssistantMessage) {
-                return conversations
-            }
-        }
-        return visible
+        if effectiveShowAll { return conversations }
+        return Array(conversations.prefix(maxCollapsed))
     }
 
     // MARK: - Sub-group helpers


### PR DESCRIPTION
## Summary

- Introduces `SidebarSectionHeader` and `SidebarSectionView` components that replace the inline three-section rendering in `MainWindowView+Sidebar.swift` with group-driven rendering via `ForEach` over `conversationManager.groupedConversations`
- Replaces `showAllConversations`/`showAllScheduleConversations`/`showAllBackgroundConversations` booleans with `expandedSections: Set<String>` and `showAllInSection: Set<String>`, persisted to UserDefaults with migration from old keys
- Adds auto-expand behavior when selecting a conversation in a collapsed group, and auto-expand for Scheduled section on unread

## Test plan

- [ ] Verify collapsible section headers render for Pinned, Scheduled, and Background groups
- [ ] Verify ungrouped conversations render flat without a header (same as before)
- [ ] Verify expand/collapse animates the disclosure chevron
- [ ] Verify show-more/show-less per-section works
- [ ] Verify schedule sub-groups by `scheduleJobId` render correctly (single-conversation inline, multi-conversation with disclosure)
- [ ] Verify auto-expand Scheduled section on unread messages
- [ ] Verify selecting a conversation in a collapsed group auto-expands that group
- [ ] Verify collapsed sidebar drawer shows correct count
- [ ] Verify continuous scroll with `.scrollIndicators(.never)` preserved
- [ ] Verify `drawingGroup()` on pinned apps VStack stays scoped
- [ ] Verify drag-and-drop reorder still works for ungrouped conversations
- [ ] Verify schedule conversation reorder drag-and-drop still works
- [ ] Verify mark-all-seen button still works globally

Part of #21830. See #21833 for full spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21852" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
