### PR TITLE
docs: document @Observable deinit task cancellation pattern in AGENTS.md

### DIFF
--- a/clients/AGENTS.md
+++ b/clients/AGENTS.md
@@ -105,6 +105,14 @@ These classes stay `ObservableObject` because they have deep Combine integration
 
 **`@ObservationIgnored` for non-reactive bookkeeping.** Mark stored properties that should not trigger view updates with `@ObservationIgnored`. Use this for: Combine cancellables (`Set<AnyCancellable>`), background `Task` handles, delegate/callback closures, internal caches, and constants. Example: `@ObservationIgnored private var cancellables = Set<AnyCancellable>()`.
 
+**`@ObservationIgnored` enables deinit access on `@MainActor @Observable` classes.** The `@Observable` macro synthesizes getter/setter pairs that create actor isolation conflicts in `deinit` ([swift#79551](https://github.com/swiftlang/swift/issues/79551)). To cancel owned tasks in `deinit`, mark them `@ObservationIgnored` so they remain plain stored properties that `deinit` can access. Always explicitly cancel unstructured `Task {}` in `deinit` — do not rely solely on `[weak self]` cleanup, as the task continues running until its next cancellation check ([WWDC23 — Beyond the basics of structured concurrency](https://developer.apple.com/videos/play/wwdc2023/10170/)).
+```swift
+@MainActor @Observable final class MyState {
+    @ObservationIgnored var myTask: Task<Void, Never>?
+    deinit { myTask?.cancel() }
+}
+```
+
 **`withObservationTracking` bridge for `@Observable` → `ObservableObject`.** When an `@Observable` class is owned by an `ObservableObject` parent, bridge changes using a recursive `withObservationTracking` loop that calls `objectWillChange.send()` (or a coalesced publish) on change:
 ```swift
 private func observeChild() {


### PR DESCRIPTION
## Why

During the ChatViewModel @Observable migration, we discovered that `@MainActor @Observable` classes cannot access their own stored properties in `deinit` due to the macro's property synthesis creating actor isolation conflicts ([swift#79551](https://github.com/swiftlang/swift/issues/79551)). The workaround — marking task properties `@ObservationIgnored` — was not documented, leading to repeated trial-and-error with `nonisolated` and `nonisolated(unsafe)`.

Additionally, Apple's WWDC23 "Beyond the basics of structured concurrency" explicitly states that unstructured tasks must be explicitly cancelled — relying on `[weak self]` alone leaves tasks running until their next cancellation check (up to 60s for sleep-based timeouts).

## What

Add a new guidance section under "@Observable migration patterns" documenting:
- Why `@ObservationIgnored` is needed for deinit access (with swift#79551 reference)
- That explicit `task?.cancel()` in deinit is required for unstructured tasks (with WWDC23 reference)
- Code example showing the correct pattern

## References

- [swift#79551 — Observation prevents use of Sendable properties in deinit](https://github.com/swiftlang/swift/issues/79551)
- [WWDC23 — Beyond the basics of structured concurrency](https://developer.apple.com/videos/play/wwdc2023/10170/)
- [SE-0371 — Isolated synchronous deinit](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0371-isolated-synchronous-deinit.md) (future Swift 6.2+ alternative)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21949" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
