### PR TITLE
feat(memory): replace per-message extraction with batched extraction over conversation windows

### DIFF
--- a/assistant/src/config/schemas/memory-processing.ts
+++ b/assistant/src/config/schemas/memory-processing.ts
@@ -8,14 +8,6 @@ export const MemoryExtractionConfigSchema = z
       .describe(
         "Whether to use an LLM for extracting structured memory items from conversations",
       ),
-    modelIntent: z
-      .enum(["latency-optimized", "quality-optimized", "vision-optimized"], {
-        error: "memory.extraction.modelIntent must be a valid model intent",
-      })
-      .default("quality-optimized")
-      .describe(
-        "Model selection strategy for extraction — trade off speed vs quality",
-      ),
     extractFromAssistant: z
       .boolean({
         error: "memory.extraction.extractFromAssistant must be a boolean",
@@ -23,6 +15,22 @@ export const MemoryExtractionConfigSchema = z
       .default(true)
       .describe(
         "Whether to extract memory items from the assistant's own messages (in addition to user messages)",
+      ),
+    batchSize: z
+      .number()
+      .int()
+      .positive()
+      .default(10)
+      .describe(
+        "Number of unextracted messages before triggering batch extraction",
+      ),
+    idleTimeoutMs: z
+      .number()
+      .int()
+      .positive()
+      .default(300000)
+      .describe(
+        "Milliseconds of idle time before triggering extraction of pending messages",
       ),
   })
   .describe("Controls how memory items are extracted from conversations");

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -9,11 +9,13 @@ import type { EventBus } from "../events/bus.js";
 import type { AssistantDomainEvents } from "../events/domain-events.js";
 import type { ToolProfiler } from "../events/tool-profiling-listener.js";
 import { getHookManager } from "../hooks/manager.js";
+import { getMemoryCheckpoint } from "../memory/checkpoints.js";
 import {
   getConversation,
   getMessages,
   type MessageRow,
 } from "../memory/conversation-crud.js";
+import { enqueueMemoryJob } from "../memory/jobs-store.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
 import type { ContentBlock, Message } from "../providers/types.js";
@@ -266,6 +268,20 @@ export function disposeConversation(ctx: DisposeContext): void {
   void getHookManager().trigger("conversation-end", {
     conversationId: ctx.conversationId,
   });
+
+  // Trigger batch extraction for any remaining unextracted messages
+  try {
+    const pendingKey = `batch_extract:${ctx.conversationId}:pending_count`;
+    const pending = getMemoryCheckpoint(pendingKey);
+    if (pending && parseInt(pending, 10) > 0) {
+      enqueueMemoryJob("batch_extract", {
+        conversationId: ctx.conversationId,
+      });
+    }
+  } catch {
+    // Best-effort — don't block conversation disposal
+  }
+
   ctx.abort();
   unregisterCallNotifiers(ctx.conversationId);
   unregisterConversationSender(ctx.conversationId);

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -5,6 +5,7 @@ import { getConfig } from "../config/loader.js";
 import type { MemoryConfig } from "../config/types.js";
 import type { TrustClass } from "../runtime/actor-trust-resolver.js";
 import { getLogger } from "../util/logger.js";
+import { getMemoryCheckpoint, setMemoryCheckpoint } from "./checkpoints.js";
 import { getDb } from "./db.js";
 import { selectedBackendSupportsMultimodal } from "./embedding-backend.js";
 import { enqueueMemoryJob, upsertDebouncedJob } from "./jobs-store.js";
@@ -16,11 +17,6 @@ import { memorySegments } from "./schema.js";
 import { segmentText } from "./segmenter.js";
 
 const log = getLogger("memory-indexer");
-
-/** Delay before a conversation summary job becomes eligible to run.
- *  Each new message in the same conversation resets the timer, so the
- *  summary is only built once the conversation has been idle for this long. */
-const SUMMARY_DEBOUNCE_MS = 3 * 60 * 1000; // 3 minutes
 
 export interface IndexMessageInput {
   messageId: string;
@@ -59,12 +55,7 @@ export async function indexMessageNow(
 
   const text = extractTextFromStoredMessageContent(input.content);
   if (text.length === 0) {
-    upsertDebouncedJob(
-      "build_conversation_summary",
-      { conversationId: input.conversationId },
-      Date.now() + SUMMARY_DEBOUNCE_MS,
-    );
-    return { indexedSegments: 0, enqueuedJobs: 1 };
+    return { indexedSegments: 0, enqueuedJobs: 0 };
   }
 
   const db = getDb();
@@ -151,22 +142,36 @@ export async function indexMessageNow(
       );
     }
 
-    if (shouldExtract && isTrustedActor && !input.automated && config.extraction.useLLM) {
-      enqueueMemoryJob(
-        "extract_items",
-        { messageId: input.messageId, scopeId: input.scopeId ?? "default" },
-        Date.now(),
-        tx,
-      );
+  });
+
+  // ── Batch extraction tracking ──────────────────────────────────────
+  // Instead of per-message extraction, track pending unextracted messages
+  // and trigger batch extraction when the threshold is reached or after idle.
+  if (shouldExtract && isTrustedActor && !input.automated && config.extraction.useLLM) {
+    const pendingKey = `batch_extract:${input.conversationId}:pending_count`;
+    const currentVal = getMemoryCheckpoint(pendingKey);
+    const pendingCount = (currentVal ? parseInt(currentVal, 10) : 0) + 1;
+    setMemoryCheckpoint(pendingKey, String(pendingCount));
+
+    const batchSize = config.extraction.batchSize ?? 10;
+    const idleTimeoutMs = config.extraction.idleTimeoutMs ?? 300_000;
+
+    if (pendingCount >= batchSize) {
+      // Threshold reached — trigger immediate batch extraction
+      enqueueMemoryJob("batch_extract", {
+        conversationId: input.conversationId,
+        scopeId: input.scopeId ?? "default",
+      });
     }
 
+    // Also maintain idle debounce: enqueue a delayed batch_extract that fires
+    // if no new messages arrive within the idle timeout window.
     upsertDebouncedJob(
-      "build_conversation_summary",
+      "batch_extract",
       { conversationId: input.conversationId },
-      Date.now() + SUMMARY_DEBOUNCE_MS,
-      tx,
+      Date.now() + idleTimeoutMs,
     );
-  });
+  }
 
   if (skippedEmbedJobs > 0) {
     log.debug(
@@ -188,12 +193,10 @@ export async function indexMessageNow(
     log.info("Skipping extraction job: LLM extraction is disabled (useLLM=false)");
   }
 
-  const extractionGated = !isTrustedActor || !!input.automated || !config.extraction.useLLM;
   const enqueuedJobs =
     segments.length -
     skippedEmbedJobs +
-    mediaBlocks.length +
-    (shouldExtract && !extractionGated ? 2 : 1);
+    mediaBlocks.length;
   return {
     indexedSegments: segments.length,
     enqueuedJobs,

--- a/assistant/src/memory/items-extractor.ts
+++ b/assistant/src/memory/items-extractor.ts
@@ -39,7 +39,7 @@ export type MemoryItemKind =
 
 export type OverrideConfidence = "explicit" | "tentative" | "inferred";
 
-interface ExtractedItem {
+export interface ExtractedItem {
   kind: MemoryItemKind;
   subject: string;
   statement: string;
@@ -52,7 +52,7 @@ interface ExtractedItem {
   supersedesRejected?: boolean;
 }
 
-const VALID_KINDS = new Set<string>([
+export const VALID_KINDS = new Set<string>([
   "identity",
   "preference",
   "project",
@@ -67,10 +67,10 @@ const VALID_KINDS = new Set<string>([
  * because journal memories are created directly from disk files — any
  * LLM-produced journal items would be silently dropped, wasting tokens.
  */
-const EXTRACTION_KINDS = [...VALID_KINDS].filter((k) => k !== "journal");
+export const EXTRACTION_KINDS = [...VALID_KINDS].filter((k) => k !== "journal");
 
 /** Maps old kind names to their new equivalents for graceful migration. */
-const KIND_MIGRATION_MAP: Record<string, MemoryItemKind> = {
+export const KIND_MIGRATION_MAP: Record<string, MemoryItemKind> = {
   profile: "identity",
   fact: "identity",
   relationship: "identity",
@@ -80,70 +80,13 @@ const KIND_MIGRATION_MAP: Record<string, MemoryItemKind> = {
   style: "preference",
 };
 
-const SUPERSEDE_KINDS = new Set<MemoryItemKind>([
+export const SUPERSEDE_KINDS = new Set<MemoryItemKind>([
   "identity",
   "preference",
   "project",
   "decision",
   "constraint",
 ]);
-
-// ── Semantic density gating ────────────────────────────────────────────
-// Skip messages that are too short or consist of low-value filler.
-
-const LOW_VALUE_PATTERNS = new Set([
-  "ok",
-  "okay",
-  "k",
-  "sure",
-  "yes",
-  "no",
-  "yep",
-  "nope",
-  "yeah",
-  "nah",
-  "thanks",
-  "thank you",
-  "ty",
-  "thx",
-  "thanks!",
-  "thank you!",
-  "got it",
-  "understood",
-  "makes sense",
-  "sounds good",
-  "sounds great",
-  "cool",
-  "nice",
-  "great",
-  "awesome",
-  "perfect",
-  "done",
-  "lgtm",
-  "agreed",
-  "right",
-  "correct",
-  "exactly",
-  "yup",
-  "ack",
-  "hm",
-  "hmm",
-  "hmmm",
-  "ah",
-  "oh",
-  "i see",
-]);
-
-function hasSemanticDensity(text: string): boolean {
-  const trimmed = text.trim();
-  if (trimmed.length < 15) return false;
-  const lower = trimmed.toLowerCase().replace(/[.!?,;:\s]+$/, "");
-  if (LOW_VALUE_PATTERNS.has(lower)) return false;
-  // Very short messages with only 1-2 words are typically not memorable
-  const wordCount = trimmed.split(/\s+/).length;
-  if (wordCount <= 2) return false;
-  return true;
-}
 
 // ── LLM-powered extraction ────────────────────────────────────────────
 
@@ -154,7 +97,7 @@ function hasSemanticDensity(text: string): boolean {
 // tokens. ~6000 tokens ≈ 24 000 chars is a safe ceiling.
 const EXTRACTION_SYSTEM_PROMPT_CHAR_BUDGET = 24_000;
 
-function buildExtractionSystemPrompt(
+export function buildExtractionSystemPrompt(
   existingItems: Array<{
     id: string;
     kind: string;
@@ -296,7 +239,7 @@ Low importance (still worth storing):
   return prompt;
 }
 
-const VALID_OVERRIDE_CONFIDENCES = new Set<string>([
+export const VALID_OVERRIDE_CONFIDENCES = new Set<string>([
   "explicit",
   "tentative",
   "inferred",
@@ -317,7 +260,7 @@ interface LLMExtractedItem {
  * extraction LLM awareness of existing items it might supersede.
  * This is a write-path-only heuristic — not used at read time.
  */
-function queryExistingItemsForContext(
+export function queryExistingItemsForContext(
   scopeId: string,
   text: string,
 ): Array<{ id: string; kind: string; subject: string; statement: string }> {
@@ -489,7 +432,7 @@ async function extractItemsWithLLM(
     systemPrompt,
     {
       config: {
-        modelIntent: extractionConfig.modelIntent,
+        modelIntent: "quality-optimized" as const,
         tool_choice: { type: "tool" as const, name: "store_memory_items" },
       },
     },
@@ -643,11 +586,7 @@ export async function extractAndUpsertMemoryItemsForMessage(
   }
 
   const text = extractTextFromStoredMessageContent(message.content);
-  if (!hasSemanticDensity(text)) {
-    log.debug(
-      { messageId },
-      "Skipping extraction — message lacks semantic density",
-    );
+  if (text.length === 0) {
     triggerConversationStartersIfNeeded(journalUpserted, effectiveScopeId);
     return journalUpserted;
   }
@@ -900,7 +839,7 @@ export async function extractAndUpsertMemoryItemsForMessage(
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
-function deduplicateItems(items: ExtractedItem[]): ExtractedItem[] {
+export function deduplicateItems(items: ExtractedItem[]): ExtractedItem[] {
   const seen = new Set<string>();
   const unique: ExtractedItem[] = [];
   for (const item of items) {
@@ -912,7 +851,7 @@ function deduplicateItems(items: ExtractedItem[]): ExtractedItem[] {
 }
 
 /** Parse a score value, returning `fallback` for null, undefined, empty strings, and non-finite numbers. */
-function parseScore(value: unknown, fallback: number): number {
+export function parseScore(value: unknown, fallback: number): number {
   if (value == null || value === "") return fallback;
   const n = Number(value);
   return Number.isFinite(n) ? n : fallback;

--- a/assistant/src/memory/job-handlers/batch-extraction.ts
+++ b/assistant/src/memory/job-handlers/batch-extraction.ts
@@ -1,0 +1,706 @@
+import { and, asc, desc, eq, gt, sql } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
+
+import { estimateTextTokens } from "../../context/token-estimator.js";
+import { getAssistantName } from "../../daemon/identity-helpers.js";
+import { resolveGuardianPersona } from "../../prompts/persona-resolver.js";
+import {
+  extractToolUse,
+  getConfiguredProvider,
+  userMessage,
+} from "../../providers/provider-send-message.js";
+import { BackendUnavailableError, ProviderError } from "../../util/errors.js";
+import { getLogger } from "../../util/logger.js";
+import {
+  getMemoryCheckpoint,
+  setMemoryCheckpoint,
+} from "../checkpoints.js";
+import { getConversationMemoryScopeId } from "../conversation-crud.js";
+import { getDb } from "../db.js";
+import { computeMemoryFingerprint } from "../fingerprint.js";
+import { enqueueMemoryJob, type MemoryJob } from "../jobs-store.js";
+import {
+  buildExtractionSystemPrompt,
+  deduplicateItems,
+  type ExtractedItem,
+  EXTRACTION_KINDS,
+  KIND_MIGRATION_MAP,
+  type MemoryItemKind,
+  type OverrideConfidence,
+  parseScore,
+  SUPERSEDE_KINDS,
+  VALID_KINDS,
+  VALID_OVERRIDE_CONFIDENCES,
+} from "../items-extractor.js";
+import { asString } from "../job-utils.js";
+import { extractTextFromStoredMessageContent } from "../message-content.js";
+import { withQdrantBreaker } from "../qdrant-circuit-breaker.js";
+import { getQdrantClient } from "../qdrant-client.js";
+import {
+  memoryItems,
+  memoryItemSources,
+  memorySummaries,
+  messages,
+} from "../schema.js";
+import { isConversationFailed } from "../task-memory-cleanup.js";
+import { clampUnitInterval } from "../validation.js";
+
+const log = getLogger("memory-batch-extraction");
+
+interface LLMBatchExtractedItem {
+  kind: string;
+  subject: string;
+  statement: string;
+  confidence: number;
+  importance: number;
+  supersedes: string | null;
+  overrideConfidence: string;
+}
+
+interface BatchExtractResult {
+  items: LLMBatchExtractedItem[];
+  extraction_summary: string;
+  conversation_summary: string;
+}
+
+export async function batchExtractJob(job: MemoryJob): Promise<void> {
+  const conversationId = asString(job.payload.conversationId);
+  const payloadScopeId = asString(job.payload.scopeId);
+  if (!conversationId) return;
+
+  // If the conversation has been marked as failed, skip extraction entirely.
+  if (isConversationFailed(conversationId)) {
+    log.info(
+      { conversationId },
+      "Skipping batch extraction for failed conversation",
+    );
+    return;
+  }
+
+  const db = getDb();
+
+  // Resolve scopeId: prefer payload, fall back to conversation's stored scope
+  const scopeId =
+    payloadScopeId ?? getConversationMemoryScopeId(conversationId);
+
+  // ── Load unextracted messages ────────────────────────────────────────
+  const lastMessageIdKey = `batch_extract:${conversationId}:last_message_id`;
+  const lastExtractedMessageId = getMemoryCheckpoint(lastMessageIdKey);
+
+  let unextractedMessages: Array<{
+    id: string;
+    role: string;
+    content: string;
+    createdAt: number;
+  }>;
+
+  if (lastExtractedMessageId) {
+    // Get the createdAt of the last extracted message so we can find messages after it
+    const lastMsg = db
+      .select({ createdAt: messages.createdAt })
+      .from(messages)
+      .where(eq(messages.id, lastExtractedMessageId))
+      .get();
+
+    if (lastMsg) {
+      unextractedMessages = db
+        .select({
+          id: messages.id,
+          role: messages.role,
+          content: messages.content,
+          createdAt: messages.createdAt,
+        })
+        .from(messages)
+        .where(
+          and(
+            eq(messages.conversationId, conversationId),
+            gt(messages.createdAt, lastMsg.createdAt),
+          ),
+        )
+        .orderBy(asc(messages.createdAt))
+        .all();
+    } else {
+      // Checkpoint references a deleted message — fetch all
+      unextractedMessages = db
+        .select({
+          id: messages.id,
+          role: messages.role,
+          content: messages.content,
+          createdAt: messages.createdAt,
+        })
+        .from(messages)
+        .where(eq(messages.conversationId, conversationId))
+        .orderBy(asc(messages.createdAt))
+        .all();
+    }
+  } else {
+    // No checkpoint — process all messages in the conversation
+    unextractedMessages = db
+      .select({
+        id: messages.id,
+        role: messages.role,
+        content: messages.content,
+        createdAt: messages.createdAt,
+      })
+      .from(messages)
+      .where(eq(messages.conversationId, conversationId))
+      .orderBy(asc(messages.createdAt))
+      .all();
+  }
+
+  if (unextractedMessages.length === 0) {
+    log.debug({ conversationId }, "No unextracted messages for batch extraction");
+    // Reset pending count since there's nothing to extract
+    setMemoryCheckpoint(
+      `batch_extract:${conversationId}:pending_count`,
+      "0",
+    );
+    return;
+  }
+
+  // ── Load running extraction summary ─────────────────────────────────
+  const existingExtractionSummary = db
+    .select({ summary: memorySummaries.summary })
+    .from(memorySummaries)
+    .where(
+      and(
+        eq(memorySummaries.scope, "extraction_context"),
+        eq(memorySummaries.scopeKey, conversationId),
+      ),
+    )
+    .get();
+
+  // ── Load existing global items for supersession ─────────────────────
+  const existingItems = db
+    .select({
+      id: memoryItems.id,
+      kind: memoryItems.kind,
+      subject: memoryItems.subject,
+      statement: memoryItems.statement,
+    })
+    .from(memoryItems)
+    .where(
+      and(
+        eq(memoryItems.scopeId, scopeId),
+        eq(memoryItems.status, "active"),
+      ),
+    )
+    .orderBy(desc(memoryItems.lastSeenAt))
+    .limit(20)
+    .all();
+
+  // ── Build the batch extraction prompt ───────────────────────────────
+  const userPersona = resolveGuardianPersona();
+  const baseSystemPrompt = buildExtractionSystemPrompt(
+    existingItems,
+    "user", // batch processes both roles
+    userPersona,
+  );
+
+  let systemPrompt = baseSystemPrompt;
+  systemPrompt += `\n\nIMPORTANT: You are processing a batch of messages from a single conversation window, not individual messages. Extract items from the entire batch — look for cross-message patterns, evolving themes, and composite facts that only emerge from reading multiple messages together.`;
+
+  if (existingExtractionSummary?.summary) {
+    systemPrompt += `\n\nPreviously extracted from this conversation:\n${existingExtractionSummary.summary}`;
+  }
+
+  // ── Build user message from unextracted messages ────────────────────
+  const assistantName = getAssistantName() ?? "the assistant";
+  const messageParts: string[] = [];
+  for (const msg of unextractedMessages) {
+    const text = extractTextFromStoredMessageContent(msg.content);
+    if (text.length === 0) continue;
+    const roleLabel = msg.role === "assistant" ? assistantName : "user";
+    const timestamp = new Date(msg.createdAt).toISOString();
+    messageParts.push(`[${timestamp}] [${roleLabel}]: ${text}`);
+  }
+
+  if (messageParts.length === 0) {
+    log.debug(
+      { conversationId },
+      "All unextracted messages have empty text content",
+    );
+    setMemoryCheckpoint(
+      `batch_extract:${conversationId}:pending_count`,
+      "0",
+    );
+    // Still update the last message ID checkpoint
+    const lastMsg = unextractedMessages[unextractedMessages.length - 1];
+    setMemoryCheckpoint(lastMessageIdKey, lastMsg.id);
+    return;
+  }
+
+  const userContent = messageParts.join("\n\n");
+
+  // ── Call LLM ────────────────────────────────────────────────────────
+  const provider = await getConfiguredProvider();
+  if (!provider) {
+    throw new BackendUnavailableError(
+      "Provider unavailable for batch memory extraction",
+    );
+  }
+
+  const response = await provider.sendMessage(
+    [userMessage(userContent)],
+    [
+      {
+        name: "batch_extract_results",
+        description:
+          "Store extracted memory items and summaries from the conversation batch",
+        input_schema: {
+          type: "object" as const,
+          properties: {
+            items: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  kind: {
+                    type: "string",
+                    enum: EXTRACTION_KINDS,
+                    description: "Category of memory item",
+                  },
+                  subject: {
+                    type: "string",
+                    description:
+                      "Short label (2-8 words) for what this is about",
+                  },
+                  statement: {
+                    type: "string",
+                    description:
+                      "Relationship-rich factual statement to remember (1-2 sentences). Include relational context.",
+                  },
+                  confidence: {
+                    type: "number",
+                    description: "Confidence that this is accurate (0.0-1.0)",
+                  },
+                  importance: {
+                    type: "number",
+                    description: "How valuable this is to remember (0.0-1.0)",
+                  },
+                  supersedes: {
+                    type: ["string", "null"],
+                    description:
+                      "ID of the existing memory item this replaces, or null if not replacing anything",
+                  },
+                  overrideConfidence: {
+                    type: "string",
+                    enum: ["explicit", "tentative", "inferred"],
+                    description:
+                      "How confident you are that this overrides an existing item",
+                  },
+                },
+                required: [
+                  "kind",
+                  "subject",
+                  "statement",
+                  "confidence",
+                  "importance",
+                  "supersedes",
+                  "overrideConfidence",
+                ],
+              },
+            },
+            extraction_summary: {
+              type: "string",
+              description:
+                "Updated summary of what has been extracted from this conversation so far",
+            },
+            conversation_summary: {
+              type: "string",
+              description: "Updated summary of the conversation so far",
+            },
+          },
+          required: ["items", "extraction_summary", "conversation_summary"],
+        },
+      },
+    ],
+    systemPrompt,
+    {
+      config: {
+        modelIntent: "quality-optimized" as const,
+        tool_choice: {
+          type: "tool" as const,
+          name: "batch_extract_results",
+        },
+      },
+    },
+  );
+
+  const toolBlock = extractToolUse(response);
+  if (!toolBlock) {
+    throw new ProviderError(
+      "No tool_use block in batch extraction LLM response",
+      "unknown",
+      502,
+    );
+  }
+
+  const input = toolBlock.input as unknown as BatchExtractResult;
+  if (!Array.isArray(input.items)) {
+    throw new ProviderError(
+      "Invalid items structure in batch extraction LLM response",
+      "unknown",
+      502,
+    );
+  }
+
+  // Guard: re-check after the async LLM call
+  if (isConversationFailed(conversationId)) {
+    log.info(
+      { conversationId },
+      "Skipping upsert — conversation marked failed during batch extraction",
+    );
+    return;
+  }
+
+  // ── Validate and process extracted items ────────────────────────────
+  const existingItemIds = new Set(existingItems.map((e) => e.id));
+
+  const validatedItems: ExtractedItem[] = [];
+  for (const raw of input.items) {
+    const resolvedKind = KIND_MIGRATION_MAP[raw.kind] ?? raw.kind;
+    if (resolvedKind === "journal") continue;
+    if (!VALID_KINDS.has(resolvedKind)) continue;
+    if (!raw.subject || !raw.statement) continue;
+    const subject = String(raw.subject).trim();
+    const statement = String(raw.statement).trim();
+    const confidence = clampUnitInterval(parseScore(raw.confidence, 0.5));
+    const importance = clampUnitInterval(parseScore(raw.importance, 0.5));
+    const fingerprint = computeMemoryFingerprint(
+      scopeId,
+      resolvedKind,
+      subject,
+      statement,
+    );
+
+    const rawSupersedes =
+      typeof raw.supersedes === "string" && raw.supersedes.length > 0
+        ? raw.supersedes
+        : null;
+    const supersedes =
+      rawSupersedes && existingItemIds.has(rawSupersedes)
+        ? rawSupersedes
+        : null;
+    const supersedesRejected = !!rawSupersedes && !supersedes;
+    const overrideConfidence = VALID_OVERRIDE_CONFIDENCES.has(
+      raw.overrideConfidence,
+    )
+      ? (raw.overrideConfidence as OverrideConfidence)
+      : "inferred";
+
+    validatedItems.push({
+      kind: resolvedKind as MemoryItemKind,
+      subject,
+      statement,
+      confidence,
+      importance,
+      fingerprint,
+      supersedes,
+      overrideConfidence,
+      supersedesRejected,
+    });
+  }
+
+  const dedupedItems = deduplicateItems(validatedItems);
+
+  // ── Upsert extracted items ──────────────────────────────────────────
+  // Use the last message in the batch as the source message for all items
+  const lastMessage = unextractedMessages[unextractedMessages.length - 1];
+  let upserted = 0;
+
+  for (const item of dedupedItems) {
+    const now = Date.now();
+    const seenAt = lastMessage.createdAt;
+    const existing = db
+      .select()
+      .from(memoryItems)
+      .where(
+        and(
+          eq(memoryItems.fingerprint, item.fingerprint),
+          eq(memoryItems.scopeId, scopeId),
+        ),
+      )
+      .get();
+
+    let memoryItemId: string;
+    let effectiveStatus: string = "active";
+    if (existing) {
+      memoryItemId = existing.id;
+      effectiveStatus = "active";
+      const effectiveSourceType =
+        existing.sourceType === "tool" ? "tool" : "extraction";
+      const effectiveVerificationState =
+        existing.verificationState === "user_reported"
+          ? "user_reported"
+          : existing.verificationState === "user_confirmed"
+            ? "user_confirmed"
+            : "assistant_inferred";
+
+      db.update(memoryItems)
+        .set({
+          status: effectiveStatus,
+          confidence: clampUnitInterval(
+            Math.max(existing.confidence, item.confidence),
+          ),
+          importance: clampUnitInterval(
+            Math.max(existing.importance ?? 0, item.importance),
+          ),
+          lastSeenAt: Math.max(existing.lastSeenAt, seenAt),
+          sourceType: effectiveSourceType,
+          verificationState: effectiveVerificationState,
+        })
+        .where(eq(memoryItems.id, existing.id))
+        .run();
+    } else {
+      memoryItemId = uuid();
+      db.insert(memoryItems)
+        .values({
+          id: memoryItemId,
+          kind: item.kind,
+          subject: item.subject,
+          statement: item.statement,
+          status: "active",
+          confidence: item.confidence,
+          importance: item.importance,
+          fingerprint: item.fingerprint,
+          sourceType: "extraction",
+          verificationState: "assistant_inferred",
+          scopeId,
+          firstSeenAt: lastMessage.createdAt,
+          lastSeenAt: seenAt,
+          lastUsedAt: null,
+          supersedes: item.supersedes,
+          overrideConfidence: item.overrideConfidence,
+        })
+        .run();
+      upserted += 1;
+    }
+
+    // Handle LLM-directed supersession based on overrideConfidence
+    if (
+      item.supersedes &&
+      item.supersedes !== memoryItemId &&
+      item.overrideConfidence === "explicit" &&
+      effectiveStatus === "active"
+    ) {
+      const oldItem = db
+        .select({ id: memoryItems.id })
+        .from(memoryItems)
+        .where(
+          and(
+            eq(memoryItems.id, item.supersedes),
+            eq(memoryItems.scopeId, scopeId),
+            eq(memoryItems.status, "active"),
+          ),
+        )
+        .get();
+
+      if (oldItem) {
+        db.update(memoryItems)
+          .set({
+            status: "superseded",
+            supersededBy: memoryItemId,
+          })
+          .where(eq(memoryItems.id, oldItem.id))
+          .run();
+
+        db.update(memoryItems)
+          .set({ supersedes: oldItem.id })
+          .where(eq(memoryItems.id, memoryItemId))
+          .run();
+
+        try {
+          const qdrant = getQdrantClient();
+          await withQdrantBreaker(() =>
+            qdrant.deleteByTarget("item", oldItem.id),
+          );
+        } catch (err) {
+          const errMsg = err instanceof Error ? err.message : String(err);
+          log.warn(
+            { err: errMsg, oldItemId: oldItem.id },
+            "Failed to remove superseded item from Qdrant — will be cleaned up by index maintenance",
+          );
+        }
+
+        log.debug(
+          { newItemId: memoryItemId, oldItemId: oldItem.id },
+          "Explicitly superseded memory item (batch)",
+        );
+      }
+    } else if (item.supersedes && item.overrideConfidence === "tentative") {
+      log.debug(
+        {
+          newItemId: memoryItemId,
+          supersedes: item.supersedes,
+          overrideConfidence: "tentative",
+        },
+        "Tentative override — both items coexist (batch)",
+      );
+    } else if (item.supersedes && item.overrideConfidence === "inferred") {
+      log.debug(
+        {
+          newItemId: memoryItemId,
+          supersedes: item.supersedes,
+          overrideConfidence: "inferred",
+        },
+        "Inferred override — both items coexist (batch)",
+      );
+    }
+
+    // Fallback subject-match supersession
+    if (
+      !item.supersedes &&
+      !item.supersedesRejected &&
+      SUPERSEDE_KINDS.has(item.kind) &&
+      effectiveStatus === "active"
+    ) {
+      db.update(memoryItems)
+        .set({ status: "superseded" })
+        .where(
+          and(
+            eq(memoryItems.kind, item.kind),
+            eq(memoryItems.subject, item.subject),
+            eq(memoryItems.status, "active"),
+            eq(memoryItems.scopeId, scopeId),
+            sql`${memoryItems.id} <> ${memoryItemId}`,
+          ),
+        )
+        .run();
+    }
+
+    // Record source linkage for the last message in the batch
+    db.insert(memoryItemSources)
+      .values({
+        memoryItemId,
+        messageId: lastMessage.id,
+        evidence: item.statement,
+        createdAt: Date.now(),
+      })
+      .onConflictDoNothing()
+      .run();
+
+    enqueueMemoryJob("embed_item", { itemId: memoryItemId });
+  }
+
+  // ── Update running extraction summary ───────────────────────────────
+  if (input.extraction_summary) {
+    const now = Date.now();
+    const summaryId =
+      existingExtractionSummary
+        ? db
+            .select({ id: memorySummaries.id })
+            .from(memorySummaries)
+            .where(
+              and(
+                eq(memorySummaries.scope, "extraction_context"),
+                eq(memorySummaries.scopeKey, conversationId),
+              ),
+            )
+            .get()?.id ?? uuid()
+        : uuid();
+
+    db.insert(memorySummaries)
+      .values({
+        id: summaryId,
+        scope: "extraction_context",
+        scopeKey: conversationId,
+        scopeId,
+        summary: input.extraction_summary,
+        tokenEstimate: estimateTextTokens(input.extraction_summary),
+        version: 1,
+        startAt: unextractedMessages[0].createdAt,
+        endAt: lastMessage.createdAt,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [memorySummaries.scope, memorySummaries.scopeKey],
+        set: {
+          summary: input.extraction_summary,
+          tokenEstimate: estimateTextTokens(input.extraction_summary),
+          version: sql`${memorySummaries.version} + 1`,
+          scopeId,
+          endAt: lastMessage.createdAt,
+          updatedAt: now,
+        },
+      })
+      .run();
+  }
+
+  // ── Update conversation summary ─────────────────────────────────────
+  if (input.conversation_summary) {
+    const now = Date.now();
+    const existingConvSummary = db
+      .select({ id: memorySummaries.id })
+      .from(memorySummaries)
+      .where(
+        and(
+          eq(memorySummaries.scope, "conversation"),
+          eq(memorySummaries.scopeKey, conversationId),
+        ),
+      )
+      .get();
+
+    const convSummaryId = existingConvSummary?.id ?? uuid();
+
+    db.insert(memorySummaries)
+      .values({
+        id: convSummaryId,
+        scope: "conversation",
+        scopeKey: conversationId,
+        scopeId,
+        summary: input.conversation_summary,
+        tokenEstimate: estimateTextTokens(input.conversation_summary),
+        version: 1,
+        startAt: unextractedMessages[0].createdAt,
+        endAt: lastMessage.createdAt,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [memorySummaries.scope, memorySummaries.scopeKey],
+        set: {
+          summary: input.conversation_summary,
+          tokenEstimate: estimateTextTokens(input.conversation_summary),
+          version: sql`${memorySummaries.version} + 1`,
+          scopeId,
+          endAt: lastMessage.createdAt,
+          updatedAt: now,
+        },
+      })
+      .run();
+
+    // Re-query to get the persisted row ID and enqueue embed job
+    const actualRow = db
+      .select({ id: memorySummaries.id })
+      .from(memorySummaries)
+      .where(
+        and(
+          eq(memorySummaries.scope, "conversation"),
+          eq(memorySummaries.scopeKey, conversationId),
+        ),
+      )
+      .get();
+    if (actualRow) {
+      enqueueMemoryJob("embed_summary", { summaryId: actualRow.id });
+    }
+  }
+
+  // ── Update checkpoints ──────────────────────────────────────────────
+  setMemoryCheckpoint(lastMessageIdKey, lastMessage.id);
+  setMemoryCheckpoint(
+    `batch_extract:${conversationId}:pending_count`,
+    "0",
+  );
+
+  log.info(
+    {
+      conversationId,
+      messagesProcessed: unextractedMessages.length,
+      itemsExtracted: dedupedItems.length,
+      itemsUpserted: upserted,
+    },
+    "Batch extraction completed",
+  );
+}

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -18,6 +18,7 @@ export type MemoryJobType =
   | "embed_summary"
   | "extract_items"
   | "extract_entities"
+  | "batch_extract"
   | "cleanup_stale_superseded_items"
   | "prune_old_conversations"
   | "backfill_entity_relations"

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -1,8 +1,9 @@
 import { getConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/types.js";
 import { getLogger } from "../util/logger.js";
-import { rawRun } from "./db.js";
+import { rawAll, rawRun } from "./db.js";
 import { backfillJob } from "./job-handlers/backfill.js";
+import { batchExtractJob } from "./job-handlers/batch-extraction.js";
 import {
   cleanupStaleSupersededItemsJob,
   pruneOldConversationsJob,
@@ -23,7 +24,6 @@ import {
 } from "./job-handlers/index-maintenance.js";
 import { journalCarryForwardJob } from "./job-handlers/journal-carry-forward.js";
 import { mediaProcessingJob } from "./job-handlers/media-processing.js";
-import { buildConversationSummaryJob } from "./job-handlers/summarization.js";
 import {
   BackendUnavailableError,
   classifyError,
@@ -35,6 +35,7 @@ import {
   completeMemoryJob,
   deferMemoryJob,
   enqueueCleanupStaleSupersededItemsJob,
+  enqueueMemoryJob,
   enqueuePruneOldConversationsJob,
   failMemoryJob,
   failStalledJobs,
@@ -57,6 +58,31 @@ export function startMemoryJobsWorker(): MemoryJobsWorker {
   const recovered = resetRunningJobsToPending();
   if (recovered > 0) {
     log.info({ recovered }, "Recovered stale running memory jobs");
+  }
+
+  // Startup recovery: enqueue batch_extract for conversations with pending
+  // unextracted messages (e.g. after a crash mid-conversation).
+  try {
+    const pendingRows = rawAll<{ key: string; value: string }>(
+      `SELECT key, value FROM memory_checkpoints WHERE key LIKE 'batch_extract:%:pending_count' AND CAST(value AS INTEGER) > 0`,
+    );
+    for (const row of pendingRows) {
+      // Extract conversationId from key: "batch_extract:<conversationId>:pending_count"
+      const parts = row.key.split(":");
+      if (parts.length >= 3) {
+        const conversationId = parts.slice(1, -1).join(":");
+        enqueueMemoryJob("batch_extract", { conversationId });
+        log.info(
+          { conversationId, pendingCount: row.value },
+          "Recovered pending batch extraction on startup",
+        );
+      }
+    }
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Failed to recover pending batch extractions on startup",
+    );
   }
 
   let stopped = false;
@@ -295,6 +321,9 @@ async function processJob(
     case "extract_items":
       await extractItemsJob(job);
       return;
+    case "batch_extract":
+      await batchExtractJob(job);
+      return;
     case "extract_entities":
       // Entity extraction has been removed — silently drop legacy jobs
       return;
@@ -305,7 +334,12 @@ async function processJob(
       pruneOldConversationsJob(job, config);
       return;
     case "build_conversation_summary":
-      await buildConversationSummaryJob(job, config);
+      // Deprecated: conversation summaries are now produced as a side-effect
+      // of batch extraction. Silently skip legacy jobs.
+      log.debug(
+        { jobId: job.id },
+        "Skipping deprecated build_conversation_summary job — handled by batch extraction",
+      );
       return;
     case "backfill":
       await backfillJob(job, config);


### PR DESCRIPTION
## Summary
- Replace per-message extract_items with batched extraction over conversation windows
- Unified process: extraction + supersession + running summary + conversation summary in one LLM call
- Trigger conditions: N messages accumulated, 5-min idle timeout, conversation end, crash recovery on startup
- Cross-conversation supersession: batch sees global memory items for supersession decisions
- Remove LOW_VALUE_PATTERNS and per-message semantic density gating

Part of plan: memory-system-rework.md (PR 8 of 8)