### PR TITLE
Fix import sort order in heartbeat.ts

### DIFF
--- a/assistant/src/config/schemas/heartbeat.ts
+++ b/assistant/src/config/schemas/heartbeat.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+
 import { SpeedSchema } from "./inference.js";
 
 export const HeartbeatConfigSchema = z


### PR DESCRIPTION
## Summary
- Add blank line between third-party (`zod`) and relative (`./inference.js`) imports in `heartbeat.ts` to satisfy `simple-import-sort/imports` lint rule

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23723284193/job/69102017100
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
