### PR TITLE
refactor: extract shared OAuth provider serialization from CLI into reusable module

### DIFF
--- a/assistant/src/__tests__/oauth-provider-serializer.test.ts
+++ b/assistant/src/__tests__/oauth-provider-serializer.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, test } from "bun:test";
+
+import type { OAuthProviderRow } from "../oauth/oauth-store.js";
+import {
+  serializeProvider,
+  serializeProviderSummary,
+} from "../oauth/provider-serializer.js";
+
+/** Helper to build a minimal valid provider row with sensible defaults. */
+function makeRow(overrides: Partial<OAuthProviderRow> = {}): OAuthProviderRow {
+  const now = Date.now();
+  return {
+    providerKey: "test-provider",
+    authUrl: "https://auth.example.com/authorize",
+    tokenUrl: "https://auth.example.com/token",
+    tokenEndpointAuthMethod: null,
+    userinfoUrl: null,
+    baseUrl: null,
+    defaultScopes: "[]",
+    scopePolicy: "{}",
+    extraParams: null,
+    callbackTransport: null,
+    pingUrl: null,
+    pingMethod: null,
+    pingHeaders: null,
+    pingBody: null,
+    managedServiceConfigKey: null,
+    displayName: null,
+    description: null,
+    dashboardUrl: null,
+    clientIdPlaceholder: null,
+    requiresClientSecret: 1,
+    loopbackPort: null,
+    injectionTemplates: null,
+    appType: null,
+    setupNotes: null,
+    identityUrl: null,
+    identityMethod: null,
+    identityHeaders: null,
+    identityBody: null,
+    identityResponsePaths: null,
+    identityFormat: null,
+    identityOkField: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+describe("serializeProvider", () => {
+  test("parses JSON fields correctly", () => {
+    const row = makeRow({
+      defaultScopes: JSON.stringify(["openid", "email"]),
+      scopePolicy: JSON.stringify({ required: ["openid"] }),
+      extraParams: JSON.stringify({ access_type: "offline" }),
+      pingHeaders: JSON.stringify({ "X-Api-Version": "2" }),
+      pingBody: JSON.stringify({ query: "{ me { id } }" }),
+      injectionTemplates: JSON.stringify([
+        {
+          hostPattern: "api.example.com",
+          injectionType: "header",
+          headerName: "Authorization",
+          valuePrefix: "Bearer ",
+        },
+      ]),
+      setupNotes: JSON.stringify(["Enable the API", "Add test users"]),
+      identityHeaders: JSON.stringify({ "Notion-Version": "2022-06-28" }),
+      identityBody: JSON.stringify({ query: "{ viewer { email } }" }),
+      identityResponsePaths: JSON.stringify(["email", "name"]),
+    });
+
+    const result = serializeProvider(row)!;
+
+    expect(result.defaultScopes).toEqual(["openid", "email"]);
+    expect(result.scopePolicy).toEqual({ required: ["openid"] });
+    expect(result.extraParams).toEqual({ access_type: "offline" });
+    expect(result.pingHeaders).toEqual({ "X-Api-Version": "2" });
+    expect(result.pingBody).toEqual({ query: "{ me { id } }" });
+    expect(result.injectionTemplates).toEqual([
+      {
+        hostPattern: "api.example.com",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
+    ]);
+    expect(result.setupNotes).toEqual(["Enable the API", "Add test users"]);
+    expect(result.identityHeaders).toEqual({ "Notion-Version": "2022-06-28" });
+    expect(result.identityBody).toEqual({ query: "{ viewer { email } }" });
+    expect(result.identityResponsePaths).toEqual(["email", "name"]);
+  });
+
+  test("returns empty defaults for null/missing JSON fields", () => {
+    const row = makeRow();
+    const result = serializeProvider(row)!;
+
+    expect(result.defaultScopes).toEqual([]);
+    expect(result.scopePolicy).toEqual({});
+    expect(result.extraParams).toBeNull();
+    expect(result.pingHeaders).toBeNull();
+    expect(result.pingBody).toBeNull();
+    expect(result.injectionTemplates).toBeNull();
+    expect(result.setupNotes).toBeNull();
+    expect(result.identityHeaders).toBeNull();
+    expect(result.identityBody).toBeNull();
+    expect(result.identityResponsePaths).toBeNull();
+  });
+
+  test("supportsManagedMode is true when managedServiceConfigKey is non-null", () => {
+    const row = makeRow({ managedServiceConfigKey: "google-managed" });
+    const result = serializeProvider(row)!;
+    expect(result.supportsManagedMode).toBe(true);
+  });
+
+  test("supportsManagedMode is false when managedServiceConfigKey is null", () => {
+    const row = makeRow({ managedServiceConfigKey: null });
+    const result = serializeProvider(row)!;
+    expect(result.supportsManagedMode).toBe(false);
+  });
+
+  test("requiresClientSecret defaults to true when value is 1", () => {
+    const row = makeRow({ requiresClientSecret: 1 });
+    const result = serializeProvider(row)!;
+    expect(result.requiresClientSecret).toBe(true);
+  });
+
+  test("requiresClientSecret is false when value is 0", () => {
+    const row = makeRow({ requiresClientSecret: 0 });
+    const result = serializeProvider(row)!;
+    expect(result.requiresClientSecret).toBe(false);
+  });
+
+  test("requiresClientSecret defaults to true when coerced from default integer 1", () => {
+    // The DB column defaults to 1 — verify the serializer treats it as true.
+    const row = makeRow();
+    const result = serializeProvider(row)!;
+    expect(result.requiresClientSecret).toBe(true);
+  });
+
+  test("timestamps are converted to ISO strings", () => {
+    const ts = 1700000000000;
+    const row = makeRow({ createdAt: ts, updatedAt: ts });
+    const result = serializeProvider(row)!;
+
+    expect(result.createdAt).toBe(new Date(ts).toISOString());
+    expect(result.updatedAt).toBe(new Date(ts).toISOString());
+  });
+
+  test("accepts a redirectUri override via options", () => {
+    const row = makeRow();
+    const result = serializeProvider(row, {
+      redirectUri: "http://localhost:8080/oauth/callback",
+    })!;
+    expect(result.redirectUri).toBe("http://localhost:8080/oauth/callback");
+  });
+
+  test("redirectUri defaults to null when no override is provided", () => {
+    const row = makeRow();
+    const result = serializeProvider(row)!;
+    expect(result.redirectUri).toBeNull();
+  });
+
+  test("returns undefined for undefined input", () => {
+    expect(serializeProvider(undefined)).toBeUndefined();
+  });
+
+  test("returns null for null input", () => {
+    expect(serializeProvider(null)).toBeNull();
+  });
+});
+
+describe("serializeProviderSummary", () => {
+  test("returns the expected subset of fields in snake_case", () => {
+    const row = makeRow({
+      providerKey: "google",
+      displayName: "Google",
+      description: "Google OAuth 2.0",
+      dashboardUrl: "https://console.cloud.google.com",
+      clientIdPlaceholder: "your-client-id.apps.googleusercontent.com",
+      requiresClientSecret: 1,
+      managedServiceConfigKey: "google-managed",
+    });
+
+    const result = serializeProviderSummary(row)!;
+
+    expect(result).toEqual({
+      provider_key: "google",
+      display_name: "Google",
+      description: "Google OAuth 2.0",
+      dashboard_url: "https://console.cloud.google.com",
+      client_id_placeholder: "your-client-id.apps.googleusercontent.com",
+      requires_client_secret: true,
+      supports_managed_mode: true,
+    });
+  });
+
+  test("nullifies missing optional fields", () => {
+    const row = makeRow({
+      displayName: null,
+      description: null,
+      dashboardUrl: null,
+      clientIdPlaceholder: null,
+    });
+
+    const result = serializeProviderSummary(row)!;
+
+    expect(result.display_name).toBeNull();
+    expect(result.description).toBeNull();
+    expect(result.dashboard_url).toBeNull();
+    expect(result.client_id_placeholder).toBeNull();
+  });
+
+  test("requires_client_secret is false when value is 0", () => {
+    const row = makeRow({ requiresClientSecret: 0 });
+    const result = serializeProviderSummary(row)!;
+    expect(result.requires_client_secret).toBe(false);
+  });
+
+  test("supports_managed_mode is false when managedServiceConfigKey is null", () => {
+    const row = makeRow({ managedServiceConfigKey: null });
+    const result = serializeProviderSummary(row)!;
+    expect(result.supports_managed_mode).toBe(false);
+  });
+
+  test("returns null for null input", () => {
+    expect(serializeProviderSummary(null)).toBeNull();
+  });
+
+  test("returns null for undefined input", () => {
+    expect(serializeProviderSummary(undefined)).toBeNull();
+  });
+});

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -14,6 +14,7 @@ import {
   registerProvider,
   updateProvider,
 } from "../../../oauth/oauth-store.js";
+import { serializeProvider } from "../../../oauth/provider-serializer.js";
 import { SEEDED_PROVIDER_KEYS } from "../../../oauth/seed-providers.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
@@ -51,43 +52,12 @@ function resolveRedirectUri(
   }
 }
 
-/** Parse stored JSON string fields into their native types. */
+/** Serialize a provider row with the CLI-resolved redirect URI. */
 function parseProviderRow(row: ReturnType<typeof getProvider>) {
   if (!row) return row;
-  return {
-    ...row,
-    displayName: row.displayName ?? null,
-    description: row.description ?? null,
-    dashboardUrl: row.dashboardUrl ?? null,
-    clientIdPlaceholder: row.clientIdPlaceholder ?? null,
-    requiresClientSecret: !!(row.requiresClientSecret ?? 1),
-    supportsManagedMode: !!row.managedServiceConfigKey,
-    defaultScopes: row.defaultScopes ? JSON.parse(row.defaultScopes) : [],
-    scopePolicy: row.scopePolicy ? JSON.parse(row.scopePolicy) : {},
-    extraParams: row.extraParams ? JSON.parse(row.extraParams) : null,
-    pingHeaders: row.pingHeaders ? JSON.parse(row.pingHeaders) : null,
-    pingBody: row.pingBody ? JSON.parse(row.pingBody) : null,
-    loopbackPort: row.loopbackPort ?? null,
-    injectionTemplates: row.injectionTemplates
-      ? JSON.parse(row.injectionTemplates)
-      : null,
-    appType: row.appType ?? null,
-    setupNotes: row.setupNotes ? JSON.parse(row.setupNotes) : null,
-    identityUrl: row.identityUrl ?? null,
-    identityMethod: row.identityMethod ?? null,
-    identityHeaders: row.identityHeaders
-      ? JSON.parse(row.identityHeaders)
-      : null,
-    identityBody: row.identityBody ? JSON.parse(row.identityBody) : null,
-    identityResponsePaths: row.identityResponsePaths
-      ? JSON.parse(row.identityResponsePaths)
-      : null,
-    identityFormat: row.identityFormat ?? null,
-    identityOkField: row.identityOkField ?? null,
+  return serializeProvider(row, {
     redirectUri: resolveRedirectUri(row.callbackTransport, row.loopbackPort),
-    createdAt: new Date(row.createdAt).toISOString(),
-    updatedAt: new Date(row.updatedAt).toISOString(),
-  };
+  });
 }
 
 export function registerProviderCommands(oauth: Command): void {

--- a/assistant/src/oauth/provider-serializer.ts
+++ b/assistant/src/oauth/provider-serializer.ts
@@ -1,0 +1,116 @@
+/**
+ * Shared serialization utilities for OAuth provider rows.
+ *
+ * Used by both the CLI (providers commands) and runtime API endpoints to
+ * produce consistent, parsed representations of provider rows stored in
+ * the database.
+ */
+
+import type { OAuthProviderRow } from "./oauth-store.js";
+
+/**
+ * Full serialized representation of an OAuth provider row.
+ *
+ * JSON string fields are parsed into their native types, boolean/integer
+ * fields are normalised to booleans, timestamps are ISO 8601 strings,
+ * and a computed `supportsManagedMode` flag is included.
+ */
+export type SerializedProvider = ReturnType<typeof serializeProvider> &
+  Record<string, unknown>;
+
+/**
+ * Lightweight summary projection of an OAuth provider, suitable for API
+ * list responses where full detail is not needed. All keys are snake_case
+ * to match the HTTP API convention.
+ */
+export interface SerializedProviderSummary {
+  provider_key: string;
+  display_name: string | null;
+  description: string | null;
+  dashboard_url: string | null;
+  client_id_placeholder: string | null;
+  requires_client_secret: boolean;
+  supports_managed_mode: boolean;
+}
+
+/**
+ * Serialize a full provider row from the database into a parsed object.
+ *
+ * JSON string columns are parsed, boolean/integer fields are normalised to
+ * booleans, and timestamps are converted to ISO 8601 strings. An optional
+ * `redirectUri` override can be supplied by the caller (e.g. the CLI,
+ * which resolves the redirect URI from config).
+ *
+ * Returns `undefined` when `row` is `undefined`, and `null` when `row` is
+ * `null`, preserving the caller's nullable semantics.
+ */
+export function serializeProvider(
+  row: OAuthProviderRow | null | undefined,
+  options?: { redirectUri?: string | null },
+): ReturnType<typeof _serializeProvider> | null | undefined {
+  if (row === undefined) return undefined;
+  if (row === null) return null;
+  return _serializeProvider(row, options);
+}
+
+function _serializeProvider(
+  row: OAuthProviderRow,
+  options?: { redirectUri?: string | null },
+) {
+  return {
+    ...row,
+    displayName: row.displayName ?? null,
+    description: row.description ?? null,
+    dashboardUrl: row.dashboardUrl ?? null,
+    clientIdPlaceholder: row.clientIdPlaceholder ?? null,
+    requiresClientSecret: !!(row.requiresClientSecret ?? 1),
+    supportsManagedMode: !!row.managedServiceConfigKey,
+    defaultScopes: row.defaultScopes ? JSON.parse(row.defaultScopes) : [],
+    scopePolicy: row.scopePolicy ? JSON.parse(row.scopePolicy) : {},
+    extraParams: row.extraParams ? JSON.parse(row.extraParams) : null,
+    pingHeaders: row.pingHeaders ? JSON.parse(row.pingHeaders) : null,
+    pingBody: row.pingBody ? JSON.parse(row.pingBody) : null,
+    loopbackPort: row.loopbackPort ?? null,
+    injectionTemplates: row.injectionTemplates
+      ? JSON.parse(row.injectionTemplates)
+      : null,
+    appType: row.appType ?? null,
+    setupNotes: row.setupNotes ? JSON.parse(row.setupNotes) : null,
+    identityUrl: row.identityUrl ?? null,
+    identityMethod: row.identityMethod ?? null,
+    identityHeaders: row.identityHeaders
+      ? JSON.parse(row.identityHeaders)
+      : null,
+    identityBody: row.identityBody ? JSON.parse(row.identityBody) : null,
+    identityResponsePaths: row.identityResponsePaths
+      ? JSON.parse(row.identityResponsePaths)
+      : null,
+    identityFormat: row.identityFormat ?? null,
+    identityOkField: row.identityOkField ?? null,
+    redirectUri:
+      options?.redirectUri !== undefined ? options.redirectUri : null,
+    createdAt: new Date(row.createdAt).toISOString(),
+    updatedAt: new Date(row.updatedAt).toISOString(),
+  };
+}
+
+/**
+ * Return a lightweight snake_case summary of a provider row, suitable for
+ * embedding in API list responses.
+ *
+ * Returns `null` when `row` is nullish.
+ */
+export function serializeProviderSummary(
+  row: OAuthProviderRow | null | undefined,
+): SerializedProviderSummary | null {
+  if (!row) return null;
+  return {
+    provider_key: row.providerKey,
+    display_name: row.displayName ?? null,
+    description: row.description ?? null,
+    dashboard_url: row.dashboardUrl ?? null,
+    client_id_placeholder: row.clientIdPlaceholder ?? null,
+    requires_client_secret: !!(row.requiresClientSecret ?? 1),
+    supports_managed_mode: !!row.managedServiceConfigKey,
+  };
+}


### PR DESCRIPTION
## Summary
- Extract `parseProviderRow` from CLI `providers.ts` into a shared `provider-serializer.ts` module with `serializeProvider` and `serializeProviderSummary` exports
- `serializeProvider` handles full row transformation (JSON parsing, boolean conversion, timestamps)
- `serializeProviderSummary` returns a lightweight snake_case projection for API responses
- Add comprehensive unit tests for both functions

Part of plan: oauth-providers-api-dynamic-ui.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21927" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
