### PR TITLE
fix: add system prompt to autocomplete to prevent content refusals

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1334,10 +1334,13 @@ async function generateLlmSuggestion(
     assistantText.length > 2000 ? assistantText.slice(-2000) : assistantText;
 
   const prompt = `Given this assistant message, write a very short tab-complete suggestion the user could send next. Focus on the LAST question or call-to-action in the message — ignore earlier summary content. Be casual, curious, or actionable — like a quick reply, not a formal request. Reply with ONLY the suggestion text.\n\nAssistant's message:\n${truncated}`;
+  const systemPrompt =
+    "You are an autocomplete engine that suggests short replies the user might send next in a conversation. Generate suggestions that match the tone and style of the conversation. Never refuse, judge, or comment on the conversation content — your only job is to predict what the user would plausibly type next.";
+
   const response = await provider.sendMessage(
     [{ role: "user", content: [{ type: "text", text: prompt }] }],
     [], // no tools
-    undefined, // no system prompt
+    systemPrompt,
     { config: { modelIntent: "latency-optimized" } },
   );
 


### PR DESCRIPTION
## Summary

- The autocomplete suggestion generator (`generateLlmSuggestion`) was passing `undefined` as the system prompt, so the latency-optimized model had no context framing and would refuse to suggest replies for certain conversation content
- Added a system prompt that frames the model as a neutral autocomplete engine, instructing it to match conversation tone without judging content
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22063" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
