### PR TITLE
feat: plumb requesterDisplayName and requesterIdentifier into ToolContext

### DIFF
--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -177,6 +177,8 @@ export function createToolExecutor(
         ctx.surfaceActionRequestIds?.has(ctx.currentRequestId ?? "") ?? false,
       requesterExternalUserId: ctx.trustContext?.requesterExternalUserId,
       requesterChatId: ctx.trustContext?.requesterChatId,
+      requesterIdentifier: ctx.trustContext?.requesterIdentifier,
+      requesterDisplayName: ctx.trustContext?.requesterDisplayName,
       channelPermissionChannelId:
         ctx.trustContext?.sourceChannel === "slack"
           ? getBindingByConversation(ctx.conversationId)?.externalChatId

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -169,6 +169,10 @@ export interface ToolContext {
   requesterExternalUserId?: string;
   /** Chat ID of the requester (non-guardian actor). Used for tool grant request escalation notifications. */
   requesterChatId?: string;
+  /** Human-readable identifier for the requester (e.g., @username). */
+  requesterIdentifier?: string;
+  /** Preferred display name for the requester. */
+  requesterDisplayName?: string;
   /** Slack channel ID for channel-scoped permission enforcement. When set, tools are checked against the channel's permission profile. */
   channelPermissionChannelId?: string;
   /** The tool_use block ID from the LLM response, used to correlate confirmation prompts with specific tool invocations. */


### PR DESCRIPTION
## Summary
- Add `requesterDisplayName` and `requesterIdentifier` optional fields to `ToolContext` interface
- Plumb both fields from `TrustContext` in `conversation-tool-setup.ts`

Part of plan: guardian-approval-ux.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21977" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
