### PR TITLE
M2: Add .onDrop() to ComposerView and refactor ChatView to use shared handler

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -364,6 +364,7 @@ struct ChatView: View {
                     .transition(.opacity)
             }
         }
+        .environment(\.dropActions, currentDropActions)
         .onDrop(of: [.fileURL, .image, .png, .tiff], isTargeted: $isDropTargeted) { providers in
             handleDrop(providers: providers)
         }
@@ -534,114 +535,26 @@ struct ChatView: View {
         }
     }
 
-    /// Handle dropped items — supports both file URLs and raw image data.
-    /// File URLs are preferred (preserves original filenames); raw image data
-    /// is used as a fallback for providers without a backing file (e.g. screenshot
-    /// thumbnails or images dragged from certain apps).
+    /// DropActions instance built from ChatView's existing callbacks and state,
+    /// reused by both the `.onDrop()` on ChatView and the environment injection
+    /// so ComposerView's inner `.onDrop()` shares the same handler.
+    private var currentDropActions: DropActions {
+        DropActions(
+            onDropFiles: onDropFiles,
+            onDropImageData: onDropImageData,
+            onDropStarted: onDropStarted,
+            onDropEnded: onDropEnded,
+            isDropTargeted: $isDropTargeted,
+            isDraggingInternalImage: $isDraggingInternalImage,
+            onInternalDragRejected: { self.removeDragEndMonitors() }
+        )
+    }
+
+    /// Handle dropped items by delegating to the shared ComposerDropHandler.
+    /// Kept as a thin wrapper so the `.onDrop()` on ChatView (the outer/fallback
+    /// drop target for the message list area) continues to work.
     private func handleDrop(providers: [NSItemProvider]) -> Bool {
-        // Reset overlay immediately — SwiftUI's isTargeted binding may not
-        // reset reliably when AppKit's NSDraggingDestination (e.g. the
-        // NSTextView inside the composer) intercepts the drag session.
-        isDropTargeted = false
-
-        // Reject drops from internal image drags — the user is dragging an
-        // assistant-rendered image to Finder/Desktop, not uploading it back.
-        if isDraggingInternalImage {
-            isDraggingInternalImage = false
-            removeDragEndMonitors()
-            return false
-        }
-
-        // Signal loading immediately so the "Processing…" chip appears without
-        // waiting for NSItemProvider async callbacks to resolve.
-        onDropStarted?()
-
-        var urls: [URL] = []
-        var imageDataItems: [NSItemProvider] = []
-        let group = DispatchGroup()
-
-        for provider in providers {
-            if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
-                let hasImageFallback = provider.hasItemConformingToTypeIdentifier(UTType.image.identifier)
-                    || provider.hasItemConformingToTypeIdentifier(UTType.png.identifier)
-                    || provider.hasItemConformingToTypeIdentifier(UTType.tiff.identifier)
-                group.enter()
-                _ = provider.loadObject(ofClass: URL.self) { url, error in
-                    DispatchQueue.main.async {
-                        if let url, FileManager.default.fileExists(atPath: url.path) {
-                            urls.append(url)
-                            group.leave()
-                        } else if hasImageFallback {
-                            let typeIdentifier: String
-                            if provider.hasItemConformingToTypeIdentifier(UTType.png.identifier) {
-                                typeIdentifier = UTType.png.identifier
-                            } else if provider.hasItemConformingToTypeIdentifier(UTType.tiff.identifier) {
-                                typeIdentifier = UTType.tiff.identifier
-                            } else {
-                                typeIdentifier = UTType.image.identifier
-                            }
-                            let suggestedName = provider.suggestedName
-                            provider.loadDataRepresentation(forTypeIdentifier: typeIdentifier) { data, _ in
-                                DispatchQueue.main.async {
-                                    if let data {
-                                        onDropImageData(data, suggestedName)
-                                    } else if let url, url.isFileURL {
-                                        // Image data load failed — fall back to
-                                        // the file URL (may be a file promise).
-                                        urls.append(url)
-                                    }
-                                    group.leave()
-                                }
-                            }
-                        } else if let url, url.isFileURL {
-                            // File URL doesn't exist on disk yet (e.g. file
-                            // promises from Music.app, Voice Memos) and no
-                            // image data fallback is available. Try the URL
-                            // anyway — the attachment loader will report an
-                            // error if the file is truly inaccessible.
-                            urls.append(url)
-                            group.leave()
-                        } else {
-                            group.leave()
-                        }
-                    }
-                }
-            } else if provider.hasItemConformingToTypeIdentifier(UTType.image.identifier)
-                        || provider.hasItemConformingToTypeIdentifier(UTType.png.identifier)
-                        || provider.hasItemConformingToTypeIdentifier(UTType.tiff.identifier) {
-                imageDataItems.append(provider)
-            }
-        }
-
-        for provider in imageDataItems {
-            let typeIdentifier: String
-            if provider.hasItemConformingToTypeIdentifier(UTType.png.identifier) {
-                typeIdentifier = UTType.png.identifier
-            } else if provider.hasItemConformingToTypeIdentifier(UTType.tiff.identifier) {
-                typeIdentifier = UTType.tiff.identifier
-            } else {
-                typeIdentifier = UTType.image.identifier
-            }
-
-            let suggestedName = provider.suggestedName
-            group.enter()
-            provider.loadDataRepresentation(forTypeIdentifier: typeIdentifier) { data, _ in
-                DispatchQueue.main.async {
-                    if let data {
-                        onDropImageData(data, suggestedName)
-                    }
-                    group.leave()
-                }
-            }
-        }
-
-        group.notify(queue: .main) {
-            if !urls.isEmpty { onDropFiles(urls) }
-            // End the external load now that all providers have resolved and
-            // the individual addAttachment calls have taken over tracking.
-            onDropEnded?()
-        }
-        return true
+        ComposerDropHandler.handleDrop(providers: providers, actions: currentDropActions)
     }
 
     // MARK: - Search Helpers

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -64,6 +64,9 @@ struct ComposerView: View {
     var isInteractionEnabled: Bool = true
 
     @Environment(\.cmdEnterToSend) private var cmdEnterToSend
+    #if os(macOS)
+    @Environment(\.dropActions) private var dropActions
+    #endif
     @FocusState private var composerFocus: Bool
     @State private var isComposerFocused = false
     /// Incremented when inputText is cleared externally (e.g. after send) to force
@@ -117,6 +120,11 @@ struct ComposerView: View {
                 textEntryComposer
             }
         }
+        #if os(macOS)
+        .onDrop(of: [.fileURL, .image, .png, .tiff], isTargeted: dropActions.isDropTargeted) { providers in
+            ComposerDropHandler.handleDrop(providers: providers, actions: dropActions)
+        }
+        #endif
         .fixedSize(horizontal: false, vertical: true)
         .animation(VAnimation.fast, value: showSlashMenu)
         .padding(.horizontal, VSpacing.lg)


### PR DESCRIPTION
Wire DropActions environment into ComposerView with .onDrop() on outermost VStack. Refactor ChatView.handleDrop to use shared ComposerDropHandler. Fixes #21865.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21870" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
