### PR TITLE
Underline onboarding ToS/Privacy links for visibility

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -94,7 +94,7 @@ struct ImproveExperienceStepView: View {
 
     private var tosConsentText: some View {
         VStack(alignment: .leading, spacing: VSpacing.xs) {
-            Text(.init("I agree to the [Terms of Service](https://www.vellum.ai/docs/vellum-terms-of-use) and [Privacy Policy](https://www.vellum.ai/docs/privacy-policy)"))
+            Text(tosAttributedString)
                 .font(VFont.bodyMediumLighter)
                 .foregroundStyle(VColor.contentSecondary)
                 .tint(VColor.primaryBase)
@@ -103,6 +103,17 @@ struct ImproveExperienceStepView: View {
                     return .handled
                 })
         }
+    }
+
+    private var tosAttributedString: AttributedString {
+        // swiftlint:disable:next force_try
+        var str = try! AttributedString(
+            markdown: "I agree to the [Terms of Service](https://www.vellum.ai/docs/vellum-terms-of-use) and [Privacy Policy](https://www.vellum.ai/docs/privacy-policy)"
+        )
+        for run in str.runs where run.link != nil {
+            str[run.range].underlineStyle = .single
+        }
+        return str
     }
 
     // MARK: - Actions


### PR DESCRIPTION
## Summary
Makes the Terms of Service and Privacy Policy links in the onboarding `ImproveExperienceStepView` clearly visible by underlining them, while keeping the existing green tint color (`VColor.primaryBase`).

## Changes
- Switched from inline markdown `Text(.init(...))` to `AttributedString`-based approach that selectively underlines only link runs
- Added `tosAttributedString` computed property that parses markdown, iterates over runs, and applies `.underlineStyle = .single` to links
- No change to link destinations, text content, or surrounding styling

## Milestone PRs (merged into feature branch)
- #21959: M1 — Underline ToS and Privacy Policy links in ImproveExperienceStepView

## Project issue
Closes #21956

Closes LUM-560

## Test plan
- [ ] Launch the app, go through onboarding to the "Before You Start" step
- [ ] Verify "Terms of Service" and "Privacy Policy" are underlined in green
- [ ] Verify surrounding text ("I agree to the", "and") is NOT underlined
- [ ] Verify clicking links still opens them in the browser
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21960" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
