### PR TITLE
fix: use VColor.auxWhite design token in guardian decision bubble

### DIFF
--- a/clients/shared/Features/Chat/GuardianDecisionBubble.swift
+++ b/clients/shared/Features/Chat/GuardianDecisionBubble.swift
@@ -88,7 +88,7 @@ public struct GuardianDecisionBubble: View {
                     if let risk = decision.riskLevel {
                         Text(risk.uppercased())
                             .font(VFont.labelDefault)
-                            .foregroundStyle(.white)
+                            .foregroundStyle(VColor.auxWhite)
                             .padding(.horizontal, VSpacing.sm)
                             .padding(.vertical, VSpacing.xxs)
                             .background(


### PR DESCRIPTION
## Summary
- Replace hardcoded `.white` with `VColor.auxWhite` design token in `GuardianDecisionBubble.swift` risk badge text
- Fixes the design token guard CI check that flags raw color literals

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23692790683/job/69023036636
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
