### PR TITLE
fix(macos): guard @Observable scroll state writes to prevent infinite re-render loop

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -257,11 +257,13 @@ final class MessageListScrollState {
 
     /// Transitions to the detached state, suppressing all background pin requests.
     func detach() {
+        guard isFollowingBottom else { return }
         isFollowingBottom = false
     }
 
     /// Transitions to the following state, allowing pin requests to proceed.
     func reattach() {
+        guard !isFollowingBottom else { return }
         isFollowingBottom = true
     }
 
@@ -279,7 +281,7 @@ final class MessageListScrollState {
         clearSuppression()
         paginationTask?.cancel()
         paginationTask = nil
-        isPaginationInFlight = false
+        if isPaginationInFlight { isPaginationInFlight = false }
         wasPaginationTriggerInRange = false
         // Invalidate the layout cache so the new conversation doesn't
         // hit a stale cache from the previous conversation.
@@ -294,7 +296,7 @@ final class MessageListScrollState {
         // Update the live conversation ID so closures read the new value.
         currentConversationId = newConversationId
         // Reset follow state for the new conversation.
-        isFollowingBottom = true
+        if !isFollowingBottom { isFollowingBottom = true }
         if pushToTopMessageId != nil { pushToTopMessageId = nil }
         isAtBottom = true
         hasReceivedScrollEvent = false
@@ -302,11 +304,11 @@ final class MessageListScrollState {
         // Hide scroll indicators during the conversation switch grace period
         // to mask LazyVStack content size estimation changes.
         scrollIndicatorRestoreTask?.cancel()
-        hideScrollIndicators = true
+        if !hideScrollIndicators { hideScrollIndicators = true }
         scrollIndicatorRestoreTask = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: 300_000_000) // 300ms
             guard !Task.isCancelled, let self else { return }
-            self.hideScrollIndicators = false
+            if self.hideScrollIndicators { self.hideScrollIndicators = false }
             self.scrollIndicatorRestoreTask = nil
         }
     }
@@ -324,7 +326,7 @@ final class MessageListScrollState {
         highlightDismissTask = nil
         scrollIndicatorRestoreTask?.cancel()
         scrollIndicatorRestoreTask = nil
-        hideScrollIndicators = false
-        isPaginationInFlight = false
+        if hideScrollIndicators { hideScrollIndicators = false }
+        if isPaginationInFlight { isPaginationInFlight = false }
     }
 }

--- a/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
@@ -42,6 +42,32 @@ final class MessageListScrollStateTests: XCTestCase {
         XCTAssertTrue(state.isFollowingBottom)
     }
 
+    func testDetachWhenAlreadyDetachedIsNoop() {
+        state.detach()
+        XCTAssertFalse(state.isFollowingBottom)
+
+        // Second detach should be a no-op (no crash, no state change).
+        state.detach()
+        XCTAssertFalse(state.isFollowingBottom)
+    }
+
+    func testReattachWhenAlreadyAttachedIsNoop() {
+        // Initial state is already following bottom.
+        XCTAssertTrue(state.isFollowingBottom)
+
+        // Reattach when already attached should be a no-op.
+        state.reattach()
+        XCTAssertTrue(state.isFollowingBottom)
+    }
+
+    func testRapidDetachCallsDoNotAccumulate() {
+        for _ in 0..<100 {
+            state.detach()
+        }
+        XCTAssertFalse(state.isFollowingBottom)
+        XCTAssertTrue(state.showScrollToLatest)
+    }
+
     // MARK: - Pin Gating
 
     func testPinSuppressedWhileDetached() {


### PR DESCRIPTION
## Summary
- Add value-change guards to `detach()` and `reattach()` so no-op writes don't fire @Observable mutation notifications
- Guard all other observed property writes in `reset(for:)` and `cancelAll()` (isPaginationInFlight, hideScrollIndicators, pushToTopMessageId, isFollowingBottom)
- Add 3 new tests verifying no-op behavior

Part of plan: fix-scroll-noop-loop.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
