### PR TITLE
M5: Custom Group CRUD

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -55,6 +55,8 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
     /// Tracks the number of rows already fetched from the daemon so pagination
     /// offsets stay correct even when the client filters out some conversations.
     private let conversationListClient: any ConversationListClientProtocol = ConversationListClient()
+    /// Concrete client for group CRUD operations (not on the protocol).
+    private let groupClient = ConversationListClient()
     var serverOffset: Int = 0
     @Published var activeConversationId: UUID? {
         didSet {
@@ -1324,23 +1326,43 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         }
     }
 
-    // MARK: - Group CRUD (stubs for M5)
+    // MARK: - Group CRUD
 
     func createGroup(name: String) async -> ConversationGroup? {
-        // TODO: M5 — call server to create group, return created group
-        return nil
+        // sort_position is server-authoritative: server assigns max(custom sort_position) + 1.
+        // Client just sends name; server returns the group with its assigned sort_position.
+        guard let response = await groupClient.createGroup(name: name) else { return nil }
+        let group = ConversationGroup(from: response)
+        groups.append(group)
+        return group
     }
 
     func renameGroup(_ groupId: String, name: String) async {
-        // TODO: M5 — call server to rename group
+        guard let idx = groups.firstIndex(where: { $0.id == groupId }),
+              !groups[idx].isSystemGroup else { return }
+        groups[idx].name = name
+        _ = await groupClient.updateGroup(groupId: groupId, name: name, sortPosition: nil)
     }
 
     func deleteGroup(_ groupId: String) async {
-        // TODO: M5 — call server to delete group, move conversations to ungrouped
+        guard let idx = groups.firstIndex(where: { $0.id == groupId }),
+              !groups[idx].isSystemGroup else { return }
+        for i in conversations.indices where conversations[i].groupId == groupId {
+            conversations[i].groupId = nil
+            conversations[i].displayOrder = nil
+        }
+        groups.remove(at: idx)
+        _ = await groupClient.deleteGroup(groupId: groupId)
+        sendReorderConversations()
     }
 
     func reorderGroups(_ updates: [(groupId: String, sortPosition: Double)]) async {
-        // TODO: M5 — call server to reorder groups
+        for update in updates {
+            if let idx = groups.firstIndex(where: { $0.id == update.groupId }) {
+                groups[idx].sortPosition = update.sortPosition
+            }
+        }
+        _ = await groupClient.reorderGroups(updates: updates)
     }
 
     /// Merge groups from a conversation list response into the local groups array.

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -1347,10 +1347,13 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
     func deleteGroup(_ groupId: String) async {
         guard let idx = groups.firstIndex(where: { $0.id == groupId }),
               !groups[idx].isSystemGroup else { return }
-        for i in conversations.indices where conversations[i].groupId == groupId {
-            conversations[i].groupId = nil
-            conversations[i].displayOrder = nil
+        // Batch-mutate a copy to avoid per-element SwiftUI re-renders
+        var updated = conversations
+        for i in updated.indices where updated[i].groupId == groupId {
+            updated[i].groupId = nil
+            updated[i].displayOrder = nil
         }
+        conversations = updated
         groups.remove(at: idx)
         _ = await groupClient.deleteGroup(groupId: groupId)
         sendReorderConversations()

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
@@ -164,4 +164,11 @@ final class SidebarInteractionState {
     /// Whether the drop indicator should appear at the bottom of the target (true)
     /// or the top (false). Set based on drag direction.
     var dropIndicatorAtBottom: Bool = false
+
+    // MARK: - Group Rename State
+
+    /// Group ID currently being renamed inline. Set when "Rename" is selected from context menu.
+    var renamingGroupId: String?
+    /// Text field content for the group currently being renamed.
+    var renamingGroupName: String = ""
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -152,7 +152,16 @@ extension MainWindowView {
             } : nil,
             onShowFeedback: conversation.conversationId != nil && !LogExporter.isManagedAssistant ? {
                 AppDelegate.shared?.showLogReportWindow(scope: .conversation(conversationId: conversation.conversationId!, conversationTitle: conversation.title))
-            } : nil
+            } : nil,
+            moveToGroups: conversationManager.groups.filter { $0.id != conversation.groupId },
+            onMoveToGroup: { targetGroupId in
+                if let targetGroupId, targetGroupId == ConversationGroup.pinned.id {
+                    // Route through pinConversation to get correct bottom-append ordering.
+                    conversationManager.pinConversation(id: conversation.id)
+                } else {
+                    conversationManager.moveConversationToGroup(conversation.id, groupId: targetGroupId)
+                }
+            }
         )
     }
 
@@ -329,11 +338,22 @@ extension MainWindowView {
                                 countMode: group.id == ConversationGroup.scheduled.id
                                     ? .subGroups(grouper: { $0.scheduleJobId })
                                     : .items,
-                                isRenaming: false,
-                                renamingName: .constant(""),
-                                onRename: nil,
-                                onCommitRename: nil,
-                                onDelete: nil,
+                                isRenaming: sidebar.renamingGroupId == group.id,
+                                renamingName: Binding(
+                                    get: { sidebar.renamingGroupName },
+                                    set: { sidebar.renamingGroupName = $0 }
+                                ),
+                                onRename: group.isSystemGroup ? nil : { name in
+                                    sidebar.renamingGroupId = group.id
+                                    sidebar.renamingGroupName = name
+                                },
+                                onCommitRename: group.isSystemGroup ? nil : { newName in
+                                    sidebar.renamingGroupId = nil
+                                    Task { await conversationManager.renameGroup(group.id, name: newName) }
+                                },
+                                onDelete: group.isSystemGroup ? nil : {
+                                    Task { await conversationManager.deleteGroup(group.id) }
+                                },
                                 onToggleExpand: { sidebar.toggleSection(group.id) },
                                 onToggleShowAll: { sidebar.toggleShowAll(group.id) },
                                 makeRow: { makeSidebarRow(conversation: $0) },
@@ -351,6 +371,26 @@ extension MainWindowView {
                             ungroupedConversationRows(entry.conversations)
                         }
                     }
+
+                    // "New Group" button below last group section
+                    Button {
+                        Task {
+                            if let group = await conversationManager.createGroup(name: "New Group") {
+                                sidebar.expandedSections.insert(group.id)
+                                sidebar.renamingGroupId = group.id
+                                sidebar.renamingGroupName = group.name
+                            }
+                        }
+                    } label: {
+                        HStack {
+                            Image(systemName: "plus")
+                            Text("New Group")
+                        }
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.top, VSpacing.xs)
                 }
             }
             .scrollIndicators(.never)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -351,6 +351,9 @@ extension MainWindowView {
                                     sidebar.renamingGroupId = nil
                                     Task { await conversationManager.renameGroup(group.id, name: newName) }
                                 },
+                                onCancelRename: group.isSystemGroup ? nil : {
+                                    sidebar.renamingGroupId = nil
+                                },
                                 onDelete: group.isSystemGroup ? nil : {
                                     Task { await conversationManager.deleteGroup(group.id) }
                                 },
@@ -383,7 +386,7 @@ extension MainWindowView {
                         }
                     } label: {
                         HStack {
-                            Image(systemName: "plus")
+                            VIconView(.plus, size: 12)
                             Text("New Group")
                         }
                         .font(.caption)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -23,12 +23,28 @@ struct SidebarConversationItem: View, Equatable {
     var onDragStart: () -> Void
     var onOpenInNewWindow: (() -> Void)?
     var onShowFeedback: (() -> Void)?
+    /// Available groups for the "Move to" submenu. Excludes the conversation's current group.
+    var moveToGroups: [ConversationGroup] = []
+    /// Moves the conversation to the specified group (nil = ungrouped).
+    var onMoveToGroup: ((String?) -> Void)? = nil
 
     static func == (lhs: SidebarConversationItem, rhs: SidebarConversationItem) -> Bool {
         lhs.conversation == rhs.conversation &&
         lhs.isSelected == rhs.isSelected &&
         lhs.interactionState == rhs.interactionState &&
         lhs.isHovered == rhs.isHovered
+    }
+
+    /// The conversation's current group (if any), used for "Remove from group" visibility.
+    private var moveToCurrentGroup: ConversationGroup? {
+        guard let gid = conversation.groupId else { return nil }
+        // The moveToGroups list excludes the current group, so check all system groups + search moveToGroups
+        // by looking at the conversation's groupId against known groups.
+        if gid == ConversationGroup.pinned.id { return ConversationGroup.pinned }
+        if gid == ConversationGroup.scheduled.id { return ConversationGroup.scheduled }
+        if gid == ConversationGroup.background.id { return ConversationGroup.background }
+        // Custom group — not in moveToGroups (it's filtered out), but we know it's non-system
+        return ConversationGroup(id: gid, name: "", sortPosition: 0, isSystemGroup: false)
     }
 
     @State private var isMenuOpen: Bool = false
@@ -54,6 +70,26 @@ struct SidebarConversationItem: View, Equatable {
             onMarkUnread()
         }
         .disabled(!canMarkUnread)
+
+        if !moveToGroups.isEmpty, let onMoveToGroup {
+            Menu("Move to") {
+                ForEach(moveToGroups) { group in
+                    Button(group.name) {
+                        onMoveToGroup(group.id)
+                    }
+                }
+                // "Remove from group" only for custom groups — system groups have dedicated
+                // actions (Pin/Unpin for Pinned; Scheduled/Background are provenance-assigned).
+                if conversation.groupId != nil,
+                   let currentGroup = moveToCurrentGroup,
+                   !currentGroup.isSystemGroup {
+                    Divider()
+                    Button("Remove from group") {
+                        onMoveToGroup(nil)
+                    }
+                }
+            }
+        }
 
         if let onOpenInNewWindow {
             VMenuItem(icon: VIcon.externalLink.rawValue, label: "Open in New Window") {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -32,7 +32,8 @@ struct SidebarConversationItem: View, Equatable {
         lhs.conversation == rhs.conversation &&
         lhs.isSelected == rhs.isSelected &&
         lhs.interactionState == rhs.interactionState &&
-        lhs.isHovered == rhs.isHovered
+        lhs.isHovered == rhs.isHovered &&
+        lhs.moveToGroups == rhs.moveToGroups
     }
 
     /// The conversation's current group (if any), used for "Remove from group" visibility.

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
@@ -19,15 +19,33 @@ struct SidebarSectionHeader: View {
     var onCommitRename: ((String) -> Void)?     // M5: commits the rename (nil for system groups)
     var onDelete: (() -> Void)?                 // M5: nil for system groups
 
+    @FocusState private var isRenameFocused: Bool
+
     var body: some View {
         HStack(spacing: SidebarLayoutMetrics.listRowGap) {
             VIconView(.chevronRight, size: SidebarLayoutMetrics.sectionChevronSize)
                 .foregroundStyle(VColor.contentTertiary)
                 .rotationEffect(.degrees(isExpanded ? 90 : 0))
                 .animation(VAnimation.fast, value: isExpanded)
-            Text(group.name)
+
+            if isRenaming {
+                TextField("Group name", text: $renamingName, onCommit: {
+                    onCommitRename?(renamingName)
+                })
                 .font(.caption)
-                .foregroundStyle(.secondary)
+                .textFieldStyle(.plain)
+                .focused($isRenameFocused)
+                .onAppear { isRenameFocused = true }
+                .onExitCommand {
+                    // Cancel rename on Escape — parent clears renamingGroupId
+                    onCommitRename?(group.name)
+                }
+            } else {
+                Text(group.name)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             Spacer()
             if !isExpanded {
                 if unreadCount > 0 {
@@ -49,5 +67,50 @@ struct SidebarSectionHeader: View {
         .onTapGesture { withAnimation(VAnimation.fast) { onToggleExpand() } }
         .background(isDropTarget ? Color.accentColor.opacity(0.15) : .clear)
         .cornerRadius(4)
+        .modifier(ConditionalGroupContextMenu(
+            onRename: onRename.map { rename in { rename(group.name) } },
+            onDelete: onDelete
+        ))
+        .conditionalOnDrag(enabled: !group.isSystemGroup) {
+            NSItemProvider(object: "group:\(group.id)" as NSString)
+        }
+    }
+}
+
+// MARK: - Conditional context menu modifier
+
+/// Only attaches a `.vContextMenu` when at least one action is available.
+/// System groups (where onRename and onDelete are both nil) get no context menu.
+private struct ConditionalGroupContextMenu: ViewModifier {
+    let onRename: (() -> Void)?
+    let onDelete: (() -> Void)?
+
+    func body(content: Content) -> some View {
+        if onRename != nil || onDelete != nil {
+            content.vContextMenu {
+                if let onRename {
+                    Button("Rename") { onRename() }
+                }
+                if let onDelete {
+                    Button("Delete") { onDelete() }
+                }
+            }
+        } else {
+            content
+        }
+    }
+}
+
+// MARK: - Conditional onDrag modifier
+
+private extension View {
+    /// Applies .onDrag only when `enabled` is true. System groups are not draggable.
+    @ViewBuilder
+    func conditionalOnDrag(enabled: Bool, data: @escaping () -> NSItemProvider) -> some View {
+        if enabled {
+            self.onDrag(data)
+        } else {
+            self
+        }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
@@ -17,6 +17,7 @@ struct SidebarSectionHeader: View {
     var onToggleExpand: () -> Void
     var onRename: ((String) -> Void)?           // M5: enters rename mode (nil for system groups)
     var onCommitRename: ((String) -> Void)?     // M5: commits the rename (nil for system groups)
+    var onCancelRename: (() -> Void)?           // M5: cancels rename without persisting (Escape key)
     var onDelete: (() -> Void)?                 // M5: nil for system groups
 
     @FocusState private var isRenameFocused: Bool
@@ -37,8 +38,8 @@ struct SidebarSectionHeader: View {
                 .focused($isRenameFocused)
                 .onAppear { isRenameFocused = true }
                 .onExitCommand {
-                    // Cancel rename on Escape — parent clears renamingGroupId
-                    onCommitRename?(group.name)
+                    // Cancel rename on Escape — discard edits without API call
+                    onCancelRename?()
                 }
             } else {
                 Text(group.name)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeaderDropDelegate.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeaderDropDelegate.swift
@@ -1,8 +1,9 @@
 import SwiftUI
+import UniformTypeIdentifiers
 import VellumAssistantShared
 
 /// Drop delegate for sidebar section headers.
-/// Handles conversation drops (M4) — group reorder (.group) returns false for now (M5 adds it).
+/// Handles conversation drops (M4) and group reorder drops (M5).
 struct SidebarSectionHeaderDropDelegate: DropDelegate {
     let groupId: String?
     let group: ConversationGroup?
@@ -10,8 +11,20 @@ struct SidebarSectionHeaderDropDelegate: DropDelegate {
     let conversationManager: ConversationManager
 
     func validateDrop(info: DropInfo) -> Bool {
-        // M4: only conversation drops are supported (via sidebar.draggingConversationId).
-        // M5 extends this to also handle group reorder via SidebarDropPayload.parse.
+        // Check if this is a group reorder drop first (M5).
+        // Group drops come through as NSItemProvider with "group:" prefix.
+        // We detect them by checking if there's NO draggingConversationId set
+        // (group drags don't set draggingConversationId) AND the info contains items.
+        if sidebar.draggingConversationId == nil {
+            // Potential group drag — validate group reorder conditions
+            guard let targetGroup = group, !targetGroup.isSystemGroup else { return false }
+            // We can't parse the payload in validateDrop, but we know:
+            // - Target must be a non-system group header
+            // - The actual source validation happens in performDrop
+            return true
+        }
+
+        // M4: conversation drop path
         guard let sourceId = sidebar.draggingConversationId,
               let source = conversationManager.conversations.first(where: { $0.id == sourceId }),
               source.groupId != groupId else { return false }
@@ -35,8 +48,44 @@ struct SidebarSectionHeaderDropDelegate: DropDelegate {
     }
 
     func performDrop(info: DropInfo) -> Bool {
-        let sourceId = sidebar.draggingConversationId
         sidebar.dropTargetSectionId = nil
+
+        // Try to load dropped items to detect group vs conversation payload
+        let providers = info.itemProviders(for: [.plainText])
+        guard let provider = providers.first else {
+            // Fallback to conversation drag path (M4)
+            return performConversationDrop()
+        }
+
+        // Check for draggingConversationId first — if set, this is a conversation drag
+        if sidebar.draggingConversationId != nil {
+            return performConversationDrop()
+        }
+
+        // Async load the payload string for group reorder
+        provider.loadObject(ofClass: NSString.self) { item, _ in
+            guard let string = item as? String else { return }
+            Task { @MainActor in
+                guard let payload = SidebarDropPayload.parse(from: string) else { return }
+                switch payload {
+                case .conversation(let uuid):
+                    // Late-arriving conversation drop
+                    if let source = self.conversationManager.conversations.first(where: { $0.id == uuid }),
+                       source.groupId != self.groupId {
+                        self.conversationManager.moveConversationToGroup(uuid, groupId: self.groupId)
+                    }
+                case .group(let sourceId):
+                    self.performGroupReorder(sourceId: sourceId)
+                }
+            }
+        }
+        return true
+    }
+
+    // MARK: - Conversation Drop (M4)
+
+    private func performConversationDrop() -> Bool {
+        let sourceId = sidebar.draggingConversationId
         sidebar.draggingConversationId = nil
         guard let sourceId else { return false }
         // No-op if the conversation is already in this group (prevents clearing displayOrder)
@@ -44,5 +93,29 @@ struct SidebarSectionHeaderDropDelegate: DropDelegate {
            source.groupId == groupId { return false }
         conversationManager.moveConversationToGroup(sourceId, groupId: groupId)
         return true
+    }
+
+    // MARK: - Group Reorder (M5)
+
+    private func performGroupReorder(sourceId: String) {
+        // Source must be a custom group (system groups can't be dragged)
+        guard let source = conversationManager.groups.first(where: { $0.id == sourceId }),
+              !source.isSystemGroup else { return }
+        // Target must also be a custom group header
+        guard let targetGroup = group, !targetGroup.isSystemGroup else { return }
+        // No-op if dropping onto self
+        guard sourceId != targetGroup.id else { return }
+
+        // Reindex all custom groups to clean integer positions starting at 3.
+        var customGroups = conversationManager.groups
+            .filter { !$0.isSystemGroup }
+            .sorted { $0.sortPosition < $1.sortPosition }
+        customGroups.removeAll { $0.id == sourceId }
+        let insertIdx = customGroups.firstIndex(where: { $0.id == targetGroup.id }) ?? customGroups.endIndex
+        customGroups.insert(source, at: insertIdx)
+        let updates = customGroups.enumerated().map { (i, g) in
+            (groupId: g.id, sortPosition: Double(3 + i))
+        }
+        Task { await conversationManager.reorderGroups(updates) }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -30,6 +30,7 @@ struct SidebarSectionView: View {
     @Binding var renamingName: String
     var onRename: ((String) -> Void)?
     var onCommitRename: ((String) -> Void)?
+    var onCancelRename: (() -> Void)?
     var onDelete: (() -> Void)?
 
     var onToggleExpand: () -> Void
@@ -99,6 +100,7 @@ struct SidebarSectionView: View {
                 onToggleExpand: onToggleExpand,
                 onRename: onRename,
                 onCommitRename: onCommitRename,
+                onCancelRename: onCancelRename,
                 onDelete: onDelete
             )
             .modifier(SectionHeaderDropModifier(


### PR DESCRIPTION
## Summary
- Implements full group CRUD: create, rename, delete, reorder custom groups via ConversationManager + ConversationListClient
- Adds inline rename in SidebarSectionHeader with TextField, focus management, and Escape-to-cancel
- Adds context menu (Rename/Delete) on custom group headers; system groups get no context menu
- Adds group drag-to-reorder on custom group headers with reindex to sortPosition >= 3
- Adds "Move to" submenu on conversation context menus with "Remove from group" for custom groups
- "Move to Pinned" routes through pinConversation for correct bottom-append ordering
- "New Group" button below the last group section creates group and enters rename mode

## Test plan
- [ ] Click "New Group" button -- creates group, enters inline rename mode
- [ ] Type a name and press Enter -- group is renamed
- [ ] Press Escape during rename -- reverts to original name
- [ ] Right-click custom group header -- shows Rename and Delete
- [ ] Right-click system group header (Pinned, Scheduled, Background) -- no context menu
- [ ] Delete a custom group -- conversations move to ungrouped
- [ ] Drag a custom group header onto another custom group header -- groups reorder
- [ ] Drag a custom group header onto a system group header -- rejected
- [ ] Drag a group onto itself -- no-op
- [ ] Right-click conversation -- "Move to" submenu shows all other groups
- [ ] "Move to Pinned" -- conversation appears at bottom of Pinned section
- [ ] "Remove from group" only appears for conversations in custom groups
- [ ] System group conversations don't show "Remove from group"

Part of #21830. See #21835 for full spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21864" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
