### PR TITLE
fix: add space guard to slashCommandRange to prevent cursor misplacement on file paths

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSlashCommands.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSlashCommands.swift
@@ -55,7 +55,7 @@ extension ComposerView {
 
     /// Range of a slash command token (e.g. `/model`) at the start of input.
     var slashCommandRange: Range<String.Index>? {
-        guard !inputText.isEmpty else { return nil }
+        guard !inputText.isEmpty, !inputText.contains(" ") else { return nil }
         return inputText.range(of: #"^/\w+"#, options: .regularExpression)
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSlashCommands.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSlashCommands.swift
@@ -56,7 +56,10 @@ extension ComposerView {
     /// Range of a slash command token (e.g. `/model`) at the start of input.
     var slashCommandRange: Range<String.Index>? {
         guard !inputText.isEmpty, !inputText.contains(" ") else { return nil }
-        return inputText.range(of: #"^/\w+"#, options: .regularExpression)
+        guard let range = inputText.range(of: #"^/\w+"#, options: .regularExpression) else { return nil }
+        let command = String(inputText[range].dropFirst()) // drop the leading "/"
+        guard SlashCommand.all.contains(where: { $0.name == command }) else { return nil }
+        return range
     }
 
     /// Builds an `AttributedString` of the full input where the leading


### PR DESCRIPTION
## Summary
- Add `!inputText.contains(" ")` guard to `slashCommandRange` in ComposerSlashCommands.swift, matching the existing guard in `updateSlashState`.
- This prevents the slash highlight overlay from activating on file paths (e.g., `/Users/...`), which caused cursor misplacement on multi-line text due to layout engine differences between the Text overlay (Core Text) and the underlying TextField (NSTextView/TextKit).

## Test plan
- [ ] Type `/model` in composer — slash highlight overlay should still appear
- [ ] Type `/Users/foo/bar` in composer — no slash highlight, cursor should stay aligned with text
- [ ] Type `/model some text` — slash highlight should disappear once a space is typed
- [ ] Paste a multi-line file path starting with `/` — no cursor drift

Closes #21859

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21861" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
