### PR TITLE
Fix user message rendering after assistant response in history merge

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1994,6 +1994,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
                 if !isDuplicate { localOnly.append(local) }
             }
             var mergedMessages = chatMessages + localOnly
+            mergedMessages.sort { $0.timestamp < $1.timestamp }
             let hasModelCommand = applyHistoryResponseMarkers(to: &mergedMessages)
             self.messages = mergedMessages
             self.reconnectLatchTimeoutTask?.cancel()
@@ -2014,6 +2015,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
                 uniqueHistory = chatMessages
             }
             var mergedMessages = uniqueHistory + self.messages
+            mergedMessages.sort { $0.timestamp < $1.timestamp }
             let hasModelCommand = applyHistoryResponseMarkers(to: &mergedMessages)
             self.messages = mergedMessages
             refreshModelMetadataIfNeeded(hasModelCommand)


### PR DESCRIPTION
## Summary
- Sort merged messages by timestamp in `populateFromHistory` after both the reconnect catch-up merge and the history-arrived-after-send merge
- Fixes a bug where a user message could appear after the assistant message that responds to it when: (1) an SSE reconnect triggers a history reload, or (2) history arrives after the user already sent a message
- Swift's `sort(by:)` is stable since Swift 5, so server-ordered messages with equal timestamps preserve their relative order

## Original prompt
this user message is showing up after the assistant message that's responding to it - that doesn't make any sense. I drew an arrow showing where it should have been rendered
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
