### PR TITLE
fix(macos): restore italic/bold-italic rendering for DM Sans chat font

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -352,6 +352,43 @@ struct MarkdownSegmentView: View, Equatable {
             leading.backgroundColor = codeBackgroundColor
             result.insert(leading, at: range.lowerBound)
         }
+        // Apply synthetic italic/bold to emphasized runs.
+        // DM Sans doesn't ship an italic font face, so SwiftUI can't resolve
+        // the italic trait from .emphasized inlinePresentationIntent. We detect
+        // emphasized runs and apply a synthetic oblique via affine transform.
+        var emphOnlyRanges: [Range<AttributedString.Index>] = []
+        var boldEmphRanges: [Range<AttributedString.Index>] = []
+        for run in result.runs {
+            guard let intent = run.inlinePresentationIntent, !intent.contains(.code) else { continue }
+            let isEmph = intent.contains(.emphasized)
+            let isBold = intent.contains(.stronglyEmphasized)
+            if isEmph && isBold {
+                boldEmphRanges.append(run.range)
+            } else if isEmph {
+                emphOnlyRanges.append(run.range)
+            }
+        }
+        if !emphOnlyRanges.isEmpty || !boldEmphRanges.isEmpty {
+            let sz: CGFloat = 16 // matches VFont.chat size
+            var oblique = CGAffineTransform(a: 1, b: 0, c: CGFloat(tan(12.0 * .pi / 180.0)), d: 1, tx: 0, ty: 0)
+            if !emphOnlyRanges.isEmpty {
+                let italicCT = CTFontCreateWithName("DMSans-Regular" as CFString, sz, &oblique)
+                let italicFont = Font(italicCT as NSFont)
+                for range in emphOnlyRanges { result[range].font = italicFont }
+            }
+            if !boldEmphRanges.isEmpty {
+                let wght = 0x77676874
+                let baseCT = CTFontCreateWithName("DMSans-Regular" as CFString, sz, nil)
+                let boldVars: [CFNumber: CFNumber] = [wght as CFNumber: 700 as CFNumber]
+                let boldItalicCT = CTFontCreateCopyWithAttributes(
+                    baseCT, sz, &oblique,
+                    CTFontDescriptorCreateWithAttributes([kCTFontVariationAttribute: boldVars] as CFDictionary)
+                )
+                let boldItalicFont = Font(boldItalicCT as NSFont)
+                for range in boldEmphRanges { result[range].font = boldItalicFont }
+            }
+        }
+
         // Underline links so they are visually distinct from plain text
         for run in result.runs where result[run.range].link != nil {
             result[run.range].underlineStyle = .single


### PR DESCRIPTION
## Summary
- After switching chat body font from system to DM Sans (#21737), italic (`*text*`) and bold-italic (`***text***`) stopped rendering because DM Sans has no italic font face registered
- Detect `.emphasized` and `.stronglyEmphasized` runs in the attributed string and apply synthetic oblique via 12-degree CTFont affine transform
- Bold-only (`**text**`) is unaffected — NSFontManager resolves heavier DM Sans weights automatically
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21878" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
