### PR TITLE
Fix extended cache TTL beta header for non-fast-mode requests

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -37,25 +37,37 @@ mock.module("@anthropic-ai/sdk", () => ({
     constructor(args: Record<string, unknown>) {
       lastConstructorArgs = { ...args };
     }
+    #streamImpl = (
+      params: Record<string, unknown>,
+      options?: Record<string, unknown>,
+    ) => {
+      lastStreamParams = JSON.parse(JSON.stringify(params));
+      _lastStreamOptions = options ?? null;
+      const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+      return {
+        on(event: string, cb: (...args: unknown[]) => void) {
+          (handlers[event] ??= []).push(cb);
+          return this;
+        },
+        async finalMessage() {
+          // Fire text events
+          for (const cb of handlers["text"] ?? []) cb("Hello");
+          return fakeResponse;
+        },
+      };
+    };
     messages = {
       stream: (
         params: Record<string, unknown>,
         options?: Record<string, unknown>,
-      ) => {
-        lastStreamParams = JSON.parse(JSON.stringify(params));
-        _lastStreamOptions = options ?? null;
-        const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
-        return {
-          on(event: string, cb: (...args: unknown[]) => void) {
-            (handlers[event] ??= []).push(cb);
-            return this;
-          },
-          async finalMessage() {
-            // Fire text events
-            for (const cb of handlers["text"] ?? []) cb("Hello");
-            return fakeResponse;
-          },
-        };
+      ) => this.#streamImpl(params, options),
+    };
+    beta = {
+      messages: {
+        stream: (
+          params: Record<string, unknown>,
+          options?: Record<string, unknown>,
+        ) => this.#streamImpl(params, options),
       },
     };
   },

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -972,6 +972,13 @@ export class AnthropicProvider implements Provider {
       const useFastMode =
         speed === "fast" && effectiveModel.includes("opus");
 
+      // Collect required betas: extended cache TTL for 1h system prompt caching,
+      // and fast-mode when applicable.
+      const betas: string[] = ["extended-cache-ttl-2025-04-11"];
+      if (useFastMode) {
+        betas.push("fast-mode-2026-02-01");
+      }
+
       let response: Anthropic.Message;
       try {
         const stream: UnifiedStream = useFastMode
@@ -979,14 +986,19 @@ export class AnthropicProvider implements Provider {
               {
                 ...(params as Record<string, unknown>),
                 speed: "fast" as const,
-                betas: ["fast-mode-2026-02-01" as const],
+                betas,
               } as Anthropic.Beta.Messages.MessageCreateParamsNonStreaming &
                 Anthropic.Beta.Messages.MessageCreateParamsStreaming,
               { signal: timeoutSignal },
             ) as unknown as UnifiedStream)
-          : (this.client.messages.stream(params, {
-              signal: timeoutSignal,
-            }) as unknown as UnifiedStream);
+          : (this.client.beta.messages.stream(
+              {
+                ...(params as Record<string, unknown>),
+                betas,
+              } as Anthropic.Beta.Messages.MessageCreateParamsNonStreaming &
+                Anthropic.Beta.Messages.MessageCreateParamsStreaming,
+              { signal: timeoutSignal },
+            ) as unknown as UnifiedStream);
 
         stream.on("text", (text) => {
           onEvent?.({ type: "text_delta", text });


### PR DESCRIPTION
## Summary
- Non-fast-mode API requests were failing with 400 because `cache_control.ttl: "1h"` requires the `extended-cache-ttl-2025-04-11` beta header
- Route all requests through `client.beta.messages.stream` with the extended cache TTL beta (combining with fast-mode beta when needed)
- Update test mock to expose `beta.messages.stream` alongside `messages.stream`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
