### PR TITLE
Fix thinking blocks leaking across conversations

### DIFF
--- a/assistant/src/__tests__/runtime-events-sse-parity.test.ts
+++ b/assistant/src/__tests__/runtime-events-sse-parity.test.ts
@@ -141,12 +141,14 @@ describe("SSE HTTP parity — streaming/delta message types", () => {
     const msg = {
       type: "assistant_thinking_delta" as const,
       thinking: "Let me reason through this...",
+      conversationId: "conv-thinking-test",
     };
     const event = await publishAndReadFrame("parity-thinking-delta", msg);
 
     expect(event.message.type).toBe("assistant_thinking_delta");
     const m = event.message as typeof msg;
     expect(m.thinking).toBe("Let me reason through this...");
+    expect(m.conversationId).toBe("conv-thinking-test");
   });
 
   // ── tool_input_delta ─────────────────────────────────────────────────────

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -270,7 +270,7 @@ export function handleThinkingDelta(
   }
   if (!deps.ctx.streamThinking) return;
   emitLlmCallStartedIfNeeded(state, deps);
-  deps.onEvent({ type: "assistant_thinking_delta", thinking: event.thinking });
+  deps.onEvent({ type: "assistant_thinking_delta", thinking: event.thinking, conversationId: deps.ctx.conversationId });
 }
 
 export function handleToolUse(

--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -71,6 +71,7 @@ export interface AssistantTextDelta {
 export interface AssistantThinkingDelta {
   type: "assistant_thinking_delta";
   thinking: string;
+  conversationId?: string;
 }
 
 export interface ToolUseStart {

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -107,6 +107,7 @@ final class ChatActionHandler {
             vm.isThinking = true
 
         case .assistantThinkingDelta(let delta):
+            guard belongsToConversation(delta.conversationId) else { return }
             guard !vm.isCancelling else { break }
             guard !vm.isLoadingHistory else { break }
             guard MacOSClientFeatureFlagManager.shared.isEnabled("show-thinking-blocks") else { break }

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -532,10 +532,12 @@ public struct AssistantTextDelta: Codable, Sendable {
 public struct AssistantThinkingDelta: Codable, Sendable {
     public let type: String
     public let thinking: String
+    public let conversationId: String?
 
-    public init(type: String, thinking: String) {
+    public init(type: String, thinking: String, conversationId: String? = nil) {
         self.type = type
         self.thinking = thinking
+        self.conversationId = conversationId
     }
 }
 

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -653,8 +653,8 @@ extension AssistantTextDelta {
 public typealias AssistantThinkingDeltaMessage = AssistantThinkingDelta
 
 extension AssistantThinkingDelta {
-    public init(thinking: String) {
-        self.init(type: "assistant_thinking_delta", thinking: thinking)
+    public init(thinking: String, conversationId: String? = nil) {
+        self.init(type: "assistant_thinking_delta", thinking: thinking, conversationId: conversationId)
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `conversationId` to `AssistantThinkingDelta` at every layer (server TS type, event emission, Swift type, convenience init)
- Add missing `belongsToConversation()` guard in `ChatActionHandler` for thinking deltas, matching the existing `assistantTextDelta` pattern
- Update SSE parity test to verify `conversationId` preservation on thinking deltas

**Root cause**: `assistant_thinking_delta` was the only streaming delta type without `conversationId`. The event hub treated these as system-wide broadcasts, and the client handler accumulated them into whichever ChatViewModel received them — causing thinking content from separate conversations to merge.

## Original prompt

Fix thinking blocks leaking across conversations. The root cause is that `assistant_thinking_delta` events are missing `conversationId` at every layer — server-side message type, event emission, client-side Swift type, and client-side guard. Every other streaming delta type has this plumbing.

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
