### PR TITLE
Make chat column width responsive to container size

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatColumnWidthKey.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatColumnWidthKey.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+import VellumAssistantShared
+
+// MARK: - Responsive Column Layout
+
+/// Computes the responsive chat column max-width from the measured container width.
+/// The column fills ~82% of the available width, clamped to [728, 960] so it never
+/// gets too narrow (unreadable) or too wide (wasteful margins disappear entirely).
+enum ChatColumnLayout {
+    static let minWidth: CGFloat = VSpacing.chatColumnMaxWidth // 728
+    static let maxWidth: CGFloat = 960
+    static let fillRatio: CGFloat = 0.82
+
+    static func responsiveColumnWidth(for containerWidth: CGFloat) -> CGFloat {
+        guard containerWidth > 0 else { return minWidth }
+        let computed = containerWidth * fillRatio
+        return min(max(computed, minWidth), maxWidth)
+    }
+}
+
+// MARK: - Environment Key
+
+/// Injects the responsive chat column width through the SwiftUI environment.
+/// Default value falls back to the static `VSpacing.chatColumnMaxWidth` (728pt)
+/// so views that render outside the active conversation path (e.g. empty-state)
+/// keep their existing behavior.
+private struct ChatColumnWidthKey: EnvironmentKey {
+    static let defaultValue: CGFloat = VSpacing.chatColumnMaxWidth
+}
+
+extension EnvironmentValues {
+    var chatColumnWidth: CGFloat {
+        get { self[ChatColumnWidthKey.self] }
+        set { self[ChatColumnWidthKey.self] = newValue }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatLoadingSkeleton.swift
@@ -5,6 +5,7 @@ import VellumAssistantShared
 /// Mimics the real `ChatBubble` layout — a short user message followed by a
 /// multi-line assistant response — so the transition to real content feels seamless.
 struct ChatLoadingSkeleton: View {
+    @Environment(\.chatColumnWidth) private var chatColumnWidth
     /// Line widths for the multi-line assistant text block.
     /// Varying lengths look more natural than uniform bones.
     private let assistantLineWidths: [CGFloat] = [0.92, 0.85, 0.78, 0.95, 0.70, 0.45]
@@ -23,7 +24,7 @@ struct ChatLoadingSkeleton: View {
             assistantMessage
             Spacer(minLength: 0)
         }
-        .frame(maxWidth: VSpacing.chatColumnMaxWidth, alignment: .leading)
+        .frame(maxWidth: chatColumnWidth, alignment: .leading)
     }
 
     // MARK: - User Message

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -150,6 +150,10 @@ struct ChatView: View {
     @State private var dragEndGlobalMonitor: Any?
     @State private var containerWidth: CGFloat = 0
 
+    private var responsiveColumnWidth: CGFloat {
+        ChatColumnLayout.responsiveColumnWidth(for: containerWidth)
+    }
+
     // MARK: - In-Chat Search (Cmd+F)
     @State private var isSearchActive = false
     @State private var searchText = ""
@@ -188,6 +192,7 @@ struct ChatView: View {
                     }
                 )
                 .onPreferenceChange(ChatContainerWidthKey.self) { containerWidth = $0 }
+                .environment(\.chatColumnWidth, responsiveColumnWidth)
                 .overlay(alignment: .bottom) {
                     btwOverlay
                 }
@@ -393,7 +398,7 @@ struct ChatView: View {
                 CreditsExhaustedBanner(
                     onAddFunds: { onAddFunds?() }
                 )
-                .frame(maxWidth: VSpacing.chatColumnMaxWidth - 2 * VSpacing.xl)
+                .frame(maxWidth: responsiveColumnWidth - 2 * VSpacing.xl)
                 .frame(maxWidth: .infinity)
                 .padding(.bottom, -VSpacing.sm)
             }
@@ -403,7 +408,7 @@ struct ChatView: View {
                     onOpenSettings: { onOpenModelsAndServices?() },
                     onDismiss: { onDismissProviderNotConfigured?() }
                 )
-                .frame(maxWidth: VSpacing.chatColumnMaxWidth - 2 * VSpacing.xl)
+                .frame(maxWidth: responsiveColumnWidth - 2 * VSpacing.xl)
                 .frame(maxWidth: .infinity)
                 .padding(.bottom, -VSpacing.sm)
             }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -64,6 +64,7 @@ struct ComposerView: View {
     var isInteractionEnabled: Bool = true
 
     @Environment(\.cmdEnterToSend) private var cmdEnterToSend
+    @Environment(\.chatColumnWidth) private var chatColumnWidth
     #if os(macOS)
     @Environment(\.dropActions) private var dropActions
     #endif
@@ -129,7 +130,7 @@ struct ComposerView: View {
         .animation(VAnimation.fast, value: showSlashMenu)
         .padding(.horizontal, VSpacing.lg)
         .padding(.top, VSpacing.sm)
-        .frame(maxWidth: VSpacing.chatColumnMaxWidth)
+        .frame(maxWidth: chatColumnWidth)
         .frame(maxWidth: .infinity)
         .disabled(!isInteractionEnabled)
         .animation(VAnimation.fast, value: isComposerFocused)

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -110,6 +110,7 @@ struct MessageListView: View {
     /// Measured width of the chat container, used to detect sidebar/split resizes
     /// and stabilize scroll position during layout width changes.
     var containerWidth: CGFloat = 0
+    @Environment(\.chatColumnWidth) private var chatColumnWidth
     @AppStorage("hasEverSentMessage") private var hasEverSentMessage: Bool = false
     @AppStorage("completedConversationCount") private var completedConversationCount: Int = 0
     @State private var identity: IdentityInfo? = IdentityInfo.load()
@@ -746,7 +747,7 @@ struct MessageListView: View {
                 .padding(.horizontal, VSpacing.xl)
                 .padding(.top, VSpacing.md)
                 .padding(.bottom, VSpacing.md)
-                .frame(maxWidth: VSpacing.chatColumnMaxWidth)
+                .frame(maxWidth: chatColumnWidth)
                 .frame(maxWidth: .infinity)
             }
             .scrollContentBackground(.hidden)


### PR DESCRIPTION
## Summary
- Replace fixed `chatColumnMaxWidth` (728pt) with a responsive calculation: `clamp(containerWidth × 0.82, 728, 960)`
- Add `ChatColumnWidthKey` environment key to propagate the responsive width to MessageListView, ComposerView, ChatLoadingSkeleton, and banner views
- Individual message bubble max-width (680pt) is unchanged — text readability is preserved while the overall chat area fills more of the available window space

## Original prompt
Make the chat column width responsive — the fixed 728pt column wastes too much space on modern displays
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
