### PR TITLE
fix: raise echoes importance floor and fix re-extraction importance ratchet

### DIFF
--- a/assistant/src/memory/job-handlers/batch-extraction.ts
+++ b/assistant/src/memory/job-handlers/batch-extraction.ts
@@ -452,7 +452,9 @@ export async function batchExtractJob(job: MemoryJob): Promise<void> {
             Math.max(existing.confidence, item.confidence),
           ),
           importance: clampUnitInterval(
-            Math.max(existing.importance ?? 0, item.importance),
+            fullReextract
+              ? item.importance
+              : Math.max(existing.importance ?? 0, item.importance),
           ),
           lastSeenAt: Math.max(existing.lastSeenAt, seenAt),
           sourceType: effectiveSourceType,

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -903,10 +903,10 @@ function filterInContextItems(
  * importance value (importance-weighted sampling).
  *
  * Only items with importance >= MIN_SERENDIPITY_IMPORTANCE are eligible,
- * filtering out mundane facts (infrastructure details, tooling, etc.)
- * so echoes stay meaningful.
+ * so only genuinely significant memories (decisions, personal moments,
+ * turning points) surface as echoes.
  */
-const MIN_SERENDIPITY_IMPORTANCE = 0.5;
+const MIN_SERENDIPITY_IMPORTANCE = 0.7;
 
 function sampleSerendipityItems(
   existingCandidates: TieredCandidate[],


### PR DESCRIPTION
## Summary
- Raise `MIN_SERENDIPITY_IMPORTANCE` from 0.5 to 0.7 — filters out infrastructure items (Docker, TTS, API keys) from echoes
- Fix importance ratchet in batch extraction: when `fullReextract` is true, use the new importance score directly instead of `Math.max(old, new)`, allowing re-extraction to properly downgrade inflated scores

## Original prompt
both of these in parallel
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
