### PR TITLE
Remove hardcoded secrets from env examples before open-sourcing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,13 +4,13 @@
 
 # --- Sentry (crash reporting) ---
 # Omit or leave empty to disable Sentry in local builds.
-SENTRY_DSN_MACOS=https://c8d6b12505ab6b1785f0e82b5fb50662@o4504590528675840.ingest.us.sentry.io/4511015779696640
-SENTRY_DSN_ASSISTANT=https://db2d38a082e4ee35eeaea08c44b376ec@o4504590528675840.ingest.us.sentry.io/4510874712276992
+SENTRY_DSN_MACOS=
+SENTRY_DSN_ASSISTANT=
 
 # --- Telemetry ---
 # Omit or leave empty to disable telemetry.
 TELEMETRY_PLATFORM_URL=https://platform.vellum.ai
-TELEMETRY_APP_TOKEN=e01cf85768cc3617e986f0a7f1966b72e25316526c5db54c8b94a9c3c5c9eaed
+TELEMETRY_APP_TOKEN=
 
 # --- Doctor service ---
 # Omit to disable the doctor command.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,19 +181,9 @@ When making changes that could affect the cloud platform, review the sibling `..
 
 ## Sentry & Linear Integration
 
-The Sentry organization is `vellum` (region: `us.sentry.io`, URL: `vellum.sentry.io`). Two projects exist: `vellum-assistant-brain` (daemon/runtime) and `vellum-assistant-macos` (desktop app).
+Error reporting uses Sentry. Two projects exist: one for the daemon/runtime (Node) and one for the macOS app (Swift). DSNs are configured via environment variables (`SENTRY_DSN_ASSISTANT`, `SENTRY_DSN_MACOS`) — see `.env.example`.
 
-**Sentry CLI**: Use the newer `sentry` CLI (not the legacy `sentry-cli`). Install from `https://cli.sentry.dev/install`. Authenticate with `sentry auth login`. The [sentry-cli skill](https://github.com/vellum-ai/claude-skills/tree/main/skills/sentry-cli) documents all available commands. Use `sentry api` for raw API calls.
-
-**Linking Sentry ↔ Linear**: Linear is installed as a Sentry App (third-party), not a first-party integration. It lives under `/sentry-app-installations/` (UUID: `d72b980e-5340-4284-a381-095feeb37905`), not `/integrations/`. To link a Sentry issue to a Linear issue:
-
-```bash
-sentry api '/sentry-app-installations/d72b980e-5340-4284-a381-095feeb37905/external-issues/' \
-  --method POST \
-  -d '{"issueId": "<sentry_issue_id>", "webUrl": "<linear_issue_url>", "displayName": "<linear_identifier>", "identifier": "<linear_identifier>", "project": "<sentry_project_slug>"}'
-```
-
-For the reverse direction (Linear → Sentry), use `mcp__linear-server__save_issue` with a `links` attachment containing the Sentry issue URL.
+**Sentry CLI**: Use the newer `sentry` CLI (not the legacy `sentry-cli`). Install from `https://cli.sentry.dev/install`. Authenticate with `sentry auth login`.
 
 ## See Also
 

--- a/assistant/.env.example
+++ b/assistant/.env.example
@@ -21,12 +21,12 @@ VELLUM_PLATFORM_URL=https://dev-platform.vellum.ai
 
 # --- Sentry (crash reporting) ---
 # Omit to disable Sentry.
-SENTRY_DSN_ASSISTANT=https://db2d38a082e4ee35eeaea08c44b376ec@o4504590528675840.ingest.us.sentry.io/4510874712276992
+SENTRY_DSN_ASSISTANT=
 
 # --- Telemetry ---
 # Omit to disable telemetry reporting.
 TELEMETRY_PLATFORM_URL=https://platform.vellum.ai
-TELEMETRY_APP_TOKEN=e01cf85768cc3617e986f0a7f1966b72e25316526c5db54c8b94a9c3c5c9eaed
+TELEMETRY_APP_TOKEN=
 
 # --- Network proxy ---
 # Comma-separated host patterns allowed through the proxy.


### PR DESCRIPTION
## Summary
- Remove hardcoded Sentry DSN strings from `.env.example` and `assistant/.env.example` — these pointed to our internal Sentry org
- Remove hardcoded `TELEMETRY_APP_TOKEN` from both `.env.example` files — real token was checked in
- Genericize the Sentry section in `AGENTS.md` — remove internal org name, app installation UUIDs, and claude-skills repo link

All env vars are left as empty placeholders so the self-service setup flow is preserved.

## Original prompt
the items you suggest
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21919" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
