### PR TITLE
fix(macos): allow scrolling in readonly channel conversations

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -188,7 +188,6 @@ struct ChatView: View {
                     }
                 )
                 .onPreferenceChange(ChatContainerWidthKey.self) { containerWidth = $0 }
-                .disabled(!isInteractionEnabled)
                 .overlay(alignment: .bottom) {
                     btwOverlay
                 }


### PR DESCRIPTION
## Summary
- Remove blanket `.disabled(!isInteractionEnabled)` from `mainContentStack` in `ChatView.swift`
- This modifier was preventing scrolling in readonly channel conversations because SwiftUI's `.disabled()` blocks all user interactions including scroll gestures
- Individual interactive components (composer, key handlers) already guard on `isInteractionEnabled`, so the modifier was redundant

## Original prompt
I can't scroll up and down in readonly threads, can you fix this?