### PR TITLE
fix: use DM Sans for empty-state greeting font

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -104,7 +104,7 @@ struct ChatEmptyStateView: View {
 
             if let greeting = effectiveGreeting {
                 Text(greeting)
-                    .font(VFont.brandMedium)
+                    .font(VFont.displayLarge)
                     .foregroundStyle(VColor.contentSecondary)
                     .multilineTextAlignment(.leading)
                     .transition(.opacity)


### PR DESCRIPTION
## Summary
- Switch the empty-state greeting font from `VFont.brandMedium` (Instrument Serif) to `VFont.displayLarge` (DM Sans 32pt)
- The serif font felt too formal/editorial for casual greetings like "hey love, what're we building today"
- Same size (32pt), just uses the geometric sans-serif consistent with the rest of the app
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
