### PR TITLE
Show disabled remove button on core skills to indicate they are installed

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -424,20 +424,21 @@ struct SkillItemRow: View {
                         .truncationMode(.tail)
                 }
 
-                if isRemovable {
-                    VButton(
-                        label: "Delete",
-                        iconOnly: VIcon.trash.rawValue,
-                        style: .dangerGhost,
-                        size: .compact,
-                        action: onDelete
-                    )
-                    .accessibilityLabel("Uninstall skill")
-                }
+                VButton(
+                    label: "Delete",
+                    iconOnly: VIcon.trash.rawValue,
+                    style: .dangerGhost,
+                    size: .compact,
+                    action: onDelete
+                )
+                .disabled(!isRemovable)
+                .accessibilityLabel(isRemovable ? "Uninstall skill" : "Core skill cannot be removed")
             }
         }
-        .contextMenu {
-            Button("Remove", role: .destructive, action: onDelete)
+        .if(isRemovable) { view in
+            view.contextMenu {
+                Button("Remove", role: .destructive, action: onDelete)
+            }
         }
         .accessibilityElement(children: .combine)
     }


### PR DESCRIPTION
## Summary
- Always show trash button on installed skill rows, disabled for non-removable skills (bundled, workspace)
- Only show right-click Remove context menu on removable skills (managed, clawhub)
- Improves clarity so users can distinguish installed vs removable skills

Part of plan: skills-source-filter-redesign.md (PR 4 of 5)
Part of LUM-425
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21965" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
