### PR TITLE
fix(macos): silence trailing closure warning in LogExporter

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -216,7 +216,7 @@ enum LogExporter {
                 log.warning("Skipping invalid attachment at \(attachmentURL.lastPathComponent)")
                 continue
             }
-            guard let fileData = await Task.detached { try? Data(contentsOf: attachmentURL) }.value else {
+            guard let fileData = await Task.detached(operation: { try? Data(contentsOf: attachmentURL) }).value else {
                 log.warning("Skipping unreadable attachment at \(attachmentURL.lastPathComponent)")
                 continue
             }


### PR DESCRIPTION
## Summary
- Changed `Task.detached { ... }` to `Task.detached(operation: { ... })` in `LogExporter.swift` to silence the Swift compiler warning about a trailing closure being confusable with the body of a `guard` statement.

## Original prompt
fix: trailing closure warning in LogExporter.swift:219 — "trailing closure in this context is confusable with the body of the statement"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
