### PR TITLE
Include attachment files in feedback multipart upload

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -2,6 +2,7 @@ import AppKit
 import Foundation
 import os
 import OSLog
+import UniformTypeIdentifiers
 import VellumAssistantShared
 
 private let log = Logger(
@@ -44,6 +45,18 @@ enum LogExporter {
     /// On each retry, the largest file or directory in the staging directory is removed
     /// and logged before re-creating the archive.
     private static let maxUploadRetries = 10
+
+    /// MIME types the platform backend accepts for feedback attachments.
+    private static let allowedAttachmentMIMETypes: Set<String> = [
+        "image/png", "image/jpeg", "image/gif", "image/webp",
+        "video/mp4", "video/quicktime", "video/webm",
+    ]
+
+    /// Derives a MIME type string from a file URL's extension using `UTType`.
+    private static func mimeType(for url: URL) -> String? {
+        guard let utType = UTType(filenameExtension: url.pathExtension) else { return nil }
+        return utType.preferredMIMEType
+    }
 
     /// Collects logs, archives them, and uploads the archive to the platform API
     /// (`POST /v1/upload/feedback/`) for storage.
@@ -193,6 +206,22 @@ enum LogExporter {
             body.append("\r\n".data(using: .utf8)!)
         } else {
             log.warning("Failed to read archive at \(archiveURL.path) — submitting feedback without logs")
+        }
+
+        // Attachment file parts
+        for attachmentURL in formData.attachments {
+            guard let mime = mimeType(for: attachmentURL),
+                  allowedAttachmentMIMETypes.contains(mime),
+                  let fileData = try? Data(contentsOf: attachmentURL) else {
+                log.warning("Skipping invalid attachment at \(attachmentURL.lastPathComponent)")
+                continue
+            }
+            let filename = attachmentURL.lastPathComponent
+            body.append("--\(boundary)\r\n".data(using: .utf8)!)
+            body.append("Content-Disposition: form-data; name=\"attachments\"; filename=\"\(filename)\"\r\n".data(using: .utf8)!)
+            body.append("Content-Type: \(mime)\r\n\r\n".data(using: .utf8)!)
+            body.append(fileData)
+            body.append("\r\n".data(using: .utf8)!)
         }
 
         // Final boundary


### PR DESCRIPTION
## Summary
- Add MIME type detection helper using UTType
- Add attachment file parts to multipart upload body
- Invalid/unreadable files are silently skipped with a log warning

Part of plan: feedback-attach-mac.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22078" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
