### PR TITLE
fix: stop truncating error messages in conversation errors

### DIFF
--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -458,10 +458,8 @@ function classifyByMessage(
       .split("\n")
       .map((l) => l.trim())
       .find((l) => l.length > 0) ?? "";
-  const summary =
-    firstLine.length > 150 ? firstLine.slice(0, 150) + "..." : firstLine;
-  const userMessage = summary
-    ? `Processing failed: ${summary}`
+  const userMessage = firstLine
+    ? `Processing failed: ${firstLine}`
     : "Something went wrong processing your message. Please try again.";
   return {
     code: "CONVERSATION_PROCESSING_FAILED",


### PR DESCRIPTION
## Summary
- Remove the 150-character truncation (`firstLine.slice(0, 150) + "..."`) from conversation processing-failed errors
- The client already wraps long text via `.fixedSize(horizontal: false, vertical: true)`, so server-side truncation is unnecessary and hides useful error details

## Original prompt
Fix truncated error messages in conversation errors.

In `assistant/src/daemon/conversation-error.ts` around line 461-462, the error message's first line is truncated to 150 characters with `...`:

```
const summary = firstLine.length > 150 ? firstLine.slice(0, 150) + "..." : firstLine;
```

Remove this truncation — just use `firstLine` directly as the summary. The client already handles text wrapping via `.fixedSize(horizontal: false, vertical: true)`, so there's no reason to truncate server-side.