### PR TITLE
Use 1h cache TTL on all cache_control blocks for valid ordering

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -204,7 +204,7 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     expect(tools[1].cache_control).toBeUndefined();
 
     // Last tool: cache_control ephemeral
-    expect(tools[2].cache_control).toEqual({ type: "ephemeral" });
+    expect(tools[2].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
   });
 
   test("single tool gets cache_control", async () => {
@@ -215,7 +215,7 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
       cache_control?: { type: string };
     }>;
     expect(tools).toHaveLength(1);
-    expect(tools[0].cache_control).toEqual({ type: "ephemeral" });
+    expect(tools[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
   });
 
   test("no tools param when tools are omitted", async () => {
@@ -276,7 +276,7 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     // Second user turn (second-to-last): cache_control ephemeral
     const secondUserLastBlock =
       userMessages[1].content[userMessages[1].content.length - 1];
-    expect(secondUserLastBlock.cache_control).toEqual({ type: "ephemeral" });
+    expect(secondUserLastBlock.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
 
     // Third user turn (last): no cache_control
     const thirdUserLastBlock =
@@ -320,7 +320,7 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     const userMsgs = sent.filter((m) => m.role === "user");
     // First user msg (second-to-last) should get cache
     const firstLast = userMsgs[0].content[userMsgs[0].content.length - 1];
-    expect(firstLast.cache_control).toEqual({ type: "ephemeral" });
+    expect(firstLast.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
     // tool_result msg (last) should NOT get cache
     const secondLast = userMsgs[1].content[userMsgs[1].content.length - 1];
     expect(secondLast.cache_control).toBeUndefined();
@@ -1333,7 +1333,7 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
 
     // Turn 2 (second-to-last): cache on last block only
     expect(userMsgs[1].content[0].cache_control).toBeUndefined();
-    expect(userMsgs[1].content[1].cache_control).toEqual({ type: "ephemeral" });
+    expect(userMsgs[1].content[1].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
 
     // Turn 3 (last): no cache
     expect(userMsgs[2].content[0].cache_control).toBeUndefined();
@@ -1570,6 +1570,7 @@ describe("AnthropicProvider — Managed Proxy Fallback", () => {
     }>;
     expect(tools[tools.length - 1].cache_control).toEqual({
       type: "ephemeral",
+      ttl: "1h",
     });
   });
 });

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -903,7 +903,7 @@ export class AnthropicProvider implements Provider {
             description: t.description,
             input_schema: t.input_schema as Anthropic.Tool["input_schema"],
             ...(i === otherTools.length - 1
-              ? { cache_control: { type: "ephemeral" as const } }
+              ? { cache_control: { type: "ephemeral" as const, ttl: "1h" as const } }
               : {}),
           }));
           const webSearchTool: Anthropic.WebSearchTool20250305 = {
@@ -918,7 +918,7 @@ export class AnthropicProvider implements Provider {
             description: t.description,
             input_schema: t.input_schema as Anthropic.Tool["input_schema"],
             ...(i === tools.length - 1
-              ? { cache_control: { type: "ephemeral" as const } }
+              ? { cache_control: { type: "ephemeral" as const, ttl: "1h" as const } }
               : {}),
           }));
         }
@@ -947,9 +947,9 @@ export class AnthropicProvider implements Provider {
         if (Array.isArray(content) && content.length > 0) {
           (
             content[content.length - 1] as unknown as {
-              cache_control?: { type: string };
+              cache_control?: { type: string; ttl?: string };
             }
-          ).cache_control = { type: "ephemeral" };
+          ).cache_control = { type: "ephemeral", ttl: "1h" };
         }
       }
 


### PR DESCRIPTION
## Summary
- The Anthropic API requires `cache_control.ttl` values to be non-increasing across blocks (tools -> system -> messages)
- Tools had default 5m TTL while system blocks used 1h, causing: `a ttl='1h' cache_control block must not come after a ttl='5m' cache_control block`
- Set 1h TTL on all cache_control blocks to maintain valid ordering
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
