### PR TITLE
M1: Underline ToS and Privacy Policy links in onboarding

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -94,7 +94,7 @@ struct ImproveExperienceStepView: View {
 
     private var tosConsentText: some View {
         VStack(alignment: .leading, spacing: VSpacing.xs) {
-            Text(.init("I agree to the [Terms of Service](https://www.vellum.ai/docs/vellum-terms-of-use) and [Privacy Policy](https://www.vellum.ai/docs/privacy-policy)"))
+            Text(tosAttributedString)
                 .font(VFont.bodyMediumLighter)
                 .foregroundStyle(VColor.contentSecondary)
                 .tint(VColor.primaryBase)
@@ -103,6 +103,17 @@ struct ImproveExperienceStepView: View {
                     return .handled
                 })
         }
+    }
+
+    private var tosAttributedString: AttributedString {
+        // swiftlint:disable:next force_try
+        var str = try! AttributedString(
+            markdown: "I agree to the [Terms of Service](https://www.vellum.ai/docs/vellum-terms-of-use) and [Privacy Policy](https://www.vellum.ai/docs/privacy-policy)"
+        )
+        for run in str.runs where run.link != nil {
+            str[run.range].underlineStyle = .single
+        }
+        return str
     }
 
     // MARK: - Actions


### PR DESCRIPTION
Underlines the Terms of Service and Privacy Policy links in ImproveExperienceStepView so they are clearly distinguishable from surrounding text. Uses AttributedString to selectively underline only link runs while preserving the green tint color.

Part of #21956, closes #21957
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21959" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
