### PR TITLE
M4: Drag-and-Drop — Cross-Group Movement

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -1225,7 +1225,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
     /// to the target's group. displayOrder is scoped to the TARGET GROUP only — conversations
     /// in other groups are untouched.
     @discardableResult
-    func moveConversation(sourceId: UUID, targetId: UUID) -> Bool {
+    func moveConversation(sourceId: UUID, targetId: UUID, insertAfterTarget: Bool? = nil) -> Bool {
         guard let sourceIdx = conversations.firstIndex(where: { $0.id == sourceId }),
               let targetIdx = conversations.firstIndex(where: { $0.id == targetId }) else { return false }
         let targetConversation = conversations[targetIdx]
@@ -1256,9 +1256,14 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         // Direction-aware insertion:
         // Determine if source was visually above target (dragging down) using
         // section-local indices, not global visibleConversations indices.
+        // For cross-group drags, use the caller-provided insertAfterTarget
+        // (derived from the drop indicator) so the insertion position matches
+        // the visual indicator the user saw.
         let draggingDown: Bool
-        if sourceGroupId != targetGroupId {
-            // Cross-group drag: treat as dragging down (insert after target)
+        if let insertAfterTarget {
+            draggingDown = insertAfterTarget
+        } else if sourceGroupId != targetGroupId {
+            // Cross-group without explicit direction: default to insert after target
             draggingDown = true
         } else {
             let sourceLocalIdx = groupMembers.firstIndex(where: { $0.id == sourceId })

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -1221,15 +1221,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
     }
 
     /// Move a conversation to a new position in the visible list (for drag-and-drop reorder).
-    /// Works for any conversation: pinned-to-pinned reorders among pinned items,
-    /// unpinned-to-pinned pins the source, and unpinned-to-unpinned reorders
-    /// using displayOrder. When the target is a schedule conversation, the source is
-    /// inserted at the end of the unpinned regular conversations list (the boundary
-    /// between regular and scheduled conversations).
-    ///
-    /// Only assigns displayOrder to the dragged conversation and conversations that already
-    /// had an explicit displayOrder. Conversations without explicit ordering (sorted
-    /// by recency) keep nil displayOrder so new conversations continue to appear at top.
+    /// Group-aware: if source and target are in different groups, the source is reassigned
+    /// to the target's group. displayOrder is scoped to the TARGET GROUP only — conversations
+    /// in other groups are untouched.
     @discardableResult
     func moveConversation(sourceId: UUID, targetId: UUID) -> Bool {
         guard let sourceIdx = conversations.firstIndex(where: { $0.id == sourceId }),
@@ -1240,90 +1234,59 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         // @Published write, preventing SwiftUI ForEach re-entrancy crashes.
         var draft = conversations
 
-        if targetConversation.isPinned {
-            // Dropping onto a pinned conversation — pin the source if needed and reorder
-            let sourceWasPinned = draft[sourceIdx].isPinned
-            if !sourceWasPinned {
-                draft[sourceIdx].groupId = ConversationGroup.pinned.id
-            }
-            let targetOrder = targetConversation.displayOrder ?? 0
-            let sourceOrder = sourceWasPinned ? (draft[sourceIdx].displayOrder ?? Int.max) : Int.max
+        let sourceGroupId = draft[sourceIdx].groupId
+        let targetGroupId = targetConversation.groupId
 
-            // Direction-aware: if source is above target (lower order), insert after target
-            let insertOrder = sourceOrder < targetOrder ? targetOrder + 1 : targetOrder
+        // Cross-group drag: assign source to target's group
+        if sourceGroupId != targetGroupId {
+            draft[sourceIdx].groupId = targetGroupId
+        }
 
-            draft[sourceIdx].displayOrder = insertOrder
-            for i in draft.indices where draft[i].isPinned && draft[i].id != sourceId {
-                if let order = draft[i].displayOrder, order >= insertOrder {
-                    draft[i].displayOrder = order + 1
-                }
-            }
-            recompactPinnedDisplayOrders(in: &draft)
+        // Reorder within TARGET GROUP only (not global — prevents corrupting other groups).
+        var groupMembers = draft
+            .filter { $0.groupId == targetGroupId && !$0.isArchived && $0.kind != .private }
+            .sorted { visibleConversationSortOrder($0, $1) }
+
+        // Remove source from the group member list
+        var reordered = groupMembers.filter { $0.id != sourceId }
+
+        // Find target's index in the filtered list
+        let targetInReordered = reordered.firstIndex(where: { $0.id == targetId })
+
+        // Direction-aware insertion:
+        // Determine if source was visually above target (dragging down) using
+        // section-local indices, not global visibleConversations indices.
+        let draggingDown: Bool
+        if sourceGroupId != targetGroupId {
+            // Cross-group drag: treat as dragging down (insert after target)
+            draggingDown = true
         } else {
-            // Dropping onto an unpinned conversation — reorder using displayOrder.
-            // Capture pinned state BEFORE modifications so direction detection
-            // isn't affected by the unpin changing the source's list position.
-            let sourceWasPinned = draft[sourceIdx].isPinned
+            let sourceLocalIdx = groupMembers.firstIndex(where: { $0.id == sourceId })
+            let targetLocalIdx = groupMembers.firstIndex(where: { $0.id == targetId })
+            draggingDown = (sourceLocalIdx ?? 0) < (targetLocalIdx ?? 0)
+        }
 
-            if sourceWasPinned {
-                draft[sourceIdx].groupId = nil
-                draft[sourceIdx].displayOrder = nil
-            }
+        let insertPos: Int
+        if draggingDown {
+            let targetIdx = targetInReordered ?? reordered.endIndex
+            insertPos = min(targetIdx + 1, reordered.endIndex)
+        } else {
+            insertPos = targetInReordered ?? reordered.endIndex
+        }
 
-            // Build the unpinned list in sidebar display order: regular conversations first,
-            // then schedule conversations. This matches the UI sections and prevents dropping
-            // onto a schedule conversation from inserting the source among regular conversations
-            // at the wrong position.
-            let visible = draft.filter { !$0.isArchived && $0.kind != .private }
-                .sorted { visibleConversationSortOrder($0, $1) }
-            let allUnpinned = visible.filter { !$0.isPinned }
-            let regularUnpinned = allUnpinned.filter { !$0.isScheduleConversation }
-            let scheduleUnpinned = allUnpinned.filter { $0.isScheduleConversation }
-            let unpinned = regularUnpinned + scheduleUnpinned
+        if let movedConversation = groupMembers.first(where: { $0.id == sourceId }) ?? [draft[sourceIdx]].first {
+            reordered.insert(movedConversation, at: insertPos)
+        }
 
-            var reordered = unpinned.filter { $0.id != sourceId }
-
-            let insertPos: Int
-            let sourceConversation = draft[sourceIdx]
-            if targetConversation.isScheduleConversation && !sourceConversation.isScheduleConversation {
-                // Cross-section drag: insert at section boundary
-                insertPos = reordered.firstIndex(where: { $0.isScheduleConversation }) ?? reordered.endIndex
-            } else {
-                // Direction-aware: if source was visually above target (dragging down),
-                // insert AFTER target; if below (dragging up), insert BEFORE target.
-                // Pinned conversations are always visually above unpinned ones, so a
-                // pinned→unpinned drag is always "dragging down".
-                let draggingDown: Bool
-                if sourceWasPinned {
-                    draggingDown = true
-                } else {
-                    let sourceVisualIdx = unpinned.firstIndex(where: { $0.id == sourceId })
-                    let targetVisualIdx = unpinned.firstIndex(where: { $0.id == targetId })
-                    draggingDown = (sourceVisualIdx ?? 0) < (targetVisualIdx ?? 0)
-                }
-
-                if draggingDown {
-                    let targetInFiltered = reordered.firstIndex(where: { $0.id == targetId }) ?? reordered.endIndex
-                    insertPos = min(targetInFiltered + 1, reordered.endIndex)
-                } else {
-                    insertPos = reordered.firstIndex(where: { $0.id == targetId }) ?? reordered.endIndex
-                }
-            }
-
-            if let movedConversation = unpinned.first(where: { $0.id == sourceId }) ?? [draft[sourceIdx]].first {
-                reordered.insert(movedConversation, at: insertPos)
-            }
-
-            // Assign displayOrder to ALL conversations in the reordered list. When a
-            // user drags a conversation they are explicitly defining an ordering, so every
-            // conversation in the affected section needs a concrete displayOrder. Without
-            // this, dragging between recency-sorted conversations (nil displayOrder) would
-            // only assign an order to the source, causing it to jump to the top of
-            // the list since visibleConversations sorts non-nil displayOrder above nil.
-            for (order, item) in reordered.enumerated() {
-                if let idx = draft.firstIndex(where: { $0.id == item.id }) {
-                    draft[idx].displayOrder = order
-                }
+        // Assign displayOrder to ALL conversations in the target group. When a
+        // user drags a conversation they are explicitly defining an ordering, so every
+        // conversation in the affected group needs a concrete displayOrder. Without
+        // this, dragging between recency-sorted conversations (nil displayOrder) would
+        // only assign an order to the source, causing it to jump to the top of
+        // the list since visibleConversations sorts non-nil displayOrder above nil.
+        for (order, item) in reordered.enumerated() {
+            if let idx = draft.firstIndex(where: { $0.id == item.id }) {
+                draft[idx].displayOrder = order
             }
         }
 
@@ -1331,16 +1294,6 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         conversations = draft
         sendReorderConversations()
         return true
-    }
-
-    /// Recompact displayOrders for pinned conversations (no @Published writes).
-    private func recompactPinnedDisplayOrders(in draft: inout [ConversationModel]) {
-        let pinned = draft.enumerated()
-            .filter { $0.element.isPinned }
-            .sorted { ($0.element.displayOrder ?? 0) < ($1.element.displayOrder ?? 0) }
-        for (order, item) in pinned.enumerated() {
-            draft[item.offset].displayOrder = order
-        }
     }
 
     /// Send the current conversation ordering to the daemon so it persists across restarts.

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -189,9 +189,11 @@ extension MainWindowView {
                     if isTargeted && conversation.id != sidebar.draggingConversationId {
                         sidebar.dropTargetConversationId = conversation.id
                         if let dragId = sidebar.draggingConversationId {
-                            let visible = conversationManager.visibleConversations
-                            let sIdx = visible.firstIndex(where: { $0.id == dragId }) ?? 0
-                            let tIdx = visible.firstIndex(where: { $0.id == conversation.id }) ?? 0
+                            // Use section-local index (ungrouped conversations only)
+                            let ungroupedConvs = conversationManager.groupedConversations
+                                .first { $0.group == nil }?.conversations ?? []
+                            let sIdx = ungroupedConvs.firstIndex(where: { $0.id == dragId }) ?? 0
+                            let tIdx = ungroupedConvs.firstIndex(where: { $0.id == conversation.id }) ?? 0
                             sidebar.dropIndicatorAtBottom = sIdx < tIdx
                         }
                     } else if !isTargeted && sidebar.dropTargetConversationId == conversation.id {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ScheduleDropDelegates.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ScheduleDropDelegates.swift
@@ -13,6 +13,7 @@ struct ScheduleReorderDropDelegate: DropDelegate {
               dragId != targetConversation.id,
               let sourceConversation = conversationManager.visibleConversations.first(where: { $0.id == dragId }),
               sourceConversation.isScheduleConversation,
+              sourceConversation.groupId == targetConversation.groupId,
               sourceConversation.scheduleJobId == targetConversation.scheduleJobId
         else { return false }
         return true
@@ -27,13 +28,16 @@ struct ScheduleReorderDropDelegate: DropDelegate {
               dragId != targetConversation.id,
               let sourceConversation = conversationManager.visibleConversations.first(where: { $0.id == dragId }),
               sourceConversation.isScheduleConversation,
+              sourceConversation.groupId == targetConversation.groupId,
               sourceConversation.scheduleJobId == targetConversation.scheduleJobId
         else { return }
 
         sidebar.dropTargetConversationId = targetConversation.id
-        let visible = conversationManager.visibleConversations
-        let sIdx = visible.firstIndex(where: { $0.id == dragId }) ?? 0
-        let tIdx = visible.firstIndex(where: { $0.id == targetConversation.id }) ?? 0
+        // Use section-local index for direction detection (not global visibleConversations)
+        let groupConversations = conversationManager.groupedConversations
+            .first { $0.group?.id == targetConversation.groupId }?.conversations ?? []
+        let sIdx = groupConversations.firstIndex(where: { $0.id == dragId }) ?? 0
+        let tIdx = groupConversations.firstIndex(where: { $0.id == targetConversation.id }) ?? 0
         sidebar.dropIndicatorAtBottom = sIdx < tIdx
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarDropPayload.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarDropPayload.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Shared payload parser for sidebar drag-and-drop operations.
+/// Distinguishes between conversation drops (UUID string) and group drops ("group:xyz" prefix).
+///
+/// M4: conversations are the only drag source — callers use `.conversation(uuid)`.
+/// M5: adds group dragging with a "group:" prefix via `.group(id)`.
+enum SidebarDropPayload {
+    case conversation(UUID)
+    case group(String)
+
+    /// Parse a drop payload from a raw string.
+    /// - "group:xyz" -> `.group("xyz")`
+    /// - Valid UUID string -> `.conversation(uuid)`
+    /// - Otherwise -> nil
+    static func parse(from string: String) -> SidebarDropPayload? {
+        if string.hasPrefix("group:") {
+            let groupId = String(string.dropFirst("group:".count))
+            return .group(groupId)
+        } else if let uuid = UUID(uuidString: string) {
+            return .conversation(uuid)
+        }
+        return nil
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeaderDropDelegate.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeaderDropDelegate.swift
@@ -12,7 +12,9 @@ struct SidebarSectionHeaderDropDelegate: DropDelegate {
     func validateDrop(info: DropInfo) -> Bool {
         // M4: only conversation drops are supported (via sidebar.draggingConversationId).
         // M5 extends this to also handle group reorder via SidebarDropPayload.parse.
-        guard sidebar.draggingConversationId != nil else { return false }
+        guard let sourceId = sidebar.draggingConversationId,
+              let source = conversationManager.conversations.first(where: { $0.id == sourceId }),
+              source.groupId != groupId else { return false }
         return true
     }
 
@@ -37,6 +39,9 @@ struct SidebarSectionHeaderDropDelegate: DropDelegate {
         sidebar.dropTargetSectionId = nil
         sidebar.draggingConversationId = nil
         guard let sourceId else { return false }
+        // No-op if the conversation is already in this group (prevents clearing displayOrder)
+        if let source = conversationManager.conversations.first(where: { $0.id == sourceId }),
+           source.groupId == groupId { return false }
         conversationManager.moveConversationToGroup(sourceId, groupId: groupId)
         return true
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeaderDropDelegate.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeaderDropDelegate.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Drop delegate for sidebar section headers.
+/// Handles conversation drops (M4) — group reorder (.group) returns false for now (M5 adds it).
+struct SidebarSectionHeaderDropDelegate: DropDelegate {
+    let groupId: String?
+    let group: ConversationGroup?
+    let sidebar: SidebarInteractionState
+    let conversationManager: ConversationManager
+
+    func validateDrop(info: DropInfo) -> Bool {
+        // M4: only conversation drops are supported (via sidebar.draggingConversationId).
+        // M5 extends this to also handle group reorder via SidebarDropPayload.parse.
+        guard sidebar.draggingConversationId != nil else { return false }
+        return true
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        return DropProposal(operation: .move)
+    }
+
+    func dropEntered(info: DropInfo) {
+        if let groupId {
+            sidebar.dropTargetSectionId = groupId
+        }
+    }
+
+    func dropExited(info: DropInfo) {
+        if let groupId, sidebar.dropTargetSectionId == groupId {
+            sidebar.dropTargetSectionId = nil
+        }
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        let sourceId = sidebar.draggingConversationId
+        sidebar.dropTargetSectionId = nil
+        sidebar.draggingConversationId = nil
+        guard let sourceId else { return false }
+        conversationManager.moveConversationToGroup(sourceId, groupId: groupId)
+        return true
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -434,9 +434,17 @@ struct GroupedReorderDropDelegate: DropDelegate {
         // Use section-local index for direction detection (not global visibleConversations)
         let groupConversations = conversationManager.groupedConversations
             .first { $0.group?.id == groupId }?.conversations ?? []
-        let sIdx = groupConversations.firstIndex(where: { $0.id == dragId }) ?? 0
+        let sIdx = groupConversations.firstIndex(where: { $0.id == dragId })
         let tIdx = groupConversations.firstIndex(where: { $0.id == targetConversation.id }) ?? 0
-        sidebar.dropIndicatorAtBottom = sIdx < tIdx
+        if let sIdx {
+            // Same-group drag: compare indices to determine direction
+            sidebar.dropIndicatorAtBottom = sIdx < tIdx
+        } else {
+            // Cross-group drag: source isn't in this section, default to top
+            // indicator (insert before the target) so the visual position matches
+            // the actual insertion point.
+            sidebar.dropIndicatorAtBottom = false
+        }
     }
 
     func dropExited(info: DropInfo) {
@@ -447,10 +455,11 @@ struct GroupedReorderDropDelegate: DropDelegate {
 
     func performDrop(info: DropInfo) -> Bool {
         let sourceId = sidebar.draggingConversationId
+        let insertAfter = sidebar.dropIndicatorAtBottom
         sidebar.dropTargetConversationId = nil
         sidebar.draggingConversationId = nil
         guard let sourceId = sourceId, sourceId != targetConversation.id else { return false }
-        return conversationManager.moveConversation(sourceId: sourceId, targetId: targetConversation.id)
+        return conversationManager.moveConversation(sourceId: sourceId, targetId: targetConversation.id, insertAfterTarget: insertAfter)
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -101,6 +101,11 @@ struct SidebarSectionView: View {
                 onCommitRename: onCommitRename,
                 onDelete: onDelete
             )
+            .modifier(SectionHeaderDropModifier(
+                group: group,
+                sidebar: sidebar,
+                conversationManager: conversationManager
+            ))
 
             if isExpanded {
                 sectionContent
@@ -124,10 +129,32 @@ struct SidebarSectionView: View {
     @ViewBuilder
     private var flatContent: some View {
         let displayed = displayedConversations
-        ForEach(displayed) { conversation in
-            makeRow(conversation)
-                .equatable()
-                .padding(.bottom, SidebarLayoutMetrics.listRowGap)
+        if let sidebar, let conversationManager {
+            ForEach(displayed) { conversation in
+                makeRow(conversation)
+                    .equatable()
+                    .padding(.bottom, SidebarLayoutMetrics.listRowGap)
+                    .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
+                        if sidebar.dropTargetConversationId == conversation.id {
+                            Rectangle()
+                                .fill(VColor.primaryBase)
+                                .frame(height: 2)
+                                .transition(.opacity)
+                        }
+                    }
+                    .onDrop(of: [.plainText], delegate: GroupedReorderDropDelegate(
+                        targetConversation: conversation,
+                        groupId: group?.id,
+                        sidebar: sidebar,
+                        conversationManager: conversationManager
+                    ))
+            }
+        } else {
+            ForEach(displayed) { conversation in
+                makeRow(conversation)
+                    .equatable()
+                    .padding(.bottom, SidebarLayoutMetrics.listRowGap)
+            }
         }
 
         showMoreLessButton
@@ -337,6 +364,7 @@ struct ScheduleSubGroupHeaderDropDelegate: DropDelegate {
               dragId != firstConversation.id,
               let sourceConversation = conversationManager.visibleConversations.first(where: { $0.id == dragId }),
               sourceConversation.isScheduleConversation,
+              sourceConversation.groupId == firstConversation.groupId,
               sourceConversation.scheduleJobId == firstConversation.scheduleJobId
         else { return false }
         return true
@@ -352,6 +380,7 @@ struct ScheduleSubGroupHeaderDropDelegate: DropDelegate {
               dragId != firstConversation.id,
               let sourceConversation = conversationManager.visibleConversations.first(where: { $0.id == dragId }),
               sourceConversation.isScheduleConversation,
+              sourceConversation.groupId == firstConversation.groupId,
               sourceConversation.scheduleJobId == firstConversation.scheduleJobId
         else { return }
 
@@ -374,5 +403,74 @@ struct ScheduleSubGroupHeaderDropDelegate: DropDelegate {
               sourceId != firstConversation.id
         else { return false }
         return conversationManager.moveConversation(sourceId: sourceId, targetId: firstConversation.id)
+    }
+}
+
+/// Drop delegate for reordering conversations within a grouped (non-schedule) section.
+/// Uses section-local index comparison for drop indicator direction.
+struct GroupedReorderDropDelegate: DropDelegate {
+    let targetConversation: ConversationModel
+    let groupId: String?
+    let sidebar: SidebarInteractionState
+    let conversationManager: ConversationManager
+
+    func validateDrop(info: DropInfo) -> Bool {
+        guard let dragId = sidebar.draggingConversationId,
+              dragId != targetConversation.id
+        else { return false }
+        return true
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        return DropProposal(operation: .move)
+    }
+
+    func dropEntered(info: DropInfo) {
+        guard let dragId = sidebar.draggingConversationId,
+              dragId != targetConversation.id
+        else { return }
+
+        sidebar.dropTargetConversationId = targetConversation.id
+        // Use section-local index for direction detection (not global visibleConversations)
+        let groupConversations = conversationManager.groupedConversations
+            .first { $0.group?.id == groupId }?.conversations ?? []
+        let sIdx = groupConversations.firstIndex(where: { $0.id == dragId }) ?? 0
+        let tIdx = groupConversations.firstIndex(where: { $0.id == targetConversation.id }) ?? 0
+        sidebar.dropIndicatorAtBottom = sIdx < tIdx
+    }
+
+    func dropExited(info: DropInfo) {
+        if sidebar.dropTargetConversationId == targetConversation.id {
+            sidebar.dropTargetConversationId = nil
+        }
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        let sourceId = sidebar.draggingConversationId
+        sidebar.dropTargetConversationId = nil
+        sidebar.draggingConversationId = nil
+        guard let sourceId = sourceId, sourceId != targetConversation.id else { return false }
+        return conversationManager.moveConversation(sourceId: sourceId, targetId: targetConversation.id)
+    }
+}
+
+/// ViewModifier that conditionally attaches a SidebarSectionHeaderDropDelegate
+/// to a section header when sidebar and conversationManager are available.
+struct SectionHeaderDropModifier: ViewModifier {
+    let group: ConversationGroup
+    let sidebar: SidebarInteractionState?
+    let conversationManager: ConversationManager?
+
+    func body(content: Content) -> some View {
+        if let sidebar, let conversationManager {
+            content.onDrop(of: [.plainText], delegate: SidebarSectionHeaderDropDelegate(
+                groupId: group.id,
+                group: group,
+                sidebar: sidebar,
+                conversationManager: conversationManager
+            ))
+        } else {
+            content
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `SidebarDropPayload` enum for parsing drag payloads (conversation UUID vs group prefix) 
- Adds `SidebarSectionHeaderDropDelegate` for section header drop targets, enabling cross-group conversation moves
- Makes `ConversationManager.moveConversation` group-aware: scopes `displayOrder` to target group only, handles cross-group reassignment
- Fixes drop indicator direction to use section-local index comparison instead of global `visibleConversations`
- Adds `GroupedReorderDropDelegate` for within-group reordering in flat content sections
- Adds `groupId` check alongside `scheduleJobId` in schedule drop delegates
- Removes dead `recompactPinnedDisplayOrders` method

Part of #21830. See #21834 for full spec.

## Test plan
- [ ] Drag conversation onto a section header → assigns to that group
- [ ] Cross-group drag between sections works correctly
- [ ] Within-group reorder preserves correct order
- [ ] Drop indicator shows on correct side (top/bottom) based on drag direction
- [ ] Schedule sub-group validation: both groupId AND scheduleJobId must match
- [ ] `draggingConversationId` cleared in all drop delegates after drop
- [ ] Empty/collapsed group headers accept drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21860" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
