### PR TITLE
fix(macos): fetch full-res image in lightbox when inline data is stripped

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -330,7 +330,7 @@ extension ChatBubble {
                 image: image,
                 filename: attachment.filename,
                 base64Data: attachment.data.isEmpty ? nil : attachment.data,
-                lazyAttachmentId: attachment.isLazyLoad && !attachment.id.isEmpty ? attachment.id : nil
+                lazyAttachmentId: attachment.data.isEmpty && !attachment.id.isEmpty ? attachment.id : nil
             )
         }) { attachment in
             fileAttachmentChip(attachment)


### PR DESCRIPTION
## Summary
- Changed the lightbox `lazyAttachmentId` condition from `attachment.isLazyLoad` to `attachment.data.isEmpty` so that attachments whose data was cleared by `stripHeavyContent()` can still fetch full-resolution content from the server
- Previously, after sending a message and the data being stripped for memory, expanding the image preview showed only the thumbnail with no way to get full-res. Now the lightbox fetches from the `attachments/:id/content` endpoint.

## Original prompt
whenever I expand the image for the preview, it should always show the full res version
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
