### PR TITLE
Increase thinking block max height to show more lines

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
@@ -26,7 +26,7 @@ struct ThinkingBlockView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(VSpacing.sm)
                 }
-                .frame(maxHeight: 300)
+                .frame(maxHeight: 600)
                 .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }


### PR DESCRIPTION
## Summary
- Doubled the `maxHeight` of the thinking block ScrollView from 300 to 600 points so more reasoning text is visible without scrolling.

## Original prompt
Let's display more lines in this thinking block here (screenshot of truncated Thought process block)