### PR TITLE
Fix composer drag-and-drop: process files as attachments instead of inserting path

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -364,6 +364,7 @@ struct ChatView: View {
                     .transition(.opacity)
             }
         }
+        .environment(\.dropActions, currentDropActions)
         .onDrop(of: [.fileURL, .image, .png, .tiff], isTargeted: $isDropTargeted) { providers in
             handleDrop(providers: providers)
         }
@@ -534,114 +535,26 @@ struct ChatView: View {
         }
     }
 
-    /// Handle dropped items — supports both file URLs and raw image data.
-    /// File URLs are preferred (preserves original filenames); raw image data
-    /// is used as a fallback for providers without a backing file (e.g. screenshot
-    /// thumbnails or images dragged from certain apps).
+    /// DropActions instance built from ChatView's existing callbacks and state,
+    /// reused by both the `.onDrop()` on ChatView and the environment injection
+    /// so ComposerView's inner `.onDrop()` shares the same handler.
+    private var currentDropActions: DropActions {
+        DropActions(
+            onDropFiles: onDropFiles,
+            onDropImageData: onDropImageData,
+            onDropStarted: onDropStarted,
+            onDropEnded: onDropEnded,
+            isDropTargeted: $isDropTargeted,
+            isDraggingInternalImage: $isDraggingInternalImage,
+            onInternalDragRejected: { self.removeDragEndMonitors() }
+        )
+    }
+
+    /// Handle dropped items by delegating to the shared ComposerDropHandler.
+    /// Kept as a thin wrapper so the `.onDrop()` on ChatView (the outer/fallback
+    /// drop target for the message list area) continues to work.
     private func handleDrop(providers: [NSItemProvider]) -> Bool {
-        // Reset overlay immediately — SwiftUI's isTargeted binding may not
-        // reset reliably when AppKit's NSDraggingDestination (e.g. the
-        // NSTextView inside the composer) intercepts the drag session.
-        isDropTargeted = false
-
-        // Reject drops from internal image drags — the user is dragging an
-        // assistant-rendered image to Finder/Desktop, not uploading it back.
-        if isDraggingInternalImage {
-            isDraggingInternalImage = false
-            removeDragEndMonitors()
-            return false
-        }
-
-        // Signal loading immediately so the "Processing…" chip appears without
-        // waiting for NSItemProvider async callbacks to resolve.
-        onDropStarted?()
-
-        var urls: [URL] = []
-        var imageDataItems: [NSItemProvider] = []
-        let group = DispatchGroup()
-
-        for provider in providers {
-            if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
-                let hasImageFallback = provider.hasItemConformingToTypeIdentifier(UTType.image.identifier)
-                    || provider.hasItemConformingToTypeIdentifier(UTType.png.identifier)
-                    || provider.hasItemConformingToTypeIdentifier(UTType.tiff.identifier)
-                group.enter()
-                _ = provider.loadObject(ofClass: URL.self) { url, error in
-                    DispatchQueue.main.async {
-                        if let url, FileManager.default.fileExists(atPath: url.path) {
-                            urls.append(url)
-                            group.leave()
-                        } else if hasImageFallback {
-                            let typeIdentifier: String
-                            if provider.hasItemConformingToTypeIdentifier(UTType.png.identifier) {
-                                typeIdentifier = UTType.png.identifier
-                            } else if provider.hasItemConformingToTypeIdentifier(UTType.tiff.identifier) {
-                                typeIdentifier = UTType.tiff.identifier
-                            } else {
-                                typeIdentifier = UTType.image.identifier
-                            }
-                            let suggestedName = provider.suggestedName
-                            provider.loadDataRepresentation(forTypeIdentifier: typeIdentifier) { data, _ in
-                                DispatchQueue.main.async {
-                                    if let data {
-                                        onDropImageData(data, suggestedName)
-                                    } else if let url, url.isFileURL {
-                                        // Image data load failed — fall back to
-                                        // the file URL (may be a file promise).
-                                        urls.append(url)
-                                    }
-                                    group.leave()
-                                }
-                            }
-                        } else if let url, url.isFileURL {
-                            // File URL doesn't exist on disk yet (e.g. file
-                            // promises from Music.app, Voice Memos) and no
-                            // image data fallback is available. Try the URL
-                            // anyway — the attachment loader will report an
-                            // error if the file is truly inaccessible.
-                            urls.append(url)
-                            group.leave()
-                        } else {
-                            group.leave()
-                        }
-                    }
-                }
-            } else if provider.hasItemConformingToTypeIdentifier(UTType.image.identifier)
-                        || provider.hasItemConformingToTypeIdentifier(UTType.png.identifier)
-                        || provider.hasItemConformingToTypeIdentifier(UTType.tiff.identifier) {
-                imageDataItems.append(provider)
-            }
-        }
-
-        for provider in imageDataItems {
-            let typeIdentifier: String
-            if provider.hasItemConformingToTypeIdentifier(UTType.png.identifier) {
-                typeIdentifier = UTType.png.identifier
-            } else if provider.hasItemConformingToTypeIdentifier(UTType.tiff.identifier) {
-                typeIdentifier = UTType.tiff.identifier
-            } else {
-                typeIdentifier = UTType.image.identifier
-            }
-
-            let suggestedName = provider.suggestedName
-            group.enter()
-            provider.loadDataRepresentation(forTypeIdentifier: typeIdentifier) { data, _ in
-                DispatchQueue.main.async {
-                    if let data {
-                        onDropImageData(data, suggestedName)
-                    }
-                    group.leave()
-                }
-            }
-        }
-
-        group.notify(queue: .main) {
-            if !urls.isEmpty { onDropFiles(urls) }
-            // End the external load now that all providers have resolved and
-            // the individual addAttachment calls have taken over tracking.
-            onDropEnded?()
-        }
-        return true
+        ComposerDropHandler.handleDrop(providers: providers, actions: currentDropActions)
     }
 
     // MARK: - Search Helpers

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerDropHandler.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerDropHandler.swift
@@ -1,0 +1,168 @@
+#if os(macOS)
+import Foundation
+import SwiftUI
+import UniformTypeIdentifiers
+
+// MARK: - DropActions
+
+/// Groups all drop-related callbacks and state needed by the composer drop handler.
+struct DropActions {
+    /// Called with resolved file URLs after a drop completes.
+    var onDropFiles: ([URL]) -> Void
+    /// Called with raw image data (and optional suggested name) for providers without a backing file.
+    var onDropImageData: (Data, String?) -> Void
+    /// Called immediately when a drop begins, before async provider loading starts.
+    var onDropStarted: (() -> Void)?
+    /// Called after all providers have resolved and individual attachment calls have taken over.
+    var onDropEnded: (() -> Void)?
+    /// Binding to the drop-targeted overlay state.
+    var isDropTargeted: Binding<Bool>
+    /// Binding that tracks whether the user is dragging an internally-rendered image
+    /// (e.g. to Finder/Desktop), which should be rejected as an upload.
+    var isDraggingInternalImage: Binding<Bool>
+    /// Called when an internal image drag is rejected so the caller can perform
+    /// cleanup (e.g. removing drag-end monitors) that would otherwise be skipped
+    /// by the early return.
+    var onInternalDragRejected: (() -> Void)?
+
+    /// A no-op default suitable for use as an EnvironmentKey default value.
+    static let noop = DropActions(
+        onDropFiles: { _ in },
+        onDropImageData: { _, _ in },
+        onDropStarted: nil,
+        onDropEnded: nil,
+        isDropTargeted: .constant(false),
+        isDraggingInternalImage: .constant(false),
+        onInternalDragRejected: nil
+    )
+}
+
+// MARK: - EnvironmentKey
+
+private struct DropActionsKey: EnvironmentKey {
+    static let defaultValue: DropActions = .noop
+}
+
+extension EnvironmentValues {
+    var dropActions: DropActions {
+        get { self[DropActionsKey.self] }
+        set { self[DropActionsKey.self] = newValue }
+    }
+}
+
+// MARK: - ComposerDropHandler
+
+/// Utility that extracts the drop-handling logic from ChatView into a reusable static method.
+enum ComposerDropHandler {
+
+    /// Handle dropped items — supports both file URLs and raw image data.
+    /// File URLs are preferred (preserves original filenames); raw image data
+    /// is used as a fallback for providers without a backing file (e.g. screenshot
+    /// thumbnails or images dragged from certain apps).
+    static func handleDrop(providers: [NSItemProvider], actions: DropActions) -> Bool {
+        // Reset overlay immediately — SwiftUI's isTargeted binding may not
+        // reset reliably when AppKit's NSDraggingDestination (e.g. the
+        // NSTextView inside the composer) intercepts the drag session.
+        actions.isDropTargeted.wrappedValue = false
+
+        // Reject drops from internal image drags — the user is dragging an
+        // assistant-rendered image to Finder/Desktop, not uploading it back.
+        if actions.isDraggingInternalImage.wrappedValue {
+            actions.isDraggingInternalImage.wrappedValue = false
+            actions.onInternalDragRejected?()
+            return false
+        }
+
+        // Signal loading immediately so the "Processing…" chip appears without
+        // waiting for NSItemProvider async callbacks to resolve.
+        actions.onDropStarted?()
+
+        var urls: [URL] = []
+        var imageDataItems: [NSItemProvider] = []
+        let group = DispatchGroup()
+
+        for provider in providers {
+            if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
+                let hasImageFallback = provider.hasItemConformingToTypeIdentifier(UTType.image.identifier)
+                    || provider.hasItemConformingToTypeIdentifier(UTType.png.identifier)
+                    || provider.hasItemConformingToTypeIdentifier(UTType.tiff.identifier)
+                group.enter()
+                _ = provider.loadObject(ofClass: URL.self) { url, error in
+                    DispatchQueue.main.async {
+                        if let url, FileManager.default.fileExists(atPath: url.path) {
+                            urls.append(url)
+                            group.leave()
+                        } else if hasImageFallback {
+                            let typeIdentifier: String
+                            if provider.hasItemConformingToTypeIdentifier(UTType.png.identifier) {
+                                typeIdentifier = UTType.png.identifier
+                            } else if provider.hasItemConformingToTypeIdentifier(UTType.tiff.identifier) {
+                                typeIdentifier = UTType.tiff.identifier
+                            } else {
+                                typeIdentifier = UTType.image.identifier
+                            }
+                            let suggestedName = provider.suggestedName
+                            provider.loadDataRepresentation(forTypeIdentifier: typeIdentifier) { data, _ in
+                                DispatchQueue.main.async {
+                                    if let data {
+                                        actions.onDropImageData(data, suggestedName)
+                                    } else if let url, url.isFileURL {
+                                        // Image data load failed — fall back to
+                                        // the file URL (may be a file promise).
+                                        urls.append(url)
+                                    }
+                                    group.leave()
+                                }
+                            }
+                        } else if let url, url.isFileURL {
+                            // File URL doesn't exist on disk yet (e.g. file
+                            // promises from Music.app, Voice Memos) and no
+                            // image data fallback is available. Try the URL
+                            // anyway — the attachment loader will report an
+                            // error if the file is truly inaccessible.
+                            urls.append(url)
+                            group.leave()
+                        } else {
+                            group.leave()
+                        }
+                    }
+                }
+            } else if provider.hasItemConformingToTypeIdentifier(UTType.image.identifier)
+                        || provider.hasItemConformingToTypeIdentifier(UTType.png.identifier)
+                        || provider.hasItemConformingToTypeIdentifier(UTType.tiff.identifier) {
+                imageDataItems.append(provider)
+            }
+        }
+
+        for provider in imageDataItems {
+            let typeIdentifier: String
+            if provider.hasItemConformingToTypeIdentifier(UTType.png.identifier) {
+                typeIdentifier = UTType.png.identifier
+            } else if provider.hasItemConformingToTypeIdentifier(UTType.tiff.identifier) {
+                typeIdentifier = UTType.tiff.identifier
+            } else {
+                typeIdentifier = UTType.image.identifier
+            }
+
+            let suggestedName = provider.suggestedName
+            group.enter()
+            provider.loadDataRepresentation(forTypeIdentifier: typeIdentifier) { data, _ in
+                DispatchQueue.main.async {
+                    if let data {
+                        actions.onDropImageData(data, suggestedName)
+                    }
+                    group.leave()
+                }
+            }
+        }
+
+        group.notify(queue: .main) {
+            if !urls.isEmpty { actions.onDropFiles(urls) }
+            // End the external load now that all providers have resolved and
+            // the individual addAttachment calls have taken over tracking.
+            actions.onDropEnded?()
+        }
+        return true
+    }
+}
+#endif

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -64,6 +64,9 @@ struct ComposerView: View {
     var isInteractionEnabled: Bool = true
 
     @Environment(\.cmdEnterToSend) private var cmdEnterToSend
+    #if os(macOS)
+    @Environment(\.dropActions) private var dropActions
+    #endif
     @FocusState private var composerFocus: Bool
     @State private var isComposerFocused = false
     /// Incremented when inputText is cleared externally (e.g. after send) to force
@@ -117,6 +120,11 @@ struct ComposerView: View {
                 textEntryComposer
             }
         }
+        #if os(macOS)
+        .onDrop(of: [.fileURL, .image, .png, .tiff], isTargeted: dropActions.isDropTargeted) { providers in
+            ComposerDropHandler.handleDrop(providers: providers, actions: dropActions)
+        }
+        #endif
         .fixedSize(horizontal: false, vertical: true)
         .animation(VAnimation.fast, value: showSlashMenu)
         .padding(.horizontal, VSpacing.lg)


### PR DESCRIPTION
## Summary
When files are dropped directly onto the composer's NSTextView, the file path was inserted as text instead of being processed as an attachment. This happened because the outer `ChatView.onDrop()` couldn't intercept drops that AppKit's NSTextView handled first, due to a timing gap in drag type unregistration.

The fix extracts the drop handling logic into a shared `ComposerDropHandler` utility, injects drop actions via a SwiftUI `EnvironmentKey`, and adds `.onDrop()` directly on `ComposerView.body` — catching drops before the NSTextView can process them.

## Changes
- **New file: `ComposerDropHandler.swift`** — Shared `ComposerDropHandler.handleDrop()` static method, `DropActions` struct grouping all drop callbacks/state, and `DropActionsKey` SwiftUI EnvironmentKey
- **`ChatView.swift`** — Replaced 100+ line inline `handleDrop` with delegation to shared handler; injects `DropActions` into environment via `.environment(\.dropActions, ...)`
- **`ComposerView.swift`** — Reads `@Environment(\.dropActions)`, adds `.onDrop()` on outermost VStack covering all three composer modes (textEntry, dictationInline, voiceConversation)
- **No changes** to `ComposerSection.swift` (environment injection bypasses it) or `ComposerBridge.swift` (drag type guard kept as belt-and-suspenders backup)

## Milestone PRs (merged into feature branch)
- #21868: M1 — Create ComposerDropHandler utility and DropActions EnvironmentKey
- #21870: M2 — Add .onDrop() to ComposerView and refactor ChatView to use shared handler

## Project issue
Closes #21865

## Test plan
- [ ] Drag an image from Finder onto the composer text field — should create an attachment chip, NOT insert the file path
- [ ] Drag an image onto the message list area (drop zone) — should still work as before
- [ ] Drag a PDF/text file onto the composer — should create an attachment chip
- [ ] Paste an image via Cmd+V — should still work as before
- [ ] Use the paperclip button to attach a file — should still work as before
- [ ] Drag an assistant-rendered image from the chat — should NOT create a duplicate attachment (internal drag rejection)
- [ ] Verify drop zone overlay appears when dragging over both the message list and the composer area
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21871" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
