### PR TITLE
fix: use app name in version history instead of turn number

### DIFF
--- a/assistant/src/__tests__/app-git-history.test.ts
+++ b/assistant/src/__tests__/app-git-history.test.ts
@@ -55,7 +55,7 @@ describe("App Git History", () => {
 
     const history = await getAppHistory(app.id);
     expect(history.length).toBeGreaterThanOrEqual(2);
-    expect(history[0].message).toContain("Turn 2");
+    expect(history[0].message).toContain("update ");
     expect(history[0].commitHash).toMatch(/^[0-9a-f]+$/);
     expect(history[0].timestamp).toBeGreaterThan(0);
   });

--- a/assistant/src/__tests__/app-git-service.test.ts
+++ b/assistant/src/__tests__/app-git-service.test.ts
@@ -100,7 +100,9 @@ describe("App Git Service", () => {
     expect(commits.length).toBeLessThanOrEqual(2);
     // The turn commit message should appear (or files are in the initial commit)
     expect(
-      commits.some((c) => c.includes("Turn 1") || c.includes("Initial commit")),
+      commits.some(
+        (c) => c.includes("update ") || c.includes("Initial commit"),
+      ),
     ).toBe(true);
   });
 
@@ -141,6 +143,6 @@ describe("App Git Service", () => {
 
     const appsDir = getAppsDir();
     const commits = getGitLog(appsDir);
-    expect(commits[0]).toContain("Turn 2: app changes");
+    expect(commits[0]).toContain("update ");
   });
 });

--- a/assistant/src/config/bundled-skills/app-builder/TOOLS.json
+++ b/assistant/src/config/bundled-skills/app-builder/TOOLS.json
@@ -75,6 +75,10 @@
             },
             "required": ["title"]
           },
+          "change_summary": {
+            "type": "string",
+            "description": "Short summary of what changed, using git conventional commit format (e.g. 'feat: add coin flip app', 'fix: correct button alignment'). Used as the version history entry."
+          },
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
@@ -97,6 +101,10 @@
             "type": "string",
             "description": "The ID of the app to delete"
           },
+          "change_summary": {
+            "type": "string",
+            "description": "Short summary of what changed, using git conventional commit format (e.g. 'chore: delete unused app'). Used as the version history entry."
+          },
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
@@ -118,6 +126,10 @@
           "app_id": {
             "type": "string",
             "description": "The ID of the app to refresh"
+          },
+          "change_summary": {
+            "type": "string",
+            "description": "Short summary of what changed, using git conventional commit format (e.g. 'feat: add dark mode toggle', 'fix: form validation'). Used as the version history entry."
           },
           "activity": {
             "type": "string",
@@ -144,6 +156,10 @@
           "description": {
             "type": "string",
             "description": "Optional description to guide icon generation (e.g. 'a blue calendar with a checkmark'). If omitted, the app name and description are used."
+          },
+          "change_summary": {
+            "type": "string",
+            "description": "Short summary of what changed, using git conventional commit format (e.g. 'feat: generate app icon'). Used as the version history entry."
           },
           "activity": {
             "type": "string",

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-create.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-create.ts
@@ -14,7 +14,7 @@ export async function run(
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
   if (typeof input.change_summary === "string" && input.change_summary.trim()) {
-    setAppCommitMessage(input.change_summary.trim());
+    setAppCommitMessage(context.conversationId, input.change_summary.trim());
   }
   const multifileEnabled = isAssistantFeatureFlagEnabled(
     "app-builder-multifile",

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-create.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-create.ts
@@ -1,5 +1,6 @@
 import { isAssistantFeatureFlagEnabled } from "../../../../config/assistant-feature-flags.js";
 import { getConfig } from "../../../../config/loader.js";
+import { setAppCommitMessage } from "../../../../memory/app-git-service.js";
 import * as appStore from "../../../../memory/app-store.js";
 import type { AppCreateInput } from "../../../../tools/apps/executors.js";
 import { executeAppCreate } from "../../../../tools/apps/executors.js";
@@ -12,6 +13,9 @@ export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  if (typeof input.change_summary === "string" && input.change_summary.trim()) {
+    setAppCommitMessage(input.change_summary.trim());
+  }
   const multifileEnabled = isAssistantFeatureFlagEnabled(
     "app-builder-multifile",
     getConfig(),

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-delete.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-delete.ts
@@ -1,3 +1,4 @@
+import { setAppCommitMessage } from "../../../../memory/app-git-service.js";
 import * as appStore from "../../../../memory/app-store.js";
 import { executeAppDelete } from "../../../../tools/apps/executors.js";
 import type {
@@ -9,5 +10,8 @@ export async function run(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  if (typeof input.change_summary === "string" && input.change_summary.trim()) {
+    setAppCommitMessage(input.change_summary.trim());
+  }
   return executeAppDelete({ app_id: input.app_id as string }, appStore);
 }

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-delete.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-delete.ts
@@ -8,10 +8,10 @@ import type {
 
 export async function run(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
 ): Promise<ToolExecutionResult> {
   if (typeof input.change_summary === "string" && input.change_summary.trim()) {
-    setAppCommitMessage(input.change_summary.trim());
+    setAppCommitMessage(context.conversationId, input.change_summary.trim());
   }
   return executeAppDelete({ app_id: input.app_id as string }, appStore);
 }

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-generate-icon.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-generate-icon.ts
@@ -1,3 +1,4 @@
+import { setAppCommitMessage } from "../../../../memory/app-git-service.js";
 import * as appStore from "../../../../memory/app-store.js";
 import type { AppGenerateIconInput } from "../../../../tools/apps/executors.js";
 import { executeAppGenerateIcon } from "../../../../tools/apps/executors.js";
@@ -6,6 +7,9 @@ import type { ToolExecutionResult } from "../../../../tools/types.js";
 export async function run(
   input: Record<string, unknown>,
 ): Promise<ToolExecutionResult> {
+  if (typeof input.change_summary === "string" && input.change_summary.trim()) {
+    setAppCommitMessage(input.change_summary.trim());
+  }
   return executeAppGenerateIcon(
     input as unknown as AppGenerateIconInput,
     appStore,

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-generate-icon.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-generate-icon.ts
@@ -2,13 +2,17 @@ import { setAppCommitMessage } from "../../../../memory/app-git-service.js";
 import * as appStore from "../../../../memory/app-store.js";
 import type { AppGenerateIconInput } from "../../../../tools/apps/executors.js";
 import { executeAppGenerateIcon } from "../../../../tools/apps/executors.js";
-import type { ToolExecutionResult } from "../../../../tools/types.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
 
 export async function run(
   input: Record<string, unknown>,
+  context: ToolContext,
 ): Promise<ToolExecutionResult> {
   if (typeof input.change_summary === "string" && input.change_summary.trim()) {
-    setAppCommitMessage(input.change_summary.trim());
+    setAppCommitMessage(context.conversationId, input.change_summary.trim());
   }
   return executeAppGenerateIcon(
     input as unknown as AppGenerateIconInput,

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-refresh.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-refresh.ts
@@ -8,10 +8,10 @@ import type {
 
 export async function run(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
 ): Promise<ToolExecutionResult> {
   if (typeof input.change_summary === "string" && input.change_summary.trim()) {
-    setAppCommitMessage(input.change_summary.trim());
+    setAppCommitMessage(context.conversationId, input.change_summary.trim());
   }
   return executeAppRefresh({ app_id: input.app_id as string }, appStore);
 }

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-refresh.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-refresh.ts
@@ -1,3 +1,4 @@
+import { setAppCommitMessage } from "../../../../memory/app-git-service.js";
 import * as appStore from "../../../../memory/app-store.js";
 import { executeAppRefresh } from "../../../../tools/apps/executors.js";
 import type {
@@ -9,5 +10,8 @@ export async function run(
   input: Record<string, unknown>,
   _context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  if (typeof input.change_summary === "string" && input.change_summary.trim()) {
+    setAppCommitMessage(input.change_summary.trim());
+  }
   return executeAppRefresh({ app_id: input.app_id as string }, appStore);
 }

--- a/assistant/src/memory/app-git-service.ts
+++ b/assistant/src/memory/app-git-service.ts
@@ -22,6 +22,7 @@ import { join } from "node:path";
 
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceGitService } from "../workspace/git-service.js";
+import { getCommitMessageGenerator } from "../workspace/provider-commit-message-generator.js";
 import { getAppsDir, resolveAppDir } from "./app-store.js";
 
 const log = getLogger("app-git");
@@ -175,16 +176,55 @@ export async function commitAppTurnChanges(
     ensureAppGitignoreRules(appsDir);
 
     const gitService = getWorkspaceGitService(appsDir);
+
+    // Pre-check for changes and attempt LLM message before taking the mutex
+    let llmMessage: string | undefined;
+    try {
+      const preStatus = await gitService.getStatus();
+      if (preStatus.clean) return;
+
+      const changedFiles = [
+        ...new Set([
+          ...preStatus.staged,
+          ...preStatus.modified,
+          ...preStatus.untracked,
+        ]),
+      ];
+
+      const generator = getCommitMessageGenerator();
+      const result = await generator.generateCommitMessage(
+        {
+          workspaceDir: appsDir,
+          trigger: "turn",
+          conversationId,
+          turnNumber,
+          changedFiles,
+          timestampMs: Date.now(),
+        },
+        { changedFiles },
+      );
+      if (result.source === "llm") {
+        llmMessage = result.message;
+      }
+    } catch {
+      // Non-fatal — fall through to deterministic message
+    }
+
     await gitService.commitIfDirty((status) => {
+      if (llmMessage) {
+        return {
+          message: llmMessage,
+          metadata: { conversationId, turnNumber },
+        };
+      }
+
+      // Deterministic fallback: derive app names from changed file paths
       const allFiles = [
         ...new Set([...status.staged, ...status.modified, ...status.untracked]),
       ];
-
-      // Derive unique app names from file paths like "my-app.json" or "my-app/index.html"
       const appNames = [
         ...new Set(allFiles.map((f) => f.split("/")[0].replace(/\.json$/, ""))),
       ];
-
       const subject =
         appNames.length === 1
           ? `update ${appNames[0]}`

--- a/assistant/src/memory/app-git-service.ts
+++ b/assistant/src/memory/app-git-service.ts
@@ -22,10 +22,27 @@ import { join } from "node:path";
 
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceGitService } from "../workspace/git-service.js";
-import { getCommitMessageGenerator } from "../workspace/provider-commit-message-generator.js";
 import { getAppsDir, resolveAppDir } from "./app-store.js";
 
 const log = getLogger("app-git");
+
+// ---------------------------------------------------------------------------
+// Pending commit message — set by app tool executors, consumed at turn boundary
+// ---------------------------------------------------------------------------
+
+let pendingAppCommitMessage: string | undefined;
+
+/** Set the commit message for the next app turn-boundary commit. */
+export function setAppCommitMessage(message: string): void {
+  pendingAppCommitMessage = message;
+}
+
+/** Consume and clear the pending commit message. */
+function consumeAppCommitMessage(): string | undefined {
+  const msg = pendingAppCommitMessage;
+  pendingAppCommitMessage = undefined;
+  return msg;
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -176,55 +193,33 @@ export async function commitAppTurnChanges(
     ensureAppGitignoreRules(appsDir);
 
     const gitService = getWorkspaceGitService(appsDir);
-
-    // Pre-check for changes and attempt LLM message before taking the mutex
-    let llmMessage: string | undefined;
-    try {
-      const preStatus = await gitService.getStatus();
-      if (preStatus.clean) return;
-
-      const changedFiles = [
-        ...new Set([
-          ...preStatus.staged,
-          ...preStatus.modified,
-          ...preStatus.untracked,
-        ]),
-      ];
-
-      const generator = getCommitMessageGenerator();
-      const result = await generator.generateCommitMessage(
-        {
-          workspaceDir: appsDir,
-          trigger: "turn",
-          conversationId,
-          turnNumber,
-          changedFiles,
-          timestampMs: Date.now(),
-        },
-        { changedFiles },
-      );
-      if (result.source === "llm") {
-        llmMessage = result.message;
-      }
-    } catch {
-      // Non-fatal — fall through to deterministic message
-    }
+    const changeSummary = consumeAppCommitMessage();
 
     await gitService.commitIfDirty((status) => {
-      if (llmMessage) {
+      if (changeSummary) {
         return {
-          message: llmMessage,
+          message: changeSummary,
           metadata: { conversationId, turnNumber },
         };
       }
 
-      // Deterministic fallback: derive app names from changed file paths
+      // Fallback: derive app names from changed file paths
       const allFiles = [
         ...new Set([...status.staged, ...status.modified, ...status.untracked]),
       ];
-      const appNames = [
+      const dirNames = [
         ...new Set(allFiles.map((f) => f.split("/")[0].replace(/\.json$/, ""))),
       ];
+      const appNames = dirNames.map((dirName) => {
+        try {
+          const jsonPath = join(appsDir, `${dirName}.json`);
+          const raw = readFileSync(jsonPath, "utf-8");
+          const app = JSON.parse(raw) as { name?: string };
+          return app.name || dirName;
+        } catch {
+          return dirName;
+        }
+      });
       const subject =
         appNames.length === 1
           ? `update ${appNames[0]}`

--- a/assistant/src/memory/app-git-service.ts
+++ b/assistant/src/memory/app-git-service.ts
@@ -30,17 +30,20 @@ const log = getLogger("app-git");
 // Pending commit message — set by app tool executors, consumed at turn boundary
 // ---------------------------------------------------------------------------
 
-let pendingAppCommitMessage: string | undefined;
+const pendingAppCommitMessages = new Map<string, string>();
 
 /** Set the commit message for the next app turn-boundary commit. */
-export function setAppCommitMessage(message: string): void {
-  pendingAppCommitMessage = message;
+export function setAppCommitMessage(
+  conversationId: string,
+  message: string,
+): void {
+  pendingAppCommitMessages.set(conversationId, message);
 }
 
-/** Consume and clear the pending commit message. */
-function consumeAppCommitMessage(): string | undefined {
-  const msg = pendingAppCommitMessage;
-  pendingAppCommitMessage = undefined;
+/** Consume and clear the pending commit message for a conversation. */
+function consumeAppCommitMessage(conversationId: string): string | undefined {
+  const msg = pendingAppCommitMessages.get(conversationId);
+  pendingAppCommitMessages.delete(conversationId);
   return msg;
 }
 
@@ -188,12 +191,13 @@ export async function commitAppTurnChanges(
   conversationId: string,
   turnNumber: number,
 ): Promise<void> {
+  // Consume before any work that could throw, so the message doesn't leak
+  const changeSummary = consumeAppCommitMessage(conversationId);
   try {
     const appsDir = getAppsDir();
     ensureAppGitignoreRules(appsDir);
 
     const gitService = getWorkspaceGitService(appsDir);
-    const changeSummary = consumeAppCommitMessage();
 
     await gitService.commitIfDirty((status) => {
       if (changeSummary) {

--- a/assistant/src/memory/app-git-service.ts
+++ b/assistant/src/memory/app-git-service.ts
@@ -175,10 +175,28 @@ export async function commitAppTurnChanges(
     ensureAppGitignoreRules(appsDir);
 
     const gitService = getWorkspaceGitService(appsDir);
-    await gitService.commitIfDirty(() => ({
-      message: `Turn ${turnNumber}: app changes`,
-      metadata: { conversationId, turnNumber },
-    }));
+    await gitService.commitIfDirty((status) => {
+      const allFiles = [
+        ...new Set([...status.staged, ...status.modified, ...status.untracked]),
+      ];
+
+      // Derive unique app names from file paths like "my-app.json" or "my-app/index.html"
+      const appNames = [
+        ...new Set(allFiles.map((f) => f.split("/")[0].replace(/\.json$/, ""))),
+      ];
+
+      const subject =
+        appNames.length === 1
+          ? `update ${appNames[0]}`
+          : appNames.length <= 3
+            ? `update ${appNames.join(", ")}`
+            : `update ${appNames.length} apps`;
+
+      return {
+        message: subject,
+        metadata: { conversationId, turnNumber },
+      };
+    });
   } catch (err) {
     log.error(
       { err, conversationId, turnNumber },


### PR DESCRIPTION
## Summary
- Replace `Turn X: app changes` with descriptive commit messages like `update my-app` in app version history
- Derives app names from changed file paths (e.g., `my-app.json` → `my-app`)
- Handles multiple apps: `update app1, app2` or `update 4 apps`
- Update tests to match new message format

Closes JARVIS-388

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21911" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
