### PR TITLE
fix: exclude dotfiles when loading journal entries

### DIFF
--- a/assistant/src/memory/journal-memory.ts
+++ b/assistant/src/memory/journal-memory.ts
@@ -143,7 +143,10 @@ export function upsertJournalMemoriesFromDisk(
 
     // Filter for .md files, excluding readme.md (case-insensitive)
     const mdFiles = files.filter(
-      (f) => f.endsWith(".md") && f.toLowerCase() !== "readme.md",
+      (f) =>
+        f.endsWith(".md") &&
+        !f.startsWith(".") &&
+        f.toLowerCase() !== "readme.md",
     );
 
     let upserted = 0;
@@ -178,7 +181,10 @@ export function upsertJournalMemoriesFromDisk(
         if (!statSync(subdirPath).isDirectory()) continue;
 
         const subFiles = readdirSync(subdirPath).filter(
-          (f) => f.endsWith(".md") && f.toLowerCase() !== "readme.md",
+          (f) =>
+            f.endsWith(".md") &&
+            !f.startsWith(".") &&
+            f.toLowerCase() !== "readme.md",
         );
 
         for (const filename of subFiles) {

--- a/assistant/src/prompts/journal-context.ts
+++ b/assistant/src/prompts/journal-context.ts
@@ -78,7 +78,10 @@ export function buildJournalContext(
 
   // Filter for .md files, excluding README.md (case-insensitive)
   const mdFiles = files.filter(
-    (f) => f.endsWith(".md") && f.toLowerCase() !== "readme.md",
+    (f) =>
+      f.endsWith(".md") &&
+      !f.startsWith(".") &&
+      f.toLowerCase() !== "readme.md",
   );
 
   // Collect file info with birthtime (creation time), skipping unreadable entries


### PR DESCRIPTION
## Summary
- Add `!f.startsWith(".")` filter to all three journal file loading locations (journal-context.ts and both filters in journal-memory.ts)
- Prevents hidden files (e.g. `.DS_Store.md`, editor swap files) from being processed as journal entries

## Original prompt
When loading journal entries, exclude files that start with `.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
