### PR TITLE
fix(memory): remove dead sourceConversationId from MemoryRecallToolResult

### DIFF
--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -252,7 +252,7 @@ export interface MemoryRecallToolResult {
   text: string;
   resultCount: number;
   degraded: boolean;
-  items: Array<{ id: string; type: string; kind: string; sourceConversationId?: string; sourceConversationTitle?: string }>;
+  items: Array<{ id: string; type: string; kind: string; sourceConversationTitle?: string }>;
   sources: {
     semantic: number;
     recency: number;


### PR DESCRIPTION
## Summary
Removes unpopulated sourceConversationId field from MemoryRecallToolResult items type to avoid confusing consumers.