### PR TITLE
Clarify Slack credential errors on cloud-hosted assistants

### DIFF
--- a/assistant/src/__tests__/shell-credential-ref.test.ts
+++ b/assistant/src/__tests__/shell-credential-ref.test.ts
@@ -245,6 +245,37 @@ describe("shell tool credential ref resolution", () => {
     }
   });
 
+  test("managed mode falls back to the generic error for mixed Slack and non-Slack refs", async () => {
+    const originalManagedMode = process.env["CES_MANAGED_MODE"];
+    process.env["CES_MANAGED_MODE"] = "1";
+
+    try {
+      const result = await shellTool.execute(
+        {
+          command: "echo hello",
+          reason: "test",
+          network_mode: "proxied",
+          credential_ids: ["slack_channel/bot_token", "fal/api_key"],
+        },
+        ctx,
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("assistant credentials list");
+      expect(result.content).toContain("slack_channel/bot_token, fal/api_key");
+      expect(result.content).not.toContain(
+        "Slack Web API access isn't available on cloud-hosted assistants yet",
+      );
+      expect(mockGetOrStartSession).not.toHaveBeenCalled();
+    } finally {
+      if (originalManagedMode === undefined) {
+        delete process.env["CES_MANAGED_MODE"];
+      } else {
+        process.env["CES_MANAGED_MODE"] = originalManagedMode;
+      }
+    }
+  });
+
   test("duplicate refs are deduped", async () => {
     const meta = upsertCredentialMetadata("fal", "api_key");
 

--- a/assistant/src/__tests__/shell-credential-ref.test.ts
+++ b/assistant/src/__tests__/shell-credential-ref.test.ts
@@ -187,6 +187,64 @@ describe("shell tool credential ref resolution", () => {
     expect(mockGetOrStartSession).not.toHaveBeenCalled();
   });
 
+  test("managed mode surfaces a Slack-specific error for unresolved slack_channel refs", async () => {
+    const originalManagedMode = process.env["CES_MANAGED_MODE"];
+    process.env["CES_MANAGED_MODE"] = "1";
+
+    try {
+      const result = await shellTool.execute(
+        {
+          command: "echo hello",
+          reason: "test",
+          network_mode: "proxied",
+          credential_ids: ["slack_channel/bot_token"],
+        },
+        ctx,
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain(
+        "Slack Web API access isn't available on cloud-hosted assistants yet",
+      );
+      expect(result.content).toContain("Slack App Setup");
+      expect(mockGetOrStartSession).not.toHaveBeenCalled();
+    } finally {
+      if (originalManagedMode === undefined) {
+        delete process.env["CES_MANAGED_MODE"];
+      } else {
+        process.env["CES_MANAGED_MODE"] = originalManagedMode;
+      }
+    }
+  });
+
+  test("managed mode points generic unresolved refs at assistant credentials list", async () => {
+    const originalManagedMode = process.env["CES_MANAGED_MODE"];
+    process.env["CES_MANAGED_MODE"] = "1";
+
+    try {
+      const result = await shellTool.execute(
+        {
+          command: "echo hello",
+          reason: "test",
+          network_mode: "proxied",
+          credential_ids: ["unknown/ref"],
+        },
+        ctx,
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("assistant credentials list");
+      expect(result.content).toContain("cloud-hosted");
+      expect(mockGetOrStartSession).not.toHaveBeenCalled();
+    } finally {
+      if (originalManagedMode === undefined) {
+        delete process.env["CES_MANAGED_MODE"];
+      } else {
+        process.env["CES_MANAGED_MODE"] = originalManagedMode;
+      }
+    }
+  });
+
   test("duplicate refs are deduped", async () => {
     const meta = upsertCredentialMetadata("fal", "api_key");
 

--- a/assistant/src/config/bundled-skills/slack/SKILL.md
+++ b/assistant/src/config/bundled-skills/slack/SKILL.md
@@ -10,6 +10,8 @@ metadata:
 
 You help users interact with their Slack workspace. All Slack operations use the **Slack Web API** directly via the `bash` tool with credential proxy — there are no dedicated Slack tools.
 
+This skill currently requires a **local assistant** with Slack connected through the **slack-app-setup** flow. Do not use this skill on cloud-hosted assistants — that environment does not expose the local `slack_channel/*` credentials this workflow depends on.
+
 ## Making Slack API Calls
 
 Use `bash` with these parameters:
@@ -85,6 +87,8 @@ When responding to messages from Slack channels, replies should be threaded. Pas
 ## Connection
 
 Before making any Slack API calls, verify that Slack is connected. If not connected, load the **slack-app-setup** skill (`skill_load` with `skill: "slack-app-setup"`) and follow its guided flow. Do NOT improvise setup instructions — the `slack-app-setup` skill is the single source of truth. Slack uses Socket Mode and does not require redirect URLs or any OAuth flow.
+
+If you are running on a cloud-hosted assistant, do **not** attempt Slack API calls through this skill. Instead, explain that Slack is not available on cloud-hosted assistants yet and that the user needs a local assistant to reconnect Slack with **slack-app-setup**.
 
 ## Communication Style
 

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -52,7 +52,7 @@ function formatUnknownCredentialRefError(unresolvedRefs: string[]): string {
     );
   }
 
-  if (unresolvedRefs.some(isSlackChannelCredentialRef)) {
+  if (unresolvedRefs.every(isSlackChannelCredentialRef)) {
     return (
       "Error: Slack Web API access isn't available on cloud-hosted assistants yet. " +
       `This Slack workflow expects a locally connected Slack app, but ${joinedRefs} is not available on this assistant. ` +

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -34,6 +34,39 @@ function buildCredentialRefTrace(
   return { rawRefs, resolvedIds, unresolvedRefs };
 }
 
+function isManagedDeployment(): boolean {
+  return !!process.env["CES_MANAGED_MODE"];
+}
+
+function isSlackChannelCredentialRef(ref: string): boolean {
+  return ref.startsWith("slack_channel/");
+}
+
+function formatUnknownCredentialRefError(unresolvedRefs: string[]): string {
+  const joinedRefs = unresolvedRefs.join(", ");
+
+  if (!isManagedDeployment()) {
+    return (
+      `Error: unknown credential reference(s): ${joinedRefs}. ` +
+      "Use credential_store list to see available credentials."
+    );
+  }
+
+  if (unresolvedRefs.some(isSlackChannelCredentialRef)) {
+    return (
+      "Error: Slack Web API access isn't available on cloud-hosted assistants yet. " +
+      `This Slack workflow expects a locally connected Slack app, but ${joinedRefs} is not available on this assistant. ` +
+      "Use a local assistant and reconnect Slack with Slack App Setup."
+    );
+  }
+
+  return (
+    `Error: unknown credential reference(s): ${joinedRefs}. ` +
+    "This assistant is cloud-hosted, so local credential refs only work for credentials stored on the assistant itself. " +
+    "Use `assistant credentials list` to inspect available local and platform-managed credentials."
+  );
+}
+
 /**
  * Build the list of absolute paths that should be blocked from read access
  * inside the sandbox when CES shell lockdown is active.
@@ -228,9 +261,7 @@ class ShellTool implements Tool {
           "Credential ref resolution failed",
         );
         return {
-          content: `Error: unknown credential reference(s): ${unresolvedRefs.join(
-            ", ",
-          )}. Use credential_store list to see available credentials.`,
+          content: formatUnknownCredentialRefError(unresolvedRefs),
           isError: true,
         };
       }

--- a/docs/internal-reference.md
+++ b/docs/internal-reference.md
@@ -120,6 +120,8 @@ When using `credential_ids` in proxied shell commands, you can use either format
 
 Unknown references fail immediately with a clear error before the command executes.
 
+> **Cloud-hosted assistants:** `credential_ids` only resolve local credentials. Platform-managed credentials show up in `assistant credentials list`, and some local-only integrations (such as Slack Socket Mode) are not available on cloud-hosted assistants.
+
 #### Wildcard Host Matching
 
 Wildcard patterns like `*.fal.run` match:
@@ -144,7 +146,7 @@ Requests that match zero session credentials are handled in two ways: if the tar
 
 If a proxied command receives a 401 or 403 despite having the correct credential stored:
 
-1. **Check the credential reference**: Run `credential_store list` and verify the credential ID or `service/field` matches what you're passing to `credential_ids`.
+1. **Check the credential reference**: Run `credential_store list` to verify local `service/field` references. On cloud-hosted assistants, run `assistant credentials list` to see both local credentials and platform-managed entries.
 2. **Check host pattern matching**: The credential's `hostPattern` must match the target host. A wildcard pattern `*.example.com` matches `api.example.com` and the bare domain `example.com`. An exact pattern `api.example.com` only matches that specific host.
 3. **Check for ambiguity**: If two credentials match the same host with equal specificity, injection is blocked. Use `credential_store list` to check for overlapping patterns.
 4. **Check the header template**: Ensure the credential has an `injectionTemplate` with `injectionType: "header"` and the correct `headerName` (e.g., `Authorization`) and `valuePrefix` (e.g., `Bearer `).
@@ -221,6 +223,8 @@ Vellum integrates with third-party services via OAuth2. Each integration is expo
 The unified messaging layer provides platform-agnostic tools (`messaging_send`, `messaging_read`, `messaging_search`, etc.) that delegate to provider adapters. Gmail implements the `MessagingProvider` interface. Telegram is also supported as a messaging provider, though with limited capabilities compared to Gmail: bots can send messages to known chat IDs but cannot list conversations, retrieve message history, or search messages (Bot API limitations). Bots can only message users or groups that have previously interacted with the bot. Platform-specific tools (e.g. `gmail_archive`) extend beyond the generic interface where needed.
 
 **Slack is not handled by the messaging skill.** Slack messaging (send, read, search) uses the Slack Web API directly via CLI. The `slack` skill provides instructions for using the Web API via `bash` with `network_mode: "proxied"` and `credential_ids: ["slack_channel/bot_token"]` — the credential proxy injects the bot token automatically. There are no dedicated Slack tools.
+
+This path is currently **local-assistant only**. It depends on the Socket Mode credentials created by `slack-app-setup`, and those `slack_channel/*` credentials are not exposed on cloud-hosted assistants.
 
 Connect Gmail via the Settings UI or the `integration_connect` HTTP endpoint. OAuth2 tokens are stored in the credential vault — the LLM never sees raw tokens. Slack connects via Socket Mode using a bot token and app-level token — see the `slack-app-setup` skill. Telegram uses a bot token (not OAuth) — see the `telegram-setup` skill for setup instructions.
 


### PR DESCRIPTION
## Summary
- make proxied bash return a Slack-specific cloud-hosted error instead of suggesting a missing local `slack_channel/*` credential
- add regression coverage for managed-mode unresolved refs and point generic hosted-mode guidance at `assistant credentials list`
- clarify in the bundled Slack skill and internal reference that the Slack Socket Mode path is local-assistant only

## Original prompt
--safe ok fix this up in a pr please
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
