### PR TITLE
feat(memory): add source conversation path to injected segments and items

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -17,6 +17,7 @@ import {
   logMemoryEmbeddingWarning,
 } from "./embedding-backend.js";
 import { isQdrantBreakerOpen } from "./qdrant-circuit-breaker.js";
+import { getConversationDirName } from "./conversation-directories.js";
 import {
   conversations,
   memoryItems,
@@ -764,17 +765,17 @@ function enrichSourceLabels(candidates: TieredCandidate[]): void {
   try {
     const db = getDb();
 
-    // Collect item IDs for items that need source label lookup
+    // ── Items: find conversation via memoryItemSources → messages → conversations ──
     const itemCandidates = candidates.filter((c) => c.type === "item");
     const itemIds = itemCandidates.map((c) => c.id);
 
     if (itemIds.length > 0) {
-      // For items: find conversation titles via memoryItemSources → messages → conversations.
-      // Pick the most recent conversation title per item.
       const rows = db
         .select({
           memoryItemId: memoryItemSources.memoryItemId,
+          conversationId: conversations.id,
           title: conversations.title,
+          conversationCreatedAt: conversations.createdAt,
           conversationUpdatedAt: conversations.updatedAt,
         })
         .from(memoryItemSources)
@@ -789,31 +790,58 @@ function enrichSourceLabels(candidates: TieredCandidate[]): void {
         .where(inArray(memoryItemSources.memoryItemId, itemIds))
         .all();
 
-      // Group by item ID and pick the most recently updated conversation title
-      const titleMap = new Map<string, string>();
-      const updatedAtMap = new Map<string, number>();
+      // Group by item ID and pick the most recently updated conversation
+      const bestConvMap = new Map<string, { title: string | null; conversationId: string; createdAt: number; updatedAt: number }>();
       for (const row of rows) {
-        if (!row.title) continue;
-        const existing = updatedAtMap.get(row.memoryItemId);
-        if (existing === undefined || row.conversationUpdatedAt > existing) {
-          titleMap.set(row.memoryItemId, row.title);
-          updatedAtMap.set(row.memoryItemId, row.conversationUpdatedAt);
+        const existing = bestConvMap.get(row.memoryItemId);
+        if (existing === undefined || row.conversationUpdatedAt > existing.updatedAt) {
+          bestConvMap.set(row.memoryItemId, {
+            title: row.title,
+            conversationId: row.conversationId,
+            createdAt: row.conversationCreatedAt,
+            updatedAt: row.conversationUpdatedAt,
+          });
         }
       }
 
       for (const c of itemCandidates) {
-        const title = titleMap.get(c.id);
-        if (title) {
-          c.sourceLabel = title;
+        const conv = bestConvMap.get(c.id);
+        if (conv) {
+          if (conv.title) c.sourceLabel = conv.title;
+          const dirName = getConversationDirName(conv.conversationId, conv.createdAt);
+          c.sourcePath = `conversations/${dirName}/messages.jsonl`;
         }
       }
     }
 
-    // For segment candidates: the key format is "seg:<segmentId>" and the id is the segment's id.
-    // We can look up the conversation title via the segment's conversationId in memory_segments.
-    // However, segments already reference a conversationId in the schema — but the Candidate type
-    // doesn't carry it. For now, skip segment source labels as the join path would require
-    // importing memorySegments and an additional query. The primary value is item source labels.
+    // ── Segments: look up conversation via conversationId on the candidate ──
+    const segmentCandidates = candidates.filter(
+      (c) => (c.type === "segment" || c.type === "summary") && c.conversationId,
+    );
+
+    if (segmentCandidates.length > 0) {
+      const convIds = [...new Set(segmentCandidates.map((c) => c.conversationId!))];
+      const convRows = db
+        .select({
+          id: conversations.id,
+          title: conversations.title,
+          createdAt: conversations.createdAt,
+        })
+        .from(conversations)
+        .where(inArray(conversations.id, convIds))
+        .all();
+
+      const convMap = new Map(convRows.map((r) => [r.id, r]));
+
+      for (const c of segmentCandidates) {
+        const conv = convMap.get(c.conversationId!);
+        if (conv) {
+          if (conv.title) c.sourceLabel = conv.title;
+          const dirName = getConversationDirName(conv.id, conv.createdAt);
+          c.sourcePath = `conversations/${dirName}/messages.jsonl`;
+        }
+      }
+    }
   } catch (err) {
     log.warn({ err }, "Failed to enrich candidates with source labels");
   }

--- a/assistant/src/memory/search/formatting.ts
+++ b/assistant/src/memory/search/formatting.ts
@@ -226,6 +226,9 @@ function renderCandidate(c: Candidate & { sourceLabel?: string; supersedes?: str
   const fromAttr = c.sourceLabel
     ? ` from="${escapeXmlAttr(c.sourceLabel)}"`
     : "";
+  const pathAttr = c.sourcePath
+    ? ` path="${escapeXmlAttr(c.sourcePath)}"`
+    : "";
 
   // Build inline supersession suffix for items
   let supersessionSuffix = "";
@@ -239,14 +242,14 @@ function renderCandidate(c: Candidate & { sourceLabel?: string; supersedes?: str
 
   switch (c.type) {
     case "item":
-      return `<item id="item:${escapeXmlAttr(c.id)}" kind="${escapeXmlAttr(c.kind)}" importance="${c.importance.toFixed(2)}" timestamp="${escapeXmlAttr(timestamp)}"${fromAttr}>${text}${supersessionSuffix}</item>`;
+      return `<item id="item:${escapeXmlAttr(c.id)}" kind="${escapeXmlAttr(c.kind)}" importance="${c.importance.toFixed(2)}" timestamp="${escapeXmlAttr(timestamp)}"${fromAttr}${pathAttr}>${text}${supersessionSuffix}</item>`;
     case "segment":
-      return `<segment id="seg:${escapeXmlAttr(c.id)}" timestamp="${escapeXmlAttr(timestamp)}"${fromAttr}>${text}</segment>`;
+      return `<segment id="seg:${escapeXmlAttr(c.id)}" timestamp="${escapeXmlAttr(timestamp)}"${fromAttr}${pathAttr}>${text}</segment>`;
     case "summary":
-      return `<summary id="sum:${escapeXmlAttr(c.id)}" timestamp="${escapeXmlAttr(timestamp)}"${fromAttr}>${text}</summary>`;
+      return `<summary id="sum:${escapeXmlAttr(c.id)}" timestamp="${escapeXmlAttr(timestamp)}"${fromAttr}${pathAttr}>${text}</summary>`;
     default:
       // media or unknown types — render as item
-      return `<item id="item:${escapeXmlAttr(c.id)}" kind="${escapeXmlAttr(c.kind)}" importance="${c.importance.toFixed(2)}" timestamp="${escapeXmlAttr(timestamp)}"${fromAttr}>${text}${supersessionSuffix}</item>`;
+      return `<item id="item:${escapeXmlAttr(c.id)}" kind="${escapeXmlAttr(c.kind)}" importance="${c.importance.toFixed(2)}" timestamp="${escapeXmlAttr(timestamp)}"${fromAttr}${pathAttr}>${text}${supersessionSuffix}</item>`;
   }
 }
 

--- a/assistant/src/memory/search/types.ts
+++ b/assistant/src/memory/search/types.ts
@@ -17,6 +17,8 @@ export interface Candidate {
   messageId?: string;
   /** The ID of the memory item this candidate supersedes (items only). */
   supersedes?: string;
+  /** Relative workspace path to the source conversation's messages file. */
+  sourcePath?: string;
   confidence: number;
   importance: number;
   createdAt: number;


### PR DESCRIPTION
## Summary
- Extend enrichSourceLabels to enrich segments with source labels (was items-only)
- Add sourcePath (relative disk path to messages.jsonl) to all candidates using getConversationDirName
- Render path attribute on both <item> and <segment> tags in injection format
- Enables the assistant to navigate from any injected memory back to the full conversation on disk