### PR TITLE
Add downloadSlackFile function for fetching Slack file attachments

### DIFF
--- a/gateway/src/slack/download.test.ts
+++ b/gateway/src/slack/download.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import type { SlackFile } from "./normalize.js";
+
+type FetchFn = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(
+  async () => new Response(),
+);
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+const { downloadSlackFile } = await import("./download.js");
+
+function makeSlackFile(overrides?: Partial<SlackFile>): SlackFile {
+  return {
+    id: "F12345",
+    name: "test-image.png",
+    mimetype: "image/png",
+    url_private_download: "https://files.slack.com/download/F12345",
+    url_private: "https://files.slack.com/files-pri/F12345",
+    ...overrides,
+  };
+}
+
+/** Create a minimal valid PNG buffer that file-type can detect. */
+function makePngBuffer(): ArrayBuffer {
+  // PNG signature (8 bytes) + minimal IHDR chunk (25 bytes)
+  const png = new Uint8Array([
+    // PNG signature
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    // IHDR chunk: length (13)
+    0x00, 0x00, 0x00, 0x0d,
+    // IHDR type
+    0x49, 0x48, 0x44, 0x52,
+    // Width: 1
+    0x00, 0x00, 0x00, 0x01,
+    // Height: 1
+    0x00, 0x00, 0x00, 0x01,
+    // Bit depth, color type, compression, filter, interlace
+    0x08, 0x02, 0x00, 0x00, 0x00,
+    // CRC (placeholder)
+    0x90, 0x77, 0x53, 0xde,
+  ]);
+  return png.buffer;
+}
+
+/** Create a plain text buffer (undetectable by file-type). */
+function makeTextBuffer(): ArrayBuffer {
+  return new TextEncoder().encode("hello world").buffer;
+}
+
+describe("downloadSlackFile", () => {
+  afterEach(() => {
+    fetchMock = mock(async () => new Response());
+  });
+
+  test("downloads file using url_private_download", async () => {
+    const fileBuffer = makePngBuffer();
+    fetchMock = mock(async () => new Response(fileBuffer));
+
+    const file = makeSlackFile();
+    const result = await downloadSlackFile(file, "xoxb-test-token");
+
+    expect(result.filename).toBe("test-image.png");
+    expect(result.mimeType).toBe("image/png");
+    expect(result.data).toBe(
+      Buffer.from(fileBuffer).toString("base64"),
+    );
+
+    // Verify the correct URL and auth header were used
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://files.slack.com/download/F12345");
+    expect((init as RequestInit).headers).toEqual({
+      Authorization: "Bearer xoxb-test-token",
+    });
+  });
+
+  test("falls back to url_private when url_private_download is absent", async () => {
+    const fileBuffer = makePngBuffer();
+    fetchMock = mock(async () => new Response(fileBuffer));
+
+    const file = makeSlackFile({
+      url_private_download: undefined,
+    });
+    const result = await downloadSlackFile(file, "xoxb-test-token");
+
+    expect(result.filename).toBe("test-image.png");
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://files.slack.com/files-pri/F12345");
+  });
+
+  test("throws when neither URL is present", async () => {
+    const file = makeSlackFile({
+      url_private_download: undefined,
+      url_private: undefined,
+    });
+
+    await expect(
+      downloadSlackFile(file, "xoxb-test-token"),
+    ).rejects.toThrow("Slack file F12345 has no download URL");
+  });
+
+  test("throws on HTTP error response", async () => {
+    fetchMock = mock(
+      async () => new Response("Forbidden", { status: 403, statusText: "Forbidden" }),
+    );
+
+    const file = makeSlackFile();
+
+    await expect(
+      downloadSlackFile(file, "xoxb-test-token"),
+    ).rejects.toThrow(
+      "Failed to download Slack file F12345: 403 Forbidden",
+    );
+  });
+
+  test("file.mimetype wins over detected and Content-Type", async () => {
+    // Return a PNG buffer but set file.mimetype to a custom type
+    const fileBuffer = makePngBuffer();
+    fetchMock = mock(
+      async () =>
+        new Response(fileBuffer, {
+          headers: { "Content-Type": "application/octet-stream" },
+        }),
+    );
+
+    const file = makeSlackFile({ mimetype: "image/webp" });
+    const result = await downloadSlackFile(file, "xoxb-test-token");
+
+    expect(result.mimeType).toBe("image/webp");
+  });
+
+  test("falls back to detected MIME when file.mimetype is absent", async () => {
+    const fileBuffer = makePngBuffer();
+    fetchMock = mock(async () => new Response(fileBuffer));
+
+    const file = makeSlackFile({ mimetype: undefined });
+    const result = await downloadSlackFile(file, "xoxb-test-token");
+
+    expect(result.mimeType).toBe("image/png");
+  });
+
+  test("falls back to Content-Type when mimetype is absent and type is undetectable", async () => {
+    const fileBuffer = makeTextBuffer();
+    fetchMock = mock(
+      async () =>
+        new Response(fileBuffer, {
+          headers: { "Content-Type": "text/plain; charset=utf-8" },
+        }),
+    );
+
+    const file = makeSlackFile({ mimetype: undefined });
+    const result = await downloadSlackFile(file, "xoxb-test-token");
+
+    expect(result.mimeType).toBe("text/plain");
+  });
+
+  test("falls back to application/octet-stream when nothing else is available", async () => {
+    const fileBuffer = makeTextBuffer();
+    fetchMock = mock(async () => new Response(fileBuffer));
+
+    const file = makeSlackFile({ mimetype: undefined });
+    const result = await downloadSlackFile(file, "xoxb-test-token");
+
+    expect(result.mimeType).toBe("application/octet-stream");
+  });
+
+  test("falls back to slack_file_{id} when file.name is absent", async () => {
+    const fileBuffer = makeTextBuffer();
+    fetchMock = mock(async () => new Response(fileBuffer));
+
+    const file = makeSlackFile({ name: undefined, mimetype: "text/plain" });
+    const result = await downloadSlackFile(file, "xoxb-test-token");
+
+    expect(result.filename).toBe("slack_file_F12345");
+  });
+});

--- a/gateway/src/slack/download.ts
+++ b/gateway/src/slack/download.ts
@@ -1,0 +1,50 @@
+import { fileTypeFromBuffer } from "file-type";
+import { fetchImpl } from "../fetch.js";
+import type { SlackFile } from "./normalize.js";
+
+export interface DownloadedFile {
+  filename: string;
+  mimeType: string;
+  data: string; // base64-encoded
+}
+
+const DOWNLOAD_TIMEOUT_MS = 30_000;
+
+/**
+ * Download a Slack file using the bot token for authentication.
+ * Prefers url_private_download; falls back to url_private.
+ */
+export async function downloadSlackFile(
+  file: SlackFile,
+  botToken: string,
+): Promise<DownloadedFile> {
+  const url = file.url_private_download || file.url_private;
+  if (!url) {
+    throw new Error(`Slack file ${file.id} has no download URL`);
+  }
+
+  const response = await fetchImpl(url, {
+    headers: { Authorization: `Bearer ${botToken}` },
+    signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to download Slack file ${file.id}: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const buffer = await response.arrayBuffer();
+  const detected = await fileTypeFromBuffer(new Uint8Array(buffer));
+
+  const mimeType =
+    file.mimetype ||
+    detected?.mime ||
+    response.headers.get("Content-Type")?.split(";")[0].trim() ||
+    "application/octet-stream";
+
+  const filename = file.name || `slack_file_${file.id}`;
+  const data = Buffer.from(buffer).toString("base64");
+
+  return { filename, mimeType, data };
+}


### PR DESCRIPTION
## Summary
- Create gateway/src/slack/download.ts with downloadSlackFile function
- Prefers url_private_download, falls back to url_private, with bot token auth
- MIME type detection priority: file.mimetype > fileTypeFromBuffer > Content-Type header > octet-stream
- Add comprehensive tests with mocked fetchImpl

Part of plan: slack-file-attachments.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
