### PR TITLE
refactor(credentials): remove legacy oauth2_connect and describe actions from credential_store

### DIFF
--- a/assistant/src/__tests__/credential-vault-unit.test.ts
+++ b/assistant/src/__tests__/credential-vault-unit.test.ts
@@ -48,27 +48,10 @@ mock.module("../tools/registry.js", () => ({
 // Mock oauth-store to avoid SQLite dependency in unit tests
 // ---------------------------------------------------------------------------
 
-let mockGetMostRecentAppByProvider: ReturnType<
-  typeof mock<(key: string) => unknown>
->;
-let mockGetAppByProviderAndClientId: ReturnType<
-  typeof mock<(key: string, clientId: string) => unknown>
->;
-let mockGetProvider: ReturnType<typeof mock<(key: string) => unknown>>;
-
-mock.module("../oauth/oauth-store.js", () => {
-  mockGetMostRecentAppByProvider = mock(() => undefined);
-  mockGetAppByProviderAndClientId = mock(() => undefined);
-  mockGetProvider = mock(() => undefined);
-  return {
-    getMostRecentAppByProvider: mockGetMostRecentAppByProvider,
-    getAppByProviderAndClientId: mockGetAppByProviderAndClientId,
-    getProvider: mockGetProvider,
-    listConnections: mock(() => []),
-    seedProviders: mock(() => {}),
-    disconnectOAuthProvider: mock(async () => "not-found" as const),
-  };
-});
+mock.module("../oauth/oauth-store.js", () => ({
+  disconnectOAuthProvider: mock(async () => "not-found" as const),
+  getActiveConnection: mock(() => undefined),
+}));
 
 let manualConnectionStore: Record<string, string> = {};
 let slackChannelConfigCalls: Array<{
@@ -179,36 +162,6 @@ mock.module("../daemon/handlers/config-slack-channel.js", () => ({
       warning,
     };
   },
-}));
-
-// ---------------------------------------------------------------------------
-// Mock public ingress URL — not available in unit tests. The connect
-// orchestrator dynamically imports this for non-interactive flows.
-// ---------------------------------------------------------------------------
-
-mock.module("../inbound/public-ingress-urls.js", () => ({
-  getPublicBaseUrl: () => {
-    throw new Error("No public ingress URL configured");
-  },
-}));
-
-// ---------------------------------------------------------------------------
-// Mock prepareOAuth2Flow — unit tests should not start real loopback HTTP
-// servers. The connect orchestrator still runs its own validation logic
-// (scope policy, non-interactive ingress checks, etc.) but the actual
-// OAuth flow setup is stubbed.
-// ---------------------------------------------------------------------------
-
-mock.module("../security/oauth2.js", () => ({
-  prepareOAuth2Flow: mock(async () => ({
-    authUrl: "https://mock-auth-url.example.com/authorize",
-    state: "mock-state",
-    completion: new Promise(() => {}),
-  })),
-  startOAuth2Flow: mock(async () => ({
-    grantedScopes: [],
-    tokens: { access_token: "mock-token" },
-  })),
 }));
 
 // ---------------------------------------------------------------------------
@@ -749,372 +702,7 @@ describe("credential_store tool — prompt action", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 4. Vault — oauth2_connect error paths
-// ---------------------------------------------------------------------------
-
-describe("credential_store tool — oauth2_connect error paths", () => {
-  /** Well-known provider rows returned by the mocked getProvider */
-  const wellKnownProviders: Record<string, object> = {
-    google: {
-      key: "google",
-      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-      tokenUrl: "https://oauth2.googleapis.com/token",
-      defaultScopes: JSON.stringify(["https://mail.google.com/"]),
-      scopePolicy: JSON.stringify({}),
-      callbackTransport: "loopback",
-      loopbackPort: 8756,
-    },
-    slack: {
-      key: "slack",
-      authUrl: "https://slack.com/oauth/v2/authorize",
-      tokenUrl: "https://slack.com/api/oauth.v2.access",
-      defaultScopes: JSON.stringify(["channels:read"]),
-      scopePolicy: JSON.stringify({}),
-    },
-  };
-
-  beforeEach(() => {
-    if (existsSync(TEST_DIR)) rmSync(TEST_DIR, { recursive: true });
-    mkdirSync(TEST_DIR, { recursive: true });
-    _setStorePath(STORE_PATH);
-    _resetBackend();
-    _setMetadataPath(join(TEST_DIR, "metadata.json"));
-    // Return well-known provider rows so vault.ts knows google/slack are
-    // registered, and custom providers return undefined.
-    mockGetProvider.mockImplementation(
-      (key: string) => wellKnownProviders[key] ?? undefined,
-    );
-    mockGetMostRecentAppByProvider.mockClear();
-    mockGetMostRecentAppByProvider.mockImplementation(() => undefined);
-    mockGetAppByProviderAndClientId.mockClear();
-    mockGetAppByProviderAndClientId.mockImplementation(() => undefined);
-  });
-
-  afterEach(() => {
-    _setMetadataPath(null);
-    _setStorePath(null);
-    _resetBackend();
-    mockGetProvider.mockImplementation(() => undefined);
-    mockGetMostRecentAppByProvider.mockImplementation(() => undefined);
-    mockGetAppByProviderAndClientId.mockImplementation(() => undefined);
-  });
-
-  test("requires service parameter", async () => {
-    const result = await credentialStoreTool.execute(
-      { action: "oauth2_connect" },
-      _ctx,
-    );
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain("service is required");
-  });
-
-  test("rejects unknown service without registered provider", async () => {
-    const result = await credentialStoreTool.execute(
-      {
-        action: "oauth2_connect",
-        service: "custom-svc",
-        auth_url: "https://a",
-        token_url: "https://t",
-        scopes: ["read"],
-      },
-      _ctx,
-    );
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain("no OAuth provider registered");
-  });
-
-  test("requires client_id", async () => {
-    mockGetProvider.mockImplementation((key: string) => {
-      if (key === "custom-svc") {
-        return {
-          key: "custom-svc",
-          authUrl: "https://auth.example.com",
-          tokenUrl: "https://token.example.com",
-          defaultScopes: JSON.stringify(["read"]),
-          scopePolicy: JSON.stringify({}),
-        };
-      }
-      return wellKnownProviders[key] ?? undefined;
-    });
-    const result = await credentialStoreTool.execute(
-      {
-        action: "oauth2_connect",
-        service: "custom-svc",
-        scopes: ["read"],
-      },
-      _ctx,
-    );
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain("client_id is required");
-  });
-
-  test("non-interactive loopback oauth2_connect returns deferred auth URL", async () => {
-    // After the blanket non-interactive guard was removed (#16337),
-    // loopback-transport flows succeed with a deferred auth URL so the
-    // agent can present it to the user.
-    mockGetProvider.mockImplementation((key: string) => {
-      if (key === "custom-svc") {
-        return {
-          key: "custom-svc",
-          authUrl: "https://auth.example.com",
-          tokenUrl: "https://token.example.com",
-          defaultScopes: JSON.stringify(["read"]),
-          scopePolicy: JSON.stringify({}),
-        };
-      }
-      return wellKnownProviders[key] ?? undefined;
-    });
-
-    const result = await credentialStoreTool.execute(
-      {
-        action: "oauth2_connect",
-        service: "custom-svc",
-        auth_url: "https://auth.example.com",
-        token_url: "https://token.example.com",
-        scopes: ["read"],
-        client_id: "test-client-id",
-      },
-      { ..._ctx, isInteractive: false },
-    );
-    expect(result.isError).toBe(false);
-    expect(result.content).toContain("mock-auth-url.example.com");
-  });
-
-  test("rejects missing client_id for google", async () => {
-    // Missing client_id should fail
-    const result = await credentialStoreTool.execute(
-      {
-        action: "oauth2_connect",
-        service: "google",
-      },
-      _ctx,
-    );
-    expect(result.isError).toBe(true);
-    // Should fail on client_id since none is stored
-    expect(result.content).toContain("client_id is required");
-  });
-
-  test("resolves slack to its canonical name", async () => {
-    const result = await credentialStoreTool.execute(
-      {
-        action: "oauth2_connect",
-        service: "slack",
-      },
-      _ctx,
-    );
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain("client_id is required");
-  });
-
-  test("uses stored client_id from oauth-store DB", async () => {
-    // Mock getMostRecentAppByProvider to return an app with a client_id
-    // and store client_secret in the secure store.
-    mockGetMostRecentAppByProvider.mockImplementation(() => ({
-      id: "test-app-id",
-      providerKey: "google",
-      clientId: "stored-client-id-123",
-      clientSecretCredentialPath: "oauth_app/test-app-id/client_secret",
-      createdAt: Date.now(),
-    }));
-    mockGetProvider.mockImplementation(() => ({
-      key: "google",
-      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-      tokenUrl: "https://oauth2.googleapis.com/token",
-      defaultScopes: JSON.stringify(["https://mail.google.com/"]),
-      scopePolicy: JSON.stringify({}),
-      callbackTransport: "loopback",
-      loopbackPort: 8756,
-    }));
-    await setSecureKeyAsync(
-      "oauth_app/test-app-id/client_secret",
-      "test-secret",
-    );
-
-    const result = await credentialStoreTool.execute(
-      {
-        action: "oauth2_connect",
-        service: "google",
-      },
-      { ..._ctx, isInteractive: false },
-    );
-
-    // Should pass client_id and client_secret checks — the flow proceeds
-    // through the channel path (google uses loopback transport so no
-    // public ingress URL is needed) and returns the authorization URL.
-    expect(result.isError).toBe(false);
-    expect(result.content).toContain("To connect google, open this link");
-    expect(result.content).not.toContain("client_id is required");
-    expect(result.content).not.toContain("client_secret is required");
-
-    // Reset mocks
-    mockGetMostRecentAppByProvider.mockImplementation(() => undefined);
-    mockGetProvider.mockImplementation(() => undefined);
-  });
-
-  test("uses getAppByProviderAndClientId when client_id is provided without client_secret", async () => {
-    // When client_id is supplied but client_secret is not, the vault should
-    // look up the matching app via getAppByProviderAndClientId (not the
-    // most-recent-app heuristic) so the secret comes from the correct app.
-    mockGetAppByProviderAndClientId.mockImplementation(
-      (providerKey: string, cId: string) => {
-        if (providerKey === "google" && cId === "caller-supplied-client-id") {
-          return {
-            id: "matched-app-id",
-            providerKey: "google",
-            clientId: "caller-supplied-client-id",
-            clientSecretCredentialPath:
-              "oauth_app/matched-app-id/client_secret",
-            createdAt: Date.now(),
-          };
-        }
-        return undefined;
-      },
-    );
-    mockGetProvider.mockImplementation(() => ({
-      key: "google",
-      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-      tokenUrl: "https://oauth2.googleapis.com/token",
-      defaultScopes: JSON.stringify(["https://mail.google.com/"]),
-      scopePolicy: JSON.stringify({}),
-      callbackTransport: "loopback",
-      loopbackPort: 8756,
-    }));
-    await setSecureKeyAsync(
-      "oauth_app/matched-app-id/client_secret",
-      "matched-secret",
-    );
-
-    const result = await credentialStoreTool.execute(
-      {
-        action: "oauth2_connect",
-        service: "google",
-        client_id: "caller-supplied-client-id",
-      },
-      { ..._ctx, isInteractive: false },
-    );
-
-    // Should succeed — client_secret resolved from the matched app
-    expect(result.isError).toBe(false);
-    expect(result.content).toContain("To connect google, open this link");
-    // getMostRecentAppByProvider should NOT have been called since client_id was known
-    expect(mockGetMostRecentAppByProvider).not.toHaveBeenCalled();
-
-    // Reset mocks
-    mockGetAppByProviderAndClientId.mockImplementation(() => undefined);
-    mockGetProvider.mockImplementation(() => undefined);
-  });
-
-  test("falls back to getMostRecentAppByProvider when client_id is not provided", async () => {
-    // When neither client_id nor client_secret is provided, the vault should
-    // use getMostRecentAppByProvider (the fallback heuristic).
-    mockGetMostRecentAppByProvider.mockImplementation(() => ({
-      id: "recent-app-id",
-      providerKey: "google",
-      clientId: "recent-client-id",
-      clientSecretCredentialPath: "oauth_app/recent-app-id/client_secret",
-      createdAt: Date.now(),
-    }));
-    mockGetProvider.mockImplementation(() => ({
-      key: "google",
-      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-      tokenUrl: "https://oauth2.googleapis.com/token",
-      defaultScopes: JSON.stringify(["https://mail.google.com/"]),
-      scopePolicy: JSON.stringify({}),
-      callbackTransport: "loopback",
-      loopbackPort: 8756,
-    }));
-    await setSecureKeyAsync(
-      "oauth_app/recent-app-id/client_secret",
-      "recent-secret",
-    );
-
-    const result = await credentialStoreTool.execute(
-      {
-        action: "oauth2_connect",
-        service: "google",
-      },
-      { ..._ctx, isInteractive: false },
-    );
-
-    expect(result.isError).toBe(false);
-    expect(result.content).toContain("To connect google, open this link");
-    // getAppByProviderAndClientId should NOT have been called since client_id was unknown
-    expect(mockGetAppByProviderAndClientId).not.toHaveBeenCalled();
-
-    // Reset mocks
-    mockGetMostRecentAppByProvider.mockImplementation(() => undefined);
-    mockGetProvider.mockImplementation(() => undefined);
-  });
-
-  test("getAppByProviderAndClientId returning undefined leaves client_secret unresolved", async () => {
-    // When client_id is provided but getAppByProviderAndClientId returns no
-    // matching app, client_secret remains unresolved and the vault should
-    // report the missing secret error.
-    mockGetAppByProviderAndClientId.mockImplementation(() => undefined);
-    mockGetProvider.mockImplementation(() => ({
-      key: "google",
-      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-      tokenUrl: "https://oauth2.googleapis.com/token",
-      defaultScopes: JSON.stringify(["https://mail.google.com/"]),
-      requiresClientSecret: 1,
-    }));
-
-    const result = await credentialStoreTool.execute(
-      {
-        action: "oauth2_connect",
-        service: "google",
-        client_id: "unknown-client-id",
-      },
-      _ctx,
-    );
-
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain("client_secret is required for google");
-    // getMostRecentAppByProvider should NOT have been called
-    expect(mockGetMostRecentAppByProvider).not.toHaveBeenCalled();
-
-    // Reset mocks
-    mockGetAppByProviderAndClientId.mockImplementation(() => undefined);
-    mockGetProvider.mockImplementation(() => undefined);
-  });
-
-  test("rejects when client_secret is missing for service that requires it", async () => {
-    // Mock getMostRecentAppByProvider to return an app with client_id but
-    // no client_secret in secure storage — validates the requiresClientSecret
-    // guardrail.
-    mockGetMostRecentAppByProvider.mockImplementation(() => ({
-      id: "test-app-id-no-secret",
-      providerKey: "google",
-      clientId: "stored-client-id-456",
-      createdAt: Date.now(),
-    }));
-    mockGetProvider.mockImplementation(() => ({
-      key: "google",
-      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-      tokenUrl: "https://oauth2.googleapis.com/token",
-      defaultScopes: JSON.stringify(["https://mail.google.com/"]),
-      requiresClientSecret: 1,
-    }));
-
-    const result = await credentialStoreTool.execute(
-      {
-        action: "oauth2_connect",
-        service: "google",
-      },
-      _ctx,
-    );
-
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain("client_secret is required for google");
-
-    // Reset mocks
-    mockGetMostRecentAppByProvider.mockImplementation(() => undefined);
-    mockGetProvider.mockImplementation(() => undefined);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// 5. Vault — store action validation edge cases
+// 4. Vault — store action validation edge cases
 // ---------------------------------------------------------------------------
 
 describe("credential_store tool — store validation edge cases", () => {
@@ -1282,7 +870,7 @@ describe("credential_store tool — store validation edge cases", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 6. Vault — tool definition schema
+// 5. Vault — tool definition schema
 // ---------------------------------------------------------------------------
 
 describe("credential_store tool — tool definition", () => {
@@ -1298,14 +886,7 @@ describe("credential_store tool — tool definition", () => {
     expect(schema.type).toBe("object");
     expect(schema.required).toContain("action");
     const props = schema.properties as Record<string, Record<string, unknown>>;
-    expect(props.action.enum).toEqual([
-      "store",
-      "list",
-      "delete",
-      "prompt",
-      "oauth2_connect",
-      "describe",
-    ]);
+    expect(props.action.enum).toEqual(["store", "list", "delete", "prompt"]);
   });
 
   test("getDefinition includes injection_templates schema", () => {
@@ -1326,7 +907,7 @@ describe("credential_store tool — tool definition", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 7. Broker — serverUseById with transient not supported
+// 6. Broker — serverUseById with transient not supported
 //    (transient is scoped to authorize+consume and browserFill/serverUse)
 // ---------------------------------------------------------------------------
 
@@ -1399,7 +980,7 @@ describe("CredentialBroker — serverUseById edge cases", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 8. Broker — revokeAll clears transient values indirectly via token cleanup
+// 7. Broker — revokeAll clears transient values indirectly via token cleanup
 // ---------------------------------------------------------------------------
 
 describe("CredentialBroker — revokeAll", () => {

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -1209,12 +1209,6 @@ describe("isSideEffectTool", () => {
       );
     });
 
-    test("credential_store oauth2_connect is a side-effect", () => {
-      expect(
-        isSideEffectTool("credential_store", { action: "oauth2_connect" }),
-      ).toBe(true);
-    });
-
     test("credential_store list is NOT a side-effect", () => {
       expect(isSideEffectTool("credential_store", { action: "list" })).toBe(
         false,
@@ -1724,20 +1718,6 @@ describe("ToolExecutor forcePromptSideEffects enforcement", () => {
     const result = await executor.execute(
       "credential_store",
       { action: "delete", name: "api-key" },
-      makeContext({ forcePromptSideEffects: true }),
-    );
-
-    expect(result.isError).toBe(false);
-    expect(promptCalled).toBe(true);
-  });
-
-  test("credential_store oauth2_connect forces prompt in private conversation", async () => {
-    checkResultOverride = { decision: "allow", reason: "Matched trust rule" };
-
-    const executor = new ToolExecutor(makeTrackingPrompter());
-    const result = await executor.execute(
-      "credential_store",
-      { action: "oauth2_connect", provider: "google" },
       makeContext({ forcePromptSideEffects: true }),
     );
 

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -3,25 +3,16 @@ import {
   setSlackChannelConfig,
   type SlackChannelConfigResult,
 } from "../../daemon/handlers/config-slack-channel.js";
-import { orchestrateOAuthConnect } from "../../oauth/connect-orchestrator.js";
 import { syncManualTokenConnection } from "../../oauth/manual-token-connection.js";
 import {
   disconnectOAuthProvider,
   getActiveConnection,
-  getAppByProviderAndClientId,
-  getMostRecentAppByProvider,
-  getProvider,
-  listProviders,
 } from "../../oauth/oauth-store.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
-import { buildAssistantEvent } from "../../runtime/assistant-event.js";
-import { assistantEventHub } from "../../runtime/assistant-event-hub.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../runtime/assistant-scope.js";
 import { credentialKey } from "../../security/credential-key.js";
 import {
   deleteSecureKeyAsync,
-  getSecureKeyAsync,
   listSecureKeysAsync,
   setSecureKeyAsync,
 } from "../../security/secure-keys.js";
@@ -90,16 +81,9 @@ class CredentialStoreTool implements Tool {
         properties: {
           action: {
             type: "string",
-            enum: [
-              "store",
-              "list",
-              "delete",
-              "prompt",
-              "oauth2_connect",
-              "describe",
-            ],
+            enum: ["store", "list", "delete", "prompt"],
             description:
-              'The operation to perform. Use "prompt" to ask the user for a secret via secure UI - the value never enters the conversation. Use "oauth2_connect" to connect an OAuth2 service via browser authorization. Use "describe" to get setup metadata for a well-known OAuth service (dashboard URL, scopes, redirect URI, etc.). For well-known services (google, slack), only the service name is required - endpoints, scopes, and stored client credentials are resolved automatically.',
+              'The operation to perform. Use "prompt" to ask the user for a secret via secure UI - the value never enters the conversation. For well-known services (google, slack), only the service name is required - endpoints, scopes, and stored client credentials are resolved automatically.',
           },
           service: {
             type: "string",
@@ -149,22 +133,6 @@ class CredentialStoreTool implements Tool {
             type: "string",
             description:
               'Human-readable description of intended usage (for store/prompt actions), e.g. "GitHub login for pushing changes"',
-          },
-          scopes: {
-            type: "array",
-            items: { type: "string" },
-            description:
-              "OAuth2 scopes to request (only for oauth2_connect action). Auto-filled for well-known services (google, slack).",
-          },
-          client_id: {
-            type: "string",
-            description:
-              "OAuth2 client ID (only for oauth2_connect action). If omitted, looked up from previously stored credentials.",
-          },
-          client_secret: {
-            type: "string",
-            description:
-              "OAuth2 client secret for providers that require it (e.g. Google, Slack). If omitted, looked up from previously stored credentials; if still absent, PKCE-only is used (only for oauth2_connect action)",
           },
           alias: {
             type: "string",
@@ -815,221 +783,6 @@ class CredentialStoreTool implements Tool {
           }`,
           isError: false,
         };
-      }
-
-      case "oauth2_connect": {
-        const service = input.service as string | undefined;
-        if (!service)
-          return {
-            content: "Error: service is required for oauth2_connect action",
-            isError: true,
-          };
-
-        // Protocol-level config from the DB (authUrl, tokenUrl, scopes, etc.)
-        const providerRow = getProvider(service);
-
-        // Resolve client_id and client_secret.
-        // Priority:
-        //   1. Explicit input from the caller
-        //   2. oauth-store DB - when clientId is already known, look up the
-        //      matching app so the secret comes from the same app. Only fall
-        //      back to the most-recent-app heuristic when clientId is unknown.
-        let clientId = input.client_id as string | undefined;
-        let clientSecret = input.client_secret as string | undefined;
-
-        if (!clientId || !clientSecret) {
-          const dbApp = clientId
-            ? getAppByProviderAndClientId(service, clientId)
-            : getMostRecentAppByProvider(service);
-          if (dbApp) {
-            if (!clientId) clientId = dbApp.clientId;
-            if (!clientSecret) {
-              clientSecret = await getSecureKeyAsync(
-                dbApp.clientSecretCredentialPath,
-              );
-            }
-          }
-        }
-
-        // Early guardrails that stay in vault.ts (credential resolution is vault-specific)
-        const inputScopes = input.scopes as string[] | undefined;
-
-        if (!providerRow) {
-          return {
-            content: `Error: no OAuth provider registered for "${service}". Ensure the provider is seeded in the database.`,
-            isError: true,
-          };
-        }
-
-        if (!clientId)
-          return {
-            content:
-              "Error: client_id is required for oauth2_connect action. Provide it directly or store it first with credential_store.",
-            isError: true,
-          };
-
-        // Fail early when client_secret is required but missing - guide the
-        // agent to collect it from the user rather than letting it improvise
-        // browser-automation workarounds that inevitably fail.
-        const requiresSecret = !!providerRow.requiresClientSecret;
-        if (requiresSecret && !clientSecret) {
-          return {
-            content: `Error: client_secret is required for ${service} but not found in the vault.\n\nUse credential_store with action "prompt" to securely collect the client_secret from the user before calling oauth2_connect again.`,
-            isError: true,
-          };
-        }
-
-        // Delegate to the shared orchestrator - it resolves authUrl, tokenUrl,
-        // extraParams, userinfoUrl, and tokenEndpointAuthMethod from the DB.
-        const result = await orchestrateOAuthConnect({
-          service,
-          clientId,
-          clientSecret,
-          isInteractive: !!context.isInteractive,
-          sendToClient: context.sendToClient,
-          ...(inputScopes ? { requestedScopes: inputScopes } : {}),
-          onDeferredComplete: (deferredResult) => {
-            // Emit oauth_connect_result to all connected SSE clients so the
-            // UI can update immediately when the deferred browser flow completes.
-            assistantEventHub
-              .publish(
-                buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, {
-                  type: "oauth_connect_result",
-                  success: deferredResult.success,
-                  service: deferredResult.service,
-                  accountInfo: deferredResult.accountInfo,
-                  error: deferredResult.error,
-                }),
-              )
-              .catch((err) => {
-                log.warn(
-                  { err, service: deferredResult.service },
-                  "Failed to publish oauth_connect_result event",
-                );
-              });
-
-            if (deferredResult.success) {
-              log.info(
-                {
-                  service: deferredResult.service,
-                  accountInfo: deferredResult.accountInfo,
-                },
-                "Deferred OAuth connect completed successfully",
-              );
-            } else {
-              log.warn(
-                {
-                  service: deferredResult.service,
-                  err: deferredResult.error,
-                },
-                "Deferred OAuth connect failed",
-              );
-            }
-          },
-        });
-
-        if (!result.success) {
-          return { content: `Error: ${result.error}`, isError: true };
-        }
-
-        if (result.deferred) {
-          return {
-            content: `To connect ${service}, open this link and authorize access:\n\n${result.authUrl}\n\nOnce you authorize, the connection will be set up automatically. You can verify by asking me to check your inbox.`,
-            isError: false,
-          };
-        }
-
-        return {
-          content: `Successfully connected "${service}"${
-            result.accountInfo ? ` as ${result.accountInfo}` : ""
-          }. The service is now ready to use.`,
-          isError: false,
-        };
-      }
-
-      case "describe": {
-        const descService = (input.service as string | undefined) ?? "";
-        if (!descService) {
-          return {
-            content: "Error: service is required for describe action",
-            isError: true,
-          };
-        }
-        const descProviderRow = getProvider(descService);
-        if (!descProviderRow) {
-          const availableServices = listProviders().map((p) => p.providerKey);
-          return {
-            content: `No well-known OAuth config found for "${descService}". Available services: ${availableServices.join(", ")}`,
-            isError: false,
-          };
-        }
-
-        // Compute the redirect URI based on callback transport
-        let redirectUri: string;
-        const transport =
-          (descProviderRow.callbackTransport as
-            | "loopback"
-            | "gateway"
-            | null) ?? "loopback";
-        const loopbackPort = descProviderRow.loopbackPort;
-        if (transport === "loopback" && loopbackPort) {
-          redirectUri = `http://localhost:${loopbackPort}/oauth/callback`;
-        } else if (transport === "loopback") {
-          redirectUri =
-            "(automatic - no redirect URI needed, uses random localhost port)";
-        } else {
-          // Try to compute the actual URL from config/env
-          try {
-            const { loadConfig } = await import("../../config/loader.js");
-            const { getPublicBaseUrl } =
-              await import("../../inbound/public-ingress-urls.js");
-            const baseUrl = getPublicBaseUrl(loadConfig());
-            redirectUri = `${baseUrl}/webhooks/oauth/callback`;
-          } catch {
-            redirectUri =
-              "(requires ingress.publicBaseUrl - not currently configured)";
-          }
-        }
-
-        const requiresClientSecret = !!descProviderRow.requiresClientSecret;
-
-        const descDefaultScopes: string[] = descProviderRow.defaultScopes
-          ? JSON.parse(descProviderRow.defaultScopes)
-          : [];
-
-        const info: Record<string, unknown> = {
-          service: descService,
-          authUrl: descProviderRow.authUrl,
-          tokenUrl: descProviderRow.tokenUrl,
-          scopes: descDefaultScopes,
-          callbackTransport: transport,
-          redirectUri,
-          requiresClientSecret,
-        };
-        if (
-          descProviderRow.displayName &&
-          descProviderRow.dashboardUrl &&
-          descProviderRow.appType
-        ) {
-          info.setup = {
-            displayName: descProviderRow.displayName,
-            dashboardUrl: descProviderRow.dashboardUrl,
-            appType: descProviderRow.appType,
-            requiresClientSecret: !!descProviderRow.requiresClientSecret,
-            ...(descProviderRow.setupNotes
-              ? { notes: JSON.parse(descProviderRow.setupNotes) }
-              : {}),
-          };
-        }
-        if (descProviderRow.extraParams) {
-          try {
-            info.extraParams = JSON.parse(descProviderRow.extraParams);
-          } catch {
-            // Non-fatal
-          }
-        }
-
-        return { content: JSON.stringify(info, null, 2), isError: false };
       }
 
       default:

--- a/assistant/src/tools/side-effects.ts
+++ b/assistant/src/tools/side-effects.ts
@@ -47,12 +47,7 @@ export function isSideEffectTool(
   // Action-aware checks for mixed-action tools
   if (toolName === "credential_store") {
     const action = input?.action;
-    return (
-      action === "store" ||
-      action === "delete" ||
-      action === "prompt" ||
-      action === "oauth2_connect"
-    );
+    return action === "store" || action === "delete" || action === "prompt";
   }
 
   return false;


### PR DESCRIPTION
## Summary
- Removes the `oauth2_connect` and `describe` actions from the `credential_store` tool enum and implementation
- Removes OAuth-specific parameters (`scopes`, `client_id`, `client_secret`) from the tool schema
- Removes `oauth2_connect` from the side-effects check in `isSideEffectTool`
- Cleans up unused imports that were only used by the removed actions

Part of plan: rm-oauth2-connect.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21902" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
