### PR TITLE
Use 1-hour cache TTL for system prompt blocks

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -138,16 +138,16 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
   // -----------------------------------------------------------------------
   // System prompt cache control
   // -----------------------------------------------------------------------
-  test("system prompt has cache_control ephemeral", async () => {
+  test("system prompt has cache_control ephemeral with 1h TTL", async () => {
     await provider.sendMessage([userMsg("Hi")], undefined, "You are helpful.");
 
     const system = lastStreamParams!.system as Array<{
       type: string;
       text: string;
-      cache_control?: { type: string };
+      cache_control?: { type: string; ttl?: string };
     }>;
     expect(system).toHaveLength(1);
-    expect(system[0].cache_control).toEqual({ type: "ephemeral" });
+    expect(system[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
   });
 
   test("no system param when system prompt is omitted", async () => {
@@ -166,13 +166,13 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     const system = lastStreamParams!.system as Array<{
       type: string;
       text: string;
-      cache_control?: { type: string };
+      cache_control?: { type: string; ttl?: string };
     }>;
     expect(system).toHaveLength(2);
     expect(system[0].text).toBe(staticBlock);
-    expect(system[0].cache_control).toEqual({ type: "ephemeral" });
+    expect(system[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
     expect(system[1].text).toBe(dynamicBlock);
-    expect(system[1].cache_control).toEqual({ type: "ephemeral" });
+    expect(system[1].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
   });
 
   // -----------------------------------------------------------------------
@@ -1548,9 +1548,9 @@ describe("AnthropicProvider — Managed Proxy Fallback", () => {
 
     // System prompt cache control
     const system = lastStreamParams!.system as Array<{
-      cache_control?: { type: string };
+      cache_control?: { type: string; ttl?: string };
     }>;
-    expect(system[0].cache_control).toEqual({ type: "ephemeral" });
+    expect(system[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
 
     // Last tool cache control
     const tools = lastStreamParams!.tools as Array<{

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -862,6 +862,9 @@ export class AnthropicProvider implements Provider {
           // turns) and dynamic workspace content (changes when files are
           // edited).  The static prefix stays cached even when workspace
           // files change, saving ~8-10K tokens of cache creation per turn.
+          // Both blocks use 1-hour cache TTL to avoid repeated cache misses
+          // for conversations with turn gaps exceeding the default 5-minute
+          // window.
           const staticBlock = systemPrompt.slice(0, boundaryIdx);
           const dynamicBlock = systemPrompt.slice(
             boundaryIdx + SYSTEM_PROMPT_CACHE_BOUNDARY.length,
@@ -870,12 +873,12 @@ export class AnthropicProvider implements Provider {
             {
               type: "text" as const,
               text: staticBlock,
-              cache_control: { type: "ephemeral" as const },
+              cache_control: { type: "ephemeral" as const, ttl: "1h" as const },
             },
             {
               type: "text" as const,
               text: dynamicBlock,
-              cache_control: { type: "ephemeral" as const },
+              cache_control: { type: "ephemeral" as const, ttl: "1h" as const },
             },
           ];
         } else {
@@ -883,7 +886,7 @@ export class AnthropicProvider implements Provider {
             {
               type: "text" as const,
               text: systemPrompt,
-              cache_control: { type: "ephemeral" as const },
+              cache_control: { type: "ephemeral" as const, ttl: "1h" as const },
             },
           ];
         }


### PR DESCRIPTION
## Summary
- Switch system prompt cache blocks from 5-minute to 1-hour TTL to reduce cache misses for conversations with 5-60 min turn gaps
- Tools and user turn cache remain on default 5-minute TTL (these change frequently)
- Updated test assertions to expect the new TTL value

Part of plan: llm-cost-optimize.md (PR 3 of 4)