### PR TITLE
fix: align questionText format between bridge and guardian-action-routes

### DIFF
--- a/assistant/src/runtime/confirmation-request-guardian-bridge.ts
+++ b/assistant/src/runtime/confirmation-request-guardian-bridge.ts
@@ -141,8 +141,8 @@ export function bridgeConfirmationRequestToGuardian(
     "unknown";
 
   const questionText = canonicalRequest.activityText
-    ? `Tool approval: ${toolName} — ${canonicalRequest.activityText}`
-    : `Tool approval request: ${toolName}`;
+    ? `Approve tool: ${toolName} — ${canonicalRequest.activityText}`
+    : `Approve tool: ${toolName}`;
 
   // Emit guardian.question notification so the guardian is alerted.
   const signalPromise = emitNotificationSignal({


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for guardian-approval-ux.md.

**Gap:** Inconsistent questionText format between bridge and guardian-action-routes
**What was expected:** Same format in both paths
**What was found:** Bridge used 'Tool approval:' while routes used 'Approve tool:'
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
