### PR TITLE
fix: shorten temporal approval labels to fit WhatsApp 20-char button limit

### DIFF
--- a/assistant/src/runtime/guardian-decision-types.ts
+++ b/assistant/src/runtime/guardian-decision-types.ts
@@ -63,12 +63,12 @@ export const GUARDIAN_DECISION_ACTIONS = {
   },
   approve_10m: {
     action: "approve_10m",
-    label: "Allow all for 10 min",
+    label: "Allow all, 10 min",
     description: "All tools for 10 minutes",
   },
   approve_conversation: {
     action: "approve_conversation",
-    label: "Allow all for conversation",
+    label: "Allow all, convo",
     description: "All tools for this conversation",
   },
   approve_always: {


### PR DESCRIPTION
## Summary
Fixes WhatsApp button truncation for guardian approval labels.

**Gap:** 'Allow all for conversation' (25 chars) exceeded WhatsApp's 20-char button title limit
**Fix:** Shortened to 'Allow all, convo' (16 chars) and 'Allow all, 10 min' (17 chars)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
