### PR TITLE
fix: remove dead code and prevent duplicate attachment URLs

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AttachmentThumbnailView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AttachmentThumbnailView.swift
@@ -11,7 +11,6 @@ struct AttachmentThumbnailView: View {
 
     private static let thumbnailSize: CGFloat = 56
     private static let imageExtensions: Set<String> = ["png", "jpg", "jpeg", "gif", "webp"]
-    private static let videoExtensions: Set<String> = ["mp4", "mov", "webm"]
 
     private var isImage: Bool {
         Self.imageExtensions.contains(url.pathExtension.lowercased())

--- a/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
@@ -84,7 +84,6 @@ struct LogReportFormView: View {
             includeLogs = reason.isErrorCategory
         }
         .onDrop(of: [.fileURL], isTargeted: nil) { providers in
-            var added = false
             for provider in providers {
                 _ = provider.loadObject(ofClass: URL.self) { url, _ in
                     guard let url else { return }
@@ -95,9 +94,9 @@ struct LogReportFormView: View {
                           let size = attrs[.size] as? Int,
                           size <= maxAttachmentBytes else { return }
                     Task { @MainActor in
-                        guard attachments.count < maxAttachments else { return }
+                        guard attachments.count < maxAttachments,
+                              !attachments.contains(url) else { return }
                         attachments.append(url)
-                        added = true
                     }
                 }
             }
@@ -205,6 +204,7 @@ struct LogReportFormView: View {
                 guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
                       let size = attrs[.size] as? Int,
                       size <= maxAttachmentBytes else { continue }
+                guard !attachments.contains(url) else { continue }
                 attachments.append(url)
             }
         }


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for feedback-attach-mac.md.

- Prevent duplicate attachment URLs by checking contains() before appending
- Remove dead `added` variable from onDrop handler
- Remove unused `videoExtensions` property from AttachmentThumbnailView
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22081" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
