### PR TITLE
fix: rename toolbar() to avoid shadowing deprecated SwiftUI modifier

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ImageLightbox/ImageLightboxOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ImageLightbox/ImageLightboxOverlay.swift
@@ -46,7 +46,7 @@ struct ImageLightboxOverlay: View {
                 // Floating toolbar (bottom)
                 VStack {
                     Spacer()
-                    toolbar(lightbox)
+                    lightboxToolbar(lightbox)
                 }
                 .padding(.bottom, VSpacing.xl)
             }
@@ -75,7 +75,7 @@ struct ImageLightboxOverlay: View {
     // MARK: - Toolbar
 
     @available(macOS, deprecated: 13.0)
-    private func toolbar(_ lightbox: ImageLightboxState) -> some View {
+    private func lightboxToolbar(_ lightbox: ImageLightboxState) -> some View {
         HStack(spacing: VSpacing.md) {
             // Filename
             Text(lightbox.filename)


### PR DESCRIPTION
## Why

`ImageLightboxOverlay` has a `private func toolbar(_:)` that shadows SwiftUI's deprecated `.toolbar()` modifier, producing a deprecation warning on every compilation unit that imports the file. The warning is misleading — it's not actually using the deprecated SwiftUI API — but it clutters the build output.

## What

Rename `toolbar(_:)` → `lightboxToolbar(_:)` to eliminate the name collision.

## Safety

Pure rename of a private method with one call site in the same file.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21958" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
