### PR TITLE
fix: sort imports in memory/admin.ts

### DIFF
--- a/assistant/src/memory/admin.ts
+++ b/assistant/src/memory/admin.ts
@@ -12,8 +12,8 @@ import {
   enqueueMemoryJob,
   getMemoryJobCounts,
 } from "./jobs-store.js";
-import { getQdrantClient } from "./qdrant-client.js";
 import { withQdrantBreaker } from "./qdrant-circuit-breaker.js";
+import { getQdrantClient } from "./qdrant-client.js";
 import { queryMemoryForCli } from "./retriever.js";
 import { conversations, memorySegments, memorySummaries, messages } from "./schema.js";
 


### PR DESCRIPTION
## Summary
- Fix alphabetical import ordering in `assistant/src/memory/admin.ts` — `qdrant-circuit-breaker` sorts before `qdrant-client`
- Resolves CI lint failure (`simple-import-sort/imports`)

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23696197471/job/69031764894
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
