### PR TITLE
Cache Slack user info in contacts for faster DM resolution

### DIFF
--- a/assistant/src/config/bundled-skills/contacts/TOOLS.json
+++ b/assistant/src/config/bundled-skills/contacts/TOOLS.json
@@ -47,6 +47,14 @@
                 "is_primary": {
                   "type": "boolean",
                   "description": "Whether this is the primary channel for this type"
+                },
+                "external_user_id": {
+                  "type": "string",
+                  "description": "Platform-native user ID (e.g. Slack user ID like U12345). Used to cache user lookups."
+                },
+                "external_chat_id": {
+                  "type": "string",
+                  "description": "Platform-native chat/DM channel ID (e.g. Slack DM channel like D12345). Used to cache DM channel lookups."
                 }
               },
               "required": ["type", "address"]

--- a/assistant/src/config/bundled-skills/contacts/tools/contact-search.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/contact-search.ts
@@ -11,6 +11,8 @@ interface ContactChannel {
   type: string;
   address: string;
   isPrimary: boolean;
+  externalUserId?: string | null;
+  externalChatId?: string | null;
 }
 
 interface ContactResponse {
@@ -28,7 +30,14 @@ function formatContactSummary(c: ContactResponse): string {
     parts.push(`  Interactions: ${c.interactionCount}`);
   if (c.channels.length > 0) {
     const channelList = c.channels
-      .map((ch) => `${ch.type}:${ch.address}${ch.isPrimary ? "*" : ""}`)
+      .map((ch) => {
+        let s = `${ch.type}:${ch.address}${ch.isPrimary ? "*" : ""}`;
+        const extras: string[] = [];
+        if (ch.externalUserId) extras.push(`userId: ${ch.externalUserId}`);
+        if (ch.externalChatId) extras.push(`chatId: ${ch.externalChatId}`);
+        if (extras.length > 0) s += ` (${extras.join(", ")})`;
+        return s;
+      })
       .join(", ");
     parts.push(`  Channels: ${channelList}`);
   }

--- a/assistant/src/config/bundled-skills/contacts/tools/contact-upsert.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/contact-upsert.ts
@@ -11,6 +11,8 @@ interface ContactChannel {
   type: string;
   address: string;
   isPrimary: boolean;
+  externalUserId?: string | null;
+  externalChatId?: string | null;
 }
 
 interface ContactResponse {
@@ -30,7 +32,11 @@ function formatContact(c: ContactResponse): string {
     lines.push("  Channels:");
     for (const ch of c.channels) {
       const primary = ch.isPrimary ? " (primary)" : "";
-      lines.push(`    - ${ch.type}: ${ch.address}${primary}`);
+      const extras: string[] = [];
+      if (ch.externalUserId) extras.push(`userId: ${ch.externalUserId}`);
+      if (ch.externalChatId) extras.push(`chatId: ${ch.externalChatId}`);
+      const extrasStr = extras.length > 0 ? ` (${extras.join(", ")})` : "";
+      lines.push(`    - ${ch.type}: ${ch.address}${primary}${extrasStr}`);
     }
   }
   return lines.join("\n");
@@ -53,12 +59,20 @@ export async function executeContactUpsert(
   }
 
   const rawChannels = input.channels as
-    | Array<{ type: string; address: string; is_primary?: boolean }>
+    | Array<{
+        type: string;
+        address: string;
+        is_primary?: boolean;
+        external_user_id?: string;
+        external_chat_id?: string;
+      }>
     | undefined;
   const channels = rawChannels?.map((ch) => ({
     type: ch.type,
     address: ch.address,
     isPrimary: ch.is_primary,
+    externalUserId: ch.external_user_id,
+    externalChatId: ch.external_chat_id,
   }));
 
   try {

--- a/assistant/src/config/bundled-skills/slack/SKILL.md
+++ b/assistant/src/config/bundled-skills/slack/SKILL.md
@@ -62,6 +62,20 @@ When the user asks to scan or catch up on Slack:
 3. Offer to drill into specific threads with `conversations.replies`
 4. Summarize with attribution: who said what, decisions made, open questions
 
+## User Resolution
+
+When you need to send a DM or look up a Slack user by name, check contacts first to avoid redundant API calls:
+
+1. **Before calling `users.list`**: Use `contact_search` with `query: "<name>"` and `channel_type: "slack"`. If a matching contact has `externalUserId` (Slack user ID) and `externalChatId` (DM channel ID), skip the API lookups and use those IDs directly with `chat.postMessage`.
+
+2. **After resolving via API**: When you had to call `users.list` or `conversations.open` to resolve a user, save the mapping with `contact_upsert` so future lookups are instant:
+   ```
+   contact_upsert {
+     display_name: "<display name>"
+     channels: [{ type: "slack", address: "<slack handle>", external_user_id: "<U...>", external_chat_id: "<D...>" }]
+   }
+   ```
+
 ## Privacy Rules
 
 **Channel privacy must be respected at all times:**

--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -5,6 +5,8 @@
  * implements the MessagingProvider interface.
  */
 
+import { findContactChannel } from "../../../contacts/contact-store.js";
+import { upsertContactChannel } from "../../../contacts/contacts-write.js";
 import type { OAuthConnection } from "../../../oauth/connection.js";
 import { resolveOAuthConnection } from "../../../oauth/connection-resolver.js";
 import { isProviderConnected } from "../../../oauth/oauth-store.js";
@@ -62,6 +64,21 @@ async function resolveUserName(
   const cached = userNameCache.get(userId);
   if (cached) return cached;
 
+  // Check contacts DB for a persistent cache hit
+  try {
+    const result = findContactChannel({
+      channelType: "slack",
+      externalUserId: userId,
+    });
+    if (result) {
+      const name = result.contact.displayName;
+      userNameCache.set(userId, name);
+      return name;
+    }
+  } catch {
+    // Contact lookup failures are non-fatal — fall through to API
+  }
+
   try {
     const resp = await slack.userInfo(auth, userId);
     const name =
@@ -70,6 +87,18 @@ async function resolveUserName(
       resp.user.real_name ||
       resp.user.name;
     userNameCache.set(userId, name);
+
+    // Persist to contacts for future sessions
+    try {
+      upsertContactChannel({
+        sourceChannel: "slack",
+        externalUserId: userId,
+        displayName: name,
+      });
+    } catch {
+      // Non-fatal — caching failure shouldn't break messaging
+    }
+
     return name;
   } catch {
     return userId;
@@ -216,13 +245,29 @@ export const slackProvider: MessagingProvider = {
       (!options?.limit || conversations.length < options.limit)
     );
 
-    // Resolve DM user names
+    // Resolve DM user names and cache channel mappings
     for (const conv of conversations) {
       if (conv.type === "dm" && conv.metadata?.dmUserId) {
-        conv.name = await resolveUserName(
-          auth,
-          conv.metadata.dmUserId as string,
-        );
+        const dmUserId = conv.metadata.dmUserId as string;
+        conv.name = await resolveUserName(auth, dmUserId);
+
+        // Persist the DM channel ID so future sends skip conversations.open
+        try {
+          const existing = findContactChannel({
+            channelType: "slack",
+            externalUserId: dmUserId,
+          });
+          if (existing && !existing.channel.externalChatId) {
+            upsertContactChannel({
+              sourceChannel: "slack",
+              externalUserId: dmUserId,
+              externalChatId: conv.id,
+              displayName: conv.name,
+            });
+          }
+        } catch {
+          // Non-fatal
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- Expose `externalUserId` and `externalChatId` in `contact_search` and `contact_upsert` tools so the assistant can see and save Slack user/channel ID mappings
- Add "User Resolution" section to Slack SKILL.md instructing the assistant to check contacts before making Slack API calls, and persist the mapping after resolving via API
- Enhance the programmatic Slack adapter (`resolveUserName`, `listConversations`) to use the contacts table as a persistent cache layer

## Original prompt
Cache Slack user info in contacts so the assistant doesn't have to look it up each time she sends a DM

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
