### PR TITLE
feat: expand OpenRouter catalog with DeepSeek, Qwen, Mistral, Meta, Moonshot, and Amazon models

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -76,10 +76,30 @@ export const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     id: "openrouter",
     displayName: "OpenRouter",
     models: [
-      { id: "x-ai/grok-4", displayName: "Grok 4" },
+      // xAI
       { id: "x-ai/grok-4.20-beta", displayName: "Grok 4.20 Beta" },
+      { id: "x-ai/grok-4", displayName: "Grok 4" },
+      // DeepSeek
+      { id: "deepseek/deepseek-r1-0528", displayName: "DeepSeek R1" },
+      { id: "deepseek/deepseek-chat-v3-0324", displayName: "DeepSeek V3" },
+      // Qwen
+      { id: "qwen/qwen3.5-plus-02-15", displayName: "Qwen 3.5 Plus" },
+      { id: "qwen/qwen3.5-397b-a17b", displayName: "Qwen 3.5 397B" },
+      { id: "qwen/qwen3.5-flash-02-23", displayName: "Qwen 3.5 Flash" },
+      { id: "qwen/qwen3-coder-next", displayName: "Qwen 3 Coder" },
+      // Moonshot
+      { id: "moonshotai/kimi-k2.5", displayName: "Kimi K2.5" },
+      // Mistral
+      { id: "mistralai/mistral-medium-3", displayName: "Mistral Medium 3" },
+      { id: "mistralai/mistral-small-2603", displayName: "Mistral Small 4" },
+      { id: "mistralai/devstral-2512", displayName: "Devstral 2" },
+      // Meta
+      { id: "meta-llama/llama-4-maverick", displayName: "Llama 4 Maverick" },
+      { id: "meta-llama/llama-4-scout", displayName: "Llama 4 Scout" },
+      // Amazon
+      { id: "amazon/nova-pro-v1", displayName: "Amazon Nova Pro" },
     ],
-    defaultModel: "x-ai/grok-4",
+    defaultModel: "x-ai/grok-4.20-beta",
     apiKeyUrl: "https://openrouter.ai/keys",
     apiKeyPlaceholder: "sk-or-v1-...",
   },

--- a/assistant/src/providers/model-intents.ts
+++ b/assistant/src/providers/model-intents.ts
@@ -37,9 +37,9 @@ const PROVIDER_MODEL_INTENTS: Record<string, Record<ModelIntent, string>> = {
     "vision-optimized": "accounts/fireworks/models/kimi-k2p5",
   },
   openrouter: {
-    "latency-optimized": "x-ai/grok-4",
+    "latency-optimized": "qwen/qwen3.5-flash-02-23",
     "quality-optimized": "x-ai/grok-4.20-beta",
-    "vision-optimized": "x-ai/grok-4",
+    "vision-optimized": "x-ai/grok-4.20-beta",
   },
 };
 


### PR DESCRIPTION
## Summary
- Add 13 new models to OpenRouter catalog: DeepSeek R1 and V3, Qwen 3.5 Plus/397B/Flash and Qwen 3 Coder, Kimi K2.5, Mistral Medium 3/Small 4/Devstral 2, Llama 4 Maverick/Scout, and Amazon Nova Pro
- Update default model from Grok 4 to Grok 4.20 Beta (cheaper, 8x larger context)
- Remap latency-optimized intent from Grok 4 to Qwen 3.5 Flash (50x cheaper)

Part of plan: expand-openrouter-catalog.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
