### PR TITLE
fix: balanced #if os(macOS) in InlineSurfaceRouter overlay

### DIFF
--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -126,13 +126,13 @@ public struct InlineSurfaceRouter: View {
                 }
                 .buttonStyle(.plain)
                 .padding(VSpacing.sm)
-            #if os(macOS)
             } else if isTableSurface, case .table(let tableData) = surface.data {
+                #if os(macOS)
                 VCopyButton(text: Self.tableAsMarkdown(tableData), size: .compact)
                     .opacity(isCardHovered ? 1 : 0)
                     .animation(VAnimation.fast, value: isCardHovered)
                     .padding(VSpacing.sm)
-            #endif
+                #endif
             } else if isDocumentPreview {
                 if case .documentPreview(let data) = surface.data {
                     Button {


### PR DESCRIPTION
## Summary
- Moved `#if os(macOS)` / `#endif` inside the `else if isTableSurface` branch body instead of wrapping the `} else if` chain segment. Swift requires balanced braces within conditional compilation blocks.
- On non-macOS platforms, the table surface overlay branch now compiles (renders nothing). No behavior change on macOS.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23634770264/job/68841612846
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21875" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
