### PR TITLE
feat: add description field to GuardianActionOption Swift type

### DIFF
--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2794,10 +2794,12 @@ public struct ApprovedDevicesClearMessage: Encodable, Sendable {
 public struct GuardianActionOption: Decodable, Sendable, Equatable {
     public let action: String
     public let label: String
+    public let description: String?
 
-    public init(action: String, label: String) {
+    public init(action: String, label: String, description: String? = nil) {
         self.action = action
         self.label = label
+        self.description = description
     }
 }
 


### PR DESCRIPTION
## Summary
Adds optional description property to GuardianActionOption in Swift client.

**Gap:** Server sends per-action scope descriptions but Swift client silently drops them
**Fix:** Added description: String? so the client decodes the field for future UI use
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
