### PR TITLE
feat: persist sidebar section collapse state across restarts

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
@@ -42,8 +42,12 @@ final class SidebarInteractionState {
     var showAllConversations: Bool = false
     var showAllScheduleConversations: Bool = false
     var showAllBackgroundConversations: Bool = false
-    var scheduleSectionCollapsed: Bool = false
-    var backgroundSectionCollapsed: Bool = false
+    var scheduleSectionCollapsed: Bool = UserDefaults.standard.bool(forKey: "scheduleSectionCollapsed") {
+        didSet { UserDefaults.standard.set(scheduleSectionCollapsed, forKey: "scheduleSectionCollapsed") }
+    }
+    var backgroundSectionCollapsed: Bool = UserDefaults.standard.bool(forKey: "backgroundSectionCollapsed") {
+        didSet { UserDefaults.standard.set(backgroundSectionCollapsed, forKey: "backgroundSectionCollapsed") }
+    }
     /// Set of schedule group keys (scheduleJobId values) that are currently expanded.
     var expandedScheduleGroups: Set<String> = []
     var showAllApps: Bool = false


### PR DESCRIPTION
## Summary
- Back `scheduleSectionCollapsed` and `backgroundSectionCollapsed` with `UserDefaults` so collapse state survives app restarts
- Read initial value from UserDefaults on init, write back on every change via `didSet`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21944" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
