### PR TITLE
fix: respect telemetry opt-out at flush time

### DIFF
--- a/assistant/src/memory/lifecycle-events-store.ts
+++ b/assistant/src/memory/lifecycle-events-store.ts
@@ -1,6 +1,7 @@
 import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
+import { getConfig } from "../config/loader.js";
 import { getDb } from "./db.js";
 import { lifecycleEvents } from "./schema.js";
 
@@ -10,8 +11,9 @@ export interface LifecycleEvent {
   createdAt: number;
 }
 
-/** Record a lifecycle event (e.g. app_open, hatch). */
-export function recordLifecycleEvent(eventName: string): LifecycleEvent {
+/** Record a lifecycle event (e.g. app_open, hatch). Returns null when usage data collection is disabled. */
+export function recordLifecycleEvent(eventName: string): LifecycleEvent | null {
+  if (!getConfig().collectUsageData) return null;
   const db = getDb();
   const event: LifecycleEvent = {
     id: uuid(),

--- a/assistant/src/runtime/routes/telemetry-routes.ts
+++ b/assistant/src/runtime/routes/telemetry-routes.ts
@@ -35,6 +35,9 @@ export async function handleRecordLifecycleEvent(
   }
 
   const event = recordLifecycleEvent(eventName);
+  if (!event) {
+    return Response.json({ skipped: true });
+  }
   log.info({ eventName, eventId: event.id }, "Recorded lifecycle event");
 
   return Response.json({ id: event.id, event_name: event.eventName });

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -91,6 +91,20 @@ mock.module("../version.js", () => ({
   APP_VERSION: "1.2.3-test",
 }));
 
+let mockCollectUsageData = true;
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({ collectUsageData: mockCollectUsageData }),
+}));
+
+const mockQueryUnreportedLifecycleEvents = mock(
+  () => [] as { id: string; eventName: string; createdAt: number }[],
+);
+
+mock.module("../memory/lifecycle-events-store.js", () => ({
+  queryUnreportedLifecycleEvents: mockQueryUnreportedLifecycleEvents,
+}));
+
 // ---------------------------------------------------------------------------
 // Production import (after mocks)
 // ---------------------------------------------------------------------------
@@ -135,11 +149,14 @@ let mockFetch: ReturnType<typeof mock>;
 
 beforeEach(() => {
   eventIdCounter = 0;
+  mockCollectUsageData = true;
   mockGetMemoryCheckpoint.mockReset();
   mockSetMemoryCheckpoint.mockReset();
   mockQueryUnreportedUsageEvents.mockReset();
   mockQueryUnreportedTurnEvents.mockReset();
   mockQueryUnreportedTurnEvents.mockReturnValue([]);
+  mockQueryUnreportedLifecycleEvents.mockReset();
+  mockQueryUnreportedLifecycleEvents.mockReturnValue([]);
   mockPlatformClient = null;
   mockGetPlatformBaseUrl.mockReset();
   mockGetTelemetryAppToken.mockReset();
@@ -476,5 +493,57 @@ describe("UsageTelemetryReporter", () => {
     expect(turnEvent).toBeDefined();
     expect(turnEvent.daemon_event_id).toBe("evt-mixed-turn");
     expect(turnEvent.recorded_at).toBe(1700000050000);
+  });
+
+  test("flush is skipped and watermarks advanced when collectUsageData is false", async () => {
+    mockCollectUsageData = false;
+    const events = [makeUsageEvent()];
+    mockQueryUnreportedUsageEvents.mockReturnValue(events);
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
+    );
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    // No HTTP call should have been made
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    // All 6 watermarks should have been advanced (3 timestamps + 3 IDs)
+    expect(mockSetMemoryCheckpoint).toHaveBeenCalledTimes(6);
+
+    const calls = mockSetMemoryCheckpoint.mock.calls;
+    const keys = calls.map((c) => c[0]);
+    expect(keys).toContain("telemetry:usage:last_reported_at");
+    expect(keys).toContain("telemetry:usage:last_reported_id");
+    expect(keys).toContain("telemetry:turns:last_reported_at");
+    expect(keys).toContain("telemetry:turns:last_reported_id");
+    expect(keys).toContain("telemetry:lifecycle:last_reported_at");
+    expect(keys).toContain("telemetry:lifecycle:last_reported_id");
+  });
+
+  test("events sent normally after re-enabling collectUsageData", async () => {
+    // First flush with opt-out — watermarks advance, nothing sent
+    mockCollectUsageData = false;
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+    expect(mockFetch).not.toHaveBeenCalled();
+    mockSetMemoryCheckpoint.mockReset();
+
+    // Re-enable and flush with new events
+    mockCollectUsageData = true;
+    const events = [makeUsageEvent({ id: "evt-after-reenable" })];
+    mockQueryUnreportedUsageEvents.mockReturnValue(events);
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
+    );
+
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(body.events[0].daemon_event_id).toBe("evt-after-reenable");
   });
 });

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -15,6 +15,7 @@ import {
   getPlatformUserId,
   getTelemetryAppToken,
 } from "../config/env.js";
+import { getConfig } from "../config/loader.js";
 import {
   getMemoryCheckpoint,
   setMemoryCheckpoint,
@@ -92,6 +93,20 @@ export class UsageTelemetryReporter {
   private async _doFlush(batchCount = 0): Promise<void> {
     try {
       if (batchCount >= MAX_CONSECUTIVE_BATCHES) return;
+
+      // Respect runtime opt-out: if the user has disabled usage data collection,
+      // skip the flush and advance watermarks so events recorded during the
+      // opt-out window are never sent retroactively.
+      if (!getConfig().collectUsageData) {
+        const now = String(Date.now());
+        setMemoryCheckpoint(CHECKPOINT_KEY_WATERMARK, now);
+        setMemoryCheckpoint(CHECKPOINT_KEY_WATERMARK_ID, "");
+        setMemoryCheckpoint(CHECKPOINT_KEY_TURN_WATERMARK, now);
+        setMemoryCheckpoint(CHECKPOINT_KEY_TURN_WATERMARK_ID, "");
+        setMemoryCheckpoint(CHECKPOINT_KEY_LIFECYCLE_WATERMARK, now);
+        setMemoryCheckpoint(CHECKPOINT_KEY_LIFECYCLE_WATERMARK_ID, "");
+        return;
+      }
 
       // Read usage watermark (compound cursor: createdAt + id)
       const watermark = Number(


### PR DESCRIPTION
## Summary

- Check `collectUsageData` at the start of each telemetry flush cycle instead of only at daemon startup. When opted out, advance watermarks so events from the opt-out window are never sent retroactively.
- Gate `recordLifecycleEvent()` on `collectUsageData` so telemetry-only lifecycle events aren't written to SQLite when opted out.
- Handle `null` return from `recordLifecycleEvent()` in the telemetry routes handler.

## Original prompt
Check if we're sending telemetry for users who don't opt in during setup. Fix the two bugs: race condition at initial hatch and reporter ignoring runtime config changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22001" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
