### PR TITLE
fix: add surfaceOverlay background to Logs and Usage panels

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -33,6 +33,8 @@ extension MainWindowView {
                 activeSessionId: conversationManager.activeViewModel?.conversationId,
                 onClose: { windowState.selection = nil }
             )
+            .background(VColor.surfaceOverlay)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
         case .generated:
             GeneratedPanel(
                 onClose: { sharing.showSharePicker = false; windowState.closeDynamicPanel() },
@@ -118,6 +120,8 @@ extension MainWindowView {
                 store: usageDashboardStore,
                 onClose: { windowState.selection = nil }
             )
+            .background(VColor.surfaceOverlay)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
         }
     }
 
@@ -438,6 +442,8 @@ extension MainWindowView {
                 activeSessionId: conversationManager.activeViewModel?.conversationId,
                 onClose: { windowState.dismissOverlay() }
             )
+            .background(VColor.surfaceOverlay)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
         case .avatarCustomization:
             AvatarCustomizationPanel(onClose: { windowState.selection = .panel(windowState.avatarCustomizationReturnPanel) })
         case .generated:
@@ -513,6 +519,8 @@ extension MainWindowView {
                 store: usageDashboardStore,
                 onClose: { windowState.dismissOverlay() }
             )
+            .background(VColor.surfaceOverlay)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
         }
     }
 


### PR DESCRIPTION
## Summary
- Add surfaceOverlay background with rounded corners to Debug (Logs) and Usage panels
- Matches the About/Library panel styling

## Test plan
- [ ] Logs panel has surfaceOverlay background with rounded corners
- [ ] Usage panel has surfaceOverlay background with rounded corners

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21894" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
