### PR TITLE
fix: sort imports in memory retriever to fix lint

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -9,6 +9,7 @@ import {
   computeRetryDelay,
   isRetryableNetworkError,
 } from "../util/retry.js";
+import { getConversationDirName } from "./conversation-directories.js";
 import { getDb } from "./db.js";
 import {
   embedWithBackend,
@@ -17,7 +18,6 @@ import {
   logMemoryEmbeddingWarning,
 } from "./embedding-backend.js";
 import { isQdrantBreakerOpen } from "./qdrant-circuit-breaker.js";
-import { getConversationDirName } from "./conversation-directories.js";
 import {
   conversations,
   memoryItems,


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error in `assistant/src/memory/retriever.ts` by reordering the `conversation-directories` import to its correct alphabetical position

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23679422842/job/68988738300