### PR TITLE
Add pendingSkillId to MainWindowState for skill deep-linking

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -65,6 +65,10 @@ public final class MainWindowState: ObservableObject {
     /// Transient memory ID to deep-link into when the Intelligence panel opens.
     /// Consumed once by IntelligencePanel/MemoriesPanel, then set back to nil.
     @Published var pendingMemoryId: String?
+
+    /// Transient skill ID to deep-link into when the Intelligence panel opens.
+    /// Consumed once by IntelligencePanel/SkillsPanel, then set back to nil.
+    @Published var pendingSkillId: String?
     @Published var activeDynamicSurface: UiSurfaceShowMessage?
     @Published var activeDynamicParsedSurface: Surface?
     @Published var workspaceComposerExpanded = false
@@ -241,6 +245,12 @@ public final class MainWindowState: ObservableObject {
     /// Navigate to the Intelligence panel and deep-link to a specific memory.
     func showMemory(id: String) {
         pendingMemoryId = id
+        showPanel(.intelligence)
+    }
+
+    /// Navigate to the Intelligence panel and deep-link to a specific skill.
+    func showSkill(id: String) {
+        pendingSkillId = id
         showPanel(.intelligence)
     }
 


### PR DESCRIPTION
## Summary
- Add `pendingSkillId` published property to MainWindowState
- Add `showSkill(id:)` method following the existing `showMemory(id:)` pattern

Part of plan: graph-deep-links.md (PR 2 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21924" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
