### PR TITLE
fix(macos): prevent background conversations from jumping to top on click

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -2450,7 +2450,12 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             return
         }
         guard let index = conversations.firstIndex(where: { $0.id == conversationId }) else { return }
-        updateLastInteracted(conversationId: conversationId)
+        // Don't bump background conversations to the top — they receive frequent
+        // automated messages (heartbeats) that would constantly re-sort them,
+        // especially when an LRU-evicted ViewModel is recreated on click.
+        if !conversations[index].isBackgroundConversation {
+            updateLastInteracted(conversationId: conversationId)
+        }
         let isNewMessage = previousSnapshot?.messageId != currentSnapshot.messageId
         // Keep the local attention timestamp current for live assistant replies
         // so unread eligibility survives until the next conversation-list refresh.


### PR DESCRIPTION
## Summary
- Skip `updateLastInteracted` for background conversations in `handleAssistantMessageArrival`
- Background conversations receive frequent automated heartbeat messages that would constantly re-sort them to the top, especially when an LRU-evicted ViewModel is recreated on click
- Preserves the unseen/attention tracking (latestAssistantMessageAt, hasUnseenLatestAssistantMessage) so unread indicators still work

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22088" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
