### PR TITLE
feat: cross-post outbound messages to channel-bound conversations

### DIFF
--- a/assistant/src/__tests__/messaging-send-tool.test.ts
+++ b/assistant/src/__tests__/messaging-send-tool.test.ts
@@ -41,11 +41,70 @@ mock.module("../config/bundled-skills/messaging/tools/shared.js", () => ({
   extractEmail: (a: string) => a.toLowerCase(),
 }));
 
+// ── Cross-post dependency mocks ──
+
+const addMessageMock = mock(
+  async (
+    conversationId: string,
+    role: string,
+    content: string,
+    _metadata?: Record<string, unknown>,
+    _opts?: { skipIndexing?: boolean },
+  ) => ({
+    id: "xpost-msg-1",
+    conversationId,
+    role,
+    content,
+    createdAt: Date.now(),
+  }),
+);
+
+const getConversationMock = mock(
+  (_id: string) => null as { id: string; createdAt: number } | null,
+);
+
+const syncMessageToDiskMock = mock(
+  (
+    _conversationId: string,
+    _messageId: string,
+    _createdAtMs: number,
+  ) => {},
+);
+
+const getBindingByChannelChatMock = mock(
+  (_sourceChannel: string, _externalChatId: string) =>
+    null as { conversationId: string; sourceChannel: string; externalChatId: string } | null,
+);
+
+mock.module("../memory/conversation-crud.js", () => ({
+  addMessage: addMessageMock,
+  getConversation: getConversationMock,
+}));
+
+mock.module("../memory/conversation-disk-view.js", () => ({
+  syncMessageToDisk: syncMessageToDiskMock,
+}));
+
+mock.module("../memory/external-conversation-store.js", () => ({
+  getBindingByChannelChat: getBindingByChannelChatMock,
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
 import { run } from "../config/bundled-skills/messaging/tools/messaging-send.js";
 
 describe("messaging-send tool", () => {
   beforeEach(() => {
     sendMessageMock.mockClear();
+    addMessageMock.mockClear();
+    getConversationMock.mockClear();
+    syncMessageToDiskMock.mockClear();
+    getBindingByChannelChatMock.mockClear();
   });
 
   test("passes assistantId from tool context to provider send options", async () => {
@@ -105,5 +164,147 @@ describe("messaging-send tool", () => {
         assistantId: "ast-alpha",
       },
     );
+  });
+
+  test("cross-posts outbound message to bound conversation", async () => {
+    getBindingByChannelChatMock.mockImplementation(() => ({
+      conversationId: "bound-conv-99",
+      sourceChannel: "phone",
+      externalChatId: "+15550004444",
+    }));
+    getConversationMock.mockImplementation(() => ({
+      id: "bound-conv-99",
+      createdAt: 1700000000000,
+    }));
+
+    const result = await run(
+      {
+        platform: "phone",
+        conversation_id: "+15550004444",
+        text: "hello from A",
+      },
+      {
+        workingDir: "/tmp",
+        conversationId: "conv-A",
+        assistantId: "ast-1",
+        trustClass: "guardian" as const,
+      },
+    );
+
+    expect(result.isError).toBe(false);
+    expect(addMessageMock).toHaveBeenCalledWith(
+      "bound-conv-99",
+      "assistant",
+      "hello from A",
+      { automated: true, crossPostedFrom: "conv-A" },
+      { skipIndexing: true },
+    );
+    expect(syncMessageToDiskMock).toHaveBeenCalledWith(
+      "bound-conv-99",
+      "xpost-msg-1",
+      1700000000000,
+    );
+  });
+
+  test("does not cross-post when bound conversation is the sender", async () => {
+    getBindingByChannelChatMock.mockImplementation(() => ({
+      conversationId: "conv-A",
+      sourceChannel: "phone",
+      externalChatId: "+15550004444",
+    }));
+
+    await run(
+      {
+        platform: "phone",
+        conversation_id: "+15550004444",
+        text: "hello",
+      },
+      {
+        workingDir: "/tmp",
+        conversationId: "conv-A",
+        assistantId: "ast-1",
+        trustClass: "guardian" as const,
+      },
+    );
+
+    expect(addMessageMock).not.toHaveBeenCalled();
+  });
+
+  test("does not cross-post when no binding exists", async () => {
+    getBindingByChannelChatMock.mockImplementation(() => null);
+
+    await run(
+      {
+        platform: "phone",
+        conversation_id: "+15550004444",
+        text: "hello",
+      },
+      {
+        workingDir: "/tmp",
+        conversationId: "conv-A",
+        assistantId: "ast-1",
+        trustClass: "guardian" as const,
+      },
+    );
+
+    expect(addMessageMock).not.toHaveBeenCalled();
+  });
+
+  test("cross-post failure does not fail the send", async () => {
+    getBindingByChannelChatMock.mockImplementation(() => ({
+      conversationId: "bound-conv-99",
+      sourceChannel: "phone",
+      externalChatId: "+15550004444",
+    }));
+    getConversationMock.mockImplementation(() => ({
+      id: "bound-conv-99",
+      createdAt: 1700000000000,
+    }));
+    addMessageMock.mockImplementation(async () => {
+      throw new Error("DB write failed");
+    });
+
+    const result = await run(
+      {
+        platform: "phone",
+        conversation_id: "+15550004444",
+        text: "hello",
+      },
+      {
+        workingDir: "/tmp",
+        conversationId: "conv-A",
+        assistantId: "ast-1",
+        trustClass: "guardian" as const,
+      },
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Message sent");
+  });
+
+  test("does not cross-post when bound conversation no longer exists", async () => {
+    getBindingByChannelChatMock.mockImplementation(() => ({
+      conversationId: "deleted-conv",
+      sourceChannel: "phone",
+      externalChatId: "+15550004444",
+    }));
+    getConversationMock.mockImplementation(() => null);
+
+    await run(
+      {
+        platform: "phone",
+        conversation_id: "+15550004444",
+        text: "hello",
+      },
+      {
+        workingDir: "/tmp",
+        conversationId: "conv-A",
+        assistantId: "ast-1",
+        trustClass: "guardian" as const,
+      },
+    );
+
+    expect(getBindingByChannelChatMock).toHaveBeenCalled();
+    expect(addMessageMock).not.toHaveBeenCalled();
   });
 });

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
@@ -9,10 +9,17 @@ import {
   listMessages,
 } from "../../../../messaging/providers/gmail/client.js";
 import { buildMultipartMime } from "../../../../messaging/providers/gmail/mime-builder.js";
+import {
+  addMessage,
+  getConversation,
+} from "../../../../memory/conversation-crud.js";
+import { syncMessageToDisk } from "../../../../memory/conversation-disk-view.js";
+import { getBindingByChannelChat } from "../../../../memory/external-conversation-store.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+import { getLogger } from "../../../../util/logger.js";
 import { guessMimeType } from "./gmail-mime-helpers.js";
 import {
   err,
@@ -23,6 +30,8 @@ import {
   parseAddressList,
   resolveProvider,
 } from "./shared.js";
+
+const log = getLogger("messaging-send");
 
 export async function run(
   input: Record<string, unknown>,
@@ -219,6 +228,34 @@ export async function run(
     const threadSuffix = result.threadId
       ? `, "thread_id": "${result.threadId}"`
       : "";
+
+    // Cross-post to the conversation bound to this channel so replies have context.
+    try {
+      const binding = getBindingByChannelChat(provider.id, conversationId);
+      if (binding && binding.conversationId !== context.conversationId) {
+        const boundConv = getConversation(binding.conversationId);
+        if (boundConv) {
+          const crossPosted = await addMessage(
+            binding.conversationId,
+            "assistant",
+            text,
+            { automated: true, crossPostedFrom: context.conversationId },
+            { skipIndexing: true },
+          );
+          syncMessageToDisk(
+            binding.conversationId,
+            crossPosted.id,
+            boundConv.createdAt,
+          );
+        }
+      }
+    } catch (e) {
+      log.warn(
+        { err: e, provider: provider.id, externalChatId: conversationId },
+        "Failed to cross-post outbound message to bound conversation",
+      );
+    }
+
     return ok(`Message sent (ID: ${result.id}${threadSuffix}).`);
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));


### PR DESCRIPTION
## Summary
- When the messaging skill sends to a channel that has a different conversation bound to it, the sent text is now replicated as an assistant message in the bound conversation
- This ensures the assistant has context when the recipient replies (replies route to the bound conversation, which previously had no record of the outbound message)
- Cross-posting is best-effort — failures are logged but don't affect the primary send

## Original prompt
Cross-post outbound messages to bound conversations so replies have context. When Velissa sends a Slack DM from one conversation thread, the message should be replicated to the conversation bound to that DM channel.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21976" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
