### PR TITLE
feat: accumulate thinking deltas into chat messages during streaming

### DIFF
--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -106,9 +106,12 @@ final class ChatActionHandler {
             vm.isSending = true
             vm.isThinking = true
 
-        case .assistantThinkingDelta:
-            // Stay in thinking state
-            break
+        case .assistantThinkingDelta(let delta):
+            guard !vm.isCancelling else { break }
+            guard !vm.isLoadingHistory else { break }
+            guard MacOSClientFeatureFlagManager.shared.isEnabled("show-thinking-blocks") else { break }
+            vm.thinkingDeltaBuffer += delta.thinking
+            vm.scheduleThinkingFlush()
 
         case .assistantTextDelta(let delta):
             handleAssistantTextDelta(delta, vm: vm)

--- a/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
@@ -7,11 +7,72 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ChatV
 
 extension ChatViewModel {
 
+    // MARK: - Thinking Delta Throttle
+
+    /// Cancel any pending thinking flush and discard buffered thinking text.
+    func discardThinkingBuffer() {
+        thinkingFlushTask?.cancel()
+        thinkingFlushTask = nil
+        thinkingDeltaBuffer = ""
+    }
+
+    /// Flush any buffered thinking text into the messages array.
+    /// Called eagerly before text flushes to maintain correct interleaving order.
+    func flushThinkingBuffer() {
+        thinkingFlushTask?.cancel()
+        thinkingFlushTask = nil
+        guard !thinkingDeltaBuffer.isEmpty else { return }
+        let buffered = thinkingDeltaBuffer
+        thinkingDeltaBuffer = ""
+        appendThinkingToCurrentMessage(buffered)
+    }
+
+    /// Append a chunk of thinking text to the current assistant message.
+    func appendThinkingToCurrentMessage(_ text: String) {
+        guard !text.isEmpty else { return }
+        if let existingId = currentAssistantMessageId,
+           let index = messages.firstIndex(where: { $0.id == existingId }) {
+            if let lastRef = messages[index].contentOrder.last,
+               case .thinking(let segIdx) = lastRef {
+                // Append to the existing thinking segment
+                messages[index].thinkingSegments[segIdx] += text
+            } else {
+                // Create a new thinking segment
+                let segIdx = messages[index].thinkingSegments.count
+                messages[index].thinkingSegments.append(text)
+                messages[index].contentOrder.append(.thinking(segIdx))
+            }
+        } else if currentAssistantMessageId != nil {
+            log.warning("Stale currentAssistantMessageId \(self.currentAssistantMessageId!.uuidString) — discarding \(text.count) buffered thinking chars")
+            currentAssistantMessageId = nil
+            return
+        } else {
+            var msg = ChatMessage(role: .assistant, text: "", isStreaming: true)
+            msg.thinkingSegments = [text]
+            msg.contentOrder = [.thinking(0)]
+            currentAssistantMessageId = msg.id
+            messages.append(msg)
+        }
+    }
+
+    /// Schedule a thinking flush after the throttle interval if one isn't already pending.
+    func scheduleThinkingFlush() {
+        guard thinkingFlushTask == nil else { return }
+        thinkingFlushTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(Self.streamingFlushInterval * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            self?.flushThinkingBuffer()
+        }
+    }
+
+    // MARK: - Streaming Delta Throttle
+
     /// Cancel any pending flush and discard buffered text.
     /// Called on every path that clears `currentAssistantMessageId` without
     /// a normal `messageComplete` (cancel, error, handoff, reconnect, etc.)
     /// to prevent a stale flush from creating an orphan assistant message.
     func discardStreamingBuffer() {
+        discardThinkingBuffer()
         streamingFlushTask?.cancel()
         streamingFlushTask = nil
         streamingDeltaBuffer = ""
@@ -21,6 +82,7 @@ extension ChatViewModel {
     /// Called on a timer and also eagerly on `messageComplete`,
     /// `toolUseStart`, `uiSurfaceShow`, etc.
     func flushStreamingBuffer() {
+        flushThinkingBuffer()  // thinking before text in content order
         streamingFlushTask?.cancel()
         streamingFlushTask = nil
         guard !streamingDeltaBuffer.isEmpty else { return }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -635,6 +635,11 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     /// Scheduled flush work item; cancelled and re-created on each delta.
     @ObservationIgnored var streamingFlushTask: Task<Void, Never>?
 
+    /// Buffered thinking text that has not yet been flushed to `messages`.
+    @ObservationIgnored var thinkingDeltaBuffer: String = ""
+    /// Scheduled flush task for coalescing thinking delta writes.
+    @ObservationIgnored var thinkingFlushTask: Task<Void, Never>?
+
     // MARK: - Partial Output Coalescing
 
     /// Buffered partial-output chunks keyed by "messageUUID:tcIndex".


### PR DESCRIPTION
## Summary
- Add thinking delta buffer and flush logic mirroring the existing text streaming pattern
- Accumulate `assistant_thinking_delta` events into `ChatMessage.thinkingSegments`
- Gate accumulation behind `show-thinking-blocks` feature flag
- Flush thinking buffer before text buffer to maintain correct content order

Part of plan: inline-thinking-blocks.md (PR 5 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22069" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
