### PR TITLE
perf: instrument Chat view body evaluations with os_signpost for SwiftUI profiling

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -1,4 +1,5 @@
 import os
+import os.signpost
 import SwiftUI
 import VellumAssistantShared
 
@@ -307,8 +308,10 @@ struct ChatBubble: View {
     }
 
     var body: some View {
+        #if DEBUG
         let _ = os_signpost(.event, log: PerfSignposts.log, name: "chatBubbleBody",
                             "id=%{public}s streaming=%d", message.id.uuidString, message.isStreaming ? 1 : 0)
+        #endif
         // Outer HStack: Spacer pushes the content group to the correct side.
         HStack(alignment: .top, spacing: 0) {
             if isUser { Spacer(minLength: 0) }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -1,9 +1,21 @@
 import os
+import os.signpost
 import SwiftUI
 import VellumAssistantShared
 import UniformTypeIdentifiers
 
 private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ChatView")
+
+// MARK: - Performance Baseline Success Criteria
+//
+// The os_signpost instrumentation in ChatView, MessageListView, and ChatBubble
+// establishes a performance baseline for the @Observable migration. Measure
+// these metrics during a 50-message streaming session using Instruments (Points
+// of Interest template) BEFORE and AFTER the migration:
+//
+//   1. ≥50% reduction in ChatBubble body evaluations per streaming burst
+//   2. < 500ms total hitch time during 50-message streaming session
+//   3. ≥30% reduction in mean graph update duration during streaming
 
 struct ChatView: View {
     let messages: [ChatMessage]
@@ -161,6 +173,9 @@ struct ChatView: View {
     }
 
     var body: some View {
+        #if DEBUG
+        let _ = os_signpost(.event, log: PerfSignposts.log, name: "ChatView.body")
+        #endif
         ZStack {
             VStack(spacing: 0) {
                 if showSkeleton {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Combine
 import os
+import os.signpost
 import SwiftUI
 import VellumAssistantShared
 
@@ -623,6 +624,9 @@ struct MessageListView: View {
     }
 
     var body: some View {
+        #if DEBUG
+        let _ = os_signpost(.event, log: PerfSignposts.log, name: "MessageListView.body")
+        #endif
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: VSpacing.md) {
                     // MARK: - Pagination sentinel


### PR DESCRIPTION
## Why

ChatViewModel is an ObservableObject with ~30 @Published properties. Any property change fires objectWillChange, which invalidates every view observing the model — even views that don't read the changed property. During streaming, this causes hundreds of redundant body evaluations per second across ChatView, MessageListView, and ChatBubble.

Before migrating to @Observable (which provides property-level tracking), we need a measurable baseline of how many body evaluations occur and how much hitch time they produce, so we can verify the migration actually improves performance.

## What

Add `os_signpost(.event)` markers to the `body` getters of ChatView, MessageListView, and ChatBubble. These appear as discrete events in Instruments' Points of Interest lane, making it easy to count evaluations per streaming burst and correlate them with hitches.

All signposts are wrapped in `#if DEBUG` — zero overhead in release builds. The existing ChatBubble signpost (added in an earlier PR) is also wrapped for consistency.

A success criteria comment block documents the three metrics to measure before and after the migration:
1. ChatBubble body evaluation count per streaming burst (target: ≥50% reduction)
2. Total hitch time during a 50-message streaming session (target: <500ms)
3. Mean graph update duration (target: ≥30% reduction)

## Safety

- `os_signpost` with `.event` is a no-op when Instruments is not attached — the system short-circuits at the kernel level ([Apple docs](https://developer.apple.com/documentation/os/logging/recording_performance_data))
- `#if DEBUG` ensures the signpost calls are compiled out entirely in release builds
- No behavioral changes — only import additions and `let _ =` statements in body getters

## References

- [WWDC23 — Demystify SwiftUI performance](https://developer.apple.com/videos/play/wwdc2023/10160/) — explains body evaluation counting as the primary metric for SwiftUI performance
- [os_signpost documentation](https://developer.apple.com/documentation/os/os_signpost) — `.event` type for discrete markers
- [Migrating from ObservableObject to Observable](https://developer.apple.com/documentation/swiftui/migrating-from-the-observable-object-protocol-to-the-observable-macro) — the migration this baseline supports