### PR TITLE
fix(macos): remove lightboxToolbar deprecation warning

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ImageLightbox/ImageLightboxOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ImageLightbox/ImageLightboxOverlay.swift
@@ -74,7 +74,6 @@ struct ImageLightboxOverlay: View {
 
     // MARK: - Toolbar
 
-    @available(macOS, deprecated: 13.0)
     private func lightboxToolbar(_ lightbox: ImageLightboxState) -> some View {
         HStack(spacing: VSpacing.md) {
             // Filename


### PR DESCRIPTION
## Summary
- Remove erroneous `@available(macOS, deprecated: 13.0)` annotation from `lightboxToolbar()` — this is a custom function, not a system API, so the annotation just produces build warnings with no value.

## Original prompt
Fix deprecation warning: `'lightboxToolbar' was deprecated in macOS 13.0` in `ImageLightboxOverlay.swift:49`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22092" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
