### PR TITLE
feat: allow approve_10m and approve_conversation for guardian-on-behalf tool grants

### DIFF
--- a/assistant/src/__tests__/guardian-decision-primitive-canonical.test.ts
+++ b/assistant/src/__tests__/guardian-decision-primitive-canonical.test.ts
@@ -376,7 +376,7 @@ describe("applyCanonicalGuardianDecision", () => {
     expect(unchanged!.status).toBe("pending");
   });
 
-  // ── approve_always downgrade ───────────────────────────────────────
+  // ── approve_always downgrade / temporal mode preservation ──────────
 
   test("downgrades approve_always to approve_once", async () => {
     const req = createCanonicalGuardianRequest({
@@ -410,6 +410,80 @@ describe("applyCanonicalGuardianDecision", () => {
     // correctly skips grant minting when the resolver reports a failure.
     expect(result.grantMinted).toBe(false);
     expect(result.resolverFailed).toBe(true);
+  });
+
+  test("preserves approve_10m (not downgraded) and mints grant", async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: "unknown_kind",
+      sourceType: "voice",
+      sourceChannel: "phone",
+      conversationId: "conv-10m-1",
+      callSessionId: "call-10m-1",
+      toolName: "host_bash",
+      inputDigest: "sha256:10m-digest",
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      expiresAt: Date.now() + 60_000,
+    });
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: "approve_10m",
+      actorContext: guardianActor(),
+    });
+
+    expect(result.applied).toBe(true);
+    if (!result.applied) return;
+
+    // approve_10m is preserved — the request is approved (not downgraded)
+    const resolved = getCanonicalGuardianRequest(req.id);
+    expect(resolved!.status).toBe("approved");
+
+    // Grant is minted because approve_10m is not downgraded and the request
+    // has tool metadata (unknown_kind has no resolver, so resolver doesn't fail)
+    expect(result.grantMinted).toBe(true);
+
+    const db = getDb();
+    const grants = db.select().from(scopedApprovalGrants).all();
+    expect(grants.length).toBe(1);
+    expect(grants[0].toolName).toBe("host_bash");
+    expect(grants[0].conversationId).toBe("conv-10m-1");
+  });
+
+  test("preserves approve_conversation (not downgraded) and mints grant", async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: "unknown_kind",
+      sourceType: "voice",
+      sourceChannel: "phone",
+      conversationId: "conv-session-1",
+      callSessionId: "call-session-1",
+      toolName: "file_write",
+      inputDigest: "sha256:session-digest",
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      expiresAt: Date.now() + 60_000,
+    });
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: "approve_conversation",
+      actorContext: guardianActor(),
+    });
+
+    expect(result.applied).toBe(true);
+    if (!result.applied) return;
+
+    // approve_conversation is preserved — the request is approved (not downgraded)
+    const resolved = getCanonicalGuardianRequest(req.id);
+    expect(resolved!.status).toBe("approved");
+
+    // Grant is minted because approve_conversation is not downgraded and the
+    // request has tool metadata (unknown_kind has no resolver, so no failure)
+    expect(result.grantMinted).toBe(true);
+
+    const db = getDb();
+    const grants = db.select().from(scopedApprovalGrants).all();
+    expect(grants.length).toBe(1);
+    expect(grants[0].toolName).toBe("file_write");
+    expect(grants[0].conversationId).toBe("conv-session-1");
   });
 
   // ── Expired request ────────────────────────────────────────────────

--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -5,7 +5,8 @@
  * legacy parser, requester self-cancel) call through this module instead of
  * inlining the decision-application logic.  This centralizes:
  *
- *   1. `approve_always` downgrade for guardian-on-behalf requests
+ *   1. `approve_always` downgrade for guardian-on-behalf requests (time-bounded
+ *      modes like `approve_10m` and `approve_conversation` are preserved)
  *   2. Identity validation (actor must match assigned guardian)
  *   3. Approval-info capture before the pending interaction is consumed
  *   4. Atomic decision application via `handleChannelDecision`
@@ -21,7 +22,9 @@
  *   - Decision authorization is purely principal-based:
  *     actor.guardianPrincipalId === request.guardianPrincipalId (strict equality)
  *   - Decisions are first-response-wins (CAS-like stale protection)
- *   - `approve_always` is rejected/downgraded for guardian-on-behalf requests
+ *   - `approve_always` is downgraded to `approve_once` for guardian-on-behalf
+ *     requests; time-bounded modes (`approve_10m`, `approve_conversation`) are
+ *     preserved since grants are scoped via `scopeMode: "tool_signature"`
  *   - Scoped grant minting only on explicit approve for requests with tool metadata
  */
 
@@ -166,7 +169,8 @@ export interface ApplyGuardianDecisionParams {
  * self-cancel paths:
  *
  *   1. Downgrade `approve_always` to `approve_once` (guardians cannot
- *      permanently allowlist tools on behalf of requesters)
+ *      permanently allowlist tools on behalf of requesters). Time-bounded
+ *      modes (`approve_10m`, `approve_conversation`) are preserved.
  *   2. Capture pending approval info before resolution
  *   3. Apply the decision atomically via `handleChannelDecision`
  *   4. Update the guardian approval record
@@ -186,11 +190,11 @@ export function applyGuardianDecision(
     decisionContext,
   } = params;
 
-  // Guardians cannot grant broad allow modes on behalf of requesters -- downgrade.
+  // Guardians cannot grant permanent allow modes on behalf of requesters.
+  // Time-bounded modes (approve_10m, approve_conversation) are safe because
+  // grants are scoped to the tool+input signature via scopeMode: "tool_signature".
   const effectiveDecision: ApprovalDecisionResult =
-    decision.action === "approve_always" ||
-    decision.action === "approve_10m" ||
-    decision.action === "approve_conversation"
+    decision.action === "approve_always"
       ? { ...decision, action: "approve_once" }
       : decision;
 
@@ -371,7 +375,8 @@ export type CanonicalDecisionResult =
  * Steps:
  *   1. Look up the canonical request by ID
  *   2. Validate: exists, pending status, identity match, valid action
- *   3. Downgrade approve_always to approve_once (guardian-on-behalf invariant)
+ *   3. Downgrade `approve_always` to `approve_once` (guardian-on-behalf invariant;
+ *      time-bounded modes like `approve_10m`/`approve_conversation` are preserved)
  *   4. CAS resolve the canonical request atomically
  *   5. Dispatch to kind-specific resolver
  *   6. Mint grant if applicable
@@ -491,13 +496,10 @@ export async function applyCanonicalGuardianDecision(
     return { applied: false, reason: "expired" };
   }
 
-  // 3. Downgrade approve_always and temporary modes to approve_once for
-  // guardian-on-behalf requests. Guardians cannot grant broad allow modes
-  // (permanent, timed, or conversation-scoped) on behalf of requesters.
+  // 3. Downgrade approve_always to approve_once for guardian-on-behalf requests.
+  // Time-bounded modes (approve_10m, approve_conversation) are permitted.
   const effectiveAction: ApprovalAction =
-    action === "approve_always" ||
-    action === "approve_10m" ||
-    action === "approve_conversation"
+    action === "approve_always"
       ? "approve_once"
       : action;
 

--- a/assistant/src/runtime/guardian-decision-types.ts
+++ b/assistant/src/runtime/guardian-decision-types.ts
@@ -76,12 +76,11 @@ export const GUARDIAN_DECISION_ACTIONS = {
  * respecting whether persistent decisions (approve_always) are allowed.
  *
  * When `persistentDecisionsAllowed` is `false`, the `approve_always` action
- * is excluded. When `forGuardianOnBehalf` is `true` (guardian acting on behalf
- * of a requester), both `approve_always` and the temporary modes are excluded
- * since guardians cannot grant broad delegated allow modes on behalf of others.
- *
- * Temporary modes (`approve_10m`, `approve_conversation`) are included for
- * requester-side standard approval flows when persistent decisions are allowed.
+ * and temporary modes are excluded. When `forGuardianOnBehalf` is `true`
+ * (guardian acting on behalf of a requester), only `approve_always` is excluded
+ * — temporary modes (`approve_10m`, `approve_conversation`) are permitted
+ * because grants are scoped to the tool+input signature via scopeMode:
+ * "tool_signature".
  */
 export function buildDecisionActions(opts?: {
   persistentDecisionsAllowed?: boolean;
@@ -89,8 +88,7 @@ export function buildDecisionActions(opts?: {
 }): GuardianDecisionAction[] {
   const showAlways =
     opts?.persistentDecisionsAllowed !== false && !opts?.forGuardianOnBehalf;
-  const showTemporary =
-    opts?.persistentDecisionsAllowed !== false && !opts?.forGuardianOnBehalf;
+  const showTemporary = opts?.persistentDecisionsAllowed !== false;
   return [
     GUARDIAN_DECISION_ACTIONS.approve_once,
     ...(showTemporary


### PR DESCRIPTION
## Summary
- Allow time-bounded approval modes (approve_10m, approve_conversation) for guardian-on-behalf flows
- Only approve_always is still downgraded to approve_once (permanent allowlisting remains restricted)
- Update both downgrade locations in guardian-decision-primitive.ts
- Update buildDecisionActions to include temporal modes for forGuardianOnBehalf

Part of plan: guardian-approval-ux.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
