### PR TITLE
Clarify that Allow 10 min and Allow conversation apply to all tools

### DIFF
--- a/assistant/src/runtime/guardian-decision-types.ts
+++ b/assistant/src/runtime/guardian-decision-types.ts
@@ -63,12 +63,12 @@ export const GUARDIAN_DECISION_ACTIONS = {
   },
   approve_10m: {
     action: "approve_10m",
-    label: "Allow 10 min",
+    label: "Allow all for 10 min",
     description: "All tools for 10 minutes",
   },
   approve_conversation: {
     action: "approve_conversation",
-    label: "Allow conversation",
+    label: "Allow all for conversation",
     description: "All tools for this conversation",
   },
   approve_always: {

--- a/clients/shared/Features/Chat/GuardianDecisionBubble.swift
+++ b/clients/shared/Features/Chat/GuardianDecisionBubble.swift
@@ -74,6 +74,13 @@ public struct GuardianDecisionBubble: View {
                 onAction(decision.requestId, action)
             }
 
+            // Scope hint for temporal approval options
+            if decision.actions.contains(where: { $0.action == "approve_10m" || $0.action == "approve_conversation" }) {
+                Text("Temporal options apply to all tools in this conversation")
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+
             // Secondary metadata: tool name and request code reference
             if hasSecondaryMetadata {
                 Divider()


### PR DESCRIPTION
## Summary
- Rename 'Allow 10 min' to 'Allow all for 10 min' and 'Allow conversation' to 'Allow all for conversation'
- Add scope hint text below buttons explaining temporal options cover all tools
- Update test assertions for new label strings

Part of plan: guardian-approval-ux.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
