### PR TITLE
fix: update relay-server test mock OpenRouter default model

### DIFF
--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -162,7 +162,7 @@ mock.module("../providers/registry.js", () => {
         gemini: "gemini-3-flash",
         ollama: "llama3.2",
         fireworks: "accounts/fireworks/models/kimi-k2p5",
-        openrouter: "x-ai/grok-4",
+        openrouter: "x-ai/grok-4.20-beta",
       };
       return defaults[providerName] ?? defaults.anthropic;
     },


### PR DESCRIPTION
## Summary
Updates the hardcoded OpenRouter default model in the relay-server test mock from x-ai/grok-4 to x-ai/grok-4.20-beta to match the updated catalog.

Part of plan: expand-openrouter-catalog.md (fix round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22012" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
