### PR TITLE
fix(macos): make push-to-top overflow detection atomic and backfill streaming segment cache

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -56,6 +56,23 @@ extension ChatBubble {
             if let async = asyncSegments[text] {
                 return async
             }
+            // When a message transitions from streaming to non-streaming,
+            // the segment cache won't have the entry (streaming results
+            // go to lastStreamingSegments, not the main cache). Use the
+            // streaming result directly to avoid flashing unformatted
+            // plain text and the expensive synchronous
+            // AttributedString(markdown:) call on the full text while
+            // the async parse runs.
+            if let last = Self.lastStreamingSegments, last.text == text {
+                if text.count <= Self.maxCacheableTextLength {
+                    Self.segmentCache.setObject(
+                        SegmentCacheEntry(last.value),
+                        forKey: text as NSString,
+                        cost: text.utf8.count * 10
+                    )
+                }
+                return last.value
+            }
             // Fast placeholder: single plain-text segment avoids expensive parsing
             return [.text(text)]
         }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -843,13 +843,22 @@ struct MessageListView: View {
                 }
 
                 // --- Push-to-top overflow detection ---
+                // Only clear push-to-top if the pin request succeeds.
+                // When the scroll loop guard is tripped or the user has
+                // detached from bottom, requestBottomPin returns false.
+                // Clearing pushToTopMessageId without a successful pin
+                // removes the tail spacer without the accompanying scroll
+                // adjustment, causing a content-height discontinuity that
+                // makes the scroll position jump.
                 if scrollCoordinator.pushToTopMessageId != nil && distanceFromBottom > 50 {
-                    scrollCoordinator.pushToTopMessageId = nil
-                    scrollCoordinator.requestBottomPin(
+                    let pinned = scrollCoordinator.requestBottomPin(
                         reason: .messageCount,
                         conversationId: conversationId,
                         animated: true
                     )
+                    if pinned {
+                        scrollCoordinator.pushToTopMessageId = nil
+                    }
                 }
 
                 // --- Pagination trigger ---


### PR DESCRIPTION
## Summary
- Make overflow detection atomic: only clear `pushToTopMessageId` (removing the tail spacer) when `requestBottomPin` succeeds — prevents content-height discontinuity when the scroll loop guard is tripped or the user is detached from bottom
- Backfill `segmentCache` from `lastStreamingSegments` when a message transitions from streaming to non-streaming, eliminating the expensive placeholder render path and visual flash of unformatted text