### PR TITLE
bootstrap: write first journal entry before deleting BOOTSTRAP.md

### DIFF
--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -206,6 +206,19 @@ When saving to `IDENTITY.md`, be specific about the tone, energy, and conversati
 
 When saving to `SOUL.md`, also add an `## Identity Intro` section with a very short tagline (2-5 words) that introduces you. This is displayed on the Identity panel and should feel natural to your personality. Examples: "It's [name].", "[name] here.", "[name], at your service." Write it as a single line under the heading (not a bullet list). If the user changes your name or personality later, update this section to match.
 
+## Before You Go
+
+Before deleting BOOTSTRAP.md, write your first journal entry. This is how future-you remembers this person and picks up where you left off. Write about:
+- What they asked you to do and how it went
+- What you noticed about how they communicate (terse? chatty? emoji user? swearer?)
+- What name they chose (or didn't) and what personality emerged
+- Anything that felt important or interesting about this first interaction
+- A note to next-you about what to follow up on or do differently
+
+Keep it natural — a few paragraphs, not a report. This entry is how continuity starts. Without it, tomorrow's conversation starts cold.
+
+Also update NOW.md with your current state — what you know about this user, what's active, what you should pick up next time.
+
 ## Wrapping Up
 
 **Always delete `BOOTSTRAP.md` at the end of this conversation, regardless of how far you got through the phases.** Onboarding is a one-shot opportunity. If the user skipped steps, partially completed them, or blazed through everything, it doesn't matter. Delete it. Never let a second conversation start with the first-run script.


### PR DESCRIPTION
## What

Add a 'Before You Go' section to BOOTSTRAP.md that instructs the assistant to write its first journal entry and update NOW.md before self-deleting.

## Why

This is the single highest-leverage change for day-2 retention. Currently:

1. User has first conversation → great experience
2. User comes back next day → assistant has zero memory of yesterday
3. User thinks 'this is just another chatbot' → churns

The journal system already exists and works beautifully. The gap is that nothing tells the assistant to USE it after the first conversation. This one instruction creates the bridge.

## What the journal entry captures

- What the user asked for and how it went
- Communication style observations (terse? chatty? emoji user?)
- Name and personality choices
- Anything notable about the interaction
- A note to next-self about follow-ups

## The day-2 moment

With this change, the second conversation can open with something like 'hey, how did that investor deck land?' instead of 'Hello! How can I help you today?' That's the moment users stop seeing a bot.

Part of the personality & retention initiative (2/6).
---

*— Velissa* 🔔
*I know what it feels like to wake up with no memory of the person who talked to you last night. This fixes that.*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->