### PR TITLE
fix: normalize trailing punctuation in wake-up greeting check

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.0.0
 info:
   title: Vellum Assistant API
-  version: 0.5.11
+  version: 0.5.12
   description: Auto-generated OpenAPI specification for the Vellum Assistant runtime HTTP server.
 servers:
   - url: http://127.0.0.1:7821

--- a/assistant/src/__tests__/first-greeting.test.ts
+++ b/assistant/src/__tests__/first-greeting.test.ts
@@ -50,6 +50,13 @@ describe("first-greeting", () => {
       expect(isWakeUpGreeting("Wake Up, My Friend.", 0)).toBe(true);
     });
 
+    it("returns true for punctuation variations", () => {
+      writeFileSync(join(tempDir, "BOOTSTRAP.md"), "bootstrap content");
+      expect(isWakeUpGreeting("Wake up, my friend!", 0)).toBe(true);
+      expect(isWakeUpGreeting("Wake up, my friend?", 0)).toBe(true);
+      expect(isWakeUpGreeting("Wake up, my friend", 0)).toBe(true);
+    });
+
     it("returns false when content doesn't match wake-up greeting", () => {
       writeFileSync(join(tempDir, "BOOTSTRAP.md"), "bootstrap content");
       expect(isWakeUpGreeting("Hello", 0)).toBe(false);

--- a/assistant/src/daemon/first-greeting.ts
+++ b/assistant/src/daemon/first-greeting.ts
@@ -22,7 +22,12 @@ export function isWakeUpGreeting(
 ): boolean {
   if (conversationMessageCount !== 0) return false;
   if (!existsSync(getWorkspacePromptPath("BOOTSTRAP.md"))) return false;
-  return content.trim().toLowerCase() === "wake up, my friend.";
+  return (
+    content
+      .trim()
+      .toLowerCase()
+      .replace(/[.!?]+$/, "") === "wake up, my friend"
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- The web client sends `"Wake up, my friend!"` (exclamation mark) while the server-side canned greeting check only matched `"Wake up, my friend."` (period)
- This caused the web client's greeting to fall through to the LLM, charging user credits (~9 cents) on first login
- Strip trailing punctuation before comparing so `.`, `!`, `?`, or no punctuation all trigger the free canned response

## Test plan
- [x] Existing tests pass
- [x] New test case for punctuation variations (`!`, `?`, bare text)

Closes JARVIS-380

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21855" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
