### PR TITLE
feat: add gateway proxy routes for `GET /v1/oauth/providers` endpoints

### DIFF
--- a/gateway/src/http/routes/oauth-providers-proxy.ts
+++ b/gateway/src/http/routes/oauth-providers-proxy.ts
@@ -1,0 +1,114 @@
+/**
+ * Gateway proxy endpoints for OAuth provider discovery routes.
+ *
+ * These routes remain available even when the broad runtime proxy is
+ * disabled, so skills and clients can use gateway URLs exclusively.
+ */
+
+import { mintServiceToken } from "../../auth/token-exchange.js";
+import type { GatewayConfig } from "../../config.js";
+import { fetchImpl } from "../../fetch.js";
+import { getLogger } from "../../logger.js";
+import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
+
+const log = getLogger("oauth-providers-proxy");
+
+export function createOAuthProvidersProxyHandler(config: GatewayConfig) {
+  async function proxyToRuntime(
+    req: Request,
+    upstreamPath: string,
+    upstreamSearch: string,
+  ): Promise<Response> {
+    const start = performance.now();
+    const upstream = `${config.assistantRuntimeBaseUrl}${upstreamPath}${upstreamSearch}`;
+
+    const reqHeaders = stripHopByHop(new Headers(req.headers));
+    reqHeaders.delete("host");
+    reqHeaders.delete("authorization");
+
+    reqHeaders.set("authorization", `Bearer ${mintServiceToken()}`);
+
+    const hasBody = req.method !== "GET" && req.method !== "HEAD";
+    const bodyBuffer = hasBody ? await req.arrayBuffer() : null;
+    if (bodyBuffer !== null) {
+      reqHeaders.set("content-length", String(bodyBuffer.byteLength));
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort(
+        new DOMException(
+          "The operation was aborted due to timeout",
+          "TimeoutError",
+        ),
+      );
+    }, config.runtimeTimeoutMs);
+
+    let response: Response;
+    try {
+      response = await fetchImpl(upstream, {
+        method: req.method,
+        headers: reqHeaders,
+        body: bodyBuffer,
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+    } catch (err) {
+      clearTimeout(timeoutId);
+      const duration = Math.round(performance.now() - start);
+      if (err instanceof DOMException && err.name === "TimeoutError") {
+        log.error(
+          { path: upstreamPath, duration },
+          "OAuth providers proxy upstream timed out",
+        );
+        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
+      }
+      log.error(
+        { err, path: upstreamPath, duration },
+        "OAuth providers proxy upstream connection failed",
+      );
+      return Response.json({ error: "Bad Gateway" }, { status: 502 });
+    }
+
+    const resHeaders = stripHopByHop(new Headers(response.headers));
+    const duration = Math.round(performance.now() - start);
+
+    if (response.status >= 400) {
+      const body = await response.text();
+      log.warn(
+        { path: upstreamPath, status: response.status, duration },
+        "OAuth providers proxy upstream error",
+      );
+      return new Response(body, {
+        status: response.status,
+        headers: resHeaders,
+      });
+    }
+
+    log.info(
+      { path: upstreamPath, status: response.status, duration },
+      "OAuth providers proxy completed",
+    );
+    return new Response(response.body, {
+      status: response.status,
+      headers: resHeaders,
+    });
+  }
+
+  return {
+    async handleListProviders(req: Request): Promise<Response> {
+      return proxyToRuntime(
+        req,
+        "/v1/oauth/providers",
+        new URL(req.url).search,
+      );
+    },
+
+    async handleGetProvider(
+      req: Request,
+      providerKey: string,
+    ): Promise<Response> {
+      return proxyToRuntime(req, `/v1/oauth/providers/${providerKey}`, "");
+    },
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -56,6 +56,7 @@ import { createVercelControlPlaneProxyHandler } from "./http/routes/vercel-contr
 import { createContactsControlPlaneProxyHandler } from "./http/routes/contacts-control-plane-proxy.js";
 import { createSlackControlPlaneProxyHandler } from "./http/routes/slack-control-plane-proxy.js";
 import { createOAuthAppsProxyHandler } from "./http/routes/oauth-apps-proxy.js";
+import { createOAuthProvidersProxyHandler } from "./http/routes/oauth-providers-proxy.js";
 import { createChannelReadinessProxyHandler } from "./http/routes/channel-readiness-proxy.js";
 import { createRuntimeHealthProxyHandler } from "./http/routes/runtime-health-proxy.js";
 import { createUpgradeBroadcastProxyHandler } from "./http/routes/upgrade-broadcast-proxy.js";
@@ -276,6 +277,7 @@ async function main() {
   const twilioControlPlaneProxy = createTwilioControlPlaneProxyHandler(config);
   const slackControlPlaneProxy = createSlackControlPlaneProxyHandler(config);
   const oauthAppsProxy = createOAuthAppsProxyHandler(config);
+  const oauthProvidersProxy = createOAuthProvidersProxyHandler(config);
   const channelReadinessProxy = createChannelReadinessProxyHandler(config);
   const runtimeHealthProxy = createRuntimeHealthProxyHandler(config);
   const upgradeBroadcastProxy = createUpgradeBroadcastProxyHandler(config);
@@ -706,6 +708,21 @@ async function main() {
       method: "POST",
       auth: "edge",
       handler: (req) => slackControlPlaneProxy.handleShareToSlack(req),
+    },
+
+    // ── OAuth providers ──
+    {
+      path: "/v1/oauth/providers",
+      method: "GET",
+      auth: "edge",
+      handler: (req) => oauthProvidersProxy.handleListProviders(req),
+    },
+    {
+      path: /^\/v1\/oauth\/providers\/([^/]+)\/?$/,
+      method: "GET",
+      auth: "edge",
+      handler: (req, params) =>
+        oauthProvidersProxy.handleGetProvider(req, params[0]),
     },
 
     // ── OAuth apps ──

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1725,6 +1725,74 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/v1/oauth/providers": {
+        get: {
+          summary: "List OAuth providers",
+          description:
+            "Authenticated gateway endpoint that lists available OAuth providers by proxying to the assistant runtime.",
+          operationId: "oauthProvidersList",
+          parameters: [
+            {
+              name: "supports_managed_mode",
+              in: "query",
+              required: false,
+              schema: { type: "boolean" },
+              description:
+                "When true, only return providers that support managed mode.",
+            },
+          ],
+          security: [{ BearerAuth: [] }],
+          responses: {
+            "200": {
+              description: "OAuth providers returned",
+              content: {
+                "application/json": {
+                  schema: { type: "object" },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+      },
+      "/v1/oauth/providers/{providerKey}": {
+        get: {
+          summary: "Get OAuth provider",
+          description:
+            "Authenticated gateway endpoint that retrieves a single OAuth provider by key by proxying to the assistant runtime.",
+          operationId: "oauthProvidersGet",
+          parameters: [
+            {
+              name: "providerKey",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+              description: "The provider key, for example `google`.",
+            },
+          ],
+          security: [{ BearerAuth: [] }],
+          responses: {
+            "200": {
+              description: "OAuth provider returned",
+              content: {
+                "application/json": {
+                  schema: { type: "object" },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "404": { description: "OAuth provider not found" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+      },
       "/v1/oauth/apps": {
         get: {
           summary: "List OAuth apps",


### PR DESCRIPTION
## Summary
- Add new gateway proxy handler `oauth-providers-proxy.ts` mirroring the oauth-apps-proxy pattern
- Expose `handleListProviders` and `handleGetProvider` methods that forward to runtime
- Register routes in gateway index before oauth-apps routes with edge auth
- Query params (e.g. `supports_managed_mode=true`) are forwarded transparently

Part of plan: oauth-providers-api-dynamic-ui.md (PR 4 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21935" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
