### PR TITLE
fix: add host-proxied tool variants to summarizeToolInput

### DIFF
--- a/assistant/src/__tests__/tool-input-summary.test.ts
+++ b/assistant/src/__tests__/tool-input-summary.test.ts
@@ -94,4 +94,31 @@ describe("summarizeToolInput", () => {
     expect(summarizeToolInput("bash", { command: "   " })).toBe("");
     expect(summarizeToolInput("custom_tool", { data: "  \n\t  " })).toBe("");
   });
+
+  test("host_bash behaves like bash", () => {
+    expect(summarizeToolInput("host_bash", { command: "git status" })).toBe(
+      "git status",
+    );
+  });
+
+  test("host_file_read behaves like file_read", () => {
+    expect(
+      summarizeToolInput("host_file_read", { file_path: "/src/index.ts" }),
+    ).toBe("/src/index.ts");
+  });
+
+  test("host_file_write behaves like file_write", () => {
+    expect(
+      summarizeToolInput("host_file_write", { path: "/src/main.ts" }),
+    ).toBe("/src/main.ts");
+  });
+
+  test("host_file_edit behaves like file_edit", () => {
+    expect(
+      summarizeToolInput("host_file_edit", {
+        file_path: "/preferred.ts",
+        path: "/fallback.ts",
+      }),
+    ).toBe("/preferred.ts");
+  });
 });

--- a/assistant/src/tools/tool-input-summary.ts
+++ b/assistant/src/tools/tool-input-summary.ts
@@ -39,13 +39,17 @@ export function summarizeToolInput(
 ): string {
   switch (toolName) {
     case "bash":
-    case "terminal": {
+    case "terminal":
+    case "host_bash": {
       const cmd = extractString(input, "command");
       return cmd ? truncate(cmd, 120) : "";
     }
     case "file_read":
     case "file_write":
-    case "file_edit": {
+    case "file_edit":
+    case "host_file_read":
+    case "host_file_write":
+    case "host_file_edit": {
       const path = extractString(input, "file_path", "path");
       return path ? path.trim() : "";
     }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for guardian-approval-ux.md.

**Gap:** summarizeToolInput missing host-proxied tool variants
**What was expected:** host_bash, host_file_read, host_file_write, host_file_edit handled like their non-host counterparts
**What was found:** Host variants fell through to generic default case
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
