### PR TITLE
feat(memory): include source conversation info in memory_recall tool output

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -537,6 +537,7 @@ export async function buildMemoryRecall(
       finalScore: c.finalScore,
       semantic: c.semantic,
       recency: c.recency,
+      ...(c.sourceLabel ? { sourceLabel: c.sourceLabel } : {}),
     }));
 
   const latencyMs = Date.now() - start;

--- a/assistant/src/memory/search/types.ts
+++ b/assistant/src/memory/search/types.ts
@@ -32,6 +32,7 @@ export interface MemoryRecallCandiateDebug {
   finalScore: number;
   semantic: number;
   recency: number;
+  sourceLabel?: string;
 }
 
 export type DegradationReason =

--- a/assistant/src/tools/memory/definitions.ts
+++ b/assistant/src/tools/memory/definitions.ts
@@ -3,7 +3,7 @@ import type { ToolDefinition } from "../../providers/types.js";
 export const memoryRecallDefinition: ToolDefinition = {
   name: "memory_recall",
   description:
-    "Semantic search across memory for specific information. Relevant memories are auto-injected each turn, so only call this when the auto-injected context doesn't contain what you need - e.g. the user references a past session, or you need deeper recall. Be specific in your query for best results. Returns formatted memory context with item IDs for use with memory_manage.",
+    "Semantic search across memory for specific information. Relevant memories are auto-injected each turn, so only call this when the auto-injected context doesn't contain what you need - e.g. the user references a past session, or you need deeper recall. Be specific in your query for best results. Returns formatted memory context with item IDs for use with memory_manage. Results include source conversation titles so you can identify which conversation a memory originated from.",
   input_schema: {
     type: "object",
     properties: {

--- a/assistant/src/tools/memory/handlers.test.ts
+++ b/assistant/src/tools/memory/handlers.test.ts
@@ -523,6 +523,40 @@ describe("handleMemoryRecall", () => {
     expect(parsed.sources.recency).toBe(0);
   });
 
+  // ── Source conversation info ───────────────────────────────────────
+  // These tests must come after normal tests and before the error test,
+  // because mock.module replaces the retriever for all subsequent imports.
+
+  test("items include sourceConversationTitle when sourceLabel is present", async () => {
+    mock.module("../../memory/retriever.js", () => ({
+      buildMemoryRecall: async () => ({
+        injectedText: "<memory>test memory</memory>",
+        selectedCount: 2,
+        semanticHits: 2,
+        degraded: false,
+        topCandidates: [
+          { key: "item:abc-1", type: "item", kind: "preference", id: "abc-1", sourceLabel: "API Design Discussion" },
+          { key: "item:abc-2", type: "item", kind: "identity", id: "abc-2" },
+        ],
+      }),
+    }));
+
+    const { handleMemoryRecall: recallWithLabels } =
+      await import("./handlers.js");
+
+    const result = await recallWithLabels({ query: "test" }, TEST_CONFIG);
+    expect(result.isError).toBe(false);
+
+    const parsed = parseResult(result.content);
+    expect(parsed.items).toHaveLength(2);
+
+    // First item has a sourceLabel -> should have sourceConversationTitle
+    expect(parsed.items[0].sourceConversationTitle).toBe("API Design Discussion");
+
+    // Second item has no sourceLabel -> should not have sourceConversationTitle
+    expect(parsed.items[1].sourceConversationTitle).toBeUndefined();
+  });
+
   // ── Error handling ────────────────────────────────────────────────
   // This test must be last: mock.module replaces the retriever for all
   // subsequent imports and cannot be cleanly reverted within the same

--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -252,7 +252,7 @@ export interface MemoryRecallToolResult {
   text: string;
   resultCount: number;
   degraded: boolean;
-  items: Array<{ id: string; type: string; kind: string }>;
+  items: Array<{ id: string; type: string; kind: string; sourceConversationId?: string; sourceConversationTitle?: string }>;
   sources: {
     semantic: number;
     recency: number;
@@ -328,6 +328,7 @@ export async function handleMemoryRecall(
         id: c.key,
         type: c.type,
         kind: c.kind,
+        ...(c.sourceLabel ? { sourceConversationTitle: c.sourceLabel } : {}),
       })),
       sources: {
         semantic: recall.semanticHits,


### PR DESCRIPTION
## Summary
- Add sourceConversationTitle to memory_recall tool result items
- Propagate existing sourceLabel from enrichSourceLabels() through to tool output
- Add sourceLabel to MemoryRecallCandiateDebug type so it flows through the retriever pipeline
- Update tool description to mention source conversation info
- Add test verifying sourceConversationTitle is included when sourceLabel is present

Part of plan: memory-system-rework.md (PR 3 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22038" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
