### PR TITLE
Rename now_scratchpad to NOW.md

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -1341,7 +1341,7 @@ describe("applyRuntimeInjections — injection mode", () => {
     expect(allText).toContain("<turn_context>");
     expect(allText).toContain("<inbound_actor_context>");
     expect(allText).toContain("<non_interactive_context>");
-    expect(allText).toContain("<now_scratchpad>");
+    expect(allText).toContain("<NOW.md");
   });
 
   test("explicit mode: 'full' behaves the same as default", () => {
@@ -1358,7 +1358,7 @@ describe("applyRuntimeInjections — injection mode", () => {
     expect(allText).toContain("<temporal_context>");
     expect(allText).toContain("<channel_command_context>");
     expect(allText).toContain("<active_workspace>");
-    expect(allText).toContain("<now_scratchpad>");
+    expect(allText).toContain("<NOW.md");
   });
 
   test("minimal mode skips high-token optional blocks", () => {
@@ -1376,7 +1376,7 @@ describe("applyRuntimeInjections — injection mode", () => {
     expect(allText).not.toContain("<temporal_context>");
     expect(allText).not.toContain("<channel_command_context>");
     expect(allText).not.toContain("<active_workspace>");
-    expect(allText).not.toContain("<now_scratchpad>");
+    expect(allText).not.toContain("<NOW.md");
   });
 
   test("minimal mode preserves safety-critical blocks", () => {
@@ -1435,7 +1435,7 @@ describe("injectNowScratchpad", () => {
     content: [{ type: "text", text: "What should I work on?" }],
   };
 
-  test("appends now_scratchpad block to user message", () => {
+  test("appends NOW.md block to user message", () => {
     const result = injectNowScratchpad(
       baseUserMessage,
       "Current focus: shipping PR 3",
@@ -1450,7 +1450,7 @@ describe("injectNowScratchpad", () => {
     expect(injected.type).toBe("text");
     const text = (injected as { type: "text"; text: string }).text;
     expect(text).toBe(
-      "<now_scratchpad>\nCurrent focus: shipping PR 3\n</now_scratchpad>",
+      "<NOW.md Always keep this up to date>\nCurrent focus: shipping PR 3\n</NOW.md>",
     );
   });
 
@@ -1473,7 +1473,7 @@ describe("injectNowScratchpad", () => {
     );
     expect(
       (result.content[2] as { type: "text"; text: string }).text,
-    ).toContain("<now_scratchpad>");
+    ).toContain("<NOW.md");
   });
 });
 
@@ -1482,7 +1482,7 @@ describe("injectNowScratchpad", () => {
 // ---------------------------------------------------------------------------
 
 describe("stripNowScratchpad", () => {
-  test("strips now_scratchpad blocks from user messages", () => {
+  test("strips NOW.md blocks from user messages", () => {
     const messages: Message[] = [
       {
         role: "user",
@@ -1490,7 +1490,7 @@ describe("stripNowScratchpad", () => {
           { type: "text", text: "Hello" },
           {
             type: "text",
-            text: "<now_scratchpad>\nSome notes\n</now_scratchpad>",
+            text: "<NOW.md Always keep this up to date>\nSome notes\n</NOW.md>",
           },
         ],
       },
@@ -1511,14 +1511,14 @@ describe("stripNowScratchpad", () => {
     expect(result[1].content.length).toBe(1);
   });
 
-  test("removes user messages that only contain now_scratchpad", () => {
+  test("removes user messages that only contain NOW.md", () => {
     const messages: Message[] = [
       {
         role: "user",
         content: [
           {
             type: "text",
-            text: "<now_scratchpad>\nSome notes\n</now_scratchpad>",
+            text: "<NOW.md Always keep this up to date>\nSome notes\n</NOW.md>",
           },
         ],
       },
@@ -1528,7 +1528,7 @@ describe("stripNowScratchpad", () => {
     expect(result.length).toBe(0);
   });
 
-  test("leaves messages without now_scratchpad untouched", () => {
+  test("leaves messages without NOW.md untouched", () => {
     const messages: Message[] = [
       {
         role: "user",
@@ -1543,11 +1543,11 @@ describe("stripNowScratchpad", () => {
 });
 
 // ---------------------------------------------------------------------------
-// stripInjectedContext removes now_scratchpad blocks
+// stripInjectedContext removes NOW.md blocks
 // ---------------------------------------------------------------------------
 
-describe("stripInjectedContext with now_scratchpad", () => {
-  test("strips now_scratchpad blocks alongside other injections", () => {
+describe("stripInjectedContext with NOW.md", () => {
+  test("strips NOW.md blocks alongside other injections", () => {
     const messages: Message[] = [
       {
         role: "user",
@@ -1559,7 +1559,7 @@ describe("stripInjectedContext with now_scratchpad", () => {
           { type: "text", text: "Hello" },
           {
             type: "text",
-            text: "<now_scratchpad>\nCurrent focus\n</now_scratchpad>",
+            text: "<NOW.md Always keep this up to date>\nCurrent focus\n</NOW.md>",
           },
         ],
       },
@@ -1586,7 +1586,7 @@ describe("applyRuntimeInjections with nowScratchpad", () => {
     },
   ];
 
-  test("injects now_scratchpad block when provided", () => {
+  test("injects NOW.md block when provided", () => {
     const result = applyRuntimeInjections(baseMessages, {
       nowScratchpad: "Current focus: fix the bug",
     });
@@ -1595,7 +1595,7 @@ describe("applyRuntimeInjections with nowScratchpad", () => {
     expect(result[0].content.length).toBe(2);
     const injected = result[0].content[1];
     const text = (injected as { type: "text"; text: string }).text;
-    expect(text).toContain("<now_scratchpad>");
+    expect(text).toContain("<NOW.md");
     expect(text).toContain("Current focus: fix the bug");
   });
 
@@ -1611,7 +1611,7 @@ describe("applyRuntimeInjections with nowScratchpad", () => {
     // Scratchpad is appended after
     expect(
       (result[0].content[1] as { type: "text"; text: string }).text,
-    ).toContain("<now_scratchpad>");
+    ).toContain("<NOW.md");
   });
 
   test("does not inject when nowScratchpad is null", () => {
@@ -1641,6 +1641,6 @@ describe("applyRuntimeInjections with nowScratchpad", () => {
       .map((b) => b.text)
       .join("\n");
 
-    expect(allText).not.toContain("<now_scratchpad>");
+    expect(allText).not.toContain("<NOW.md");
   });
 });

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -500,15 +500,18 @@ export function injectNowScratchpad(
       ...message.content,
       {
         type: "text",
-        text: `<now_scratchpad>\n${content}\n</now_scratchpad>`,
+        text: `<NOW.md Always keep this up to date>\n${content}\n</NOW.md>`,
       },
     ],
   };
 }
 
-/** Strip `<now_scratchpad>` blocks injected by `injectNowScratchpad`. */
+/** Strip `<NOW.md>` blocks injected by `injectNowScratchpad`. */
 export function stripNowScratchpad(messages: Message[]): Message[] {
-  return stripUserTextBlocksByPrefix(messages, ["<now_scratchpad>"]);
+  return stripUserTextBlocksByPrefix(messages, [
+    "<NOW.md",
+    "<now_scratchpad>", // backward-compat: strip legacy blocks from pre-rename history
+  ]);
 }
 
 /**
@@ -1034,7 +1037,8 @@ const RUNTIME_INJECTION_PREFIXES = [
   "<active_workspace>",
   "<active_dynamic_page>",
   "<non_interactive_context>",
-  "<now_scratchpad>",
+  "<NOW.md",
+  "<now_scratchpad>", // backward-compat: strip legacy blocks from pre-rename history
   "<transport_hints>",
 ];
 


### PR DESCRIPTION
## Summary
- Rename the `<now_scratchpad>` XML tag to `<NOW.md Always keep this up to date>` / `</NOW.md>` so the assistant sees the tag as a filename with an instruction note
- Add backward-compat legacy prefix stripping for existing conversation history that contains the old `<now_scratchpad>` tag
- Update all test assertions to match the new tag format

## Original prompt
Let's change `now_scratchpad` to `NOW.md` and add a note in the opening tag `<NOW.md Always keep this up to date>`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22033" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
