### PR TITLE
fix: use contentDefault color for conversation title button

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
@@ -16,16 +16,24 @@ struct ConversationTitleActionsControl: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
-            VButton(
-                label: presentation.displayTitle,
-                rightIcon: presentation.showsActionsMenu ? VIcon.chevronDown.rawValue : nil,
-                style: .ghost
-            ) {
+            Button {
                 if presentation.showsActionsMenu {
                     showDrawer.toggle()
                 }
+            } label: {
+                HStack(spacing: VSpacing.xs) {
+                    Text(presentation.displayTitle)
+                        .font(VFont.bodyMediumEmphasised)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    if presentation.showsActionsMenu {
+                        VIconView(.chevronDown, size: 10)
+                    }
+                }
+                .foregroundStyle(VColor.contentDefault)
             }
-            .foregroundStyle(VColor.contentDefault)
+            .buttonStyle(.plain)
+            .pointerCursor()
 
             if let parentTitle = presentation.forkParentTitle, presentation.showsForkParentLink {
                 Button(action: onOpenForkParent) {


### PR DESCRIPTION
## Summary
- Replace VButton (ghost style forces primaryBase green) with a plain Button using contentDefault for both text and chevron icon

## Test plan
- [ ] Conversation title text and chevron are neutral contentDefault color, not green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21885" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
