### PR TITLE
fix(macos): apply readonly mode for channel conversations in thread windows

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
@@ -325,6 +325,8 @@ private struct ThreadWindowContentView: View {
             subagentDetailStore: viewModel.subagentDetailStore,
             isHistoryLoaded: viewModel.isHistoryLoaded,
             activePendingRequestId: viewModel.activePendingRequestId,
+            isInteractionEnabled: !(conversation?.isChannelConversation ?? false),
+            isReadonly: conversation?.isChannelConversation ?? false,
             anchorMessageId: $anchorMessageId,
             highlightedMessageId: $highlightedMessageId,
             creditsExhaustedError: viewModel.errorManager.conversationError?.isCreditsExhausted == true ? viewModel.errorManager.conversationError : nil,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for channel-sidebar-views.md.

**Gap:** Thread window does not apply readonly mode for channel conversations
**What was expected:** Channel conversations opened in new windows should show readonly banner, not composer
**What was found:** ThreadWindowContentView did not pass isReadonly to ChatView
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22002" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
