### PR TITLE
fix: ensure all panel dividers use borderBase color

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppVersionHistoryPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppVersionHistoryPanel.swift
@@ -43,8 +43,7 @@ struct AppVersionHistoryPanel: View {
             .padding(.horizontal, VSpacing.lg)
             .padding(.vertical, VSpacing.md)
 
-            Divider()
-                .foregroundStyle(VColor.borderBase)
+            Divider().background(VColor.borderBase)
 
             if isLoading {
                 Spacer()
@@ -204,7 +203,7 @@ struct AppVersionHistoryPanel: View {
             .padding(.horizontal, VSpacing.lg)
             .padding(.vertical, VSpacing.md)
 
-            Divider()
+            Divider().background(VColor.borderBase)
 
             if isDiffLoading {
                 Spacer()

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -119,7 +119,7 @@ struct IdentityPanel: View {
                             Spacer()
 
                             // Divider
-                            Divider().background(VColor.surfaceOverlay)
+                            Divider().background(VColor.borderBase)
 
                             // Role + Hatched date
                             VStack(alignment: .leading, spacing: VSpacing.lg) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MarkdownPreviewView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MarkdownPreviewView.swift
@@ -373,7 +373,7 @@ struct MarkdownPreviewView: View {
                 if let fm = frontmatter {
                     frontmatterHeader(fm)
                     if !blocks.isEmpty {
-                        Divider()
+                        Divider().background(VColor.borderBase)
                             .padding(.vertical, VSpacing.xs)
                     }
                 }
@@ -433,7 +433,7 @@ struct MarkdownPreviewView: View {
         case .orderedList(let items):
             orderedListView(items: items)
         case .horizontalRule:
-            Divider()
+            Divider().background(VColor.borderBase)
                 .padding(.vertical, VSpacing.sm)
         case .blockquote(let text):
             blockquoteView(text: text)
@@ -456,7 +456,7 @@ struct MarkdownPreviewView: View {
                 renderInlineMarkdown(text)
                     .font(VFont.titleMedium)
                     .foregroundStyle(VColor.contentEmphasized)
-                Divider()
+                Divider().background(VColor.borderBase)
             }
         case 3:
             renderInlineMarkdown(text)


### PR DESCRIPTION
## Summary
- Fix bare `Divider()` calls and wrong-colored dividers in panel pages
- AppVersionHistoryPanel: fix `.foregroundStyle` → `.background`, add missing borderBase
- IdentityPanel: fix `surfaceOverlay` → `borderBase`
- MarkdownPreviewView: add borderBase to bare dividers

## Test plan
- [ ] Dividers across all panels render with consistent borderBase color

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21895" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
