### PR TITLE
feat(macos): add seconds precision to LLM Context Inspector timestamps

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorSummaryFormatters.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorSummaryFormatters.swift
@@ -158,7 +158,7 @@ enum MessageInspectorSummaryFormatters {
 
     static func formattedCreatedAt(_ epochMs: Int) -> String {
         Date(timeIntervalSince1970: TimeInterval(epochMs) / 1000.0)
-            .formatted(date: .abbreviated, time: .shortened)
+            .formatted(date: .abbreviated, time: .standard)
     }
 
     static func isProviderOnlySummary(_ summary: LLMCallSummary) -> Bool {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
@@ -502,12 +502,12 @@ struct MessageInspectorView: View {
 
     private func formattedTimestamp(_ epochMs: Int) -> String {
         Date(timeIntervalSince1970: TimeInterval(epochMs) / 1000.0)
-            .formatted(date: .omitted, time: .shortened)
+            .formatted(date: .omitted, time: .standard)
     }
 
     private func formattedDateTime(_ epochMs: Int) -> String {
         Date(timeIntervalSince1970: TimeInterval(epochMs) / 1000.0)
-            .formatted(date: .abbreviated, time: .shortened)
+            .formatted(date: .abbreviated, time: .standard)
     }
 }
 


### PR DESCRIPTION
## Summary
- Changed time format from `.shortened` to `.standard` in all three timestamp formatters in the LLM Context Inspector
- Timestamps now display with seconds (e.g., "6:18:42 AM" instead of "6:18 AM") across the call rail, call subtitle, and detail header

## Original prompt
let's add seconds precision to the timestamps here