### PR TITLE
fix: resolve lint errors in memory files

### DIFF
--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -131,7 +131,6 @@ import {
   injectMemoryRecallAsUserBlock,
   lookupSupersessionChain,
 } from "../memory/retriever.js";
-import { buildMemoryInjection } from "../memory/search/formatting.js";
 import {
   conversations,
   memoryEmbeddings,
@@ -142,6 +141,7 @@ import {
   memorySummaries,
   messages,
 } from "../memory/schema.js";
+import { buildMemoryInjection } from "../memory/search/formatting.js";
 import { buildCoreIdentityContext } from "../prompts/system-prompt.js";
 import type { Message } from "../providers/types.js";
 

--- a/assistant/src/memory/job-handlers/batch-extraction.ts
+++ b/assistant/src/memory/job-handlers/batch-extraction.ts
@@ -18,7 +18,6 @@ import {
 import { getConversationMemoryScopeId } from "../conversation-crud.js";
 import { getDb } from "../db.js";
 import { computeMemoryFingerprint } from "../fingerprint.js";
-import { enqueueMemoryJob, type MemoryJob } from "../jobs-store.js";
 import {
   buildExtractionSystemPrompt,
   deduplicateItems,
@@ -33,6 +32,7 @@ import {
   VALID_OVERRIDE_CONFIDENCES,
 } from "../items-extractor.js";
 import { asString } from "../job-utils.js";
+import { enqueueMemoryJob, type MemoryJob } from "../jobs-store.js";
 import { extractTextFromStoredMessageContent } from "../message-content.js";
 import { withQdrantBreaker } from "../qdrant-circuit-breaker.js";
 import { getQdrantClient } from "../qdrant-client.js";
@@ -410,7 +410,6 @@ export async function batchExtractJob(job: MemoryJob): Promise<void> {
   let upserted = 0;
 
   for (const item of dedupedItems) {
-    const now = Date.now();
     const seenAt = lastMessage.createdAt;
     const existing = db
       .select()

--- a/assistant/src/memory/search/formatting.test.ts
+++ b/assistant/src/memory/search/formatting.test.ts
@@ -4,8 +4,8 @@
  */
 import { describe, expect, test } from "bun:test";
 
-import type { Candidate } from "./types.js";
 import { buildMemoryInjection } from "./formatting.js";
+import type { Candidate } from "./types.js";
 
 type CandidateWithLabel = Candidate & { sourceLabel?: string };
 


### PR DESCRIPTION
## Summary
- Fix import sort order in `memory-regressions.test.ts`, `batch-extraction.ts`, and `formatting.test.ts`
- Remove unused `now` variable in `batch-extraction.ts`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23678844146/job/68987189483
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22051" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
