### PR TITLE
refactor(macos): remove runtime configuredBaseURL from AuthService

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -95,13 +95,6 @@ extension AppDelegate {
 
         let assistant = loadAssistantFromLockfile()
 
-        // Seed AuthService with the platform URL from the lockfile so that any
-        // platform API calls before the daemon connects (e.g. organization
-        // resolution during managed bootstrap) use the correct URL.
-        if let assistant, assistant.isManaged, let runtimeUrl = assistant.runtimeUrl, !runtimeUrl.isEmpty {
-            AuthService.shared.configuredBaseURL = runtimeUrl
-        }
-
         configureDaemonTransport(for: assistant)
 
         // Set recovery credentials for automatic 401 re-bootstrap

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1421,16 +1421,8 @@ private struct AssistantLoadingOverlayContent: View {
     }
 
     /// Checks whether the connected managed assistant's lockfile runtime URL
-    /// matches the app's configured platform URL. Returns mismatch details
-    /// when they differ, or nil when there is no mismatch (or the assistant
-    /// is not managed).
-    ///
-    /// Only performs the check when an explicit platform URL source is
-    /// available (env var or already-populated `configuredBaseURL`). During
-    /// early loading `configuredBaseURL` may still be empty because the
-    /// daemon hasn't sent `platform_config_response` yet — falling back to
-    /// the hardcoded default would cause false positives for users on
-    /// non-default platform URLs.
+    /// matches the app's platform URL. Returns mismatch details when they
+    /// differ, or nil when there is no mismatch (or the assistant is not managed).
     @MainActor
     private static func detectPlatformURLMismatch() -> PlatformURLMismatchInfo? {
         #if os(macOS)
@@ -1442,13 +1434,7 @@ private struct AssistantLoadingOverlayContent: View {
             return nil
         }
 
-        // Resolve the platform URL only from sources that are reliably
-        // available at this point — the env var and (in debug) UserDefaults.
-        // If neither is set, configuredBaseURL hasn't arrived from the daemon
-        // yet so we can't compare reliably; skip the check.
-        let explicitURL = resolveExplicitPlatformURL()
-        guard let configuredURL = explicitURL else { return nil }
-
+        let configuredURL = AuthService.shared.baseURL
         let normalizedConfigured = normalizeURL(configuredURL)
         let normalizedLockfile = normalizeURL(lockfileURL)
 
@@ -1457,32 +1443,6 @@ private struct AssistantLoadingOverlayContent: View {
         #else
         return nil
         #endif
-    }
-
-    /// Returns the platform URL only if an explicit source is available
-    /// (env var, daemon-configured value, or debug UserDefaults). Returns
-    /// nil when the URL would just be the hardcoded default — meaning the
-    /// actual configured URL isn't known yet.
-    @MainActor
-    private static func resolveExplicitPlatformURL() -> String? {
-        // 1. Environment variable override — always available.
-        if let envURL = ProcessInfo.processInfo.environment["VELLUM_PLATFORM_URL"],
-           !envURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            return envURL.trimmingCharacters(in: .whitespacesAndNewlines)
-        }
-        // 2. Daemon-configured URL — set after platform_config_response.
-        let configured = AuthService.shared.configuredBaseURL
-        if !configured.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            return configured
-        }
-        // 3. Debug UserDefaults fallback.
-        #if DEBUG
-        if let saved = UserDefaults.standard.string(forKey: "authServiceBaseURL"),
-           !saved.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            return saved
-        }
-        #endif
-        return nil
     }
 
     private static func normalizeURL(_ url: String) -> String {

--- a/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ReauthView.swift
@@ -163,19 +163,6 @@ struct ReauthView: View {
         authManager.errorMessage = nil
         defer { isActivatingManagedAssistant = false }
 
-        // Seed AuthService with the platform URL from the existing lockfile entry
-        // so that organization resolution hits the correct platform (e.g. dev-platform
-        // vs production) before the daemon is connected.
-        if let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
-           let managedAssistant = LockfileAssistant.loadByName(connectedId),
-           managedAssistant.isManaged,
-           let runtimeUrl = managedAssistant.runtimeUrl, !runtimeUrl.isEmpty {
-            AuthService.shared.configuredBaseURL = runtimeUrl
-        } else if let managedAssistant = LockfileAssistant.loadAll().first(where: { $0.isManaged }),
-                  let runtimeUrl = managedAssistant.runtimeUrl, !runtimeUrl.isEmpty {
-            AuthService.shared.configuredBaseURL = runtimeUrl
-        }
-
         do {
             let activation = try await ManagedAssistantConnectionCoordinator().activateManagedAssistantAfterReauth()
             didComplete = true

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2049,7 +2049,6 @@ public final class SettingsStore: ObservableObject {
             guard let response = await settingsClient.fetchPlatformConfig() else { return }
             if response.success {
                 self.platformBaseUrl = response.baseUrl
-                AuthService.shared.configuredBaseURL = response.baseUrl
             }
         }
     }
@@ -2058,16 +2057,13 @@ public final class SettingsStore: ObservableObject {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         let previous = platformBaseUrl
         platformBaseUrl = trimmed
-        AuthService.shared.configuredBaseURL = trimmed
         Task {
             guard let response = await settingsClient.setPlatformConfig(baseUrl: trimmed) else {
                 self.platformBaseUrl = previous
-                AuthService.shared.configuredBaseURL = previous
                 return
             }
             if !response.success {
                 self.platformBaseUrl = previous
-                AuthService.shared.configuredBaseURL = previous
                 if let error = response.error {
                     log.error("Platform config update failed: \(error)")
                 }

--- a/clients/macos/vellum-assistantTests/AuthServiceBaseURLTests.swift
+++ b/clients/macos/vellum-assistantTests/AuthServiceBaseURLTests.swift
@@ -8,7 +8,6 @@ final class AuthServiceBaseURLTests: XCTestCase {
             defaults.set("https://defaults.example.com/", forKey: "authServiceBaseURL")
 
             let resolved = AuthService.resolveBaseURL(
-                configuredBaseURL: "https://configured.example.com/",
                 environment: ["VELLUM_PLATFORM_URL": "https://env.example.com/"],
                 userDefaults: defaults
             )
@@ -17,15 +16,18 @@ final class AuthServiceBaseURLTests: XCTestCase {
         }
     }
 
-    func testResolveBaseURLFallsBackToConfiguredValue() {
+    func testResolveBaseURLFallsBackToDefault() {
         withUserDefaultsSuite { defaults in
             let resolved = AuthService.resolveBaseURL(
-                configuredBaseURL: "https://configured.example.com/",
                 environment: [:],
                 userDefaults: defaults
             )
 
-            XCTAssertEqual(resolved, "https://configured.example.com")
+            #if DEBUG
+            XCTAssertEqual(resolved, "http://localhost:8000")
+            #else
+            XCTAssertEqual(resolved, "https://platform.vellum.ai")
+            #endif
         }
     }
 

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -3,12 +3,10 @@ import os
 
 private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "AuthService")
 
-// MARK: - Module-private constants and storage (nonisolated by default)
+// MARK: - Module-private constants (nonisolated by default)
 // These live outside the @MainActor class so nonisolated static functions
 // (resolveBaseURL, normalizedBaseURL) can reference them without crossing
 // into @MainActor isolation — which is an error in Swift 6 language mode.
-private let _configuredBaseURLLock = NSLock()
-private var _configuredBaseURLValue: String = ""
 private let _platformURLOverrideEnvironmentKey = "VELLUM_PLATFORM_URL"
 private let _authServiceBaseURLDefaultsName = "authServiceBaseURL"
 private let _defaultBaseURL: String = {
@@ -23,36 +21,8 @@ private let _defaultBaseURL: String = {
 public final class AuthService {
     public static let shared = AuthService()
 
-    /// Platform base URL from daemon config. Set by SettingsStore when the
-    /// `platform_config_response` arrives. When non-empty, takes precedence
-    /// over persisted defaults, but an explicit per-launch env override still wins.
-    ///
-    /// Backed by a lock-protected static so that `GatewayHTTPClient` (nonisolated)
-    /// can read the value without crossing into `@MainActor` isolation.
-    public var configuredBaseURL: String {
-        get {
-            _configuredBaseURLLock.lock()
-            defer { _configuredBaseURLLock.unlock() }
-            return _configuredBaseURLValue
-        }
-        set {
-            _configuredBaseURLLock.lock()
-            defer { _configuredBaseURLLock.unlock() }
-            _configuredBaseURLValue = newValue
-        }
-    }
-
-    /// Read the current configured base URL from any isolation context.
-    /// Uses lock-based synchronization — safe to call from nonisolated code.
-    nonisolated static var currentConfiguredBaseURL: String {
-        _configuredBaseURLLock.lock()
-        defer { _configuredBaseURLLock.unlock() }
-        return _configuredBaseURLValue
-    }
-
     public var baseURL: String {
         Self.resolveBaseURL(
-            configuredBaseURL: configuredBaseURL,
             environment: ProcessInfo.processInfo.environment,
             userDefaults: .standard
         )
@@ -62,16 +32,17 @@ public final class AuthService {
 
     /// Pure URL resolution logic — safe to call from any isolation context.
     /// All inputs are value types; no mutable shared state is accessed.
+    ///
+    /// Resolution order:
+    /// 1. `VELLUM_PLATFORM_URL` environment variable
+    /// 2. `authServiceBaseURL` UserDefaults key (DEBUG builds only)
+    /// 3. Build-time default (`http://localhost:8000` for DEBUG, `https://platform.vellum.ai` for RELEASE)
     nonisolated static func resolveBaseURL(
-        configuredBaseURL: String,
         environment: [String: String],
         userDefaults: UserDefaults
     ) -> String {
         if let override = normalizedBaseURL(environment[_platformURLOverrideEnvironmentKey]) {
             return override
-        }
-        if let configured = normalizedBaseURL(configuredBaseURL) {
-            return configured
         }
         #if DEBUG
         // Keep the UserDefaults override as a fallback for direct debug sessions.

--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -391,7 +391,6 @@ public enum GatewayHTTPClient {
                 // `AuthService.shared.baseURL` is @MainActor-isolated and
                 // cannot be read from a nonisolated synchronous context.
                 baseURL = AuthService.resolveBaseURL(
-                    configuredBaseURL: AuthService.currentConfiguredBaseURL,
                     environment: ProcessInfo.processInfo.environment,
                     userDefaults: .standard
                 )


### PR DESCRIPTION
We reference the same Vellum platform URL (`platform.vellum.ai`) in a number of contexts:
1. The macOS client targets a given platform URL for auth, billing, and other APIs. Currently the main entrypoint is `AuthService.swift`.
2. There is the `runtimeURL` in the client-side `.vellum.lock.json`. Roughly this is the gateway URL that a client uses to communicate with a running assistant.
    a. For Vellum managed assistants, we use an auth token from (1) to authenticate with Vellum managed gateway.
3. Each assistant stores a platform URL in some local state. The assistant access certain Vellum-managed services (like LLM providers) with an `AssistantAPIKey`.
    a. (2) and (3) are distinct -- you might have a locally running assistant that still uses Vellum managed services.

At least to me, the terminology is confusing and could be clarified.

## Problems
For (1), ideally a build of the desktop client targets only one specific platform environment. We shouldn't drive it dynamically off values in `.vellum.lock.json`.

This introduces some tension with (2): the client side `.vellum.lock.json` lockfile in (2) is global and shared across both dev and production builds of our desktop client.
For devs, the lockfile can contain state of managed assistants from both dev and production.

Longer term, we should introduce stronger separation between dev/prod hatched assistants.

We may even want to isolate assistants that were hatched locally, because platform URL is stored assistant-side.

## Changes

Platform URL is now a build-time constant, overridable only by the
VELLUM_PLATFORM_URL environment variable. This prevents cross-environment
contamination when debug and release builds share the same lockfile —
previously the dev platform URL could leak into production via lockfile
seeding or daemon platform_config_response.

Removes configuredBaseURL property, currentConfiguredBaseURL static
accessor, and all sites that seeded it (lockfile entries, daemon config,
reauth flow). The Developer Settings platform URL config for the daemon
is preserved but no longer feeds into the client's own platform URL.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Followup
Hide (and don't attempt to connect to) managed assistants whose runtimeURL differs from the client's platform URL.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21998" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
