### PR TITLE
Add configurable speed setting to heartbeat config

### DIFF
--- a/assistant/src/config/schemas/heartbeat.ts
+++ b/assistant/src/config/schemas/heartbeat.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { SpeedSchema } from "./inference.js";
 
 export const HeartbeatConfigSchema = z
   .object({
@@ -12,6 +13,9 @@ export const HeartbeatConfigSchema = z
       .positive("heartbeat.intervalMs must be a positive integer")
       .default(3_600_000)
       .describe("Time between heartbeat checks in milliseconds"),
+    speed: SpeedSchema.default("standard").describe(
+      "Inference speed mode for heartbeat conversations — defaults to standard to avoid inheriting the global fast mode multiplier",
+    ),
     activeHoursStart: z
       .number({ error: "heartbeat.activeHoursStart must be a number" })
       .int("heartbeat.activeHoursStart must be an integer")


### PR DESCRIPTION
## Summary
- Add `speed` field to `HeartbeatConfigSchema` using `SpeedSchema.default("standard")`
- Heartbeat conversations default to standard speed to avoid inheriting the global fast mode cost multiplier
- Existing configs without `speed` continue to parse correctly (Zod default)

Part of plan: llm-cost-optimize.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
