### PR TITLE
M6: Polish + Edge Cases

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -205,12 +205,12 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
 
         for group in sortedGroups {
             let members = visible.filter { $0.groupId == group.id }
-            // Show non-system groups even when empty (so "New Group" is visible immediately in M5).
-            // System groups only shown when they have members (or during drag -- handled in M3/M4).
-            if !members.isEmpty || !group.isSystemGroup {
-                result.append((group, members))
-                accountedIds.formUnion(members.map(\.id))
-            }
+            // Always include all groups so the view layer can decide visibility.
+            // Non-system groups always appear (so "New Group" is visible immediately).
+            // System groups are emitted even when empty so the view can show ghost
+            // headers during drag; the view hides empty system groups when no drag is active.
+            result.append((group, members))
+            accountedIds.formUnion(members.map(\.id))
         }
 
         // Ungrouped + orphaned (unknown groupId) -- always last
@@ -1181,19 +1181,6 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             conversations[index].groupId = nil
         }
         conversations[index].displayOrder = nil
-        sendReorderConversations()
-    }
-
-    func reorderPinnedConversations(from source: IndexSet, to destination: Int) {
-        var pinned = visibleConversations.filter(\.isPinned)
-        pinned.move(fromOffsets: source, toOffset: destination)
-        var draft = conversations
-        for (order, item) in pinned.enumerated() {
-            if let idx = draft.firstIndex(where: { $0.id == item.id }) {
-                draft[idx].displayOrder = order
-            }
-        }
-        conversations = draft
         sendReorderConversations()
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationModel.swift
@@ -39,13 +39,13 @@ struct ConversationModel: Identifiable, Hashable {
     var lastSeenAssistantMessageAt: Date?
     var forkParent: ConversationForkParent?
 
-    init(id: UUID = UUID(), title: String = "New Conversation", createdAt: Date = Date(), conversationId: String? = nil, isArchived: Bool = false, isPinned: Bool = false, groupId: String? = nil, displayOrder: Int? = nil, lastInteractedAt: Date? = nil, kind: ConversationKind = .standard, source: String? = nil, scheduleJobId: String? = nil, hasUnseenLatestAssistantMessage: Bool = false, latestAssistantMessageAt: Date? = nil, lastSeenAssistantMessageAt: Date? = nil, forkParent: ConversationForkParent? = nil) {
+    init(id: UUID = UUID(), title: String = "New Conversation", createdAt: Date = Date(), conversationId: String? = nil, isArchived: Bool = false, groupId: String? = nil, displayOrder: Int? = nil, lastInteractedAt: Date? = nil, kind: ConversationKind = .standard, source: String? = nil, scheduleJobId: String? = nil, hasUnseenLatestAssistantMessage: Bool = false, latestAssistantMessageAt: Date? = nil, lastSeenAssistantMessageAt: Date? = nil, forkParent: ConversationForkParent? = nil) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
         self.conversationId = conversationId
         self.isArchived = isArchived
-        self.groupId = groupId ?? (isPinned ? ConversationGroup.pinned.id : nil)
+        self.groupId = groupId
         self.displayOrder = displayOrder
         self.lastInteractedAt = lastInteractedAt ?? createdAt
         self.kind = kind

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -51,6 +51,13 @@ extension MainWindowView {
         conversationManager.visibleConversations.filter { !$0.isScheduleConversation && !$0.isBackgroundConversation }
     }
 
+    /// Unread count in the Scheduled section, used to trigger auto-expand.
+    private var scheduledUnreadCount: Int {
+        conversationManager.visibleConversations
+            .filter { $0.groupId == ConversationGroup.scheduled.id && $0.hasUnseenLatestAssistantMessage }
+            .count
+    }
+
     var displayedApps: [AppListManager.AppItem] {
         let all = appListManager.displayApps
         return sidebar.showAllApps ? all : Array(all.prefix(5))
@@ -317,7 +324,15 @@ extension MainWindowView {
                         DaemonLoadingConversationsSkeleton()
                     }
 
+                    let isDragging = sidebar.draggingConversationId != nil
                     let groupEntries = conversationManager.groupedConversations
+                        .filter { entry in
+                            // Hide empty system groups unless a drag is in progress
+                            // (ghost headers serve as drop targets during drag).
+                            // Non-system groups and ungrouped always appear.
+                            guard let group = entry.group, group.isSystemGroup else { return true }
+                            return !entry.conversations.isEmpty || isDragging
+                        }
                         .map { entry in
                             SidebarGroupEntry(
                                 id: entry.group?.id ?? "ungrouped",
@@ -334,7 +349,6 @@ extension MainWindowView {
                                 showAll: sidebar.showAllInSection.contains(group.id),
                                 maxCollapsed: group.isSystemGroup ? 3 : 5,
                                 isDropTarget: sidebar.dropTargetSectionId == group.id,
-                                autoExpandOnUnread: group.id == ConversationGroup.scheduled.id,
                                 countMode: group.id == ConversationGroup.scheduled.id
                                     ? .subGroups(grouper: { $0.scheduleJobId })
                                     : .items,
@@ -397,6 +411,16 @@ extension MainWindowView {
                 }
             }
             .scrollIndicators(.never)
+            .onChange(of: scheduledUnreadCount) { _, newCount in
+                // Auto-expand the Scheduled section when new unread arrives
+                // while collapsed. Other sections (Background, Custom, Pinned)
+                // do NOT auto-expand.
+                if newCount > 0 && !sidebar.expandedSections.contains(ConversationGroup.scheduled.id) {
+                    withAnimation(VAnimation.fast) {
+                        sidebar.expandedSections.insert(ConversationGroup.scheduled.id)
+                    }
+                }
+            }
 
             Spacer(minLength: VSpacing.sm)
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -19,7 +19,6 @@ struct SidebarSectionView: View {
     let showAll: Bool
     let maxCollapsed: Int
     let isDropTarget: Bool
-    let autoExpandOnUnread: Bool
     let countMode: CountMode
 
     // Rename/delete plumbing -- passed through to SidebarSectionHeader.
@@ -111,6 +110,7 @@ struct SidebarSectionView: View {
 
             if isExpanded {
                 sectionContent
+                    .transition(.opacity.combined(with: .move(edge: .top)))
             }
         } else {
             // Ungrouped -- no header, render conversations directly

--- a/clients/macos/vellum-assistantTests/ConversationHeaderPresentationTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationHeaderPresentationTests.swift
@@ -130,7 +130,7 @@ final class ConversationHeaderPresentationTests: XCTestCase {
     // MARK: - Pin state
 
     func testPinnedConversationShowsPinnedState() {
-        let conversation = ConversationModel(title: "Pinned", conversationId: "s", isPinned: true)
+        let conversation = ConversationModel(title: "Pinned", conversationId: "s", groupId: ConversationGroup.pinned.id)
         let p = ConversationHeaderPresentation(
             activeConversation: conversation,
             activeViewModel: nil,


### PR DESCRIPTION
## Summary
- Add expand/collapse animation (`.transition(.opacity.combined(with: .move(edge: .top)))`) on section content in SidebarSectionView
- Auto-expand Scheduled section when new unread messages arrive while collapsed (other groups do NOT auto-expand)
- Hide empty system group headers (Pinned, Scheduled, Background) when they have no conversations, show ghost headers during drag as drop targets
- Remove deprecated `reorderPinnedConversations` method from ConversationManager (unused, replaced by group-aware `moveConversation`)
- Remove deprecated `isPinned` convenience init parameter from ConversationModel (callers should use `groupId:` directly)
- Remove unused `autoExpandOnUnread` property from SidebarSectionView (auto-expand now handled as a side-effect in sidebar view layer)

Part of #21830. See #21836 for full spec.

## Test plan
- [ ] Verify section expand/collapse animates smoothly with opacity+slide transition
- [ ] Collapse Scheduled section, trigger a schedule run -- section should auto-expand
- [ ] Collapse Pinned/Background/Custom sections, verify they do NOT auto-expand on unread
- [ ] Verify empty system groups (no conversations) are hidden; show headers during active drag
- [ ] Verify existing drag-and-drop, rename, delete, and context menu functionality still works
- [ ] Verify collapsed sidebar conversation switcher still shows correct count

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21869" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
