### PR TITLE
fix: update macOS onboarding OpenRouter catalog to match daemon

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -39,9 +39,29 @@ struct APIKeyEntryStepView: View {
                 CatalogModel(id: "accounts/fireworks/models/kimi-k2p5", displayName: "Kimi K2.5"),
             ], defaultModel: "accounts/fireworks/models/kimi-k2p5", apiKeyUrl: "https://fireworks.ai/account/api-keys", apiKeyPlaceholder: "fw_..."),
             ProviderCatalogEntry(id: "openrouter", displayName: "OpenRouter", models: [
-                CatalogModel(id: "x-ai/grok-4", displayName: "Grok 4"),
+                // xAI
                 CatalogModel(id: "x-ai/grok-4.20-beta", displayName: "Grok 4.20 Beta"),
-            ], defaultModel: "x-ai/grok-4", apiKeyUrl: "https://openrouter.ai/keys", apiKeyPlaceholder: "sk-or-v1-..."),
+                CatalogModel(id: "x-ai/grok-4", displayName: "Grok 4"),
+                // DeepSeek
+                CatalogModel(id: "deepseek/deepseek-r1-0528", displayName: "DeepSeek R1"),
+                CatalogModel(id: "deepseek/deepseek-chat-v3-0324", displayName: "DeepSeek V3"),
+                // Qwen
+                CatalogModel(id: "qwen/qwen3.5-plus-02-15", displayName: "Qwen 3.5 Plus"),
+                CatalogModel(id: "qwen/qwen3.5-397b-a17b", displayName: "Qwen 3.5 397B"),
+                CatalogModel(id: "qwen/qwen3.5-flash-02-23", displayName: "Qwen 3.5 Flash"),
+                CatalogModel(id: "qwen/qwen3-coder-next", displayName: "Qwen 3 Coder"),
+                // Moonshot
+                CatalogModel(id: "moonshotai/kimi-k2.5", displayName: "Kimi K2.5"),
+                // Mistral
+                CatalogModel(id: "mistralai/mistral-medium-3", displayName: "Mistral Medium 3"),
+                CatalogModel(id: "mistralai/mistral-small-2603", displayName: "Mistral Small 4"),
+                CatalogModel(id: "mistralai/devstral-2512", displayName: "Devstral 2"),
+                // Meta
+                CatalogModel(id: "meta-llama/llama-4-maverick", displayName: "Llama 4 Maverick"),
+                CatalogModel(id: "meta-llama/llama-4-scout", displayName: "Llama 4 Scout"),
+                // Amazon
+                CatalogModel(id: "amazon/nova-pro-v1", displayName: "Amazon Nova Pro"),
+            ], defaultModel: "x-ai/grok-4.20-beta", apiKeyUrl: "https://openrouter.ai/keys", apiKeyPlaceholder: "sk-or-v1-..."),
         ]
     }
 


### PR DESCRIPTION
## Summary
Syncs the hardcoded OpenRouter catalog in APIKeyEntryStepView.swift with the daemon's expanded catalog (15 models, default changed to Grok 4.20 Beta).

Part of plan: expand-openrouter-catalog.md (fix round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22010" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
