### PR TITLE
fix: add openrouter and fireworks to effort-supported providers

### DIFF
--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -1055,7 +1055,7 @@ describe("effort config passthrough", () => {
     expect(config.effort).toBeUndefined();
   });
 
-  test("effort is stripped for fireworks provider", async () => {
+  test("effort is preserved for fireworks provider", async () => {
     let capturedOptions: SendMessageOptions | undefined;
     const inner = makeProvider("fireworks", (opts) => {
       capturedOptions = opts;
@@ -1067,7 +1067,22 @@ describe("effort config passthrough", () => {
     });
 
     const config = capturedOptions?.config as Record<string, unknown>;
-    expect(config.effort).toBeUndefined();
+    expect(config.effort).toBe("low");
+  });
+
+  test("effort is preserved for openrouter provider", async () => {
+    let capturedOptions: SendMessageOptions | undefined;
+    const inner = makeProvider("openrouter", (opts) => {
+      capturedOptions = opts;
+    });
+    const retry = new RetryProvider(inner);
+
+    await retry.sendMessage(DUMMY_MESSAGES, undefined, undefined, {
+      config: { effort: "high" },
+    });
+
+    const config = capturedOptions?.config as Record<string, unknown>;
+    expect(config.effort).toBe("high");
   });
 
   test("effort is preserved for anthropic provider", async () => {

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -19,7 +19,12 @@ import type {
 const log = getLogger("retry");
 
 /** Providers that support the `effort` config (extended thinking / reasoning). */
-const EFFORT_SUPPORTED_PROVIDERS = new Set(["anthropic", "openai"]);
+const EFFORT_SUPPORTED_PROVIDERS = new Set([
+  "anthropic",
+  "openai",
+  "openrouter",
+  "fireworks",
+]);
 
 /** Patterns that indicate a transient streaming corruption from the SDK. */
 const RETRYABLE_STREAM_PATTERNS = [
@@ -81,7 +86,7 @@ function normalizeSendMessageOptions(
     delete nextConfig.thinking;
   }
 
-  // effort is supported by Anthropic and OpenAI; strip it for other providers
+  // effort is supported by Anthropic, OpenAI, and OpenAI-compatible providers; strip for others
   if (
     !EFFORT_SUPPORTED_PROVIDERS.has(providerName) &&
     nextConfig.effort !== undefined


### PR DESCRIPTION
## Summary
Adds `openrouter` and `fireworks` to `EFFORT_SUPPORTED_PROVIDERS` in `retry.ts` so that `effort`/`reasoning_effort` config flows through to OpenRouter and Fireworks models that support it (e.g., Grok, DeepSeek R1, Qwen with reasoning). Both providers extend `OpenAIProvider` which already maps effort to `reasoning_effort`, but the retry layer was stripping it before it could reach `sendMessage`.

- Added `openrouter` and `fireworks` to the supported set
- Updated existing fireworks test from "stripped" to "preserved"
- Added new test for openrouter effort preservation

Part of plan: expand-openrouter-catalog.md (fix round 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22016" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
