### PR TITLE
feat: add Surface Action Buttons to component gallery

### DIFF
--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -64,6 +64,7 @@ enum ComponentGalleryCategory: String, CaseIterable, Identifiable {
                 GalleryComponent("stepIndicators", "CurrentStepIndicator", keywords: ["step indicators", "progress bar", "tool call progress"], description: "Progress bar showing the current step in a multi-step tool call."),
                 GalleryComponent("progressIndicators", "TypingIndicatorView", keywords: ["progress indicators", "typing", "running"], description: "Animated dots indicating the assistant is typing or processing."),
                 GalleryComponent("toolConfirmations", "ToolConfirmationBubble", keywords: ["tool confirmations", "permission", "approval"], description: "Approval bubble for tool calls that require user permission before execution."),
+                GalleryComponent("surfaceActions", "Surface Action Buttons", keywords: ["surface actions", "action pills", "inline buttons", "pick something"], description: "Inline action pills in assistant bubbles letting users pick from options. Supports secondary, primary, and destructive styles."),
             ]
         case .display:
             return [

--- a/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
@@ -490,6 +490,65 @@ struct ChatGallerySection: View {
                 }
             }
 
+            if filter == nil || filter == "surfaceActions" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+                // MARK: - Surface Action Buttons
+                GallerySectionHeader(
+                    title: "Surface Action Buttons",
+                    description: "Inline action pills rendered inside assistant chat bubbles. Used by InlineSurfaceRouter to let the user pick from options the assistant presents."
+                )
+
+                VCard {
+                    VStack(alignment: .leading, spacing: VSpacing.lg) {
+                        Text("Styles").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
+
+                        VStack(alignment: .leading, spacing: VSpacing.sm) {
+                            surfaceActionPill(label: "Summarize a file on my machine", style: .secondary)
+                            surfaceActionPill(label: "Research a topic and make me a deck", style: .secondary)
+                            surfaceActionPill(label: "Vibe code an app", style: .secondary)
+                        }
+
+                        Divider().background(VColor.borderBase)
+
+                        Text("Primary").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
+                        surfaceActionPill(label: "Confirm and proceed", style: .primary)
+
+                        Text("Destructive").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
+                        surfaceActionPill(label: "Delete all files", style: .destructive)
+                    }
+                }
+            }
+
+        }
+    }
+
+    private func surfaceActionPill(label: String, style: SurfaceActionStyle) -> some View {
+        Text(label)
+            .font(VFont.bodyMediumDefault)
+            .foregroundStyle(surfaceActionForeground(style))
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.sm)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(surfaceActionBackground(style))
+            )
+    }
+
+    private func surfaceActionForeground(_ style: SurfaceActionStyle) -> Color {
+        switch style {
+        case .primary: return VColor.auxWhite
+        case .destructive: return VColor.auxWhite
+        case .secondary: return VColor.contentDefault
+        }
+    }
+
+    private func surfaceActionBackground(_ style: SurfaceActionStyle) -> Color {
+        switch style {
+        case .primary: return VColor.primaryBase
+        case .destructive: return VColor.systemNegativeStrong
+        case .secondary: return VColor.borderBase.opacity(0.5)
         }
     }
 }
@@ -507,6 +566,7 @@ extension ChatGallerySection {
         case "stepIndicators": ChatGallerySection(filter: "stepIndicators")
         case "progressIndicators": ChatGallerySection(filter: "progressIndicators")
         case "toolConfirmations": ChatGallerySection(filter: "toolConfirmations")
+        case "surfaceActions": ChatGallerySection(filter: "surfaceActions")
         default: EmptyView()
         }
     }


### PR DESCRIPTION
## Summary
- Add inline action pills (from InlineSurfaceRouter) to the Chat gallery section
- Shows secondary, primary, and destructive style examples

## Test plan
- [ ] Component gallery → Chat → Surface Action Buttons renders all three styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21881" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
