### PR TITLE
fix: guard pushToTopMessageId to prevent scroll freeze

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator+ScrollBehavior.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator+ScrollBehavior.swift
@@ -73,7 +73,7 @@ extension MessageListScrollCoordinator {
             // don't trigger overflow detection leave the user stranded
             // near the top.
             let wasPushToTop = pushToTopMessageId != nil
-            pushToTopMessageId = nil
+            if wasPushToTop { pushToTopMessageId = nil }
             if wasPushToTop && isFollowingBottom {
                 requestBottomPin(
                     reason: .messageCount,
@@ -443,7 +443,7 @@ extension MessageListScrollCoordinator {
         scrollRestoreTask?.cancel()
         scrollRestoreTask = nil
         clearAllSuppression()
-        pushToTopMessageId = nil
+        if pushToTopMessageId != nil { pushToTopMessageId = nil }
         detachFromBottom()
         hasReceivedScrollEvent = true
     }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator.swift
@@ -413,7 +413,7 @@ final class MessageListScrollCoordinator: ObservableObject {
         // Reset follow state for the new conversation.
         isFollowingBottom = true
         isNearBottomBinding?.wrappedValue = true
-        pushToTopMessageId = nil
+        if pushToTopMessageId != nil { pushToTopMessageId = nil }
         isAtBottom = true
         hasReceivedScrollEvent = false
         // Hide scroll indicators during the conversation switch grace period

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -770,7 +770,8 @@ struct MessageListView: View {
                     // User-initiated scrolls that land at the bottom exit
                     // push-to-top. Programmatic scrolls (.animating) are
                     // excluded to avoid undoing the initial push-to-top.
-                    if oldPhase == .interacting || oldPhase == .decelerating {
+                    if oldPhase == .interacting || oldPhase == .decelerating,
+                       scrollCoordinator.pushToTopMessageId != nil {
                         scrollCoordinator.pushToTopMessageId = nil
                     }
                     scrollCoordinator.handleScrollToBottom()


### PR DESCRIPTION
## Summary
- Guard all `pushToTopMessageId = nil` assignments with `!= nil` checks across 4 call sites
- `pushToTopMessageId` is `@Published var ... (any Hashable)?` — no `Equatable` conformance means `@Published`'s `willSet` fires `objectWillChange` on every set, even nil→nil
- `handleScrollUp()` is called on every `onScrollGeometryChange` tick while scrolling up, causing ~60 spurious `objectWillChange` emissions/sec that trigger cascading `MessageListView.body` re-evaluations and freeze the main thread
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21947" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
