### PR TITLE
feat: enable thinking and stream thinking by default

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -102,8 +102,8 @@ describe("AssistantConfigSchema", () => {
     expect(result.services["web-search"].mode).toBe("your-own");
     expect(result.maxTokens).toBe(16000);
     expect(result.thinking).toEqual({
-      enabled: false,
-      streamThinking: false,
+      enabled: true,
+      streamThinking: true,
     });
     expect(result.contextWindow).toEqual({
       enabled: true,
@@ -1021,8 +1021,8 @@ describe("loadConfig with schema validation", () => {
     expect(config.services.inference.model).toBe("claude-opus-4-6");
     expect(config.maxTokens).toBe(16000);
     expect(config.thinking).toEqual({
-      enabled: false,
-      streamThinking: false,
+      enabled: true,
+      streamThinking: true,
     });
     expect(config.contextWindow).toEqual({
       enabled: true,

--- a/assistant/src/config/schemas/inference.ts
+++ b/assistant/src/config/schemas/inference.ts
@@ -12,13 +12,13 @@ export const ThinkingConfigSchema = z
   .object({
     enabled: z
       .boolean({ error: "thinking.enabled must be a boolean" })
-      .default(false)
+      .default(true)
       .describe(
         "Whether to enable extended thinking (chain-of-thought) for the model",
       ),
     streamThinking: z
       .boolean({ error: "thinking.streamThinking must be a boolean" })
-      .default(false)
+      .default(true)
       .describe(
         "Whether to stream the model's thinking tokens to the client in real time",
       ),


### PR DESCRIPTION
## Summary
- Change `thinking.enabled` default from `false` to `true`
- Change `thinking.streamThinking` default from `false` to `true`
- Update config schema tests to match new defaults

## Original prompt
change the default to thinking.enabled true and thinking.streamThinking true
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
