### PR TITLE
feat: dynamically render OAuth provider cards on Models & Services from API

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -113,7 +113,6 @@ struct SettingsPanel: View {
     @State private var isSchedulesEnabled: Bool = false
     @State private var isDeveloperEnabled: Bool = false
     @State private var isSoundsEnabled: Bool = true
-    @State private var isGoogleOAuthEnabled: Bool = false
     @State private var isEmbeddingProviderEnabled: Bool = false
     @State private var showingDevUnlock: Bool = false
     @State private var devUnlockText: String = ""
@@ -123,7 +122,6 @@ struct SettingsPanel: View {
     private static let schedulesFeatureFlagKey = "settings-schedules"
     private static let billingFeatureFlagKey = "settings-billing"
     private static let developerFeatureFlagKey = "settings-developer-nav"
-    private static let googleOAuthFeatureFlagKey = "managed-google-oauth"
     private static let embeddingProviderFeatureFlagKey = "settings-embedding-provider"
     private static let soundsFeatureFlagKey = "sounds"
 
@@ -234,8 +232,6 @@ struct SettingsPanel: View {
                     }
                 } else if key == Self.billingFeatureFlagKey {
                     isBillingEnabled = enabled
-                } else if key == Self.googleOAuthFeatureFlagKey {
-                    isGoogleOAuthEnabled = enabled
                 } else if key == Self.embeddingProviderFeatureFlagKey {
                     isEmbeddingProviderEnabled = enabled
                 } else if key == Self.soundsFeatureFlagKey {
@@ -479,13 +475,18 @@ struct SettingsPanel: View {
                 )
             }
 
-            // GOOGLE OAUTH (feature-flagged)
-            if isGoogleOAuthEnabled {
+            // OAUTH PROVIDERS (dynamic from API)
+            ForEach(store.managedOAuthProviders, id: \.provider_key) { provider in
                 Divider()
                     .background(VColor.borderBase)
                     .padding(.vertical, VSpacing.sm)
 
-                OAuthProviderServiceCard(store: store, authManager: authManager, showToast: showToast, providerKey: "google")
+                OAuthProviderServiceCard(
+                    store: store,
+                    authManager: authManager,
+                    showToast: showToast,
+                    providerKey: provider.provider_key
+                )
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -495,6 +496,7 @@ struct SettingsPanel: View {
             store.refreshModelInfo()
             store.loadProviderRoutingSources()
             store.refreshEmbeddingConfig()
+            store.fetchManagedOAuthProviders()
         }
     }
 
@@ -628,9 +630,6 @@ struct SettingsPanel: View {
                 if let developerFlag = flags.first(where: { $0.key == Self.developerFeatureFlagKey }) {
                     isDeveloperEnabled = developerFlag.enabled
                 }
-                if let googleOAuthFlag = flags.first(where: { $0.key == Self.googleOAuthFeatureFlagKey }) {
-                    isGoogleOAuthEnabled = googleOAuthFlag.enabled
-                }
                 if let embeddingProviderFlag = flags.first(where: { $0.key == Self.embeddingProviderFeatureFlagKey }) {
                     isEmbeddingProviderEnabled = embeddingProviderFlag.enabled
                 }
@@ -653,9 +652,6 @@ struct SettingsPanel: View {
 
         if let developerEnabled = resolved[Self.developerFeatureFlagKey] {
             isDeveloperEnabled = developerEnabled
-        }
-        if let googleOAuthEnabled = resolved[Self.googleOAuthFeatureFlagKey] {
-            isGoogleOAuthEnabled = googleOAuthEnabled
         }
         if let embeddingProviderEnabled = resolved[Self.embeddingProviderFeatureFlagKey] {
             isEmbeddingProviderEnabled = embeddingProviderEnabled

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -226,6 +226,10 @@ public final class SettingsStore: ObservableObject {
     @Published var managedOAuthIsConnecting: [String: Bool] = [:]
     /// Managed OAuth errors per provider (keyed by managedServiceConfigKey).
     @Published var managedOAuthError: [String: String] = [:]
+    /// Providers that support managed mode, fetched from the API.
+    @Published var managedOAuthProviders: [OAuthProviderMetadata] = []
+    /// Whether the managed OAuth providers list is currently loading.
+    @Published var managedOAuthProvidersLoading: Bool = false
     /// Strong reference to prevent the auth session from being deallocated mid-flow.
     private var managedOAuthWebAuthSession: ASWebAuthenticationSession?
 
@@ -2197,6 +2201,28 @@ public final class SettingsStore: ObservableObject {
         scheduleRoutingSourceRefresh()
     }
 
+    // MARK: - Managed OAuth Provider List
+
+    func fetchManagedOAuthProviders() {
+        managedOAuthProvidersLoading = true
+        Task {
+            do {
+                let (decoded, response): (OAuthProvidersListResponse?, _) =
+                    try await GatewayHTTPClient.get(
+                        path: "oauth/providers",
+                        params: ["supports_managed_mode": "true"],
+                        timeout: 10
+                    )
+                if response.isSuccess, let decoded {
+                    self.managedOAuthProviders = decoded.providers
+                }
+            } catch {
+                log.error("Failed to fetch managed OAuth providers: \(error)")
+            }
+            managedOAuthProvidersLoading = false
+        }
+    }
+
     // MARK: - Google OAuth Connections
 
     /// Resolves the platform assistant UUID for OAuth endpoints.
@@ -3137,6 +3163,10 @@ struct OAuthProviderMetadata: Codable, Sendable {
     var platformOAuthSlug: String {
         return provider_key
     }
+}
+
+struct OAuthProvidersListResponse: Codable, Sendable {
+    let providers: [OAuthProviderMetadata]
 }
 
 struct YourOwnOAuthAppsResponse: Codable, Sendable {


### PR DESCRIPTION
## Summary
- Replace hardcoded Google OAuth card on Models & Services page with a dynamic loop over providers from API
- Add `fetchManagedOAuthProviders()` to SettingsStore that calls `GET /v1/oauth/providers?supports_managed_mode=true`
- Remove `managed-google-oauth` feature flag dependency — providers are now gate-controlled server-side
- `OAuthProviderServiceCard` is already generic and works for any provider key

Part of plan: oauth-providers-api-dynamic-ui.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21937" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
