### PR TITLE
fix: update stale comment about guardian-on-behalf decision actions

### DIFF
--- a/assistant/src/runtime/routes/guardian-action-routes.ts
+++ b/assistant/src/runtime/routes/guardian-action-routes.ts
@@ -204,8 +204,8 @@ function mapCanonicalRequestToPrompt(
 ): GuardianDecisionPrompt {
   const questionText = buildKindAwareQuestionText(req);
 
-  // All guardian-on-behalf prompts use approve_once + reject only
-  // (no approve_always, no temporary modes).
+  // Guardian-on-behalf prompts include approve_once, temporal modes
+  // (approve_10m, approve_conversation), and reject — but not approve_always.
   const actions = buildDecisionActions({ forGuardianOnBehalf: true });
 
   const expiresAt = req.expiresAt


### PR DESCRIPTION
## Summary
Update comment that incorrectly states guardian-on-behalf prompts only offer approve_once + reject. Temporal modes (approve_10m, approve_conversation) are now included.

Part of plan: guardian-approval-ux.md (review fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21997" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
