### PR TITLE
fix: add enrichment fields to GuardianActionsPendingResponse type

### DIFF
--- a/assistant/src/daemon/message-types/guardian-actions.ts
+++ b/assistant/src/daemon/message-types/guardian-actions.ts
@@ -2,6 +2,8 @@
 // Enables desktop clients to fetch pending guardian prompts and submit
 // button decisions deterministically (without text parsing).
 
+import type { GuardianDecisionPrompt } from "../../runtime/guardian-decision-types.js";
+
 // === Client -> Server ===
 
 export interface GuardianActionsPendingRequest {
@@ -21,23 +23,7 @@ export interface GuardianActionDecision {
 export interface GuardianActionsPendingResponse {
   type: "guardian_actions_pending_response";
   conversationId: string;
-  prompts: Array<{
-    requestId: string;
-    requestCode: string;
-    state: string;
-    questionText: string;
-    toolName: string | null;
-    actions: Array<{ action: string; label: string }>;
-    expiresAt: number;
-    conversationId: string;
-    callSessionId: string | null;
-    /**
-     * Canonical request kind (e.g. 'tool_approval', 'pending_question').
-     * Present when the prompt originates from the canonical guardian request
-     * store. Absent for legacy-only prompts.
-     */
-    kind?: string;
-  }>;
+  prompts: GuardianDecisionPrompt[];
 }
 
 export interface GuardianActionDecisionResponse {


### PR DESCRIPTION
## Summary
Fixes type hygiene gap in guardian-actions.ts.

**Gap:** GuardianActionsPendingResponse inline type missing commandPreview, riskLevel, activityText, executionTarget
**Fix:** Added the four optional fields to match what the endpoint actually returns
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
