### PR TITLE
feat: add `GET /v1/oauth/providers` and `GET /v1/oauth/providers/:providerKey` runtime endpoints

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4644,6 +4644,28 @@ paths:
           required: true
           schema:
             type: string
+  /v1/oauth/providers:
+    get:
+      operationId: oauth_providers_get
+      tags:
+        - oauth-providers
+      responses:
+        "200":
+          description: Successful response
+  /v1/oauth/providers/{providerKey}:
+    get:
+      operationId: oauth_providers_by_providerKey_get
+      tags:
+        - oauth-providers
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: providerKey
+          in: path
+          required: true
+          schema:
+            type: string
   /v1/oauth/start:
     post:
       operationId: oauth_start_post

--- a/assistant/src/__tests__/oauth-providers-routes.test.ts
+++ b/assistant/src/__tests__/oauth-providers-routes.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, mock, test } from "bun:test";
+
+const mockListProviders = mock(() => [
+  {
+    providerKey: "google",
+    displayName: "Google",
+    description: "Google OAuth provider",
+    dashboardUrl: "https://console.cloud.google.com/apis/credentials",
+    clientIdPlaceholder: null,
+    requiresClientSecret: 1,
+    managedServiceConfigKey: "google-oauth",
+    authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+    tokenUrl: "https://oauth2.googleapis.com/token",
+    tokenEndpointAuthMethod: null,
+    userinfoUrl: null,
+    baseUrl: null,
+    defaultScopes: "[]",
+    scopePolicy: "[]",
+    extraParams: null,
+    callbackTransport: null,
+    pingUrl: null,
+    pingMethod: null,
+    pingHeaders: null,
+    pingBody: null,
+    loopbackPort: null,
+    injectionTemplates: null,
+    appType: null,
+    setupNotes: null,
+    identityUrl: null,
+    identityMethod: null,
+    identityHeaders: null,
+    identityBody: null,
+    identityFormat: null,
+    identityOkField: null,
+    identityResponsePaths: null,
+    createdAt: 1735689500000,
+    updatedAt: 1735689550000,
+  },
+  {
+    providerKey: "github",
+    displayName: "GitHub",
+    description: "GitHub OAuth provider",
+    dashboardUrl: "https://github.com/settings/developers",
+    clientIdPlaceholder: null,
+    requiresClientSecret: 1,
+    managedServiceConfigKey: null,
+    authUrl: "https://github.com/login/oauth/authorize",
+    tokenUrl: "https://github.com/login/oauth/access_token",
+    tokenEndpointAuthMethod: null,
+    userinfoUrl: null,
+    baseUrl: null,
+    defaultScopes: "[]",
+    scopePolicy: "[]",
+    extraParams: null,
+    callbackTransport: null,
+    pingUrl: null,
+    pingMethod: null,
+    pingHeaders: null,
+    pingBody: null,
+    loopbackPort: null,
+    injectionTemplates: null,
+    appType: null,
+    setupNotes: null,
+    identityUrl: null,
+    identityMethod: null,
+    identityHeaders: null,
+    identityBody: null,
+    identityFormat: null,
+    identityOkField: null,
+    identityResponsePaths: null,
+    createdAt: 1735689600000,
+    updatedAt: 1735689650000,
+  },
+]);
+
+const mockGetProvider = mock((providerKey: string) => {
+  const all = mockListProviders();
+  return all.find((p) => p.providerKey === providerKey) ?? undefined;
+});
+
+mock.module("../oauth/oauth-store.js", () => ({
+  listProviders: mockListProviders,
+  getProvider: mockGetProvider,
+}));
+
+import { oauthProvidersRouteDefinitions } from "../runtime/routes/oauth-providers.js";
+
+const routes = oauthProvidersRouteDefinitions();
+
+function getRoute(method: string, endpoint: string) {
+  const route = routes.find(
+    (r) => r.method === method && r.endpoint === endpoint,
+  );
+  if (!route) throw new Error(`Route not found: ${method} ${endpoint}`);
+  return route;
+}
+
+describe("GET /v1/oauth/providers", () => {
+  test("returns all providers with correct summary shape", async () => {
+    const req = new Request("http://localhost/v1/oauth/providers");
+    const url = new URL(req.url);
+    const res = await getRoute("GET", "oauth/providers").handler({
+      req,
+      url,
+      server: null as never,
+      authContext: null as never,
+      params: {},
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      providers: Array<{
+        provider_key: string;
+        display_name: string | null;
+        description: string | null;
+        dashboard_url: string | null;
+        client_id_placeholder: string | null;
+        requires_client_secret: boolean;
+        supports_managed_mode: boolean;
+      }>;
+    };
+
+    expect(body.providers).toHaveLength(2);
+    expect(body.providers[0]!.provider_key).toBe("google");
+    expect(body.providers[1]!.provider_key).toBe("github");
+  });
+
+  test("response shape matches serializeProviderSummary output (snake_case keys)", async () => {
+    const req = new Request("http://localhost/v1/oauth/providers");
+    const url = new URL(req.url);
+    const res = await getRoute("GET", "oauth/providers").handler({
+      req,
+      url,
+      server: null as never,
+      authContext: null as never,
+      params: {},
+    });
+
+    const body = (await res.json()) as {
+      providers: Array<Record<string, unknown>>;
+    };
+
+    const expectedKeys = [
+      "provider_key",
+      "display_name",
+      "description",
+      "dashboard_url",
+      "client_id_placeholder",
+      "requires_client_secret",
+      "supports_managed_mode",
+    ];
+
+    for (const provider of body.providers) {
+      expect(Object.keys(provider).sort()).toEqual(expectedKeys.sort());
+    }
+  });
+
+  test("supports_managed_mode=true returns only managed providers", async () => {
+    const req = new Request(
+      "http://localhost/v1/oauth/providers?supports_managed_mode=true",
+    );
+    const url = new URL(req.url);
+    const res = await getRoute("GET", "oauth/providers").handler({
+      req,
+      url,
+      server: null as never,
+      authContext: null as never,
+      params: {},
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      providers: Array<{
+        provider_key: string;
+        supports_managed_mode: boolean;
+      }>;
+    };
+
+    expect(body.providers).toHaveLength(1);
+    expect(body.providers[0]!.provider_key).toBe("google");
+    expect(body.providers[0]!.supports_managed_mode).toBe(true);
+  });
+
+  test("supports_managed_mode=false returns only non-managed providers", async () => {
+    const req = new Request(
+      "http://localhost/v1/oauth/providers?supports_managed_mode=false",
+    );
+    const url = new URL(req.url);
+    const res = await getRoute("GET", "oauth/providers").handler({
+      req,
+      url,
+      server: null as never,
+      authContext: null as never,
+      params: {},
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      providers: Array<{
+        provider_key: string;
+        supports_managed_mode: boolean;
+      }>;
+    };
+
+    expect(body.providers).toHaveLength(1);
+    expect(body.providers[0]!.provider_key).toBe("github");
+    expect(body.providers[0]!.supports_managed_mode).toBe(false);
+  });
+});
+
+describe("GET /v1/oauth/providers/:providerKey", () => {
+  test("returns the correct provider", async () => {
+    const req = new Request("http://localhost/v1/oauth/providers/google");
+    const url = new URL(req.url);
+    const res = await getRoute("GET", "oauth/providers/:providerKey").handler({
+      req,
+      url,
+      server: null as never,
+      authContext: null as never,
+      params: { providerKey: "google" },
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      provider: {
+        provider_key: string;
+        display_name: string | null;
+        description: string | null;
+        dashboard_url: string | null;
+        client_id_placeholder: string | null;
+        requires_client_secret: boolean;
+        supports_managed_mode: boolean;
+      };
+    };
+
+    expect(body.provider.provider_key).toBe("google");
+    expect(body.provider.display_name).toBe("Google");
+    expect(body.provider.supports_managed_mode).toBe(true);
+    expect(body.provider.requires_client_secret).toBe(true);
+  });
+
+  test("returns 404 for unknown provider", async () => {
+    const req = new Request("http://localhost/v1/oauth/providers/nonexistent");
+    const url = new URL(req.url);
+    const res = await getRoute("GET", "oauth/providers/:providerKey").handler({
+      req,
+      url,
+      server: null as never,
+      authContext: null as never,
+      params: { providerKey: "nonexistent" },
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("NOT_FOUND");
+  });
+});

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -463,6 +463,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "oauth/apps/connections", scopes: ["settings.read"] },
   { endpoint: "oauth/apps/connect", scopes: ["settings.write"] },
   { endpoint: "oauth/connections", scopes: ["settings.write"] },
+  { endpoint: "oauth/providers", scopes: ["settings.read"] },
 
   // Ingress config
   { endpoint: "integrations/ingress/config:GET", scopes: ["settings.read"] },

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -163,6 +163,7 @@ import { migrationRollbackRouteDefinitions } from "./routes/migration-rollback-r
 import { migrationRouteDefinitions } from "./routes/migration-routes.js";
 import { notificationRouteDefinitions } from "./routes/notification-routes.js";
 import { oauthAppsRouteDefinitions } from "./routes/oauth-apps.js";
+import { oauthProvidersRouteDefinitions } from "./routes/oauth-providers.js";
 import type { PairingHandlerContext } from "./routes/pairing-routes.js";
 import {
   handlePairingRequest,
@@ -1204,6 +1205,7 @@ export class RuntimeHttpServer {
       ...twilioRouteDefinitions(),
       ...vercelRouteDefinitions(),
       ...channelReadinessRouteDefinitions(),
+      ...oauthProvidersRouteDefinitions(),
       ...oauthAppsRouteDefinitions(),
       ...attachmentRouteDefinitions(),
 

--- a/assistant/src/runtime/routes/oauth-providers.ts
+++ b/assistant/src/runtime/routes/oauth-providers.ts
@@ -1,0 +1,60 @@
+/**
+ * Route handlers for listing and getting OAuth providers.
+ *
+ * Provides read-only endpoints for querying the registered OAuth provider
+ * catalog. All endpoints are bearer-token authenticated via the standard
+ * runtime auth middleware.
+ */
+
+import { getProvider, listProviders } from "../../oauth/oauth-store.js";
+import { serializeProviderSummary } from "../../oauth/provider-serializer.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+
+/**
+ * Build route definitions for OAuth provider list/get endpoints.
+ */
+export function oauthProvidersRouteDefinitions(): RouteDefinition[] {
+  return [
+    // GET /v1/oauth/providers — List all providers with optional filtering.
+    {
+      endpoint: "oauth/providers",
+      method: "GET",
+      handler: ({ url }) => {
+        const rows = listProviders();
+        let serialized = rows
+          .map((row) => serializeProviderSummary(row))
+          .filter((s): s is NonNullable<typeof s> => s !== null);
+
+        const supportsManagedModeParam = url.searchParams.get(
+          "supports_managed_mode",
+        );
+        if (supportsManagedModeParam === "true") {
+          serialized = serialized.filter((p) => p.supports_managed_mode);
+        } else if (supportsManagedModeParam === "false") {
+          serialized = serialized.filter((p) => !p.supports_managed_mode);
+        }
+
+        return Response.json({ providers: serialized });
+      },
+    },
+
+    // GET /v1/oauth/providers/:providerKey — Get a single provider.
+    {
+      endpoint: "oauth/providers/:providerKey",
+      method: "GET",
+      handler: ({ params }) => {
+        const row = getProvider(params.providerKey);
+        if (!row) {
+          return httpError(
+            "NOT_FOUND",
+            `No OAuth provider registered for "${params.providerKey}"`,
+            404,
+          );
+        }
+
+        return Response.json({ provider: serializeProviderSummary(row) });
+      },
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Add new runtime route file `oauth-providers.ts` with list and get endpoints
- `GET /v1/oauth/providers` returns all providers with optional `supports_managed_mode` query param filter
- `GET /v1/oauth/providers/:providerKey` returns a single provider or 404
- Both endpoints use `serializeProviderSummary` from the shared serializer module
- Register `oauth/providers` route policy with `settings.read` scope
- Add comprehensive route tests

Part of plan: oauth-providers-api-dynamic-ui.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21933" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
