### PR TITLE
Remove redundant TELEMETRY_PLATFORM_URL in favor of VELLUM_PLATFORM_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,6 @@ SENTRY_DSN_ASSISTANT=
 
 # --- Telemetry ---
 # Omit or leave empty to disable telemetry.
-TELEMETRY_PLATFORM_URL=https://platform.vellum.ai
 TELEMETRY_APP_TOKEN=
 
 # --- Doctor service ---

--- a/assistant/.env.example
+++ b/assistant/.env.example
@@ -25,7 +25,6 @@ SENTRY_DSN_ASSISTANT=
 
 # --- Telemetry ---
 # Omit to disable telemetry reporting.
-TELEMETRY_PLATFORM_URL=https://platform.vellum.ai
 TELEMETRY_APP_TOKEN=
 
 # --- Network proxy ---

--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -218,10 +218,6 @@ export function getPlatformInternalApiKey(): string {
 
 // ── Telemetry ──────────────────────────────────────────────────────────────────
 
-export function getTelemetryPlatformUrl(): string {
-  return str("TELEMETRY_PLATFORM_URL") ?? "";
-}
-
 export function getTelemetryAppToken(): string {
   return str("TELEMETRY_APP_TOKEN") ?? "";
 }

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -49,16 +49,16 @@ mock.module("../platform/client.js", () => ({
   },
 }));
 
-const mockGetTelemetryPlatformUrl = mock(() => "https://platform.vellum.ai");
+const mockGetPlatformBaseUrl = mock(() => "https://platform.vellum.ai");
 const mockGetTelemetryAppToken = mock(() => "");
 
 const mockGetPlatformOrganizationId = mock(() => "");
 const mockGetPlatformUserId = mock(() => "");
 
 mock.module("../config/env.js", () => ({
+  getPlatformBaseUrl: mockGetPlatformBaseUrl,
   getPlatformOrganizationId: mockGetPlatformOrganizationId,
   getPlatformUserId: mockGetPlatformUserId,
-  getTelemetryPlatformUrl: mockGetTelemetryPlatformUrl,
   getTelemetryAppToken: mockGetTelemetryAppToken,
   // Re-export anything else the module might import transitively
   str: () => undefined,
@@ -141,7 +141,7 @@ beforeEach(() => {
   mockQueryUnreportedTurnEvents.mockReset();
   mockQueryUnreportedTurnEvents.mockReturnValue([]);
   mockPlatformClient = null;
-  mockGetTelemetryPlatformUrl.mockReset();
+  mockGetPlatformBaseUrl.mockReset();
   mockGetTelemetryAppToken.mockReset();
   mockGetDeviceId.mockReset();
   mockGetDeviceId.mockReturnValue("test-device-id");
@@ -154,7 +154,7 @@ beforeEach(() => {
 
   // Defaults
   mockGetMemoryCheckpoint.mockReturnValue(null);
-  mockGetTelemetryPlatformUrl.mockReturnValue("https://platform.vellum.ai");
+  mockGetPlatformBaseUrl.mockReturnValue("https://platform.vellum.ai");
   mockGetTelemetryAppToken.mockReturnValue("default-test-token");
 
   mockFetch = mock(() =>
@@ -197,7 +197,7 @@ describe("UsageTelemetryReporter", () => {
 
   test("anonymous flush uses X-Telemetry-Token and default URL", async () => {
     mockPlatformClient = null;
-    mockGetTelemetryPlatformUrl.mockReturnValue("https://platform.test.ai");
+    mockGetPlatformBaseUrl.mockReturnValue("https://platform.test.ai");
     mockGetTelemetryAppToken.mockReturnValue("anon-token");
 
     const events = [makeUsageEvent()];

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -10,10 +10,10 @@
  */
 
 import {
+  getPlatformBaseUrl,
   getPlatformOrganizationId,
   getPlatformUserId,
   getTelemetryAppToken,
-  getTelemetryPlatformUrl,
 } from "../config/env.js";
 import {
   getMemoryCheckpoint,
@@ -140,7 +140,7 @@ export class UsageTelemetryReporter {
 
       // Resolve auth context — skip flush when neither auth mode is viable
       const client = await VellumPlatformClient.create();
-      if (!client && (!getTelemetryAppToken() || !getTelemetryPlatformUrl())) {
+      if (!client && !getTelemetryAppToken()) {
         return;
       }
 
@@ -203,9 +203,7 @@ export class UsageTelemetryReporter {
       if (client) {
         resp = await client.fetch(TELEMETRY_PATH, fetchInit);
       } else {
-        const platformUrl = getTelemetryPlatformUrl();
-        if (!platformUrl) return;
-        const url = `${platformUrl}${TELEMETRY_PATH}`;
+        const url = `${getPlatformBaseUrl()}${TELEMETRY_PATH}`;
         resp = await fetch(url, {
           ...fetchInit,
           headers: {

--- a/clients/macos/vellum-assistant/App/VellumCli.swift
+++ b/clients/macos/vellum-assistant/App/VellumCli.swift
@@ -112,7 +112,7 @@ final class VellumCli {
     nonisolated private static let forwardedEnvKeys: [String] = [
         "BASE_DATA_DIR",
         "VELLUM_PLATFORM_URL",
-        "TELEMETRY_PLATFORM_URL", "TELEMETRY_APP_TOKEN",
+        "TELEMETRY_APP_TOKEN",
         "ASSISTANT_GIT_USER_NAME", "ASSISTANT_GIT_USER_EMAIL",
         "CLI_GIT_USER_NAME", "CLI_GIT_USER_EMAIL",
         "PROXY_ALLOWED_HOSTS", "HTTP_USER_AGENT", "DOCTOR_SERVICE_URL",


### PR DESCRIPTION
## Summary
- Remove `TELEMETRY_PLATFORM_URL` env var — it was always identical to `VELLUM_PLATFORM_URL` and redundant
- Update the anonymous telemetry fallback path to use `getPlatformBaseUrl()` which already handles dev/prod defaults and config-file overrides
- Remove from `.env.example` files, Swift forwarded env keys, and `env.ts` config

## Original prompt
that clean up
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21923" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
