### PR TITLE
feat: add summarizeToolInput helper for guardian approval context

### DIFF
--- a/assistant/src/__tests__/tool-input-summary.test.ts
+++ b/assistant/src/__tests__/tool-input-summary.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+
+import { summarizeToolInput } from "../tools/tool-input-summary.js";
+
+describe("summarizeToolInput", () => {
+  test("bash with short command returns full command", () => {
+    expect(summarizeToolInput("bash", { command: "ls -la" })).toBe("ls -la");
+  });
+
+  test("bash with long command truncates with ellipsis", () => {
+    const longCmd = "a".repeat(200);
+    const result = summarizeToolInput("bash", { command: longCmd });
+    expect(result.length).toBe(121); // 120 chars + ellipsis
+    expect(result.endsWith("…")).toBe(true);
+    expect(result.startsWith("a".repeat(120))).toBe(true);
+  });
+
+  test("terminal tool behaves like bash", () => {
+    expect(summarizeToolInput("terminal", { command: "echo hello" })).toBe(
+      "echo hello",
+    );
+  });
+
+  test("file_read returns file path", () => {
+    expect(
+      summarizeToolInput("file_read", { file_path: "/src/index.ts" }),
+    ).toBe("/src/index.ts");
+  });
+
+  test("file_write returns file path from path key", () => {
+    expect(summarizeToolInput("file_write", { path: "/src/main.ts" })).toBe(
+      "/src/main.ts",
+    );
+  });
+
+  test("file_edit prefers file_path over path", () => {
+    expect(
+      summarizeToolInput("file_edit", {
+        file_path: "/preferred.ts",
+        path: "/fallback.ts",
+      }),
+    ).toBe("/preferred.ts");
+  });
+
+  test("web_fetch returns URL truncated to 100 chars", () => {
+    const longUrl = `https://example.com/${"x".repeat(200)}`;
+    const result = summarizeToolInput("web_fetch", { url: longUrl });
+    expect(result.length).toBe(101); // 100 chars + ellipsis
+    expect(result.endsWith("…")).toBe(true);
+  });
+
+  test("web_fetch with short URL returns full URL", () => {
+    expect(
+      summarizeToolInput("web_fetch", { url: "https://example.com" }),
+    ).toBe("https://example.com");
+  });
+
+  test("network_request behaves like web_fetch", () => {
+    expect(
+      summarizeToolInput("network_request", { url: "https://api.test.com" }),
+    ).toBe("https://api.test.com");
+  });
+
+  test("empty input returns empty string", () => {
+    expect(summarizeToolInput("bash", {})).toBe("");
+    expect(summarizeToolInput("file_read", {})).toBe("");
+    expect(summarizeToolInput("web_fetch", {})).toBe("");
+    expect(summarizeToolInput("unknown_tool", {})).toBe("");
+  });
+
+  test("unknown tool with string input returns first string value", () => {
+    expect(
+      summarizeToolInput("custom_tool", {
+        query: "search for something",
+        count: 10,
+      }),
+    ).toBe("search for something");
+  });
+
+  test("unknown tool with long string truncates to 80 chars", () => {
+    const longVal = "b".repeat(150);
+    const result = summarizeToolInput("custom_tool", { data: longVal });
+    expect(result.length).toBe(81); // 80 chars + ellipsis
+    expect(result.endsWith("…")).toBe(true);
+  });
+
+  test("input with no string values returns empty string", () => {
+    expect(
+      summarizeToolInput("custom_tool", { count: 42, flag: true, obj: {} }),
+    ).toBe("");
+  });
+
+  test("whitespace-only string values are treated as empty", () => {
+    expect(summarizeToolInput("bash", { command: "   " })).toBe("");
+    expect(summarizeToolInput("custom_tool", { data: "  \n\t  " })).toBe("");
+  });
+});

--- a/assistant/src/tools/tool-input-summary.ts
+++ b/assistant/src/tools/tool-input-summary.ts
@@ -1,0 +1,62 @@
+/**
+ * Summarizes tool input into a concise string for guardian approval display.
+ *
+ * The summary is shown only to the guardian who already has full access,
+ * so no secret masking is applied.
+ */
+
+function truncate(value: string, maxLen: number): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= maxLen) return trimmed;
+  return `${trimmed.slice(0, maxLen)}…`;
+}
+
+function extractString(
+  input: Record<string, unknown>,
+  ...keys: string[]
+): string | undefined {
+  for (const key of keys) {
+    const val = input[key];
+    if (typeof val === "string" && val.trim().length > 0) {
+      return val;
+    }
+  }
+  return undefined;
+}
+
+function firstStringValue(input: Record<string, unknown>): string | undefined {
+  for (const val of Object.values(input)) {
+    if (typeof val === "string" && val.trim().length > 0) {
+      return val;
+    }
+  }
+  return undefined;
+}
+
+export function summarizeToolInput(
+  toolName: string,
+  input: Record<string, unknown>,
+): string {
+  switch (toolName) {
+    case "bash":
+    case "terminal": {
+      const cmd = extractString(input, "command");
+      return cmd ? truncate(cmd, 120) : "";
+    }
+    case "file_read":
+    case "file_write":
+    case "file_edit": {
+      const path = extractString(input, "file_path", "path");
+      return path ? path.trim() : "";
+    }
+    case "web_fetch":
+    case "network_request": {
+      const url = extractString(input, "url");
+      return url ? truncate(url, 100) : "";
+    }
+    default: {
+      const fallback = firstStringValue(input);
+      return fallback ? truncate(fallback, 80) : "";
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `summarizeToolInput()` helper that extracts concise summaries from tool input for guardian approval display
- Handle bash commands, file paths, URLs, and generic string fallback with truncation
- Add comprehensive test coverage

Part of plan: guardian-approval-ux.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
