### PR TITLE
fix: apply 6x pricing multiplier for Anthropic fast mode usage

### DIFF
--- a/assistant/src/daemon/conversation-usage.ts
+++ b/assistant/src/daemon/conversation-usage.ts
@@ -75,6 +75,25 @@ function extractAnthropicCacheCreation(
   };
 }
 
+/**
+ * Extract the speed indicator from Anthropic fast mode API responses.
+ * The API returns `usage.speed: "fast" | "standard"` when using the
+ * fast-mode beta. For multi-response arrays, returns "fast" if any
+ * response used fast mode.
+ */
+function extractAnthropicSpeed(
+  rawResponse: unknown,
+): "fast" | "standard" | null {
+  const responses = Array.isArray(rawResponse) ? rawResponse : [rawResponse];
+  for (const response of responses) {
+    const rec = asRecord(response);
+    const usage = asRecord(rec?.usage);
+    if (usage?.speed === "fast") return "fast";
+    if (usage?.speed === "standard") return "standard";
+  }
+  return null;
+}
+
 function resolveStructuredPricing(
   providerName: string,
   model: string,
@@ -120,15 +139,16 @@ export function recordUsage(
     0,
   );
 
+  const isAnthropic = ctx.providerName === "anthropic";
   const pricingUsage: PricingUsage = {
     directInputTokens,
     outputTokens,
     cacheCreationInputTokens: normalizedCacheCreationInputTokens,
     cacheReadInputTokens: normalizedCacheReadInputTokens,
-    anthropicCacheCreation:
-      ctx.providerName === "anthropic"
-        ? extractAnthropicCacheCreation(rawResponse)
-        : null,
+    anthropicCacheCreation: isAnthropic
+      ? extractAnthropicCacheCreation(rawResponse)
+      : null,
+    speed: isAnthropic ? extractAnthropicSpeed(rawResponse) : null,
   };
   const pricing = resolveStructuredPricing(
     ctx.providerName,

--- a/assistant/src/usage/types.ts
+++ b/assistant/src/usage/types.ts
@@ -19,6 +19,8 @@ export interface PricingUsage {
   cacheCreationInputTokens: number;
   cacheReadInputTokens: number;
   anthropicCacheCreation: AnthropicCacheCreationTokenDetails | null;
+  /** Anthropic fast mode speed indicator from the API response. */
+  speed?: "fast" | "standard" | null;
 }
 
 /**

--- a/assistant/src/util/pricing.ts
+++ b/assistant/src/util/pricing.ts
@@ -12,6 +12,9 @@ const ANTHROPIC_PROMPT_CACHE_MULTIPLIERS = {
   write1h: 2,
 } as const;
 
+/** Fast mode pricing is 6x standard rates for all token types. */
+const ANTHROPIC_FAST_MODE_MULTIPLIER = 6;
+
 /**
  * Multi-provider pricing catalog keyed by provider then model pattern.
  * Model patterns are matched by exact match first, then by prefix.
@@ -147,12 +150,22 @@ function calculateUsageCost(
   pricing: ModelPricing,
   usage: PricingUsage,
 ): number {
+  // Anthropic fast mode: 6x multiplier on base rates (cache multipliers stack on top)
+  const speedMultiplier =
+    provider === "anthropic" && usage.speed === "fast"
+      ? ANTHROPIC_FAST_MODE_MULTIPLIER
+      : 1;
+  const effectivePricing: ModelPricing = {
+    inputPer1M: pricing.inputPer1M * speedMultiplier,
+    outputPer1M: pricing.outputPer1M * speedMultiplier,
+  };
+
   const directInputCost = calculateTokenCost(
-    pricing.inputPer1M,
+    effectivePricing.inputPer1M,
     usage.directInputTokens,
   );
   const outputCost = calculateTokenCost(
-    pricing.outputPer1M,
+    effectivePricing.outputPer1M,
     usage.outputTokens,
   );
 
@@ -161,7 +174,7 @@ function calculateUsageCost(
       directInputCost +
       outputCost +
       calculateTokenCost(
-        pricing.inputPer1M,
+        effectivePricing.inputPer1M,
         usage.cacheCreationInputTokens + usage.cacheReadInputTokens,
       )
     );
@@ -174,15 +187,15 @@ function calculateUsageCost(
     directInputCost +
     outputCost +
     calculateTokenCost(
-      pricing.inputPer1M * ANTHROPIC_PROMPT_CACHE_MULTIPLIERS.read,
+      effectivePricing.inputPer1M * ANTHROPIC_PROMPT_CACHE_MULTIPLIERS.read,
       usage.cacheReadInputTokens,
     ) +
     calculateTokenCost(
-      pricing.inputPer1M * ANTHROPIC_PROMPT_CACHE_MULTIPLIERS.write5m,
+      effectivePricing.inputPer1M * ANTHROPIC_PROMPT_CACHE_MULTIPLIERS.write5m,
       ephemeral5mInputTokens,
     ) +
     calculateTokenCost(
-      pricing.inputPer1M * ANTHROPIC_PROMPT_CACHE_MULTIPLIERS.write1h,
+      effectivePricing.inputPer1M * ANTHROPIC_PROMPT_CACHE_MULTIPLIERS.write1h,
       ephemeral1hInputTokens,
     )
   );


### PR DESCRIPTION
## Summary
- Extracts `usage.speed` from Anthropic API responses to detect fast mode usage
- Applies 6x pricing multiplier to base rates when speed is `"fast"` ($5→$30 input, $25→$150 output per MTok)
- Cache multipliers correctly stack on top of fast mode rates, matching Anthropic's documented pricing behavior

## Original prompt
https://platform.claude.com/docs/en/build-with-claude/fast-mode add support for opus 4.6 fast mode behind a feature flag
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
