### PR TITLE
fix: suppress SendableClosureCaptures warning in AppDelegate

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -366,7 +366,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
             let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
             let commitSHA = Bundle.main.infoDictionary?["VellumCommitSHA"] as? String
-            var crashedLastRun = false
+            nonisolated(unsafe) var crashedLastRun = false
             SentrySDK.start { options in
                 options.dsn = MetricKitManager.macosDSN
                 options.releaseName = "vellum-macos@\(appVersion)"


### PR DESCRIPTION
## Summary
- Mark `crashedLastRun` as `nonisolated(unsafe)` to suppress the Swift 6 `#SendableClosureCaptures` warning
- The variable is mutated inside a `@Sendable` closure (`onCrashedLastRun`) but the callback is invoked synchronously during `SentrySDK.start()`, so the access is safe

## Original prompt
Fix: ~v/clients/macos (main) ❯❯❯ VELLUM_NO_WATCH=1 ./build.sh run
Building (debug)...
[1/1] Planning build
Building for debugging...
/Users/sidd/vocify/vellum-assistant/clients/macos/vellum-assistant/App/AppDelegate.swift:384:55: warning: mutation of captured var 'crashedLastRun' in concurrently-executing code; this is an error in the Swift 6 language mode [#SendableClosureCaptures]
382 |
383 |                 if !crashLogURLs.isEmpty {
384 |                     options.onCrashedLastRun = { _ in crashedLastRun = true }
    |                                                       `- warning: mutation of captured var 'crashedLastRun' in concurrently-executing code; this is an error in the Swift 6 language mode [#SendableClosureCaptures]
385 |                 }
386 |
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21876" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
