### PR TITLE
fix: guard table copy button to macOS and escape markdown delimiters

### DIFF
--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -126,11 +126,13 @@ public struct InlineSurfaceRouter: View {
                 }
                 .buttonStyle(.plain)
                 .padding(VSpacing.sm)
+            #if os(macOS)
             } else if isTableSurface, case .table(let tableData) = surface.data {
                 VCopyButton(text: Self.tableAsMarkdown(tableData), size: .compact)
                     .opacity(isCardHovered ? 1 : 0)
                     .animation(VAnimation.fast, value: isCardHovered)
                     .padding(VSpacing.sm)
+            #endif
             } else if isDocumentPreview {
                 if case .documentPreview(let data) = surface.data {
                     Button {
@@ -401,12 +403,16 @@ public struct InlineSurfaceRouter: View {
 
     /// Builds a markdown table string from TableSurfaceData for clipboard copy.
     static func tableAsMarkdown(_ data: TableSurfaceData) -> String {
-        let headers = data.columns.map(\.label)
+        func escapeCell(_ text: String) -> String {
+            text.replacingOccurrences(of: "|", with: "\\|")
+                .replacingOccurrences(of: "\n", with: " ")
+        }
+        let headers = data.columns.map { escapeCell($0.label) }
         let headerLine = "| " + headers.joined(separator: " | ") + " |"
         let separatorLine = "| " + headers.map { _ in "---" }.joined(separator: " | ") + " |"
         let rowLines = data.rows.map { row in
             "| " + data.columns.map { col in
-                row.cells[col.id]?.text ?? ""
+                escapeCell(row.cells[col.id]?.text ?? "")
             }.joined(separator: " | ") + " |"
         }
         return ([headerLine, separatorLine] + rowLines).joined(separator: "\n")


### PR DESCRIPTION
## Summary
- Wrap table copy button in `#if os(macOS)` to prevent invisible tappable area on iOS
- Escape pipe (`|`) and newline characters in `tableAsMarkdown` to prevent malformed clipboard output

Addresses review feedback from #21828.

## Test plan
- [ ] macOS: hover over table card — copy button appears, copies valid markdown
- [ ] iOS: no invisible copy button in table card overlay
- [ ] Table cells containing `|` characters produce valid markdown when copied

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21873" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
