### PR TITLE
fix(macos): don't treat vellum-channel conversations as readonly

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationModel.swift
@@ -66,7 +66,10 @@ struct ConversationModel: Identifiable, Hashable {
         return title.hasPrefix("Schedule: ") || title.hasPrefix("Schedule (manual): ") || title.hasPrefix("Reminder: ")
     }
 
-    var isChannelConversation: Bool { originChannel != nil }
+    var isChannelConversation: Bool {
+        guard let originChannel else { return false }
+        return originChannel != "vellum"
+    }
 
     static func == (lhs: ConversationModel, rhs: ConversationModel) -> Bool {
         lhs.id == rhs.id &&


### PR DESCRIPTION
## Summary
- Conversations originating from the `vellum` channel were incorrectly treated as readonly channel conversations
- The `vellum` channel is the platform's own interactive channel (renamed from `macos`/`ios`) and should behave like a normal conversation
- Updated `isChannelConversation` to exclude `vellum` from the readonly check

## Original prompt
The Vellum conversations shouldn't be readonly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
