### PR TITLE
Add attachments property to LogReportFormData

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogReportReason.swift
+++ b/clients/macos/vellum-assistant/Logging/LogReportReason.swift
@@ -81,4 +81,5 @@ struct LogReportFormData: Sendable {
     var scope: LogExportScope = .global
     var includeLogs: Bool = true
     var logTimeRange: LogTimeRange = .pastHour
+    var attachments: [URL] = []
 }


### PR DESCRIPTION
## Summary
- Add `attachments: [URL]` property with default empty array to `LogReportFormData`
- Preserves backward compatibility with existing callers

Part of plan: feedback-attach-mac.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22077" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
