### PR TITLE
chore: remove accidental submodule reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ vellum-assistant-safe-do-permissions
 
 # macOS binary
 clients/macos/assistant-bin/vellum-assistant
+vellum-assistant-do-fix-retriever-null-check


### PR DESCRIPTION
## Summary
- Removes the `vellum-assistant-do-fix-retriever-null-check` submodule reference that was accidentally staged in #22053
- Adds it to `.gitignore` to prevent recurrence

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22054" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
