### PR TITLE
Add attachment picker section with thumbnails to feedback form

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -621,7 +621,7 @@ extension AppDelegate {
 
         let hostingController = NSHostingController(rootView: view)
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 480, height: 420),
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 540),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false

--- a/clients/macos/vellum-assistant/Features/Settings/AttachmentThumbnailView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AttachmentThumbnailView.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// A small thumbnail preview for a single file attachment URL.
+/// Images show an actual preview; videos show a generic icon.
+struct AttachmentThumbnailView: View {
+    let url: URL
+    let onRemove: () -> Void
+
+    @State private var loadedImage: NSImage?
+
+    private static let thumbnailSize: CGFloat = 56
+    private static let imageExtensions: Set<String> = ["png", "jpg", "jpeg", "gif", "webp"]
+    private static let videoExtensions: Set<String> = ["mp4", "mov", "webm"]
+
+    private var isImage: Bool {
+        Self.imageExtensions.contains(url.pathExtension.lowercased())
+    }
+
+    private var truncatedFilename: String {
+        let name = url.lastPathComponent
+        if name.count <= 10 { return name }
+        return String(name.prefix(7)) + "..." + String(name.suffix(min(3, name.count)))
+    }
+
+    var body: some View {
+        VStack(spacing: VSpacing.xxs) {
+            ZStack(alignment: .topTrailing) {
+                thumbnailContent
+                    .frame(width: Self.thumbnailSize, height: Self.thumbnailSize)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+
+                removeButton
+            }
+
+            Text(truncatedFilename)
+                .font(VFont.bodySmallDefault)
+                .foregroundStyle(VColor.contentSecondary)
+                .lineLimit(1)
+        }
+        .task(id: url) {
+            guard isImage else { return }
+            let fileURL = url
+            let image = await Task.detached {
+                NSImage(contentsOf: fileURL)
+            }.value
+            loadedImage = image
+        }
+    }
+
+    @ViewBuilder
+    private var thumbnailContent: some View {
+        if isImage, let nsImage = loadedImage {
+            Image(nsImage: nsImage)
+                .resizable()
+                .scaledToFill()
+        } else if isImage {
+            // Loading placeholder for images
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .fill(VColor.surfaceBase)
+        } else {
+            // Video or unknown type — show generic video icon
+            ZStack {
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(VColor.surfaceBase)
+                VIconView(.video, size: 20)
+                    .foregroundStyle(VColor.contentSecondary)
+            }
+        }
+    }
+
+    private var removeButton: some View {
+        Button(action: onRemove) {
+            ZStack {
+                Circle()
+                    .fill(VColor.surfaceOverlay)
+                    .frame(width: 16, height: 16)
+                VIconView(.x, size: 10)
+                    .foregroundStyle(VColor.contentSecondary)
+            }
+        }
+        .buttonStyle(.plain)
+        .offset(x: 4, y: -4)
+        .accessibilityLabel("Remove attachment")
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UniformTypeIdentifiers
 import VellumAssistantShared
 
 /// A sheet displayed for sharing feedback, letting the user pick a reason
@@ -18,8 +19,20 @@ struct LogReportFormView: View {
     @State private var includeLogs: Bool = true
     @State private var hasManuallyToggledLogs: Bool = false
     @State private var logTimeRange: LogTimeRange = .pastHour
+    @State private var attachments: [URL] = []
     @State private var isSubmitting: Bool = false
     @FocusState private var focusedField: Field?
+
+    private let maxAttachments = 10
+    private let maxAttachmentBytes = 50 * 1024 * 1024
+
+    private var allowedFileTypes: [UTType] {
+        var types: [UTType] = [.png, .jpeg, .gif, .webP, .mpeg4Movie, .quickTimeMovie]
+        if let webm = UTType(filenameExtension: "webm") {
+            types.append(webm)
+        }
+        return types
+    }
 
     init(
         authManager: AuthManager,
@@ -47,6 +60,7 @@ struct LogReportFormView: View {
             }
             reasonCards
             messageField
+            attachmentSection
             logAttachmentRow
             Spacer(minLength: 0)
             actionRow
@@ -68,6 +82,26 @@ struct LogReportFormView: View {
         .onChange(of: selectedReason) { _, newReason in
             guard !hasManuallyToggledLogs, let reason = newReason else { return }
             includeLogs = reason.isErrorCategory
+        }
+        .onDrop(of: [.fileURL], isTargeted: nil) { providers in
+            var added = false
+            for provider in providers {
+                _ = provider.loadObject(ofClass: URL.self) { url, _ in
+                    guard let url else { return }
+                    let ext = url.pathExtension.lowercased()
+                    let allowedExtensions: Set<String> = ["png", "jpg", "jpeg", "gif", "webp", "mp4", "mov", "webm"]
+                    guard allowedExtensions.contains(ext) else { return }
+                    guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+                          let size = attrs[.size] as? Int,
+                          size <= maxAttachmentBytes else { return }
+                    Task { @MainActor in
+                        guard attachments.count < maxAttachments else { return }
+                        attachments.append(url)
+                        added = true
+                    }
+                }
+            }
+            return true
         }
     }
 
@@ -116,6 +150,64 @@ struct LogReportFormView: View {
         )
         .focused($focusedField, equals: .email)
         .opacity(isSubmitting ? 0.5 : 1)
+    }
+
+    @ViewBuilder
+    private var attachmentSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            HStack {
+                Text("Attachments")
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                Spacer()
+                VButton(
+                    label: "Add files",
+                    leftIcon: VIcon.paperclip.rawValue,
+                    style: .outlined,
+                    size: .compact
+                ) {
+                    openFilePicker()
+                }
+                .disabled(attachments.count >= maxAttachments)
+            }
+
+            if !attachments.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: VSpacing.sm) {
+                        ForEach(attachments, id: \.absoluteString) { url in
+                            AttachmentThumbnailView(url: url) {
+                                attachments.removeAll { $0 == url }
+                            }
+                        }
+                    }
+                }
+
+                Text("\(attachments.count)/\(maxAttachments) files")
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+            }
+        }
+        .opacity(isSubmitting ? 0.5 : 1)
+    }
+
+    private func openFilePicker() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = true
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowedContentTypes = allowedFileTypes
+        panel.begin { response in
+            guard response == .OK else { return }
+            let remaining = maxAttachments - attachments.count
+            guard remaining > 0 else { return }
+            let selected = Array(panel.urls.prefix(remaining))
+            for url in selected {
+                guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+                      let size = attrs[.size] as? Int,
+                      size <= maxAttachmentBytes else { continue }
+                attachments.append(url)
+            }
+        }
     }
 
     @ViewBuilder
@@ -182,7 +274,8 @@ struct LogReportFormView: View {
                                 message: message,
                                 email: email,
                                 includeLogs: includeLogs,
-                                logTimeRange: logTimeRange
+                                logTimeRange: logTimeRange,
+                                attachments: attachments
                             ))
                         } catch {
                             isSubmitting = false


### PR DESCRIPTION
## Summary
- Add AttachmentThumbnailView for image/video file previews
- Add attachment picker section to LogReportFormView with file picker and drag-and-drop
- Increase feedback window height to accommodate new section

Part of plan: feedback-attach-mac.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22079" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
