### PR TITLE
fix: include thinkingSegments in RuntimeMessagePayload

### DIFF
--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -272,5 +272,6 @@ export interface RuntimeMessagePayload {
     display?: string;
   }>;
   textSegments?: string[];
+  thinkingSegments?: string[];
   contentOrder?: string[];
 }

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -547,6 +547,7 @@ export function handleListMessages(
       ...(interfaces ? { interfaces } : {}),
       ...(m.surfaces.length > 0 ? { surfaces: m.surfaces } : {}),
       ...(m.textSegments.length > 0 ? { textSegments: m.textSegments } : {}),
+      ...(m.thinkingSegments?.length ? { thinkingSegments: m.thinkingSegments } : {}),
       ...(m.contentOrder.length > 0 ? { contentOrder: m.contentOrder } : {}),
     };
   });


### PR DESCRIPTION
## Summary
Fixes gap where thinkingSegments was extracted by renderHistoryContent but dropped during the final HTTP response payload construction. Adds the field to RuntimeMessagePayload and forwards it in the history message mapping.

**Gap:** thinkingSegments dropped from RuntimeMessagePayload construction
**What was expected:** thinkingSegments included in history response
**What was found:** dropped in final mapping step
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22072" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
