### PR TITLE
feat(memory): replace tier 1/tier 2 system with top-N retrieval and simplified injection format

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -23,16 +23,11 @@ import {
   memoryItemSources,
   messages,
 } from "./schema.js";
-import {
-  buildTwoLayerInjection,
-  CAPABILITY_KINDS,
-  IDENTITY_KINDS,
-  PREFERENCE_KINDS,
-} from "./search/formatting.js";
+import { buildMemoryInjection } from "./search/formatting.js";
 import { isQdrantConnectionError, semanticSearch } from "./search/semantic.js";
-import { applyStaleDemotion, computeStaleness } from "./search/staleness.js";
+import { computeStaleness } from "./search/staleness.js";
 import {
-  classifyTiers,
+  filterByMinScore,
   type TieredCandidate,
 } from "./search/tier-classifier.js";
 import type {
@@ -235,19 +230,18 @@ async function generateQueryEmbedding(
 }
 
 /**
- * Memory recall pipeline: hybrid search → tier classification →
- * staleness annotation → two-layer XML injection.
+ * Memory recall pipeline: hybrid search → score filtering →
+ * staleness annotation → unified XML injection.
  *
  * Pipeline steps:
  *   1. Build query text (caller provides via buildMemoryQuery)
  *   2. Generate dense + sparse embeddings
  *   3. Hybrid search on Qdrant (dense + sparse RRF fusion)
  *   4. Deduplicate results
- *   5. Classify tiers (score > 0.6 → tier 1, > 0.4 → tier 2)
- *   6. Enrich item candidates with metadata for staleness
- *   7. Compute staleness per item
- *   8. Demote very_stale tier 1 → tier 2
- *   9. Build two-layer XML injection with budget allocation
+ *   5. Filter by minimum score threshold
+ *   6. Enrich candidates with source labels and item metadata
+ *   7. Compute staleness per item (for debugging/logging)
+ *   8. Build unified XML injection with budget allocation
  */
 export async function buildMemoryRecall(
   query: string,
@@ -443,19 +437,19 @@ export async function buildMemoryRecall(
   }
   allCandidates.sort((a, b) => b.finalScore - a.finalScore);
 
-  // ── Step 5: Tier classification ─────────────────────────────────
-  const tiered = classifyTiers(allCandidates);
+  // ── Step 5: Filter by minimum score threshold ───────────────────
+  const filtered = filterByMinScore(allCandidates);
 
   // ── Step 5b: Enrich candidates with source labels ──────────────
-  enrichSourceLabels(tiered);
+  enrichSourceLabels(filtered);
 
   // ── Step 6: Enrich with item metadata for staleness ─────────────
-  const itemIds = tiered.filter((c) => c.type === "item").map((c) => c.id);
+  const itemIds = filtered.filter((c) => c.type === "item").map((c) => c.id);
   const itemMetadataMap = enrichItemMetadata(itemIds);
 
-  // ── Step 7: Compute staleness per item ──────────────────────────
+  // ── Step 7: Compute staleness per item (for debugging/logging) ─
   const now = Date.now();
-  for (const c of tiered) {
+  for (const c of filtered) {
     if (c.type !== "item") continue;
     const meta = itemMetadataMap.get(c.id);
     if (!meta) continue;
@@ -470,10 +464,7 @@ export async function buildMemoryRecall(
     c.staleness = level;
   }
 
-  // ── Step 8: Demote very_stale tier 1 → tier 2 ──────────────────
-  const afterDemotion = applyStaleDemotion(tiered);
-
-  // ── Step 9: Budget allocation and two-layer injection ──────────
+  // ── Step 8: Budget allocation and unified injection ────────────
   const maxInjectTokens = Math.max(
     1,
     Math.floor(
@@ -482,53 +473,22 @@ export async function buildMemoryRecall(
     ),
   );
 
-  // Split into sections for two-layer injection
-  const identityItems = afterDemotion.filter(
-    (c) => c.tier === 1 && IDENTITY_KINDS.has(c.kind),
-  );
-  const preferences = afterDemotion.filter(
-    (c) => c.tier === 1 && PREFERENCE_KINDS.has(c.kind),
-  );
-  const capabilities = afterDemotion.filter(
-    (c) => c.tier === 1 && CAPABILITY_KINDS.has(c.kind),
-  );
-  const tier1Candidates = afterDemotion.filter(
-    (c) =>
-      c.tier === 1 &&
-      !IDENTITY_KINDS.has(c.kind) &&
-      !PREFERENCE_KINDS.has(c.kind) &&
-      !CAPABILITY_KINDS.has(c.kind),
-  );
-  const tier2Candidates = afterDemotion.filter((c) => c.tier === 2);
-
-  const injectedText = buildTwoLayerInjection({
-    identityItems,
-    tier1Candidates,
-    tier2Candidates,
-    preferences,
-    capabilities,
+  const injectedText = buildMemoryInjection({
+    candidates: filtered,
     totalBudgetTokens: maxInjectTokens,
   });
 
   // ── Assemble result ─────────────────────────────────────────────
-  const selectedCount =
-    identityItems.length +
-    tier1Candidates.length +
-    tier2Candidates.length +
-    preferences.length +
-    capabilities.length;
+  const selectedCount = filtered.length;
 
-  const tier1Count = afterDemotion.filter((c) => c.tier === 1).length;
-  const tier2Count = afterDemotion.filter((c) => c.tier === 2).length;
   const stalenessStats = {
-    fresh: afterDemotion.filter((c) => c.staleness === "fresh").length,
-    aging: afterDemotion.filter((c) => c.staleness === "aging").length,
-    stale: afterDemotion.filter((c) => c.staleness === "stale").length,
-    very_stale: afterDemotion.filter((c) => c.staleness === "very_stale")
-      .length,
+    fresh: filtered.filter((c) => c.staleness === "fresh").length,
+    aging: filtered.filter((c) => c.staleness === "aging").length,
+    stale: filtered.filter((c) => c.staleness === "stale").length,
+    very_stale: filtered.filter((c) => c.staleness === "very_stale").length,
   };
 
-  const topCandidates: MemoryRecallCandiateDebug[] = afterDemotion
+  const topCandidates: MemoryRecallCandiateDebug[] = filtered
     .slice(0, 10)
     .map((c) => ({
       key: c.key,
@@ -561,8 +521,6 @@ export async function buildMemoryRecall(
       query: truncate(query, 120),
       hybridHits: hybridCandidates.length,
       mergedCount: allCandidates.length,
-      tier1Count,
-      tier2Count,
       stalenessStats,
       selectedCount,
       maxInjectTokens,
@@ -586,8 +544,8 @@ export async function buildMemoryRecall(
     injectedText,
     latencyMs,
     topCandidates,
-    tier1Count,
-    tier2Count,
+    tier1Count: 0,
+    tier2Count: 0,
     hybridSearchMs,
     sparseVectorUsed,
   };

--- a/assistant/src/memory/search/formatting.ts
+++ b/assistant/src/memory/search/formatting.ts
@@ -1,5 +1,5 @@
 import { estimateTextTokens } from "../../context/token-estimator.js";
-import type { TieredCandidate } from "./tier-classifier.js";
+import type { Candidate } from "./types.js";
 
 /**
  * Escape XML-like tag sequences in recalled text to prevent delimiter injection.
@@ -68,215 +68,108 @@ export function formatRelativeTime(epochMs: number): string {
 }
 
 // ---------------------------------------------------------------------------
-// Two-layer injection format
+// Unified injection format
 // ---------------------------------------------------------------------------
 
-/** Kinds classified as identity for the <user_identity> section. */
-export const IDENTITY_KINDS = new Set(["identity"]);
-
-/** Kinds classified as preferences for the <applicable_preferences> section. */
-export const PREFERENCE_KINDS = new Set(["preference", "constraint"]);
-
-/** Kinds classified as capabilities for the <available_capabilities> section. */
-export const CAPABILITY_KINDS = new Set(["capability"]);
-
 /**
- * Build a two-layer XML injection block from tiered candidates.
+ * Build a unified `<memory_context>` XML injection block from scored candidates.
  *
- * Sections:
- * - `<user_identity>`: identity-kind items from tier 1 (plain statements)
- * - `<relevant_context>`: tier 1 non-identity, non-preference items (episode-wrapped)
- * - `<applicable_preferences>`: preference/constraint items from tier 1 (plain statements)
- * - `<possibly_relevant>`: tier 2 items (episode-wrapped with optional staleness)
+ * All candidates are rendered in a single `<recalled>` section sorted by
+ * `finalScore` descending, with each candidate tagged by type:
+ * - items: `<item id="item:ID" kind="KIND" importance="N.NN" timestamp="..." from="...">`
+ * - segments: `<segment id="seg:ID" timestamp="..." from="...">`
+ * - summaries: `<summary id="sum:ID" timestamp="..." from="...">`
  *
- * Empty sections are omitted. If all sections are empty, returns `""`.
+ * An optional `<echoes>` section is reserved for serendipity items (future PR 6).
+ *
+ * Respects token budget: iterates candidates in score order, accumulates
+ * token estimates, and stops when the budget is exhausted.
  */
-export function buildTwoLayerInjection(params: {
-  identityItems: TieredCandidate[];
-  tier1Candidates: TieredCandidate[];
-  tier2Candidates: TieredCandidate[];
-  preferences: TieredCandidate[];
-  capabilities: TieredCandidate[];
+export function buildMemoryInjection(params: {
+  candidates: Array<Candidate & { sourceLabel?: string; staleness?: string; supersedes?: string }>;
+  serendipityItems?: Array<Candidate & { sourceLabel?: string }>;
   totalBudgetTokens?: number;
 }): string {
-  const {
-    identityItems,
-    tier1Candidates,
-    tier2Candidates,
-    preferences,
-    capabilities,
-    totalBudgetTokens,
-  } = params;
+  const { candidates, serendipityItems, totalBudgetTokens } = params;
 
-  // If everything is empty, return empty string
-  if (
-    identityItems.length === 0 &&
-    tier1Candidates.length === 0 &&
-    tier2Candidates.length === 0 &&
-    preferences.length === 0 &&
-    capabilities.length === 0
-  ) {
+  if (candidates.length === 0 && (!serendipityItems || serendipityItems.length === 0)) {
     return "";
   }
 
-  // Budget tracking — tier 1 gets priority.
-  // Reserve tokens for XML wrapper overhead (<memory_context>, section tags,
-  // newlines between sections) so the final assembled text stays within budget.
+  // Sort by finalScore descending
+  const sorted = [...candidates].sort((a, b) => b.finalScore - a.finalScore);
+
+  // Reserve tokens for structural overhead
   const WRAPPER_OVERHEAD_TOKENS = estimateTextTokens(
-    "<memory_context __injected>\n\n\n\n</memory_context>",
+    "<memory_context __injected>\n<recalled>\n</recalled>\n</memory_context>",
   );
-  const SECTION_TAG_TOKENS = estimateTextTokens(
-    "<possibly_relevant>\n\n</possibly_relevant>",
-  );
-  const sectionCount = [
-    identityItems.length,
-    tier1Candidates.length,
-    tier2Candidates.length,
-    preferences.length,
-    capabilities.length,
-  ].filter((n) => n > 0).length;
-  const structuralOverhead =
-    WRAPPER_OVERHEAD_TOKENS + sectionCount * SECTION_TAG_TOKENS;
   let remainingTokens = totalBudgetTokens
-    ? Math.max(1, totalBudgetTokens - structuralOverhead)
+    ? Math.max(1, totalBudgetTokens - WRAPPER_OVERHEAD_TOKENS)
     : Infinity;
 
-  // Render tier 1 items first (identity, relevant context, preferences)
-  const identityLines = renderPlainStatements(identityItems, remainingTokens);
-  remainingTokens -= estimateTextTokens(identityLines.join("\n"));
+  // Render candidates within budget
+  const lines: string[] = [];
+  for (const c of sorted) {
+    if (remainingTokens <= 0) break;
+    const line = renderCandidate(c);
+    const tokens = estimateTextTokens(line);
+    if (tokens > remainingTokens) break;
+    lines.push(line);
+    remainingTokens -= tokens;
+  }
 
-  const relevantEpisodes = renderEpisodes(tier1Candidates, remainingTokens);
-  remainingTokens -= estimateTextTokens(relevantEpisodes.join("\n"));
+  if (lines.length === 0 && (!serendipityItems || serendipityItems.length === 0)) {
+    return "";
+  }
 
-  const preferenceLines = renderPlainStatements(preferences, remainingTokens);
-  remainingTokens -= estimateTextTokens(preferenceLines.join("\n"));
-
-  const capabilityLines = renderPlainStatements(capabilities, remainingTokens);
-  remainingTokens -= estimateTextTokens(capabilityLines.join("\n"));
-
-  // Tier 2 uses remaining budget
-  const possiblyRelevantEpisodes = renderEpisodesWithStaleness(
-    tier2Candidates,
-    remainingTokens,
-  );
-
-  // Assemble sections — omit empty ones
   const sections: string[] = [];
 
-  if (identityLines.length > 0) {
-    sections.push(
-      `<user_identity>\n${identityLines.join("\n")}\n</user_identity>`,
-    );
+  if (lines.length > 0) {
+    sections.push(`<recalled>\n${lines.join("\n")}\n</recalled>`);
   }
 
-  if (relevantEpisodes.length > 0) {
-    sections.push(
-      `<relevant_context>\n${relevantEpisodes.join("\n")}\n</relevant_context>`,
-    );
-  }
-
-  if (preferenceLines.length > 0) {
-    sections.push(
-      `<applicable_preferences>\n${preferenceLines.join("\n")}\n</applicable_preferences>`,
-    );
-  }
-
-  if (capabilityLines.length > 0) {
-    sections.push(
-      `<available_capabilities>\n${capabilityLines.join("\n")}\n</available_capabilities>`,
-    );
-  }
-
-  if (possiblyRelevantEpisodes.length > 0) {
-    sections.push(
-      `<possibly_relevant>\n${possiblyRelevantEpisodes.join("\n")}\n</possibly_relevant>`,
-    );
+  // Echoes section for serendipity items (future PR 6)
+  if (serendipityItems && serendipityItems.length > 0) {
+    const echoLines: string[] = [];
+    for (const c of serendipityItems) {
+      if (remainingTokens <= 0) break;
+      const line = renderCandidate(c);
+      const tokens = estimateTextTokens(line);
+      if (tokens > remainingTokens) break;
+      echoLines.push(line);
+      remainingTokens -= tokens;
+    }
+    if (echoLines.length > 0) {
+      sections.push(`<echoes>\n${echoLines.join("\n")}\n</echoes>`);
+    }
   }
 
   if (sections.length === 0) return "";
 
-  return `<memory_context __injected>\n\n${sections.join("\n\n")}\n\n</memory_context>`;
+  return `<memory_context __injected>\n${sections.join("\n")}\n</memory_context>`;
 }
 
 /**
- * Render candidates as plain statement lines (for identity / preference sections).
+ * Render a single candidate as an XML element based on its type.
  */
-function renderPlainStatements(
-  items: TieredCandidate[],
-  remainingBudget: number,
-): string[] {
-  const lines: string[] = [];
-  let used = 0;
-  for (const item of items) {
-    if (used >= remainingBudget) break;
-    const text = escapeXmlTags(item.text);
-    const tokens = estimateTextTokens(text);
-    if (used + tokens > remainingBudget) break;
-    lines.push(text);
-    used += tokens;
-  }
-  return lines;
-}
+function renderCandidate(c: Candidate & { sourceLabel?: string }): string {
+  const text = escapeXmlTags(c.text);
+  const timestamp = formatAbsoluteTime(c.createdAt);
+  const fromAttr = c.sourceLabel
+    ? ` from="${escapeXmlAttr(c.sourceLabel)}"`
+    : "";
 
-/**
- * Render candidates as `<episode>` elements with source attribution.
- */
-function renderEpisodes(
-  items: TieredCandidate[],
-  remainingBudget: number,
-): string[] {
-  const lines: string[] = [];
-  let used = 0;
-  for (const item of items) {
-    if (used >= remainingBudget) break;
-    const text = escapeXmlTags(item.text);
-    const sourceAttr = buildSourceAttr(item);
-    const line = `<episode${sourceAttr}>\n${text}\n</episode>`;
-    const tokens = estimateTextTokens(line);
-    if (used + tokens > remainingBudget) break;
-    lines.push(line);
-    used += tokens;
+  switch (c.type) {
+    case "item":
+      return `<item id="item:${escapeXmlAttr(c.id)}" kind="${escapeXmlAttr(c.kind)}" importance="${c.importance.toFixed(2)}" timestamp="${escapeXmlAttr(timestamp)}"${fromAttr}>${text}</item>`;
+    case "segment":
+      return `<segment id="seg:${escapeXmlAttr(c.id)}" timestamp="${escapeXmlAttr(timestamp)}"${fromAttr}>${text}</segment>`;
+    case "summary":
+      return `<summary id="sum:${escapeXmlAttr(c.id)}" timestamp="${escapeXmlAttr(timestamp)}"${fromAttr}>${text}</summary>`;
+    default:
+      // media or unknown types — render as item
+      return `<item id="item:${escapeXmlAttr(c.id)}" kind="${escapeXmlAttr(c.kind)}" importance="${c.importance.toFixed(2)}" timestamp="${escapeXmlAttr(timestamp)}"${fromAttr}>${text}</item>`;
   }
-  return lines;
-}
-
-/**
- * Render tier 2 candidates as `<episode>` elements with staleness annotation.
- */
-function renderEpisodesWithStaleness(
-  items: TieredCandidate[],
-  remainingBudget: number,
-): string[] {
-  const lines: string[] = [];
-  let used = 0;
-  for (const item of items) {
-    if (used >= remainingBudget) break;
-    const text = escapeXmlTags(item.text);
-    const sourceAttr = buildSourceAttr(item);
-    const stalenessAttr =
-      item.staleness && item.staleness !== "fresh"
-        ? ` staleness="${escapeXmlAttr(item.staleness)}"`
-        : "";
-    const line = `<episode${sourceAttr}${stalenessAttr}>\n${text}\n</episode>`;
-    const tokens = estimateTextTokens(line);
-    if (used + tokens > remainingBudget) break;
-    lines.push(line);
-    used += tokens;
-  }
-  return lines;
-}
-
-/**
- * Build the `source="..."` attribute for an episode tag.
- * Uses the candidate's sourceLabel (conversation title) if available,
- * combined with a short date from createdAt.
- */
-function buildSourceAttr(item: TieredCandidate): string {
-  const date = formatShortDate(item.createdAt);
-  if (item.sourceLabel) {
-    return ` source="${escapeXmlAttr(`${item.sourceLabel} (${date})`)}"`;
-  }
-  return ` source="${escapeXmlAttr(date)}"`;
 }
 
 function escapeXmlAttr(text: string): string {
@@ -285,33 +178,4 @@ function escapeXmlAttr(text: string): string {
     .replace(/"/g, "&quot;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
-}
-
-/**
- * Format epoch-ms as a short human-readable date like "Mar 7" or "Mar 7 2024".
- * Omits the year when the date is in the current year.
- */
-function formatShortDate(epochMs: number): string {
-  const date = new Date(epochMs);
-  const now = new Date();
-  const months = [
-    "Jan",
-    "Feb",
-    "Mar",
-    "Apr",
-    "May",
-    "Jun",
-    "Jul",
-    "Aug",
-    "Sep",
-    "Oct",
-    "Nov",
-    "Dec",
-  ];
-  const month = months[date.getMonth()];
-  const day = date.getDate();
-  if (date.getFullYear() === now.getFullYear()) {
-    return `${month} ${day}`;
-  }
-  return `${month} ${day} ${date.getFullYear()}`;
 }

--- a/assistant/src/memory/search/staleness.ts
+++ b/assistant/src/memory/search/staleness.ts
@@ -1,4 +1,3 @@
-import type { TieredCandidate } from "./tier-classifier.js";
 import type { StalenessLevel } from "./types.js";
 
 const BASE_LIFETIME_MS: Record<string, number> = {
@@ -38,18 +37,4 @@ export function computeStaleness(
   if (ratio <= 1) return { level: "aging", ratio };
   if (ratio <= 2) return { level: "stale", ratio };
   return { level: "very_stale", ratio };
-}
-
-/**
- * Demote very_stale tier-1 candidates to tier 2.
- */
-export function applyStaleDemotion(
-  candidates: TieredCandidate[],
-): TieredCandidate[] {
-  return candidates.map((c) => {
-    if (c.tier === 1 && c.staleness === "very_stale") {
-      return { ...c, tier: 2 as const };
-    }
-    return c;
-  });
 }

--- a/assistant/src/memory/search/tier-classifier.ts
+++ b/assistant/src/memory/search/tier-classifier.ts
@@ -1,29 +1,18 @@
 import type { Candidate } from "./types.js";
 
-export type Tier = 1 | 2;
-
-export interface TieredCandidate extends Candidate {
-  tier: Tier;
+/** Backward-compatible alias — downstream files import this type. */
+export type TieredCandidate = Candidate & {
   /** Human-readable label for the source conversation/summary (e.g. conversation title). */
   sourceLabel?: string;
-}
+};
+
+const MIN_SCORE_THRESHOLD = 0.2;
 
 /**
- * Map a composite relevance score to an injection tier.
- *
- * Thresholds are intentionally set lower than raw-embedding ceilings because
- * the multiplicative scoring pipeline (semantic × recency × metadata) compresses
- * the effective score range.  Lowering the gates lets moderately-relevant items
- * surface rather than being silently dropped.
+ * Filter candidates to those exceeding the minimum relevance threshold.
+ * Replaces the former tier 1/tier 2 classification — all surviving candidates
+ * are treated equally and ranked by score.
  */
-export function classifyTier(score: number): Tier | null {
-  if (score > 0.6) return 1;
-  if (score > 0.4) return 2;
-  return null;
-}
-
-export function classifyTiers(candidates: Candidate[]): TieredCandidate[] {
-  return candidates
-    .map((c) => ({ ...c, tier: classifyTier(c.finalScore) }))
-    .filter((c): c is TieredCandidate => c.tier != null);
+export function filterByMinScore(candidates: Candidate[]): TieredCandidate[] {
+  return candidates.filter((c) => c.finalScore > MIN_SCORE_THRESHOLD);
 }


### PR DESCRIPTION
## Summary
- Replace tier 1/tier 2 classification with simple top-N filtering (min score 0.20)
- New simplified injection format: `<memory_context><recalled><item>...</item></recalled></memory_context>`
- Remove staleness demotion (staleness remains a scoring signal, not a gate)
- Remove dead code: IDENTITY_KINDS, PREFERENCE_KINDS, CAPABILITY_KINDS, section-splitting logic

Part of plan: memory-system-rework.md (PR 5 of 8)