### PR TITLE
fix: correct scope hint text for guardian temporal approvals

### DIFF
--- a/clients/shared/Features/Chat/GuardianDecisionBubble.swift
+++ b/clients/shared/Features/Chat/GuardianDecisionBubble.swift
@@ -152,7 +152,7 @@ public struct GuardianDecisionBubble: View {
 
             // Scope hint for temporal approval options
             if decision.actions.contains(where: { $0.action == "approve_10m" || $0.action == "approve_conversation" }) {
-                Text("Temporal options apply to all tools in this conversation")
+                Text("Temporal options apply to all pending tool requests")
                     .font(VFont.bodySmallDefault)
                     .foregroundStyle(VColor.contentTertiary)
             }


### PR DESCRIPTION
## Summary
Fixes misleading scope hint in GuardianDecisionBubble.

**Gap:** Hint said temporal options apply to 'all tools in this conversation' but they only apply to pending requests in the guardian-on-behalf case
**Fix:** Changed to 'all pending tool requests' which is accurate for both guardian-self and on-behalf flows
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
