### PR TITLE
Add skill deep-link navigation from constellation graph to skill detail view

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -24,6 +24,7 @@ struct AgentPanelContent: View {
     var onCreateSkill: (() -> Void)?
     var onSkillsChanged: (() -> Void)?
     let connectionManager: GatewayConnectionManager
+    @Binding var focusedSkillId: String?
 
     @State private var skillsManager: SkillsManager
     @State private var selectedInstalledSkillId: String?
@@ -34,11 +35,12 @@ struct AgentPanelContent: View {
     @State private var showSkillFilterPopover = false
     @AppStorage("skillsBannerDismissed") private var bannerDismissed = false
 
-    init(onInvokeSkill: ((SkillInfo) -> Void)? = nil, onCreateSkill: (() -> Void)? = nil, onSkillsChanged: (() -> Void)? = nil, connectionManager: GatewayConnectionManager) {
+    init(onInvokeSkill: ((SkillInfo) -> Void)? = nil, onCreateSkill: (() -> Void)? = nil, onSkillsChanged: (() -> Void)? = nil, connectionManager: GatewayConnectionManager, focusedSkillId: Binding<String?> = .constant(nil)) {
         self.onInvokeSkill = onInvokeSkill
         self.onCreateSkill = onCreateSkill
         self.onSkillsChanged = onSkillsChanged
         self.connectionManager = connectionManager
+        _focusedSkillId = focusedSkillId
         _skillsManager = State(wrappedValue: SkillsManager(connectionManager: connectionManager))
     }
 
@@ -105,6 +107,16 @@ struct AgentPanelContent: View {
         }
         .onAppear {
             skillsManager.fetchSkills()
+            if let skillId = focusedSkillId {
+                selectedInstalledSkillId = skillId
+                focusedSkillId = nil
+            }
+        }
+        .onChange(of: focusedSkillId) {
+            if let skillId = focusedSkillId {
+                selectedInstalledSkillId = skillId
+                focusedSkillId = nil
+            }
         }
         .onChange(of: skillsManager.skills.map(\.id)) {
             onSkillsChanged?()

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -378,6 +378,7 @@ private enum AnimationPhase: Equatable {
 
 private struct SkillPopoverView: View {
     let item: OrbitItem
+    var onViewDetails: (() -> Void)?
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
@@ -413,6 +414,20 @@ private struct SkillPopoverView: View {
                         Capsule()
                             .fill(category.color.opacity(0.15))
                     )
+            }
+
+            if let onViewDetails {
+                Button(action: onViewDetails) {
+                    HStack(spacing: VSpacing.xxs) {
+                        Text("View Details")
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.primaryBase)
+                        VIconView(.arrowRight, size: 10)
+                            .foregroundStyle(VColor.primaryBase)
+                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("View skill details")
             }
         }
         .padding(VSpacing.md)
@@ -692,6 +707,7 @@ struct ConstellationView: View {
     let skills: [SkillInfo]
     let workspaceFiles: [WorkspaceFileNode]
     var onFileSelected: ((String) -> Void)?
+    var onNavigateToSkill: ((String) -> Void)?
     @Binding var isFullscreen: Bool
     @State private var appearance = AvatarAppearanceManager.shared
 
@@ -969,7 +985,13 @@ struct ConstellationView: View {
                     let scaledX = viewCenter.x + (nodePos.x - canvasCenter.x) * zoomScale + totalOffset.width
                     let scaledY = viewCenter.y + (nodePos.y - canvasCenter.y) * zoomScale + totalOffset.height - 60
 
-                    SkillPopoverView(item: selected)
+                    SkillPopoverView(item: selected, onViewDetails: selected.filePath == nil ? {
+                        withAnimation(VAnimation.fast) {
+                            selectedSkillItem = nil
+                            selectedNodeId = nil
+                        }
+                        onNavigateToSkill?(selected.id)
+                    } : nil)
                         .position(x: scaledX, y: scaledY)
                         .transition(.opacity.combined(with: .scale(scale: 0.9)))
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -4,6 +4,7 @@ import VellumAssistantShared
 struct IdentityPanel: View {
     let onClose: () -> Void
     let connectionManager: GatewayConnectionManager
+    var onNavigateToSkill: ((String) -> Void)?
     var identityClient: IdentityClientProtocol = IdentityClient()
     private let btwClient: any BtwClientProtocol = BtwClient()
     var workspaceClient: WorkspaceClientProtocol = WorkspaceClient()
@@ -181,6 +182,7 @@ struct IdentityPanel: View {
                 onFileSelected: { path in
                     viewingFilePath = path
                 },
+                onNavigateToSkill: onNavigateToSkill,
                 isFullscreen: $isFullscreen
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -19,6 +19,7 @@ struct IntelligencePanel: View {
     @State private var cachedAssistantName: String = AssistantDisplayName.resolve(IdentityInfo.load()?.name, fallback: "Your Assistant")
     @State private var isContactsEnabled: Bool = false
     @State private var isEmailEnabled: Bool = false
+    @State private var pendingSkillId: String?
     private static let contactsFeatureFlagKey = "contacts"
     private static let emailFeatureFlagKey = "email-channel"
 
@@ -131,7 +132,11 @@ struct IntelligencePanel: View {
         case .identity:
             IdentityPanel(
                 onClose: onClose,
-                connectionManager: connectionManager
+                connectionManager: connectionManager,
+                onNavigateToSkill: { skillId in
+                    pendingSkillId = skillId
+                    withAnimation(VAnimation.fast) { selectedTab = .installedSkills }
+                }
             )
             .padding(.top, VSpacing.sm)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
@@ -141,7 +146,8 @@ struct IntelligencePanel: View {
             AgentPanelContent(
                 onInvokeSkill: onInvokeSkill,
                 onCreateSkill: onCreateSkill,
-                connectionManager: connectionManager
+                connectionManager: connectionManager,
+                focusedSkillId: $pendingSkillId
             )
             .padding(.top, VSpacing.sm)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)


### PR DESCRIPTION
## Summary
- Add `onNavigateToSkill` callback to ConstellationView
- Add 'View Details →' link in skill popover that navigates to SkillDetailView
- Wire navigation through IdentityPanel → IntelligencePanel → AgentPanelContent

Part of plan: graph-deep-links.md (PR 1 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
