### PR TITLE
fix(macos): increase attachment thumbnail resolution from 120px to 800px

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -192,8 +192,8 @@ private struct AttachmentImageGrid<Fallback: View>: View {
                     if isSingleImage {
                         // Single images: prefer full-resolution data so the frame
                         // sizing (which uses native pixel dimensions) is accurate.
-                        // Thumbnails are 120px max — using them caps the display
-                        // at ~60pt on Retina, far too small.
+                        // Thumbnails are 800px max — using them gives ~400pt on
+                        // Retina, adequate for most previews.
                         if let fullData = Data(base64Encoded: attachment.data), !fullData.isEmpty,
                            let img = NSImage(data: fullData) {
                             guard !Task.isCancelled else { return }

--- a/clients/shared/Features/Chat/ChatAttachmentManager.swift
+++ b/clients/shared/Features/Chat/ChatAttachmentManager.swift
@@ -253,7 +253,7 @@ public final class ChatAttachmentManager {
 
             var thumbnail: Data?
             if let utType = UTType(filenameExtension: url.pathExtension), utType.conforms(to: .image) {
-                thumbnail = Self.generateThumbnail(from: finalData, maxDimension: 120)
+                thumbnail = Self.generateThumbnail(from: finalData, maxDimension: 800)
             }
 
             if wasCompressed {
@@ -352,7 +352,7 @@ public final class ChatAttachmentManager {
             log.debug("[Attachment] normalized id=\(attachmentId) mimeType=\(mimeType) originalBytes=\(pngData.count) finalBytes=\(finalData.count) compressed=\(wasCompressed)")
 
             let base64 = finalData.base64EncodedString()
-            let thumbnail = Self.generateThumbnail(from: finalData, maxDimension: 120)
+            let thumbnail = Self.generateThumbnail(from: finalData, maxDimension: 800)
 
             return .success(ProcessedAttachmentData(
                 id: attachmentId,

--- a/clients/shared/Features/Chat/HistoryReconstructionService.swift
+++ b/clients/shared/Features/Chat/HistoryReconstructionService.swift
@@ -272,7 +272,7 @@ enum HistoryReconstructionService {
             #endif
 
             if attachment.mimeType.hasPrefix("image/"), !base64.isEmpty, let rawData = Data(base64Encoded: base64) {
-                thumbnailData = generateThumbnail(from: rawData, maxDimension: 120)
+                thumbnailData = generateThumbnail(from: rawData, maxDimension: 800)
                 #if os(macOS)
                 thumbnailImage = thumbnailData.flatMap { NSImage(data: $0) }
                 #elseif os(iOS)


### PR DESCRIPTION
## Summary
- Increased thumbnail max dimension from 120px to 800px in `ChatAttachmentManager` (2 call sites) and `HistoryReconstructionService` (1 call site)
- After sending a message, `stripHeavyContent()` clears full image data and the display falls back to the thumbnail. At 120px, this rendered as ~60pt on Retina — completely unreadable. 800px gives ~400pt on Retina, making sent image previews readable.

## Original prompt
when I add the image to the chat the preview is full resolution, but after I sent it, the preview is hella low res to the point that it's completely unreadable, can you fix it?
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
