### PR TITLE
fix: update test mocks and clean up dead ParsedHistoryMessage interface

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -42,6 +42,12 @@ mock.module("../util/logger.js", () => ({
 mock.module("../daemon/handlers/shared.js", () => ({
   renderHistoryContent: (content: unknown) => ({
     text: typeof content === "string" ? content : JSON.stringify(content),
+    toolCalls: [],
+    toolCallsBeforeText: false,
+    textSegments: [],
+    contentOrder: [],
+    surfaces: [],
+    thinkingSegments: [],
   }),
 }));
 

--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -32,6 +32,7 @@ let renderedHistoryContent: {
   toolCallsBeforeText: boolean;
   contentOrder: string[];
   surfaces: unknown[];
+  thinkingSegments: string[];
 } = {
   text: "",
   textSegments: [],
@@ -39,6 +40,7 @@ let renderedHistoryContent: {
   toolCallsBeforeText: false,
   contentOrder: [],
   surfaces: [],
+  thinkingSegments: [],
 };
 
 let deliveryFailAtIndex = -1;
@@ -111,6 +113,7 @@ describe("channel-reply-delivery", () => {
       toolCallsBeforeText: false,
       contentOrder: [],
       surfaces: [],
+      thinkingSegments: [],
     };
   });
 
@@ -197,6 +200,7 @@ describe("channel-reply-delivery", () => {
       toolCallsBeforeText: false,
       contentOrder: ["text:0", "tool:0", "text:1"],
       surfaces: [],
+      thinkingSegments: [],
     };
 
     await deliverReplyViaCallback(
@@ -432,6 +436,7 @@ describe("channel-reply-delivery", () => {
       toolCallsBeforeText: false,
       contentOrder: ["text:0", "tool:0", "text:1", "tool:1", "text:2"],
       surfaces: [],
+      thinkingSegments: [],
     };
 
     const delivered: number[] = [];

--- a/assistant/src/__tests__/suggestion-routes.test.ts
+++ b/assistant/src/__tests__/suggestion-routes.test.ts
@@ -81,6 +81,7 @@ mock.module("../daemon/handlers/shared.js", () => ({
         textSegments: [],
         contentOrder: [],
         surfaces: [],
+        thinkingSegments: [],
       };
     }
     return {
@@ -90,6 +91,7 @@ mock.module("../daemon/handlers/shared.js", () => ({
       textSegments: [],
       contentOrder: [],
       surfaces: [],
+      thinkingSegments: [],
     };
   },
 }));

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -95,27 +95,6 @@ export interface RenderedHistoryContent {
   thinkingSegments: string[];
 }
 
-export interface SubagentNotificationData {
-  subagentId: string;
-  label: string;
-  status: "completed" | "failed" | "aborted";
-  error?: string;
-  conversationId?: string;
-}
-
-export interface ParsedHistoryMessage {
-  id?: string;
-  role: string;
-  text: string;
-  timestamp: number;
-  toolCalls: HistoryToolCall[];
-  toolCallsBeforeText: boolean;
-  textSegments: string[];
-  contentOrder: string[];
-  surfaces: HistorySurface[];
-  subagentNotification?: SubagentNotificationData;
-}
-
 /**
  * Optional overrides for conversation creation (e.g. interview mode).
  */


### PR DESCRIPTION
## Summary
- Add `thinkingSegments: []` to test mocks for `renderHistoryContent` to match updated interface
- Remove dead `ParsedHistoryMessage` and `SubagentNotificationData` interfaces from `shared.ts`

Fixes review gaps from inline-thinking-blocks plan.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
