### PR TITLE
fix: make processing-failed errors retryable

### DIFF
--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -464,7 +464,7 @@ function classifyByMessage(
   return {
     code: "CONVERSATION_PROCESSING_FAILED",
     userMessage,
-    retryable: false,
+    retryable: true,
     errorCategory: "processing_failed",
   };
 }


### PR DESCRIPTION
## Summary
- Set `retryable: true` for `CONVERSATION_PROCESSING_FAILED` errors so the client shows a Retry button
- These errors (e.g. content filtering, transient API failures) are often worth retrying — the Retry button was already implemented in the client but never shown for this error category

## Original prompt
Add a retry button to processing-failed error messages. The client already has a retry button that renders when `isRetryable == true`, but `CONVERSATION_PROCESSING_FAILED` errors were hardcoded to `retryable: false`.