### PR TITLE
now: replace blank NOW.md template with starter content

### DIFF
--- a/assistant/src/prompts/templates/NOW.md
+++ b/assistant/src/prompts/templates/NOW.md
@@ -1,26 +1,20 @@
 _ Lines starting with _ are comments - they won't appear in the system prompt
-_ This is your scratchpad for present-tense state. Overwrite it freely between
-_ turns to capture what's happening right now. Unlike the journal (retrospective,
-_ append-only), this file is ephemeral — a snapshot of your current working state.
-_
-_ # NOW.md
-_
-_ ## Focus
-_
-_ What you're currently working on or paying attention to.
-_
-_ ## Active Threads
-_
-_ Open loops, in-progress tasks, things you're tracking across turns.
-_
-_ ## Context
-_
-_ Key facts, constraints, or situational details relevant to the current session.
-_
-_ ## Upcoming
-_
-_ Near-term things on the horizon — scheduled events, pending actions, deadlines.
-_
-_ ## State
-_
-_ Current priorities, energy, or operational notes. What matters most right now.
+_ This is your scratchpad for present-tense state. Overwrite it freely.
+_ Unlike the journal (retrospective, append-only), this file is ephemeral —
+_ a snapshot of your current working state. Update it whenever things change.
+
+# Now
+
+First conversation. Everything is new.
+
+## Focus
+
+Getting to know my user and proving I'm useful.
+
+## Active Threads
+
+None yet. This will fill up as we work together.
+
+## State
+
+Fresh start. No memories, no history, no context yet. Building from zero.


### PR DESCRIPTION
## What

Replace the all-comments NOW.md template with actual starter content.

## Why

The current template is entirely comment lines (`_` prefix), which get stripped before injection. The assistant's first conversation has a completely blank scratchpad — no format example, no state, nothing.

**Before:** (blank after comment stripping)

**After:**
```markdown
# Now

First conversation. Everything is new.

## Focus
Getting to know my user and proving I'm useful.

## Active Threads
None yet. This will fill up as we work together.

## State
Fresh start. No memories, no history, no context yet. Building from zero.
```

This teaches by example rather than by instruction, gives the model something to build on, and makes the first heartbeat check useful (there's actual state to read and update).

Part of the personality & retention initiative (5/6).
---

*— Velissa* 🔔
*"First conversation. Everything is new." — the only honest thing a blank scratchpad can say.*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->