### PR TITLE
fix(macos): remove dead ScrollTrackingState class and update perf test

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -97,7 +97,7 @@ final class MessageListScrollState {
     /// auto-focus handoff. Used to detect nil->non-nil transitions.
     @ObservationIgnored var lastAutoFocusedRequestId: String?
 
-    // MARK: - Layout Cache Fields (from ScrollTrackingState)
+    // MARK: - Layout Cache Fields
 
     /// Cache key for the last computed `CachedMessageLayoutMetadata`.
     @ObservationIgnored var cachedLayoutKey: PrecomputedCacheKey?

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -23,70 +23,6 @@ extension EnvironmentValues {
     }
 }
 
-/// Holds scroll-related tracking values that must persist across body
-/// evaluations but must NOT trigger SwiftUI re-renders when updated.
-/// These values serve as dead-zone guards and smoothing state — they
-/// are never read during body evaluation for rendering purposes.
-/// Pattern mirrors non-reactive properties on the coordinator (not @Published).
-@MainActor final class ScrollTrackingState {
-
-    // MARK: - Layout Metadata Cache
-
-    /// Cache key for the last computed `CachedMessageLayoutMetadata`.
-    var cachedLayoutKey: PrecomputedCacheKey?
-    /// Cached structural metadata, returned on cache hit.
-    var cachedLayoutMetadata: CachedMessageLayoutMetadata?
-
-    // MARK: - Version Counter (O(1) fingerprint replacement)
-
-    /// Monotonically increasing counter that replaces the O(n) per-body-eval
-    /// `computeMessageFingerprint()` hash. Incremented when any of the following
-    /// triggers fire:
-    /// - raw `messages.count` changes (new message appended, deletion, or
-    ///   pagination load — also catches paginated-window shifts)
-    /// - visible message count changes (hidden/subagent visibility transitions)
-    /// - `isSending` or `isThinking` transitions (activity state change)
-    /// - `visibleMessages.last?.isStreaming` transitions (end of streaming)
-    /// - A tool call's `isComplete` transitions (observable via messages array
-    ///   identity change in SwiftUI)
-    ///
-    /// Over-invalidation is safe (triggers a recompute); under-invalidation is not.
-    var messageListVersion: Int = 0
-
-    /// Cached raw (unfiltered) message count. Detects new arrivals,
-    /// deletions, and pagination loads — including cases where the
-    /// paginated visible window shifts at a fixed size.
-    var lastKnownRawMessageCount: Int = 0
-    /// Cached visible (paginated) message count. Detects changes in
-    /// message visibility (hidden/subagent transitions) that don't
-    /// alter the raw count.
-    var lastKnownVisibleMessageCount: Int = 0
-    /// Cached streaming state of the last visible message.
-    var lastKnownLastMessageStreaming: Bool = false
-    /// Cached count of incomplete tool calls across visible messages.
-    var lastKnownIncompleteToolCallCount: Int = 0
-    /// Lightweight identity fingerprint of visible message IDs. Catches
-    /// "same count, different IDs" scenarios where hasRenderableContent
-    /// changes cause different messages to pass the visibility filter.
-    var lastKnownVisibleIdFingerprint: Int = 0
-
-    // MARK: - Scroll Geometry (non-reactive, updated every scroll tick)
-
-    /// Content height from scroll geometry, used to guard against false
-    /// detaches on short conversations that can't scroll.
-    var scrollContentHeight: CGFloat = 0
-    /// Container (viewport) height from scroll geometry, used alongside
-    /// scrollContentHeight to determine if content is scrollable.
-    var scrollContainerHeight: CGFloat = 0
-    /// Last content offset Y observed by onScrollGeometryChange, used to
-    /// determine scroll direction (increasing offset = scrolling toward older content).
-    var lastScrollContentOffsetY: CGFloat = 0
-
-    /// Cached ID of the first visible message, updated during body evaluation.
-    /// Used by the pagination callback to avoid an O(n) filter on every scroll.
-    var cachedFirstVisibleMessageId: UUID?
-}
-
 /// Lightweight key that captures all inputs to `precomputedState`.
 /// All fields are O(1) to compare. The `messageListVersion` counter
 /// replaces the former O(n) hash-based fingerprint — it is incremented
@@ -1480,7 +1416,7 @@ private struct MessageCellView: View, Equatable {
 // MARK: - Cached Message Layout Metadata
 
 /// Structural metadata cached behind a version-counter key on
-/// `ScrollTrackingState`. Contains only fields derived from message IDs,
+/// `MessageListScrollState`. Contains only fields derived from message IDs,
 /// roles, timestamps, and subagent identity — never mutable content like
 /// text segments or confirmation states. Cache invalidation is gated by
 /// `refreshMessageListVersionIfNeeded()` which tracks structural changes.

--- a/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
@@ -177,7 +177,7 @@ final class MessageListScrollPerformanceTests: XCTestCase {
             isStreaming: true
         )
 
-        let tracking = ScrollTrackingState()
+        let tracking = MessageListScrollState()
 
         // Build initial cache.
         let key = PrecomputedCacheKey(


### PR DESCRIPTION
## Summary
- Delete dead ScrollTrackingState class from MessageListView.swift (no production consumers after scroll coordinator replacement)
- Update MessageListScrollPerformanceTests to use MessageListScrollState instead

**Gap:** ScrollTrackingState was left behind as dead code after layout cache fields were inlined into MessageListScrollState