### PR TITLE
feat(macos): default Raw tab to Response pane in LLM Context Inspector

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
@@ -574,7 +574,7 @@ struct MessageInspectorViewState {
     private(set) var memoryRecall: MemoryRecallData?
     private(set) var selectedLogID: String?
     private(set) var selectedDetailTab: MessageInspectorDetailTab = .overview
-    private(set) var selectedRawPane: RawPayloadPane = .request
+    private(set) var selectedRawPane: RawPayloadPane = .response
     private(set) var activeLoadToken: UUID?
 
     var selectedLog: LLMRequestLogEntry? {


### PR DESCRIPTION
## Summary
- Changed the default selected pane in the LLM Context Inspector's Raw tab from "Request" to "Response"

## Original prompt
I want this to default to selecting "Response" instead of "Request"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
