### PR TITLE
feat: add Anthropic fast mode support behind feature flag

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -24,6 +24,7 @@ export interface AgentLoopConfig {
   maxInputTokens?: number; // context window size for tool result truncation
   thinking?: { enabled: boolean };
   effort: "low" | "medium" | "high" | "max";
+  speed?: "standard" | "fast";
   toolChoice?:
     | { type: "auto" }
     | { type: "any" }
@@ -244,6 +245,10 @@ export class AgentLoop {
 
         if (this.config.effort) {
           providerConfig.effort = this.config.effort;
+        }
+
+        if (this.config.speed && this.config.speed !== "standard") {
+          providerConfig.speed = this.config.speed;
         }
 
         if (this.config.toolChoice) {

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -49,6 +49,7 @@ export type {
   ContextWindowConfig,
   Effort,
   ModelPricingOverride,
+  Speed,
   ThinkingConfig,
 } from "./schemas/inference.js";
 export {
@@ -56,6 +57,7 @@ export {
   ContextWindowConfigSchema,
   EffortSchema,
   ModelPricingOverrideSchema,
+  SpeedSchema,
   ThinkingConfigSchema,
 } from "./schemas/inference.js";
 export type {
@@ -201,6 +203,7 @@ import {
   ContextWindowConfigSchema,
   EffortSchema,
   ModelPricingOverrideSchema,
+  SpeedSchema,
   ThinkingConfigSchema,
 } from "./schemas/inference.js";
 import { IngressConfigSchema } from "./schemas/ingress.js";
@@ -240,6 +243,7 @@ export const AssistantConfigSchema = z
       .default(16000)
       .describe("Maximum number of output tokens per LLM response"),
     effort: EffortSchema,
+    speed: SpeedSchema,
     thinking: ThinkingConfigSchema.default(ThinkingConfigSchema.parse({})),
     contextWindow: ContextWindowConfigSchema.default(
       ContextWindowConfigSchema.parse({}),

--- a/assistant/src/config/schemas/inference.ts
+++ b/assistant/src/config/schemas/inference.ts
@@ -36,6 +36,17 @@ export const EffortSchema = z
 
 export type Effort = z.infer<typeof EffortSchema>;
 
+export const SpeedSchema = z
+  .enum(["standard", "fast"], {
+    error: 'speed must be "standard" or "fast"',
+  })
+  .default("standard")
+  .describe(
+    'Inference speed mode — "fast" enables higher output token throughput on supported models (Opus 4.6) at premium pricing',
+  );
+
+export type Speed = z.infer<typeof SpeedSchema>;
+
 export const ContextOverflowRecoveryConfigSchema = z
   .object({
     enabled: z

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -21,6 +21,7 @@ import type {
   TurnChannelContext,
   TurnInterfaceContext,
 } from "../channels/types.js";
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
 import { ContextWindowManager } from "../context/window-manager.js";
 import type { CesClient } from "../credential-execution/client.js";
@@ -383,6 +384,8 @@ export class Conversation {
       return resolved;
     };
 
+    const fastModeEnabled = isAssistantFeatureFlagEnabled("fast-mode", config);
+
     this.agentLoop = new AgentLoop(
       provider,
       systemPrompt,
@@ -391,6 +394,9 @@ export class Conversation {
         maxInputTokens: config.contextWindow.maxInputTokens,
         thinking: config.thinking,
         effort: config.effort,
+        ...(fastModeEnabled && config.speed === "fast"
+          ? { speed: config.speed }
+          : {}),
       },
       toolDefs.length > 0 ? toolDefs : undefined,
       toolDefs.length > 0 ? toolExecutor : undefined,

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -802,11 +802,10 @@ export class AnthropicProvider implements Provider {
       const expanded = expandCollapsedAssistantTurns(formatted);
 
       sentMessages = ensureToolPairing(repairOrphanedServerToolUse(expanded));
-      const { effort, output_config, ...restConfig } = (config ?? {}) as Record<
-        string,
-        unknown
-      > & {
+      const { effort, speed, output_config, ...restConfig } = (config ??
+        {}) as Record<string, unknown> & {
         effort?: Anthropic.OutputConfig["effort"];
+        speed?: "standard" | "fast";
         output_config?: Record<string, unknown>;
       };
       // Haiku does not support the effort / output_config parameter.
@@ -939,11 +938,25 @@ export class AnthropicProvider implements Provider {
         finalMessage(): Promise<Anthropic.Message>;
       }
 
+      // Fast mode: use the beta endpoint with speed: "fast" for Opus 4.6
+      const useFastMode =
+        speed === "fast" && effectiveModel.includes("opus");
+
       let response: Anthropic.Message;
       try {
-        const stream: UnifiedStream = this.client.messages.stream(params, {
-          signal: timeoutSignal,
-        }) as unknown as UnifiedStream;
+        const stream: UnifiedStream = useFastMode
+          ? (this.client.beta.messages.stream(
+              {
+                ...(params as Record<string, unknown>),
+                speed: "fast" as const,
+                betas: ["fast-mode-2026-02-01" as const],
+              } as Anthropic.Beta.Messages.MessageCreateParamsNonStreaming &
+                Anthropic.Beta.Messages.MessageCreateParamsStreaming,
+              { signal: timeoutSignal },
+            ) as unknown as UnifiedStream)
+          : (this.client.messages.stream(params, {
+              signal: timeoutSignal,
+            }) as unknown as UnifiedStream);
 
         stream.on("text", (text) => {
           onEvent?.({ type: "text_delta", text });

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -68,12 +68,15 @@ function normalizeSendMessageOptions(
     providerName !== "anthropic" && config.thinking !== undefined;
   const needsEffortStrip =
     !EFFORT_SUPPORTED_PROVIDERS.has(providerName) && config.effort !== undefined;
+  const needsSpeedStrip =
+    providerName !== "anthropic" && config.speed !== undefined;
 
   if (
     !hasIntent &&
     explicitModel === config.model &&
     !needsThinkingStrip &&
-    !needsEffortStrip
+    !needsEffortStrip &&
+    !needsSpeedStrip
   ) {
     return options;
   }
@@ -92,6 +95,11 @@ function normalizeSendMessageOptions(
     nextConfig.effort !== undefined
   ) {
     delete nextConfig.effort;
+  }
+
+  // speed (fast mode) is Anthropic-specific; strip for other providers
+  if (providerName !== "anthropic" && nextConfig.speed !== undefined) {
+    delete nextConfig.speed;
   }
 
   if (explicitModel) {

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -132,6 +132,7 @@ export interface SendMessageConfig {
   model?: string;
   modelIntent?: ModelIntent;
   effort?: "low" | "medium" | "high" | "max";
+  speed?: "standard" | "fast";
   [key: string]: unknown;
 }
 

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -344,6 +344,14 @@
       "label": "Voice Mode",
       "description": "Show the live voice conversation button in the composer",
       "defaultEnabled": false
+    },
+    {
+      "id": "fast-mode",
+      "scope": "assistant",
+      "key": "fast-mode",
+      "label": "Fast Mode",
+      "description": "Enable Anthropic fast mode for Opus 4.6, delivering up to 2.5x higher output tokens per second at premium pricing",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `fast-mode` feature flag (disabled by default) and `speed` config option (`"standard"` | `"fast"`, defaults to `"standard"`)
- When the flag is enabled and speed is `"fast"`, the Anthropic provider uses the beta endpoint with `speed: "fast"` and `betas: ["fast-mode-2026-02-01"]` for Opus 4.6 models
- Speed config flows through the full pipeline: config schema → conversation → agent loop → retry provider (stripped for non-Anthropic) → Anthropic provider

## Original prompt
https://platform.claude.com/docs/en/build-with-claude/fast-mode add support for opus 4.6 fast mode behind a feature flag
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22020" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
