### PR TITLE
fix: use precise URL matching in teleport transfer routing tests

### DIFF
--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -613,8 +613,11 @@ describe("teleport transfer routing", () => {
       expect(platformPollExportStatusMock).toHaveBeenCalled();
       expect(platformDownloadExportMock).toHaveBeenCalled();
 
-      // Local import: should call fetch to /v1/migrations/import
-      const importCalls = filterFetchCalls(fetchMock, "/v1/migrations/import");
+      // Local import: should call fetch to /v1/migrations/import (but not /import-preflight)
+      const importCalls = filterFetchCalls(
+        fetchMock,
+        "/v1/migrations/import",
+      ).filter((call) => !extractUrl(call[0]).includes("/import-preflight"));
       expect(importCalls.length).toBe(1);
 
       // Should NOT call platformImportBundle


### PR DESCRIPTION
## Summary
- Fixes imprecise URL assertions in teleport tests that could match both /import and /import-preflight
- Ensures tests correctly distinguish between the actual import and preflight endpoints

Addresses review feedback on #21974
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/21999" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
