### PR TITLE
fix(macos): restyle scheduled group count to not look like notification badge

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -455,15 +455,9 @@ extension MainWindowView {
                                             .foregroundStyle(VColor.contentDefault)
                                             .lineLimit(1)
                                             .truncationMode(.tail)
-                                        Text("\(group.conversations.count)")
-                                            .font(.system(size: 10, weight: .medium))
+                                        Text("(\(group.conversations.count))")
+                                            .font(.system(size: 12))
                                             .foregroundStyle(VColor.contentTertiary)
-                                            .padding(.horizontal, 6)
-                                            .padding(.vertical, 2)
-                                            .background(
-                                                Capsule()
-                                                    .fill(VColor.contentTertiary.opacity(0.12))
-                                            )
                                         Spacer()
                                     }
                                     .padding(.leading, VSpacing.xs)


### PR DESCRIPTION
## Summary
- Removed the capsule/pill background from the scheduled conversation group child count in the sidebar
- Count now renders as plain parenthetical text (e.g. "(3)") in a muted style, so it no longer looks like an unread notification indicator

## Original prompt
it

🤖 Generated with [Claude Code](https://claude.com/claude-code)