### PR TITLE
Fix native web search test to expect 1h cache TTL

### DIFF
--- a/assistant/src/__tests__/native-web-search.test.ts
+++ b/assistant/src/__tests__/native-web-search.test.ts
@@ -380,7 +380,7 @@ describe("Native Web Search — Tool Filtering", () => {
     // file_read is the last custom tool (only custom tool in this case)
     // and it should get cache_control since it's the last in the mappedOther list
     expect(tools[0].name).toBe("file_read");
-    expect(tools[0].cache_control).toEqual({ type: "ephemeral" });
+    expect(tools[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
 
     // Native web search tool should NOT have cache_control set by the mapping logic
     // (it's appended after the mapped custom tools)


### PR DESCRIPTION
## Summary
- Update `native-web-search.test.ts` to expect `{ type: "ephemeral", ttl: "1h" }` instead of `{ type: "ephemeral" }`, matching the cache TTL change from #22191

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23724954651/job/69106659132
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
