### PR TITLE
fix(macos): eliminate conversation switch freeze from cache eviction cascade

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -704,28 +704,13 @@ struct ChatBubble: View {
                 }
             }
         }
-        .task(id: "\(message.text)|\(message.isStreaming)") {
-            // Async-parse large messages that missed the synchronous cache
-            let text = message.text
-            guard !message.isStreaming,
-                  text.count > Self.asyncParseThreshold,
-                  Self.segmentCache.object(forKey: text as NSString) == nil,
-                  asyncSegments[text] == nil else { return }
-            let result = await MarkdownParseActor.shared.parse(text)
-            guard !Task.isCancelled else { return }
-            asyncSegments[text] = result
-            // Backfill synchronous cache with cost tracking.
-            // Re-check cache after await to avoid double-inserting when
-            // multiple bubbles parse the same text concurrently.
-            if text.count <= Self.maxCacheableTextLength,
-               Self.segmentCache.object(forKey: text as NSString) == nil {
-                Self.segmentCache.setObject(
-                    SegmentCacheEntry(result),
-                    forKey: text as NSString,
-                    cost: text.utf8.count * 10
-                )
-            }
-        }
+        // NOTE: The per-segment .task(id:) in ChatBubbleTextContent handles
+        // async parsing for each individual text segment. A prior whole-message
+        // .task(id:) here parsed message.text (all segments joined), but
+        // resolveSegments looks up individual segment text — so the whole-message
+        // result was cached under a key never queried, producing only a wasted
+        // @State update and re-render per message. Removed to eliminate the
+        // redundant re-render cycle.
     }
 
     // MARK: - Document Widget

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -199,8 +199,8 @@ struct MarkdownSegmentView: View, Equatable {
     /// evaluation. NSCache handles eviction automatically under memory pressure.
     @MainActor private static var attributedStringCache: NSCache<NSNumber, AttributedStringCacheEntry> = {
         let cache = NSCache<NSNumber, AttributedStringCacheEntry>()
-        cache.countLimit = 500
-        cache.totalCostLimit = 5_000_000
+        cache.countLimit = 1_000
+        cache.totalCostLimit = 10_000_000
         return cache
     }()
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -879,9 +879,16 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
 
         touchVMAccessOrder(id)
         activeConversationId = id
-        // Switching conversations is a natural point to shed cached render
-        // artefacts from the previous conversation.
-        Self.clearRenderCaches()
+        // Render caches are keyed by content + appearance (text hash +
+        // color descriptions), not by conversation — entries from one
+        // conversation are valid for any conversation with the same text.
+        // Clearing them here caused every visible message to re-parse and
+        // re-build AttributedStrings synchronously, and the height
+        // mismatch between placeholder and proper renders triggered a
+        // LazyVStack re-estimation cascade that froze the app.
+        // NSCache handles memory pressure automatically; explicit clears
+        // are kept on close/archive/delete where freeing memory for
+        // discarded conversations is appropriate.
 
         // Emit explicit seen signal for user-initiated conversation selection.
         // Skip if this conversation was already active to avoid duplicate signals


### PR DESCRIPTION
## Summary
- Remove `clearRenderCaches()` from `selectConversation()` — caches are keyed by content + appearance, not conversation, so entries are valid across conversations and NSCache handles memory pressure automatically
- Remove redundant ChatBubble-level `.task(id:)` that parsed `message.text` (all segments joined) while `resolveSegments` looks up individual segment text — the result was never used, producing only a wasted @State update and re-render per message
- Increase `attributedStringCache` limits from 500 entries / 5MB to 1000 entries / 10MB
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22095" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
