### PR TITLE
fix: generate per-doc sparse embeddings for HyDE searches

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -320,24 +320,26 @@ async function runHyDESearch(
     };
   }
 
-  // Run parallel semantic searches for each hypothetical doc embedding
-  const hydeSearchPromises = hydeVectors.map((vector) =>
-    semanticSearch(
+  // Run parallel semantic searches for each hypothetical doc embedding,
+  // generating per-doc sparse embeddings so sparse and dense components match.
+  const hydeSearchPromises = hydeVectors.map((vector, i) => {
+    const docSparseVector = generateSparseEmbedding(hypotheticalDocs[i]!);
+    return semanticSearch(
       vector,
       provider,
       model,
       limit,
       excludeMessageIds,
       scopeIds,
-      sparseVector,
+      docSparseVector,
     ).catch((err) => {
       log.warn(
         { err: err instanceof Error ? err.message : String(err) },
         "HyDE hypothetical doc search failed; skipping",
       );
       return [] as Candidate[];
-    }),
-  );
+    });
+  });
 
   // Await all searches in parallel (raw + hypothetical)
   const [rawResults, ...hydeResults] = await Promise.all([


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for query-reform-mmr.md.

**Gap:** HyDE searches reuse raw query's sparse vector
**What was expected:** Per-doc sparse embeddings for each hypothetical document
**What was found:** All HyDE searches used the raw query's sparse vector
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
