### PR TITLE
Remove TELEMETRY_APP_TOKEN from macOS app environment forwarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,10 +7,6 @@
 SENTRY_DSN_MACOS=
 SENTRY_DSN_ASSISTANT=
 
-# --- Telemetry ---
-# Omit or leave empty to disable telemetry.
-TELEMETRY_APP_TOKEN=
-
 # --- Doctor service ---
 # Omit to disable the doctor command.
 DOCTOR_SERVICE_URL=https://doctor.vellum.ai

--- a/clients/macos/vellum-assistant/App/VellumCli.swift
+++ b/clients/macos/vellum-assistant/App/VellumCli.swift
@@ -112,7 +112,6 @@ final class VellumCli {
     nonisolated private static let forwardedEnvKeys: [String] = [
         "BASE_DATA_DIR",
         "VELLUM_PLATFORM_URL",
-        "TELEMETRY_APP_TOKEN",
         "ASSISTANT_GIT_USER_NAME", "ASSISTANT_GIT_USER_EMAIL",
         "CLI_GIT_USER_NAME", "CLI_GIT_USER_EMAIL",
         "PROXY_ALLOWED_HOSTS", "HTTP_USER_AGENT", "DOCTOR_SERVICE_URL",


### PR DESCRIPTION
## Summary
- Remove TELEMETRY_APP_TOKEN from macOS app forwardedEnvKeys in VellumCli.swift
- Remove TELEMETRY_APP_TOKEN from root .env.example

Part of plan: remove-telemetry-token-auth.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
