### PR TITLE
feat: enable HyDE expansion for memory_recall tool

### DIFF
--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -298,6 +298,7 @@ export async function handleMemoryRecall(
       {
         scopeId,
         scopePolicyOverride,
+        hydeEnabled: true,
       },
     );
 


### PR DESCRIPTION
## Summary
- Add `hydeEnabled: true` to `buildMemoryRecall()` options in `handleMemoryRecall()`
- Auto-injection path remains unchanged (no HyDE, no added latency)

Part of plan: query-reform-mmr.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
