### PR TITLE
fix: filter duplicate attachments before applying slot cap in file picker

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/LogReportFormView.swift
@@ -199,12 +199,14 @@ struct LogReportFormView: View {
             guard response == .OK else { return }
             let remaining = maxAttachments - attachments.count
             guard remaining > 0 else { return }
-            let selected = Array(panel.urls.prefix(remaining))
-            for url in selected {
+            let eligible = panel.urls.filter { url in
+                guard !attachments.contains(url) else { return false }
                 guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
                       let size = attrs[.size] as? Int,
-                      size <= maxAttachmentBytes else { continue }
-                guard !attachments.contains(url) else { continue }
+                      size <= maxAttachmentBytes else { return false }
+                return true
+            }
+            for url in eligible.prefix(remaining) {
                 attachments.append(url)
             }
         }


### PR DESCRIPTION
## Summary
Fixes slot consumption regression in openFilePicker().

Reorders the logic to filter out duplicate URLs and validate file sizes
before applying the prefix(remaining) cap, so duplicates don't consume
slots meant for new unique files.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22083" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
