### PR TITLE
feat: include requester name and tool input in guardian approval questionText

### DIFF
--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -11,6 +11,7 @@ import { getTaskRunRules } from "../tasks/ephemeral-permissions.js";
 import { getLogger } from "../util/logger.js";
 import { getAllTools, getTool } from "./registry.js";
 import { isSideEffectTool } from "./side-effects.js";
+import { summarizeToolInput } from "./tool-input-summary.js";
 import type {
   ExecutionTarget,
   Tool,
@@ -21,6 +22,22 @@ import type {
 import { enforceVerificationControlPlanePolicy } from "./verification-control-plane-policy.js";
 
 const log = getLogger("tool-approval-handler");
+
+function buildToolGrantQuestionText(
+  toolName: string,
+  input: Record<string, unknown>,
+  context: ToolContext,
+): string {
+  const senderLabel =
+    context.requesterDisplayName ||
+    context.requesterIdentifier ||
+    context.requesterExternalUserId ||
+    "A trusted contact";
+  const inputSummary = summarizeToolInput(toolName, input);
+  return inputSummary
+    ? `${senderLabel} wants to use "${toolName}": ${inputSummary}`
+    : `${senderLabel} is requesting permission to use "${toolName}"`;
+}
 
 /** Default polling interval for inline grant wait (ms). */
 export const TC_GRANT_WAIT_INTERVAL_MS = 500;
@@ -494,7 +511,8 @@ export class ToolApprovalHandler {
           requesterChatId: context.requesterChatId,
           toolName: name,
           inputDigest,
-          questionText: `Trusted contact is requesting permission to use "${name}"`,
+          questionText: buildToolGrantQuestionText(name, input, context),
+          requesterIdentifier: context.requesterDisplayName || context.requesterIdentifier,
         });
 
         // Only wait inline if the escalation succeeded (created or deduped).


### PR DESCRIPTION
## Summary
- Replace generic questionText with informative text including requester name and tool input summary
- Pass requesterIdentifier through to notification signal for human-readable sender labels

Part of plan: guardian-approval-ux.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
