### PR TITLE
fix: render user-sent image attachments at full size

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -95,73 +95,79 @@ private struct AttachmentImageGrid<Fallback: View>: View {
     /// gray-placeholder state.
     @State private var failedIds: Set<String> = []
 
+    @Environment(\.displayScale) private var displayScale
+
+    /// Single images render at full width; multiple images use a compact grid.
+    private var isSingleImage: Bool { imageAttachments.count == 1 }
+
     @available(macOS, deprecated: 13.0)
     var body: some View {
         HStack(spacing: VSpacing.sm) {
             ForEach(imageAttachments, id: \.id) { attachment in
                 Group {
                     if let nsImage = loadedImages[attachment.id] {
-                        Image(nsImage: nsImage)
-                            .resizable()
-                            .aspectRatio(contentMode: .fill)
-                            .frame(width: 60, height: 60)
-                            .clipped()
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-                            .onTapGesture {
-                                onTap(attachment, nsImage)
+                        Group {
+                            if isSingleImage {
+                                singleImageContent(nsImage)
+                            } else {
+                                gridImageContent(nsImage)
                             }
-                            .contextMenu {
-                                ImageActions.contextMenuItems(
-                                    image: nsImage,
-                                    filename: attachment.filename,
-                                    base64Data: attachment.data.isEmpty ? nil : attachment.data,
-                                    lazyAttachmentId: attachment.isLazyLoad ? attachment.id : nil
-                                )
-                            }
-                            .onDrag {
-                                NotificationCenter.default.post(name: .internalImageDragStarted, object: nil)
-                                let provider = NSItemProvider()
-                                let hasBase64 = !attachment.data.isEmpty
+                        }
+                        .onTapGesture {
+                            onTap(attachment, nsImage)
+                        }
+                        .contextMenu {
+                            ImageActions.contextMenuItems(
+                                image: nsImage,
+                                filename: attachment.filename,
+                                base64Data: attachment.data.isEmpty ? nil : attachment.data,
+                                lazyAttachmentId: attachment.isLazyLoad ? attachment.id : nil
+                            )
+                        }
+                        .onDrag {
+                            NotificationCenter.default.post(name: .internalImageDragStarted, object: nil)
+                            let provider = NSItemProvider()
+                            let hasBase64 = !attachment.data.isEmpty
 
-                                // Pre-compute thumbnail PNG on main thread as a fallback.
-                                // tiffRepresentation is not thread-safe so this must happen
-                                // here, not in the lazy registerDataRepresentation callback.
-                                let thumbnailPNG: Data? = {
-                                    guard let img = loadedImages[attachment.id],
-                                          let tiff = img.tiffRepresentation,
-                                          let rep = NSBitmapImageRep(data: tiff) else { return nil }
-                                    return rep.representation(using: .png, properties: [:])
-                                }()
+                            // Pre-compute thumbnail PNG on main thread as a fallback.
+                            // tiffRepresentation is not thread-safe so this must happen
+                            // here, not in the lazy registerDataRepresentation callback.
+                            let thumbnailPNG: Data? = {
+                                guard let img = loadedImages[attachment.id],
+                                      let tiff = img.tiffRepresentation,
+                                      let rep = NSBitmapImageRep(data: tiff) else { return nil }
+                                return rep.representation(using: .png, properties: [:])
+                            }()
 
-                                if hasBase64 {
-                                    let mimeType = attachment.mimeType
-                                    let utType = UTType(mimeType: mimeType) ?? .png
-                                    let base64String = attachment.data
-                                    provider.registerDataRepresentation(forTypeIdentifier: utType.identifier, visibility: .all) { completion in
-                                        // Decode lazily when drop target requests data
-                                        if let decoded = Data(base64Encoded: base64String), !decoded.isEmpty {
-                                            completion(decoded, nil)
-                                        } else if let thumbnailPNG {
-                                            // Corrupt base64 — fall back to pre-computed thumbnail
-                                            completion(thumbnailPNG, nil)
-                                        } else {
-                                            completion(nil, nil)
-                                        }
-                                        return nil
-                                    }
-                                } else if let thumbnailPNG {
-                                    provider.registerDataRepresentation(forTypeIdentifier: UTType.png.identifier, visibility: .all) { completion in
+                            if hasBase64 {
+                                let mimeType = attachment.mimeType
+                                let utType = UTType(mimeType: mimeType) ?? .png
+                                let base64String = attachment.data
+                                provider.registerDataRepresentation(forTypeIdentifier: utType.identifier, visibility: .all) { completion in
+                                    // Decode lazily when drop target requests data
+                                    if let decoded = Data(base64Encoded: base64String), !decoded.isEmpty {
+                                        completion(decoded, nil)
+                                    } else if let thumbnailPNG {
+                                        // Corrupt base64 — fall back to pre-computed thumbnail
                                         completion(thumbnailPNG, nil)
-                                        return nil
+                                    } else {
+                                        completion(nil, nil)
                                     }
+                                    return nil
                                 }
-                                // Force .png extension when falling back to PNG encoding
-                                let filename = attachment.filename
-                                // Strip extension — Finder appends it from the UTType
-                                provider.suggestedName = (filename as NSString).deletingPathExtension
-                                return provider
+                            } else if let thumbnailPNG {
+                                provider.registerDataRepresentation(forTypeIdentifier: UTType.png.identifier, visibility: .all) { completion in
+                                    completion(thumbnailPNG, nil)
+                                    return nil
+                                }
                             }
-                            .pointerCursor()
+                            // Force .png extension when falling back to PNG encoding
+                            let filename = attachment.filename
+                            // Strip extension — Finder appends it from the UTType
+                            provider.suggestedName = (filename as NSString).deletingPathExtension
+                            return provider
+                        }
+                        .pointerCursor()
                     } else if failedIds.contains(attachment.id) {
                         // All decode paths failed — show a file chip so the user still has the
                         // filename and a download affordance for corrupt/unsupported payloads.
@@ -170,8 +176,12 @@ private struct AttachmentImageGrid<Fallback: View>: View {
                         // Placeholder shown while the image is being decoded off the main thread.
                         Rectangle()
                             .fill(VColor.surfaceActive)
-                            .frame(width: 60, height: 60)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                            .frame(
+                                width: isSingleImage ? nil : 160,
+                                height: isSingleImage ? 200 : 120
+                            )
+                            .frame(maxWidth: isSingleImage ? VSpacing.chatBubbleMaxWidth : nil)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
                     }
                 }
                 // NSImage(data:) is called directly inside .task — no Task{} wrapper — so
@@ -218,6 +228,41 @@ private struct AttachmentImageGrid<Fallback: View>: View {
                 }
             }
         }
+    }
+
+    /// Full-width rendering for a single image attachment, matching tool-generated image sizing.
+    @ViewBuilder
+    private func singleImageContent(_ nsImage: NSImage) -> some View {
+        if let cgImage = nsImage.cgImage(forProposedRect: nil, context: nil, hints: nil) {
+            let nativeWidth = CGFloat(cgImage.width) / displayScale
+            let nativeHeight = CGFloat(cgImage.height) / displayScale
+            let maxDim: CGFloat = VSpacing.chatBubbleMaxWidth
+            Image(decorative: cgImage, scale: displayScale)
+                .resizable()
+                .interpolation(.high)
+                .aspectRatio(contentMode: .fit)
+                .frame(
+                    maxWidth: min(nativeWidth, maxDim),
+                    maxHeight: min(nativeHeight, maxDim)
+                )
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        } else {
+            Image(nsImage: nsImage)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(maxWidth: VSpacing.chatBubbleMaxWidth)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        }
+    }
+
+    /// Compact grid cell for multiple image attachments.
+    private func gridImageContent(_ nsImage: NSImage) -> some View {
+        Image(nsImage: nsImage)
+            .resizable()
+            .aspectRatio(contentMode: .fill)
+            .frame(width: 160, height: 120)
+            .clipped()
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
     }
 }
 


### PR DESCRIPTION
## Summary
- Single image attachments now render at full width within the chat bubble, matching tool-generated image sizing with proper Retina display scaling
- Multiple image attachments use a larger 160×120 grid (up from 60×60) for better visibility
- Loading placeholders sized to match the new dimensions to prevent layout jumps
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22023" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
