### PR TITLE
fix(macos): prevent app freeze when scrolling during large streaming responses

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -787,6 +787,19 @@ struct ChatBubble: View {
     // redundant reevaluations return instantly without re-parsing.
 
     @MainActor static var lastStreamingSegments: (text: String, value: [MarkdownSegment])?
+
+    /// Timestamp of the last streaming markdown parse. Used with
+    /// `streamingParseThrottleInterval` to throttle O(n) re-parsing
+    /// during streaming of large messages with tables.
+    @MainActor static var lastStreamingParseTime: TimeInterval = 0
+
+    /// Streaming text length above which markdown parsing is throttled.
+    static let streamingParseThrottleThreshold = 2000
+
+    /// Minimum interval between streaming markdown parses for large text.
+    /// 150ms allows ~7 updates/sec — visually smooth while preventing
+    /// CPU saturation from synchronous O(n) table parsing on every chunk.
+    static let streamingParseThrottleInterval: TimeInterval = 0.15
 }
 
 /// NSObject wrapper for `[MarkdownSegment]` to satisfy NSCache's NSObject value requirement.

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -76,9 +76,24 @@ extension ChatBubble {
         if isStreaming, let last = lastStreamingSegments, last.text == text {
             return last.value
         }
+        // Streaming throttle: for large streaming text, reuse the previous
+        // parse result if we parsed recently. Prevents synchronous O(n)
+        // markdown re-parsing (with regex table checks per line and
+        // per-cell AttributedString builds) on every rendering pass,
+        // which otherwise pegs the CPU at 100% during streaming of
+        // large messages with tables.
+        if isStreaming,
+           text.count > streamingParseThrottleThreshold,
+           let last = lastStreamingSegments {
+            let now = ProcessInfo.processInfo.systemUptime
+            if now - lastStreamingParseTime < streamingParseThrottleInterval {
+                return last.value
+            }
+        }
         let result = parseMarkdownSegments(text)
         if isStreaming {
             lastStreamingSegments = (text, result)
+            lastStreamingParseTime = ProcessInfo.processInfo.systemUptime
             return result
         }
         // Skip caching for very long text to avoid a single huge entry

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator+ScrollBehavior.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollCoordinator+ScrollBehavior.swift
@@ -449,7 +449,12 @@ extension MessageListScrollCoordinator {
         scrollRestoreTask?.cancel()
         scrollRestoreTask = nil
         clearAllSuppression()
-        if pushToTopMessageId != nil { pushToTopMessageId = nil }
+        // Do NOT clear pushToTopMessageId here. Removing the tail spacer
+        // while the user is actively scrolling causes a content-height
+        // discontinuity (viewport-height drop) that makes the scroll
+        // position jump. Let overflow detection (distanceFromBottom > 50)
+        // or the onScrollPhaseChange idle handler clear it naturally
+        // when the layout can absorb the change.
         detachFromBottom()
         hasReceivedScrollEvent = true
     }


### PR DESCRIPTION
## Summary
- Fix scroll position jump caused by instantly removing the push-to-top tail spacer when the user scrolls up — now exits push-to-top gracefully via overflow detection or idle handler
- Add 150ms time-based throttle for streaming markdown parsing of large text (>2000 chars), preventing synchronous O(n) re-parses with table detection from pegging the CPU at 100%
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22035" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
