### PR TITLE
Add SlackFile type and files field to Slack event interfaces

### DIFF
--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -166,6 +166,16 @@ export function getUserInfoCacheSize(): number {
   return userInfoCache.size;
 }
 
+/** Slack file object (subset relevant to attachment handling). */
+export interface SlackFile {
+  id: string;
+  name?: string;
+  mimetype?: string;
+  size?: number;
+  url_private_download?: string;
+  url_private?: string;
+}
+
 /**
  * Slack `app_mention` event shape (subset relevant to normalization).
  */
@@ -178,6 +188,7 @@ export interface SlackAppMentionEvent {
   thread_ts?: string;
   client_msg_id?: string;
   event_ts?: string;
+  files?: SlackFile[];
 }
 
 /**
@@ -194,6 +205,7 @@ export interface SlackDirectMessageEvent {
   thread_ts?: string;
   client_msg_id?: string;
   event_ts?: string;
+  files?: SlackFile[];
 }
 
 /**
@@ -211,6 +223,7 @@ export interface SlackChannelMessageEvent {
   thread_ts?: string;
   client_msg_id?: string;
   event_ts?: string;
+  files?: SlackFile[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add exported SlackFile interface with id, name, mimetype, size, url_private_download, url_private fields
- Add optional files field to SlackAppMentionEvent, SlackDirectMessageEvent, and SlackChannelMessageEvent
- Type-only change — no behavioral modifications

Part of plan: slack-file-attachments.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
