### PR TITLE
fix: remove stale isNearBottom param from MessageListForkActionTests

### DIFF
--- a/clients/macos/vellum-assistantTests/MessageListForkActionTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListForkActionTests.swift
@@ -74,7 +74,6 @@ final class MessageListForkActionTests: XCTestCase {
             conversationId: nil,
             anchorMessageId: .constant(nil),
             highlightedMessageId: .constant(nil),
-            isNearBottom: .constant(true),
             containerWidth: 0
         )
     }


### PR DESCRIPTION
## Summary
- Remove the `isNearBottom: .constant(true)` argument from the `MessageListForkActionTests` helper that was causing a compile error in macOS CI
- The `isNearBottom` binding was removed from `MessageListView`'s initializer (replaced by internal `MessageListScrollState`) but the test wasn't updated

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23696333727/job/69032118949
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
