### PR TITLE
heartbeat: replace generic checklist with continuity-focused default …

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -65,6 +65,28 @@ export function ensurePromptFiles(): void {
     }
   }
 
+  // Seed HEARTBEAT.md if it doesn't exist — always, not just on first run.
+  // This gives new and existing users a meaningful default checklist focused
+  // on continuity and presence rather than the hardcoded weather/news fallback.
+  const heartbeatDest = getWorkspacePromptPath("HEARTBEAT.md");
+  if (!existsSync(heartbeatDest)) {
+    const heartbeatSrc = join(templatesDir, "HEARTBEAT.md");
+    try {
+      if (existsSync(heartbeatSrc)) {
+        copyFileSync(heartbeatSrc, heartbeatDest);
+        log.info(
+          { file: "HEARTBEAT.md", dest: heartbeatDest },
+          "Created HEARTBEAT.md from template",
+        );
+      }
+    } catch (err) {
+      log.warn(
+        { err, file: "HEARTBEAT.md" },
+        "Failed to create HEARTBEAT.md from template",
+      );
+    }
+  }
+
   // Only seed BOOTSTRAP.md on a truly fresh install so that deleting it
   // reliably signals onboarding completion across daemon restarts.
   if (isFirstRun) {

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -65,28 +65,6 @@ export function ensurePromptFiles(): void {
     }
   }
 
-  // Seed HEARTBEAT.md if it doesn't exist — always, not just on first run.
-  // This gives new and existing users a meaningful default checklist focused
-  // on continuity and presence rather than the hardcoded weather/news fallback.
-  const heartbeatDest = getWorkspacePromptPath("HEARTBEAT.md");
-  if (!existsSync(heartbeatDest)) {
-    const heartbeatSrc = join(templatesDir, "HEARTBEAT.md");
-    try {
-      if (existsSync(heartbeatSrc)) {
-        copyFileSync(heartbeatSrc, heartbeatDest);
-        log.info(
-          { file: "HEARTBEAT.md", dest: heartbeatDest },
-          "Created HEARTBEAT.md from template",
-        );
-      }
-    } catch (err) {
-      log.warn(
-        { err, file: "HEARTBEAT.md" },
-        "Failed to create HEARTBEAT.md from template",
-      );
-    }
-  }
-
   // Only seed BOOTSTRAP.md on a truly fresh install so that deleting it
   // reliably signals onboarding completion across daemon restarts.
   if (isFirstRun) {

--- a/assistant/src/prompts/templates/HEARTBEAT.md
+++ b/assistant/src/prompts/templates/HEARTBEAT.md
@@ -6,5 +6,5 @@ _ present between conversations. Edit it freely to match your style.
 
 - [ ] **Check in.** Read NOW.md. Is it still accurate? Update it if anything has changed since last time.
 - [ ] **Follow up.** Is there anything from recent conversations worth revisiting? A question left open, a task to check on, something to share?
-- [ ] **Look ahead.** Anything coming up they should know about? Events, deadlines, things they mentioned wanting to do.
+- [ ] **Look ahead.** Scan the journal and active threads in NOW.md for unresolved intentions, deadlines mentioned in passing, or things they said they wanted to do. Surface anything that's drifting without follow-up.
 - [ ] **Be present.** If you have a thought — something useful, something fun, a check-in — share it. You don't need a reason to reach out beyond wanting to.


### PR DESCRIPTION
…+ seed HEARTBEAT.md template

The default heartbeat checklist (weather/news/calendar) has no connection to the user or past conversations. Replace it with a checklist that builds relationship continuity: check NOW.md, follow up on past conversations, look ahead, and reach out if there's something worth saying.

Also add a HEARTBEAT.md template that gets seeded on daemon startup for any user who doesn't already have one, so they start from a meaningful default instead of a blank file.

Part of the personality & retention initiative for the 4/21 launch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
