### PR TITLE
Restyle available skill rows as VCard with icon-only ghost install button

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -451,47 +451,40 @@ struct AvailableSkillItemRow: View {
     var isInstalling: Bool = false
 
     var body: some View {
-        HStack(alignment: .center, spacing: VSpacing.lg) {
-            if let emoji = skill.emoji, !emoji.isEmpty {
-                Text(emoji)
-                    .font(.system(size: 32))
-                    .opacity(0.5)
-            }
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                HStack(alignment: .center, spacing: VSpacing.sm) {
-                    Text(skill.name)
-                        .font(VFont.titleSmall)
+        VCard {
+            HStack(alignment: .center, spacing: VSpacing.lg) {
+                if let emoji = skill.emoji, !emoji.isEmpty {
+                    Text(emoji)
+                        .font(.system(size: 32))
+                }
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    HStack(alignment: .center, spacing: VSpacing.sm) {
+                        Text(skill.name)
+                            .font(VFont.titleSmall)
+                            .foregroundStyle(VColor.contentEmphasized)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                        VSkillTypePill(source: skill.source)
+                        Spacer()
+                    }
+                    Text(skill.description)
+                        .font(VFont.bodyMediumDefault)
                         .foregroundStyle(VColor.contentSecondary)
                         .lineLimit(1)
                         .truncationMode(.tail)
-                    VSkillTypePill(source: skill.source)
-                    Spacer()
                 }
-                Text(skill.description)
-                    .font(VFont.bodyMediumDefault)
-                    .foregroundStyle(VColor.contentTertiary)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-            }
-            if isInstalling {
-                VLoadingIndicator()
-            } else {
-                VButton(
-                    label: "Install",
-                    style: .outlined,
-                    size: .compact,
-                    action: onInstall
-                )
+                if isInstalling {
+                    VLoadingIndicator()
+                } else {
+                    VButton(
+                        label: "Install",
+                        iconOnly: VIcon.arrowDownToLine.rawValue,
+                        style: .ghost,
+                        size: .compact,
+                        action: onInstall
+                    )
+                }
             }
         }
-        .padding(VSpacing.lg)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.xl)
-                .strokeBorder(
-                    VColor.borderDisabled,
-                    style: StrokeStyle(lineWidth: 2, dash: [6, 4])
-                )
-        )
     }
 }


### PR DESCRIPTION
## Summary
- Replace dashed-border available skill rows with VCard to match installed skill card appearance
- Use full-opacity emoji and matching text colors for visual consistency
- Replace outlined Install button with icon-only ghost button (download icon)

Part of plan: skills-source-filter-redesign.md (PR 3 of 5)
Part of LUM-425
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21964" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
