### PR TITLE
fix(macos): show full-resolution image in composer attachment lightbox

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerAttachments.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerAttachments.swift
@@ -100,14 +100,15 @@ extension ComposerView {
 
 extension ComposerView {
     func openAttachmentPreview(_ attachment: ChatAttachment) {
-        // Prefer pre-decoded thumbnail, fall back to decoding base64 data
+        // Prefer full-resolution data for the lightbox, fall back to thumbnail
         let image: NSImage?
-        if let thumbnail = attachment.thumbnailImage {
+        if !attachment.data.isEmpty,
+           let data = Data(base64Encoded: attachment.data),
+           !data.isEmpty,
+           let fullRes = NSImage(data: data) {
+            image = fullRes
+        } else if let thumbnail = attachment.thumbnailImage {
             image = thumbnail
-        } else if !attachment.data.isEmpty,
-                  let data = Data(base64Encoded: attachment.data),
-                  !data.isEmpty {
-            image = NSImage(data: data)
         } else {
             image = nil
         }


### PR DESCRIPTION
## Summary
- Reversed the image source priority in `openAttachmentPreview`: decode full-resolution base64 data first, fall back to 120px thumbnail only when data is unavailable
- Previously the lightbox always showed the tiny thumbnail because `thumbnailImage` was checked first and was always present, while the lazy-load fetch path (for full-res) only triggers for sent attachments with a `lazyAttachmentId`

## Original prompt
Fix the composer attachment lightbox preview showing a blurry 120px thumbnail instead of the full-resolution image.