### PR TITLE
Add `vellum teleport` command skeleton with `--from`/`--to` arg parsing

### DIFF
--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -1,0 +1,61 @@
+function printHelp(): void {
+  console.log(
+    "Usage: vellum teleport --from <assistant> --to <assistant> [options]",
+  );
+  console.log("");
+  console.log(
+    "Transfer assistant data between local and platform environments.",
+  );
+  console.log("");
+  console.log("Options:");
+  console.log("  --from <name>   Source assistant to export data from");
+  console.log("  --to <name>     Target assistant to import data into");
+  console.log(
+    "  --dry-run       Preview the transfer without applying changes",
+  );
+  console.log("  --help, -h      Show this help");
+}
+
+function parseArgs(argv: string[]): {
+  from: string | undefined;
+  to: string | undefined;
+  dryRun: boolean;
+  help: boolean;
+} {
+  let from: string | undefined;
+  let to: string | undefined;
+  let dryRun = false;
+  let help = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--from" && i + 1 < argv.length) {
+      from = argv[++i];
+    } else if (arg === "--to" && i + 1 < argv.length) {
+      to = argv[++i];
+    } else if (arg === "--dry-run") {
+      dryRun = true;
+    } else if (arg === "--help" || arg === "-h") {
+      help = true;
+    }
+  }
+
+  return { from, to, dryRun, help };
+}
+
+export async function teleport(): Promise<void> {
+  const args = process.argv.slice(3);
+  const { from, to, help } = parseArgs(args);
+
+  if (help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  if (!from || !to) {
+    printHelp();
+    process.exit(1);
+  }
+
+  console.log(`Teleporting from ${from} to ${to}...`);
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -15,6 +15,7 @@ import { rollback } from "./commands/rollback";
 import { setup } from "./commands/setup";
 import { sleep } from "./commands/sleep";
 import { ssh } from "./commands/ssh";
+import { teleport } from "./commands/teleport";
 import { tunnel } from "./commands/tunnel";
 import { upgrade } from "./commands/upgrade";
 import { use } from "./commands/use";
@@ -44,6 +45,7 @@ const commands = {
   setup,
   sleep,
   ssh,
+  teleport,
   tunnel,
   upgrade,
   use,
@@ -76,6 +78,7 @@ function printHelp(): void {
   console.log("  setup    Configure API keys interactively");
   console.log("  sleep    Stop the assistant process");
   console.log("  ssh      SSH into a remote assistant instance");
+  console.log("  teleport Transfer assistant data between environments");
   console.log("  tunnel   Create a tunnel for a locally hosted assistant");
   console.log("  upgrade  Upgrade an assistant to a newer version");
   console.log("  use      Set the active assistant for commands");


### PR DESCRIPTION
## Summary
- Adds new `cli/src/commands/teleport.ts` with arg parsing for `--from`, `--to`, `--dry-run`, and `--help` flags
- Registers the `teleport` command in `cli/src/index.ts` with help text
- Placeholder implementation that validates required flags and prints a message

Part of plan: cli-teleport-command.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21971" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
