### PR TITLE
fix: remove incorrect @ObservationIgnored annotations and dead deinit code

### DIFF
--- a/clients/shared/Features/Chat/ChatPaginationState.swift
+++ b/clients/shared/Features/Chat/ChatPaginationState.swift
@@ -69,17 +69,17 @@ public final class ChatPaginationState {
     // MARK: - Dependencies
 
     /// The message manager whose `messagesPublisher` drives `displayedMessages`.
-    private let messageManager: ChatMessageManager
+    @ObservationIgnored private let messageManager: ChatMessageManager
 
     /// Callback invoked when `loadPreviousMessagePage` needs to fetch an older
     /// page from the daemon. The conversation restorer sets this so the daemon
     /// client request is routed through the same pending-history tracking used
     /// for initial loads.
-    public var onLoadMoreHistory: ((_ conversationId: String, _ beforeTimestamp: Double) -> Void)?
+    @ObservationIgnored public var onLoadMoreHistory: ((_ conversationId: String, _ beforeTimestamp: Double) -> Void)?
 
     /// Closure that supplies the current conversationId from ChatViewModel.
     /// Set after init to avoid capturing `self` before ChatViewModel is fully initialized.
-    var conversationIdProvider: () -> String? = { nil }
+    @ObservationIgnored var conversationIdProvider: () -> String? = { nil }
 
     /// Combine subscription for the throttled messagesPublisher -> displayedMessages sync.
     @ObservationIgnored private var messagesSyncSub: AnyCancellable?

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -487,7 +487,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     /// response handler can display the correct resolved state (the server does
     /// not echo back the action in its acknowledgement).
     @ObservationIgnored private var pendingGuardianActions: [String: String] = [:]
-    @ObservationIgnored public var conversationId: String? {
+    public var conversationId: String? {
         didSet {
             // If the daemon reconnected before this VM had a conversation ID, a deferred
             // flush was requested. Now that we have a conversation, run it.
@@ -934,10 +934,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
 
     /// Surface the user is currently viewing in workspace mode.
     /// Set by MainWindowView when the dynamic workspace is expanded.
-    /// Marked @ObservationIgnored to preserve didSet behavior (the @Observable
-    /// macro strips property observers). Views that need reactivity to surface
-    /// changes observe `surfaceUndoCount` or sub-manager properties instead.
-    @ObservationIgnored public var activeSurfaceId: String? {
+    public var activeSurfaceId: String? {
         didSet {
             if oldValue != activeSurfaceId {
                 surfaceUndoCount = 0
@@ -2079,7 +2076,6 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         // Cancel all Combine subscriptions first so no new work can be scheduled
         // from incoming publisher events while the remaining cleanup runs.
         cancellables.removeAll()
-        subManagerPublishTask?.cancel()
         messageLoopTask?.cancel()
         streamingFlushTask?.cancel()
         partialOutputFlushTask?.cancel()


### PR DESCRIPTION
## Summary
Fixes 4 gaps identified during self-review of the @Observable migration:

1. Remove @ObservationIgnored from conversationId — was breaking iOS .onChange(of:) scroll reset handler
2. Remove @ObservationIgnored from activeSurfaceId — unnecessary, @Observable preserves didSet
3. Remove dangling subManagerPublishTask?.cancel() from deinit (property was already removed)
4. Add @ObservationIgnored to ChatPaginationState non-reactive properties (messageManager, callbacks, subscription)

Part of plan: chatvm-observable-migration.md (review fix round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21862" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
