### PR TITLE
fix(macos): make ThinkingBlockView hug content height instead of expanding to maxHeight

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
@@ -25,6 +25,7 @@ struct ThinkingBlockView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(VSpacing.sm)
                 }
+                .fixedSize(horizontal: false, vertical: true)
                 .frame(maxHeight: 300)
             }
         }


### PR DESCRIPTION
## Summary
- Add `.fixedSize(horizontal: false, vertical: true)` to the ThinkingBlockView ScrollView so it sizes to its content rather than expanding to fill the 300pt max height
- Short thinking content no longer wastes vertical space with a large empty area
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22074" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
