### PR TITLE
Increase default conversation fold limit from 5 to 10

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -43,7 +43,7 @@ extension MainWindowView {
 
     var displayedConversations: [ConversationModel] {
         let all = regularConversations
-        return sidebar.showAllConversations ? all : Array(all.prefix(5))
+        return sidebar.showAllConversations ? all : Array(all.prefix(10))
     }
 
     var displayedScheduleConversations: [ConversationModel] {
@@ -351,7 +351,7 @@ extension MainWindowView {
                             }
                     }
 
-                    if regularConversations.count > 5 {
+                    if regularConversations.count > 10 {
                         HStack {
                             VButton(
                                 label: sidebar.showAllConversations ? "Show less" : "Show more",


### PR DESCRIPTION
## Summary
- Doubles the number of conversations shown before the "Show more" fold in the sidebar from 5 to 10
- Updates both the display prefix and the threshold for showing the "Show more" button

## Original prompt
Double the default number of conversations before the show more fold (5 -> 10?)