### PR TITLE
Fix Swift 6 actor-isolation warning in AttachmentThumbnailView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AttachmentThumbnailView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AttachmentThumbnailView.swift
@@ -41,15 +41,13 @@ struct AttachmentThumbnailView: View {
         .task(id: url) {
             guard isImage else { return }
             let fileURL = url
+            let maxPixels = Int(Self.thumbnailSize) * 2 // 2x for Retina
             // Load image data off the main thread using thread-safe CGImageSource APIs.
             // NSImage is NOT thread-safe and must not be used off the main thread.
             let cgImage = await Task.detached {
                 guard let source = CGImageSourceCreateWithURL(fileURL as CFURL, nil) else {
                     return nil as CGImage?
                 }
-                // Decode at thumbnail size instead of full resolution to avoid
-                // large pixel buffer allocations for high-res screenshots/GIFs.
-                let maxPixels = Int(AttachmentThumbnailView.thumbnailSize) * 2 // 2x for Retina
                 let options: [CFString: Any] = [
                     kCGImageSourceCreateThumbnailFromImageAlways: true,
                     kCGImageSourceThumbnailMaxPixelSize: maxPixels,


### PR DESCRIPTION
## Summary
- Moved `thumbnailSize` read out of `Task.detached` and into the calling (main-actor) context, eliminating the Swift 6 concurrency warning about cross-actor access to a `@MainActor`-isolated static property.

## Original prompt
```
fix: Swift 6 warning — main actor-isolated static property 'thumbnailSize' cannot be accessed from outside of the actor
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
