### PR TITLE
feat: add `--supports-managed` flag to `assistant oauth providers list` for filtering managed-mode providers

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -406,6 +406,7 @@ describe("assistant oauth providers list", () => {
       defaultScopes: "[]",
       scopePolicy: "{}",
       extraParams: null,
+      managedServiceConfigKey: "google-oauth",
       createdAt: "2025-01-01T00:00:00.000Z",
       updatedAt: "2025-01-01T00:00:00.000Z",
     },
@@ -416,6 +417,7 @@ describe("assistant oauth providers list", () => {
       defaultScopes: "[]",
       scopePolicy: "{}",
       extraParams: null,
+      managedServiceConfigKey: "google-calendar-oauth",
       createdAt: "2025-01-01T00:00:00.000Z",
       updatedAt: "2025-01-01T00:00:00.000Z",
     },
@@ -426,6 +428,7 @@ describe("assistant oauth providers list", () => {
       defaultScopes: "[]",
       scopePolicy: "{}",
       extraParams: null,
+      managedServiceConfigKey: null,
       createdAt: "2025-01-01T00:00:00.000Z",
       updatedAt: "2025-01-01T00:00:00.000Z",
     },
@@ -436,6 +439,7 @@ describe("assistant oauth providers list", () => {
       defaultScopes: "[]",
       scopePolicy: "{}",
       extraParams: null,
+      managedServiceConfigKey: null,
       createdAt: "2025-01-01T00:00:00.000Z",
       updatedAt: "2025-01-01T00:00:00.000Z",
     },
@@ -534,6 +538,54 @@ describe("assistant oauth providers list", () => {
     expect(keys).toContain("google");
     expect(keys).toContain("google-calendar");
     expect(keys).toContain("slack");
+  });
+
+  test("--supports-managed returns only providers with managedServiceConfigKey set", async () => {
+    const { exitCode, stdout } = await runCli([
+      "providers",
+      "list",
+      "--supports-managed",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toHaveLength(2);
+    const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
+    expect(keys).toContain("google");
+    expect(keys).toContain("google-calendar");
+    expect(keys).not.toContain("slack");
+    expect(keys).not.toContain("twitter");
+  });
+
+  test("--supports-managed combined with --provider-key applies both filters (AND)", async () => {
+    const { exitCode, stdout } = await runCli([
+      "providers",
+      "list",
+      "--supports-managed",
+      "--provider-key",
+      "google",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    // Both google and google-calendar match --provider-key "google" AND have
+    // managedServiceConfigKey set, so both are returned.
+    expect(parsed).toHaveLength(2);
+    const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
+    expect(keys).toContain("google");
+    expect(keys).toContain("google-calendar");
+  });
+
+  test("without --supports-managed all providers are returned (existing behavior)", async () => {
+    const { exitCode, stdout } = await runCli(["providers", "list", "--json"]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toHaveLength(4);
+    const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
+    expect(keys).toContain("google");
+    expect(keys).toContain("google-calendar");
+    expect(keys).toContain("slack");
+    expect(keys).toContain("twitter");
   });
 });
 

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -90,6 +90,10 @@ Each provider is identified by a provider key (e.g. "google").`,
       "--provider-key <key>",
       'Filter by provider key substring (case-insensitive). Comma-separated values are OR\'d (e.g. "google,slack")',
     )
+    .option(
+      "--supports-managed",
+      "Only show providers that support managed mode",
+    )
     .addHelpText(
       "after",
       `
@@ -109,37 +113,48 @@ Examples:
   $ assistant oauth providers list
   $ assistant oauth providers list --provider-key google
   $ assistant oauth providers list --provider-key "google,slack"
-  $ assistant oauth providers list --provider-key notion --json`,
+  $ assistant oauth providers list --provider-key notion --json
+  $ assistant oauth providers list --supports-managed
+  $ assistant oauth providers list --supports-managed --json`,
     )
-    .action((opts: { providerKey?: string }, cmd: Command) => {
-      try {
-        let rows = listProviders().map(parseProviderRow);
+    .action(
+      (
+        opts: { providerKey?: string; supportsManaged?: boolean },
+        cmd: Command,
+      ) => {
+        try {
+          let rows = listProviders().map(parseProviderRow);
 
-        if (opts.providerKey) {
-          const needles = opts.providerKey
-            .split(",")
-            .map((n) => n.trim().toLowerCase())
-            .filter(Boolean);
-          rows = rows.filter(
-            (r) =>
-              r &&
-              needles.some((needle) =>
-                r.providerKey.toLowerCase().includes(needle),
-              ),
-          );
+          if (opts.providerKey) {
+            const needles = opts.providerKey
+              .split(",")
+              .map((n) => n.trim().toLowerCase())
+              .filter(Boolean);
+            rows = rows.filter(
+              (r) =>
+                r &&
+                needles.some((needle) =>
+                  r.providerKey.toLowerCase().includes(needle),
+                ),
+            );
+          }
+
+          if (opts.supportsManaged) {
+            rows = rows.filter((r) => r && r.supportsManagedMode);
+          }
+
+          if (!shouldOutputJson(cmd)) {
+            log.info(`Found ${rows.length} provider(s)`);
+          }
+
+          writeOutput(cmd, rows);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          writeOutput(cmd, { ok: false, error: message });
+          process.exitCode = 1;
         }
-
-        if (!shouldOutputJson(cmd)) {
-          log.info(`Found ${rows.length} provider(s)`);
-        }
-
-        writeOutput(cmd, rows);
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        writeOutput(cmd, { ok: false, error: message });
-        process.exitCode = 1;
-      }
-    });
+      },
+    );
 
   // ---------------------------------------------------------------------------
   // providers get <provider-key>


### PR DESCRIPTION
## Summary
- Add `--supports-managed` boolean flag to `assistant oauth providers list` command
- When set, filters results to only providers where `supportsManagedMode` is true (i.e. has a `managedServiceConfigKey`)
- Composable with existing `--provider-key` filter (AND logic)
- Add tests covering the new flag alone, combined with `--provider-key`, and absence of the flag

Part of plan: oauth-providers-api-dynamic-ui.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21932" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
