### PR TITLE
fix: sort candidates by finalScore before topCandidates slice

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -688,7 +688,8 @@ export async function buildMemoryRecall(
     very_stale: diversified.filter((c) => c.staleness === "very_stale").length,
   };
 
-  const topCandidates: MemoryRecallCandiateDebug[] = diversified
+  const topCandidates: MemoryRecallCandiateDebug[] = [...diversified]
+    .sort((a, b) => b.finalScore - a.finalScore)
     .slice(0, 10)
     .map((c) => ({
       key: c.key,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for query-reform-mmr.md.

**Gap:** MMR reordering corrupts topCandidates debug slice
**What was expected:** topCandidates reflects top-scoring candidates
**What was found:** slice(0,10) after MMR captures non-items preferentially
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
