### PR TITLE
Remove X-Telemetry-Token from daemon telemetry reporter

### DIFF
--- a/assistant/.env.example
+++ b/assistant/.env.example
@@ -23,10 +23,6 @@ VELLUM_PLATFORM_URL=https://dev-platform.vellum.ai
 # Omit to disable Sentry.
 SENTRY_DSN_ASSISTANT=
 
-# --- Telemetry ---
-# Omit to disable telemetry reporting.
-TELEMETRY_APP_TOKEN=
-
 # --- Network proxy ---
 # Comma-separated host patterns allowed through the proxy.
 # localhost is always allowed.

--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -216,12 +216,6 @@ export function getPlatformInternalApiKey(): string {
   return str("PLATFORM_INTERNAL_API_KEY") ?? "";
 }
 
-// ── Telemetry ──────────────────────────────────────────────────────────────────
-
-export function getTelemetryAppToken(): string {
-  return str("TELEMETRY_APP_TOKEN") ?? "";
-}
-
 // ── Startup validation ──────────────────────────────────────────────────────
 
 /**

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -50,7 +50,6 @@ mock.module("../platform/client.js", () => ({
 }));
 
 const mockGetPlatformBaseUrl = mock(() => "https://platform.vellum.ai");
-const mockGetTelemetryAppToken = mock(() => "");
 
 const mockGetPlatformOrganizationId = mock(() => "");
 const mockGetPlatformUserId = mock(() => "");
@@ -59,7 +58,6 @@ mock.module("../config/env.js", () => ({
   getPlatformBaseUrl: mockGetPlatformBaseUrl,
   getPlatformOrganizationId: mockGetPlatformOrganizationId,
   getPlatformUserId: mockGetPlatformUserId,
-  getTelemetryAppToken: mockGetTelemetryAppToken,
   // Re-export anything else the module might import transitively
   str: () => undefined,
   num: () => undefined,
@@ -159,7 +157,6 @@ beforeEach(() => {
   mockQueryUnreportedLifecycleEvents.mockReturnValue([]);
   mockPlatformClient = null;
   mockGetPlatformBaseUrl.mockReset();
-  mockGetTelemetryAppToken.mockReset();
   mockGetDeviceId.mockReset();
   mockGetDeviceId.mockReturnValue("test-device-id");
   mockGetExternalAssistantId.mockReset();
@@ -172,7 +169,6 @@ beforeEach(() => {
   // Defaults
   mockGetMemoryCheckpoint.mockReturnValue(null);
   mockGetPlatformBaseUrl.mockReturnValue("https://platform.vellum.ai");
-  mockGetTelemetryAppToken.mockReturnValue("default-test-token");
 
   mockFetch = mock(() =>
     Promise.resolve(new Response('{"accepted":0}', { status: 200 })),
@@ -212,10 +208,9 @@ describe("UsageTelemetryReporter", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  test("anonymous flush uses X-Telemetry-Token and default URL", async () => {
+  test("anonymous flush sends request without auth headers", async () => {
     mockPlatformClient = null;
     mockGetPlatformBaseUrl.mockReturnValue("https://platform.test.ai");
-    mockGetTelemetryAppToken.mockReturnValue("anon-token");
 
     const events = [makeUsageEvent()];
     mockQueryUnreportedUsageEvents.mockReturnValue(events);
@@ -230,9 +225,9 @@ describe("UsageTelemetryReporter", () => {
     const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
     expect(url).toStartWith("https://platform.test.ai");
     expect(url).toEndWith("/telemetry/ingest/");
-    expect((opts.headers as Record<string, string>)["X-Telemetry-Token"]).toBe(
-      "anon-token",
-    );
+    const headers = opts.headers as Record<string, string>;
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(headers["X-Telemetry-Token"]).toBeUndefined();
   });
 
   test("watermark advances on successful upload", async () => {

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -6,14 +6,13 @@
  *
  * Two auth modes:
  * - Authenticated: Api-Key header via managed proxy context
- * - Anonymous: X-Telemetry-Token static token from env
+ * - Anonymous: unauthenticated POST (telemetry endpoints are public)
  */
 
 import {
   getPlatformBaseUrl,
   getPlatformOrganizationId,
   getPlatformUserId,
-  getTelemetryAppToken,
 } from "../config/env.js";
 import { getConfig } from "../config/loader.js";
 import {
@@ -153,11 +152,9 @@ export class UsageTelemetryReporter {
       )
         return;
 
-      // Resolve auth context — skip flush when neither auth mode is viable
+      // Resolve auth context — authenticated path uses client, anonymous path
+      // sends unauthenticated (telemetry endpoints are public).
       const client = await VellumPlatformClient.create();
-      if (!client && !getTelemetryAppToken()) {
-        return;
-      }
 
       // Build payload
       const typedEvents: TelemetryEvent[] = [
@@ -219,13 +216,7 @@ export class UsageTelemetryReporter {
         resp = await client.fetch(TELEMETRY_PATH, fetchInit);
       } else {
         const url = `${getPlatformBaseUrl()}${TELEMETRY_PATH}`;
-        resp = await fetch(url, {
-          ...fetchInit,
-          headers: {
-            "Content-Type": "application/json",
-            "X-Telemetry-Token": getTelemetryAppToken(),
-          },
-        });
+        resp = await fetch(url, fetchInit);
       }
 
       if (!resp.ok) {


### PR DESCRIPTION
## Summary
- Remove X-Telemetry-Token header from anonymous telemetry flush
- Remove getTelemetryAppToken() function and TELEMETRY_APP_TOKEN env var
- Update tests to verify anonymous flush sends no auth headers

Part of plan: remove-telemetry-token-auth.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
