### PR TITLE
Fix wake invalidating client auth tokens on every restart

### DIFF
--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -6,6 +6,7 @@ import { dockerResourceNames, wakeContainers } from "../lib/docker.js";
 import { isProcessAlive, stopProcessByPidFile } from "../lib/process";
 import {
   generateLocalSigningKey,
+  loadExistingSigningKey,
   isAssistantWatchModeAvailable,
   isGatewayWatchModeAvailable,
   startLocalDaemon,
@@ -107,7 +108,7 @@ export async function wake(): Promise<void> {
     }
   }
 
-  const signingKey = generateLocalSigningKey();
+  const signingKey = loadExistingSigningKey(resources) ?? generateLocalSigningKey();
 
   if (!daemonRunning) {
     await startLocalDaemon(watch, resources, { foreground, signingKey });

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -207,6 +207,39 @@ export function generateLocalSigningKey(): string {
   return randomBytes(32).toString("hex");
 }
 
+/**
+ * Load an existing signing key from disk for use during `wake`.
+ *
+ * Checks the known persisted key locations (workspace/deprecated/ and
+ * the legacy ~/.vellum/protected/ path). Returns the hex-encoded key if
+ * found, or undefined if no key exists on disk.
+ *
+ * `wake` should prefer this over `generateLocalSigningKey()` so that
+ * existing actor tokens (held by connected clients) remain valid across
+ * daemon/gateway restarts.
+ */
+export function loadExistingSigningKey(
+  resources?: LocalInstanceResources,
+): string | undefined {
+  const instanceDir = resources?.instanceDir ?? join(homedir(), ".vellum");
+  const candidates = [
+    join(instanceDir, ".vellum", "workspace", "deprecated", "actor-token-signing-key"),
+    join(homedir(), ".vellum", "protected", "actor-token-signing-key"),
+  ];
+  for (const keyPath of candidates) {
+    if (!existsSync(keyPath)) continue;
+    try {
+      const raw = readFileSync(keyPath);
+      if (raw.length === 32) {
+        return raw.toString("hex");
+      }
+    } catch {
+      // Fall through to next candidate
+    }
+  }
+  return undefined;
+}
+
 type DaemonStartOptions = {
   foreground?: boolean;
   defaultWorkspaceConfigPath?: string;


### PR DESCRIPTION
## Summary
- `wake` was generating a fresh HMAC signing key on every restart, invalidating all existing client actor tokens
- Clients got stuck in a "Disconnected" state because the token refresh endpoint also validates signatures against the new key
- Added `loadExistingSigningKey()` to load the persisted key from disk, falling back to `generateLocalSigningKey()` only when no key exists

## Original prompt
User reported "Disconnected from Velissa" / "Your assistant is unreachable" after a restart. Root cause: signing key mismatch between gateway and stored client tokens.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
