### PR TITLE
fix(oauth): update error messages to reference `assistant oauth connect` instead of oauth2_connect

### DIFF
--- a/assistant/src/cli/AGENTS.md
+++ b/assistant/src/cli/AGENTS.md
@@ -93,7 +93,7 @@ are created during the OAuth authorization flow or can be managed manually via
 their respective subcommands.
 
 Examples:
-  $ assistant oauth connect google --open-browser
+  $ assistant oauth connect google
   $ assistant oauth status google
 `,
 );

--- a/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
@@ -259,10 +259,10 @@ describe("assistant oauth connect", () => {
   });
 
   // -------------------------------------------------------------------------
-  // Managed mode: prints connect URL without --open-browser
+  // Managed mode with --no-browser: prints connect URL
   // -------------------------------------------------------------------------
 
-  test("managed mode: prints connect URL without --open-browser", async () => {
+  test("managed mode with --no-browser: prints connect URL", async () => {
     mockGetProvider = () => ({
       providerKey: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
@@ -282,6 +282,7 @@ describe("assistant oauth connect", () => {
     const { exitCode, stdout } = await runCommand([
       "connect",
       "google",
+      "--no-browser",
       "--json",
     ]);
     expect(exitCode).toBe(0);
@@ -295,10 +296,10 @@ describe("assistant oauth connect", () => {
   });
 
   // -------------------------------------------------------------------------
-  // Managed mode with --open-browser: opens browser and polls
+  // Managed mode default: opens browser and polls
   // -------------------------------------------------------------------------
 
-  test("managed mode with --open-browser: opens browser and polls for new connection", async () => {
+  test("managed mode default: opens browser and polls for new connection", async () => {
     mockGetProvider = () => ({
       providerKey: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
@@ -336,7 +337,6 @@ describe("assistant oauth connect", () => {
     const { exitCode, stdout } = await runCommand([
       "connect",
       "google",
-      "--open-browser",
       "--json",
     ]);
     expect(exitCode).toBe(0);
@@ -352,10 +352,10 @@ describe("assistant oauth connect", () => {
   });
 
   // -------------------------------------------------------------------------
-  // BYO mode: prints auth URL without --open-browser (deferred)
+  // BYO mode with --no-browser: prints auth URL (deferred)
   // -------------------------------------------------------------------------
 
-  test("BYO mode: prints auth URL without --open-browser", async () => {
+  test("BYO mode with --no-browser: prints auth URL", async () => {
     mockGetProvider = () => ({
       providerKey: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
@@ -384,6 +384,7 @@ describe("assistant oauth connect", () => {
     const { exitCode, stdout } = await runCommand([
       "connect",
       "google",
+      "--no-browser",
       "--json",
     ]);
     expect(exitCode).toBe(0);
@@ -397,10 +398,10 @@ describe("assistant oauth connect", () => {
   });
 
   // -------------------------------------------------------------------------
-  // BYO mode with --open-browser: orchestrator called with isInteractive true
+  // BYO mode default: orchestrator called with isInteractive true
   // -------------------------------------------------------------------------
 
-  test("BYO mode with --open-browser calls orchestrator with isInteractive: true", async () => {
+  test("BYO mode default calls orchestrator with isInteractive: true", async () => {
     mockGetProvider = () => ({
       providerKey: "google",
       authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
@@ -434,13 +435,12 @@ describe("assistant oauth connect", () => {
       "google",
       "--client-id",
       "test-id",
-      "--open-browser",
       "--json",
     ]);
     expect(exitCode).toBe(0);
     expect(capturedOpts).toBeDefined();
     expect(capturedOpts!.isInteractive).toBe(true);
-    // openUrl should be provided when --open-browser is set
+    // openUrl should be provided by default (browser opens automatically)
     expect(typeof capturedOpts!.openUrl).toBe("function");
 
     const parsed = JSON.parse(stdout);
@@ -529,6 +529,7 @@ describe("assistant oauth connect", () => {
       "google",
       "--client-id",
       "should-be-ignored",
+      "--no-browser",
       "--json",
     ]);
     // Should succeed — --client-id does not cause an error in managed mode
@@ -573,6 +574,7 @@ describe("assistant oauth connect", () => {
     const { exitCode, stdout } = await runCommand([
       "connect",
       "slack",
+      "--no-browser",
       "--json",
     ]);
     expect(exitCode).toBe(0);

--- a/assistant/src/cli/commands/oauth/__tests__/ping.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/ping.test.ts
@@ -368,7 +368,7 @@ describe("assistant oauth ping", () => {
     });
 
     mockResolveOAuthConnectionResult = new Error(
-      'No active OAuth connection found for "google". Connect the service first with oauth2_connect.',
+      'No active OAuth connection found for "google". Connect the service first with `assistant oauth connect google`.',
     );
 
     const { exitCode, stdout } = await runCommand(["ping", "google", "--json"]);

--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -80,8 +80,8 @@ export function registerConnectCommand(oauth: Command): void {
     )
     .option("--scopes <scopes...>", "Scopes to request for the authorization")
     .option(
-      "--open-browser",
-      "Open the auth URL in the browser and wait for completion",
+      "--no-browser",
+      "Print the auth URL instead of opening it in the browser",
     )
     .option("--client-id <id>", "BYO app client ID disambiguation")
     .addHelpText(
@@ -93,21 +93,22 @@ Arguments:
 
 In managed mode, --scopes must be in the provider's allowed set (use full
 scope URLs). In BYO mode, --scopes are appended to the provider's defaults.
-The --open-browser flag polls for a platform connection (managed) or starts
-a local callback server (BYO).
+By default, the browser opens automatically and the command waits for
+completion. Use --no-browser to print the URL instead (useful for headless
+or SSH sessions).
 
 Examples:
   $ assistant oauth connect google
-  $ assistant oauth connect google --open-browser
+  $ assistant oauth connect google --no-browser
   $ assistant oauth connect google --scopes https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/calendar.events
-  $ assistant oauth connect google --client-id abc123 --open-browser`,
+  $ assistant oauth connect google --client-id abc123`,
     )
     .action(
       async (
         provider: string,
         opts: {
           scopes?: string[];
-          openBrowser?: boolean;
+          browser?: boolean;
           clientId?: string;
         },
         cmd: Command,
@@ -166,7 +167,7 @@ Examples:
             let redirectServer:
               | { redirectUrl: string; cleanup: () => void }
               | undefined;
-            if (opts.openBrowser) {
+            if (opts.browser !== false) {
               try {
                 redirectServer = await startManagedRedirectServer(provider);
                 body.redirect_after_connect = redirectServer.redirectUrl;
@@ -201,7 +202,7 @@ Examples:
                 return;
               }
 
-              if (opts.openBrowser) {
+              if (opts.browser !== false) {
                 // Snapshot existing connection IDs before opening browser
                 const snapshotEntries = await fetchActiveConnections(
                   client,
@@ -287,7 +288,7 @@ Examples:
                   }
                 }
               } else {
-                // No --open-browser: output the connect URL
+                // --no-browser: output the connect URL
                 if (jsonMode) {
                   writeOutput(cmd, {
                     ok: true,
@@ -357,8 +358,8 @@ Examples:
               service: provider,
               clientId,
               clientSecret,
-              isInteractive: !!opts.openBrowser,
-              openUrl: opts.openBrowser ? openInBrowser : undefined,
+              isInteractive: opts.browser !== false,
+              openUrl: opts.browser !== false ? openInBrowser : undefined,
               ...(opts.scopes ? { requestedScopes: opts.scopes } : {}),
             });
 

--- a/assistant/src/cli/commands/oauth/index.ts
+++ b/assistant/src/cli/commands/oauth/index.ts
@@ -38,7 +38,7 @@ Examples:
   assistant oauth providers list
   assistant oauth providers get google
   assistant oauth mode google --set=managed
-  assistant oauth connect google --open-browser
+  assistant oauth connect google
   assistant oauth status google
   assistant oauth ping google
   assistant oauth request --provider google /gmail/v1/users/me/messages

--- a/assistant/src/oauth/connect-orchestrator.ts
+++ b/assistant/src/oauth/connect-orchestrator.ts
@@ -229,7 +229,7 @@ export async function orchestrateOAuthConnect(
           return {
             success: false,
             error:
-              "oauth2_connect from a non-interactive session requires a public ingress URL. Configure ingress.publicBaseUrl first.",
+              "OAuth connect from a non-interactive session requires a public ingress URL. Configure ingress.publicBaseUrl first.",
             safeError: true,
           };
         }

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -88,7 +88,7 @@ export async function resolveOAuthConnection(
       ? ` matching ${filters.join(" and ")}`
       : "";
     throw new Error(
-      `No active OAuth connection found for "${providerKey}"${qualifier}. Connect the service first with oauth2_connect.`,
+      `No active OAuth connection found for "${providerKey}"${qualifier}. Connect the service first with \`assistant oauth connect ${providerKey}\`.`,
     );
   }
 
@@ -97,7 +97,7 @@ export async function resolveOAuthConnection(
   );
   if (!accessToken) {
     throw new Error(
-      `OAuth connection for "${providerKey}" exists but has no access token. Re-authorize with oauth2_connect.`,
+      `OAuth connection for "${providerKey}" exists but has no access token. Re-authorize with \`assistant oauth connect ${providerKey}\`.`,
     );
   }
 

--- a/skills/google-oauth-app-setup/SKILL.md
+++ b/skills/google-oauth-app-setup/SKILL.md
@@ -203,8 +203,8 @@ Google-specific override for macOS desktop app:
 
 1. Before app registration, check the provider mode and set it to `your-own` if needed with `assistant oauth mode google --set your-own`.
 2. Register the OAuth app normally via `assistant oauth apps upsert`.
-3. For authorization, do **not** use `assistant oauth connect google --open-browser`.
-4. Instead, run `assistant oauth connect google` without `--open-browser` so the command returns the authorization URL.
+3. For authorization, do **not** use the default browser behavior.
+4. Instead, run `assistant oauth connect google --no-browser` so the command returns the authorization URL.
 5. Open that returned authorization URL in Google Chrome using the same `host_bash` + `osascript` pattern as every other `Open:` step in this skill.
 6. Never use browser automation or computer-use for the Google consent screen.
 

--- a/skills/vellum-oauth-integrations/references/CONNECTING_ACCOUNTS.md
+++ b/skills/vellum-oauth-integrations/references/CONNECTING_ACCOUNTS.md
@@ -28,12 +28,12 @@ If there are none, they will either need to opt in to using "managed" mode or th
 To actually initiate a connection with the OAuth provider, run:
 
 ```bash
-assistant oauth connect <provider-key> --open-browser
+assistant oauth connect <provider-key>
 ```
 
 **Tip:** You can optionally specify scopes using the `--scopes` flag. This is useful if you know ahead of time what your user is trying to accomplish and want to request the bare minimum scopes needed to accomplish the task at hand.
 
-If the provider-specific setup skill gives its own browser handoff instructions, follow those instead of `--open-browser`. Google bring-your-own setup on the macOS desktop app is one example: request the auth URL without `--open-browser`, then open it using the provider skill's AppleScript/browser handoff rules.
+If the provider-specific setup skill gives its own browser handoff instructions, follow those instead of the default browser behavior. Google bring-your-own setup on the macOS desktop app is one example: request the auth URL with `--no-browser`, then open it using the provider skill's AppleScript/browser handoff rules.
 
 This will open a new web browser tab where the user can log in to the third-party provider. Upon success, they should be redirected to a confirmation page and told that it's safe to close the browser tab and come back here.
 


### PR DESCRIPTION
## Summary
- Updates error messages in `connection-resolver.ts` to reference `assistant oauth connect <provider>` instead of legacy `oauth2_connect`
- Updates error message in `connect-orchestrator.ts` to remove `oauth2_connect` terminology
- Updates corresponding test assertion in `ping.test.ts` to match new message

Part of plan: rm-oauth2-connect.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21901" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
