### PR TITLE
fix(memory): update top-level maxInjectTokens default to 16000

### DIFF
--- a/assistant/docs/architecture/memory.md
+++ b/assistant/docs/architecture/memory.md
@@ -260,10 +260,10 @@ The key distinction: normal compaction is a cost-optimized background process th
 | Config key                                            |                   Default | Purpose                                                              |
 | ----------------------------------------------------- | ------------------------: | -------------------------------------------------------------------- |
 | `memory.retrieval.dynamicBudget.enabled`              |                    `true` | Toggle per-turn recall budget calculation from live prompt headroom. |
-| `memory.retrieval.dynamicBudget.minInjectTokens`      |                    `1200` | Lower clamp for computed recall injection budget.                    |
-| `memory.retrieval.dynamicBudget.maxInjectTokens`      |                   `10000` | Upper clamp for computed recall injection budget.                    |
+| `memory.retrieval.dynamicBudget.minInjectTokens`      |                    `2400` | Lower clamp for computed recall injection budget.                    |
+| `memory.retrieval.dynamicBudget.maxInjectTokens`      |                   `16000` | Upper clamp for computed recall injection budget.                    |
 | `memory.retrieval.dynamicBudget.targetHeadroomTokens` |                   `10000` | Reserved headroom to keep free for response generation/tool traces.  |
-| `memory.retrieval.maxInjectTokens`                    |                   `10000` | Static fallback when dynamic budget is disabled.                     |
+| `memory.retrieval.maxInjectTokens`                    |                   `16000` | Static fallback when dynamic budget is disabled.                     |
 | `memory.retrieval.scopePolicy`                        | `'allow_global_fallback'` | Scope filtering strategy: `'strict'` or `'allow_global_fallback'`.   |
 
 ### Memory Recall Debugging Playbook

--- a/assistant/src/config/schemas/memory-retrieval.ts
+++ b/assistant/src/config/schemas/memory-retrieval.ts
@@ -190,7 +190,7 @@ export const MemoryRetrievalConfigSchema = z
       .number({ error: "memory.retrieval.maxInjectTokens must be a number" })
       .int("memory.retrieval.maxInjectTokens must be an integer")
       .positive("memory.retrieval.maxInjectTokens must be a positive integer")
-      .default(10000)
+      .default(16000)
       .describe(
         "Maximum number of tokens to inject from long-term memory into the conversation context",
       ),


### PR DESCRIPTION
## Summary
- Aligns top-level `memory.retrieval.maxInjectTokens` default with the dynamic budget default (both now 16000).
- Fixes stale defaults in `docs/architecture/memory.md` for `maxInjectTokens` and `minInjectTokens`.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/config-schema.test.ts` — all 99 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22048" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
