### PR TITLE
Revert thinking block scroll constraint

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
@@ -18,16 +18,13 @@ struct ThinkingBlockView: View {
                 Divider()
                     .padding(.horizontal, VSpacing.sm)
 
-                ScrollView {
-                    Text(content)
-                        .font(VFont.bodyMediumDefault)
-                        .foregroundStyle(VColor.contentSecondary)
-                        .textSelection(.enabled)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(VSpacing.sm)
-                }
-                .frame(maxHeight: 600)
-                .transition(.opacity.combined(with: .move(edge: .top)))
+                Text(content)
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(VSpacing.sm)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
         .background(VColor.surfaceOverlay)


### PR DESCRIPTION
## Summary
- Removes the `ScrollView` wrapper and `.frame(maxHeight: 600)` constraint from `ThinkingBlockView`, reverting #22164
- Thinking blocks now display their full content inline without scrolling

## Original prompt
Let's get rid of the scrolling and just show the whole thinking block regardless of how long it is. We made a PR adding this today so you can probably just revert that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)