### PR TITLE
fix: sort imports in journal-carry-forward test and jobs-worker

### DIFF
--- a/assistant/src/memory/job-handlers/journal-carry-forward.test.ts
+++ b/assistant/src/memory/job-handlers/journal-carry-forward.test.ts
@@ -70,6 +70,7 @@ mock.module("../../providers/provider-send-message.js", () => ({
 }));
 
 import { eq } from "drizzle-orm";
+
 import { getDb, initializeDb, resetDb } from "../db.js";
 import type { MemoryJob } from "../jobs-store.js";
 import { memoryItems } from "../schema.js";

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -8,7 +8,6 @@ import {
   pruneOldConversationsJob,
 } from "./job-handlers/cleanup.js";
 import { generateConversationStartersJob } from "./job-handlers/conversation-starters.js";
-import { journalCarryForwardJob } from "./job-handlers/journal-carry-forward.js";
 // ── Per-job-type handlers ──────────────────────────────────────────
 import {
   embedAttachmentJob,
@@ -22,6 +21,7 @@ import {
   deleteQdrantVectorsJob,
   rebuildIndexJob,
 } from "./job-handlers/index-maintenance.js";
+import { journalCarryForwardJob } from "./job-handlers/journal-carry-forward.js";
 import { mediaProcessingJob } from "./job-handlers/media-processing.js";
 import { buildConversationSummaryJob } from "./job-handlers/summarization.js";
 import {


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint errors in `jobs-worker.ts` (moved `journal-carry-forward` import to alphabetical position) and `journal-carry-forward.test.ts` (added blank line between external and internal import groups)

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23678615066/job/68986569499
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22041" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
