### PR TITLE
fix: re-link LLM request logs during message consolidation

### DIFF
--- a/assistant/src/__tests__/llm-request-log-turn-query.test.ts
+++ b/assistant/src/__tests__/llm-request-log-turn-query.test.ts
@@ -53,6 +53,7 @@ import {
   backfillMessageIdOnLogs,
   getRequestLogsByMessageId,
   recordRequestLog,
+  relinkLlmRequestLogs,
 } from "../memory/llm-request-log-store.js";
 import { llmRequestLogs, toolInvocations } from "../memory/schema.js";
 
@@ -330,5 +331,50 @@ describe("getRequestLogsByMessageId — turn-aware query", () => {
     expect(logs[0]?.id).toBe("log-orphan-1");
     expect(logs[1]?.id).toBe("log-orphan-2");
     expect(logs[2]?.id).toBe("log-surviving");
+  });
+
+  test("relinkLlmRequestLogs moves logs from deleted messages to consolidated message", async () => {
+    const conv = createConversation("relink-test");
+
+    // Simulate multi-step turn: user → A1 (+ log1) → tool_result → A2 (+ log2)
+    await addMessage(conv.id, "user", "Do the task", undefined, {
+      skipIndexing: true,
+    });
+
+    // First LLM call → A1 (tool_use response)
+    recordRequestLog(conv.id, '{"step":1}', '{"tool_use":"bash"}');
+    const a1 = await addMessage(
+      conv.id,
+      "assistant",
+      "Using tool...",
+      undefined,
+      { skipIndexing: true },
+    );
+    backfillMessageIdOnLogs(conv.id, a1.id);
+
+    // tool_result user message
+    await addMessage(
+      conv.id,
+      "user",
+      toolResultContent(["tool-1"]),
+      undefined,
+      { skipIndexing: true },
+    );
+
+    // Second LLM call → A2 (text response)
+    recordRequestLog(conv.id, '{"step":2}', '{"result":"done"}');
+    const a2 = await addMessage(conv.id, "assistant", "All done!", undefined, {
+      skipIndexing: true,
+    });
+    backfillMessageIdOnLogs(conv.id, a2.id);
+
+    // Simulate consolidation: re-link logs from A2 to A1, then delete A2
+    relinkLlmRequestLogs([a2.id], a1.id);
+
+    // Both logs should now be findable via A1
+    const logs = getRequestLogsByMessageId(a1.id);
+    expect(logs).toHaveLength(2);
+    expect(logs[0]?.messageId).toBe(a1.id);
+    expect(logs[1]?.messageId).toBe(a1.id);
   });
 });

--- a/assistant/src/daemon/conversation-history.ts
+++ b/assistant/src/daemon/conversation-history.ts
@@ -10,6 +10,7 @@ import {
 } from "../memory/conversation-crud.js";
 import { isLastUserMessageToolResult } from "../memory/conversation-queries.js";
 import { enqueueMemoryJob } from "../memory/jobs-store.js";
+import { relinkLlmRequestLogs } from "../memory/llm-request-log-store.js";
 import { withQdrantBreaker } from "../memory/qdrant-circuit-breaker.js";
 import { getQdrantClient } from "../memory/qdrant-client.js";
 import type { ContentBlock, Message } from "../providers/types.js";
@@ -295,9 +296,10 @@ export function consolidateAssistantMessages(
     JSON.stringify(consolidatedContent),
   );
 
-  // Re-link attachments from messages about to be deleted to the consolidated
-  // message. Without this, ON DELETE CASCADE on message_attachments destroys
-  // the attachment links, and deleteOrphanAttachments removes the data.
+  // Re-link attachments and LLM request logs from messages about to be
+  // deleted to the consolidated message. Without this, ON DELETE CASCADE on
+  // message_attachments destroys the attachment links, and LLM call logs
+  // become orphaned (invisible in the context inspector).
   const messageIdsToDelete = [
     ...messagesToConsolidate.slice(1).map((m) => m.id),
     ...messagesToDelete,
@@ -313,6 +315,8 @@ export function consolidateAssistantMessages(
         "Re-linked attachments to consolidated message",
       );
     }
+
+    relinkLlmRequestLogs(messageIdsToDelete, firstAssistantMsg.id);
   }
 
   // Delete the other assistant messages and internal tool_result messages,

--- a/assistant/src/memory/llm-request-log-store.ts
+++ b/assistant/src/memory/llm-request-log-store.ts
@@ -84,6 +84,24 @@ export function backfillMessageIdOnLogs(
 }
 
 /**
+ * Re-link LLM request logs from a set of source message IDs to a target
+ * message. Used during message consolidation so logs from deleted
+ * intermediate messages survive and remain queryable via the consolidated
+ * message.
+ */
+export function relinkLlmRequestLogs(
+  fromMessageIds: string[],
+  toMessageId: string,
+): void {
+  if (fromMessageIds.length === 0) return;
+  const db = getDb();
+  db.update(llmRequestLogs)
+    .set({ messageId: toMessageId })
+    .where(inArray(llmRequestLogs.messageId, fromMessageIds))
+    .run();
+}
+
+/**
  * Internal helper: query `llm_request_logs` for rows matching any of the
  * given message IDs, ordered by `createdAt ASC`. Uses the existing
  * `idx_llm_request_logs_message_id` index via `inArray`.


### PR DESCRIPTION
## Summary
- After a multi-step agent turn (tool_use + text = 2 LLM calls), `consolidateAssistantMessages` merges assistant messages and deletes intermediates. LLM request logs pointing to deleted messages became invisible in the context inspector — showing only 1 of 2 calls.
- Added `relinkLlmRequestLogs()` to re-point logs from deleted messages to the surviving consolidated message before deletion, mirroring the existing `relinkAttachments` pattern.
- Added test covering the relink-then-query scenario.