### PR TITLE
Lower minimum zoom level from 75% to 50%

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ZoomManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ZoomManager.swift
@@ -3,7 +3,7 @@ import SwiftUI
 @MainActor
 @Observable
 final class ZoomManager {
-    static let zoomSteps: [CGFloat] = [0.75, 0.80, 0.90, 1.00, 1.10, 1.25, 1.50, 1.75, 2.00]
+    static let zoomSteps: [CGFloat] = [0.50, 0.60, 0.70, 0.75, 0.80, 0.90, 1.00, 1.10, 1.25, 1.50, 1.75, 2.00]
 
     var zoomLevel: CGFloat {
         didSet { UserDefaults.standard.set(zoomLevel, forKey: "windowZoomLevel") }


### PR DESCRIPTION
## Summary
- Extended the zoom steps array in `ZoomManager.swift` to allow zooming out to 50% (previously 75%)
- Added intermediate steps at 60% and 70% for smoother zoom granularity below 75%

## Original prompt
the desktop app should allow zooming out to 50% instead of 75%