### PR TITLE
fix: batch UI polish — menu animation, title color, composer font, app card description

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -262,7 +262,7 @@ struct ComposerView: View {
     }
 
     private var composerTextField: some View {
-        let scaledBody = VFont.bodyMediumLighter
+        let scaledBody = VFont.chat
         let hasSlashHighlight = slashCommandRange != nil
 
         return ScrollView(.vertical, showsIndicators: false) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
@@ -22,11 +22,10 @@ struct ConversationTitleActionsControl: View {
                 style: .ghost
             ) {
                 if presentation.showsActionsMenu {
-                    withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
-                        showDrawer.toggle()
-                    }
+                    showDrawer.toggle()
                 }
             }
+            .foregroundStyle(VColor.contentDefault)
 
             if let parentTitle = presentation.forkParentTitle, presentation.showsForkParentLink {
                 Button(action: onOpenForkParent) {
@@ -82,6 +81,6 @@ struct ConversationActionsDrawer: View {
 
             VMenuItem(icon: VIcon.archive.rawValue, label: "Archive", action: onArchive)
         }
-        .transition(.opacity.combined(with: .scale(scale: 0.95, anchor: .top)))
+        .transition(.identity)
     }
 }

--- a/clients/shared/Features/Chat/InlineWidgets/InlineAppCreatedCard.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineAppCreatedCard.swift
@@ -40,7 +40,7 @@ struct InlineAppCreatedCard: View {
 
             if let description = preview.description, !description.isEmpty {
                 Text(description)
-                    .font(VFont.labelDefault)
+                    .font(VFont.bodyMediumDefault)
                     .foregroundStyle(VColor.contentSecondary)
                     .lineLimit(3)
             }


### PR DESCRIPTION
## Summary
- Remove animation from conversation actions dropdown (instant appear/disappear like preferences drawer)
- Use `contentDefault` color for conversation title button text and icon
- Use `VFont.chat` (DM Sans 16pt) for composer input text and placeholder
- Bump app created card description from `labelDefault` (11pt) to `bodyMediumDefault` (14pt)

## Test plan
- [ ] Click conversation title — menu appears instantly without animation
- [ ] Title text and chevron are contentDefault color (not primaryBase green)
- [ ] Composer input text and placeholder render in DM Sans 16pt
- [ ] Generated app card description text is 14pt and balances the card

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21882" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
