### PR TITLE
Fix cache_control type annotation in native web search test to include ttl

### DIFF
--- a/assistant/src/__tests__/native-web-search.test.ts
+++ b/assistant/src/__tests__/native-web-search.test.ts
@@ -374,7 +374,7 @@ describe("Native Web Search — Tool Filtering", () => {
 
     const tools = lastStreamParams!.tools as Array<{
       name: string;
-      cache_control?: { type: string };
+      cache_control?: { type: string; ttl?: string };
     }>;
 
     // file_read is the last custom tool (only custom tool in this case)


### PR DESCRIPTION
## Summary
- Add `ttl` to the `cache_control` type annotation in native-web-search.test.ts to match the actual value being asserted (`{ type: "ephemeral", ttl: "1h" }`)
- This was missed in #22193 which fixed similar annotations in the anthropic-provider tests

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23725091468/job/69107018869
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
