### PR TITLE
fix: remove X dismiss button from panels, use surfaceOverlay for Library

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -294,8 +294,7 @@ extension MainWindowView {
                         startNewConversation()
                     }
                 )
-                .overlay(alignment: .topTrailing) { panelDismissButton }
-                .background(VColor.surfaceBase)
+                    .background(VColor.surfaceBase)
             } else if panelType == .documentEditor {
                 let config = windowState.layoutConfig
                 VSplitView(
@@ -439,7 +438,6 @@ extension MainWindowView {
                 activeSessionId: conversationManager.activeViewModel?.conversationId,
                 onClose: { windowState.dismissOverlay() }
             )
-            .overlay(alignment: .topTrailing) { panelDismissButton }
         case .avatarCustomization:
             AvatarCustomizationPanel(onClose: { windowState.selection = .panel(windowState.avatarCustomizationReturnPanel) })
         case .generated:
@@ -477,8 +475,6 @@ extension MainWindowView {
                     startNewConversation()
                 }
             )
-            .overlay(alignment: .topTrailing) { panelDismissButton }
-            .background(VColor.surfaceBase)
         case .intelligence:
             IntelligencePanel(
                 onClose: { windowState.dismissOverlay() },
@@ -511,14 +507,12 @@ extension MainWindowView {
                 initialTab: windowState.pendingMemoryId != nil ? "Memories" : nil,
                 pendingMemoryId: $windowState.pendingMemoryId
             )
-            .overlay(alignment: .topTrailing) { panelDismissButton }
             .background(VColor.surfaceOverlay)
         case .usageDashboard:
             UsageDashboardPanel(
                 store: usageDashboardStore,
                 onClose: { windowState.dismissOverlay() }
             )
-            .overlay(alignment: .topTrailing) { panelDismissButton }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -66,7 +66,8 @@ struct AppsGridView: View {
                 .padding(VSpacing.xl)
             }
         }
-        .background(VColor.surfaceBase)
+        .background(VColor.surfaceOverlay)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
         .onAppear {
             if !hasFetchedShared { fetchSharedApps() }
             if !hasFetchedLocalApps { refreshLocalAppsFromDaemon() }


### PR DESCRIPTION
## Summary
- Remove all X dismiss button overlays from panel pages (About, Library, Usage, Debug, etc.)
- Change Library background from surfaceBase to surfaceOverlay with rounded corners, matching the About page

## Test plan
- [ ] No X button visible on any panel page
- [ ] Library page has surfaceOverlay background with rounded corners
- [ ] All panels still navigable via sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21890" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
