### PR TITLE
feat: include thinking segments in rendered history content

### DIFF
--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -91,6 +91,8 @@ export interface RenderedHistoryContent {
   contentOrder: string[];
   /** UI surfaces (widgets) embedded in the message. */
   surfaces: HistorySurface[];
+  /** Thinking segments extracted from thinking blocks. */
+  thinkingSegments: string[];
 }
 
 export interface SubagentNotificationData {
@@ -220,6 +222,7 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
       textSegments: text ? [text] : [],
       contentOrder: text ? ["text:0"] : [],
       surfaces: [],
+      thinkingSegments: [],
     };
   }
 
@@ -227,6 +230,7 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
   const attachmentParts: string[] = [];
   const toolCalls: HistoryToolCall[] = [];
   const surfaces: HistorySurface[] = [];
+  const thinkingSegments: string[] = [];
   const pendingToolUses = new Map<string, HistoryToolCall>();
   let seenText = false;
   let seenToolUse = false;
@@ -297,6 +301,13 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
       };
       surfaces.push(surface);
       contentOrder.push(`surface:${surfaces.length - 1}`);
+      continue;
+    }
+
+    if (block.type === "thinking" && typeof block.thinking === "string") {
+      finalizeSegment();
+      thinkingSegments.push(block.thinking);
+      contentOrder.push(`thinking:${thinkingSegments.length - 1}`);
       continue;
     }
 
@@ -410,6 +421,7 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
     textSegments,
     contentOrder,
     surfaces,
+    thinkingSegments,
   };
 }
 


### PR DESCRIPTION
## Summary
- Extract thinking blocks from persisted message content into a `thinkingSegments` array
- Add `thinking:N` entries to `contentOrder` for correct interleaving
- Skip `redacted_thinking` blocks (opaque encrypted data)

Part of plan: inline-thinking-blocks.md (PR 2 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
