### PR TITLE
fix: increase iOS always-allow test timeouts from 2s to 5s

### DIFF
--- a/clients/ios/Tests/ChatViewModelIOSTests.swift
+++ b/clients/ios/Tests/ChatViewModelIOSTests.swift
@@ -387,7 +387,7 @@ final class ChatViewModelIOSTests: XCTestCase {
             decision: "always_allow_high_risk"
         )
 
-        await fulfillment(of: [exp], timeout: 2.0)
+        await fulfillment(of: [exp], timeout: 5.0)
 
         XCTAssertEqual(mockInteraction.calls.count, 1)
         XCTAssertEqual(mockInteraction.calls[0].decision, "always_allow_high_risk")
@@ -411,7 +411,7 @@ final class ChatViewModelIOSTests: XCTestCase {
             selectedScope: "project"
         )
 
-        await fulfillment(of: [exp], timeout: 2.0)
+        await fulfillment(of: [exp], timeout: 5.0)
 
         XCTAssertEqual(mockInteraction.calls.count, 1)
         XCTAssertEqual(mockInteraction.calls[0].decision, "always_allow")
@@ -450,7 +450,7 @@ final class ChatViewModelIOSTests: XCTestCase {
             decision: "always_allow_high_risk"
         )
 
-        await fulfillment(of: [exp], timeout: 2.0)
+        await fulfillment(of: [exp], timeout: 5.0)
 
         // Both attempts failed — confirmation should be reverted to pending
         XCTAssertEqual(mockInteraction.calls.count, 2)
@@ -492,7 +492,7 @@ final class ChatViewModelIOSTests: XCTestCase {
             decision: "always_allow_high_risk"
         )
 
-        await fulfillment(of: [exp], timeout: 2.0)
+        await fulfillment(of: [exp], timeout: 5.0)
 
         // First attempted decision should be always_allow_high_risk (the one that failed)
         XCTAssertEqual(mockInteraction.calls.count, 2)


### PR DESCRIPTION
## Summary
- Increased `fulfillment(of:timeout:)` timeouts in `ChatViewModelIOSTests.swift` from 2.0s to 5.0s
- The `testRespondToAlwaysAllowFallsBackWhenSendFails` test was timing out on CI (3.67s for two sequential async mock calls)
- Now consistent with the `waitForBootstrap` timeout (5.0s) in the same file and more forgiving of CI runner load

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23634860450/job/68841861230
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21877" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
