### PR TITLE
feat: allow HEIC/HEIF file attachments

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/tools/ingest-media.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/ingest-media.ts
@@ -55,6 +55,7 @@ const MIME_MAP: Record<string, string> = {
   ".tiff": "image/tiff",
   ".svg": "image/svg+xml",
   ".heic": "image/heic",
+  ".heif": "image/heif",
 };
 
 function detectMimeType(filePath: string): string | null {

--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -63,6 +63,8 @@ const EXTENSION_MIME_MAP: Record<string, string> = {
   svg: "image/svg+xml",
   ico: "image/x-icon",
   bmp: "image/bmp",
+  heic: "image/heic",
+  heif: "image/heif",
 
   // Documents
   pdf: "application/pdf",

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -345,6 +345,8 @@ const ALLOWED_MIME_TYPES = new Set([
   "image/bmp",
   "image/tiff",
   "image/x-icon",
+  "image/heic",
+  "image/heif",
   // Audio
   "audio/mpeg",
   "audio/ogg",


### PR DESCRIPTION
## Summary
- Add `image/heic` and `image/heif` to `ALLOWED_MIME_TYPES` in `attachments-store.ts` so the server accepts HEIC/HEIF uploads
- Add `heic`/`heif` entries to the extension→MIME inference maps in `assistant-attachments.ts` and `ingest-media.ts`

## Original prompt
when attaching files I should be able to attach .HEIC files
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
