### PR TITLE
fix: add circuit breaker to scroll loop guard to prevent CPU freeze

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatScrollLoopGuard.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatScrollLoopGuard.swift
@@ -162,6 +162,27 @@ final class ChatScrollLoopGuard {
         states.removeAll()
     }
 
+    /// Returns `true` when the guard is in cooldown for the given conversation,
+    /// meaning a scroll loop was recently detected. Callers (e.g. `requestBottomPin`)
+    /// use this as a circuit breaker to suppress programmatic scroll requests until
+    /// the loop subsides — the guard re-arms after a full quiet window elapses.
+    func isTripped(
+        conversationId: String,
+        timestamp: TimeInterval = ProcessInfo.processInfo.systemUptime
+    ) -> Bool {
+        guard var state = states[conversationId] else { return false }
+
+        // Re-arm check: if enough quiet time has elapsed, exit cooldown.
+        if state.inCooldown, let lastEvent = state.lastEventTime {
+            if timestamp - lastEvent >= Self.cooldownDuration {
+                state.inCooldown = false
+                states[conversationId] = state
+            }
+        }
+
+        return state.inCooldown
+    }
+
     /// Returns the current rolling event counts for a conversation.
     /// Used by `DebugStateWriter` to include hot-path rates in `debug-state.json`.
     func currentCounts(

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator+ScrollBehavior.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator+ScrollBehavior.swift
@@ -363,16 +363,22 @@ extension MessageListScrollCoordinator {
             return true
         }
 
-        // Non-user-initiated requests are gated on BOTH follow-state and
-        // suppression. The isFollowingBottom check prevents yanking detached
-        // users to the bottom. The !isSuppressed check prevents auto-scroll
-        // from fighting pagination, expansion, and resize suppression.
+        // Non-user-initiated requests are gated on follow-state, suppression,
+        // AND scroll-loop detection. The loop guard acts as a circuit breaker:
+        // when a scroll loop is detected (>15 scrollTo or >40 body evals in 2s),
+        // all programmatic pin requests are suppressed until the loop subsides.
+        // This breaks the scroll→body-eval→scroll feedback cycle that otherwise
+        // pins the CPU at 100%.
         guard isFollowingBottom else {
             scrollCoordinatorLog.debug("[BottomPin] suppressed reason=\(reason.rawValue) isFollowingBottom=false")
             return false
         }
         guard !isSuppressed else {
             scrollCoordinatorLog.debug("[BottomPin] suppressed reason=\(reason.rawValue) isSuppressed=true")
+            return false
+        }
+        guard !diagnostics.isScrollLoopTripped(conversationId: currentConversationId) else {
+            scrollCoordinatorLog.debug("[BottomPin] suppressed reason=\(reason.rawValue) scrollLoopTripped=true")
             return false
         }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ScrollDiagnosticsRecorder.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ScrollDiagnosticsRecorder.swift
@@ -63,6 +63,14 @@ final class ScrollDiagnosticsRecorder {
         }
     }
 
+    /// Returns `true` when the loop guard is tripped (in cooldown) for the given
+    /// conversation, meaning a scroll loop was recently detected. Used by the
+    /// scroll coordinator as a circuit breaker to suppress programmatic scrolls.
+    func isScrollLoopTripped(conversationId: UUID?) -> Bool {
+        let convId = conversationId?.uuidString ?? "unknown"
+        return scrollLoopGuard.isTripped(conversationId: convId)
+    }
+
     // MARK: - Non-Finite Geometry Logging
 
     /// Logs a one-time warning when scroll geometry first becomes non-finite.

--- a/clients/macos/vellum-assistantTests/ChatScrollLoopGuardTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatScrollLoopGuardTests.swift
@@ -394,6 +394,61 @@ final class ChatScrollLoopGuardTests: XCTestCase {
         XCTAssertTrue(counts.isEmpty)
     }
 
+    // MARK: - isTripped (Circuit Breaker)
+
+    func testIsTrippedReturnsFalseBeforeTripping() {
+        XCTAssertFalse(guard_.isTripped(conversationId: conversationId))
+    }
+
+    func testIsTrippedReturnsTrueAfterTripping() {
+        var timestamp: TimeInterval = 1000.0
+
+        // Trip the guard with a scrollTo burst.
+        for _ in 0..<20 {
+            guard_.record(.scrollToRequested, conversationId: conversationId, timestamp: timestamp)
+            timestamp += 0.1
+        }
+
+        XCTAssertTrue(
+            guard_.isTripped(conversationId: conversationId, timestamp: timestamp),
+            "isTripped should return true during cooldown"
+        )
+    }
+
+    func testIsTrippedReturnsFalseAfterCooldown() {
+        var timestamp: TimeInterval = 1000.0
+
+        // Trip the guard.
+        for _ in 0..<20 {
+            guard_.record(.scrollToRequested, conversationId: conversationId, timestamp: timestamp)
+            timestamp += 0.1
+        }
+
+        // Advance past the cooldown window.
+        timestamp += ChatScrollLoopGuard.cooldownDuration + 0.1
+
+        XCTAssertFalse(
+            guard_.isTripped(conversationId: conversationId, timestamp: timestamp),
+            "isTripped should return false after quiet cooldown window"
+        )
+    }
+
+    func testIsTrippedIsolatedByConversation() {
+        var timestamp: TimeInterval = 1000.0
+
+        // Trip the guard for conversation A.
+        for _ in 0..<20 {
+            guard_.record(.scrollToRequested, conversationId: "conv-a", timestamp: timestamp)
+            timestamp += 0.1
+        }
+
+        XCTAssertTrue(guard_.isTripped(conversationId: "conv-a", timestamp: timestamp))
+        XCTAssertFalse(
+            guard_.isTripped(conversationId: "conv-b", timestamp: timestamp),
+            "Unrelated conversation should not be tripped"
+        )
+    }
+
     // MARK: - ScrollTo Threshold Boundary Tests
 
     func testNormalScrollToRateDoesNotTrip() {


### PR DESCRIPTION
## Summary
- The `ChatScrollLoopGuard` detected runaway scroll loops but only logged warnings — it never broke the cycle, allowing 100% CPU freezes during streaming
- Added `isTripped()` to the guard and wired it as a circuit breaker in `requestBottomPin()`, suppressing programmatic scroll requests when a loop is detected until it subsides (2s quiet window)
- Added 4 tests for the new `isTripped` method covering trip detection, cooldown re-arm, and conversation isolation