### PR TITLE
Wire heartbeat service to use configured speed override

### DIFF
--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -9,6 +9,7 @@ let mockConfig = {
   heartbeat: {
     enabled: true,
     intervalMs: 60_000,
+    speed: "standard" as "standard" | "fast",
     activeHoursStart: undefined as number | undefined,
     activeHoursEnd: undefined as number | undefined,
   },
@@ -74,7 +75,11 @@ mock.module("../memory/conversation-title-service.js", () => ({
 const { HeartbeatService } = await import("../heartbeat/heartbeat-service.js");
 
 describe("HeartbeatService", () => {
-  let processMessageCalls: Array<{ conversationId: string; content: string }>;
+  let processMessageCalls: Array<{
+    conversationId: string;
+    content: string;
+    options?: { speed?: string };
+  }>;
   let alerterCalls: Array<{ type: string; title: string; body: string }>;
 
   afterEach(() => {
@@ -92,6 +97,7 @@ describe("HeartbeatService", () => {
       heartbeat: {
         enabled: true,
         intervalMs: 60_000,
+        speed: "standard",
         activeHoursStart: undefined,
         activeHoursEnd: undefined,
       },
@@ -102,14 +108,19 @@ describe("HeartbeatService", () => {
     processMessage?: (
       id: string,
       content: string,
+      options?: { speed?: string },
     ) => Promise<{ messageId: string }>;
     getCurrentHour?: () => number;
   }) {
     return new HeartbeatService({
       processMessage:
         overrides?.processMessage ??
-        (async (conversationId: string, content: string) => {
-          processMessageCalls.push({ conversationId, content });
+        (async (
+          conversationId: string,
+          content: string,
+          options?: { speed?: string },
+        ) => {
+          processMessageCalls.push({ conversationId, content, options });
           return { messageId: "msg-1" };
         }),
       alerter: (alert: { type: string; title: string; body: string }) => {
@@ -404,5 +415,33 @@ describe("HeartbeatService", () => {
     expect(service.nextRunAt).toBeNull();
     service.resetTimer();
     expect(service.nextRunAt).toBeNull();
+  });
+
+  test("passes heartbeat config speed to processMessage", async () => {
+    mockConfig.heartbeat.speed = "standard";
+    const service = createService();
+    await service.runOnce();
+
+    expect(processMessageCalls).toHaveLength(1);
+    expect(processMessageCalls[0].options).toEqual({ speed: "standard" });
+  });
+
+  test("heartbeat uses its own speed even when global config differs", async () => {
+    // Simulate: global config has fast, but heartbeat config has standard
+    mockConfig.heartbeat.speed = "standard";
+    const service = createService();
+    await service.runOnce();
+
+    expect(processMessageCalls).toHaveLength(1);
+    expect(processMessageCalls[0].options?.speed).toBe("standard");
+  });
+
+  test("heartbeat passes fast speed when explicitly configured", async () => {
+    mockConfig.heartbeat.speed = "fast";
+    const service = createService();
+    await service.runOnce();
+
+    expect(processMessageCalls).toHaveLength(1);
+    expect(processMessageCalls[0].options?.speed).toBe("fast");
   });
 });

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -1152,12 +1152,13 @@ export async function runDaemon(): Promise<void> {
 
     const heartbeatConfig = config.heartbeat;
     const heartbeat = new HeartbeatService({
-      processMessage: (conversationId, content) =>
+      processMessage: (conversationId, content, options) =>
         server.processMessage(conversationId, content, undefined, {
           trustContext: {
             sourceChannel: "vellum",
             trustClass: "guardian",
           },
+          ...options,
         }),
       alerter: (alert) => server.broadcast(alert),
       onConversationCreated: (info) =>

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -1,4 +1,5 @@
 import { getConfig } from "../config/loader.js";
+import type { Speed } from "../config/schemas/inference.js";
 import type { HeartbeatAlert } from "../daemon/message-protocol.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import { readTextFileSync } from "../util/fs.js";
@@ -17,6 +18,7 @@ export interface HeartbeatDeps {
   processMessage: (
     conversationId: string,
     content: string,
+    options?: { speed?: Speed },
   ) => Promise<{ messageId: string }>;
   alerter: (alert: HeartbeatAlert) => void;
   onConversationCreated?: (info: {
@@ -169,6 +171,7 @@ export class HeartbeatService {
     log.info("Running heartbeat");
 
     try {
+      const config = getConfig().heartbeat;
       const checklist = this.readChecklist();
       const prompt = this.buildPrompt(checklist);
 
@@ -184,7 +187,9 @@ export class HeartbeatService {
         title: "Heartbeat",
       });
 
-      await this.deps.processMessage(conversation.id, prompt);
+      await this.deps.processMessage(conversation.id, prompt, {
+        speed: config.speed,
+      });
       log.info({ conversationId: conversation.id }, "Heartbeat completed");
     } catch (err) {
       log.error({ err }, "Heartbeat failed");


### PR DESCRIPTION
## Summary
- Update HeartbeatDeps processMessage callback to accept speed override option
- Heartbeat service passes its configured speed to processMessage in executeRun()
- lifecycle.ts forwards the speed option when wiring HeartbeatService to server.processMessage()
- Default behavior (speed: "standard") ensures heartbeats never use fast mode unless explicitly configured

Part of plan: llm-cost-optimize.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
