### PR TITLE
fix: update conversation-error test for retryable processing-failed errors

### DIFF
--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -368,7 +368,7 @@ describe("classifyConversationError", () => {
         baseCtx,
       );
       expect(result.code).toBe("CONVERSATION_PROCESSING_FAILED");
-      expect(result.retryable).toBe(false);
+      expect(result.retryable).toBe(true);
       expect(result.userMessage).toContain("something completely unexpected");
       expect(result.errorCategory).toBe("processing_failed");
     });


### PR DESCRIPTION
## Summary
- Updates the `conversation-error.test.ts` assertion for unknown errors to expect `retryable: true`, matching the behavior change shipped in #22029.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23674919980/job/68975973804