### PR TITLE
fix: resolve OAuth provider display name by fixing requires_client_secret type mismatch

### DIFF
--- a/assistant/src/__tests__/oauth-apps-routes.test.ts
+++ b/assistant/src/__tests__/oauth-apps-routes.test.ts
@@ -10,7 +10,7 @@ const mockListConnections = mock(() => [
   {
     id: "conn-1",
     providerKey: "google",
-    accountInfo: "{\"email\":\"alice@example.com\"}",
+    accountInfo: '{"email":"alice@example.com"}',
     grantedScopes: '["email","profile"]',
     status: "active",
     hasRefreshToken: 1,
@@ -37,7 +37,44 @@ mock.module("../oauth/oauth-store.js", () => ({
   getApp: mockGetApp,
   getAppClientSecret: mock(() => Promise.resolve(undefined)),
   getConnection: mock(() => undefined),
-  getProvider: mock(() => undefined),
+  getProvider: mock((providerKey: string) =>
+    providerKey === "google"
+      ? {
+          providerKey: "google",
+          displayName: "Google",
+          description: "Google OAuth provider",
+          dashboardUrl: "https://console.cloud.google.com/apis/credentials",
+          clientIdPlaceholder: null,
+          requiresClientSecret: 1,
+          managedServiceConfigKey: "google-oauth",
+          authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+          tokenUrl: "https://oauth2.googleapis.com/token",
+          tokenEndpointAuthMethod: null,
+          userinfoUrl: null,
+          baseUrl: null,
+          defaultScopes: "[]",
+          scopePolicy: "[]",
+          extraParams: null,
+          callbackTransport: null,
+          pingUrl: null,
+          pingMethod: null,
+          pingHeaders: null,
+          pingBody: null,
+          loopbackPort: null,
+          injectionTemplates: null,
+          appType: null,
+          setupNotes: null,
+          identityUrl: null,
+          identityMethod: null,
+          identityHeaders: null,
+          identityBody: null,
+          identityFormat: null,
+          identityOkField: null,
+          createdAt: 1735689500000,
+          updatedAt: 1735689550000,
+        }
+      : undefined,
+  ),
   listApps: mock(() => []),
   listConnections: mockListConnections,
   upsertApp: mock(() =>
@@ -99,5 +136,69 @@ describe("GET /v1/oauth/apps/:appId/connections", () => {
     expect(body.connections[0]?.has_refresh_token).toBe(true);
     expect(body.connections[1]?.granted_scopes).toEqual([]);
     expect(body.connections[1]?.has_refresh_token).toBe(false);
+  });
+});
+
+describe("GET /v1/oauth/apps", () => {
+  test("returns provider metadata with correct types when provider exists", async () => {
+    const req = new Request(
+      "http://localhost/v1/oauth/apps?provider_key=google",
+    );
+    const url = new URL(req.url);
+    const res = await getRoute("GET", "oauth/apps").handler({
+      req,
+      url,
+      server: null as never,
+      authContext: null as never,
+      params: {},
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      provider: {
+        provider_key: string;
+        display_name: string | null;
+        description: string | null;
+        dashboard_url: string | null;
+        client_id_placeholder: string | null;
+        requires_client_secret: number;
+        supports_managed_mode: boolean;
+      } | null;
+      apps: unknown[];
+    };
+
+    expect(body.provider).not.toBeNull();
+    expect(body.provider!.provider_key).toBe("google");
+    expect(body.provider!.display_name).toBe("Google");
+    expect(body.provider!.description).toBe("Google OAuth provider");
+
+    // requires_client_secret must be an integer (1 or 0), not a boolean
+    expect(body.provider!.requires_client_secret).toBe(1);
+    expect(typeof body.provider!.requires_client_secret).toBe("number");
+
+    // supports_managed_mode is derived from the presence of managedServiceConfigKey
+    expect(body.provider!.supports_managed_mode).toBe(true);
+  });
+
+  test("returns null provider when provider does not exist", async () => {
+    const req = new Request(
+      "http://localhost/v1/oauth/apps?provider_key=unknown",
+    );
+    const url = new URL(req.url);
+    const res = await getRoute("GET", "oauth/apps").handler({
+      req,
+      url,
+      server: null as never,
+      authContext: null as never,
+      params: {},
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      provider: unknown;
+      apps: unknown[];
+    };
+
+    expect(body.provider).toBeNull();
   });
 });

--- a/assistant/src/runtime/routes/oauth-apps.ts
+++ b/assistant/src/runtime/routes/oauth-apps.ts
@@ -81,7 +81,7 @@ export function oauthAppsRouteDefinitions(): RouteDefinition[] {
               description: providerRow.description ?? null,
               dashboard_url: providerRow.dashboardUrl ?? null,
               client_id_placeholder: providerRow.clientIdPlaceholder ?? null,
-              requires_client_secret: !!(providerRow.requiresClientSecret ?? 1),
+              requires_client_secret: providerRow.requiresClientSecret ?? 1,
               supports_managed_mode: !!providerRow.managedServiceConfigKey,
             }
           : null;


### PR DESCRIPTION
## Summary
- Fix type mismatch where requires_client_secret was serialized as JSON boolean instead of integer
- Add test coverage for the GET /v1/oauth/apps provider metadata response shape
- This fixes the 'OAuth OAuth' display issue on the Models & Services page

Part of plan: fix-oauth-display-name.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21916" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
