### PR TITLE
fix: handle thinking case in MessageBubbleView switch statements

### DIFF
--- a/clients/shared/Features/Chat/MessageBubbleView.swift
+++ b/clients/shared/Features/Chat/MessageBubbleView.swift
@@ -184,7 +184,7 @@ public struct MessageBubbleView: View {
         for ref in message.contentOrder {
             switch ref {
             case .text: hasText = true
-            case .toolCall, .surface: hasNonText = true
+            case .toolCall, .surface, .thinking: hasNonText = true
             }
             if hasText && hasNonText { return true }
         }
@@ -197,6 +197,7 @@ public struct MessageBubbleView: View {
 
     private enum ContentGroup {
         case text(Int)
+        case thinking(Int)
         case toolCalls([Int])
         case surface(Int)
     }
@@ -207,6 +208,8 @@ public struct MessageBubbleView: View {
             switch ref {
             case .text(let i):
                 groups.append(.text(i))
+            case .thinking(let i):
+                groups.append(.thinking(i))
             case .toolCall(let i):
                 if case .toolCalls(let indices) = groups.last {
                     groups[groups.count - 1] = .toolCalls(indices + [i])
@@ -233,6 +236,8 @@ public struct MessageBubbleView: View {
                             messageBubble(text: segmentText, role: message.role)
                         }
                     }
+                case .thinking:
+                    EmptyView()
                 case .toolCalls(let indices):
                     let calls = indices.compactMap { i in i < message.toolCalls.count ? message.toolCalls[i] : nil }
                     if !calls.isEmpty {


### PR DESCRIPTION
## Summary
- Add missing `.thinking` case to the two non-exhaustive switch statements in `MessageBubbleView.swift` that were causing the macOS CI build to fail
- Treats thinking blocks as non-text in `hasInterleavedContent` (matching the macOS `ChatBubble` behavior)
- Renders as `EmptyView()` in the shared interleaved content view since the macOS target has its own `ThinkingBlockView` rendering in `ChatBubbleInterleavedContent`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23679983313/job/68990189350
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
