### PR TITLE
fix: remove stale OAuth description from credential_store and regenerate OpenAPI spec

### DIFF
--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -83,7 +83,7 @@ class CredentialStoreTool implements Tool {
             type: "string",
             enum: ["store", "list", "delete", "prompt"],
             description:
-              'The operation to perform. Use "prompt" to ask the user for a secret via secure UI - the value never enters the conversation. For well-known services (google, slack), only the service name is required - endpoints, scopes, and stored client credentials are resolved automatically.',
+              'The operation to perform. Use "prompt" to ask the user for a secret via secure UI - the value never enters the conversation.',
           },
           service: {
             type: "string",


### PR DESCRIPTION
## Summary
- Removes misleading OAuth auto-resolution guidance from credential_store action description
- Regenerates OpenAPI spec to match the updated tool schema

Addresses review feedback from Devin and Codex on #21904.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21912" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
