### PR TITLE
fix(macos): show runtime URL for managed assistants in developer settings list

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -554,9 +554,7 @@ struct SettingsDeveloperTab: View {
                             Text(displayLabel(for: assistant))
                                 .font(VFont.bodyMediumDefault)
                                 .foregroundStyle(VColor.contentDefault)
-                            Text(displayNames[assistant.assistantId] != nil
-                                ? "\(assistant.assistantId) · \(assistant.home.displayLabel)"
-                                : assistant.home.displayLabel)
+                            Text(assistantSubtitle(for: assistant))
                                 .font(VFont.labelDefault)
                                 .foregroundStyle(VColor.contentTertiary)
                         }
@@ -614,6 +612,18 @@ struct SettingsDeveloperTab: View {
 
     private func displayLabel(for assistant: LockfileAssistant) -> String {
         displayNames[assistant.assistantId] ?? assistant.assistantId
+    }
+
+    private func assistantSubtitle(for assistant: LockfileAssistant) -> String {
+        var parts: [String] = []
+        if displayNames[assistant.assistantId] != nil {
+            parts.append(assistant.assistantId)
+        }
+        parts.append(assistant.home.displayLabel)
+        if assistant.isManaged, let runtimeUrl = assistant.runtimeUrl, !runtimeUrl.isEmpty {
+            parts.append(runtimeUrl)
+        }
+        return parts.joined(separator: " · ")
     }
 
     private func refreshAwakeStates() async {


### PR DESCRIPTION
Surfaces the platform runtime URL (e.g. https://platform.vellum.ai vs https://dev-platform.vellum.ai) in the assistant list subtitle so developers can distinguish which environment each managed assistant belongs to.

<img width="891" height="253" alt="Screenshot 2026-03-27 at 5 19 17 PM" src="https://github.com/user-attachments/assets/12f9c2c8-a3ee-48ae-9e98-ee2aa151fc4c" />


Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21973" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
