### PR TITLE
fix: add new OpenRouter models to self-knowledge skill

### DIFF
--- a/skills/vellum-self-knowledge/references/inference.md
+++ b/skills/vellum-self-knowledge/references/inference.md
@@ -25,6 +25,19 @@ All known models by provider, so you can interpret model IDs from config:
 | Fireworks | `accounts/fireworks/models/kimi-k2p5` | Kimi K2.5 |
 | OpenRouter | `x-ai/grok-4` | Grok 4 |
 | OpenRouter | `x-ai/grok-4.20-beta` | Grok 4.20 Beta |
+| OpenRouter | `deepseek/deepseek-r1-0528` | DeepSeek R1 |
+| OpenRouter | `deepseek/deepseek-chat-v3-0324` | DeepSeek V3 |
+| OpenRouter | `qwen/qwen3.5-plus-02-15` | Qwen 3.5 Plus |
+| OpenRouter | `qwen/qwen3.5-397b-a17b` | Qwen 3.5 397B |
+| OpenRouter | `qwen/qwen3.5-flash-02-23` | Qwen 3.5 Flash |
+| OpenRouter | `qwen/qwen3-coder-next` | Qwen 3 Coder |
+| OpenRouter | `moonshotai/kimi-k2.5` | Kimi K2.5 |
+| OpenRouter | `mistralai/mistral-medium-3` | Mistral Medium 3 |
+| OpenRouter | `mistralai/mistral-small-2603` | Mistral Small 4 |
+| OpenRouter | `mistralai/devstral-2512` | Devstral 2 |
+| OpenRouter | `meta-llama/llama-4-maverick` | Llama 4 Maverick |
+| OpenRouter | `meta-llama/llama-4-scout` | Llama 4 Scout |
+| OpenRouter | `amazon/nova-pro-v1` | Amazon Nova Pro |
 
 ## Inference Configuration
 

--- a/skills/vellum-self-knowledge/scripts/self-info.ts
+++ b/skills/vellum-self-knowledge/scripts/self-info.ts
@@ -29,6 +29,19 @@ const MODEL_DISPLAY_NAMES: Record<string, string> = {
   "accounts/fireworks/models/kimi-k2p5": "Kimi K2.5",
   "x-ai/grok-4": "Grok 4",
   "x-ai/grok-4.20-beta": "Grok 4.20 Beta",
+  "deepseek/deepseek-r1-0528": "DeepSeek R1",
+  "deepseek/deepseek-chat-v3-0324": "DeepSeek V3",
+  "qwen/qwen3.5-plus-02-15": "Qwen 3.5 Plus",
+  "qwen/qwen3.5-397b-a17b": "Qwen 3.5 397B",
+  "qwen/qwen3.5-flash-02-23": "Qwen 3.5 Flash",
+  "qwen/qwen3-coder-next": "Qwen 3 Coder",
+  "moonshotai/kimi-k2.5": "Kimi K2.5",
+  "mistralai/mistral-medium-3": "Mistral Medium 3",
+  "mistralai/mistral-small-2603": "Mistral Small 4",
+  "mistralai/devstral-2512": "Devstral 2",
+  "meta-llama/llama-4-maverick": "Llama 4 Maverick",
+  "meta-llama/llama-4-scout": "Llama 4 Scout",
+  "amazon/nova-pro-v1": "Amazon Nova Pro",
 };
 
 const PROVIDER_DISPLAY_NAMES: Record<string, string> = {


### PR DESCRIPTION
## Summary
Adds all 13 new OpenRouter model display names to the self-knowledge skill's MODEL_DISPLAY_NAMES map and updates the inference.md reference doc.

Part of plan: expand-openrouter-catalog.md (fix round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22011" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
