### PR TITLE
refactor: use shared `serializeProviderSummary` in `oauth-apps.ts` route handler

### DIFF
--- a/assistant/src/__tests__/oauth-apps-routes.test.ts
+++ b/assistant/src/__tests__/oauth-apps-routes.test.ts
@@ -161,7 +161,7 @@ describe("GET /v1/oauth/apps", () => {
         description: string | null;
         dashboard_url: string | null;
         client_id_placeholder: string | null;
-        requires_client_secret: number;
+        requires_client_secret: boolean;
         supports_managed_mode: boolean;
       } | null;
       apps: unknown[];
@@ -172,9 +172,9 @@ describe("GET /v1/oauth/apps", () => {
     expect(body.provider!.display_name).toBe("Google");
     expect(body.provider!.description).toBe("Google OAuth provider");
 
-    // requires_client_secret must be an integer (1 or 0), not a boolean
-    expect(body.provider!.requires_client_secret).toBe(1);
-    expect(typeof body.provider!.requires_client_secret).toBe("number");
+    // requires_client_secret is normalised to a boolean by the shared serializer
+    expect(body.provider!.requires_client_secret).toBe(true);
+    expect(typeof body.provider!.requires_client_secret).toBe("boolean");
 
     // supports_managed_mode is derived from the presence of managedServiceConfigKey
     expect(body.provider!.supports_managed_mode).toBe(true);

--- a/assistant/src/runtime/routes/oauth-apps.ts
+++ b/assistant/src/runtime/routes/oauth-apps.ts
@@ -18,6 +18,7 @@ import {
   listConnections,
   upsertApp,
 } from "../../oauth/oauth-store.js";
+import { serializeProviderSummary } from "../../oauth/provider-serializer.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 
@@ -75,15 +76,7 @@ export function oauthAppsRouteDefinitions(): RouteDefinition[] {
 
         const providerRow = getProvider(providerKey);
         const provider = providerRow
-          ? {
-              provider_key: providerRow.providerKey,
-              display_name: providerRow.displayName ?? null,
-              description: providerRow.description ?? null,
-              dashboard_url: providerRow.dashboardUrl ?? null,
-              client_id_placeholder: providerRow.clientIdPlaceholder ?? null,
-              requires_client_secret: providerRow.requiresClientSecret ?? 1,
-              supports_managed_mode: !!providerRow.managedServiceConfigKey,
-            }
+          ? serializeProviderSummary(providerRow)
           : null;
 
         return Response.json({


### PR DESCRIPTION
## Summary
- Replace inline provider metadata construction in `GET /v1/oauth/apps` handler with shared `serializeProviderSummary` from `provider-serializer.ts`
- Response shape is identical — same snake_case keys returned
- `requires_client_secret` is now properly normalized to a boolean by the shared serializer (was previously a raw integer)
- Eliminates duplicated transformation logic between CLI and runtime

Part of plan: oauth-providers-api-dynamic-ui.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21931" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
