### PR TITLE
Add commandPreview, riskLevel, activityText, executionTarget to GuardianDecisionPrompt

### DIFF
--- a/assistant/src/runtime/guardian-decision-types.ts
+++ b/assistant/src/runtime/guardian-decision-types.ts
@@ -31,6 +31,14 @@ export interface GuardianDecisionPrompt {
    * store. Absent for legacy-only prompts.
    */
   kind?: string;
+  /** Human-readable preview of the command being approved (e.g. shell command). */
+  commandPreview?: string;
+  /** Risk level label for the request (e.g. 'low', 'medium', 'high'). */
+  riskLevel?: string;
+  /** Short activity description for richer prompt display. */
+  activityText?: string;
+  /** Where the tool will execute — sandbox or host. */
+  executionTarget?: "sandbox" | "host";
 }
 
 export interface GuardianDecisionAction {

--- a/assistant/src/runtime/routes/guardian-action-routes.ts
+++ b/assistant/src/runtime/routes/guardian-action-routes.ts
@@ -226,6 +226,10 @@ function mapCanonicalRequestToPrompt(
     conversationId,
     callSessionId: req.callSessionId ?? null,
     kind: req.kind,
+    commandPreview: req.commandPreview ?? undefined,
+    riskLevel: req.riskLevel ?? undefined,
+    activityText: req.activityText ?? undefined,
+    executionTarget: (req.executionTarget as "sandbox" | "host") ?? undefined,
   };
 }
 
@@ -240,7 +244,9 @@ function buildKindAwareQuestionText(req: CanonicalGuardianRequest): string {
   const baseText =
     req.questionText ??
     (req.toolName
-      ? `Approve tool: ${req.toolName}`
+      ? req.activityText
+        ? `Approve tool: ${req.toolName} — ${req.activityText}`
+        : `Approve tool: ${req.toolName}`
       : `Guardian request: ${req.kind}`);
 
   if (req.kind === "access_request") {


### PR DESCRIPTION
## Summary
- Extend GuardianDecisionPrompt interface with enrichment fields
- Forward commandPreview, riskLevel, activityText, executionTarget from canonical request to wire format
- Enrich questionText with activity context when available

Part of plan: guardian-approval-ux.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22098" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
