### PR TITLE
Add workspace file deep-link from constellation graph to Workspace tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -429,6 +429,62 @@ private struct SkillPopoverView: View {
     }
 }
 
+// MARK: - File Popover View
+
+private struct FilePopoverView: View {
+    let item: OrbitItem
+    var onOpenFile: () -> Void
+    var onViewInWorkspace: (() -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            HStack(spacing: VSpacing.sm) {
+                VIconView(.file, size: 14)
+                    .foregroundStyle(item.color)
+
+                Text(item.label)
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentDefault)
+                    .lineLimit(2)
+            }
+
+            if let filePath = item.filePath {
+                Text(filePath)
+                    .font(VFont.labelSmall)
+                    .foregroundStyle(VColor.contentTertiary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+
+            Divider()
+                .padding(.vertical, VSpacing.xxs)
+
+            VButton(label: "Open File", icon: VIcon.externalLink.rawValue, style: .ghost, size: .compact) {
+                onOpenFile()
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            if let onViewInWorkspace {
+                VButton(label: "View in Workspace \u{2192}", icon: VIcon.folderSearch.rawValue, style: .ghost, size: .compact) {
+                    onViewInWorkspace()
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .padding(VSpacing.md)
+        .frame(maxWidth: 260, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .fill(VColor.surfaceBase)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(VColor.borderBase, lineWidth: 1)
+        )
+        .vShadow(VShadow.md)
+    }
+}
+
 // MARK: - Overlap Resolution
 
 /// Pushes a proposed position away from any overlapping existing nodes.
@@ -692,6 +748,7 @@ struct ConstellationView: View {
     let skills: [SkillInfo]
     let workspaceFiles: [WorkspaceFileNode]
     var onFileSelected: ((String) -> Void)?
+    var onNavigateToFile: ((String) -> Void)?
     @Binding var isFullscreen: Bool
     @State private var appearance = AvatarAppearanceManager.shared
 
@@ -702,6 +759,8 @@ struct ConstellationView: View {
     @State private var baseZoomScale: CGFloat = 1.0
     @State private var selectedSkillItem: OrbitItem?
     @State private var selectedNodeId: String?
+    @State private var selectedFileItem: OrbitItem?
+    @State private var selectedFileNodeId: String?
     @State private var zoomedNodeId: String?
 
     // Node sizes
@@ -950,13 +1009,15 @@ struct ConstellationView: View {
                     .offset(totalOffset)
 
                 // Dismiss layer for popover
-                if selectedSkillItem != nil {
+                if selectedSkillItem != nil || selectedFileItem != nil {
                     Color.clear
                         .contentShape(Rectangle())
                         .onTapGesture {
                             withAnimation(VAnimation.fast) {
                                 selectedSkillItem = nil
                                 selectedNodeId = nil
+                                selectedFileItem = nil
+                                selectedFileNodeId = nil
                             }
                         }
                 }
@@ -972,6 +1033,39 @@ struct ConstellationView: View {
                     SkillPopoverView(item: selected)
                         .position(x: scaledX, y: scaledY)
                         .transition(.opacity.combined(with: .scale(scale: 0.9)))
+                }
+
+                // File popover overlay
+                if let fileItem = selectedFileItem, let fileNodeId = selectedFileNodeId {
+                    let canvasCenter = CGPoint(x: proxy.size.width / 2, y: proxy.size.height / 2)
+                    let fileNodePos = effectivePosition(forId: fileNodeId)
+                    let fileViewCenter = CGPoint(x: proxy.size.width / 2, y: proxy.size.height / 2)
+                    let fileScaledX = fileViewCenter.x + (fileNodePos.x - canvasCenter.x) * zoomScale + totalOffset.width
+                    let fileScaledY = fileViewCenter.y + (fileNodePos.y - canvasCenter.y) * zoomScale + totalOffset.height - 80
+
+                    FilePopoverView(
+                        item: fileItem,
+                        onOpenFile: {
+                            withAnimation(VAnimation.fast) {
+                                selectedFileItem = nil
+                                selectedFileNodeId = nil
+                            }
+                            if let path = fileItem.filePath {
+                                onFileSelected?(path)
+                            }
+                        },
+                        onViewInWorkspace: onNavigateToFile != nil ? {
+                            withAnimation(VAnimation.fast) {
+                                selectedFileItem = nil
+                                selectedFileNodeId = nil
+                            }
+                            if let path = fileItem.filePath {
+                                onNavigateToFile?(path)
+                            }
+                        } : nil
+                    )
+                    .position(x: fileScaledX, y: fileScaledY)
+                    .transition(.opacity.combined(with: .scale(scale: 0.9)))
                 }
             }
                 .frame(width: proxy.size.width, height: proxy.size.height)
@@ -1018,10 +1112,12 @@ struct ConstellationView: View {
                 }
                 #if os(macOS)
                 .onKeyPress(.escape) {
-                    if selectedSkillItem != nil {
+                    if selectedSkillItem != nil || selectedFileItem != nil {
                         withAnimation(VAnimation.fast) {
                             selectedSkillItem = nil
                             selectedNodeId = nil
+                            selectedFileItem = nil
+                            selectedFileNodeId = nil
                         }
                         return .handled
                     }
@@ -1209,10 +1305,26 @@ struct ConstellationView: View {
                         size: skillNodeSize,
                         onDoubleTap: { zoomToNode(nodeId, viewSize: size) },
                         onTap: item.filePath != nil
-                            ? { onFileSelected?(item.filePath!) }
+                            ? {
+                                withAnimation(VAnimation.fast) {
+                                    // Dismiss any open skill popover
+                                    selectedSkillItem = nil
+                                    selectedNodeId = nil
+                                    if selectedFileItem?.id == item.id {
+                                        selectedFileItem = nil
+                                        selectedFileNodeId = nil
+                                    } else {
+                                        selectedFileItem = item
+                                        selectedFileNodeId = node.id
+                                    }
+                                }
+                            }
                             : item.description != nil
                                 ? {
                                     withAnimation(VAnimation.fast) {
+                                        // Dismiss any open file popover
+                                        selectedFileItem = nil
+                                        selectedFileNodeId = nil
                                         if selectedSkillItem?.id == item.id {
                                             selectedSkillItem = nil
                                             selectedNodeId = nil

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -4,6 +4,7 @@ import VellumAssistantShared
 struct IdentityPanel: View {
     let onClose: () -> Void
     let connectionManager: GatewayConnectionManager
+    var onNavigateToFile: ((String) -> Void)?
     var identityClient: IdentityClientProtocol = IdentityClient()
     private let btwClient: any BtwClientProtocol = BtwClient()
     var workspaceClient: WorkspaceClientProtocol = WorkspaceClient()
@@ -181,6 +182,7 @@ struct IdentityPanel: View {
                 onFileSelected: { path in
                     viewingFilePath = path
                 },
+                onNavigateToFile: onNavigateToFile,
                 isFullscreen: $isFullscreen
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -19,6 +19,7 @@ struct IntelligencePanel: View {
     @State private var cachedAssistantName: String = AssistantDisplayName.resolve(IdentityInfo.load()?.name, fallback: "Your Assistant")
     @State private var isContactsEnabled: Bool = false
     @State private var isEmailEnabled: Bool = false
+    @State private var pendingFilePath: String?
     private static let contactsFeatureFlagKey = "contacts"
     private static let emailFeatureFlagKey = "email-channel"
 
@@ -131,7 +132,11 @@ struct IntelligencePanel: View {
         case .identity:
             IdentityPanel(
                 onClose: onClose,
-                connectionManager: connectionManager
+                connectionManager: connectionManager,
+                onNavigateToFile: { path in
+                    pendingFilePath = path
+                    withAnimation(VAnimation.fast) { selectedTab = .workspace }
+                }
             )
             .padding(.top, VSpacing.sm)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
@@ -147,7 +152,7 @@ struct IntelligencePanel: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
 
         case .workspace:
-            WorkspacePanel()
+            WorkspacePanel(pendingFilePath: $pendingFilePath)
                 .padding(.top, VSpacing.sm)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -112,6 +112,7 @@ final class WorkspaceBrowserState {
 // MARK: - Workspace Panel
 
 struct WorkspacePanel: View {
+    @Binding var pendingFilePath: String?
     @State private var state = WorkspaceBrowserState()
     let workspaceClient = WorkspaceClient()
     @State private var sidebarWidth: CGFloat = 300
@@ -122,6 +123,10 @@ struct WorkspacePanel: View {
     private let maxSidebarWidth: CGFloat = 500
 
     private let dragCoordinateSpace = "WorkspacePanelDrag"
+
+    init(pendingFilePath: Binding<String?> = .constant(nil)) {
+        _pendingFilePath = pendingFilePath
+    }
 
     var body: some View {
         HStack(spacing: 0) {
@@ -169,6 +174,12 @@ struct WorkspacePanel: View {
         }
         .coordinateSpace(name: dragCoordinateSpace)
         .task { await loadRoot() }
+        .onChange(of: pendingFilePath) {
+            if let path = pendingFilePath {
+                pendingFilePath = nil
+                Task { await state.loadFile(path: path, using: workspaceClient) }
+            }
+        }
         .onDisappear {
             state.fileLoadTask?.cancel()
             state.fileLoadTask = nil


### PR DESCRIPTION
## Summary
- Add `onNavigateToFile` callback to ConstellationView
- Show popover on file node tap with 'Open File' and 'View in Workspace →' options
- Wire navigation through to IntelligencePanel's Workspace tab

Part of plan: graph-deep-links.md (PR 6 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21929" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
