### PR TITLE
fix: use spyOn instead of mock.module for assistant-config in teleport tests

### DIFF
--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -22,14 +22,16 @@ process.env.VELLUM_LOCKFILE_DIR = testDir;
 // Mocks — must be set up before importing the module under test
 // ---------------------------------------------------------------------------
 
-const findAssistantByNameMock = mock(
-  (_name: string): import("../lib/assistant-config.js").AssistantEntry | null =>
-    null,
-);
+// Import the real assistant-config module — do NOT mock it with mock.module()
+// because Bun's mock.module() replaces the module globally and leaks into
+// other test files (e.g. multi-local.test.ts) running in the same process.
+// Instead, we use spyOn to mock findAssistantByName on the imported module object.
+import * as assistantConfig from "../lib/assistant-config.js";
 
-mock.module("../lib/assistant-config.js", () => ({
-  findAssistantByName: findAssistantByNameMock,
-}));
+const findAssistantByNameMock = spyOn(
+  assistantConfig,
+  "findAssistantByName",
+).mockReturnValue(null);
 
 const loadGuardianTokenMock = mock((_id: string) => ({
   accessToken: "local-token",
@@ -103,6 +105,7 @@ import type { AssistantEntry } from "../lib/assistant-config.js";
 // ---------------------------------------------------------------------------
 
 afterAll(() => {
+  findAssistantByNameMock.mockRestore();
   rmSync(testDir, { recursive: true, force: true });
   delete process.env.VELLUM_LOCKFILE_DIR;
 });


### PR DESCRIPTION
## Summary
Fixes CI failure in `multi-local.test.ts` caused by teleport test's `mock.module("../lib/assistant-config.js", ...)` leaking across test files in the same Bun process. 

Replaced `mock.module` with `spyOn(assistantConfig, "findAssistantByName")` which only affects the spy target and doesn't replace the module globally. This prevents cross-test pollution while maintaining the same test behavior.

**Root cause:** Bun's `mock.module()` replaces the module at the module registry level before any tests run (at module evaluation time), so even test files that import after the mock get the replaced module with missing exports like `resolveTargetAssistant`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21980" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
