### PR TITLE
fix: update Swift OAuthProviderMetadata.requires_client_secret from Int to Bool

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/OAuthProviderServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/OAuthProviderServiceCard.swift
@@ -444,7 +444,7 @@ struct OAuthProviderServiceCard: View {
                     placeholder: providerMeta?.client_id_placeholder ?? "Enter client ID",
                     text: $createAppClientId
                 )
-                if (providerMeta?.requires_client_secret ?? 1) != 0 {
+                if providerMeta?.requires_client_secret ?? true {
                     VTextField(
                         "Client Secret",
                         placeholder: "Enter client secret",
@@ -465,7 +465,7 @@ struct OAuthProviderServiceCard: View {
                 VButton(
                     label: createAppIsSubmitting ? "Creating..." : "Create",
                     style: .primary,
-                    isDisabled: createAppClientId.isEmpty || ((providerMeta?.requires_client_secret ?? 1) != 0 && createAppClientSecret.isEmpty) || createAppIsSubmitting
+                    isDisabled: createAppClientId.isEmpty || ((providerMeta?.requires_client_secret ?? true) && createAppClientSecret.isEmpty) || createAppIsSubmitting
                 ) {
                     createAppIsSubmitting = true
                     Task {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3157,7 +3157,7 @@ struct OAuthProviderMetadata: Codable, Sendable {
     let description: String?
     let dashboard_url: String?
     let client_id_placeholder: String?
-    let requires_client_secret: Int
+    let requires_client_secret: Bool
 
     /// The platform OAuth slug is the provider_key itself (bare name, e.g. "google").
     var platformOAuthSlug: String {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-providers-api-dynamic-ui.md.

**Gap:** requires_client_secret type changed from integer to boolean, breaking the macOS Swift client
**What was expected:** Swift client can decode the provider metadata response
**What was found:** serializeProviderSummary returns a boolean but the Swift struct expects Int, causing silent JSON decode failures
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
