### PR TITLE
fix(memory): preserve journal_carry_forward sourceType during batch re-extraction

### DIFF
--- a/assistant/src/memory/job-handlers/batch-extraction.ts
+++ b/assistant/src/memory/job-handlers/batch-extraction.ts
@@ -429,7 +429,11 @@ export async function batchExtractJob(job: MemoryJob): Promise<void> {
       memoryItemId = existing.id;
       effectiveStatus = "active";
       const effectiveSourceType =
-        existing.sourceType === "tool" ? "tool" : "extraction";
+        existing.sourceType === "tool"
+          ? "tool"
+          : existing.sourceType === "journal_carry_forward"
+            ? "journal_carry_forward"
+            : "extraction";
       const effectiveVerificationState =
         existing.verificationState === "user_reported"
           ? "user_reported"


### PR DESCRIPTION
## Summary
Fixes sourceType downgrade — journal_carry_forward items now preserve their provenance when re-encountered by batch extraction, alongside the existing preservation for tool-sourced items.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
