### PR TITLE
Add mouse wheel zoom to skills constellation graph

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -177,6 +177,92 @@ struct ChatView: View {
         #if DEBUG
         let _ = os_signpost(.event, log: PerfSignposts.log, name: "ChatView.body")
         #endif
+        chatContent
+            .environment(\.dropActions, currentDropActions)
+            .onDrop(of: [.fileURL, .image, .png, .tiff], isTargeted: $isDropTargeted) { providers in
+                handleDrop(providers: providers)
+            }
+            .onKeyPress(.escape) {
+                guard isInteractionEnabled else { return .ignored }
+                if isSearchActive {
+                    dismissSearch()
+                    return .handled
+                }
+                if btwResponse != nil {
+                    onDismissBtw?()
+                    return .handled
+                }
+                return .ignored
+            }
+            .onKeyPress("f", phases: .down) { press in
+                guard isInteractionEnabled, press.modifiers == .command else { return .ignored }
+                activateSearch()
+                return .handled
+            }
+            .overlay(alignment: .topTrailing) {
+                if isSearchActive {
+                    ChatSearchBar(
+                        searchText: $searchText,
+                        matchCount: searchMatches.count,
+                        currentMatchIndex: currentMatchIndex,
+                        onPrevious: { navigateMatch(delta: -1) },
+                        onNext: { navigateMatch(delta: 1) },
+                        onDismiss: { dismissSearch() }
+                    )
+                    .padding(.trailing, VSpacing.xl)
+                    .padding(.top, VSpacing.sm)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+                }
+            }
+            .animation(VAnimation.fast, value: isSearchActive)
+            .onChange(of: searchText) {
+                // Reset to first match when query changes
+                currentMatchIndex = 0
+                scrollToCurrentMatch()
+            }
+            .onChange(of: searchMatches.count) {
+                // Clamp currentMatchIndex when matches change (e.g. streaming, deletion)
+                // to avoid "4 of 2" display or broken navigation.
+                let count = searchMatches.count
+                if currentMatchIndex >= count {
+                    currentMatchIndex = max(count - 1, 0)
+                }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .activateChatSearch)) { notification in
+                // Scope to the active conversation so only the visible ChatView activates.
+                if let targetId = notification.object as? UUID, targetId != conversationId {
+                    return
+                }
+                activateSearch()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .internalImageDragStarted)) { _ in
+                isDraggingInternalImage = true
+                // Install one-shot monitors to detect when the drag ends.
+                // NSDraggingSession consumes the drag-ending mouse-up internally,
+                // so a single local monitor misses drops on external apps.
+                // Global monitor catches mouse-up in other apps (Finder, Desktop).
+                // Local monitor catches mouse-up within our app (cancel + release).
+                installDragEndMonitors()
+            }
+            .onChange(of: shouldShowSkeleton, initial: true) { _, shouldShow in
+                skeletonDebounceTask?.cancel()
+                if shouldShow {
+                    skeletonDebounceTask = Task {
+                        try? await Task.sleep(nanoseconds: 200_000_000) // 200ms
+                        guard !Task.isCancelled else { return }
+                        showSkeleton = true
+                    }
+                } else {
+                    showSkeleton = false
+                }
+            }
+            .onDisappear {
+                removeDragEndMonitors()
+            }
+    }
+
+    @ViewBuilder
+    private var chatContent: some View {
         ZStack {
             VStack(spacing: 0) {
                 if showSkeleton {
@@ -192,165 +278,9 @@ struct ChatView: View {
                         ChatBootstrapLoadingView()
                     }
                 } else if isEmptyState {
-                    if isTemporaryChat {
-                        ChatTemporaryChatEmptyStateView(
-                            inputText: $inputText,
-                            isSending: isSending,
-                            isAssistantBusy: isAssistantBusy,
-                            isRecording: isRecording,
-                            suggestion: suggestion,
-                            pendingAttachments: pendingAttachments,
-                            isLoadingAttachment: isLoadingAttachment,
-                            onSend: onSend,
-                            onStop: onStop,
-                            onAcceptSuggestion: onAcceptSuggestion,
-                            onAttach: onAttach,
-                            onRemoveAttachment: onRemoveAttachment,
-                            onPaste: onPaste,
-                            onMicrophoneToggle: onMicrophoneToggle,
-                            recordingAmplitude: recordingAmplitude,
-                            onDictateToggle: onDictateToggle,
-                            onVoiceModeToggle: onVoiceModeToggle,
-                            conversationId: conversationId
-                        )
-                    } else {
-                        ChatEmptyStateView(
-                            inputText: $inputText,
-                            isSending: isSending,
-                            isAssistantBusy: isAssistantBusy,
-                            isRecording: isRecording,
-                            suggestion: suggestion,
-                            pendingAttachments: pendingAttachments,
-                            isLoadingAttachment: isLoadingAttachment,
-                            onSend: onSend,
-                            onStop: onStop,
-                            onAcceptSuggestion: onAcceptSuggestion,
-                            onAttach: onAttach,
-                            onRemoveAttachment: onRemoveAttachment,
-                            onPaste: onPaste,
-                            onMicrophoneToggle: onMicrophoneToggle,
-                            recordingAmplitude: recordingAmplitude,
-                            onDictateToggle: onDictateToggle,
-                            onVoiceModeToggle: onVoiceModeToggle,
-                            conversationId: conversationId,
-                            daemonGreeting: daemonGreeting,
-                            onRequestGreeting: onRequestGreeting,
-                            conversationStarters: conversationStarters,
-                            conversationStartersLoading: conversationStartersLoading,
-                            onSelectStarter: onSelectStarter,
-                            onFetchConversationStarters: onFetchConversationStarters
-                        )
-                    }
+                    chatEmptyState
                 } else {
-                    VStack(spacing: 0) {
-                        MessageListView(
-                            messages: messages,
-                            isSending: isSending,
-                            isThinking: isThinking,
-                            isCompacting: isCompacting,
-                            assistantActivityPhase: assistantActivityPhase,
-                            assistantActivityAnchor: assistantActivityAnchor,
-                            assistantActivityReason: assistantActivityReason,
-                            assistantStatusText: assistantStatusText,
-                            selectedModel: selectedModel,
-                            configuredProviders: configuredProviders,
-                            providerCatalog: providerCatalog,
-                            activeSubagents: activeSubagents,
-                            dismissedDocumentSurfaceIds: dismissedDocumentSurfaceIds,
-                            onConfirmationAllow: onConfirmationAllow,
-                            onConfirmationDeny: onConfirmationDeny,
-                            onAlwaysAllow: onAlwaysAllow,
-                            onTemporaryAllow: onTemporaryAllow,
-                            onSurfaceAction: onSurfaceAction,
-                            onGuardianAction: onGuardianAction,
-                            onDismissDocumentWidget: onDismissDocumentWidget,
-                            onForkFromMessage: onForkFromMessage,
-                            showInspectButton: showInspectButton,
-                            isTTSEnabled: isTTSEnabled,
-                            onInspectMessage: onInspectMessage,
-                            mediaEmbedSettings: mediaEmbedSettings,
-                            onAbortSubagent: onAbortSubagent,
-                            onSubagentTap: onSubagentTap,
-                            onRehydrateMessage: onRehydrateMessage,
-                            onSurfaceRefetch: onSurfaceRefetch,
-                            onRetryFailedMessage: onRetryFailedMessage,
-                            onRetryConversationError: onRetryConversationError,
-                            subagentDetailStore: subagentDetailStore,
-                            activePendingRequestId: activePendingRequestId,
-                            displayedMessageCount: displayedMessageCount,
-                            hasMoreMessages: hasMoreMessages,
-                            isLoadingMoreMessages: isLoadingMoreMessages,
-                            loadPreviousMessagePage: loadPreviousMessagePage,
-                            conversationId: conversationId,
-                            anchorMessageId: $anchorMessageId,
-                            highlightedMessageId: $highlightedMessageId,
-                            isNearBottom: $isNearBottom,
-                            containerWidth: containerWidth
-                        )
-
-                        if let exhaustedError = creditsExhaustedError, exhaustedError.isCreditsExhausted {
-                            CreditsExhaustedBanner(
-                                onAddFunds: { onAddFunds?() }
-                            )
-                            .frame(maxWidth: VSpacing.chatColumnMaxWidth - 2 * VSpacing.xl)
-                            .frame(maxWidth: .infinity)
-                            .padding(.bottom, -VSpacing.sm)
-                        }
-
-                        if let _ = providerNotConfiguredError {
-                            MissingApiKeyBanner(
-                                onOpenSettings: { onOpenModelsAndServices?() },
-                                onDismiss: { onDismissProviderNotConfigured?() }
-                            )
-                            .frame(maxWidth: VSpacing.chatColumnMaxWidth - 2 * VSpacing.xl)
-                            .frame(maxWidth: .infinity)
-                            .padding(.bottom, -VSpacing.sm)
-                        }
-
-                        if isReadonly {
-                            HStack(spacing: VSpacing.xs) {
-                                VIconView(.eye, size: 14)
-                                Text("Read-only conversation")
-                                    .font(VFont.caption)
-                            }
-                            .foregroundStyle(VColor.contentTertiary)
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, VSpacing.md)
-                        } else {
-                            ComposerSection(
-                                inputText: $inputText,
-                                isSending: isSending,
-                                isAssistantBusy: isAssistantBusy,
-                                hasPendingConfirmation: activePendingRequestId != nil,
-                                onAllowPendingConfirmation: {
-                                    if let requestId = activePendingRequestId {
-                                        onConfirmationAllow(requestId)
-                                    }
-                                },
-                                isRecording: isRecording,
-                                suggestion: suggestion,
-                                pendingAttachments: pendingAttachments,
-                                isLoadingAttachment: isLoadingAttachment,
-                                onSend: onSend,
-                                onStop: onStop,
-                                onAcceptSuggestion: onAcceptSuggestion,
-                                onAttach: onAttach,
-                                onRemoveAttachment: onRemoveAttachment,
-                                onPaste: onPaste,
-                                onMicrophoneToggle: onMicrophoneToggle,
-                                watchSession: watchSession,
-                                onStopWatch: onStopWatch,
-                                voiceModeManager: voiceModeManager,
-                                voiceService: voiceService,
-                                onEndVoiceMode: onEndVoiceMode,
-                                recordingAmplitude: recordingAmplitude,
-                                onDictateToggle: onDictateToggle,
-                                onVoiceModeToggle: onVoiceModeToggle,
-                                conversationId: conversationId,
-                                isInteractionEnabled: isInteractionEnabled
-                            )
-                        }
-                    }
+                    chatActiveState
                 }
             }
             .background(alignment: .bottom) {
@@ -391,86 +321,171 @@ struct ChatView: View {
                     .transition(.opacity)
             }
         }
-        .environment(\.dropActions, currentDropActions)
-        .onDrop(of: [.fileURL, .image, .png, .tiff], isTargeted: $isDropTargeted) { providers in
-            handleDrop(providers: providers)
+    }
+
+    @ViewBuilder
+    private var chatEmptyState: some View {
+        if isTemporaryChat {
+            ChatTemporaryChatEmptyStateView(
+                inputText: $inputText,
+                isSending: isSending,
+                isAssistantBusy: isAssistantBusy,
+                isRecording: isRecording,
+                suggestion: suggestion,
+                pendingAttachments: pendingAttachments,
+                isLoadingAttachment: isLoadingAttachment,
+                onSend: onSend,
+                onStop: onStop,
+                onAcceptSuggestion: onAcceptSuggestion,
+                onAttach: onAttach,
+                onRemoveAttachment: onRemoveAttachment,
+                onPaste: onPaste,
+                onMicrophoneToggle: onMicrophoneToggle,
+                recordingAmplitude: recordingAmplitude,
+                onDictateToggle: onDictateToggle,
+                onVoiceModeToggle: onVoiceModeToggle,
+                conversationId: conversationId
+            )
+        } else {
+            ChatEmptyStateView(
+                inputText: $inputText,
+                isSending: isSending,
+                isAssistantBusy: isAssistantBusy,
+                isRecording: isRecording,
+                suggestion: suggestion,
+                pendingAttachments: pendingAttachments,
+                isLoadingAttachment: isLoadingAttachment,
+                onSend: onSend,
+                onStop: onStop,
+                onAcceptSuggestion: onAcceptSuggestion,
+                onAttach: onAttach,
+                onRemoveAttachment: onRemoveAttachment,
+                onPaste: onPaste,
+                onMicrophoneToggle: onMicrophoneToggle,
+                recordingAmplitude: recordingAmplitude,
+                onDictateToggle: onDictateToggle,
+                onVoiceModeToggle: onVoiceModeToggle,
+                conversationId: conversationId,
+                daemonGreeting: daemonGreeting,
+                onRequestGreeting: onRequestGreeting,
+                conversationStarters: conversationStarters,
+                conversationStartersLoading: conversationStartersLoading,
+                onSelectStarter: onSelectStarter,
+                onFetchConversationStarters: onFetchConversationStarters
+            )
         }
-        .onKeyPress(.escape) {
-            guard isInteractionEnabled else { return .ignored }
-            if isSearchActive {
-                dismissSearch()
-                return .handled
-            }
-            if btwResponse != nil {
-                onDismissBtw?()
-                return .handled
-            }
-            return .ignored
-        }
-        .onKeyPress("f", phases: .down) { press in
-            guard isInteractionEnabled, press.modifiers == .command else { return .ignored }
-            activateSearch()
-            return .handled
-        }
-        .overlay(alignment: .topTrailing) {
-            if isSearchActive {
-                ChatSearchBar(
-                    searchText: $searchText,
-                    matchCount: searchMatches.count,
-                    currentMatchIndex: currentMatchIndex,
-                    onPrevious: { navigateMatch(delta: -1) },
-                    onNext: { navigateMatch(delta: 1) },
-                    onDismiss: { dismissSearch() }
+    }
+
+    @ViewBuilder
+    private var chatActiveState: some View {
+        VStack(spacing: 0) {
+            MessageListView(
+                messages: messages,
+                isSending: isSending,
+                isThinking: isThinking,
+                isCompacting: isCompacting,
+                assistantActivityPhase: assistantActivityPhase,
+                assistantActivityAnchor: assistantActivityAnchor,
+                assistantActivityReason: assistantActivityReason,
+                assistantStatusText: assistantStatusText,
+                selectedModel: selectedModel,
+                configuredProviders: configuredProviders,
+                providerCatalog: providerCatalog,
+                activeSubagents: activeSubagents,
+                dismissedDocumentSurfaceIds: dismissedDocumentSurfaceIds,
+                onConfirmationAllow: onConfirmationAllow,
+                onConfirmationDeny: onConfirmationDeny,
+                onAlwaysAllow: onAlwaysAllow,
+                onTemporaryAllow: onTemporaryAllow,
+                onSurfaceAction: onSurfaceAction,
+                onGuardianAction: onGuardianAction,
+                onDismissDocumentWidget: onDismissDocumentWidget,
+                onForkFromMessage: onForkFromMessage,
+                showInspectButton: showInspectButton,
+                isTTSEnabled: isTTSEnabled,
+                onInspectMessage: onInspectMessage,
+                mediaEmbedSettings: mediaEmbedSettings,
+                onAbortSubagent: onAbortSubagent,
+                onSubagentTap: onSubagentTap,
+                onRehydrateMessage: onRehydrateMessage,
+                onSurfaceRefetch: onSurfaceRefetch,
+                onRetryFailedMessage: onRetryFailedMessage,
+                onRetryConversationError: onRetryConversationError,
+                subagentDetailStore: subagentDetailStore,
+                activePendingRequestId: activePendingRequestId,
+                displayedMessageCount: displayedMessageCount,
+                hasMoreMessages: hasMoreMessages,
+                isLoadingMoreMessages: isLoadingMoreMessages,
+                loadPreviousMessagePage: loadPreviousMessagePage,
+                conversationId: conversationId,
+                anchorMessageId: $anchorMessageId,
+                highlightedMessageId: $highlightedMessageId,
+                isNearBottom: $isNearBottom,
+                containerWidth: containerWidth
+            )
+
+            if let exhaustedError = creditsExhaustedError, exhaustedError.isCreditsExhausted {
+                CreditsExhaustedBanner(
+                    onAddFunds: { onAddFunds?() }
                 )
-                .padding(.trailing, VSpacing.xl)
-                .padding(.top, VSpacing.sm)
-                .transition(.opacity.combined(with: .move(edge: .top)))
+                .frame(maxWidth: VSpacing.chatColumnMaxWidth - 2 * VSpacing.xl)
+                .frame(maxWidth: .infinity)
+                .padding(.bottom, -VSpacing.sm)
             }
-        }
-        .animation(VAnimation.fast, value: isSearchActive)
-        .onChange(of: searchText) {
-            // Reset to first match when query changes
-            currentMatchIndex = 0
-            scrollToCurrentMatch()
-        }
-        .onChange(of: searchMatches.count) {
-            // Clamp currentMatchIndex when matches change (e.g. streaming, deletion)
-            // to avoid "4 of 2" display or broken navigation.
-            let count = searchMatches.count
-            if currentMatchIndex >= count {
-                currentMatchIndex = max(count - 1, 0)
+
+            if let _ = providerNotConfiguredError {
+                MissingApiKeyBanner(
+                    onOpenSettings: { onOpenModelsAndServices?() },
+                    onDismiss: { onDismissProviderNotConfigured?() }
+                )
+                .frame(maxWidth: VSpacing.chatColumnMaxWidth - 2 * VSpacing.xl)
+                .frame(maxWidth: .infinity)
+                .padding(.bottom, -VSpacing.sm)
             }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .activateChatSearch)) { notification in
-            // Scope to the active conversation so only the visible ChatView activates.
-            if let targetId = notification.object as? UUID, targetId != conversationId {
-                return
-            }
-            activateSearch()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .internalImageDragStarted)) { _ in
-            isDraggingInternalImage = true
-            // Install one-shot monitors to detect when the drag ends.
-            // NSDraggingSession consumes the drag-ending mouse-up internally,
-            // so a single local monitor misses drops on external apps.
-            // Global monitor catches mouse-up in other apps (Finder, Desktop).
-            // Local monitor catches mouse-up within our app (cancel + release).
-            installDragEndMonitors()
-        }
-        .onChange(of: shouldShowSkeleton, initial: true) { _, shouldShow in
-            skeletonDebounceTask?.cancel()
-            if shouldShow {
-                skeletonDebounceTask = Task {
-                    try? await Task.sleep(nanoseconds: 200_000_000) // 200ms
-                    guard !Task.isCancelled else { return }
-                    showSkeleton = true
+
+            if isReadonly {
+                HStack(spacing: VSpacing.xs) {
+                    VIconView(.eye, size: 14)
+                    Text("Read-only conversation")
+                        .font(VFont.labelDefault)
                 }
+                .foregroundStyle(VColor.contentTertiary)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, VSpacing.md)
             } else {
-                showSkeleton = false
+                ComposerSection(
+                    inputText: $inputText,
+                    isSending: isSending,
+                    isAssistantBusy: isAssistantBusy,
+                    hasPendingConfirmation: activePendingRequestId != nil,
+                    onAllowPendingConfirmation: {
+                        if let requestId = activePendingRequestId {
+                            onConfirmationAllow(requestId)
+                        }
+                    },
+                    isRecording: isRecording,
+                    suggestion: suggestion,
+                    pendingAttachments: pendingAttachments,
+                    isLoadingAttachment: isLoadingAttachment,
+                    onSend: onSend,
+                    onStop: onStop,
+                    onAcceptSuggestion: onAcceptSuggestion,
+                    onAttach: onAttach,
+                    onRemoveAttachment: onRemoveAttachment,
+                    onPaste: onPaste,
+                    onMicrophoneToggle: onMicrophoneToggle,
+                    watchSession: watchSession,
+                    onStopWatch: onStopWatch,
+                    voiceModeManager: voiceModeManager,
+                    voiceService: voiceService,
+                    onEndVoiceMode: onEndVoiceMode,
+                    recordingAmplitude: recordingAmplitude,
+                    onDictateToggle: onDictateToggle,
+                    onVoiceModeToggle: onVoiceModeToggle,
+                    conversationId: conversationId,
+                    isInteractionEnabled: isInteractionEnabled
+                )
             }
-        }
-        .onDisappear {
-            removeDragEndMonitors()
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -801,8 +801,6 @@ struct ConstellationView: View {
     /// Accumulated drag offset for the node currently being dragged.
     @State private var activeNodeDrag: (id: String, offset: CGSize)?
 
-    /// Event monitor for mouse-wheel scroll zoom.
-    @State private var scrollWheelMonitor: Any?
 
     private var existingFiles: [WorkspaceFileNode] {
         workspaceFiles.filter { $0.exists }
@@ -996,34 +994,6 @@ struct ConstellationView: View {
         }
     }
 
-    // MARK: - Mouse Wheel Zoom
-
-    private func installScrollWheelMonitor() {
-        scrollWheelMonitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { event in
-            // Only handle discrete mouse-wheel scrolling.
-            // Precise scrolling (trackpad two-finger) is handled by MagnifyGesture.
-            guard !event.hasPreciseScrollingDeltas else { return event }
-
-            let delta = event.scrollingDeltaY / 10
-            guard abs(delta) > 0.001 else { return event }
-
-            let newScale = max(0.4, min(3.0, zoomScale * (1 + delta)))
-            withAnimation(VAnimation.snappy) {
-                zoomScale = newScale
-                baseZoomScale = newScale
-                zoomedNodeId = nil
-            }
-            return nil
-        }
-    }
-
-    private func removeScrollWheelMonitor() {
-        if let monitor = scrollWheelMonitor {
-            NSEvent.removeMonitor(monitor)
-            scrollWheelMonitor = nil
-        }
-    }
-
     /// Shared drag gesture for any draggable node.
     private func nodeDragGesture(nodeId: String) -> some Gesture {
         DragGesture(minimumDistance: 4)
@@ -1178,12 +1148,18 @@ struct ConstellationView: View {
                             zoomedNodeId = nil
                         }
                 )
+                .background {
+                    ScrollWheelZoomHelper { delta in
+                        let newScale = max(0.4, min(3.0, zoomScale * (1 + delta)))
+                        withAnimation(VAnimation.snappy) {
+                            zoomScale = newScale
+                            baseZoomScale = newScale
+                            zoomedNodeId = nil
+                        }
+                    }
+                }
                 .onAppear {
                     layoutAndAnimate(viewSize: proxy.size)
-                    installScrollWheelMonitor()
-                }
-                .onDisappear {
-                    removeScrollWheelMonitor()
                 }
                 .onChange(of: skills.count) { _, _ in
                     layoutAndAnimate(viewSize: proxy.size)
@@ -1478,6 +1454,60 @@ private struct DottedGridBackground: View {
                     )
                 }
             }
+        }
+    }
+}
+
+// MARK: - Scroll Wheel Zoom Helper
+
+/// Transparent NSViewRepresentable that intercepts discrete mouse-wheel scroll
+/// events over this view's bounds and converts them into zoom deltas.
+/// Trackpad (precise) scrolling is left untouched for `MagnifyGesture`.
+private struct ScrollWheelZoomHelper: NSViewRepresentable {
+    var onZoomDelta: (CGFloat) -> Void
+
+    func makeCoordinator() -> Coordinator { Coordinator(onZoomDelta: onZoomDelta) }
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        let coordinator = context.coordinator
+        coordinator.view = view
+        coordinator.monitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { event in
+            guard let v = coordinator.view,
+                  let window = v.window,
+                  event.window == window else { return event }
+            let location = v.convert(event.locationInWindow, from: nil)
+            guard v.bounds.width > 0, v.bounds.contains(location) else { return event }
+
+            // Only handle discrete mouse-wheel scrolling.
+            guard !event.hasPreciseScrollingDeltas else { return event }
+
+            let delta = event.scrollingDeltaY / 10
+            guard abs(delta) > 0.001 else { return event }
+
+            coordinator.onZoomDelta(delta)
+            return nil
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        context.coordinator.onZoomDelta = onZoomDelta
+    }
+
+    static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+        if let monitor = coordinator.monitor {
+            NSEvent.removeMonitor(monitor)
+        }
+    }
+
+    class Coordinator {
+        weak var view: NSView?
+        var monitor: Any?
+        var onZoomDelta: (CGFloat) -> Void
+
+        init(onZoomDelta: @escaping (CGFloat) -> Void) {
+            self.onZoomDelta = onZoomDelta
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -1472,8 +1472,9 @@ private struct ScrollWheelZoomHelper: NSViewRepresentable {
         let view = NSView()
         let coordinator = context.coordinator
         coordinator.view = view
-        coordinator.monitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { event in
-            guard let v = coordinator.view,
+        coordinator.monitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { [weak coordinator] event in
+            guard let coordinator,
+                  let v = coordinator.view,
                   let window = v.window,
                   event.window == window else { return event }
             let location = v.convert(event.locationInWindow, from: nil)
@@ -1498,6 +1499,7 @@ private struct ScrollWheelZoomHelper: NSViewRepresentable {
     static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
         if let monitor = coordinator.monitor {
             NSEvent.removeMonitor(monitor)
+            coordinator.monitor = nil
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ConstellationView.swift
@@ -801,6 +801,9 @@ struct ConstellationView: View {
     /// Accumulated drag offset for the node currently being dragged.
     @State private var activeNodeDrag: (id: String, offset: CGSize)?
 
+    /// Event monitor for mouse-wheel scroll zoom.
+    @State private var scrollWheelMonitor: Any?
+
     private var existingFiles: [WorkspaceFileNode] {
         workspaceFiles.filter { $0.exists }
     }
@@ -993,6 +996,34 @@ struct ConstellationView: View {
         }
     }
 
+    // MARK: - Mouse Wheel Zoom
+
+    private func installScrollWheelMonitor() {
+        scrollWheelMonitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { event in
+            // Only handle discrete mouse-wheel scrolling.
+            // Precise scrolling (trackpad two-finger) is handled by MagnifyGesture.
+            guard !event.hasPreciseScrollingDeltas else { return event }
+
+            let delta = event.scrollingDeltaY / 10
+            guard abs(delta) > 0.001 else { return event }
+
+            let newScale = max(0.4, min(3.0, zoomScale * (1 + delta)))
+            withAnimation(VAnimation.snappy) {
+                zoomScale = newScale
+                baseZoomScale = newScale
+                zoomedNodeId = nil
+            }
+            return nil
+        }
+    }
+
+    private func removeScrollWheelMonitor() {
+        if let monitor = scrollWheelMonitor {
+            NSEvent.removeMonitor(monitor)
+            scrollWheelMonitor = nil
+        }
+    }
+
     /// Shared drag gesture for any draggable node.
     private func nodeDragGesture(nodeId: String) -> some Gesture {
         DragGesture(minimumDistance: 4)
@@ -1149,6 +1180,10 @@ struct ConstellationView: View {
                 )
                 .onAppear {
                     layoutAndAnimate(viewSize: proxy.size)
+                    installScrollWheelMonitor()
+                }
+                .onDisappear {
+                    removeScrollWheelMonitor()
                 }
                 .onChange(of: skills.count) { _, _ in
                     layoutAndAnimate(viewSize: proxy.size)


### PR DESCRIPTION
## Summary
- Add mouse scroll wheel zoom support to the constellation graph view
- Uses NSEvent local monitor for `.scrollWheel` events, filtering for discrete (non-trackpad) deltas
- Follows the same pattern already used in `ZoomableImageView` for the image lightbox
- Trackpad pinch-to-zoom continues to work via the existing `MagnifyGesture`

## Original prompt
--safe https://linear.app/vellum/issue/LUM-496/skills-constellation-graph-missing-mouse-wheel-zoom-only-trackpad

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21995" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
