### PR TITLE
feat: include thinkingSegments in conversation history response

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -454,6 +454,7 @@ export function handleListMessages(
         textSegments: filteredSegments,
         contentOrder: filteredContentOrder,
         surfaces: rendered.surfaces,
+        ...(rendered.thinkingSegments.length > 0 ? { thinkingSegments: rendered.thinkingSegments } : {}),
         id: msg.id,
       };
     }
@@ -467,6 +468,7 @@ export function handleListMessages(
       textSegments: rendered.textSegments,
       contentOrder: rendered.contentOrder,
       surfaces: rendered.surfaces,
+      ...(rendered.thinkingSegments.length > 0 ? { thinkingSegments: rendered.thinkingSegments } : {}),
       id: msg.id,
     };
   });


### PR DESCRIPTION
## Summary
- Wire `thinkingSegments` from `renderHistoryContent()` into the conversation history HTTP response
- Conditionally include only when thinking segments are present (empty omitted)
- Applied to both assistant-message and default branches

Part of plan: inline-thinking-blocks.md (PR 3 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22067" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
