### PR TITLE
fix: sort imports in messaging-send.ts

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
@@ -2,6 +2,12 @@ import { readFile } from "node:fs/promises";
 import { basename } from "node:path";
 
 import {
+  addMessage,
+  getConversation,
+} from "../../../../memory/conversation-crud.js";
+import { syncMessageToDisk } from "../../../../memory/conversation-disk-view.js";
+import { getBindingByChannelChat } from "../../../../memory/external-conversation-store.js";
+import {
   batchGetMessages,
   createDraft,
   createDraftRaw,
@@ -9,12 +15,6 @@ import {
   listMessages,
 } from "../../../../messaging/providers/gmail/client.js";
 import { buildMultipartMime } from "../../../../messaging/providers/gmail/mime-builder.js";
-import {
-  addMessage,
-  getConversation,
-} from "../../../../memory/conversation-crud.js";
-import { syncMessageToDisk } from "../../../../memory/conversation-disk-view.js";
-import { getBindingByChannelChat } from "../../../../memory/external-conversation-store.js";
 import type {
   ToolContext,
   ToolExecutionResult,


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error in `messaging-send.ts` by reordering imports alphabetically (memory imports before messaging imports)

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23668319550
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
