### PR TITLE
fix: place now_scratchpad before user message content

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -1435,26 +1435,51 @@ describe("injectNowScratchpad", () => {
     content: [{ type: "text", text: "What should I work on?" }],
   };
 
-  test("appends now_scratchpad block to user message", () => {
+  test("inserts now_scratchpad before user content", () => {
     const result = injectNowScratchpad(
       baseUserMessage,
       "Current focus: shipping PR 3",
     );
     expect(result.content.length).toBe(2);
-    // Original content comes first
-    expect((result.content[0] as { type: "text"; text: string }).text).toBe(
-      "What should I work on?",
-    );
-    // Scratchpad is appended (not prepended)
-    const injected = result.content[1];
+    // Scratchpad comes first (before user content)
+    const injected = result.content[0];
     expect(injected.type).toBe("text");
     const text = (injected as { type: "text"; text: string }).text;
     expect(text).toBe(
       "<now_scratchpad>\nCurrent focus: shipping PR 3\n</now_scratchpad>",
     );
+    // Original content comes last
+    expect((result.content[1] as { type: "text"; text: string }).text).toBe(
+      "What should I work on?",
+    );
   });
 
-  test("preserves existing multi-block content and appends at end", () => {
+  test("inserts after memory_context but before user content", () => {
+    const messageWithMemory: Message = {
+      role: "user",
+      content: [
+        { type: "text", text: "<memory_context __injected>\nrecalled notes\n</memory_context>" },
+        { type: "text", text: "What should I work on?" },
+      ],
+    };
+
+    const result = injectNowScratchpad(messageWithMemory, "scratchpad notes");
+    expect(result.content.length).toBe(3);
+    // Memory context stays first
+    expect(
+      (result.content[0] as { type: "text"; text: string }).text,
+    ).toContain("<memory_context");
+    // Scratchpad inserted after memory
+    expect(
+      (result.content[1] as { type: "text"; text: string }).text,
+    ).toContain("<now_scratchpad>");
+    // User content is last
+    expect((result.content[2] as { type: "text"; text: string }).text).toBe(
+      "What should I work on?",
+    );
+  });
+
+  test("preserves existing multi-block content with scratchpad before it", () => {
     const multiBlockMessage: Message = {
       role: "user",
       content: [
@@ -1465,15 +1490,16 @@ describe("injectNowScratchpad", () => {
 
     const result = injectNowScratchpad(multiBlockMessage, "scratchpad notes");
     expect(result.content.length).toBe(3);
-    expect((result.content[0] as { type: "text"; text: string }).text).toBe(
+    // Scratchpad is first (no memory_context to skip)
+    expect(
+      (result.content[0] as { type: "text"; text: string }).text,
+    ).toContain("<now_scratchpad>");
+    expect((result.content[1] as { type: "text"; text: string }).text).toBe(
       "First block",
     );
-    expect((result.content[1] as { type: "text"; text: string }).text).toBe(
+    expect((result.content[2] as { type: "text"; text: string }).text).toBe(
       "Second block",
     );
-    expect(
-      (result.content[2] as { type: "text"; text: string }).text,
-    ).toContain("<now_scratchpad>");
   });
 });
 
@@ -1593,25 +1619,25 @@ describe("applyRuntimeInjections with nowScratchpad", () => {
 
     expect(result.length).toBe(1);
     expect(result[0].content.length).toBe(2);
-    const injected = result[0].content[1];
+    const injected = result[0].content[0];
     const text = (injected as { type: "text"; text: string }).text;
     expect(text).toContain("<now_scratchpad>");
     expect(text).toContain("Current focus: fix the bug");
   });
 
-  test("appended block appears after user's original text content", () => {
+  test("scratchpad appears before user's original text content", () => {
     const result = applyRuntimeInjections(baseMessages, {
       nowScratchpad: "scratchpad notes",
     });
 
-    // Original text is first
+    // Scratchpad comes first (before user content)
     expect(
       (result[0].content[0] as { type: "text"; text: string }).text,
-    ).toBe("What should I do?");
-    // Scratchpad is appended after
+    ).toContain("<now_scratchpad>");
+    // Original text is last
     expect(
       (result[0].content[1] as { type: "text"; text: string }).text,
-    ).toContain("<now_scratchpad>");
+    ).toBe("What should I do?");
   });
 
   test("does not inject when nowScratchpad is null", () => {

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -487,21 +487,42 @@ export function readNowScratchpad(): string | null {
 }
 
 /**
- * Append NOW.md scratchpad content to the last user message so the model
- * has access to the user's ephemeral scratchpad notes at the end of context.
+ * Insert NOW.md scratchpad content into the user message, after any
+ * injected context blocks (e.g. memory_context) but before the user's
+ * original content.  This keeps the user's actual message as the last
+ * thing the model reads.
  */
 export function injectNowScratchpad(
   message: Message,
   content: string,
 ): Message {
+  const scratchpadBlock = {
+    type: "text" as const,
+    text: `<now_scratchpad>\n${content}\n</now_scratchpad>`,
+  };
+
+  // Find insertion point: skip any leading injected-context text blocks
+  // (e.g. memory_context) so the scratchpad lands between injected context
+  // and the user's original content.
+  let insertIdx = 0;
+  for (let i = 0; i < message.content.length; i++) {
+    const block = message.content[i];
+    if (
+      block.type === "text" &&
+      block.text.startsWith("<memory_context")
+    ) {
+      insertIdx = i + 1;
+    } else {
+      break;
+    }
+  }
+
   return {
     ...message,
     content: [
-      ...message.content,
-      {
-        type: "text",
-        text: `<now_scratchpad>\n${content}\n</now_scratchpad>`,
-      },
+      ...message.content.slice(0, insertIdx),
+      scratchpadBlock,
+      ...message.content.slice(insertIdx),
     ],
   };
 }


### PR DESCRIPTION
## Summary
- Changed `injectNowScratchpad` to insert the scratchpad block **before** the user's original content rather than after it, so the user message is always the last thing in the content array
- The scratchpad is inserted after any leading `memory_context` blocks, preserving the order: injected context → memory → scratchpad → user message
- Updated tests to reflect the new ordering

## Original prompt
Let's reorder this so that the user message is last after now_scratchpad
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22032" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
