### PR TITLE
fix(macos): prevent thinking block content overlapping header

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
@@ -16,6 +16,7 @@ struct ThinkingBlockView: View {
 
             if isExpanded {
                 Divider()
+                    .padding(.horizontal, VSpacing.sm)
 
                 ScrollView {
                     Text(content)
@@ -27,6 +28,8 @@ struct ThinkingBlockView: View {
                 }
                 .fixedSize(horizontal: false, vertical: true)
                 .frame(maxHeight: 300)
+                .clipped()
+                .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
         .background(VColor.surfaceOverlay)
@@ -37,7 +40,7 @@ struct ThinkingBlockView: View {
 
     private var headerRow: some View {
         Button(action: {
-            withAnimation(.easeInOut(duration: 0.2)) {
+            withAnimation(VAnimation.fast) {
                 isExpanded.toggle()
             }
         }) {


### PR DESCRIPTION
## Summary
- Add `.clipped()` to the thinking block ScrollView to prevent content from overflowing its frame during the expand/collapse animation, which caused intermittent overlap with the header
- Add `.transition(.opacity.combined(with: .move(edge: .top)))` matching the established `VDisclosureSection` pattern for smooth enter/exit
- Switch from raw `easeInOut(duration: 0.2)` to `VAnimation.fast` for design system consistency
- Inset the Divider with horizontal padding to align with the content text below

## Original prompt
fix thinking block layout overlap (content overlapping "Thought process" header)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
