### PR TITLE
fix: consistent menu options for channel conversations

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationHeaderPresentation.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationHeaderPresentation.swift
@@ -9,6 +9,7 @@ struct ConversationHeaderPresentation {
     let isStarted: Bool
     let showsActionsMenu: Bool
     let isPrivateConversation: Bool
+    let isChannelConversation: Bool
     let canCopy: Bool
     let isPinned: Bool
     let showsForkConversationAction: Bool
@@ -26,6 +27,7 @@ struct ConversationHeaderPresentation {
             self.isStarted = false
             self.showsActionsMenu = false
             self.isPrivateConversation = false
+            self.isChannelConversation = false
             self.canCopy = false
             self.isPinned = false
             self.showsForkConversationAction = false
@@ -38,6 +40,7 @@ struct ConversationHeaderPresentation {
         self.displayTitle = conversation.title
         self.isPinned = conversation.isPinned
         self.isPrivateConversation = conversation.kind == .private
+        self.isChannelConversation = conversation.isChannelConversation
 
         // "Started" = has a conversationId OR has at least one non-empty user message
         let hasUserMessage = activeViewModel?.messages.contains(where: {

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
@@ -63,7 +63,7 @@ struct ConversationActionsDrawer: View {
                 VMenuItem(icon: VIcon.copy.rawValue, label: "Copy full conversation", action: onCopy)
             }
 
-            if presentation.showsForkConversationAction {
+            if presentation.showsForkConversationAction && !presentation.isChannelConversation {
                 VMenuItem(icon: VIcon.gitBranch.rawValue, label: "Fork conversation", action: onForkConversation)
             }
 
@@ -79,7 +79,9 @@ struct ConversationActionsDrawer: View {
 
             VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename", action: onRename)
 
-            VMenuItem(icon: VIcon.archive.rawValue, label: "Archive", action: onArchive)
+            if !presentation.isChannelConversation {
+                VMenuItem(icon: VIcon.archive.rawValue, label: "Archive", action: onArchive)
+            }
         }
         .transition(.identity)
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -41,13 +41,15 @@ struct SidebarConversationItem: View, Equatable {
 
     @ViewBuilder
     private var contextMenuContent: some View {
+        VMenuItem(icon: conversation.isPinned ? VIcon.pinOff.rawValue : VIcon.pin.rawValue, label: conversation.isPinned ? "Unpin" : "Pin") {
+            onTogglePin()
+        }
+
+        VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename") {
+            onStartRename()
+        }
+
         if !conversation.isChannelConversation {
-            VMenuItem(icon: conversation.isPinned ? VIcon.pinOff.rawValue : VIcon.pin.rawValue, label: conversation.isPinned ? "Unpin" : "Pin") {
-                onTogglePin()
-            }
-            VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename") {
-                onStartRename()
-            }
             VMenuItem(icon: VIcon.archive.rawValue, label: "Archive") {
                 onArchive()
             }
@@ -63,14 +65,12 @@ struct SidebarConversationItem: View, Equatable {
             }
         }
 
-        if !conversation.isChannelConversation {
-            VMenuDivider()
+        VMenuDivider()
 
-            VMenuItem(icon: VIcon.messageCircle.rawValue, label: "Share Feedback") {
-                onShowFeedback?()
-            }
-            .disabled(onShowFeedback == nil)
+        VMenuItem(icon: VIcon.messageCircle.rawValue, label: "Share Feedback") {
+            onShowFeedback?()
         }
+        .disabled(onShowFeedback == nil)
     }
 
     var body: some View {
@@ -80,23 +80,18 @@ struct SidebarConversationItem: View, Equatable {
             // Leading 20x20 slot: single render path.
             // Hovered -> interactive pin button; not hovered -> status indicator.
             if isHovered {
-                if !conversation.isChannelConversation {
-                    VButton(
-                        label: conversation.isPinned ? "Unpin \(conversation.title)" : "Pin \(conversation.title)",
-                        iconOnly: VIcon.pin.rawValue,
-                        style: .ghost,
-                        iconSize: 20,
-                        tooltip: conversation.isPinned ? "Unpin" : "Pin",
-                        iconColor: conversation.isPinned ? VColor.contentTertiary : VColor.contentSecondary,
-                        iconRotation: .degrees(-45)
-                    ) {
-                        onTogglePin()
-                    }
-                    .transition(.opacity)
-                } else {
-                    Color.clear
-                        .frame(width: 20, height: 20)
+                VButton(
+                    label: conversation.isPinned ? "Unpin \(conversation.title)" : "Pin \(conversation.title)",
+                    iconOnly: VIcon.pin.rawValue,
+                    style: .ghost,
+                    iconSize: 20,
+                    tooltip: conversation.isPinned ? "Unpin" : "Pin",
+                    iconColor: conversation.isPinned ? VColor.contentTertiary : VColor.contentSecondary,
+                    iconRotation: .degrees(-45)
+                ) {
+                    onTogglePin()
                 }
+                .transition(.opacity)
             } else {
                 switch interactionState {
                 case .processing:

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
@@ -252,10 +252,12 @@ private struct ThreadWindowContentView: View {
                     showTitleActions = false
                 }
             )
-            SidebarPrimaryRow(icon: VIcon.archive.rawValue, label: "Archive", action: {
-                conversationManager.archiveConversation(id: conversationLocalId)
-                showTitleActions = false
-            })
+            if !(conversation?.isChannelConversation ?? false) {
+                SidebarPrimaryRow(icon: VIcon.archive.rawValue, label: "Archive", action: {
+                    conversationManager.archiveConversation(id: conversationLocalId)
+                    showTitleActions = false
+                })
+            }
         }
         .padding(VSpacing.sm)
         .background(VColor.surfaceLift)


### PR DESCRIPTION
## Summary
- Sidebar context menu was hiding almost all options for channel conversations (only showed Open in New Window), while the top dropdown showed the full set
- Made all three menus (sidebar, top dropdown, ThreadWindow) consistent: show Copy, Open in new window, Pin/Unpin, Rename, Share Feedback; hide Fork, Archive, Mark as unread
- Added `isChannelConversation` to `ConversationHeaderPresentation` so the top dropdown can filter appropriately

## Original prompt
Make channel conversation menus consistent across sidebar and top dropdown
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
