### PR TITLE
feat(macos): stop filtering channel-bound conversations, wire originChannel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -806,7 +806,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         serverOffset += response.conversations.count
 
         let recentConversations = response.conversations.filter {
-            $0.conversationType != "private" && $0.channelBinding?.sourceChannel == nil
+            $0.conversationType != "private"
         }
 
         // Compute the next pinnedOrder based on existing pinned conversations AND
@@ -982,8 +982,8 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             return true
         }
 
-        // Don't insert external-channel or private conversations into the main sidebar
-        if conversation.conversationType == "private" || conversation.channelBinding?.sourceChannel != nil {
+        // Don't insert private conversations into the main sidebar
+        if conversation.conversationType == "private" {
             return false
         }
 
@@ -1016,8 +1016,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
 
     @discardableResult
     private func upsertConversation(from item: ConversationListResponseItem, isArchived: Bool) -> UUID? {
-        guard item.conversationType != "private",
-              item.channelBinding?.sourceChannel == nil else { return nil }
+        guard item.conversationType != "private" else { return nil }
 
         if !isArchived && isConversationArchived(item.id) {
             var archived = archivedConversationIds
@@ -1087,7 +1086,8 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             lastSeenAssistantMessageAt: item.assistantAttention?.lastSeenAssistantMessageAt.map {
                 Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
             },
-            forkParent: item.forkParent
+            forkParent: item.forkParent,
+            originChannel: item.channelBinding?.sourceChannel ?? item.conversationOriginChannel
         )
     }
 
@@ -1328,7 +1328,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
     /// explicitly reordered (non-nil displayOrder), sends their displayOrder. For
     /// unpinned conversations without explicit ordering, sends nil so they sort by recency.
     private func sendReorderConversations() {
-        let visible = visibleConversations
+        let visible = visibleConversations.filter { !$0.isChannelConversation }
         var updates: [ReorderConversationsRequestUpdate] = []
         for conversation in visible {
             guard let conversationId = conversation.conversationId else { continue }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -210,11 +210,9 @@ final class ConversationRestorer {
             return
         }
 
-        // Filter out private conversations and conversations bound to external channels
-        // (e.g. Telegram). External channel-bound conversations belong to their own
-        // lane and should not appear in the desktop conversation list.
+        // Filter out private conversations.
         let recentConversations = response.conversations.filter {
-            $0.conversationType != "private" && $0.channelBinding?.sourceChannel == nil
+            $0.conversationType != "private"
         }
 
         let defaultConversationIsEmpty = delegate.conversations.count == 1
@@ -275,7 +273,8 @@ final class ConversationRestorer {
                 lastSeenAssistantMessageAt: session.assistantAttention?.lastSeenAssistantMessageAt.map {
                     Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
                 },
-                forkParent: session.forkParent
+                forkParent: session.forkParent,
+                originChannel: session.channelBinding?.sourceChannel ?? session.conversationOriginChannel
             )
             if isPinned && session.displayOrder == nil { pinnedCount += 1 }
             // VM creation is lazy — only the active conversation will get a VM via

--- a/clients/macos/vellum-assistantTests/ConversationRestorerTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationRestorerTests.swift
@@ -595,7 +595,7 @@ struct ConversationRestorerTests {
     // MARK: - Channel Binding Filtering
 
     @Test @MainActor
-    func telegramBoundConversationIsExcludedFromRestore() {
+    func telegramBoundConversationIsIncludedInRestore() {
         let dc = GatewayConnectionManager()
         let restorer = ConversationRestorer(connectionManager: dc, eventStreamClient: dc.eventStreamClient)
         let delegate = MockConversationRestorerDelegate(connectionManager: dc, eventStreamClient: dc.eventStreamClient)
@@ -611,15 +611,15 @@ struct ConversationRestorerTests {
         ])
         restorer.handleConversationListResponse(response)
 
-        // Telegram-bound conversation filtered out; empty default removed; new conversation created
+        // Telegram-bound conversation is included with originChannel populated
         #expect(delegate.conversations.count == 1)
-        #expect(delegate.conversations[0].kind == .standard)
-        #expect(delegate.conversations[0].conversationId == nil)
-        #expect(delegate.createConversationCallCount == 1)
+        #expect(delegate.conversations[0].conversationId == "s1")
+        #expect(delegate.conversations[0].originChannel == "telegram")
+        #expect(delegate.createConversationCallCount == 0)
     }
 
     @Test @MainActor
-    func voiceBoundConversationIsExcludedFromRestore() {
+    func voiceBoundConversationIsIncludedInRestore() {
         let dc = GatewayConnectionManager()
         let restorer = ConversationRestorer(connectionManager: dc, eventStreamClient: dc.eventStreamClient)
         let delegate = MockConversationRestorerDelegate(connectionManager: dc, eventStreamClient: dc.eventStreamClient)
@@ -635,15 +635,15 @@ struct ConversationRestorerTests {
         ])
         restorer.handleConversationListResponse(response)
 
-        // Voice-bound conversation filtered out; empty default removed; new conversation created
+        // Voice-bound conversation is included with originChannel populated
         #expect(delegate.conversations.count == 1)
-        #expect(delegate.conversations[0].kind == .standard)
-        #expect(delegate.conversations[0].conversationId == nil)
-        #expect(delegate.createConversationCallCount == 1)
+        #expect(delegate.conversations[0].conversationId == "s1")
+        #expect(delegate.conversations[0].originChannel == "phone")
+        #expect(delegate.createConversationCallCount == 0)
     }
 
     @Test @MainActor
-    func mixedDesktopVoiceAndTelegramRestoresOnlyDesktop() {
+    func mixedDesktopVoiceAndTelegramRestoresAll() {
         let dc = GatewayConnectionManager()
         let restorer = ConversationRestorer(connectionManager: dc, eventStreamClient: dc.eventStreamClient)
         let delegate = MockConversationRestorerDelegate(connectionManager: dc, eventStreamClient: dc.eventStreamClient)
@@ -663,17 +663,17 @@ struct ConversationRestorerTests {
         ])
         restorer.handleConversationListResponse(response)
 
-        // Only the two desktop conversations should be restored
-        #expect(delegate.conversations.count == 2)
-        #expect(delegate.conversations[0].conversationId == "s1")
-        #expect(delegate.conversations[0].title == "Desktop Chat")
-        #expect(delegate.conversations[1].conversationId == "s4")
-        #expect(delegate.conversations[1].title == "Another Desktop Chat")
+        // All four conversations should be restored with correct originChannel values
+        #expect(delegate.conversations.count == 4)
+        #expect(delegate.conversations[0].originChannel == nil)
+        #expect(delegate.conversations[1].originChannel == "telegram")
+        #expect(delegate.conversations[2].originChannel == "phone")
+        #expect(delegate.conversations[3].originChannel == nil)
         #expect(delegate.createConversationCallCount == 0)
     }
 
     @Test @MainActor
-    func mixedDesktopAndTelegramRestoresOnlyDesktop() {
+    func mixedDesktopAndTelegramRestoresAll() {
         let dc = GatewayConnectionManager()
         let restorer = ConversationRestorer(connectionManager: dc, eventStreamClient: dc.eventStreamClient)
         let delegate = MockConversationRestorerDelegate(connectionManager: dc, eventStreamClient: dc.eventStreamClient)
@@ -691,12 +691,9 @@ struct ConversationRestorerTests {
         ])
         restorer.handleConversationListResponse(response)
 
-        // Only the two desktop conversations should be restored
-        #expect(delegate.conversations.count == 2)
-        #expect(delegate.conversations[0].conversationId == "s1")
-        #expect(delegate.conversations[0].title == "Desktop Chat")
-        #expect(delegate.conversations[1].conversationId == "s3")
-        #expect(delegate.conversations[1].title == "Another Desktop Chat")
+        // All three conversations should be restored with correct originChannel values
+        #expect(delegate.conversations.count == 3)
+        #expect(delegate.conversations[1].originChannel == "telegram")
         #expect(delegate.createConversationCallCount == 0)
     }
 }


### PR DESCRIPTION
## Summary
- Wire `originChannel` through conversation factories (`ConversationManager.conversationModel` and `ConversationRestorer`)
- Remove channel-binding filters at 4 ingestion points so channel conversations flow into the sidebar
- Exclude channel conversations from reorder API calls
- Update tests to verify channel conversations are now included with correct `originChannel`

Part of plan: channel-sidebar-views.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21986" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
