### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,85 @@
+name: Bug Report
+description: Report a bug in Vellum Assistant
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the details below so we can investigate.
+
+        > **Tip:** You can also submit feedback directly from the app via **Help → Share feedback**.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: Describe what went wrong.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this? Be as specific as possible.
+      placeholder: |
+        1. Run `vellum ...`
+        2. ...
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen instead?
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Vellum version
+      description: Output of `vellum --version`, or the macOS/iOS app version.
+      placeholder: e.g. 1.2.3
+    validations:
+      required: false
+
+  - type: input
+    id: os
+    attributes:
+      label: OS
+      description: Your operating system and version.
+      placeholder: e.g. macOS 15.4, iOS 18.3, Ubuntu 24.04
+    validations:
+      required: false
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Install method
+      options:
+        - CLI (bun install -g vellum)
+        - Built from source
+        - macOS Desktop App
+        - Other
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots
+      description: Paste any relevant log output or attach screenshots. Wrap logs in a code block.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Anything else that might help us understand the issue.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security Vulnerability
+    url: https://github.com/vellum-ai/vellum-assistant/blob/main/SECURITY.md
+    about: Please report security vulnerabilities privately — do not open a public issue.
+  - name: Questions & Support
+    url: https://vellum.ai/community
+    about: For general questions or help, join us on Discord.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature Request
+description: Suggest an idea or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        We'd love to hear your ideas! Describe the problem you're trying to solve and how you imagine the solution.
+
+        > **Tip:** You can also submit feedback directly from the app via **Help → Share feedback**.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What are you trying to do? What's frustrating or missing today?
+      placeholder: I want to be able to ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: How would you imagine this working?
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you tried any workarounds or considered other approaches?
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Anything else — screenshots, links, related issues, etc.
+    validations:
+      required: false

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+    "configurations": [
+        {
+            "type": "swift",
+            "request": "launch",
+            "args": [],
+            "cwd": "${workspaceFolder:vellum-assistant}/clients",
+            "name": "Debug vellum-assistant (clients)",
+            "target": "vellum-assistant",
+            "configuration": "debug",
+            "preLaunchTask": "swift: Build Debug vellum-assistant (clients)"
+        },
+        {
+            "type": "swift",
+            "request": "launch",
+            "args": [],
+            "cwd": "${workspaceFolder:vellum-assistant}/clients",
+            "name": "Release vellum-assistant (clients)",
+            "target": "vellum-assistant",
+            "configuration": "release",
+            "preLaunchTask": "swift: Build Release vellum-assistant (clients)"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- Add structured GitHub issue templates (bug report + feature request) with auto-labels
- Add config.yml to disable blank issues and redirect security reports to SECURITY.md and support questions to Discord
- Include in-app feedback tip (Help → Share feedback) in both templates

## Original prompt
Add issue guidelines and templates for open-sourcing the repo. Issues-only (no outside PRs). Bug reports, feature requests, security redirect, Discord redirect.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21914" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
