### PR TITLE
fix: use Bundle.appBundleIdentifier in extracted Chat files and remove dead code

### DIFF
--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -8,7 +8,7 @@ import UIKit
 #error("Unsupported platform")
 #endif
 
-private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ChatActionHandler")
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ChatActionHandler")
 
 // MARK: - ChatActionHandler
 

--- a/clients/shared/Features/Chat/ChatGreetingState.swift
+++ b/clients/shared/Features/Chat/ChatGreetingState.swift
@@ -1,7 +1,7 @@
 import Foundation
 import os
 
-private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ChatGreetingState")
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ChatGreetingState")
 
 /// Owns empty-state greeting and conversation starter properties that were
 /// previously part of ChatViewModel.  ChatViewModel holds a reference to this

--- a/clients/shared/Features/Chat/ChatPaginationState.swift
+++ b/clients/shared/Features/Chat/ChatPaginationState.swift
@@ -2,7 +2,7 @@ import Combine
 import Foundation
 import os
 
-private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ChatPaginationState")
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ChatPaginationState")
 
 /// Owns message-pagination and display-window state: the visible message
 /// suffix window, daemon cursor-based history loading, and the throttled

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1,7 +1,4 @@
 import Foundation
-import os
-
-private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ChatViewModel+MessageHandling")
 
 // MARK: - Message Handling (thin routing layer)
 

--- a/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
@@ -1,7 +1,7 @@
 import Foundation
 import os
 
-private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ChatViewModel+StreamingHelpers")
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ChatViewModel+StreamingHelpers")
 
 // MARK: - Streaming Delta Throttle & Partial Output Coalescing
 

--- a/clients/shared/Features/Chat/ChatViewModel+SurfaceHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+SurfaceHandling.swift
@@ -8,7 +8,7 @@ import UIKit
 #error("Unsupported platform")
 #endif
 
-private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "ChatViewModel+SurfaceHandling")
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ChatViewModel+SurfaceHandling")
 
 // MARK: - Tool Input Formatting & Display Helpers
 

--- a/clients/shared/Features/Chat/MessageSendCoordinator.swift
+++ b/clients/shared/Features/Chat/MessageSendCoordinator.swift
@@ -2,7 +2,7 @@ import Combine
 import Foundation
 import os
 
-private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "MessageSendCoordinator")
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "MessageSendCoordinator")
 
 /// Protocol defining the ChatViewModel state and actions that the send coordinator
 /// needs to read/write. ChatViewModel conforms to this, avoiding a direct reference


### PR DESCRIPTION
## Why

Six files extracted during the ChatViewModel refactoring used `Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant"` for their Logger subsystem instead of the project's `Bundle.appBundleIdentifier` helper. Per `clients/macos/AGENTS.md`: "Use `Bundle.appBundleIdentifier` for all logger subsystems — never hardcode the bundle identifier string directly."

Additionally, `ChatViewModel+MessageHandling.swift` retained an unused `import os` and `log` declaration after the action handler extraction emptied the file to a thin forwarding layer.

## What

- Replace hardcoded `Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant"` with `Bundle.appBundleIdentifier` in: ChatActionHandler, ChatGreetingState, ChatPaginationState, ChatViewModel+StreamingHelpers, ChatViewModel+SurfaceHandling, MessageSendCoordinator
- Remove unused `import os` and `private let log` from ChatViewModel+MessageHandling.swift

## Safety

- `Bundle.appBundleIdentifier` is defined as `Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant"` — identical runtime behavior, just using the canonical helper
- Removing unused imports/declarations has no behavioral impact
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
