### PR TITLE
fix: sanitize attachment filename in multipart Content-Disposition header

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -217,6 +217,9 @@ enum LogExporter {
                 continue
             }
             let filename = attachmentURL.lastPathComponent
+                .replacingOccurrences(of: "\"", with: "_")
+                .replacingOccurrences(of: "\r", with: "_")
+                .replacingOccurrences(of: "\n", with: "_")
             body.append("--\(boundary)\r\n".data(using: .utf8)!)
             body.append("Content-Disposition: form-data; name=\"attachments\"; filename=\"\(filename)\"\r\n".data(using: .utf8)!)
             body.append("Content-Type: \(mime)\r\n\r\n".data(using: .utf8)!)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for feedback-attach-mac.md.

**Gap:** Unsanitized filename in multipart Content-Disposition header
**What was expected:** Filenames should be safely encoded in the Content-Disposition header
**What was found:** lastPathComponent interpolated directly without escaping quotes or CRLF
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22082" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
