### PR TITLE
Populate message.attachments and slackFiles in Slack normalize functions

### DIFF
--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -2,8 +2,15 @@ import { describe, it, expect } from "bun:test";
 import {
   normalizeSlackBlockActions,
   normalizeSlackReactionAdded,
+  normalizeSlackDirectMessage,
+  normalizeSlackChannelMessage,
+  normalizeSlackAppMention,
   type SlackBlockActionsPayload,
   type SlackReactionAddedEvent,
+  type SlackDirectMessageEvent,
+  type SlackChannelMessageEvent,
+  type SlackAppMentionEvent,
+  type SlackFile,
 } from "./normalize.js";
 import type { GatewayConfig } from "../config.js";
 
@@ -250,5 +257,218 @@ describe("normalizeSlackReactionAdded", () => {
     expect(result!.event.message.callbackData).toBe(
       "reaction:white_check_mark",
     );
+  });
+});
+
+// --- Attachment extraction tests ---
+
+function makeSlackFile(overrides?: Partial<SlackFile>): SlackFile {
+  return {
+    id: "F001",
+    name: "photo.png",
+    mimetype: "image/png",
+    size: 12345,
+    url_private_download: "https://files.slack.com/download/photo.png",
+    url_private: "https://files.slack.com/files/photo.png",
+    ...overrides,
+  };
+}
+
+function makeDmEvent(
+  overrides?: Partial<SlackDirectMessageEvent>,
+): SlackDirectMessageEvent {
+  return {
+    type: "message",
+    user: "U123",
+    text: "hello",
+    ts: "1234567890.123456",
+    channel: "D789",
+    channel_type: "im",
+    ...overrides,
+  };
+}
+
+function makeChannelEvent(
+  overrides?: Partial<SlackChannelMessageEvent>,
+): SlackChannelMessageEvent {
+  return {
+    type: "message",
+    user: "U123",
+    text: "hello",
+    ts: "1234567890.123456",
+    channel: "C456",
+    channel_type: "channel",
+    ...overrides,
+  };
+}
+
+function makeAppMentionEvent(
+  overrides?: Partial<SlackAppMentionEvent>,
+): SlackAppMentionEvent {
+  return {
+    type: "app_mention",
+    user: "U123",
+    text: "<@UBOT> hello",
+    ts: "1234567890.123456",
+    channel: "C456",
+    ...overrides,
+  };
+}
+
+describe("attachment extraction in normalize functions", () => {
+  describe("normalizeSlackDirectMessage", () => {
+    it("populates attachments with type 'image' for image files", () => {
+      const config = makeConfig();
+      const event = makeDmEvent({
+        files: [
+          makeSlackFile({ id: "F001", mimetype: "image/png", name: "photo.png" }),
+          makeSlackFile({ id: "F002", mimetype: "image/jpeg", name: "pic.jpg" }),
+        ],
+      });
+      const result = normalizeSlackDirectMessage(event, "evt-1", config);
+
+      expect(result).not.toBeNull();
+      expect(result!.event.message.attachments).toHaveLength(2);
+      expect(result!.event.message.attachments![0]).toEqual({
+        type: "image",
+        fileId: "F001",
+        fileName: "photo.png",
+        mimeType: "image/png",
+        fileSize: 12345,
+      });
+      expect(result!.event.message.attachments![1]).toEqual({
+        type: "image",
+        fileId: "F002",
+        fileName: "pic.jpg",
+        mimeType: "image/jpeg",
+        fileSize: 12345,
+      });
+
+      // slackFiles map should be populated
+      expect(result!.slackFiles).toBeDefined();
+      expect(result!.slackFiles!.size).toBe(2);
+      expect(result!.slackFiles!.get("F001")!.id).toBe("F001");
+      expect(result!.slackFiles!.get("F002")!.id).toBe("F002");
+    });
+
+    it("populates attachments with type 'document' for non-image files", () => {
+      const config = makeConfig();
+      const event = makeDmEvent({
+        files: [
+          makeSlackFile({
+            id: "F003",
+            mimetype: "application/pdf",
+            name: "doc.pdf",
+            size: 99999,
+          }),
+        ],
+      });
+      const result = normalizeSlackDirectMessage(event, "evt-2", config);
+
+      expect(result).not.toBeNull();
+      expect(result!.event.message.attachments).toHaveLength(1);
+      expect(result!.event.message.attachments![0]).toEqual({
+        type: "document",
+        fileId: "F003",
+        fileName: "doc.pdf",
+        mimeType: "application/pdf",
+        fileSize: 99999,
+      });
+    });
+
+    it("filters out files missing download URLs", () => {
+      const config = makeConfig();
+      const event = makeDmEvent({
+        files: [
+          makeSlackFile({ id: "F004" }),
+          makeSlackFile({
+            id: "F005",
+            url_private_download: undefined,
+            url_private: undefined,
+          }),
+        ],
+      });
+      const result = normalizeSlackDirectMessage(event, "evt-3", config);
+
+      expect(result).not.toBeNull();
+      // Only F004 has download URLs
+      expect(result!.event.message.attachments).toHaveLength(1);
+      expect(result!.event.message.attachments![0].fileId).toBe("F004");
+      expect(result!.slackFiles!.size).toBe(1);
+      expect(result!.slackFiles!.has("F005")).toBe(false);
+    });
+
+    it("omits attachments field when files is empty", () => {
+      const config = makeConfig();
+      const event = makeDmEvent({ files: [] });
+      const result = normalizeSlackDirectMessage(event, "evt-4", config);
+
+      expect(result).not.toBeNull();
+      expect(result!.event.message.attachments).toBeUndefined();
+      expect(result!.slackFiles).toBeUndefined();
+    });
+
+    it("omits attachments field when files is undefined", () => {
+      const config = makeConfig();
+      const event = makeDmEvent();
+      const result = normalizeSlackDirectMessage(event, "evt-5", config);
+
+      expect(result).not.toBeNull();
+      expect(result!.event.message.attachments).toBeUndefined();
+      expect(result!.slackFiles).toBeUndefined();
+    });
+  });
+
+  describe("normalizeSlackChannelMessage", () => {
+    it("populates attachments for channel messages with files", () => {
+      const config = makeConfig();
+      const event = makeChannelEvent({
+        files: [
+          makeSlackFile({ id: "F010", mimetype: "image/gif", name: "anim.gif" }),
+        ],
+      });
+      const result = normalizeSlackChannelMessage(event, "evt-ch-1", config);
+
+      expect(result).not.toBeNull();
+      expect(result!.event.message.attachments).toHaveLength(1);
+      expect(result!.event.message.attachments![0]).toEqual({
+        type: "image",
+        fileId: "F010",
+        fileName: "anim.gif",
+        mimeType: "image/gif",
+        fileSize: 12345,
+      });
+      expect(result!.slackFiles).toBeDefined();
+      expect(result!.slackFiles!.get("F010")!.name).toBe("anim.gif");
+    });
+  });
+
+  describe("normalizeSlackAppMention", () => {
+    it("populates attachments for app mention events with files", () => {
+      const config = makeConfig();
+      const event = makeAppMentionEvent({
+        files: [
+          makeSlackFile({
+            id: "F020",
+            mimetype: "text/plain",
+            name: "notes.txt",
+            size: 500,
+          }),
+        ],
+      });
+      const result = normalizeSlackAppMention(event, "evt-am-1", config);
+
+      expect(result).not.toBeNull();
+      expect(result!.event.message.attachments).toHaveLength(1);
+      expect(result!.event.message.attachments![0]).toEqual({
+        type: "document",
+        fileId: "F020",
+        fileName: "notes.txt",
+        mimeType: "text/plain",
+        fileSize: 500,
+      });
+      expect(result!.slackFiles).toBeDefined();
+      expect(result!.slackFiles!.get("F020")!.id).toBe("F020");
+    });
   });
 });

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -264,6 +264,29 @@ export function stripBotMention(text: string): string {
   return stripped || text.trim();
 }
 
+function extractSlackAttachments(
+  files: SlackFile[] | undefined,
+): Array<{
+  type: "image" | "document";
+  fileId: string;
+  fileName?: string;
+  mimeType?: string;
+  fileSize?: number;
+}> {
+  if (!files || files.length === 0) return [];
+  return files
+    .filter((f) => f.url_private_download || f.url_private)
+    .map((f) => ({
+      type: f.mimetype?.startsWith("image/")
+        ? ("image" as const)
+        : ("document" as const),
+      fileId: f.id,
+      fileName: f.name,
+      mimeType: f.mimetype,
+      fileSize: f.size,
+    }));
+}
+
 export type NormalizedSlackEvent = {
   event: GatewayInboundEvent;
   routing: RouteResult;
@@ -271,6 +294,8 @@ export type NormalizedSlackEvent = {
   threadTs: string;
   /** Slack channel ID. */
   channel: string;
+  /** Original Slack file objects keyed by file ID, for download in the I/O layer. */
+  slackFiles?: Map<string, SlackFile>;
 };
 
 /**
@@ -313,6 +338,15 @@ export function normalizeSlackDirectMessage(
   const externalMessageId =
     event.client_msg_id ?? event.ts ?? `${event.channel}:${event.ts}`;
 
+  const attachments = extractSlackAttachments(event.files);
+  const slackFiles = event.files?.length
+    ? new Map(
+        event.files
+          .filter((f) => f.url_private_download || f.url_private)
+          .map((f) => [f.id, f]),
+      )
+    : undefined;
+
   // Use cache-only lookup to avoid blocking normalization on network calls.
   // A background fetch warms the cache for subsequent messages from this user.
   const userInfo =
@@ -329,6 +363,7 @@ export function normalizeSlackDirectMessage(
         content: event.text,
         conversationExternalId: event.channel,
         externalMessageId,
+        ...(attachments.length > 0 ? { attachments } : {}),
       },
       actor: {
         actorExternalId: event.user,
@@ -346,6 +381,7 @@ export function normalizeSlackDirectMessage(
     routing,
     threadTs: event.thread_ts ?? event.ts,
     channel: event.channel,
+    ...(slackFiles ? { slackFiles } : {}),
   };
 }
 
@@ -374,6 +410,15 @@ export function normalizeSlackChannelMessage(
   const externalMessageId =
     event.client_msg_id ?? event.ts ?? `${event.channel}:${event.ts}`;
 
+  const attachments = extractSlackAttachments(event.files);
+  const slackFiles = event.files?.length
+    ? new Map(
+        event.files
+          .filter((f) => f.url_private_download || f.url_private)
+          .map((f) => [f.id, f]),
+      )
+    : undefined;
+
   const userInfo =
     botToken && event.user
       ? resolveSlackUserSync(event.user, botToken)
@@ -388,6 +433,7 @@ export function normalizeSlackChannelMessage(
         content,
         conversationExternalId: event.channel,
         externalMessageId,
+        ...(attachments.length > 0 ? { attachments } : {}),
       },
       actor: {
         actorExternalId: event.user,
@@ -406,6 +452,7 @@ export function normalizeSlackChannelMessage(
     routing,
     threadTs: event.thread_ts ?? event.ts,
     channel: event.channel,
+    ...(slackFiles ? { slackFiles } : {}),
   };
 }
 
@@ -431,6 +478,15 @@ export function normalizeSlackAppMention(
   const externalMessageId =
     event.client_msg_id ?? event.ts ?? `${event.channel}:${event.ts}`;
 
+  const attachments = extractSlackAttachments(event.files);
+  const slackFiles = event.files?.length
+    ? new Map(
+        event.files
+          .filter((f) => f.url_private_download || f.url_private)
+          .map((f) => [f.id, f]),
+      )
+    : undefined;
+
   const userInfo =
     botToken && event.user
       ? resolveSlackUserSync(event.user, botToken)
@@ -445,6 +501,7 @@ export function normalizeSlackAppMention(
         content,
         conversationExternalId: event.channel,
         externalMessageId,
+        ...(attachments.length > 0 ? { attachments } : {}),
       },
       actor: {
         actorExternalId: event.user,
@@ -462,6 +519,7 @@ export function normalizeSlackAppMention(
     routing,
     threadTs: event.thread_ts ?? event.ts,
     channel: event.channel,
+    ...(slackFiles ? { slackFiles } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary
- Add extractSlackAttachments helper to map SlackFile[] to the gateway attachment schema
- Extend NormalizedSlackEvent with slackFiles Map for I/O layer download access
- Populate message.attachments and slackFiles in normalizeSlackDirectMessage, normalizeSlackChannelMessage, and normalizeSlackAppMention
- Add comprehensive tests for attachment extraction across all three normalize functions

Part of plan: slack-file-attachments.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
