### PR TITLE
feat: collapsible Scheduled & Background sidebar sections

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
@@ -42,6 +42,8 @@ final class SidebarInteractionState {
     var showAllConversations: Bool = false
     var showAllScheduleConversations: Bool = false
     var showAllBackgroundConversations: Bool = false
+    var scheduleSectionCollapsed: Bool = false
+    var backgroundSectionCollapsed: Bool = false
     /// Set of schedule group keys (scheduleJobId values) that are currently expanded.
     var expandedScheduleGroups: Set<String> = []
     var showAllApps: Bool = false

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -354,17 +354,39 @@ extension MainWindowView {
 
                     if !scheduleConversations.isEmpty {
                         // Scheduled conversations section
-                        HStack {
-                            Text("Scheduled")
-                                .font(VFont.labelDefault)
-                                .foregroundStyle(VColor.contentTertiary)
-                            Spacer()
+                        let scheduleSectionHasUnread = sidebar.scheduleSectionCollapsed &&
+                            scheduleConversations.contains(where: { $0.hasUnseenLatestAssistantMessage })
+
+                        Button {
+                            withAnimation(VAnimation.fast) { sidebar.scheduleSectionCollapsed.toggle() }
+                        } label: {
+                            HStack(spacing: VSpacing.xs) {
+                                HStack(spacing: 2) {
+                                    VIconView(.chevronRight, size: 10)
+                                        .foregroundStyle(VColor.contentTertiary)
+                                        .rotationEffect(.degrees(sidebar.scheduleSectionCollapsed ? 0 : 90))
+                                        .animation(VAnimation.fast, value: sidebar.scheduleSectionCollapsed)
+                                    if scheduleSectionHasUnread {
+                                        Circle()
+                                            .fill(VColor.systemNegativeStrong)
+                                            .frame(width: 6, height: 6)
+                                            .transition(.opacity)
+                                    }
+                                }
+                                Text("Scheduled")
+                                    .font(VFont.labelDefault)
+                                    .foregroundStyle(VColor.contentTertiary)
+                                Spacer()
+                            }
                         }
-                        .padding(.leading, SidebarLayoutMetrics.iconSlotSize)
+                        .buttonStyle(.plain)
+                        .padding(.leading, VSpacing.xs)
                         .padding(.trailing, VSpacing.md)
                         .padding(.top, SidebarLayoutMetrics.scheduledHeaderTopGap)
                         .padding(.bottom, SidebarLayoutMetrics.scheduledHeaderBottomGap)
+                        .pointerCursor()
 
+                        if !sidebar.scheduleSectionCollapsed {
                         ForEach(displayedScheduleGroups, id: \.key) { group in
                             if group.conversations.count == 1, let conversation = group.conversations.first {
                                 // Single-conversation group: render inline without a disclosure wrapper
@@ -490,21 +512,44 @@ extension MainWindowView {
                             .padding(.leading, VSpacing.xs + SidebarLayoutMetrics.iconSlotSize + VSpacing.xs - VSpacing.sm)
                             .padding(.bottom, VSpacing.xs)
                         }
+                        } // end scheduleSectionCollapsed
                     }
 
                     if !backgroundConversations.isEmpty {
                         // Background conversations section
-                        HStack {
-                            Text("Background")
-                                .font(VFont.labelDefault)
-                                .foregroundStyle(VColor.contentTertiary)
-                            Spacer()
+                        let backgroundSectionHasUnread = sidebar.backgroundSectionCollapsed &&
+                            backgroundConversations.contains(where: { $0.hasUnseenLatestAssistantMessage })
+
+                        Button {
+                            withAnimation(VAnimation.fast) { sidebar.backgroundSectionCollapsed.toggle() }
+                        } label: {
+                            HStack(spacing: VSpacing.xs) {
+                                HStack(spacing: 2) {
+                                    VIconView(.chevronRight, size: 10)
+                                        .foregroundStyle(VColor.contentTertiary)
+                                        .rotationEffect(.degrees(sidebar.backgroundSectionCollapsed ? 0 : 90))
+                                        .animation(VAnimation.fast, value: sidebar.backgroundSectionCollapsed)
+                                    if backgroundSectionHasUnread {
+                                        Circle()
+                                            .fill(VColor.systemNegativeStrong)
+                                            .frame(width: 6, height: 6)
+                                            .transition(.opacity)
+                                    }
+                                }
+                                Text("Background")
+                                    .font(VFont.labelDefault)
+                                    .foregroundStyle(VColor.contentTertiary)
+                                Spacer()
+                            }
                         }
-                        .padding(.leading, SidebarLayoutMetrics.iconSlotSize)
+                        .buttonStyle(.plain)
+                        .padding(.leading, VSpacing.xs)
                         .padding(.trailing, VSpacing.md)
                         .padding(.top, SidebarLayoutMetrics.scheduledHeaderTopGap)
                         .padding(.bottom, SidebarLayoutMetrics.scheduledHeaderBottomGap)
+                        .pointerCursor()
 
+                        if !sidebar.backgroundSectionCollapsed {
                         ForEach(displayedBackgroundConversations) { conversation in
                             makeSidebarRow(conversation: conversation)
                                 .equatable()
@@ -525,6 +570,7 @@ extension MainWindowView {
                             .padding(.leading, VSpacing.xs + SidebarLayoutMetrics.iconSlotSize + VSpacing.xs - VSpacing.sm)
                             .padding(.bottom, VSpacing.xs)
                         }
+                        } // end backgroundSectionCollapsed
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Scheduled and Background section headers in the sidebar are now clickable with a rotating chevron to collapse/expand
- Collapsed sections show an unread indicator dot when they contain conversations with unseen messages
- Both sections default to expanded, preserving current behavior

## Original prompt
Make the "Scheduled" and "Background" sections collapsible in the sidebar.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21943" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
