### PR TITLE
fix(tests): update experimental test expectations for batched extraction

### DIFF
--- a/assistant/src/__tests__/memory-regressions.experimental.test.ts
+++ b/assistant/src/__tests__/memory-regressions.experimental.test.ts
@@ -524,8 +524,8 @@ describe("Memory regressions (experimental)", () => {
       },
       DEFAULT_CONFIG.memory,
     );
-    // embed_segment (1 segment) + extract_items + build_conversation_summary = 3
-    expect(result.enqueuedJobs).toBe(3);
+    // embed_segment (1 segment) — extraction and conversation summary are batched, not per-message
+    expect(result.enqueuedJobs).toBe(1);
 
     const embedSegmentJobs = db
       .select()
@@ -584,9 +584,8 @@ describe("Memory regressions (experimental)", () => {
       },
       memoryConfig,
     );
-    // embed_segment (1 segment) + build_conversation_summary = 2
-    // (extract_items is skipped for assistant messages when extractFromAssistant=false)
-    expect(result.enqueuedJobs).toBe(2);
+    // embed_segment (1 segment) — extraction and conversation summary are batched, not per-message
+    expect(result.enqueuedJobs).toBe(1);
 
     const extractionJobs = db
       .select()


### PR DESCRIPTION
## Summary
Updates stale test expectations in memory-regressions.experimental.test.ts to reflect that per-message extract_items and build_conversation_summary jobs are no longer enqueued by the indexer.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
