### PR TITLE
Forward command preview, risk level, activity, and execution target to canonical guardian requests

### DIFF
--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -25,6 +25,7 @@ import {
 } from "../../memory/conversation-title-service.js";
 import * as pendingInteractions from "../../runtime/pending-interactions.js";
 import { getSubagentManager } from "../../subagent/index.js";
+import { summarizeToolInput } from "../../tools/tool-input-summary.js";
 import { truncate } from "../../util/truncate.js";
 import type { Conversation } from "../conversation.js";
 import { HostBashProxy } from "../host-bash-proxy.js";
@@ -84,6 +85,14 @@ export function makeEventSender(params: {
 
         try {
           const trustContext = conversation.trustContext;
+          const inputRecord = event.input as Record<string, unknown>;
+          const activityRaw =
+            (typeof inputRecord.activity === "string"
+              ? inputRecord.activity
+              : undefined) ??
+            (typeof inputRecord.reason === "string"
+              ? inputRecord.reason
+              : undefined);
           createCanonicalGuardianRequest({
             id: event.requestId,
             kind: "tool_approval",
@@ -92,6 +101,11 @@ export function makeEventSender(params: {
             conversationId,
             guardianPrincipalId: trustContext?.guardianPrincipalId ?? undefined,
             toolName: event.toolName,
+            commandPreview:
+              summarizeToolInput(event.toolName, inputRecord) || undefined,
+            riskLevel: event.riskLevel,
+            activityText: activityRaw,
+            executionTarget: event.executionTarget,
             status: "pending",
             requestCode: generateCanonicalRequestCode(),
             expiresAt: Date.now() + 5 * 60 * 1000,

--- a/assistant/src/runtime/confirmation-request-guardian-bridge.ts
+++ b/assistant/src/runtime/confirmation-request-guardian-bridge.ts
@@ -140,7 +140,9 @@ export function bridgeConfirmationRequestToGuardian(
     trustContext.requesterExternalUserId ||
     "unknown";
 
-  const questionText = `Tool approval request: ${toolName}`;
+  const questionText = canonicalRequest.activityText
+    ? `Tool approval: ${toolName} — ${canonicalRequest.activityText}`
+    : `Tool approval request: ${toolName}`;
 
   // Emit guardian.question notification so the guardian is alerted.
   const signalPromise = emitNotificationSignal({

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -66,6 +66,7 @@ import type { Provider } from "../../providers/types.js";
 import { checkIngressForSecrets } from "../../security/secret-ingress.js";
 import { getLogger } from "../../util/logger.js";
 import { silentlyWithLog } from "../../util/silently.js";
+import { summarizeToolInput } from "../../tools/tool-input-summary.js";
 import { buildAssistantEvent } from "../assistant-event.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import type { AuthContext } from "../auth/types.js";
@@ -607,6 +608,14 @@ function makeHubPublisher(
       try {
         const trustContext = conversation.trustContext;
         const sourceChannel = trustContext?.sourceChannel ?? "vellum";
+        const inputRecord = msg.input as Record<string, unknown>;
+        const activityRaw =
+          (typeof inputRecord.activity === "string"
+            ? inputRecord.activity
+            : undefined) ??
+          (typeof inputRecord.reason === "string"
+            ? inputRecord.reason
+            : undefined);
         const canonicalRequest = createCanonicalGuardianRequest({
           id: msg.requestId,
           kind: "tool_approval",
@@ -618,6 +627,11 @@ function makeHubPublisher(
           guardianExternalUserId: trustContext?.guardianExternalUserId,
           guardianPrincipalId: trustContext?.guardianPrincipalId ?? undefined,
           toolName: msg.toolName,
+          commandPreview:
+            summarizeToolInput(msg.toolName, inputRecord) || undefined,
+          riskLevel: msg.riskLevel,
+          activityText: activityRaw,
+          executionTarget: msg.executionTarget,
           status: "pending",
           requestCode: generateCanonicalRequestCode(),
           expiresAt: Date.now() + 5 * 60 * 1000,


### PR DESCRIPTION
## Summary
- Populate commandPreview, riskLevel, activityText, executionTarget when creating canonical guardian requests
- Use summarizeToolInput for concise command preview extraction
- Improve bridge questionText to include activity context

Part of plan: guardian-approval-ux.md (PR 2 of 6)