### PR TITLE
fix: use small spacing for library app grid

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -39,7 +39,7 @@ struct AppsGridView: View {
     /// In-flight preview fetch tasks, keyed by app ID, so they can be cancelled.
     @State private var previewTasks: [String: Task<Void, Never>] = [:]
 
-    private let columns = Array(repeating: GridItem(.flexible(), spacing: VSpacing.xl), count: 5)
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: VSpacing.sm), count: 5)
 
     /// Maximum width of the centered content area.
     private let maxContentWidth: CGFloat = 1400
@@ -509,7 +509,7 @@ struct AppsGridView: View {
                 .font(VFont.bodySmallEmphasised)
                 .foregroundStyle(VColor.contentSecondary)
 
-            LazyVGrid(columns: columns, spacing: VSpacing.xxl) {
+            LazyVGrid(columns: columns, spacing: VSpacing.sm) {
                 ForEach(apps) { app in
                     appCard(app)
                         .onAppear { fetchPreviewIfNeeded(app) }
@@ -524,7 +524,7 @@ struct AppsGridView: View {
                 .font(VFont.bodySmallEmphasised)
                 .foregroundStyle(VColor.contentSecondary)
 
-            LazyVGrid(columns: columns, spacing: VSpacing.xxl) {
+            LazyVGrid(columns: columns, spacing: VSpacing.sm) {
                 ForEach(apps) { app in
                     sharedAppCard(app)
                 }


### PR DESCRIPTION
## Summary
- Reduce library grid column spacing from xl (24pt) to sm (8pt)
- Reduce library grid row spacing from xxl (32pt) to sm (8pt)

## Test plan
- [ ] Library page shows tighter card spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21896" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
