### PR TITLE
fix: add help examples and validate flag values in teleport command

### DIFF
--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -814,10 +814,10 @@ describe("teleport malformed flag usage", () => {
     );
   });
 
-  test("--from --to target consumes --to as from's value, leaving to undefined", async () => {
+  test("--from --to target rejects flag-like value for --from, leaving from undefined", async () => {
     setArgv("--from", "--to", "target");
-    // parseArgs sees --from then consumes "--to" as from's value.
-    // "target" is left as a positional arg. to remains undefined → prints help and exits 1.
+    // parseArgs sees --from then skips "--to" (starts with --) so from stays undefined.
+    // --to then correctly consumes "target". from is undefined → prints help and exits 1.
     await expect(teleport()).rejects.toThrow("process.exit:1");
     expect(consoleLogSpy).toHaveBeenCalledWith(
       expect.stringContaining("Usage:"),

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -30,6 +30,11 @@ function printHelp(): void {
     "  --dry-run       Preview the transfer without applying changes",
   );
   console.log("  --help, -h      Show this help");
+  console.log("");
+  console.log("Examples:");
+  console.log("  vellum teleport --from my-local --to my-cloud");
+  console.log("  vellum teleport --from my-cloud --to my-local --dry-run");
+  console.log("  vellum teleport --from staging --to production --dry-run");
 }
 
 function parseArgs(argv: string[]): {
@@ -46,8 +51,14 @@ function parseArgs(argv: string[]): {
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === "--from" && i + 1 < argv.length) {
+      if (argv[i + 1].startsWith("--")) {
+        continue;
+      }
       from = argv[++i];
     } else if (arg === "--to" && i + 1 < argv.length) {
+      if (argv[i + 1].startsWith("--")) {
+        continue;
+      }
       to = argv[++i];
     } else if (arg === "--dry-run") {
       dryRun = true;


### PR DESCRIPTION
## Summary
- Adds Examples section to teleport help output per cli/AGENTS.md requirements
- Guards --from/--to parsing to reject flag-like tokens as values

Addresses review feedback on #21971
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22000" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
