### PR TITLE
feat: change default effort from high to max

### DIFF
--- a/assistant/src/config/schemas/inference.ts
+++ b/assistant/src/config/schemas/inference.ts
@@ -29,7 +29,7 @@ export const EffortSchema = z
   .enum(["low", "medium", "high", "max"], {
     error: 'effort must be "low", "medium", "high", or "max"',
   })
-  .default("high")
+  .default("max")
   .describe(
     "How much effort the model should put into its response — lower effort is faster and cheaper",
   );


### PR DESCRIPTION
## Summary
- Change the default `effort` config value from `"high"` to `"max"`

## Original prompt
change the default effort to max
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21909" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
