### PR TITLE
fix: add minimum segment content length filter

### DIFF
--- a/assistant/src/cli/commands/memory.ts
+++ b/assistant/src/cli/commands/memory.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 
 import {
+  cleanupShortSegments,
   findReextractTarget,
   findReextractTargets,
   getMemorySystemStatus,
@@ -145,6 +146,36 @@ Examples:
       log.info(
         `Queued cleanup_stale_superseded_items job: ${jobs.staleSupersededItemsJobId}`,
       );
+    });
+
+  memory
+    .command("cleanup-segments")
+    .description("Remove short segments that waste retrieval budget")
+    .option("--dry-run", "Show count of segments that would be removed")
+    .addHelpText(
+      "after",
+      `
+Removes segments shorter than the minimum character threshold from both
+SQLite and Qdrant. Short fragments (e.g. "Collar Touched") burn embedding
+budget, retrieval slots, and injection tokens without adding value.
+
+New segments are already filtered at creation time. This command cleans up
+existing short segments that were stored before the filter was added.
+
+Examples:
+  $ assistant memory cleanup-segments
+  $ assistant memory cleanup-segments --dry-run`,
+    )
+    .action(async (opts: { dryRun?: boolean }) => {
+      initializeDb();
+      const result = await cleanupShortSegments({ dryRun: opts.dryRun });
+      if (opts.dryRun) {
+        log.info(
+          `Dry run: ${result.dryRunCount} short segment(s) would be removed.`,
+        );
+      } else {
+        log.info(`Removed ${result.removed} short segment(s).`);
+      }
     });
 
   memory

--- a/assistant/src/memory/admin.ts
+++ b/assistant/src/memory/admin.ts
@@ -6,14 +6,16 @@ import { deleteMemoryCheckpoint } from "./checkpoints.js";
 import { getConversationMemoryScopeId } from "./conversation-crud.js";
 import { getDb, rawGet } from "./db.js";
 import { getMemoryBackendStatus } from "./embedding-backend.js";
-import { enqueueBackfillJob, enqueueRebuildIndexJob } from "./indexer.js";
+import { enqueueBackfillJob, enqueueRebuildIndexJob, MIN_SEGMENT_CHARS } from "./indexer.js";
 import {
   enqueueCleanupStaleSupersededItemsJob,
   enqueueMemoryJob,
   getMemoryJobCounts,
 } from "./jobs-store.js";
+import { getQdrantClient } from "./qdrant-client.js";
+import { withQdrantBreaker } from "./qdrant-circuit-breaker.js";
 import { queryMemoryForCli } from "./retriever.js";
-import { conversations, memorySummaries, messages } from "./schema.js";
+import { conversations, memorySegments, memorySummaries, messages } from "./schema.js";
 
 const log = getLogger("memory-admin");
 
@@ -111,6 +113,54 @@ export function requestMemoryCleanup(retentionMs?: number): {
 
 export async function queryMemory(query: string, conversationId: string) {
   return queryMemoryForCli(query, conversationId, getConfig());
+}
+
+// ── Short segment cleanup ─────────────────────────────────────────────
+
+export interface CleanupShortSegmentsResult {
+  removed: number;
+  dryRunCount?: number;
+}
+
+/**
+ * Remove segments shorter than MIN_SEGMENT_CHARS from SQLite and Qdrant.
+ * These short fragments waste embedding budget, retrieval slots, and
+ * injection tokens.
+ */
+export async function cleanupShortSegments(
+  opts?: { dryRun?: boolean },
+): Promise<CleanupShortSegmentsResult> {
+  const db = getDb();
+
+  const shortSegments = db
+    .select({ id: memorySegments.id })
+    .from(memorySegments)
+    .where(sql`length(${memorySegments.text}) < ${MIN_SEGMENT_CHARS}`)
+    .all();
+
+  if (opts?.dryRun) {
+    return { removed: 0, dryRunCount: shortSegments.length };
+  }
+
+  let removed = 0;
+  for (const row of shortSegments) {
+    // Delete the Qdrant embedding first (best-effort via circuit breaker)
+    try {
+      const qdrant = getQdrantClient();
+      await withQdrantBreaker(() => qdrant.deleteByTarget("segment", row.id));
+    } catch {
+      // Qdrant may not be running or the vector may not exist — continue
+      // with SQLite deletion regardless
+    }
+
+    db.delete(memorySegments)
+      .where(eq(memorySegments.id, row.id))
+      .run();
+    removed++;
+  }
+
+  log.info({ removed, threshold: MIN_SEGMENT_CHARS }, "Cleaned up short segments");
+  return { removed };
 }
 
 // ── Re-extraction ──────────────────────────────────────────────────────

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -18,6 +18,9 @@ import { segmentText } from "./segmenter.js";
 
 const log = getLogger("memory-indexer");
 
+/** Minimum character length for a segment to be worth storing and embedding (~12-15 tokens). */
+export const MIN_SEGMENT_CHARS = 50;
+
 export interface IndexMessageInput {
   messageId: string;
   conversationId: string;
@@ -86,8 +89,13 @@ export async function indexMessageNow(
   // Wrap all segment inserts and job enqueues in a single transaction so they
   // either all succeed or all roll back, preventing partial/orphaned state.
   let skippedEmbedJobs = 0;
+  let skippedShortSegments = 0;
   db.transaction((tx) => {
     for (const segment of segments) {
+      if (segment.text.length < MIN_SEGMENT_CHARS) {
+        skippedShortSegments++;
+        continue;
+      }
       const segmentId = buildSegmentId(input.messageId, segment.segmentIndex);
       const hash = createHash("sha256").update(segment.text).digest("hex");
 
@@ -173,6 +181,12 @@ export async function indexMessageNow(
     );
   }
 
+  if (skippedShortSegments > 0) {
+    log.debug(
+      `Skipped ${skippedShortSegments}/${segments.length} segments shorter than ${MIN_SEGMENT_CHARS} chars`,
+    );
+  }
+
   if (skippedEmbedJobs > 0) {
     log.debug(
       `Skipped ${skippedEmbedJobs}/${segments.length} embed_segment jobs (content unchanged)`,
@@ -193,12 +207,13 @@ export async function indexMessageNow(
     log.info("Skipping extraction job: LLM extraction is disabled (useLLM=false)");
   }
 
+  const storedSegments = segments.length - skippedShortSegments;
   const enqueuedJobs =
-    segments.length -
+    storedSegments -
     skippedEmbedJobs +
     mediaBlocks.length;
   return {
-    indexedSegments: segments.length,
+    indexedSegments: storedSegments,
     enqueuedJobs,
   };
 }


### PR DESCRIPTION
## Summary
- Add `MIN_SEGMENT_CHARS = 50` filter in `indexer.ts` — segments shorter than ~12 tokens are skipped at creation time
- Add `cleanupShortSegments()` admin function to purge existing short segments from SQLite and Qdrant
- Add `assistant memory cleanup-segments` CLI command with `--dry-run` support

## Original prompt
both of these in parallel