### PR TITLE
refactor: extract greeting and conversation starters into @Observable ChatGreetingState

### DIFF
--- a/clients/AGENTS.md
+++ b/clients/AGENTS.md
@@ -75,7 +75,7 @@ The following classes have been migrated from `ObservableObject` to `@Observable
 
 **macOS-only:** QuickInputTextModel, DevModeManager, RecordingHUDViewModel, NavigationHistory, AmbientAgent, DocumentManager, E2EStatusOverlayViewModel, WatchSession, SurfaceViewModel, SurfaceManager, AppListManager, TerminalSessionManager, MessageAudioPlayer, ContactsViewModel, OpenAIVoiceService, SkillsManager
 
-**Shared (macOS + iOS):** InlineVideoEmbedStateManager, ContactsStore, MemoryItemsStore, ChannelTrustStore, ChatErrorManager, TaskProgressOverlayManager
+**Shared (macOS + iOS):** InlineVideoEmbedStateManager, ContactsStore, MemoryItemsStore, ChannelTrustStore, ChatErrorManager, ChatGreetingState, TaskProgressOverlayManager
 
 </details>
 
@@ -90,7 +90,7 @@ These classes stay `ObservableObject` because they have deep Combine integration
 | `MainWindowState` | Bridges `@Observable` NavigationHistory via `withObservationTracking`; uses `objectWillChange` forwarding |
 | `VoiceModeManager` | Complex Combine pipelines (audio streams, state machine transitions) |
 | `ConversationManager` | Hub object subscribing to many child `objectWillChange` publishers; complex lifecycle |
-| `ChatViewModel` | Extensive Combine pipelines (SSE streaming, message coalescing, debounce); bridges `@Observable` ChatErrorManager via `withObservationTracking` |
+| `ChatViewModel` | Extensive Combine pipelines (SSE streaming, message coalescing, debounce); bridges `@Observable` ChatErrorManager and ChatGreetingState via `withObservationTracking` |
 | `ChatMessageManager` | Tightly coupled to ChatViewModel's Combine publish pipeline |
 | `GatewayConnectionManager` | Combine-based SSE event stream processing |
 | `RecordingManager` | Audio capture Combine pipelines |
@@ -119,7 +119,7 @@ private func observeChild() {
     }
 }
 ```
-See `ChatViewModel.observeErrorManager()` and `MainWindowState.observeNavigationHistory()` for production examples.
+See `ChatViewModel.observeErrorManager()`, `ChatViewModel.observeGreetingState()`, and `MainWindowState.observeNavigationHistory()` for production examples.
 
 **Computed property forwarding.** When both source and target are `@Observable`, computed properties that read from an `@Observable` dependency automatically participate in observation tracking — no manual bridging needed.
 

--- a/clients/shared/Features/Chat/ChatGreetingState.swift
+++ b/clients/shared/Features/Chat/ChatGreetingState.swift
@@ -1,0 +1,144 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ChatGreetingState")
+
+/// Owns empty-state greeting and conversation starter properties that were
+/// previously part of ChatViewModel.  ChatViewModel holds a reference to this
+/// object and forwards reads/writes via computed properties so every existing
+/// call site continues to compile without modification.
+@MainActor
+@Observable
+public final class ChatGreetingState {
+
+    // MARK: - Empty-State Greeting
+
+    /// A daemon-generated greeting shown when the conversation is empty, or nil before generation.
+    public var emptyStateGreeting: String? = nil
+    /// True while a greeting is being streamed from the daemon.
+    public var isGeneratingGreeting: Bool = false
+    /// The in-flight greeting streaming task, stored for cancellation.
+    @ObservationIgnored nonisolated(unsafe) var greetingTask: Task<Void, Never>?
+
+    // MARK: - Conversation Starters
+
+    /// Personalized suggestion chips shown on the empty conversation page.
+    public var conversationStarters: [ConversationStarter] = []
+    public var conversationStartersLoading: Bool = false
+
+    @ObservationIgnored nonisolated(unsafe) var conversationStarterPollTask: Task<Void, Never>?
+
+    // MARK: - Fallback Greetings
+
+    static let fallbackGreetings = [
+        "What are we working on?",
+        "I'm here whenever you need me.",
+        "What's on your mind?",
+        "Let's make something happen.",
+        "Ready when you are.",
+    ]
+
+    // MARK: - Dependencies
+
+    @ObservationIgnored private let btwClient: any BtwClientProtocol
+    @ObservationIgnored private let conversationStarterClient: any ConversationStarterClientProtocol
+
+    // MARK: - Init
+
+    init(
+        btwClient: any BtwClientProtocol = BtwClient(),
+        conversationStarterClient: any ConversationStarterClientProtocol = ConversationStarterClient()
+    ) {
+        self.btwClient = btwClient
+        self.conversationStarterClient = conversationStarterClient
+    }
+
+    // MARK: - Empty-State Greeting Generation
+
+    /// Stream a short, personality-matched greeting from the daemon for the empty conversation state.
+    /// Each call cancels any in-flight generation and starts fresh. On error, falls back to a
+    /// random default greeting so the UI always receives a value.
+    public func generateGreeting() {
+        greetingTask?.cancel()
+        emptyStateGreeting = nil
+        isGeneratingGreeting = true
+
+        greetingTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            let key = "greeting"
+            var result = ""
+            do {
+                let stream = self.btwClient.sendMessage(
+                    content: "Generate a short, casual greeting in your voice from you to your user. This will be displayed when the user opens a new conversation (under 8 words). Match your personality. Output ONLY the greeting text — no quotes, no formatting.",
+                    conversationKey: key
+                )
+                for try await delta in stream {
+                    guard !Task.isCancelled else { return }
+                    result += delta
+                }
+                guard !Task.isCancelled else { return }
+                self.emptyStateGreeting = result.isEmpty
+                    ? Self.fallbackGreetings.randomElement()!
+                    : result
+            } catch is CancellationError {
+                return
+            } catch {
+                guard !Task.isCancelled else { return }
+                self.emptyStateGreeting = Self.fallbackGreetings.randomElement()!
+            }
+            self.isGeneratingGreeting = false
+        }
+    }
+
+    /// Clear greeting state and cancel any in-flight generation.
+    public func dismissGreeting() {
+        greetingTask?.cancel()
+        greetingTask = nil
+        emptyStateGreeting = nil
+        isGeneratingGreeting = false
+    }
+
+    /// Fetch personalized conversation starters from the daemon for the empty conversation state.
+    public func fetchConversationStarters() {
+        conversationStarterPollTask?.cancel()
+        conversationStarterPollTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            let response = await self.conversationStarterClient.fetchConversationStarters(limit: 4)
+            guard !Task.isCancelled else { return }
+
+            if let response, !response.starters.isEmpty {
+                self.conversationStarters = response.starters
+                self.conversationStartersLoading = false
+                return
+            }
+
+            if response?.status == "generating" {
+                self.conversationStartersLoading = true
+                // Poll every 3 seconds until ready
+                while !Task.isCancelled {
+                    try? await Task.sleep(nanoseconds: 3_000_000_000)
+                    guard !Task.isCancelled else { return }
+                    let poll = await self.conversationStarterClient.fetchConversationStarters(limit: 4)
+                    guard !Task.isCancelled else { return }
+                    if let poll, !poll.starters.isEmpty {
+                        self.conversationStarters = poll.starters
+                        self.conversationStartersLoading = false
+                        return
+                    }
+                    if poll?.status != "generating" {
+                        self.conversationStartersLoading = false
+                        return
+                    }
+                }
+            } else {
+                self.conversationStartersLoading = false
+            }
+        }
+    }
+
+    /// Cancel all in-flight tasks. Called from ChatViewModel's nonisolated deinit.
+    nonisolated public func cancelAll() {
+        greetingTask?.cancel()
+        conversationStarterPollTask?.cancel()
+    }
+}

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -127,6 +127,8 @@ public final class ChatViewModel: ObservableObject {
     public let attachmentManager = ChatAttachmentManager()
     /// Owns errorText, conversationError, and connection-diagnostic properties.
     public let errorManager = ChatErrorManager()
+    /// Owns empty-state greeting and conversation starter properties.
+    public let greetingState = ChatGreetingState()
 
     private var cancellables: Set<AnyCancellable> = []
 
@@ -225,6 +227,28 @@ public final class ChatViewModel: ObservableObject {
         }
     }
 
+    // MARK: - @Observable → ObservableObject bridge for ChatGreetingState
+
+    /// Recursively observe all tracked properties on the @Observable
+    /// ChatGreetingState and forward changes into ChatViewModel's
+    /// ObservableObject objectWillChange via the coalesced publish path.
+    private func observeGreetingState() {
+        withObservationTracking {
+            _ = greetingState.emptyStateGreeting
+            _ = greetingState.isGeneratingGreeting
+            _ = greetingState.conversationStarters
+            _ = greetingState.conversationStartersLoading
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.scheduleCoalescedPublish()
+                #if DEBUG
+                self?.trackPublish(source: "greetingState")
+                #endif
+                self?.observeGreetingState() // re-arm
+            }
+        }
+    }
+
     // MARK: - Debug publish-rate counters
 
     private static let stallLog = OSLog(subsystem: "com.vellum.assistant", category: "LayoutStall")
@@ -237,6 +261,7 @@ public final class ChatViewModel: ObservableObject {
     private var attachmentManagerPublishCount = 0
     private var errorManagerPublishCount = 0
     private var btwStatePublishCount = 0
+    private var greetingStatePublishCount = 0
     private var lastRateLogTime = Date()
 
     private func trackPublish(source: String) {
@@ -246,20 +271,22 @@ public final class ChatViewModel: ObservableObject {
         case "attachmentManager": attachmentManagerPublishCount += 1
         case "errorManager": errorManagerPublishCount += 1
         case "btwState": btwStatePublishCount += 1
+        case "greetingState": greetingStatePublishCount += 1
         default: break
         }
         let now = Date()
         if now.timeIntervalSince(lastRateLogTime) >= 5 {
             os_log(
                 .debug, log: Self.perfLog,
-                "ChatViewModel publish rate: %d/5s (msg=%d, attach=%d, err=%d, btw=%d)",
-                publishCount, messageManagerPublishCount, attachmentManagerPublishCount, errorManagerPublishCount, btwStatePublishCount
+                "ChatViewModel publish rate: %d/5s (msg=%d, attach=%d, err=%d, btw=%d, greet=%d)",
+                publishCount, messageManagerPublishCount, attachmentManagerPublishCount, errorManagerPublishCount, btwStatePublishCount, greetingStatePublishCount
             )
             publishCount = 0
             messageManagerPublishCount = 0
             attachmentManagerPublishCount = 0
             errorManagerPublishCount = 0
             btwStatePublishCount = 0
+            greetingStatePublishCount = 0
             lastRateLogTime = now
         }
     }
@@ -578,7 +605,6 @@ public final class ChatViewModel: ObservableObject {
     private let settingsClient: any SettingsClientProtocol
     private let surfaceClient: any SurfaceClientProtocol = SurfaceClient()
     private let conversationListClient: any ConversationListClientProtocol = ConversationListClient()
-    private let conversationStarterClient: any ConversationStarterClientProtocol = ConversationStarterClient()
     private let btwClient: any BtwClientProtocol = BtwClient()
     let btwState: ChatBtwState
     let interactionClient: any InteractionClientProtocol
@@ -878,28 +904,22 @@ public final class ChatViewModel: ObservableObject {
     /// True while a /btw request is in flight.
     public var btwLoading: Bool { btwState.btwLoading }
 
-    // MARK: - Empty-State Greeting
+    // MARK: - Forwarding properties — ChatGreetingState
 
-    /// A daemon-generated greeting shown when the conversation is empty, or nil before generation.
-    @Published public var emptyStateGreeting: String? = nil
-    /// True while a greeting is being streamed from the daemon.
-    @Published public var isGeneratingGreeting: Bool = false
-    /// The in-flight greeting streaming task, stored for cancellation.
-    private var greetingTask: Task<Void, Never>?
-
-    // MARK: - Conversation Starters
-
-    /// Personalized suggestion chips shown on the empty conversation page.
-    @Published public var conversationStarters: [ConversationStarter] = []
-    @Published public var conversationStartersLoading: Bool = false
-
-    private static let fallbackGreetings = [
-        "What are we working on?",
-        "I'm here whenever you need me.",
-        "What's on your mind?",
-        "Let's make something happen.",
-        "Ready when you are.",
-    ]
+    public var emptyStateGreeting: String? {
+        get { greetingState.emptyStateGreeting }
+        set { greetingState.emptyStateGreeting = newValue }
+    }
+    public var isGeneratingGreeting: Bool {
+        greetingState.isGeneratingGreeting
+    }
+    public var conversationStarters: [ConversationStarter] {
+        get { greetingState.conversationStarters }
+        set { greetingState.conversationStarters = newValue }
+    }
+    public var conversationStartersLoading: Bool {
+        greetingState.conversationStartersLoading
+    }
 
     /// Whether there are more messages above the current display window.
     /// True when either:
@@ -1214,6 +1234,8 @@ public final class ChatViewModel: ObservableObject {
         observeErrorManager()
         // ChatBtwState is @Observable — same bridge pattern.
         observeBtwState()
+        // ChatGreetingState is @Observable — same bridge pattern.
+        observeGreetingState()
 
         // Surface attachment validation errors in the error manager so the UI
         // can show them without the attachment manager needing a direct reference.
@@ -1591,89 +1613,18 @@ public final class ChatViewModel: ObservableObject {
         btwState.dismissBtw()
     }
 
-    // MARK: - Empty-State Greeting Generation
+    // MARK: - Forwarding methods — ChatGreetingState
 
-    /// Stream a short, personality-matched greeting from the daemon for the empty conversation state.
-    /// Each call cancels any in-flight generation and starts fresh. On error, falls back to a
-    /// random default greeting so the UI always receives a value.
     public func generateGreeting() {
-        greetingTask?.cancel()
-        emptyStateGreeting = nil
-        isGeneratingGreeting = true
-
-        greetingTask = Task { @MainActor [weak self] in
-            guard let self else { return }
-            let key = "greeting"
-            var result = ""
-            do {
-                let stream = self.btwClient.sendMessage(
-                    content: "Generate a short, casual greeting in your voice from you to your user. This will be displayed when the user opens a new conversation (under 8 words). Match your personality. Output ONLY the greeting text — no quotes, no formatting.",
-                    conversationKey: key
-                )
-                for try await delta in stream {
-                    guard !Task.isCancelled else { return }
-                    result += delta
-                }
-                guard !Task.isCancelled else { return }
-                self.emptyStateGreeting = result.isEmpty
-                    ? Self.fallbackGreetings.randomElement()!
-                    : result
-            } catch is CancellationError {
-                return
-            } catch {
-                guard !Task.isCancelled else { return }
-                self.emptyStateGreeting = Self.fallbackGreetings.randomElement()!
-            }
-            self.isGeneratingGreeting = false
-        }
+        greetingState.generateGreeting()
     }
 
-    /// Clear greeting state and cancel any in-flight generation.
     public func dismissGreeting() {
-        greetingTask?.cancel()
-        greetingTask = nil
-        emptyStateGreeting = nil
-        isGeneratingGreeting = false
+        greetingState.dismissGreeting()
     }
 
-    private var conversationStarterPollTask: Task<Void, Never>?
-
-    /// Fetch personalized conversation starters from the daemon for the empty conversation state.
     public func fetchConversationStarters() {
-        conversationStarterPollTask?.cancel()
-        conversationStarterPollTask = Task { @MainActor [weak self] in
-            guard let self else { return }
-            let response = await self.conversationStarterClient.fetchConversationStarters(limit: 4)
-            guard !Task.isCancelled else { return }
-
-            if let response, !response.starters.isEmpty {
-                self.conversationStarters = response.starters
-                self.conversationStartersLoading = false
-                return
-            }
-
-            if response?.status == "generating" {
-                self.conversationStartersLoading = true
-                // Poll every 3 seconds until ready
-                while !Task.isCancelled {
-                    try? await Task.sleep(nanoseconds: 3_000_000_000)
-                    guard !Task.isCancelled else { return }
-                    let poll = await self.conversationStarterClient.fetchConversationStarters(limit: 4)
-                    guard !Task.isCancelled else { return }
-                    if let poll, !poll.starters.isEmpty {
-                        self.conversationStarters = poll.starters
-                        self.conversationStartersLoading = false
-                        return
-                    }
-                    if poll?.status != "generating" {
-                        self.conversationStartersLoading = false
-                        return
-                    }
-                }
-            } else {
-                self.conversationStartersLoading = false
-            }
-        }
+        greetingState.fetchConversationStarters()
     }
 
     private func bootstrapConversation(userMessage: String?, attachments: [UserMessageAttachment]?) {
@@ -3345,7 +3296,7 @@ public final class ChatViewModel: ObservableObject {
         reconnectLatchTimeoutTask?.cancel()
         reconnectDebounceTask?.cancel()
         // btwTask cancellation is handled by ChatBtwState's deinit.
-        greetingTask?.cancel()
+        greetingState.cancelAll()
         sendingWatchdogTask?.cancel()
         memoryPressureSource?.cancel()
         if let observer = reconnectObserver {


### PR DESCRIPTION
## Why

ChatViewModel owns ~120 lines of greeting generation and conversation starter polling logic that is entirely self-contained — it only depends on injected `BtwClientProtocol` and `ConversationStarterClientProtocol`, with no coupling to the rest of ChatViewModel's state. Extracting it into its own `@Observable` class reduces ChatViewModel's scope and gives the greeting subsystem property-level SwiftUI tracking.

This follows the same pattern established in the ChatBtwState extraction: an `@Observable` class with a `withObservationTracking` bridge to keep ChatViewModel's `objectWillChange` firing for existing views.

## What

- **New file**: `ChatGreetingState.swift` — `@MainActor @Observable final class` owning:
  - `emptyStateGreeting`, `isGeneratingGreeting`, `conversationStarters`, `conversationStartersLoading`
  - `generateGreeting()` — streams AI-generated greeting via `btwClient`, falls back to static greetings on error
  - `fetchConversationStarters()` — polls every 3s while status is "generating"
  - `dismissGreeting()`, `cancelAll()`
- **ChatViewModel.swift**: Replace `@Published` properties with computed forwarding, forward method calls, add `observeGreetingState()` bridge
- `cancelAll()` is `nonisolated` with `nonisolated(unsafe)` tasks so it can be called from ChatViewModel's nonisolated `deinit`

## Safety

- Zero API changes — all existing call sites compile unchanged
- Every code path preserved: generation, cancellation, fallback, polling, dismiss
- `cancelAll()` nonisolated pattern matches how ChatViewModel's deinit already cancels tasks on sub-managers
- Bridge follows the proven `observeErrorManager()` / `observeBtwState()` pattern

## References

- [Observation framework](https://developer.apple.com/documentation/observation) — `@Observable` macro
- [Migrating from ObservableObject to Observable](https://developer.apple.com/documentation/swiftui/migrating-from-the-observable-object-protocol-to-the-observable-macro) — incremental migration guide
- [SE-0412: Strict concurrency for global variables](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0412-strict-concurrency-for-global-variables.md) — `nonisolated(unsafe)` for deinit-accessible task properties
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21910" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
