### PR TITLE
fix(macos): replace nonexistent VFont.caption with bodySmallDefault

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -415,7 +415,7 @@ struct ChatView: View {
                 HStack(spacing: VSpacing.xs) {
                     VIconView(.eye, size: 14)
                     Text("Read-only conversation")
-                        .font(VFont.caption)
+                        .font(VFont.bodySmallDefault)
                 }
                 .foregroundStyle(VColor.contentTertiary)
                 .frame(maxWidth: .infinity)


### PR DESCRIPTION
## Summary
- Fix macOS CI build failure caused by `VFont.caption` — a member that doesn't exist in the `VFont` enum
- Replace with `VFont.bodySmallDefault` (12pt DM Sans) which is the appropriate caption-sized token for the read-only conversation banner

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23668853208/job/68957497252
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21996" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
