### PR TITLE
fix: correct migration comment for command_preview truncation

### DIFF
--- a/assistant/src/memory/migrations/199-guardian-request-enrichment-columns.ts
+++ b/assistant/src/memory/migrations/199-guardian-request-enrichment-columns.ts
@@ -7,7 +7,7 @@ import { withCrashRecovery } from "./validate-migration-state.js";
  * Add enrichment columns to canonical_guardian_requests for guardian
  * approval UX:
  *
- * - command_preview: truncated command/input preview (first ~500 chars)
+ * - command_preview: truncated command/input preview
  * - risk_level: "low", "medium", "high"
  * - activity_text: LLM's explanation of why it's calling the tool
  * - execution_target: "sandbox" or "host"


### PR DESCRIPTION
## Summary
Fixes inaccurate comment in migration 199.

**Gap:** Comment said 'first ~500 chars' but actual truncation varies by tool type (120/100/80 chars)
**Fix:** Changed to 'truncated command/input preview' without a specific number