### PR TITLE
feat(memory): add serendipity layer — random importance-weighted memories in retrieval

### DIFF
--- a/assistant/src/memory/retriever.test.ts
+++ b/assistant/src/memory/retriever.test.ts
@@ -1468,4 +1468,117 @@ describe("Memory Retriever Pipeline", () => {
       expect(result.mergedCount).toBe(0);
     });
   });
+
+  // -----------------------------------------------------------------------
+  // Serendipity layer
+  // -----------------------------------------------------------------------
+
+  describe("serendipity sampling", () => {
+    test("samples random active items and renders them in <echoes>", async () => {
+      const db = getDb();
+      const now = Date.now();
+      const convId = "conv-serendipity";
+
+      insertConversation(db, convId, now - 60_000);
+      insertMessage(db, "msg-s-1", convId, "user", "hello", now - 50_000);
+
+      // Insert several active items that are NOT returned by Qdrant
+      for (let i = 1; i <= 5; i++) {
+        insertItem(db, {
+          id: `serendipity-item-${i}`,
+          kind: "fact",
+          subject: `topic ${i}`,
+          statement: `Serendipity fact number ${i}`,
+          importance: i * 0.15, // 0.15..0.75
+          firstSeenAt: now - i * 10_000,
+        });
+        insertItemSource(db, `serendipity-item-${i}`, "msg-s-1", now - i * 10_000);
+      }
+
+      // Qdrant returns nothing — no recalled candidates
+      mockQdrantResults.length = 0;
+
+      const result = await buildMemoryRecall(
+        "unrelated query",
+        convId,
+        TEST_CONFIG,
+      );
+
+      expect(result.enabled).toBe(true);
+      // No semantic hits, so no recalled candidates
+      expect(result.mergedCount).toBe(0);
+      // But serendipity items should appear in the injection
+      expect(result.injectedText).toContain("<echoes>");
+      expect(result.injectedText).toContain("</echoes>");
+      // At most 3 serendipity items
+      const itemMatches = result.injectedText.match(/<item /g);
+      expect(itemMatches).toBeTruthy();
+      expect(itemMatches!.length).toBeLessThanOrEqual(3);
+      expect(itemMatches!.length).toBeGreaterThanOrEqual(1);
+      // selectedCount includes serendipity items
+      expect(result.selectedCount).toBeGreaterThan(0);
+    });
+
+    test("excludes items already in the candidate pool from serendipity", async () => {
+      const db = getDb();
+      const now = Date.now();
+      const convId = "conv-serendipity-excl";
+
+      insertConversation(db, convId, now - 60_000);
+      insertMessage(db, "msg-se-1", convId, "user", "query about X", now - 50_000);
+
+      // This item will be returned by Qdrant as a recalled candidate
+      insertItem(db, {
+        id: "recalled-item",
+        kind: "fact",
+        subject: "X",
+        statement: "Recalled fact about X",
+        importance: 0.9,
+        firstSeenAt: now - 30_000,
+      });
+      insertItemSource(db, "recalled-item", "msg-se-1", now - 30_000);
+
+      // Qdrant returns the recalled item
+      mockQdrantResults.push({
+        id: "qdrant-recalled",
+        score: 0.9,
+        payload: {
+          target_type: "item",
+          target_id: "recalled-item",
+          text: "X: Recalled fact about X",
+          created_at: now - 30_000,
+        },
+      });
+
+      const result = await buildMemoryRecall(
+        "query about X",
+        convId,
+        TEST_CONFIG,
+      );
+
+      expect(result.enabled).toBe(true);
+      // The recalled item is in <recalled>, not in <echoes>
+      if (result.injectedText.includes("<echoes>")) {
+        // If echoes exists, the recalled item should NOT be duplicated there
+        const echoesMatch = result.injectedText.match(
+          /<echoes>([\s\S]*?)<\/echoes>/,
+        );
+        if (echoesMatch) {
+          expect(echoesMatch[1]).not.toContain("recalled-item");
+        }
+      }
+    });
+
+    test("no <echoes> section when no active items exist", async () => {
+      // No items seeded at all
+      const result = await buildMemoryRecall(
+        "anything",
+        "conv-empty-seren",
+        TEST_CONFIG,
+      );
+
+      expect(result.enabled).toBe(true);
+      expect(result.injectedText).not.toContain("<echoes>");
+    });
+  });
 });

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -1,4 +1,4 @@
-import { asc, eq, inArray, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, notInArray, sql } from "drizzle-orm";
 
 import type { AssistantConfig } from "../config/types.js";
 import { estimateTextTokens } from "../context/token-estimator.js";
@@ -443,6 +443,14 @@ export async function buildMemoryRecall(
   // ── Step 5b: Enrich candidates with source labels ──────────────
   enrichSourceLabels(filtered);
 
+  // ── Serendipity: sample random memories for unexpected connections ──
+  const SERENDIPITY_COUNT = 3;
+  const serendipityCandidates = sampleSerendipityItems(
+    filtered,
+    SERENDIPITY_COUNT,
+  );
+  enrichSourceLabels(serendipityCandidates);
+
   // ── Step 6: Enrich with item metadata for staleness ─────────────
   const itemIds = filtered.filter((c) => c.type === "item").map((c) => c.id);
   const itemMetadataMap = enrichItemMetadata(itemIds);
@@ -475,11 +483,12 @@ export async function buildMemoryRecall(
 
   const injectedText = buildMemoryInjection({
     candidates: filtered,
+    serendipityItems: serendipityCandidates,
     totalBudgetTokens: maxInjectTokens,
   });
 
   // ── Assemble result ─────────────────────────────────────────────
-  const selectedCount = filtered.length;
+  const selectedCount = filtered.length + serendipityCandidates.length;
 
   const stalenessStats = {
     fresh: filtered.filter((c) => c.staleness === "fresh").length,
@@ -769,6 +778,101 @@ function enrichSourceLabels(candidates: TieredCandidate[]): void {
     // importing memorySegments and an additional query. The primary value is item source labels.
   } catch (err) {
     log.warn({ err }, "Failed to enrich candidates with source labels");
+  }
+}
+
+/**
+ * Sample random active memory items for serendipitous recall — items
+ * the user didn't ask about but might spark unexpected connections.
+ *
+ * Queries SQLite for random active items not already in the candidate pool,
+ * then selects up to `count` items with probability proportional to their
+ * importance value (importance-weighted sampling).
+ */
+function sampleSerendipityItems(
+  existingCandidates: TieredCandidate[],
+  count: number,
+): TieredCandidate[] {
+  if (count <= 0) return [];
+
+  try {
+    const db = getDb();
+
+    // Collect IDs of item candidates already in the filtered set to exclude them
+    const existingItemIds = existingCandidates
+      .filter((c) => c.type === "item")
+      .map((c) => c.id);
+
+    // Query random active items not already in the candidate pool
+    const RANDOM_POOL_SIZE = 10;
+    let rows;
+    if (existingItemIds.length > 0) {
+      rows = db
+        .select({
+          id: memoryItems.id,
+          kind: memoryItems.kind,
+          subject: memoryItems.subject,
+          statement: memoryItems.statement,
+          importance: memoryItems.importance,
+          firstSeenAt: memoryItems.firstSeenAt,
+        })
+        .from(memoryItems)
+        .where(
+          and(
+            eq(memoryItems.status, "active"),
+            notInArray(memoryItems.id, existingItemIds),
+          ),
+        )
+        .orderBy(sql`RANDOM()`)
+        .limit(RANDOM_POOL_SIZE)
+        .all();
+    } else {
+      rows = db
+        .select({
+          id: memoryItems.id,
+          kind: memoryItems.kind,
+          subject: memoryItems.subject,
+          statement: memoryItems.statement,
+          importance: memoryItems.importance,
+          firstSeenAt: memoryItems.firstSeenAt,
+        })
+        .from(memoryItems)
+        .where(eq(memoryItems.status, "active"))
+        .orderBy(sql`RANDOM()`)
+        .limit(RANDOM_POOL_SIZE)
+        .all();
+    }
+
+    if (rows.length === 0) return [];
+
+    // Importance-weighted sampling: sort by importance * random() descending
+    // and take the top `count` items
+    const weighted = rows
+      .map((row) => ({
+        row,
+        score: (row.importance ?? 0.5) * Math.random(),
+      }))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, count);
+
+    // Convert to Candidate-compatible objects
+    return weighted.map(({ row }): TieredCandidate => ({
+      type: "item",
+      id: row.id,
+      key: `item:${row.id}`,
+      kind: row.kind,
+      text: row.statement,
+      source: "semantic",
+      importance: row.importance ?? 0.5,
+      confidence: 1,
+      semantic: 0,
+      recency: 0,
+      finalScore: 0,
+      createdAt: row.firstSeenAt,
+    }));
+  } catch (err) {
+    log.warn({ err }, "Failed to sample serendipity items");
+    return [];
   }
 }
 

--- a/assistant/src/memory/search/formatting.test.ts
+++ b/assistant/src/memory/search/formatting.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Unit tests for buildMemoryInjection — focused on echoes/serendipity
+ * rendering and budget enforcement.
+ */
+import { describe, expect, test } from "bun:test";
+
+import type { Candidate } from "./types.js";
+import { buildMemoryInjection } from "./formatting.js";
+
+type CandidateWithLabel = Candidate & { sourceLabel?: string };
+
+function makeCandidate(
+  overrides: Partial<CandidateWithLabel> & { id: string },
+): CandidateWithLabel {
+  return {
+    key: `item:${overrides.id}`,
+    type: "item",
+    source: "semantic",
+    text: overrides.text ?? `Statement for ${overrides.id}`,
+    kind: overrides.kind ?? "fact",
+    confidence: 1,
+    importance: overrides.importance ?? 0.5,
+    createdAt: overrides.createdAt ?? Date.now(),
+    semantic: 0.8,
+    recency: 0.5,
+    finalScore: overrides.finalScore ?? 0.6,
+    ...overrides,
+  };
+}
+
+describe("buildMemoryInjection — echoes section", () => {
+  test("renders <echoes> after <recalled> when serendipity items provided", () => {
+    const candidates = [makeCandidate({ id: "c1", finalScore: 0.8 })];
+    const serendipityItems = [
+      makeCandidate({ id: "s1", finalScore: 0, importance: 0.7 }),
+    ];
+
+    const result = buildMemoryInjection({
+      candidates,
+      serendipityItems,
+      totalBudgetTokens: 2000,
+    });
+
+    expect(result).toContain("<recalled>");
+    expect(result).toContain("</recalled>");
+    expect(result).toContain("<echoes>");
+    expect(result).toContain("</echoes>");
+    // <echoes> comes after </recalled>
+    const recalledEnd = result.indexOf("</recalled>");
+    const echoesStart = result.indexOf("<echoes>");
+    expect(echoesStart).toBeGreaterThan(recalledEnd);
+  });
+
+  test("renders only <echoes> when no recalled candidates but serendipity items exist", () => {
+    const serendipityItems = [
+      makeCandidate({ id: "s1", finalScore: 0, importance: 0.6 }),
+      makeCandidate({ id: "s2", finalScore: 0, importance: 0.4 }),
+    ];
+
+    const result = buildMemoryInjection({
+      candidates: [],
+      serendipityItems,
+      totalBudgetTokens: 2000,
+    });
+
+    expect(result).toContain("<memory_context");
+    expect(result).not.toContain("<recalled>");
+    expect(result).toContain("<echoes>");
+    expect(result).toContain("</echoes>");
+    expect(result).toContain("s1");
+    expect(result).toContain("s2");
+  });
+
+  test("echoes section respects ~400 token cap", () => {
+    // Create serendipity items with very long text to test budget
+    const longText = "word ".repeat(200); // ~200 tokens
+    const serendipityItems = [
+      makeCandidate({ id: "s1", text: longText, finalScore: 0 }),
+      makeCandidate({ id: "s2", text: longText, finalScore: 0 }),
+      makeCandidate({ id: "s3", text: longText, finalScore: 0 }),
+    ];
+
+    const result = buildMemoryInjection({
+      candidates: [],
+      serendipityItems,
+      totalBudgetTokens: 5000, // plenty of total budget
+    });
+
+    // At ~200 tokens each, the 400-token echoes cap should allow at most 2
+    const itemMatches = result.match(/<item /g) ?? [];
+    expect(itemMatches.length).toBeLessThanOrEqual(2);
+  });
+
+  test("no <echoes> section when serendipity array is empty", () => {
+    const candidates = [makeCandidate({ id: "c1", finalScore: 0.8 })];
+
+    const result = buildMemoryInjection({
+      candidates,
+      serendipityItems: [],
+      totalBudgetTokens: 2000,
+    });
+
+    expect(result).toContain("<recalled>");
+    expect(result).not.toContain("<echoes>");
+  });
+
+  test("no <echoes> section when serendipity items omitted", () => {
+    const candidates = [makeCandidate({ id: "c1", finalScore: 0.8 })];
+
+    const result = buildMemoryInjection({
+      candidates,
+      totalBudgetTokens: 2000,
+    });
+
+    expect(result).toContain("<recalled>");
+    expect(result).not.toContain("<echoes>");
+  });
+
+  test("echoes items include importance and kind attributes", () => {
+    const serendipityItems = [
+      makeCandidate({
+        id: "echo1",
+        kind: "preference",
+        importance: 0.85,
+        text: "User likes dark mode",
+        finalScore: 0,
+      }),
+    ];
+
+    const result = buildMemoryInjection({
+      candidates: [],
+      serendipityItems,
+      totalBudgetTokens: 2000,
+    });
+
+    expect(result).toContain('kind="preference"');
+    expect(result).toContain('importance="0.85"');
+    expect(result).toContain("User likes dark mode");
+  });
+});

--- a/assistant/src/memory/search/formatting.ts
+++ b/assistant/src/memory/search/formatting.ts
@@ -80,7 +80,8 @@ export function formatRelativeTime(epochMs: number): string {
  * - segments: `<segment id="seg:ID" timestamp="..." from="...">`
  * - summaries: `<summary id="sum:ID" timestamp="..." from="...">`
  *
- * An optional `<echoes>` section is reserved for serendipity items (future PR 6).
+ * An optional `<echoes>` section renders serendipity items — random
+ * importance-weighted memories for unexpected connections.
  *
  * Respects token budget: iterates candidates in score order, accumulates
  * token estimates, and stops when the budget is exhausted.
@@ -128,15 +129,19 @@ export function buildMemoryInjection(params: {
     sections.push(`<recalled>\n${lines.join("\n")}\n</recalled>`);
   }
 
-  // Echoes section for serendipity items (future PR 6)
+  // Echoes section for serendipity items — capped at ~400 tokens of
+  // the remaining budget after <recalled> items are rendered.
   if (serendipityItems && serendipityItems.length > 0) {
+    const ECHOES_MAX_TOKENS = 400;
+    let echoesBudget = Math.min(remainingTokens, ECHOES_MAX_TOKENS);
     const echoLines: string[] = [];
     for (const c of serendipityItems) {
-      if (remainingTokens <= 0) break;
+      if (echoesBudget <= 0) break;
       const line = renderCandidate(c);
       const tokens = estimateTextTokens(line);
-      if (tokens > remainingTokens) break;
+      if (tokens > echoesBudget) break;
       echoLines.push(line);
+      echoesBudget -= tokens;
       remainingTokens -= tokens;
     }
     if (echoLines.length > 0) {


### PR DESCRIPTION
## Summary
- Sample 1-3 random active memory items per retrieval, weighted by importance
- Render serendipity items in `<echoes>` section after `<recalled>`
- Exclude items already in the candidate pool from serendipity sampling

Part of plan: memory-system-rework.md (PR 6 of 8)