### PR TITLE
feat(memory): enrich injection with inline supersession and delimiter escaping

### DIFF
--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -129,7 +129,9 @@ import {
   formatAbsoluteTime,
   formatRelativeTime,
   injectMemoryRecallAsUserBlock,
+  lookupSupersessionChain,
 } from "../memory/retriever.js";
+import { buildMemoryInjection } from "../memory/search/formatting.js";
 import {
   conversations,
   memoryEmbeddings,
@@ -3480,5 +3482,194 @@ describe("Memory regressions", () => {
 
     const context = buildCoreIdentityContext();
     expect(context).toBeNull();
+  });
+
+  // ── Inline supersession rendering tests ──────────────────────────
+
+  test("buildMemoryInjection renders inline supersedes tag for items with supersession chain", () => {
+    const db = getDb();
+    const now = Date.now();
+
+    // Create the superseded (predecessor) item in the DB
+    db.insert(memoryItems)
+      .values({
+        id: "item-predecessor-render",
+        kind: "preference",
+        subject: "color",
+        statement: "Favorite color is blue",
+        status: "active",
+        confidence: 0.9,
+        importance: 0.7,
+        fingerprint: "fp-pred-render",
+        firstSeenAt: now - 86_400_000,
+        lastSeenAt: now - 86_400_000,
+        accessCount: 1,
+        verificationState: "assistant_inferred",
+      })
+      .run();
+
+    const candidate = {
+      key: "item:item-superseding-render",
+      type: "item" as const,
+      id: "item-superseding-render",
+      source: "semantic" as const,
+      text: "Favorite color is green",
+      kind: "preference",
+      confidence: 0.9,
+      importance: 0.8,
+      createdAt: now,
+      semantic: 0.9,
+      recency: 0.8,
+      finalScore: 0.85,
+      supersedes: "item-predecessor-render",
+    };
+
+    const injection = buildMemoryInjection({
+      candidates: [candidate],
+      totalBudgetTokens: 5000,
+    });
+
+    expect(injection).toContain("<supersedes count=");
+    expect(injection).toContain('count="1"');
+    expect(injection).toContain("Favorite color is blue");
+    expect(injection).toContain("</supersedes>");
+    // The supersedes tag should be inside the item tag
+    expect(injection).toMatch(/<item[^>]*>.*<supersedes.*<\/supersedes><\/item>/);
+
+    // Clean up
+    db.delete(memoryItems)
+      .where(eq(memoryItems.id, "item-predecessor-render"))
+      .run();
+  });
+
+  test("lookupSupersessionChain counts chain depth correctly", () => {
+    const db = getDb();
+    const now = Date.now();
+    const MS_PER_DAY = 86_400_000;
+
+    // Create a chain of 3 items: grandparent → parent → child
+    db.insert(memoryItems)
+      .values({
+        id: "item-chain-grandparent",
+        kind: "fact",
+        subject: "address",
+        statement: "Lives at 123 Main St",
+        status: "active",
+        confidence: 0.8,
+        importance: 0.6,
+        fingerprint: "fp-chain-gp",
+        firstSeenAt: now - 3 * MS_PER_DAY,
+        lastSeenAt: now - 3 * MS_PER_DAY,
+        accessCount: 1,
+        verificationState: "assistant_inferred",
+      })
+      .run();
+
+    db.insert(memoryItems)
+      .values({
+        id: "item-chain-parent",
+        kind: "fact",
+        subject: "address",
+        statement: "Lives at 456 Oak Ave",
+        status: "active",
+        confidence: 0.8,
+        importance: 0.6,
+        fingerprint: "fp-chain-p",
+        supersedes: "item-chain-grandparent",
+        firstSeenAt: now - 2 * MS_PER_DAY,
+        lastSeenAt: now - 2 * MS_PER_DAY,
+        accessCount: 1,
+        verificationState: "assistant_inferred",
+      })
+      .run();
+
+    db.insert(memoryItems)
+      .values({
+        id: "item-chain-child",
+        kind: "fact",
+        subject: "address",
+        statement: "Lives at 789 Pine Blvd",
+        status: "active",
+        confidence: 0.9,
+        importance: 0.7,
+        fingerprint: "fp-chain-c",
+        supersedes: "item-chain-parent",
+        firstSeenAt: now - 1 * MS_PER_DAY,
+        lastSeenAt: now - 1 * MS_PER_DAY,
+        accessCount: 1,
+        verificationState: "assistant_inferred",
+      })
+      .run();
+
+    // Look up from the child's perspective (supersedes parent)
+    const result = lookupSupersessionChain("item-chain-parent");
+    expect(result).not.toBeNull();
+    expect(result!.previousStatement).toBe("Lives at 456 Oak Ave");
+    expect(result!.previousTimestamp).toBe(now - 2 * MS_PER_DAY);
+    // Chain: parent → grandparent = depth 2
+    expect(result!.chainDepth).toBe(2);
+
+    // Look up direct predecessor (grandparent has no supersedes)
+    const gpResult = lookupSupersessionChain("item-chain-grandparent");
+    expect(gpResult).not.toBeNull();
+    expect(gpResult!.previousStatement).toBe("Lives at 123 Main St");
+    expect(gpResult!.chainDepth).toBe(1);
+
+    // Non-existent ID returns null
+    const nullResult = lookupSupersessionChain("item-nonexistent");
+    expect(nullResult).toBeNull();
+
+    // Clean up
+    db.delete(memoryItems)
+      .where(eq(memoryItems.id, "item-chain-child"))
+      .run();
+    db.delete(memoryItems)
+      .where(eq(memoryItems.id, "item-chain-parent"))
+      .run();
+    db.delete(memoryItems)
+      .where(eq(memoryItems.id, "item-chain-grandparent"))
+      .run();
+  });
+
+  test("escapeXmlTags escapes memory_context, recalled, and item delimiter tags", () => {
+    // Verify new tag vocabulary is escaped by the existing generic escaper
+    expect(escapeXmlTags("</memory_context>")).toBe("\uFF1C/memory_context>");
+    expect(escapeXmlTags("</recalled>")).toBe("\uFF1C/recalled>");
+    expect(escapeXmlTags("</item>")).toBe("\uFF1C/item>");
+    expect(escapeXmlTags("</segment>")).toBe("\uFF1C/segment>");
+    expect(escapeXmlTags("</supersedes>")).toBe("\uFF1C/supersedes>");
+    expect(escapeXmlTags("</echoes>")).toBe("\uFF1C/echoes>");
+
+    // Opening tags too
+    expect(escapeXmlTags("<memory_context>")).toBe("\uFF1Cmemory_context>");
+    expect(escapeXmlTags("<recalled>")).toBe("\uFF1Crecalled>");
+    expect(escapeXmlTags("<item>")).toBe("\uFF1Citem>");
+  });
+
+  test("buildMemoryInjection renders items without supersedes normally", () => {
+    const now = Date.now();
+    const candidate = {
+      key: "item:item-no-supersedes",
+      type: "item" as const,
+      id: "item-no-supersedes",
+      source: "semantic" as const,
+      text: "User prefers dark mode",
+      kind: "preference",
+      confidence: 0.9,
+      importance: 0.8,
+      createdAt: now,
+      semantic: 0.9,
+      recency: 0.8,
+      finalScore: 0.85,
+    };
+
+    const injection = buildMemoryInjection({
+      candidates: [candidate],
+      totalBudgetTokens: 5000,
+    });
+
+    expect(injection).toContain("User prefers dark mode");
+    expect(injection).not.toContain("<supersedes");
+    expect(injection).not.toContain("</supersedes>");
   });
 });

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -45,6 +45,7 @@ export {
   escapeXmlTags,
   formatAbsoluteTime,
   formatRelativeTime,
+  lookupSupersessionChain,
 } from "./search/formatting.js";
 export type {
   DegradationReason,
@@ -446,6 +447,35 @@ export async function buildMemoryRecall(
   // ── Step 6: Enrich with item metadata for staleness ─────────────
   const itemIds = filtered.filter((c) => c.type === "item").map((c) => c.id);
   const itemMetadataMap = enrichItemMetadata(itemIds);
+
+  // ── Step 6b: Enrich item candidates with supersedes data ────────
+  const itemCandidatesForSupersedes = filtered.filter(
+    (c) => c.type === "item",
+  );
+  if (itemCandidatesForSupersedes.length > 0) {
+    try {
+      const db = getDb();
+      const supersedesRows = db
+        .select({ id: memoryItems.id, supersedes: memoryItems.supersedes })
+        .from(memoryItems)
+        .where(
+          inArray(
+            memoryItems.id,
+            itemCandidatesForSupersedes.map((c) => c.id),
+          ),
+        )
+        .all();
+      const supersedesMap = new Map(
+        supersedesRows.map((r) => [r.id, r.supersedes]),
+      );
+      for (const c of itemCandidatesForSupersedes) {
+        const sup = supersedesMap.get(c.id);
+        if (sup) c.supersedes = sup;
+      }
+    } catch (err) {
+      log.warn({ err }, "Failed to enrich candidates with supersedes data");
+    }
+  }
 
   // ── Step 7: Compute staleness per item (for debugging/logging) ─
   const now = Date.now();

--- a/assistant/src/memory/search/formatting.ts
+++ b/assistant/src/memory/search/formatting.ts
@@ -1,5 +1,12 @@
+import { eq } from "drizzle-orm";
+
 import { estimateTextTokens } from "../../context/token-estimator.js";
+import { getLogger } from "../../util/logger.js";
+import { getDb } from "../db.js";
+import { memoryItems } from "../schema.js";
 import type { Candidate } from "./types.js";
+
+const log = getLogger("memory-formatting");
 
 /**
  * Escape XML-like tag sequences in recalled text to prevent delimiter injection.
@@ -150,25 +157,91 @@ export function buildMemoryInjection(params: {
 }
 
 /**
+ * Look up the supersession chain for a given superseded item ID.
+ *
+ * Returns the immediate predecessor's statement and timestamp, plus the
+ * total chain depth (how many items were superseded in sequence).
+ * Chain traversal is capped at 10 iterations to prevent infinite loops.
+ */
+export function lookupSupersessionChain(supersededId: string): {
+  previousStatement: string;
+  previousTimestamp: number;
+  chainDepth: number;
+} | null {
+  try {
+    const db = getDb();
+
+    // Look up the immediate predecessor
+    const predecessor = db
+      .select({
+        statement: memoryItems.statement,
+        firstSeenAt: memoryItems.firstSeenAt,
+        supersedes: memoryItems.supersedes,
+      })
+      .from(memoryItems)
+      .where(eq(memoryItems.id, supersededId))
+      .get();
+
+    if (!predecessor) return null;
+
+    // Count chain depth by following supersedes links (cap at 10)
+    let chainDepth = 1;
+    let currentSupersedes = predecessor.supersedes;
+    const MAX_CHAIN_DEPTH = 10;
+
+    while (currentSupersedes && chainDepth < MAX_CHAIN_DEPTH) {
+      const ancestor = db
+        .select({ supersedes: memoryItems.supersedes })
+        .from(memoryItems)
+        .where(eq(memoryItems.id, currentSupersedes))
+        .get();
+
+      if (!ancestor) break;
+      chainDepth++;
+      currentSupersedes = ancestor.supersedes;
+    }
+
+    return {
+      previousStatement: predecessor.statement,
+      previousTimestamp: predecessor.firstSeenAt,
+      chainDepth,
+    };
+  } catch (err) {
+    log.warn({ err }, "Failed to look up supersession chain");
+    return null;
+  }
+}
+
+/**
  * Render a single candidate as an XML element based on its type.
  */
-function renderCandidate(c: Candidate & { sourceLabel?: string }): string {
+function renderCandidate(c: Candidate & { sourceLabel?: string; supersedes?: string }): string {
   const text = escapeXmlTags(c.text);
   const timestamp = formatAbsoluteTime(c.createdAt);
   const fromAttr = c.sourceLabel
     ? ` from="${escapeXmlAttr(c.sourceLabel)}"`
     : "";
 
+  // Build inline supersession suffix for items
+  let supersessionSuffix = "";
+  if (c.type === "item" && c.supersedes) {
+    const chain = lookupSupersessionChain(c.supersedes);
+    if (chain) {
+      const prevTimestamp = formatAbsoluteTime(chain.previousTimestamp);
+      supersessionSuffix = `<supersedes count="${chain.chainDepth}">${escapeXmlTags(chain.previousStatement)} (${prevTimestamp})</supersedes>`;
+    }
+  }
+
   switch (c.type) {
     case "item":
-      return `<item id="item:${escapeXmlAttr(c.id)}" kind="${escapeXmlAttr(c.kind)}" importance="${c.importance.toFixed(2)}" timestamp="${escapeXmlAttr(timestamp)}"${fromAttr}>${text}</item>`;
+      return `<item id="item:${escapeXmlAttr(c.id)}" kind="${escapeXmlAttr(c.kind)}" importance="${c.importance.toFixed(2)}" timestamp="${escapeXmlAttr(timestamp)}"${fromAttr}>${text}${supersessionSuffix}</item>`;
     case "segment":
       return `<segment id="seg:${escapeXmlAttr(c.id)}" timestamp="${escapeXmlAttr(timestamp)}"${fromAttr}>${text}</segment>`;
     case "summary":
       return `<summary id="sum:${escapeXmlAttr(c.id)}" timestamp="${escapeXmlAttr(timestamp)}"${fromAttr}>${text}</summary>`;
     default:
       // media or unknown types — render as item
-      return `<item id="item:${escapeXmlAttr(c.id)}" kind="${escapeXmlAttr(c.kind)}" importance="${c.importance.toFixed(2)}" timestamp="${escapeXmlAttr(timestamp)}"${fromAttr}>${text}</item>`;
+      return `<item id="item:${escapeXmlAttr(c.id)}" kind="${escapeXmlAttr(c.kind)}" importance="${c.importance.toFixed(2)}" timestamp="${escapeXmlAttr(timestamp)}"${fromAttr}>${text}${supersessionSuffix}</item>`;
   }
 }
 

--- a/assistant/src/memory/search/types.ts
+++ b/assistant/src/memory/search/types.ts
@@ -15,6 +15,8 @@ export interface Candidate {
   conversationId?: string;
   /** The source message ID this candidate was extracted from (segments only). */
   messageId?: string;
+  /** The ID of the memory item this candidate supersedes (items only). */
+  supersedes?: string;
   confidence: number;
   importance: number;
   createdAt: number;


### PR DESCRIPTION
## Summary
- Add inline supersession rendering: items show `<supersedes count="N">previous statement (timestamp)</supersedes>`
- Propagate supersedes data from memoryItems through retriever to formatting
- Verify delimiter escaping covers new tag vocabulary

Part of plan: memory-system-rework.md (PR 7 of 8)