### PR TITLE
fix(macos): filter out cross-environment managed assistants

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -25,10 +25,11 @@ extension AppDelegate {
                 // without authentication. Local/remote assistants run independently
                 // of the platform auth session, so the app can open in a logged-out
                 // state and the user can sign in from Settings > General.
+                // Skip managed assistants from a different platform environment.
                 let storedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
                 let assistant = storedId.flatMap { LockfileAssistant.loadByName($0) }
                     ?? LockfileAssistant.loadLatest()
-                if let assistant, !assistant.isManaged {
+                if let assistant, !assistant.isManaged, assistant.isCurrentEnvironment {
                     log.info("[authFlow] Lockfile has non-managed assistant \(assistant.assistantId) — proceeding to app without auth")
                     proceedToApp()
                 } else {
@@ -46,7 +47,7 @@ extension AppDelegate {
             return
         }
 
-        let hasManagedAssistants = LockfileAssistant.loadAll().contains { $0.isManaged }
+        let hasManagedAssistants = LockfileAssistant.loadAll().contains { $0.isManaged && $0.isCurrentEnvironment }
         let authView: AnyView
 
         if hasManagedAssistants {
@@ -565,7 +566,7 @@ extension AppDelegate {
 
         // Check if other assistants remain in the lockfile.
         // Prefer remote assistants (always reachable), then try waking local ones.
-        let remaining = LockfileAssistant.loadAll().filter { $0.assistantId != assistantName }
+        let remaining = LockfileAssistant.loadAll().filter { $0.assistantId != assistantName && $0.isCurrentEnvironment }
         if !remaining.isEmpty {
             // Try remote assistants first — they're always reachable
             if let remote = remaining.first(where: { $0.isRemote }) {

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -20,15 +20,26 @@ extension AppDelegate {
     /// to the correct assistant.
     ///
     /// Returns the loaded assistant for transport selection, or nil if none found.
+    /// Rejects managed assistants from a different platform environment (e.g.
+    /// dev-platform assistants in a production build) and falls back to the
+    /// first valid current-environment assistant.
     @discardableResult
     func loadAssistantFromLockfile() -> LockfileAssistant? {
         let storedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
-        let assistant: LockfileAssistant?
+        var assistant: LockfileAssistant?
 
         if let storedId, let found = LockfileAssistant.loadByName(storedId) {
             assistant = found
         } else {
             assistant = LockfileAssistant.loadLatest()
+        }
+
+        // If the resolved assistant is from a different platform environment,
+        // clear the stale stored ID and fall back to any valid assistant.
+        if let resolved = assistant, !resolved.isCurrentEnvironment {
+            log.info("Stored assistant \(resolved.assistantId, privacy: .public) is cross-environment — searching for fallback")
+            UserDefaults.standard.removeObject(forKey: "connectedAssistantId")
+            assistant = LockfileAssistant.loadAll().first { $0.isCurrentEnvironment }
         }
 
         guard let assistant else { return nil }

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -376,24 +376,14 @@ extension AppDelegate {
     }
 
     /// Returns `true` when `~/.vellum.lock.json` contains at least one
-    /// assistant entry.
+    /// assistant entry that belongs to the current platform environment.
+    /// Cross-environment managed assistants (e.g. dev-platform in a
+    /// production build) are excluded.
     func lockfileHasAssistants() -> Bool {
-        let primaryPath = LockfilePaths.primaryPath
-        let fileExists = FileManager.default.fileExists(atPath: primaryPath)
-        log.info("[lockfileCheck] primaryPath=\(primaryPath, privacy: .public) exists=\(fileExists)")
-
-        guard let json = LockfilePaths.read() else {
-            log.warning("[lockfileCheck] LockfilePaths.read() returned nil")
-            return false
-        }
-
-        guard let assistants = json["assistants"] as? [[String: Any]] else {
-            log.warning("[lockfileCheck] lockfile has no 'assistants' array")
-            return false
-        }
-
-        log.info("[lockfileCheck] found \(assistants.count) assistant(s)")
-        return !assistants.isEmpty
+        let all = LockfileAssistant.loadAll()
+        let valid = all.filter { $0.isCurrentEnvironment }
+        log.info("[lockfileCheck] found \(all.count) assistant(s), \(valid.count) in current environment")
+        return !valid.isEmpty
     }
 
     /// Check whether the local gateway is healthy by hitting its /healthz endpoint.

--- a/clients/shared/Network/LockfileAssistant.swift
+++ b/clients/shared/Network/LockfileAssistant.swift
@@ -95,6 +95,22 @@ public struct LockfileAssistant {
         return normalizedCloud == "vellum" || normalizedCloud == "platform"
     }
 
+    /// Whether this managed assistant belongs to the current build's platform environment.
+    /// Local, remote, and Docker assistants always return true — they are not scoped to a
+    /// specific platform. Managed assistants are compared against the build-time platform URL.
+    public var isCurrentEnvironment: Bool {
+        guard isManaged else { return true }
+        guard let runtimeUrl = runtimeUrl, !runtimeUrl.isEmpty else { return true }
+        let expected = AuthService.resolveBaseURL(
+            environment: ProcessInfo.processInfo.environment,
+            userDefaults: .standard
+        ).lowercased().replacingOccurrences(of: "/+$", with: "", options: .regularExpression)
+        let actual = runtimeUrl.lowercased()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "/+$", with: "", options: .regularExpression)
+        return actual == expected
+    }
+
     /// Whether this assistant is running in Docker.
     public var isDocker: Bool {
         cloud.lowercased() == "docker"


### PR DESCRIPTION
Adds isCurrentEnvironment to LockfileAssistant which compares a managed
assistant's runtime URL against the build-time platform URL. Local,
remote, and Docker assistants always pass.

Applies this filter at key selection points:
- loadAssistantFromLockfile(): reject cross-environment managed assistants
- lockfileHasAssistants(): only count current-environment assistants
- startAuthenticatedFlow(): skip cross-environment in loadLatest() fallback
- showAuthWindow(): only show ReauthView if current-environment managed
  assistants exist

When only cross-environment managed assistants exist in the lockfile,
the production app now shows onboarding instead of trying to connect
to a dev-platform assistant.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22003" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
