### PR TITLE
fix: custom skill banner click target limited to link text (LUM-554)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -59,11 +59,8 @@ struct AgentPanelContent: View {
                     HStack(spacing: VSpacing.xs) {
                         VIconView(.sparkles, size: 14)
                             .foregroundStyle(VColor.primaryBase)
-                        Text("Tip: ").bold() +
-                        Text("You can ") +
-                        Text("create a new custom skill")
-                            .foregroundStyle(VColor.primaryBase) +
-                        Text(" by describing what you want in chat.")
+                        Text("**Tip:** You can [create a new custom skill](vellum://create-skill) by describing what you want in chat.")
+                            .tint(VColor.primaryBase)
                         Spacer()
                         Button(action: {
                             withAnimation(VAnimation.fast) { bannerDismissed = true }
@@ -85,8 +82,10 @@ struct AgentPanelContent: View {
                         RoundedRectangle(cornerRadius: VRadius.md)
                             .stroke(VColor.primaryBase.opacity(0.18), lineWidth: 1)
                     )
-                    .contentShape(Rectangle())
-                    .onTapGesture { onCreateSkill?() }
+                    .environment(\.openURL, OpenURLAction { _ in
+                        onCreateSkill?()
+                        return .handled
+                    })
                     .accessibilityElement(children: .combine)
                     .accessibilityLabel("Tip: You can create a new custom skill by describing what you want in chat.")
                     .accessibilityAddTraits(.isButton)


### PR DESCRIPTION
## Summary
- Replaced whole-banner `.contentShape(Rectangle())` + `.onTapGesture` with a markdown `Text` link and `.environment(\.openURL)` handler
- Only the "create a new custom skill" link text is now clickable, not the entire banner
- Dismiss button no longer competes with the banner-wide tap gesture

## Original prompt
--safe https://linear.app/vellum/issue/LUM-554/custom-skill-banner-is-clickable-across-the-whole-banner
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
