### PR TITLE
feat: track OpenAI reasoning tokens in provider usage response

### DIFF
--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -28,6 +28,9 @@ interface FakeChunk {
     prompt_tokens: number;
     completion_tokens: number;
     total_tokens: number;
+    completion_tokens_details?: {
+      reasoning_tokens?: number;
+    };
   } | null;
   model: string;
 }
@@ -149,6 +152,25 @@ function usageChunk(prompt: number, completion: number): FakeChunk {
       prompt_tokens: prompt,
       completion_tokens: completion,
       total_tokens: prompt + completion,
+    },
+    model: "gpt-5.2",
+  };
+}
+
+function reasoningUsageChunk(
+  prompt: number,
+  completion: number,
+  reasoning: number,
+): FakeChunk {
+  return {
+    choices: [{ delta: {}, finish_reason: "stop" }],
+    usage: {
+      prompt_tokens: prompt,
+      completion_tokens: completion,
+      total_tokens: prompt + completion,
+      completion_tokens_details: {
+        reasoning_tokens: reasoning,
+      },
     },
     model: "gpt-5.2",
   };
@@ -805,6 +827,47 @@ describe("OpenAIProvider", () => {
     // Only tool_use, no text block
     expect(result.content).toHaveLength(1);
     expect(result.content[0].type).toBe("tool_use");
+  });
+
+  // -----------------------------------------------------------------------
+  // Reasoning tokens
+  // -----------------------------------------------------------------------
+  test("includes reasoningTokens in usage when present in completion_tokens_details", async () => {
+    fakeChunks = [
+      textChunk("Reasoning result"),
+      reasoningUsageChunk(50, 120, 80),
+    ];
+
+    const result = await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "Think carefully" }] },
+    ]);
+
+    expect(result.usage).toEqual({
+      inputTokens: 50,
+      outputTokens: 120,
+      reasoningTokens: 80,
+    });
+
+    // Also check rawResponse diagnostics include reasoning tokens
+    const rawUsage = (result.rawResponse as any).usage;
+    expect(rawUsage.completion_tokens_details).toEqual({
+      reasoning_tokens: 80,
+    });
+  });
+
+  test("omits reasoningTokens from usage when not present", async () => {
+    fakeChunks = [textChunk("Simple reply"), usageChunk(10, 5)];
+
+    const result = await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "Hi" }] },
+    ]);
+
+    expect(result.usage).toEqual({ inputTokens: 10, outputTokens: 5 });
+    expect(result.usage).not.toHaveProperty("reasoningTokens");
+
+    // rawResponse should not include completion_tokens_details
+    const rawUsage = (result.rawResponse as any).usage;
+    expect(rawUsage).not.toHaveProperty("completion_tokens_details");
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/providers/openai/client.ts
+++ b/assistant/src/providers/openai/client.ts
@@ -154,6 +154,7 @@ export class OpenAIProvider implements Provider {
       let responseModel = modelOverride ?? this.model;
       let promptTokens = 0;
       let completionTokens = 0;
+      let reasoningTokens = 0;
 
       try {
         const stream = await this.client.chat.completions.create(params, {
@@ -188,6 +189,9 @@ export class OpenAIProvider implements Provider {
           if (chunk.usage) {
             promptTokens = chunk.usage.prompt_tokens;
             completionTokens = chunk.usage.completion_tokens;
+            reasoningTokens =
+              (chunk.usage as any).completion_tokens_details
+                ?.reasoning_tokens ?? 0;
           }
 
           responseModel = chunk.model;
@@ -239,13 +243,24 @@ export class OpenAIProvider implements Provider {
         usage: {
           prompt_tokens: promptTokens,
           completion_tokens: completionTokens,
+          ...(reasoningTokens > 0
+            ? {
+                completion_tokens_details: {
+                  reasoning_tokens: reasoningTokens,
+                },
+              }
+            : {}),
         },
       };
 
       return {
         content,
         model: responseModel,
-        usage: { inputTokens: promptTokens, outputTokens: completionTokens },
+        usage: {
+          inputTokens: promptTokens,
+          outputTokens: completionTokens,
+          ...(reasoningTokens > 0 ? { reasoningTokens } : {}),
+        },
         stopReason: finishReason,
         rawRequest: params,
         rawResponse,

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -101,6 +101,7 @@ export interface ProviderResponse {
     outputTokens: number;
     cacheCreationInputTokens?: number;
     cacheReadInputTokens?: number;
+    reasoningTokens?: number;
   };
   stopReason: string;
   /** Raw JSON request body sent to the provider (for diagnostics logging). */


### PR DESCRIPTION
## Summary
- Add optional reasoningTokens field to ProviderResponse.usage type
- Read completion_tokens_details.reasoning_tokens from OpenAI streaming chunks
- Include reasoning tokens in usage response and raw diagnostics when present
- Add tests for reasoning token tracking

Part of plan: openai-reasoning.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22004" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
