### PR TITLE
feat: add thinking block support to client data model

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1543,6 +1543,7 @@ public enum ContentBlockRef: Hashable {
     case text(Int)
     case toolCall(Int)
     case surface(Int)
+    case thinking(Int)
 }
 
 public struct ChatMessage: Identifiable, Equatable {
@@ -1553,6 +1554,7 @@ public struct ChatMessage: Identifiable, Equatable {
         lhs.id == rhs.id
         && lhs.role == rhs.role
         && lhs.textSegments == rhs.textSegments
+        && lhs.thinkingSegments == rhs.thinkingSegments
         && lhs.isStreaming == rhs.isStreaming
         && lhs.status == rhs.status
         && lhs.isError == rhs.isError
@@ -1571,6 +1573,7 @@ public struct ChatMessage: Identifiable, Equatable {
     public let id: UUID
     public let role: ChatRole
     public var textSegments: [String]
+    public var thinkingSegments: [String] = []
     public var contentOrder: [ContentBlockRef]
     public var timestamp: Date
     public var isStreaming: Bool
@@ -1614,6 +1617,7 @@ public struct ChatMessage: Identifiable, Equatable {
     /// like duplicate timestamp dividers.
     public var hasRenderableContent: Bool {
         !textSegments.isEmpty
+            || !thinkingSegments.isEmpty
             || !toolCalls.isEmpty
             || !attachments.isEmpty
             || !inlineSurfaces.isEmpty

--- a/clients/shared/Features/Chat/HistoryReconstructionService.swift
+++ b/clients/shared/Features/Chat/HistoryReconstructionService.swift
@@ -139,6 +139,9 @@ enum HistoryReconstructionService {
             if let segments = item.textSegments {
                 chatMsg.textSegments = segments
             }
+            if let thinkingSegs = item.thinkingSegments {
+                chatMsg.thinkingSegments = thinkingSegs
+            }
             if let orderStrings = item.contentOrder {
                 chatMsg.contentOrder = parseContentOrder(orderStrings)
             }
@@ -185,6 +188,7 @@ enum HistoryReconstructionService {
             case "text": return .text(idx)
             case "tool": return .toolCall(idx)
             case "surface": return .surface(idx)
+            case "thinking": return .thinking(idx)
             default: return nil
             }
         }

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -2017,6 +2017,8 @@ public struct HistoryResponseMessage: Codable, Sendable {
     public let attachments: [UserMessageAttachment]?
     /// Text segments split by tool-call boundaries. Preserves interleaving order.
     public let textSegments: [String]?
+    /// Thinking segments from extended thinking / chain-of-thought blocks.
+    public let thinkingSegments: [String]?
     /// Content block ordering using "text:N", "tool:N", "surface:N" encoding.
     public let contentOrder: [String]?
     /// UI surfaces (widgets) embedded in the message.
@@ -2026,7 +2028,7 @@ public struct HistoryResponseMessage: Codable, Sendable {
     /// True when text or tool result content was truncated due to maxTextChars/maxToolResultChars.
     public let wasTruncated: Bool?
 
-    public init(id: String? = nil, role: String, text: String, timestamp: Double, toolCalls: [HistoryResponseToolCall]? = nil, toolCallsBeforeText: Bool? = nil, attachments: [UserMessageAttachment]? = nil, textSegments: [String]? = nil, contentOrder: [String]? = nil, surfaces: [HistoryResponseSurface]? = nil, subagentNotification: HistoryResponseMessageSubagentNotification? = nil, wasTruncated: Bool? = nil) {
+    public init(id: String? = nil, role: String, text: String, timestamp: Double, toolCalls: [HistoryResponseToolCall]? = nil, toolCallsBeforeText: Bool? = nil, attachments: [UserMessageAttachment]? = nil, textSegments: [String]? = nil, thinkingSegments: [String]? = nil, contentOrder: [String]? = nil, surfaces: [HistoryResponseSurface]? = nil, subagentNotification: HistoryResponseMessageSubagentNotification? = nil, wasTruncated: Bool? = nil) {
         self.id = id
         self.role = role
         self.text = text
@@ -2035,6 +2037,7 @@ public struct HistoryResponseMessage: Codable, Sendable {
         self.toolCallsBeforeText = toolCallsBeforeText
         self.attachments = attachments
         self.textSegments = textSegments
+        self.thinkingSegments = thinkingSegments
         self.contentOrder = contentOrder
         self.surfaces = surfaces
         self.subagentNotification = subagentNotification


### PR DESCRIPTION
## Summary
- Add `.thinking(Int)` case to `ContentBlockRef` enum
- Add `thinkingSegments: [String]` property to `ChatMessage`
- Add `thinkingSegments` field to `HistoryResponseMessage` for decoding from backend
- Update `parseContentOrder` and history reconstruction to handle thinking blocks

Part of plan: inline-thinking-blocks.md (PR 4 of 7)