### PR TITLE
Fix usage dashboard to count actual LLM API calls, not turns

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -60,6 +60,8 @@ export interface EventHandlerState {
   exchangeCacheCreationInputTokens: number;
   exchangeCacheReadInputTokens: number;
   exchangeOutputTokens: number;
+  /** Number of actual LLM API calls within this exchange. */
+  exchangeLlmCallCount: number;
   readonly exchangeRawResponses: unknown[];
   model: string;
   orderingErrorDetected: boolean;
@@ -127,6 +129,7 @@ export function createEventHandlerState(): EventHandlerState {
     exchangeCacheCreationInputTokens: 0,
     exchangeCacheReadInputTokens: 0,
     exchangeOutputTokens: 0,
+    exchangeLlmCallCount: 0,
     exchangeRawResponses: [],
     model: "",
     orderingErrorDetected: false,
@@ -778,6 +781,7 @@ export function handleUsage(
 ): void {
   const providerName = event.actualProvider ?? deps.ctx.provider.name;
   state.exchangeProviderName = providerName;
+  state.exchangeLlmCallCount += 1;
   state.exchangeInputTokens += event.inputTokens;
   state.exchangeCacheCreationInputTokens += event.cacheCreationInputTokens ?? 0;
   state.exchangeCacheReadInputTokens += event.cacheReadInputTokens ?? 0;

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1601,6 +1601,7 @@ export async function runAgentLoopImpl(
       state.exchangeCacheReadInputTokens,
       collapseRawResponses(state.exchangeRawResponses),
       state.exchangeProviderName,
+      state.exchangeLlmCallCount,
     );
 
     void getHookManager().trigger("post-message", {
@@ -1868,6 +1869,7 @@ function emitUsage(
   cacheReadInputTokens = 0,
   rawResponse?: unknown,
   providerName?: string,
+  llmCallCount = 1,
 ): void {
   recordUsage(
     {
@@ -1884,6 +1886,7 @@ function emitUsage(
     cacheCreationInputTokens,
     cacheReadInputTokens,
     rawResponse,
+    llmCallCount,
   );
 }
 

--- a/assistant/src/daemon/conversation-usage.ts
+++ b/assistant/src/daemon/conversation-usage.ts
@@ -124,6 +124,7 @@ export function recordUsage(
   cacheCreationInputTokens = 0,
   cacheReadInputTokens = 0,
   rawResponse?: unknown,
+  llmCallCount = 1,
 ): void {
   if (inputTokens <= 0 && outputTokens <= 0) return;
 
@@ -194,6 +195,7 @@ export function recordUsage(
         conversationId: ctx.conversationId,
         runId: null,
         requestId,
+        llmCallCount,
       },
       pricing,
     );

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -84,6 +84,7 @@ import {
   migrateGuardianPrincipalIdNotNull,
   migrateGuardianRequestEnrichmentColumns,
   migrateGuardianTimestampsEpochMs,
+  migrateUsageLlmCallCount,
   migrateGuardianVerificationPurpose,
   migrateGuardianVerificationSessions,
   migrateInviteCodeHashColumn,
@@ -535,6 +536,9 @@ export function initializeDb(): void {
 
   // 97. Add enrichment columns to canonical_guardian_requests for guardian approval UX
   migrateGuardianRequestEnrichmentColumns(database);
+
+  // 98. Add llm_call_count column to llm_usage_events for accurate LLM call counting
+  migrateUsageLlmCallCount(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/llm-usage-store.ts
+++ b/assistant/src/memory/llm-usage-store.ts
@@ -42,6 +42,7 @@ export function recordUsageEvent(
       cacheReadInputTokens: event.cacheReadInputTokens,
       estimatedCostUsd: event.estimatedCostUsd,
       pricingStatus: event.pricingStatus,
+      llmCallCount: event.llmCallCount ?? 1,
       metadataJson: null,
     })
     .run();
@@ -213,7 +214,7 @@ export function getUsageTotals(range: UsageTimeRange): UsageTotals {
       COALESCE(SUM(cache_creation_input_tokens), 0)               AS total_cache_creation_tokens,
       COALESCE(SUM(cache_read_input_tokens), 0)                   AS total_cache_read_tokens,
       COALESCE(SUM(estimated_cost_usd), 0)                        AS total_estimated_cost_usd,
-      COUNT(*)                                                     AS event_count,
+      COALESCE(SUM(COALESCE(llm_call_count, 1)), 0)               AS event_count,
       COUNT(CASE WHEN pricing_status = 'priced' THEN 1 END)       AS priced_event_count,
       COUNT(CASE WHEN pricing_status = 'unpriced' THEN 1 END)     AS unpriced_event_count
     FROM llm_usage_events
@@ -249,7 +250,7 @@ export function getUsageDayBuckets(range: UsageTimeRange): UsageDayBucket[] {
       COALESCE(SUM(input_tokens), 0)                         AS total_input_tokens,
       COALESCE(SUM(output_tokens), 0)                        AS total_output_tokens,
       COALESCE(SUM(estimated_cost_usd), 0)                   AS total_estimated_cost_usd,
-      COUNT(*)                                                AS event_count
+      COALESCE(SUM(COALESCE(llm_call_count, 1)), 0)          AS event_count
     FROM llm_usage_events
     WHERE created_at >= ?1 AND created_at <= ?2
     GROUP BY date
@@ -292,7 +293,7 @@ export function getUsageGroupBreakdown(
       COALESCE(SUM(cache_creation_input_tokens), 0)  AS total_cache_creation_tokens,
       COALESCE(SUM(cache_read_input_tokens), 0)      AS total_cache_read_tokens,
       COALESCE(SUM(estimated_cost_usd), 0)           AS total_estimated_cost_usd,
-      COUNT(*)                                        AS event_count
+      COALESCE(SUM(COALESCE(llm_call_count, 1)), 0)  AS event_count
     FROM llm_usage_events
     WHERE created_at >= ?1 AND created_at <= ?2
     GROUP BY ${column}

--- a/assistant/src/memory/migrations/200-usage-llm-call-count.ts
+++ b/assistant/src/memory/migrations/200-usage-llm-call-count.ts
@@ -1,0 +1,20 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
+
+/**
+ * Add llm_call_count column to llm_usage_events so each row records
+ * how many actual LLM API calls it represents (an exchange/turn may
+ * contain multiple tool-use iterations, each making a separate API call).
+ *
+ * Nullable INTEGER — existing rows default to NULL and are treated as 1
+ * by the aggregation queries via COALESCE.
+ */
+export function migrateUsageLlmCallCount(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  if (!tableHasColumn(database, "llm_usage_events", "llm_call_count")) {
+    raw.exec(
+      /*sql*/ `ALTER TABLE llm_usage_events ADD COLUMN llm_call_count INTEGER`,
+    );
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -139,6 +139,7 @@ export { migrateStripIntegrationPrefixFromProviderKeys } from "./196-strip-integ
 export { migrateOAuthProvidersBehaviorColumns } from "./197-oauth-providers-behavior-columns.js";
 export { migrateDropSetupSkillIdColumn } from "./198-drop-setup-skill-id-column.js";
 export { migrateGuardianRequestEnrichmentColumns } from "./199-guardian-request-enrichment-columns.js";
+export { migrateUsageLlmCallCount } from "./200-usage-llm-call-count.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -169,6 +169,7 @@ export const llmUsageEvents = sqliteTable(
     cacheReadInputTokens: integer("cache_read_input_tokens"),
     estimatedCostUsd: real("estimated_cost_usd"),
     pricingStatus: text("pricing_status").notNull(),
+    llmCallCount: integer("llm_call_count"),
     metadataJson: text("metadata_json"),
   },
   (table) => [

--- a/assistant/src/usage/types.ts
+++ b/assistant/src/usage/types.ts
@@ -38,6 +38,8 @@ export interface UsageEventInput {
   conversationId: string | null;
   runId: string | null;
   requestId: string | null;
+  /** Number of actual LLM API calls represented by this event (defaults to 1). */
+  llmCallCount?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `llm_call_count` column to `llm_usage_events` tracking how many actual LLM API calls each usage event row represents
- Count individual API calls in the agent loop handler (`exchangeLlmCallCount`) and pass through to the usage ledger
- Update all SQL aggregation queries to use `SUM(COALESCE(llm_call_count, 1))` instead of `COUNT(*)` so the dashboard shows real API call counts

## Original prompt
fix the count so it's actually showing the number of LLM calls