### PR TITLE
Add memory deep-link from constellation graph tooltip to memory detail

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -632,6 +632,71 @@ private struct SkillPopoverView: View {
     }
 }
 
+// MARK: - Memory Popover View
+
+private struct MemoryPopoverView: View {
+    let item: OrbitItem
+    var onViewDetails: (() -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            HStack(spacing: VSpacing.sm) {
+                VIconView(item.icon, size: 14)
+                    .foregroundStyle(item.color)
+
+                Text(item.label)
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentDefault)
+                    .lineLimit(2)
+            }
+
+            if let description = item.description, !description.isEmpty {
+                Text(description)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                    .lineLimit(4)
+            }
+
+            if let memoryKind = item.memoryKind {
+                Text(memoryKind.label)
+                    .font(VFont.labelSmall)
+                    .foregroundStyle(memoryKind.color)
+                    .padding(.horizontal, VSpacing.sm)
+                    .padding(.vertical, VSpacing.xxs)
+                    .background(
+                        Capsule()
+                            .fill(memoryKind.color.opacity(0.15))
+                    )
+            }
+
+            if let onViewDetails {
+                Button(action: onViewDetails) {
+                    HStack(spacing: VSpacing.xxs) {
+                        Text("View Details")
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.primaryBase)
+                        VIconView(.arrowRight, size: 10)
+                            .foregroundStyle(VColor.primaryBase)
+                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("View memory details")
+            }
+        }
+        .padding(VSpacing.md)
+        .frame(maxWidth: 250, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .fill(VColor.surfaceBase)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(VColor.borderBase, lineWidth: 1)
+        )
+        .vShadow(VShadow.md)
+    }
+}
+
 // MARK: - File Popover View
 
 private struct FilePopoverView: View {
@@ -1093,6 +1158,7 @@ struct ConstellationView: View {
     var onFileSelected: ((String) -> Void)?
     var onNavigateToSkill: ((String) -> Void)?
     var onNavigateToFile: ((String) -> Void)?
+    var onNavigateToMemory: ((String) -> Void)?
     @Binding var isFullscreen: Bool
     @State private var appearance = AvatarAppearanceManager.shared
 
@@ -1105,6 +1171,8 @@ struct ConstellationView: View {
     @State private var selectedNodeId: String?
     @State private var selectedFileItem: OrbitItem?
     @State private var selectedFileNodeId: String?
+    @State private var selectedMemoryItem: OrbitItem?
+    @State private var selectedMemoryNodeId: String?
     @State private var zoomedNodeId: String?
 
     // Node sizes
@@ -1383,7 +1451,7 @@ struct ConstellationView: View {
                     .offset(totalOffset)
 
                 // Dismiss layer for popover
-                if selectedSkillItem != nil || selectedFileItem != nil {
+                if selectedSkillItem != nil || selectedFileItem != nil || selectedMemoryItem != nil {
                     Color.clear
                         .contentShape(Rectangle())
                         .onTapGesture {
@@ -1392,6 +1460,8 @@ struct ConstellationView: View {
                                 selectedNodeId = nil
                                 selectedFileItem = nil
                                 selectedFileNodeId = nil
+                                selectedMemoryItem = nil
+                                selectedMemoryNodeId = nil
                             }
                         }
                 }
@@ -1447,6 +1517,29 @@ struct ConstellationView: View {
                     .position(x: fileScaledX, y: fileScaledY)
                     .transition(.opacity.combined(with: .scale(scale: 0.9)))
                 }
+
+                // Memory popover overlay
+                if let memoryItem = selectedMemoryItem, let memoryNodeId = selectedMemoryNodeId {
+                    let canvasCenter = CGPoint(x: proxy.size.width / 2, y: proxy.size.height / 2)
+                    let memoryNodePos = effectivePosition(forId: memoryNodeId)
+                    let viewCenter = CGPoint(x: proxy.size.width / 2, y: proxy.size.height / 2)
+                    let memoryScaledX = viewCenter.x + (memoryNodePos.x - canvasCenter.x) * zoomScale + totalOffset.width
+                    let memoryScaledY = viewCenter.y + (memoryNodePos.y - canvasCenter.y) * zoomScale + totalOffset.height - 60
+
+                    MemoryPopoverView(
+                        item: memoryItem,
+                        onViewDetails: onNavigateToMemory != nil ? {
+                            let memoryId = memoryItem.id.replacingOccurrences(of: "memory-", with: "")
+                            withAnimation(VAnimation.fast) {
+                                selectedMemoryItem = nil
+                                selectedMemoryNodeId = nil
+                            }
+                            onNavigateToMemory?(memoryId)
+                        } : nil
+                    )
+                    .position(x: memoryScaledX, y: memoryScaledY)
+                    .transition(.opacity.combined(with: .scale(scale: 0.9)))
+                }
             }
                 .frame(width: proxy.size.width, height: proxy.size.height)
                 .clipped()
@@ -1495,12 +1588,14 @@ struct ConstellationView: View {
                 }
                 #if os(macOS)
                 .onKeyPress(.escape) {
-                    if selectedSkillItem != nil || selectedFileItem != nil {
+                    if selectedSkillItem != nil || selectedFileItem != nil || selectedMemoryItem != nil {
                         withAnimation(VAnimation.fast) {
                             selectedSkillItem = nil
                             selectedNodeId = nil
                             selectedFileItem = nil
                             selectedFileNodeId = nil
+                            selectedMemoryItem = nil
+                            selectedMemoryNodeId = nil
                         }
                         return .handled
                     }
@@ -1759,19 +1854,22 @@ struct ConstellationView: View {
                     MemoryNodeView(
                         item: item,
                         size: skillNodeSize,
-                        onTap: item.description != nil
-                            ? {
-                                withAnimation(VAnimation.fast) {
-                                    if selectedSkillItem?.id == item.id {
-                                        selectedSkillItem = nil
-                                        selectedNodeId = nil
-                                    } else {
-                                        selectedSkillItem = item
-                                        selectedNodeId = node.id
-                                    }
+                        onTap: {
+                            withAnimation(VAnimation.fast) {
+                                // Dismiss any open skill/file popovers
+                                selectedSkillItem = nil
+                                selectedNodeId = nil
+                                selectedFileItem = nil
+                                selectedFileNodeId = nil
+                                if selectedMemoryItem?.id == item.id {
+                                    selectedMemoryItem = nil
+                                    selectedMemoryNodeId = nil
+                                } else {
+                                    selectedMemoryItem = item
+                                    selectedMemoryNodeId = node.id
                                 }
                             }
-                            : nil
+                        }
                     )
                     .position(effPos)
                     .gesture(nodeDragGesture(nodeId: nodeId))

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -6,6 +6,7 @@ struct IdentityPanel: View {
     let connectionManager: GatewayConnectionManager
     var onNavigateToSkill: ((String) -> Void)?
     var onNavigateToFile: ((String) -> Void)?
+    var onNavigateToMemory: ((String) -> Void)?
     var identityClient: IdentityClientProtocol = IdentityClient()
     private let btwClient: any BtwClientProtocol = BtwClient()
     var workspaceClient: WorkspaceClientProtocol = WorkspaceClient()
@@ -187,6 +188,7 @@ struct IdentityPanel: View {
                 },
                 onNavigateToSkill: onNavigateToSkill,
                 onNavigateToFile: onNavigateToFile,
+                onNavigateToMemory: onNavigateToMemory,
                 isFullscreen: $isFullscreen
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -141,6 +141,10 @@ struct IntelligencePanel: View {
                 onNavigateToFile: { path in
                     pendingFilePath = path
                     withAnimation(VAnimation.fast) { selectedTab = .workspace }
+                },
+                onNavigateToMemory: { memoryId in
+                    pendingMemoryId = memoryId
+                    withAnimation(VAnimation.fast) { selectedTab = .memories }
                 }
             )
             .padding(.top, VSpacing.sm)


### PR DESCRIPTION
## Summary
- Add `onNavigateToMemory` callback to ConstellationView
- Show popover on memory node tap with subject, statement, kind badge, and 'View Details →' link
- Wire navigation through to IntelligencePanel's existing `pendingMemoryId` mechanism

Part of plan: graph-deep-links.md (PR 4 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21934" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
