### PR TITLE
fix(macos): remove max height constraint from thinking blocks

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
@@ -18,18 +18,13 @@ struct ThinkingBlockView: View {
                 Divider()
                     .padding(.horizontal, VSpacing.sm)
 
-                ScrollView {
-                    Text(content)
-                        .font(VFont.bodyMediumDefault)
-                        .foregroundStyle(VColor.contentSecondary)
-                        .textSelection(.enabled)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(VSpacing.sm)
-                }
-                .fixedSize(horizontal: false, vertical: true)
-                .frame(maxHeight: 300)
-                .clipped()
-                .transition(.opacity.combined(with: .move(edge: .top)))
+                Text(content)
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(VSpacing.sm)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
         .background(VColor.surfaceOverlay)


### PR DESCRIPTION
## Summary
- Removed the 300px max height constraint, ScrollView wrapper, and `.clipped()` from ThinkingBlockView
- Thinking blocks now expand to fit their full content, fixing broken scroll and collapse behavior on long thinking content

## Original prompt
this thinking block is messed up. I can't scroll, and I can't even close the block anymore. normal blocks work fine, but when it exceeds the allocated size it's fucked. Can we make it so that there's no max size and it just takes up however much room it needs to?
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
