### PR TITLE
feat: add show-thinking-blocks feature flag

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -290,6 +290,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "show-thinking-blocks",
+      "scope": "macos",
+      "key": "show-thinking-blocks",
+      "label": "Show Thinking Blocks",
+      "description": "Display the assistant's thinking/reasoning inline in chat messages as collapsible blocks",
+      "defaultEnabled": false
+    },
+    {
       "id": "inline-skill-commands",
       "scope": "assistant",
       "key": "inline-skill-commands",


### PR DESCRIPTION
## Summary
- Add `show-thinking-blocks` macOS feature flag to the registry
- Defaults to disabled; will gate inline thinking block display in chat

Part of plan: inline-thinking-blocks.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22062" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
