### PR TITLE
Record LLM logs and persist watch messages

### DIFF
--- a/assistant/src/daemon/conversation-notifiers.ts
+++ b/assistant/src/daemon/conversation-notifiers.ts
@@ -22,6 +22,7 @@ import {
   addMessage,
   provenanceFromTrustContext,
 } from "../memory/conversation-crud.js";
+import { backfillMessageIdOnLogs } from "../memory/llm-request-log-store.js";
 import type { Message } from "../providers/types.js";
 import type { WatchSession } from "../tools/watch/watch-state.js";
 import {
@@ -69,37 +70,73 @@ export function registerConversationNotifiers(
     });
   });
 
-  registerWatchCommentaryNotifier(conversationId, (_session: WatchSession) => {
-    const commentary = lastCommentaryByConversation.get(conversationId);
-    if (commentary) {
-      lastCommentaryByConversation.delete(conversationId);
-      ctx.sendToClient({
-        type: "assistant_text_delta",
-        text: commentary,
-        conversationId: conversationId,
-      });
-      ctx.sendToClient({
-        type: "message_complete",
-        conversationId: conversationId,
-      });
-    }
-  });
+  registerWatchCommentaryNotifier(
+    conversationId,
+    async (_session: WatchSession) => {
+      const commentary = lastCommentaryByConversation.get(conversationId);
+      if (commentary) {
+        lastCommentaryByConversation.delete(conversationId);
 
-  registerWatchCompletionNotifier(conversationId, (_session: WatchSession) => {
-    const summary = lastSummaryByConversation.get(conversationId);
-    if (summary) {
-      lastSummaryByConversation.delete(conversationId);
-      ctx.sendToClient({
-        type: "assistant_text_delta",
-        text: summary,
-        conversationId: conversationId,
-      });
-      ctx.sendToClient({
-        type: "message_complete",
-        conversationId: conversationId,
-      });
-    }
-  });
+        const msg = await addMessage(
+          conversationId,
+          "assistant",
+          JSON.stringify([{ type: "text", text: commentary }]),
+          provenanceFromTrustContext(ctx.trustContext),
+        );
+        ctx.messages.push(createAssistantMessage(commentary));
+
+        try {
+          backfillMessageIdOnLogs(conversationId, msg.id);
+        } catch {
+          // non-fatal — message is persisted even if log linkage fails
+        }
+
+        ctx.sendToClient({
+          type: "assistant_text_delta",
+          text: commentary,
+          conversationId: conversationId,
+        });
+        ctx.sendToClient({
+          type: "message_complete",
+          conversationId: conversationId,
+        });
+      }
+    },
+  );
+
+  registerWatchCompletionNotifier(
+    conversationId,
+    async (_session: WatchSession) => {
+      const summary = lastSummaryByConversation.get(conversationId);
+      if (summary) {
+        lastSummaryByConversation.delete(conversationId);
+
+        const msg = await addMessage(
+          conversationId,
+          "assistant",
+          JSON.stringify([{ type: "text", text: summary }]),
+          provenanceFromTrustContext(ctx.trustContext),
+        );
+        ctx.messages.push(createAssistantMessage(summary));
+
+        try {
+          backfillMessageIdOnLogs(conversationId, msg.id);
+        } catch {
+          // non-fatal — message is persisted even if log linkage fails
+        }
+
+        ctx.sendToClient({
+          type: "assistant_text_delta",
+          text: summary,
+          conversationId: conversationId,
+        });
+        ctx.sendToClient({
+          type: "message_complete",
+          conversationId: conversationId,
+        });
+      }
+    },
+  );
 
   registerCallQuestionNotifier(
     conversationId,

--- a/assistant/src/daemon/watch-handler.ts
+++ b/assistant/src/daemon/watch-handler.ts
@@ -1,3 +1,4 @@
+import { recordRequestLog } from "../memory/llm-request-log-store.js";
 import {
   extractText,
   getConfiguredProvider,
@@ -164,6 +165,20 @@ async function generateCommentary(session: WatchSession): Promise<void> {
       },
     );
 
+    if (response.rawRequest && response.rawResponse) {
+      try {
+        recordRequestLog(
+          session.conversationId,
+          JSON.stringify(response.rawRequest),
+          JSON.stringify(response.rawResponse),
+          undefined,
+          response.actualProvider ?? provider.name,
+        );
+      } catch (err) {
+        log.warn({ err }, "Failed to persist watch commentary LLM log");
+      }
+    }
+
     const commentaryText = extractText(response);
 
     if (commentaryText && commentaryText !== "SKIP") {
@@ -309,6 +324,20 @@ export async function generateSummary(session: WatchSession): Promise<void> {
         },
       },
     );
+
+    if (response.rawRequest && response.rawResponse) {
+      try {
+        recordRequestLog(
+          session.conversationId,
+          JSON.stringify(response.rawRequest),
+          JSON.stringify(response.rawResponse),
+          undefined,
+          response.actualProvider ?? provider.name,
+        );
+      } catch (err) {
+        log.warn({ err }, "Failed to persist watch summary LLM log");
+      }
+    }
 
     log.debug(
       { watchId: session.watchId },


### PR DESCRIPTION
## Summary
- Watch commentary and summary messages were sent to the client via SSE without recording the LLM call or persisting the message to the database, causing "0 LLM calls" in the LLM Context Inspector
- Added `recordRequestLog()` in `watch-handler.ts` after each `provider.sendMessage()` call to capture the raw request/response payloads
- Added `addMessage()` + `backfillMessageIdOnLogs()` in the watch notifiers in `conversation-notifiers.ts`, matching the existing call question notifier pattern

## Original prompt
Fix watch messages showing "0 LLM calls" in LLM Context Inspector

🤖 Generated with [Claude Code](https://claude.com/claude-code)