### PR TITLE
feat(macos): add per-channel collapsed/expand state to SidebarInteractionState

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
@@ -48,6 +48,19 @@ final class SidebarInteractionState {
     var backgroundSectionCollapsed: Bool = UserDefaults.standard.bool(forKey: "backgroundSectionCollapsed") {
         didSet { UserDefaults.standard.set(backgroundSectionCollapsed, forKey: "backgroundSectionCollapsed") }
     }
+    /// Set of channel names whose sidebar sections are currently collapsed.
+    /// Persisted to UserDefaults so collapse state survives app restart.
+    var collapsedChannelSections: Set<String> = {
+        let saved = UserDefaults.standard.stringArray(forKey: "collapsedChannelSections") ?? []
+        return Set(saved)
+    }() {
+        didSet {
+            UserDefaults.standard.set(Array(collapsedChannelSections), forKey: "collapsedChannelSections")
+        }
+    }
+
+    /// Per-channel "show all" toggle (default: show first 3).
+    var showAllChannelConversations: [String: Bool] = [:]
     /// Set of schedule group keys (scheduleJobId values) that are currently expanded.
     var expandedScheduleGroups: Set<String> = []
     var showAllApps: Bool = false


### PR DESCRIPTION
## Summary
- Add `collapsedChannelSections: Set<String>` to `SidebarInteractionState`, persisted to UserDefaults
- Add `showAllChannelConversations: [String: Bool]` for per-channel show more/less toggle

Part of plan: channel-sidebar-views.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21981" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
