### PR TITLE
feat(macos): hide composer and show readonly banner for channel conversations

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -92,6 +92,7 @@ struct ChatView: View {
     var onFetchConversationStarters: (() -> Void)? = nil
     var activePendingRequestId: String?
     var isInteractionEnabled: Bool = true
+    var isReadonly: Bool = false
     /// When set, scroll to this message ID and clear the binding.
     @Binding var anchorMessageId: UUID?
     /// Message ID to visually highlight after an anchor scroll completes.
@@ -306,38 +307,49 @@ struct ChatView: View {
                             .padding(.bottom, -VSpacing.sm)
                         }
 
-                        ComposerSection(
-                            inputText: $inputText,
-                            isSending: isSending,
-                            isAssistantBusy: isAssistantBusy,
-                            hasPendingConfirmation: activePendingRequestId != nil,
-                            onAllowPendingConfirmation: {
-                                if let requestId = activePendingRequestId {
-                                    onConfirmationAllow(requestId)
-                                }
-                            },
-                            isRecording: isRecording,
-                            suggestion: suggestion,
-                            pendingAttachments: pendingAttachments,
-                            isLoadingAttachment: isLoadingAttachment,
-                            onSend: onSend,
-                            onStop: onStop,
-                            onAcceptSuggestion: onAcceptSuggestion,
-                            onAttach: onAttach,
-                            onRemoveAttachment: onRemoveAttachment,
-                            onPaste: onPaste,
-                            onMicrophoneToggle: onMicrophoneToggle,
-                            watchSession: watchSession,
-                            onStopWatch: onStopWatch,
-                            voiceModeManager: voiceModeManager,
-                            voiceService: voiceService,
-                            onEndVoiceMode: onEndVoiceMode,
-                            recordingAmplitude: recordingAmplitude,
-                            onDictateToggle: onDictateToggle,
-                            onVoiceModeToggle: onVoiceModeToggle,
-                            conversationId: conversationId,
-                            isInteractionEnabled: isInteractionEnabled
-                        )
+                        if isReadonly {
+                            HStack(spacing: VSpacing.xs) {
+                                VIconView(.eye, size: 14)
+                                Text("Read-only conversation")
+                                    .font(VFont.caption)
+                            }
+                            .foregroundStyle(VColor.contentTertiary)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, VSpacing.md)
+                        } else {
+                            ComposerSection(
+                                inputText: $inputText,
+                                isSending: isSending,
+                                isAssistantBusy: isAssistantBusy,
+                                hasPendingConfirmation: activePendingRequestId != nil,
+                                onAllowPendingConfirmation: {
+                                    if let requestId = activePendingRequestId {
+                                        onConfirmationAllow(requestId)
+                                    }
+                                },
+                                isRecording: isRecording,
+                                suggestion: suggestion,
+                                pendingAttachments: pendingAttachments,
+                                isLoadingAttachment: isLoadingAttachment,
+                                onSend: onSend,
+                                onStop: onStop,
+                                onAcceptSuggestion: onAcceptSuggestion,
+                                onAttach: onAttach,
+                                onRemoveAttachment: onRemoveAttachment,
+                                onPaste: onPaste,
+                                onMicrophoneToggle: onMicrophoneToggle,
+                                watchSession: watchSession,
+                                onStopWatch: onStopWatch,
+                                voiceModeManager: voiceModeManager,
+                                voiceService: voiceService,
+                                onEndVoiceMode: onEndVoiceMode,
+                                recordingAmplitude: recordingAmplitude,
+                                onDictateToggle: onDictateToggle,
+                                onVoiceModeToggle: onVoiceModeToggle,
+                                conversationId: conversationId,
+                                isInteractionEnabled: isInteractionEnabled
+                            )
+                        }
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -413,6 +413,7 @@ extension MainWindowView {
                 conversationManager: conversationManager,
                 onMicrophoneToggle: onMicrophoneToggle,
                 isTemporaryChat: activeConversation?.kind == .private,
+                isReadonly: activeConversation?.isChannelConversation ?? false,
                 voiceModeManager: voiceModeManager,
                 voiceService: voiceModeManager.openAIVoiceService,
                 onEndVoiceMode: {
@@ -625,6 +626,7 @@ struct ActiveChatViewWrapper: View {
     let conversationManager: ConversationManager
     let onMicrophoneToggle: () -> Void
     var isTemporaryChat: Bool = false
+    var isReadonly: Bool = false
     var voiceModeManager: VoiceModeManager? = nil
     var voiceService: OpenAIVoiceService? = nil
     var onEndVoiceMode: (() -> Void)? = nil
@@ -772,7 +774,8 @@ struct ActiveChatViewWrapper: View {
             },
             onFetchConversationStarters: { [weak viewModel] in viewModel?.fetchConversationStarters() },
             activePendingRequestId: viewModel.activePendingRequestId,
-            isInteractionEnabled: inspectorMessageId == nil,
+            isInteractionEnabled: inspectorMessageId == nil && !isReadonly,
+            isReadonly: isReadonly,
             anchorMessageId: $anchorMessageId,
             highlightedMessageId: $highlightedMessageId,
             btwResponse: viewModel.btwResponse,


### PR DESCRIPTION
## Summary
- Add `isReadonly` property to `ChatView` and `ActiveChatViewWrapper`
- When a channel conversation is active, hide the composer and show a 'Read-only conversation' banner
- Disable interaction (key press handlers, etc.) when readonly
- Wire `isChannelConversation` from `ConversationManager.activeConversation` through to `ChatView`

Part of plan: channel-sidebar-views.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
