### PR TITLE
fix: remove dead oauth2_connect case branches from Swift client

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -382,8 +382,6 @@ public struct ToolConfirmationData: Equatable {
         let service = (input["service"]?.value as? String) ?? ""
 
         switch action {
-        case "oauth2_connect":
-            return service.isEmpty ? "Connect account" : "Connect \(service) account"
         case "store":
             return service.isEmpty ? "Save credential" : "Save \(service) credential"
         case "delete":
@@ -685,10 +683,6 @@ public func confirmationHumanDescription(
         let action = (input["action"]?.value as? String) ?? ""
         let service = (input["service"]?.value as? String) ?? ""
         switch action {
-        case "oauth2_connect":
-            return service.isEmpty
-                ? "Allow connecting an account?"
-                : "Allow connecting your \(service.capitalized) account?"
         case "store":
             return service.isEmpty
                 ? "Allow saving a credential securely?"


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for rm-oauth2-connect.md.

**Gap:** Swift client has dead oauth2_connect case branches
**What was expected:** All references to oauth2_connect removed across entire codebase
**What was found:** ChatMessage.swift had two unreachable case branches for oauth2_connect
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21906" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
