### PR TITLE
feat: use deterministic conversation seed for tool grant approval notifications

### DIFF
--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -147,6 +147,19 @@ export class NotificationBroadcaster {
         };
       }
 
+      // For tool_grant_request signals, prefer the deterministic template seed
+      // over LLM-generated prose. The enriched questionText is already concise
+      // and informative — LLM rewording just adds noise.
+      if (signal.contextPayload?.requestKind === "tool_grant_request") {
+        if (!fallbackCopy) {
+          fallbackCopy = composeFallbackCopy(signal, decision.selectedChannels);
+        }
+        const templateSeed = fallbackCopy[channel]?.conversationSeedMessage;
+        if (templateSeed) {
+          copy = { ...copy, conversationSeedMessage: templateSeed };
+        }
+      }
+
       // Resolve the per-channel conversation action from the decision (default: start_new)
       const conversationAction: ConversationAction | undefined =
         decision.conversationActions?.[channel];

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -326,10 +326,17 @@ const TEMPLATES: Partial<Record<NotificationSourceEventName, CopyTemplate>> = {
     const requestCode = nonEmpty(
       typeof payload.requestCode === "string" ? payload.requestCode : undefined,
     );
+
+    // For tool_grant_request, the questionText already includes requester name + input summary.
+    // Use it directly as the conversation seed to avoid LLM-generated filler.
+    const isToolGrant = payload.requestKind === "tool_grant_request";
+    const conversationSeedMessage = isToolGrant ? question : undefined;
+
     if (!requestCode) {
       return {
         title: "Guardian Question",
         body: question,
+        conversationSeedMessage,
       };
     }
 
@@ -342,6 +349,7 @@ const TEMPLATES: Partial<Record<NotificationSourceEventName, CopyTemplate>> = {
     return {
       title: "Guardian Question",
       body: `${question}\n\n${instruction}`,
+      conversationSeedMessage,
     };
   },
 


### PR DESCRIPTION
## Summary
- Set conversationSeedMessage in copy-composer template for tool_grant_request signals
- Override LLM-generated seed in broadcaster for tool_grant_request signals
- Eliminates verbose LLM filler in guardian approval notification conversations

Part of plan: guardian-approval-ux.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21988" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
