### PR TITLE
fix: use thread-safe CGImageSource instead of NSImage off main thread

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AttachmentThumbnailView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AttachmentThumbnailView.swift
@@ -1,3 +1,4 @@
+import ImageIO
 import SwiftUI
 import VellumAssistantShared
 
@@ -40,10 +41,18 @@ struct AttachmentThumbnailView: View {
         .task(id: url) {
             guard isImage else { return }
             let fileURL = url
-            let image = await Task.detached {
-                NSImage(contentsOf: fileURL)
+            // Load image data off the main thread using thread-safe CGImageSource APIs.
+            // NSImage is NOT thread-safe and must not be used off the main thread.
+            let cgImage = await Task.detached {
+                guard let source = CGImageSourceCreateWithURL(fileURL as CFURL, nil) else {
+                    return nil as CGImage?
+                }
+                return CGImageSourceCreateImageAtIndex(source, 0, nil)
             }.value
-            loadedImage = image
+            // Create NSImage on the main thread from the thread-safe CGImage.
+            if let cgImage {
+                loadedImage = NSImage(cgImage: cgImage, size: .zero)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes NSImage thread-safety violation in AttachmentThumbnailView.

Per AGENTS.md, NSImage is NOT thread-safe. Replaced NSImage(contentsOf:) in
Task.detached with CGImageSourceCreateWithURL/CGImageSourceCreateImageAtIndex,
then create NSImage on main thread from the CGImage.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22084" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
