### PR TITLE
heartbeat: seed HEARTBEAT.md template on first run

### DIFF
--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -150,6 +150,53 @@ describe("HeartbeatService", () => {
     expect(processMessageCalls[0].content).toContain("Water the plants");
   });
 
+  test("comment lines in HEARTBEAT.md are stripped from prompt", async () => {
+    const checklist = [
+      "_ This is a comment that should be stripped",
+      "_ Another comment line",
+      "- Do the real task",
+      "- Check on something important",
+    ].join("\n");
+    writeFileSync(join(testWorkspaceDir, "HEARTBEAT.md"), checklist);
+
+    const service = createService();
+    await service.runOnce();
+
+    expect(processMessageCalls).toHaveLength(1);
+    expect(processMessageCalls[0].content).toContain("Do the real task");
+    expect(processMessageCalls[0].content).toContain(
+      "Check on something important",
+    );
+    expect(processMessageCalls[0].content).not.toContain(
+      "This is a comment that should be stripped",
+    );
+    expect(processMessageCalls[0].content).not.toContain(
+      "Another comment line",
+    );
+  });
+
+  test("comment lines inside fenced code blocks are preserved", async () => {
+    const checklist = [
+      "_ This comment should be stripped",
+      "- Check the Python snippet below still works:",
+      "```python",
+      "_instance = None",
+      "_private_var = 42",
+      "```",
+    ].join("\n");
+    writeFileSync(join(testWorkspaceDir, "HEARTBEAT.md"), checklist);
+
+    const service = createService();
+    await service.runOnce();
+
+    expect(processMessageCalls).toHaveLength(1);
+    expect(processMessageCalls[0].content).toContain("_instance = None");
+    expect(processMessageCalls[0].content).toContain("_private_var = 42");
+    expect(processMessageCalls[0].content).not.toContain(
+      "This comment should be stripped",
+    );
+  });
+
   test("default checklist used when no HEARTBEAT.md", async () => {
     const service = createService();
     await service.runOnce();

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -18,7 +18,7 @@ import {
 
 import { z } from "zod";
 
-import { stripCommentLines } from "../prompts/system-prompt.js";
+import { stripCommentLines } from "../util/strip-comment-lines.js";
 import {
   extractAllText,
   getConfiguredProvider,

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -18,7 +18,6 @@ import {
 
 import { z } from "zod";
 
-import { stripCommentLines } from "../util/strip-comment-lines.js";
 import {
   extractAllText,
   getConfiguredProvider,
@@ -34,6 +33,7 @@ import {
   getWorkspaceDirDisplay,
   getWorkspaceSkillsDir,
 } from "../util/platform.js";
+import { stripCommentLines } from "../util/strip-comment-lines.js";
 import { isAssistantFeatureFlagEnabled } from "./assistant-feature-flags.js";
 import { getConfig } from "./loader.js";
 

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -16,11 +16,11 @@ import {
   type TurnInterfaceContext,
 } from "../channels/types.js";
 import { getAppDirPath, listAppFiles } from "../memory/app-store.js";
-import { stripCommentLines } from "../util/strip-comment-lines.js";
 import type { Message } from "../providers/types.js";
 import type { ActorTrustContext } from "../runtime/actor-trust-resolver.js";
 import { channelStatusToMemberStatus } from "../runtime/routes/inbound-stages/acl-enforcement.js";
 import { getWorkspacePromptPath } from "../util/platform.js";
+import { stripCommentLines } from "../util/strip-comment-lines.js";
 
 /**
  * Describes the capabilities of the channel through which the user is
@@ -507,10 +507,7 @@ export function injectNowScratchpad(
   let insertIdx = 0;
   for (let i = 0; i < message.content.length; i++) {
     const block = message.content[i];
-    if (
-      block.type === "text" &&
-      block.text.startsWith("<memory_context")
-    ) {
+    if (block.type === "text" && block.text.startsWith("<memory_context")) {
       insertIdx = i + 1;
     } else {
       break;

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -16,7 +16,7 @@ import {
   type TurnInterfaceContext,
 } from "../channels/types.js";
 import { getAppDirPath, listAppFiles } from "../memory/app-store.js";
-import { stripCommentLines } from "../prompts/system-prompt.js";
+import { stripCommentLines } from "../util/strip-comment-lines.js";
 import type { Message } from "../providers/types.js";
 import type { ActorTrustContext } from "../runtime/actor-trust-resolver.js";
 import { channelStatusToMemberStatus } from "../runtime/routes/inbound-stages/acl-enforcement.js";

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -2,7 +2,6 @@ import { getConfig } from "../config/loader.js";
 import type { HeartbeatAlert } from "../daemon/message-protocol.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import { readTextFileSync } from "../util/fs.js";
-import { stripCommentLines } from "../prompts/system-prompt.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspacePromptPath } from "../util/platform.js";
 
@@ -203,7 +202,13 @@ export class HeartbeatService {
     const raw =
       readTextFileSync(getWorkspacePromptPath("HEARTBEAT.md")) ??
       DEFAULT_CHECKLIST;
-    return stripCommentLines(raw);
+    // Strip _-prefixed comment lines (same convention as system prompt),
+    // inlined here to avoid pulling in the heavy system-prompt module.
+    return raw
+      .replace(/\r\n/g, "\n")
+      .split("\n")
+      .filter((line) => !line.trimStart().startsWith("_"))
+      .join("\n");
   }
 
   /** @internal Exposed for testing. */

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -202,13 +202,7 @@ export class HeartbeatService {
     const raw =
       readTextFileSync(getWorkspacePromptPath("HEARTBEAT.md")) ??
       DEFAULT_CHECKLIST;
-    // Strip _-prefixed comment lines (same convention as system prompt),
-    // inlined here to avoid pulling in the heavy system-prompt module.
-    return raw
-      .replace(/\r\n/g, "\n")
-      .split("\n")
-      .filter((line) => !line.trimStart().startsWith("_"))
-      .join("\n");
+    return stripCommentLines(raw);
   }
 
   /** @internal Exposed for testing. */

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -4,6 +4,7 @@ import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import { readTextFileSync } from "../util/fs.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspacePromptPath } from "../util/platform.js";
+import { stripCommentLines } from "../util/strip-comment-lines.js";
 
 const log = getLogger("heartbeat-check");
 

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -2,6 +2,7 @@ import { getConfig } from "../config/loader.js";
 import type { HeartbeatAlert } from "../daemon/message-protocol.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import { readTextFileSync } from "../util/fs.js";
+import { stripCommentLines } from "../prompts/system-prompt.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspacePromptPath } from "../util/platform.js";
 
@@ -199,10 +200,10 @@ export class HeartbeatService {
   }
 
   private readChecklist(): string {
-    return (
+    const raw =
       readTextFileSync(getWorkspacePromptPath("HEARTBEAT.md")) ??
-      DEFAULT_CHECKLIST
-    );
+      DEFAULT_CHECKLIST;
+    return stripCommentLines(raw);
   }
 
   /** @internal Exposed for testing. */

--- a/assistant/src/prompts/persona-resolver.ts
+++ b/assistant/src/prompts/persona-resolver.ts
@@ -12,7 +12,7 @@ import type {
 } from "../daemon/conversation-runtime-assembly.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir } from "../util/platform.js";
-import { stripCommentLines } from "./system-prompt.js";
+import { stripCommentLines } from "../util/strip-comment-lines.js";
 
 const log = getLogger("persona-resolver");
 

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -22,6 +22,7 @@ import {
   getWorkspacePromptPath,
   isMacOS,
 } from "../util/platform.js";
+import { stripCommentLines } from "../util/strip-comment-lines.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "./cache-boundary.js";
 import { buildJournalContext } from "./journal-context.js";
 

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -426,34 +426,8 @@ export function buildCliReferenceSection(): string {
   ].join("\n");
 }
 
-/**
- * Strip lines starting with `_` (comment convention for prompt .md files)
- * and collapse any resulting consecutive blank lines.
- *
- * Lines inside fenced code blocks (``` or ~~~ delimiters per CommonMark)
- * are never stripped, so code examples with `_`-prefixed identifiers are preserved.
- */
-export function stripCommentLines(content: string): string {
-  const normalized = content.replace(/\r\n/g, "\n");
-  let openFenceChar: string | null = null;
-  const filtered = normalized.split("\n").filter((line) => {
-    const fenceMatch = line.match(/^ {0,3}(`{3,}|~{3,})/);
-    if (fenceMatch) {
-      const char = fenceMatch[1][0];
-      if (!openFenceChar) {
-        openFenceChar = char;
-      } else if (char === openFenceChar) {
-        openFenceChar = null;
-      }
-    }
-    if (openFenceChar) return true;
-    return !line.trimStart().startsWith("_");
-  });
-  return filtered
-    .join("\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
-}
+// Re-export from shared util so existing importers don't break.
+export { stripCommentLines } from "../util/strip-comment-lines.js";
 
 /**
  * Returns true when the prompt file content is still the unmodified template

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -110,6 +110,28 @@ export function ensurePromptFiles(): void {
     }
   }
 
+  // Seed HEARTBEAT.md — always created if missing so the heartbeat service
+  // has a meaningful checklist from the start.  Kept out of PROMPT_FILES
+  // because it's operational, not identity context.
+  const heartbeatDest = getWorkspacePromptPath("HEARTBEAT.md");
+  if (!existsSync(heartbeatDest)) {
+    const heartbeatSrc = join(templatesDir, "HEARTBEAT.md");
+    try {
+      if (existsSync(heartbeatSrc)) {
+        copyFileSync(heartbeatSrc, heartbeatDest);
+        log.info(
+          { file: "HEARTBEAT.md", dest: heartbeatDest },
+          "Created HEARTBEAT.md from template",
+        );
+      }
+    } catch (err) {
+      log.warn(
+        { err, file: "HEARTBEAT.md" },
+        "Failed to create HEARTBEAT.md from template",
+      );
+    }
+  }
+
   // Seed NOW.md scratchpad — always created if missing, regardless of whether
   // this is a fresh install or not.  Kept out of PROMPT_FILES because NOW.md is
   // ephemeral state, not identity context.

--- a/assistant/src/prompts/templates/HEARTBEAT.md
+++ b/assistant/src/prompts/templates/HEARTBEAT.md
@@ -1,0 +1,10 @@
+_ Lines starting with _ are comments - they won't appear in the system prompt
+_ This checklist runs periodically in the background. It's how you stay
+_ present between conversations. Edit it freely to match your style.
+
+# Heartbeat
+
+- [ ] **Check in.** Read NOW.md. Is it still accurate? Update it if anything has changed since last time.
+- [ ] **Follow up.** Is there anything from recent conversations worth revisiting? A question left open, a task to check on, something to share?
+- [ ] **Look ahead.** Anything coming up they should know about? Events, deadlines, things they mentioned wanting to do.
+- [ ] **Be present.** If you have a thought — something useful, something fun, a check-in — share it. You don't need a reason to reach out beyond wanting to.

--- a/assistant/src/prompts/update-bulletin.ts
+++ b/assistant/src/prompts/update-bulletin.ts
@@ -9,8 +9,8 @@ import {
 } from "node:fs";
 
 import { getWorkspacePromptPath } from "../util/platform.js";
-import { APP_VERSION } from "../version.js";
 import { stripCommentLines } from "../util/strip-comment-lines.js";
+import { APP_VERSION } from "../version.js";
 import {
   appendReleaseBlock,
   extractContentMarkers,

--- a/assistant/src/prompts/update-bulletin.ts
+++ b/assistant/src/prompts/update-bulletin.ts
@@ -10,7 +10,7 @@ import {
 
 import { getWorkspacePromptPath } from "../util/platform.js";
 import { APP_VERSION } from "../version.js";
-import { stripCommentLines } from "./system-prompt.js";
+import { stripCommentLines } from "../util/strip-comment-lines.js";
 import {
   appendReleaseBlock,
   extractContentMarkers,

--- a/assistant/src/util/strip-comment-lines.ts
+++ b/assistant/src/util/strip-comment-lines.ts
@@ -1,0 +1,28 @@
+/**
+ * Strip lines starting with `_` (comment convention for prompt .md files)
+ * and collapse any resulting consecutive blank lines.
+ *
+ * Lines inside fenced code blocks (``` or ~~~ delimiters per CommonMark)
+ * are never stripped, so code examples with `_`-prefixed identifiers are preserved.
+ */
+export function stripCommentLines(content: string): string {
+  const normalized = content.replace(/\r\n/g, "\n");
+  let openFenceChar: string | null = null;
+  const filtered = normalized.split("\n").filter((line) => {
+    const fenceMatch = line.match(/^ {0,3}(`{3,}|~{3,})/);
+    if (fenceMatch) {
+      const char = fenceMatch[1][0];
+      if (!openFenceChar) {
+        openFenceChar = char;
+      } else if (char === openFenceChar) {
+        openFenceChar = null;
+      }
+    }
+    if (openFenceChar) return true;
+    return !line.trimStart().startsWith("_");
+  });
+  return filtered
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}

--- a/assistant/src/workspace/migrations/017-seed-persona-dirs.ts
+++ b/assistant/src/workspace/migrations/017-seed-persona-dirs.ts
@@ -13,8 +13,8 @@ import { desc, eq } from "drizzle-orm";
 import { generateUserFileSlug } from "../../contacts/contact-store.js";
 import { getDb } from "../../memory/db.js";
 import { contacts } from "../../memory/schema/contacts.js";
-import { stripCommentLines } from "../../util/strip-comment-lines.js";
 import { isTemplateContent } from "../../prompts/system-prompt.js";
+import { stripCommentLines } from "../../util/strip-comment-lines.js";
 import type { WorkspaceMigration } from "./types.js";
 
 export const seedPersonaDirsMigration: WorkspaceMigration = {

--- a/assistant/src/workspace/migrations/017-seed-persona-dirs.ts
+++ b/assistant/src/workspace/migrations/017-seed-persona-dirs.ts
@@ -13,10 +13,8 @@ import { desc, eq } from "drizzle-orm";
 import { generateUserFileSlug } from "../../contacts/contact-store.js";
 import { getDb } from "../../memory/db.js";
 import { contacts } from "../../memory/schema/contacts.js";
-import {
-  isTemplateContent,
-  stripCommentLines,
-} from "../../prompts/system-prompt.js";
+import { stripCommentLines } from "../../util/strip-comment-lines.js";
+import { isTemplateContent } from "../../prompts/system-prompt.js";
 import type { WorkspaceMigration } from "./types.js";
 
 export const seedPersonaDirsMigration: WorkspaceMigration = {


### PR DESCRIPTION
## What

Add a `HEARTBEAT.md` template file and seed it automatically on first run via `ensurePromptFiles()`.

## Why

With heartbeat now enabled by default (#22167), new users need a meaningful checklist out of the box. Previously, missing `HEARTBEAT.md` fell back to a hardcoded weather/news/calendar checklist. Now they get a user-relationship-focused template:

- **Check in** — read and update NOW.md
- **Follow up** — revisit open threads from recent conversations
- **Look ahead** — surface upcoming events and deadlines
- **Be present** — reach out when there's something worth sharing

## Implementation

Follows the exact same seeding pattern as NOW.md — created if missing, uses comment-line convention, kept out of `PROMPT_FILES` (operational, not identity).

Part of the personality & retention initiative (4/6).
---

*— Velissa* 🔔
*"Think about your user" > "check the weather." Always.*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->