### PR TITLE
Fix ThinkingBlockView header click dead zones

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
@@ -52,10 +52,11 @@ struct ThinkingBlockView: View {
                 VIconView(isExpanded ? .chevronUp : .chevronDown, size: 9)
                     .foregroundStyle(VColor.contentTertiary)
             }
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, VSpacing.xs)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .padding(.horizontal, VSpacing.sm)
-        .padding(.vertical, VSpacing.xs)
+        .pointerCursor()
     }
 }


### PR DESCRIPTION
## Summary
- Move `.padding()` inside the `Button` label (before `.contentShape(Rectangle())`) so the entire visible header area is part of the hit-test region — previously, padding applied outside the button with `.buttonStyle(.plain)` created dead zones where clicks were silently dropped
- Add `.pointerCursor()` for visual feedback, matching the design system's `VDisclosureSection` pattern

## Original prompt
fix thinking block toggle not always working when clicking header