### PR TITLE
Fix web search test mocks to use beta.messages API path

### DIFF
--- a/assistant/src/__tests__/conversation-history-web-search.test.ts
+++ b/assistant/src/__tests__/conversation-history-web-search.test.ts
@@ -508,22 +508,25 @@ describe("ensureToolPairing with server_tool_use / web_search_tool_result", () =
     default: class MockAnthropic {
       static APIError = FakeAPIError;
       constructor(_args: Record<string, unknown>) {}
-      messages = {
-        stream: (
-          params: Record<string, unknown>,
-          _options?: Record<string, unknown>,
-        ) => {
-          lastStreamParams = JSON.parse(JSON.stringify(params));
-          const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
-          return {
-            on(event: string, cb: (...args: unknown[]) => void) {
-              (handlers[event] ??= []).push(cb);
-              return this;
-            },
-            async finalMessage() {
-              return fakeResponse;
-            },
-          };
+      beta = {
+        messages: {
+          stream: (
+            params: Record<string, unknown>,
+            _options?: Record<string, unknown>,
+          ) => {
+            lastStreamParams = JSON.parse(JSON.stringify(params));
+            const handlers: Record<string, ((...args: unknown[]) => void)[]> =
+              {};
+            return {
+              on(event: string, cb: (...args: unknown[]) => void) {
+                (handlers[event] ??= []).push(cb);
+                return this;
+              },
+              async finalMessage() {
+                return fakeResponse;
+              },
+            };
+          },
         },
       };
     },

--- a/assistant/src/__tests__/native-web-search.test.ts
+++ b/assistant/src/__tests__/native-web-search.test.ts
@@ -44,26 +44,29 @@ mock.module("@anthropic-ai/sdk", () => ({
   default: class MockAnthropic {
     static APIError = FakeAPIError;
     constructor(_args: Record<string, unknown>) {}
-    messages = {
-      stream: (
-        params: Record<string, unknown>,
-        _options?: Record<string, unknown>,
-      ) => {
-        lastStreamParams = JSON.parse(JSON.stringify(params));
-        const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
-        return {
-          on(event: string, cb: (...args: unknown[]) => void) {
-            (handlers[event] ??= []).push(cb);
-            return this;
-          },
-          async finalMessage() {
-            // Fire any pending stream events
-            for (const ev of pendingStreamEvents) {
-              for (const cb of handlers["streamEvent"] ?? []) cb(ev);
-            }
-            return { ...fakeResponse, content: fakeResponseContent };
-          },
-        };
+    beta = {
+      messages: {
+        stream: (
+          params: Record<string, unknown>,
+          _options?: Record<string, unknown>,
+        ) => {
+          lastStreamParams = JSON.parse(JSON.stringify(params));
+          const handlers: Record<string, ((...args: unknown[]) => void)[]> =
+            {};
+          return {
+            on(event: string, cb: (...args: unknown[]) => void) {
+              (handlers[event] ??= []).push(cb);
+              return this;
+            },
+            async finalMessage() {
+              // Fire any pending stream events
+              for (const ev of pendingStreamEvents) {
+                for (const cb of handlers["streamEvent"] ?? []) cb(ev);
+              }
+              return { ...fakeResponse, content: fakeResponseContent };
+            },
+          };
+        },
       },
     };
   },


### PR DESCRIPTION
## Summary
- Update Anthropic SDK mocks in `native-web-search.test.ts` and `conversation-history-web-search.test.ts` to nest `messages` under `beta`, matching the actual `this.client.beta.messages.stream()` call path in `AnthropicProvider`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23724148790/job/69104418024
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
