### PR TITLE
feat(memory): increase retrieval generosity — scoring formula, candidate pool, budget defaults

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -175,8 +175,8 @@ describe("AssistantConfigSchema", () => {
     const result = AssistantConfigSchema.parse({});
     expect(result.memory.retrieval.dynamicBudget).toEqual({
       enabled: true,
-      minInjectTokens: 1200,
-      maxInjectTokens: 10000,
+      minInjectTokens: 2400,
+      maxInjectTokens: 16000,
       targetHeadroomTokens: 10000,
     });
   });

--- a/assistant/src/config/schemas/memory-retrieval.ts
+++ b/assistant/src/config/schemas/memory-retrieval.ts
@@ -19,7 +19,7 @@ export const MemoryDynamicBudgetConfigSchema = z
       .positive(
         "memory.retrieval.dynamicBudget.minInjectTokens must be a positive integer",
       )
-      .default(1200)
+      .default(2400)
       .describe(
         "Minimum number of tokens to inject from memory, even when context space is limited",
       ),
@@ -32,7 +32,7 @@ export const MemoryDynamicBudgetConfigSchema = z
       .positive(
         "memory.retrieval.dynamicBudget.maxInjectTokens must be a positive integer",
       )
-      .default(10000)
+      .default(16000)
       .describe(
         "Maximum number of tokens to inject from memory, even when plenty of context space is available",
       ),

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -300,7 +300,7 @@ export async function buildMemoryRecall(
     options?.scopePolicyOverride,
   );
 
-  const HYBRID_LIMIT = 20;
+  const HYBRID_LIMIT = 40;
 
   let hybridCandidates: Candidate[] = [];
   let semanticSearchFailed = false;
@@ -436,9 +436,9 @@ export async function buildMemoryRecall(
   for (const c of allCandidates) {
     // Multiplicative scoring: importance, confidence, and recency amplify semantic
     // relevance but can't substitute for it. An irrelevant item (semantic ≈ 0)
-    // stays low regardless of metadata. Multiplier range: 0.4 (all zero) to 1.0.
+    // stays low regardless of metadata. Multiplier range: 0.35 (all zero) to 1.0.
     const metadataMultiplier =
-      0.4 + c.importance * 0.25 + c.confidence * 0.15 + c.recency * 0.2;
+      0.35 + c.importance * 0.30 + c.confidence * 0.10 + c.recency * 0.25;
     c.finalScore = c.semantic * metadataMultiplier;
   }
   allCandidates.sort((a, b) => b.finalScore - a.finalScore);


### PR DESCRIPTION
## Summary
- Double HYBRID_LIMIT from 20 to 40 candidates fetched from Qdrant
- Reweight scoring formula: importance 0.30 (was 0.25), recency 0.25 (was 0.20), confidence 0.10 (was 0.15)
- Increase default maxInjectTokens to 16000 (was 10000) and minInjectTokens to 2400 (was 1200)

Part of plan: memory-system-rework.md (PR 2 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22036" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
