### PR TITLE
Wire Slack file download/upload into gateway onEvent callback

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -77,12 +77,17 @@ import {
   createTrustRulesStarterBundleHandler,
 } from "./http/routes/trust-rules.js";
 import { getLogger, initLogger } from "./logger.js";
-import { CircuitBreakerOpenError } from "./runtime/client.js";
+import {
+  AttachmentValidationError,
+  CircuitBreakerOpenError,
+  uploadAttachment,
+} from "./runtime/client.js";
 import { buildSchema } from "./schema.js";
 import {
   createSlackSocketModeClient,
   type SlackSocketModeClient,
 } from "./slack/socket-mode.js";
+import { downloadSlackFile } from "./slack/download.js";
 import { fetchThreadContext } from "./slack/thread-context.js";
 import { handleInbound } from "./handlers/handle-inbound.js";
 import { checkAuthRateLimit } from "./http/middleware/rate-limit.js";
@@ -1217,13 +1222,99 @@ async function main() {
           !isEdit &&
           !isCallback;
 
-        const forward = (threadContextHint?: string) => {
+        const forward = async (threadContextHint?: string) => {
           const hints: string[] = [];
           if (threadContextHint) hints.push(threadContextHint);
+
+          // Download and upload attachments if present (skip for edits and
+          // callback actions — edits only update text, callbacks have no media)
+          let attachmentIds: string[] | undefined;
+          const eventAttachments = normalized.event.message.attachments;
+          if (
+            eventAttachments &&
+            eventAttachments.length > 0 &&
+            normalized.slackFiles &&
+            !isEdit &&
+            !isCallback
+          ) {
+            attachmentIds = [];
+            const maxBytes =
+              config.maxAttachmentBytes.slack ??
+              config.maxAttachmentBytes.default;
+
+            // Filter oversized attachments
+            const eligible = eventAttachments.filter((att) => {
+              if (
+                att.fileSize !== undefined &&
+                att.fileSize > maxBytes
+              ) {
+                log.warn(
+                  {
+                    fileId: att.fileId,
+                    fileSize: att.fileSize,
+                    limit: maxBytes,
+                  },
+                  "Skipping oversized Slack attachment",
+                );
+                return false;
+              }
+              return true;
+            });
+
+            // Process with bounded concurrency. Socket Mode has no retry
+            // mechanism, so all errors (validation and transient) are logged
+            // and skipped — the message is still delivered without the
+            // failed attachment.
+            for (
+              let i = 0;
+              i < eligible.length;
+              i += config.maxAttachmentConcurrency
+            ) {
+              const batch = eligible.slice(
+                i,
+                i + config.maxAttachmentConcurrency,
+              );
+              const results = await Promise.allSettled(
+                batch.map(async (att) => {
+                  const slackFile = normalized.slackFiles?.get(att.fileId);
+                  if (!slackFile) {
+                    throw new Error(
+                      `No SlackFile found for attachment ${att.fileId}`,
+                    );
+                  }
+                  const downloaded = await downloadSlackFile(
+                    slackFile,
+                    botToken,
+                  );
+                  return uploadAttachment(config, downloaded);
+                }),
+              );
+              for (const result of results) {
+                if (result.status === "fulfilled") {
+                  attachmentIds.push(result.value.id);
+                } else if (
+                  result.reason instanceof AttachmentValidationError
+                ) {
+                  log.warn(
+                    { err: result.reason },
+                    "Skipping Slack attachment with validation error",
+                  );
+                } else {
+                  log.warn(
+                    { err: result.reason },
+                    "Skipping Slack attachment due to download/upload failure",
+                  );
+                }
+              }
+            }
+          }
 
           handleInbound(config, normalized.event, {
             replyCallbackUrl,
             routingOverride: normalized.routing,
+            ...(attachmentIds && attachmentIds.length > 0
+              ? { attachmentIds }
+              : {}),
             ...(hints.length > 0 ? { transportMetadata: { hints } } : {}),
           }).catch((err) => {
             log.error(


### PR DESCRIPTION
## Summary
- Wire attachment download/upload into the Slack Socket Mode onEvent callback in gateway/src/index.ts
- Download files via downloadSlackFile, upload via uploadAttachment, pass attachmentIds to handleInbound
- Follow Telegram's bounded-concurrency pattern with size filtering and error classification
- Socket Mode has no retry, so transient failures are logged and skipped (message still delivered without attachment)

Part of plan: slack-file-attachments.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
