### PR TITLE
feat: wrap signposts in #if DEBUG and clean up dead code from @Observable migration

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -308,8 +308,10 @@ struct ChatBubble: View {
     }
 
     var body: some View {
+        #if DEBUG
         let _ = os_signpost(.event, log: PerfSignposts.log, name: "chatBubbleBody",
                             "id=%{public}s streaming=%d", message.id.uuidString, message.isStreaming ? 1 : 0)
+        #endif
         // Outer HStack: Spacer pushes the content group to the correct side.
         HStack(alignment: .top, spacing: 0) {
             if isUser { Spacer(minLength: 0) }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
@@ -71,8 +71,10 @@ func parseListLine(_ line: String) -> MarkdownListItem? {
 
 /// Parses message text into segments, extracting markdown tables, code blocks, headings, lists, and rules.
 func parseMarkdownSegments(_ text: String) -> [MarkdownSegment] {
+    #if DEBUG
     os_signpost(.begin, log: PerfSignposts.log, name: "markdownParse")
     defer { os_signpost(.end, log: PerfSignposts.log, name: "markdownParse") }
+    #endif
     let lines = text.components(separatedBy: .newlines)
     var segments: [MarkdownSegment] = []
     var currentText: [String] = []

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -6,16 +6,17 @@ import UniformTypeIdentifiers
 
 private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "ChatView")
 
-// MARK: - Performance Baseline Success Criteria
+// MARK: - Performance Measurement (Post-@Observable Migration)
 //
 // The os_signpost instrumentation in ChatView, MessageListView, and ChatBubble
-// establishes a performance baseline for the @Observable migration. Measure
-// these metrics during a 50-message streaming session using Instruments (Points
-// of Interest template) BEFORE and AFTER the migration:
+// is guarded behind `#if DEBUG` for ongoing performance monitoring. To measure
+// the @Observable migration impact, run a 50-message streaming session in
+// Instruments (Points of Interest template) and compare against the pre-migration
+// baseline:
 //
-//   1. ≥50% reduction in ChatBubble body evaluations per streaming burst
-//   2. < 500ms total hitch time during 50-message streaming session
-//   3. ≥30% reduction in mean graph update duration during streaming
+//   1. ChatBubble body evaluations per streaming burst (target: ≥50% reduction)
+//   2. Total hitch time (target: < 500ms, baseline ~2s)
+//   3. Mean graph update duration (target: ≥30% reduction)
 
 struct ChatView: View {
     let messages: [ChatMessage]
@@ -173,7 +174,9 @@ struct ChatView: View {
     }
 
     var body: some View {
+        #if DEBUG
         let _ = os_signpost(.event, log: PerfSignposts.log, name: "ChatView.body")
+        #endif
         ZStack {
             VStack(spacing: 0) {
                 if showSkeleton {

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -150,8 +150,10 @@ struct MarkdownSegmentView: View, Equatable {
     }
 
     private func computeGroupedSegments() -> [SegmentGroup] {
+        #if DEBUG
         os_signpost(.begin, log: PerfSignposts.log, name: "markdownGroupSegments")
         defer { os_signpost(.end, log: PerfSignposts.log, name: "markdownGroupSegments") }
+        #endif
         var groups: [SegmentGroup] = []
         var currentRun: [MarkdownSegment] = []
 
@@ -236,8 +238,10 @@ struct MarkdownSegmentView: View, Equatable {
     /// Builds (or retrieves from cache) a single AttributedString from
     /// consecutive text-selectable segments.
     private func buildCombinedAttributedString(from segments: [MarkdownSegment]) -> AttributedString {
+        #if DEBUG
         os_signpost(.begin, log: PerfSignposts.log, name: "attributedStringBuild")
         defer { os_signpost(.end, log: PerfSignposts.log, name: "attributedStringBuild") }
+        #endif
         // Build a stable cache key from the segment contents and style
         // inputs that affect the output (e.g. secondaryTextColor for list
         // prefix coloring) so different visual contexts don't share entries.

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator+ScrollBehavior.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator+ScrollBehavior.swift
@@ -52,8 +52,10 @@ extension MessageListScrollCoordinator {
                 // response. Daemon confirmation resumes stay bottom-pinned.
                 if !isDaemonConfirmationResume, let lastUserMsg = messages.last(where: { $0.role == .user }) {
                     pushToTopMessageId = lastUserMsg.id
+                    #if DEBUG
                     os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested",
                                 "target=userMessage reason=pushToTop")
+                    #endif
                     withAnimation(VAnimation.fast) {
                         performScrollTo(lastUserMsg.id, anchor: .top)
                     }
@@ -109,8 +111,10 @@ extension MessageListScrollCoordinator {
         // Anchor scroll takes priority: when a notification deep-link
         // set anchorMessageId, retry scrolling to it as messages load.
         if let id = anchorMessageId, messages.contains(where: { $0.id == id }) {
+            #if DEBUG
             os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=anchorMessage reason=messagesChanged")
             os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundInMessages")
+            #endif
             recordScrollLoopEvent(.scrollToRequested, conversationId: conversationId, isNearBottom: isNearBottom)
             // Deep-link anchor takes priority — detach from bottom-follow.
             detachFromBottom()
@@ -130,7 +134,9 @@ extension MessageListScrollCoordinator {
             let paginationExhausted = !hasMoreMessages
             let minWaitElapsed = anchorSetTime.map { Date().timeIntervalSince($0) > 2 } ?? false
             if paginationExhausted && minWaitElapsed {
+                #if DEBUG
                 os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=paginationExhausted")
+                #endif
                 scrollCoordinatorLog.debug("Anchor message not found (pagination exhausted) — clearing stale anchor")
                 anchorMessageId = nil
                 anchorSetTime = nil
@@ -265,10 +271,14 @@ extension MessageListScrollCoordinator {
         anchorTimeoutTask?.cancel()
         anchorTimeoutTask = nil
         guard let id = anchorMessageId.wrappedValue else { return }
+        #if DEBUG
         os_signpost(.event, log: PerfSignposts.log, name: "anchorSet", "reason=anchorMessageIdChanged")
+        #endif
         if messages.contains(where: { $0.id == id }) {
+            #if DEBUG
             os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=anchorMessage reason=anchorChanged")
             os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundOnAnchorChange")
+            #endif
             recordScrollLoopEvent(.scrollToRequested, conversationId: conversationId)
             withAnimation {
                 scrollTo?(id, .center)
@@ -284,7 +294,9 @@ extension MessageListScrollCoordinator {
                     try await Task.sleep(nanoseconds: 10_000_000_000)
                 } catch { return }
                 guard !Task.isCancelled, let self, anchorMessageId.wrappedValue != nil else { return }
+                #if DEBUG
                 os_signpost(.event, log: PerfSignposts.log, name: "anchorTimedOut")
+                #endif
                 scrollCoordinatorLog.debug("Anchor message not found (timed out) — clearing stale anchor")
                 anchorMessageId.wrappedValue = nil
                 self.anchorSetTime = nil
@@ -351,8 +363,10 @@ extension MessageListScrollCoordinator {
         // User-initiated scrolls bypass both the follow-state and suppression
         // checks entirely — user intent always wins over defensive guards.
         if userInitiated {
+            #if DEBUG
             os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested",
                         "target=bottomAnchor reason=userInitiated")
+            #endif
             if animated {
                 withAnimation(VAnimation.fast) {
                     performScrollTo("scroll-bottom-anchor", anchor: .bottom)
@@ -376,8 +390,10 @@ extension MessageListScrollCoordinator {
             return false
         }
 
+        #if DEBUG
         os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested",
                     "target=bottomAnchor reason=%{public}s", reason.rawValue)
+        #endif
         recordScrollLoopEvent(.scrollToRequested, conversationId: currentConversationId)
         if animated {
             withAnimation(VAnimation.fast) {
@@ -429,7 +445,9 @@ extension MessageListScrollCoordinator {
                 && !self.hasReceivedScrollEvent
                 && !self.isAtBottom
             {
+                #if DEBUG
                 os_signpost(.event, log: PerfSignposts.log, name: "scrollRestoreStage", "stage=fallback")
+                #endif
                 self.requestBottomPin(reason: .initialRestore, conversationId: conversationId)
             }
             self.scrollRestoreTask = nil
@@ -466,11 +484,15 @@ extension MessageListScrollCoordinator {
         // Cancel any pending expansion timeout before re-evaluating.
         endExpansionSuppression()
         if isNearBottom {
+            #if DEBUG
             os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "on reason=expansionPinning")
+            #endif
             recordScrollLoopEvent(.suppressionFlip, conversationId: conversationId, isNearBottom: isNearBottom, scrollViewportHeight: scrollViewportHeight)
             requestBottomPin(reason: .expansion, conversationId: conversationId, animated: false)
         } else {
+            #if DEBUG
             os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "on reason=offBottomExpansion")
+            #endif
             recordScrollLoopEvent(.suppressionFlip, conversationId: conversationId, isNearBottom: isNearBottom, scrollViewportHeight: scrollViewportHeight)
             // Begin expansion suppression with 200ms auto-timeout. Resize and
             // pagination have their own independent boolean flags — no guards needed.
@@ -523,7 +545,9 @@ extension MessageListScrollCoordinator {
         isPaginationInFlight = true
         // Pagination scroll-position restore is higher priority than bottom-pin.
         let anchorId = firstVisibleMessageId
+        #if DEBUG
         os_signpost(.event, log: PerfSignposts.log, name: "paginationSentinelFired")
+        #endif
         scrollCoordinatorLog.debug("[pagination] fired — anchorId: \(String(describing: anchorId))")
         paginationTask = Task { [weak self] in
             guard let self else { return }
@@ -546,7 +570,9 @@ extension MessageListScrollCoordinator {
                     endPaginationSuppression()
                     return
                 }
+                #if DEBUG
                 os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=paginationAnchor")
+                #endif
                 recordScrollLoopEvent(.scrollToRequested, conversationId: conversationId)
                 performScrollTo(id, anchor: .top)
                 scrollCoordinatorLog.debug("[pagination] scroll restored to anchor \(id)")

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator.swift
@@ -303,23 +303,29 @@ final class MessageListScrollCoordinator: ObservableObject {
         expansionTimeoutTask = nil
         if wasActive {
             scrollCoordinatorLog.debug("Scroll suppression cleared: clearAll (was: \(reasons))")
+            #if DEBUG
             os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged",
                         "off reason=clearAll(was:%{public}s)", reasons)
+            #endif
         }
     }
 
     /// Shared logging for suppression state transitions.
     private func logSuppressionChange(started reason: String) {
         scrollCoordinatorLog.debug("Scroll suppression started: \(reason) — active: \(self.activeSuppressionReasons.joined(separator: ", "))")
+        #if DEBUG
         os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged",
                     "on reason=%{public}s", reason)
+        #endif
     }
 
     /// Shared logging for suppression state transitions.
     private func logSuppressionChange(ended reason: String) {
         scrollCoordinatorLog.debug("Scroll suppression ended: \(reason) — active: \(self.activeSuppressionReasons.joined(separator: ", "))")
+        #if DEBUG
         os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged",
                     "off reason=%{public}s", reason)
+        #endif
     }
 
     // MARK: - Follow/Detach State

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -6,7 +6,9 @@ import SwiftUI
 import VellumAssistantShared
 
 private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "MessageListView")
+#if DEBUG
 private let stallLog = OSLog(subsystem: "com.vellum.assistant", category: "LayoutStall")
+#endif
 
 // MARK: - Scroll Suppression Environment
 
@@ -279,7 +281,9 @@ struct MessageListView: View {
     /// always computed fresh from the live `visibleMessages` array so
     /// SwiftUI's `.equatable()` diffing sees every mutation.
     private var derivedState: MessageListDerivedState {
+        #if DEBUG
         os_signpost(.begin, log: stallLog, name: "DerivedState.resolve")
+        #endif
 
         // Compute visible messages first so version tracking and layout
         // both operate on the same filtered set.
@@ -314,10 +318,14 @@ struct MessageListView: View {
                 "layout cache stale: IDs \(cached.displayMessageIds.count) vs \(freshIds.count)"
             )
             #endif
+            #if DEBUG
             os_signpost(.event, log: stallLog, name: "DerivedState.layoutCacheHit")
+            #endif
             layout = cached
         } else {
+            #if DEBUG
             os_signpost(.event, log: stallLog, name: "DerivedState.layoutCacheMiss", "version=%d", scrollCoordinator.scrollTracking.messageListVersion)
+            #endif
 
             let displayMessageIds: [UUID] = {
                 var seen = Set<UUID>()
@@ -439,7 +447,9 @@ struct MessageListView: View {
             hasMessages: !liveMessages.isEmpty
         )
 
+        #if DEBUG
         os_signpost(.end, log: stallLog, name: "DerivedState.resolve")
+        #endif
         return result
     }
 
@@ -624,7 +634,9 @@ struct MessageListView: View {
     }
 
     var body: some View {
+        #if DEBUG
         let _ = os_signpost(.event, log: PerfSignposts.log, name: "MessageListView.body")
+        #endif
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: VSpacing.md) {
                     // MARK: - Pagination sentinel
@@ -641,7 +653,9 @@ struct MessageListView: View {
                     }
 
                     let _ = recordScrollLoopEvent(.bodyEvaluation)
+                    #if DEBUG
                     let _ = os_signpost(.event, log: stallLog, name: "MessageList.bodyEval")
+                    #endif
                     let state = derivedState
                     let catalogHash = MessageCellView.hashCatalog(providerCatalog)
                     ForEach(state.displayMessageIds, id: \.self) { messageId in
@@ -810,9 +824,13 @@ struct MessageListView: View {
                     deadZone: 0.5
                 )
                 if case .accept(let accepted) = decision {
+                    #if DEBUG
                     os_signpost(.begin, log: PerfSignposts.log, name: "viewportHeightChanged")
+                    #endif
                     scrollCoordinator.currentScrollViewportHeight = accepted
+                    #if DEBUG
                     os_signpost(.end, log: PerfSignposts.log, name: "viewportHeightChanged")
+                    #endif
                 }
 
                 // --- Bottom detection (with hysteresis) ---
@@ -871,7 +889,9 @@ struct MessageListView: View {
             .overlay(alignment: .bottom) {
                 if !isNearBottom {
                     Button(action: {
+                        #if DEBUG
                         os_signpost(.event, log: PerfSignposts.log, name: "scrollToLatestPressed")
+                        #endif
                         scrollCoordinator.hasReceivedScrollEvent = true
                         // Signal the coordinator to reattach and scroll to bottom.
                         scrollCoordinator.reattachToBottom()
@@ -905,8 +925,10 @@ struct MessageListView: View {
                 if let id = anchorMessageId, messages.contains(where: { $0.id == id }) {
                     // Anchor is already set and the target message is loaded —
                     // scroll to it immediately instead of falling through to bottom.
+                    #if DEBUG
                     os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=anchorMessage reason=onAppear")
                     os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundOnAppear")
+                    #endif
                     recordScrollLoopEvent(.scrollToRequested)
                     $scrollPosition.wrappedValue.scrollTo(id: id, anchor: .center)
                     flashHighlight(messageId: id)
@@ -914,7 +936,9 @@ struct MessageListView: View {
                     scrollCoordinator.anchorSetTime = nil
                 } else if anchorMessageId != nil {
                     // Anchor is set but the target message isn't loaded yet.
+                    #if DEBUG
                     os_signpost(.event, log: PerfSignposts.log, name: "anchorSet", "reason=onAppearPending")
+                    #endif
                     if scrollCoordinator.anchorSetTime == nil { scrollCoordinator.anchorSetTime = Date() }
                     // Start the independent timeout if not already running.
                     if scrollCoordinator.anchorTimeoutTask == nil {
@@ -923,7 +947,9 @@ struct MessageListView: View {
                                 try await Task.sleep(nanoseconds: 10_000_000_000)
                             } catch { return }
                             guard !Task.isCancelled, let scrollCoordinator, anchorMessageId != nil else { return }
+                            #if DEBUG
                             os_signpost(.event, log: PerfSignposts.log, name: "anchorTimedOut")
+                            #endif
                             log.debug("Anchor message not found (timed out) — clearing stale anchor")
                             anchorMessageId = nil
                             scrollCoordinator.anchorSetTime = nil

--- a/clients/macos/vellum-assistant/Telemetry/PerfSignposts.swift
+++ b/clients/macos/vellum-assistant/Telemetry/PerfSignposts.swift
@@ -1,3 +1,4 @@
+#if DEBUG
 import Foundation
 import os
 
@@ -6,6 +7,10 @@ import os
 /// Namespace for os_signpost markers used during Instruments profiling sessions.
 /// Use the Points of Interest or Time Profiler template in Instruments to see
 /// named coloured intervals for the hot paths identified in the scroll hang investigation.
+///
+/// Wrapped in `#if DEBUG` so release builds incur zero overhead from diagnostic
+/// instrumentation. Use Instruments (Points of Interest template) in a Debug build
+/// to measure body evaluation counts, hitch time, and graph update duration.
 enum PerfSignposts {
     /// Shared log handle targeting the Points of Interest instrument lane.
     static let log = OSLog(
@@ -14,3 +19,4 @@ enum PerfSignposts {
     )
 
 }
+#endif


### PR DESCRIPTION
## Summary
- Wrap all `os_signpost` instrumentation using `PerfSignposts.log` and `stallLog` in `#if DEBUG` guards so release builds have zero diagnostic overhead
- Update the performance baseline comment in ChatView.swift to reflect the post-migration state
- Wrap the `PerfSignposts` enum itself in `#if DEBUG` since it exists solely for diagnostic profiling

## Performance Measurement Status
Manual Instruments profiling is required to measure the @Observable migration impact. The signposts remain available in Debug builds for ongoing monitoring using the Points of Interest template. Success criteria (documented in ChatView.swift):
1. ChatBubble body evaluations per streaming burst (target: >=50% reduction)
2. Total hitch time (target: < 500ms, baseline ~2s)
3. Mean graph update duration (target: >=30% reduction)

## Dead Code Audit
Scanned ChatView.swift, MessageListView.swift, and ChatBubble.swift for:
- Orphaned `ObservableObject`/`@Published`/`objectWillChange` patterns: none found
- Unused imports: all imports are actively used
- TODO/FIXME/HACK comments from migration: none found
- Stale bridge patterns: none found
- The `@StateObject` for `MessageListScrollCoordinator` in MessageListView is intentional (documented as staying `ObservableObject`)

## Files Changed
| File | Change |
|------|--------|
| `PerfSignposts.swift` | Wrapped entire enum in `#if DEBUG` |
| `ChatView.swift` | `#if DEBUG` guard on body signpost; updated performance comment |
| `ChatBubble.swift` | `#if DEBUG` guard on body signpost |
| `MessageListView.swift` | `#if DEBUG` guards on all `PerfSignposts.log` and `stallLog` signposts |
| `MessageListScrollCoordinator.swift` | `#if DEBUG` guards on suppression signposts |
| `MessageListScrollCoordinator+ScrollBehavior.swift` | `#if DEBUG` guards on scroll/anchor/pagination signposts |
| `ChatMarkdownParser.swift` | `#if DEBUG` guards on parse signposts |
| `MarkdownSegmentView.swift` | `#if DEBUG` guards on segment grouping and attributed string signposts |

Part of plan: chatvm-observable-migration.md (PR 13 of 13)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21856" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
