### PR TITLE
feat: add attachment picker to macOS feedback form

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -621,7 +621,7 @@ extension AppDelegate {
 
         let hostingController = NSHostingController(rootView: view)
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 480, height: 420),
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 540),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false

--- a/clients/macos/vellum-assistant/Features/Settings/AttachmentThumbnailView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AttachmentThumbnailView.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// A small thumbnail preview for a single file attachment URL.
+/// Images show an actual preview; videos show a generic icon.
+struct AttachmentThumbnailView: View {
+    let url: URL
+    let onRemove: () -> Void
+
+    @State private var loadedImage: NSImage?
+
+    private static let thumbnailSize: CGFloat = 56
+    private static let imageExtensions: Set<String> = ["png", "jpg", "jpeg", "gif", "webp"]
+    private static let videoExtensions: Set<String> = ["mp4", "mov", "webm"]
+
+    private var isImage: Bool {
+        Self.imageExtensions.contains(url.pathExtension.lowercased())
+    }
+
+    private var truncatedFilename: String {
+        let name = url.lastPathComponent
+        if name.count <= 10 { return name }
+        return String(name.prefix(7)) + "..." + String(name.suffix(min(3, name.count)))
+    }
+
+    var body: some View {
+        VStack(spacing: VSpacing.xxs) {
+            ZStack(alignment: .topTrailing) {
+                thumbnailContent
+                    .frame(width: Self.thumbnailSize, height: Self.thumbnailSize)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+
+                removeButton
+            }
+
+            Text(truncatedFilename)
+                .font(VFont.bodySmallDefault)
+                .foregroundStyle(VColor.contentSecondary)
+                .lineLimit(1)
+        }
+        .task(id: url) {
+            guard isImage else { return }
+            let fileURL = url
+            let image = await Task.detached {
+                NSImage(contentsOf: fileURL)
+            }.value
+            loadedImage = image
+        }
+    }
+
+    @ViewBuilder
+    private var thumbnailContent: some View {
+        if isImage, let nsImage = loadedImage {
+            Image(nsImage: nsImage)
+                .resizable()
+                .scaledToFill()
+        } else if isImage {
+            // Loading placeholder for images
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .fill(VColor.surfaceBase)
+        } else {
+            // Video or unknown type — show generic video icon
+            ZStack {
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(VColor.surfaceBase)
+                VIconView(.video, size: 20)
+                    .foregroundStyle(VColor.contentSecondary)
+            }
+        }
+    }
+
+    private var removeButton: some View {
+        Button(action: onRemove) {
+            ZStack {
+                Circle()
+                    .fill(VColor.surfaceOverlay)
+                    .frame(width: 16, height: 16)
+                VIconView(.x, size: 10)
+                    .foregroundStyle(VColor.contentSecondary)
+            }
+        }
+        .buttonStyle(.plain)
+        .offset(x: 4, y: -4)
+        .accessibilityLabel("Remove attachment")
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/AttachmentThumbnailView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AttachmentThumbnailView.swift
@@ -11,7 +11,6 @@ struct AttachmentThumbnailView: View {
 
     private static let thumbnailSize: CGFloat = 56
     private static let imageExtensions: Set<String> = ["png", "jpg", "jpeg", "gif", "webp"]
-    private static let videoExtensions: Set<String> = ["mp4", "mov", "webm"]
 
     private var isImage: Bool {
         Self.imageExtensions.contains(url.pathExtension.lowercased())

--- a/clients/macos/vellum-assistant/Features/Settings/AttachmentThumbnailView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AttachmentThumbnailView.swift
@@ -1,3 +1,4 @@
+import ImageIO
 import SwiftUI
 import VellumAssistantShared
 
@@ -40,10 +41,18 @@ struct AttachmentThumbnailView: View {
         .task(id: url) {
             guard isImage else { return }
             let fileURL = url
-            let image = await Task.detached {
-                NSImage(contentsOf: fileURL)
+            // Load image data off the main thread using thread-safe CGImageSource APIs.
+            // NSImage is NOT thread-safe and must not be used off the main thread.
+            let cgImage = await Task.detached {
+                guard let source = CGImageSourceCreateWithURL(fileURL as CFURL, nil) else {
+                    return nil as CGImage?
+                }
+                return CGImageSourceCreateImageAtIndex(source, 0, nil)
             }.value
-            loadedImage = image
+            // Create NSImage on the main thread from the thread-safe CGImage.
+            if let cgImage {
+                loadedImage = NSImage(cgImage: cgImage, size: .zero)
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/AttachmentThumbnailView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AttachmentThumbnailView.swift
@@ -47,7 +47,15 @@ struct AttachmentThumbnailView: View {
                 guard let source = CGImageSourceCreateWithURL(fileURL as CFURL, nil) else {
                     return nil as CGImage?
                 }
-                return CGImageSourceCreateImageAtIndex(source, 0, nil)
+                // Decode at thumbnail size instead of full resolution to avoid
+                // large pixel buffer allocations for high-res screenshots/GIFs.
+                let maxPixels = Int(AttachmentThumbnailView.thumbnailSize) * 2 // 2x for Retina
+                let options: [CFString: Any] = [
+                    kCGImageSourceCreateThumbnailFromImageAlways: true,
+                    kCGImageSourceThumbnailMaxPixelSize: maxPixels,
+                    kCGImageSourceCreateThumbnailWithTransform: true,
+                ]
+                return CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary)
             }.value
             // Create NSImage on the main thread from the thread-safe CGImage.
             if let cgImage {

--- a/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
@@ -199,12 +199,14 @@ struct LogReportFormView: View {
             guard response == .OK else { return }
             let remaining = maxAttachments - attachments.count
             guard remaining > 0 else { return }
-            let selected = Array(panel.urls.prefix(remaining))
-            for url in selected {
+            let eligible = panel.urls.filter { url in
+                guard !attachments.contains(url) else { return false }
                 guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
                       let size = attrs[.size] as? Int,
-                      size <= maxAttachmentBytes else { continue }
-                guard !attachments.contains(url) else { continue }
+                      size <= maxAttachmentBytes else { return false }
+                return true
+            }
+            for url in eligible.prefix(remaining) {
                 attachments.append(url)
             }
         }

--- a/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
@@ -84,7 +84,6 @@ struct LogReportFormView: View {
             includeLogs = reason.isErrorCategory
         }
         .onDrop(of: [.fileURL], isTargeted: nil) { providers in
-            var added = false
             for provider in providers {
                 _ = provider.loadObject(ofClass: URL.self) { url, _ in
                     guard let url else { return }
@@ -95,9 +94,9 @@ struct LogReportFormView: View {
                           let size = attrs[.size] as? Int,
                           size <= maxAttachmentBytes else { return }
                     Task { @MainActor in
-                        guard attachments.count < maxAttachments else { return }
+                        guard attachments.count < maxAttachments,
+                              !attachments.contains(url) else { return }
                         attachments.append(url)
-                        added = true
                     }
                 }
             }
@@ -205,6 +204,7 @@ struct LogReportFormView: View {
                 guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
                       let size = attrs[.size] as? Int,
                       size <= maxAttachmentBytes else { continue }
+                guard !attachments.contains(url) else { continue }
                 attachments.append(url)
             }
         }

--- a/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UniformTypeIdentifiers
 import VellumAssistantShared
 
 /// A sheet displayed for sharing feedback, letting the user pick a reason
@@ -18,8 +19,20 @@ struct LogReportFormView: View {
     @State private var includeLogs: Bool = true
     @State private var hasManuallyToggledLogs: Bool = false
     @State private var logTimeRange: LogTimeRange = .pastHour
+    @State private var attachments: [URL] = []
     @State private var isSubmitting: Bool = false
     @FocusState private var focusedField: Field?
+
+    private let maxAttachments = 10
+    private let maxAttachmentBytes = 50 * 1024 * 1024
+
+    private var allowedFileTypes: [UTType] {
+        var types: [UTType] = [.png, .jpeg, .gif, .webP, .mpeg4Movie, .quickTimeMovie]
+        if let webm = UTType(filenameExtension: "webm") {
+            types.append(webm)
+        }
+        return types
+    }
 
     init(
         authManager: AuthManager,
@@ -47,6 +60,7 @@ struct LogReportFormView: View {
             }
             reasonCards
             messageField
+            attachmentSection
             logAttachmentRow
             Spacer(minLength: 0)
             actionRow
@@ -68,6 +82,26 @@ struct LogReportFormView: View {
         .onChange(of: selectedReason) { _, newReason in
             guard !hasManuallyToggledLogs, let reason = newReason else { return }
             includeLogs = reason.isErrorCategory
+        }
+        .onDrop(of: [.fileURL], isTargeted: nil) { providers in
+            var added = false
+            for provider in providers {
+                _ = provider.loadObject(ofClass: URL.self) { url, _ in
+                    guard let url else { return }
+                    let ext = url.pathExtension.lowercased()
+                    let allowedExtensions: Set<String> = ["png", "jpg", "jpeg", "gif", "webp", "mp4", "mov", "webm"]
+                    guard allowedExtensions.contains(ext) else { return }
+                    guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+                          let size = attrs[.size] as? Int,
+                          size <= maxAttachmentBytes else { return }
+                    Task { @MainActor in
+                        guard attachments.count < maxAttachments else { return }
+                        attachments.append(url)
+                        added = true
+                    }
+                }
+            }
+            return true
         }
     }
 
@@ -116,6 +150,64 @@ struct LogReportFormView: View {
         )
         .focused($focusedField, equals: .email)
         .opacity(isSubmitting ? 0.5 : 1)
+    }
+
+    @ViewBuilder
+    private var attachmentSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            HStack {
+                Text("Attachments")
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                Spacer()
+                VButton(
+                    label: "Add files",
+                    leftIcon: VIcon.paperclip.rawValue,
+                    style: .outlined,
+                    size: .compact
+                ) {
+                    openFilePicker()
+                }
+                .disabled(attachments.count >= maxAttachments)
+            }
+
+            if !attachments.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: VSpacing.sm) {
+                        ForEach(attachments, id: \.absoluteString) { url in
+                            AttachmentThumbnailView(url: url) {
+                                attachments.removeAll { $0 == url }
+                            }
+                        }
+                    }
+                }
+
+                Text("\(attachments.count)/\(maxAttachments) files")
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+            }
+        }
+        .opacity(isSubmitting ? 0.5 : 1)
+    }
+
+    private func openFilePicker() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = true
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowedContentTypes = allowedFileTypes
+        panel.begin { response in
+            guard response == .OK else { return }
+            let remaining = maxAttachments - attachments.count
+            guard remaining > 0 else { return }
+            let selected = Array(panel.urls.prefix(remaining))
+            for url in selected {
+                guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+                      let size = attrs[.size] as? Int,
+                      size <= maxAttachmentBytes else { continue }
+                attachments.append(url)
+            }
+        }
     }
 
     @ViewBuilder
@@ -182,7 +274,8 @@ struct LogReportFormView: View {
                                 message: message,
                                 email: email,
                                 includeLogs: includeLogs,
-                                logTimeRange: logTimeRange
+                                logTimeRange: logTimeRange,
+                                attachments: attachments
                             ))
                         } catch {
                             isSubmitting = false

--- a/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
@@ -60,8 +60,8 @@ struct LogReportFormView: View {
             }
             reasonCards
             messageField
-            attachmentSection
             logAttachmentRow
+            attachmentSection
             Spacer(minLength: 0)
             actionRow
         }
@@ -153,11 +153,18 @@ struct LogReportFormView: View {
 
     @ViewBuilder
     private var attachmentSection: some View {
-        VStack(alignment: .leading, spacing: VSpacing.xs) {
-            HStack {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            HStack(alignment: .center) {
                 Text("Attachments")
                     .font(VFont.bodySmallDefault)
                     .foregroundStyle(VColor.contentSecondary)
+                if !attachments.isEmpty {
+                    Text("·")
+                        .foregroundStyle(VColor.contentTertiary)
+                    Text("\(attachments.count)/\(maxAttachments)")
+                        .font(VFont.bodySmallDefault)
+                        .foregroundStyle(VColor.contentTertiary)
+                }
                 Spacer()
                 VButton(
                     label: "Add files",
@@ -180,10 +187,6 @@ struct LogReportFormView: View {
                         }
                     }
                 }
-
-                Text("\(attachments.count)/\(maxAttachments) files")
-                    .font(VFont.bodySmallDefault)
-                    .foregroundStyle(VColor.contentSecondary)
             }
         }
         .opacity(isSubmitting ? 0.5 : 1)

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -2,6 +2,7 @@ import AppKit
 import Foundation
 import os
 import OSLog
+import UniformTypeIdentifiers
 import VellumAssistantShared
 
 private let log = Logger(
@@ -44,6 +45,18 @@ enum LogExporter {
     /// On each retry, the largest file or directory in the staging directory is removed
     /// and logged before re-creating the archive.
     private static let maxUploadRetries = 10
+
+    /// MIME types the platform backend accepts for feedback attachments.
+    private static let allowedAttachmentMIMETypes: Set<String> = [
+        "image/png", "image/jpeg", "image/gif", "image/webp",
+        "video/mp4", "video/quicktime", "video/webm",
+    ]
+
+    /// Derives a MIME type string from a file URL's extension using `UTType`.
+    private static func mimeType(for url: URL) -> String? {
+        guard let utType = UTType(filenameExtension: url.pathExtension) else { return nil }
+        return utType.preferredMIMEType
+    }
 
     /// Collects logs, archives them, and uploads the archive to the platform API
     /// (`POST /v1/upload/feedback/`) for storage.
@@ -193,6 +206,22 @@ enum LogExporter {
             body.append("\r\n".data(using: .utf8)!)
         } else {
             log.warning("Failed to read archive at \(archiveURL.path) — submitting feedback without logs")
+        }
+
+        // Attachment file parts
+        for attachmentURL in formData.attachments {
+            guard let mime = mimeType(for: attachmentURL),
+                  allowedAttachmentMIMETypes.contains(mime),
+                  let fileData = try? Data(contentsOf: attachmentURL) else {
+                log.warning("Skipping invalid attachment at \(attachmentURL.lastPathComponent)")
+                continue
+            }
+            let filename = attachmentURL.lastPathComponent
+            body.append("--\(boundary)\r\n".data(using: .utf8)!)
+            body.append("Content-Disposition: form-data; name=\"attachments\"; filename=\"\(filename)\"\r\n".data(using: .utf8)!)
+            body.append("Content-Type: \(mime)\r\n\r\n".data(using: .utf8)!)
+            body.append(fileData)
+            body.append("\r\n".data(using: .utf8)!)
         }
 
         // Final boundary

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -217,6 +217,9 @@ enum LogExporter {
                 continue
             }
             let filename = attachmentURL.lastPathComponent
+                .replacingOccurrences(of: "\"", with: "_")
+                .replacingOccurrences(of: "\r", with: "_")
+                .replacingOccurrences(of: "\n", with: "_")
             body.append("--\(boundary)\r\n".data(using: .utf8)!)
             body.append("Content-Disposition: form-data; name=\"attachments\"; filename=\"\(filename)\"\r\n".data(using: .utf8)!)
             body.append("Content-Type: \(mime)\r\n\r\n".data(using: .utf8)!)

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -208,12 +208,16 @@ enum LogExporter {
             log.warning("Failed to read archive at \(archiveURL.path) — submitting feedback without logs")
         }
 
-        // Attachment file parts
+        // Attachment file parts — read data off the main thread to avoid
+        // blocking the UI for large files (up to 50 MB each).
         for attachmentURL in formData.attachments {
             guard let mime = mimeType(for: attachmentURL),
-                  allowedAttachmentMIMETypes.contains(mime),
-                  let fileData = try? Data(contentsOf: attachmentURL) else {
+                  allowedAttachmentMIMETypes.contains(mime) else {
                 log.warning("Skipping invalid attachment at \(attachmentURL.lastPathComponent)")
+                continue
+            }
+            guard let fileData = await Task.detached { try? Data(contentsOf: attachmentURL) }.value else {
+                log.warning("Skipping unreadable attachment at \(attachmentURL.lastPathComponent)")
                 continue
             }
             let filename = attachmentURL.lastPathComponent

--- a/clients/macos/vellum-assistant/Logging/LogReportReason.swift
+++ b/clients/macos/vellum-assistant/Logging/LogReportReason.swift
@@ -81,4 +81,5 @@ struct LogReportFormData: Sendable {
     var scope: LogExportScope = .global
     var includeLogs: Bool = true
     var logTimeRange: LogTimeRange = .pastHour
+    var attachments: [URL] = []
 }


### PR DESCRIPTION
## Summary
Add an attachment picker to the macOS feedback form so users can include screenshots, GIFs, and short videos when submitting bug reports or feature requests. The backend already supports attachments — this adds the client-side UI and upload wiring.

## PRs merged into feature branch
- #22077: Add attachments property to LogReportFormData
- #22078: Include attachment files in feedback multipart upload
- #22079: Add attachment picker section with thumbnails to feedback form

Part of plan: feedback-attach-mac.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
