### PR TITLE
Fix message timestamps reflecting persistence time instead of event time

### DIFF
--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -1850,6 +1850,7 @@ describe("MessageQueue byte budget", () => {
       })),
       requestId,
       onEvent: () => {},
+      sentAt: Date.now(),
     };
   }
 

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -102,6 +102,8 @@ export interface EventHandlerState {
   >;
   /** tool_use_ids emitted in the current turn (populated in handleToolUse, cleared after annotation). */
   currentTurnToolUseIds: string[];
+  /** Wall-clock time (ms since epoch) when the agent loop turn started, used as the display timestamp for assistant messages. */
+  turnStartedAt: number;
 }
 
 /** Immutable context shared across event handlers within a single agent loop run. */
@@ -154,6 +156,7 @@ export function createEventHandlerState(): EventHandlerState {
     requestIdToToolUseId: new Map(),
     toolConfirmationOutcomes: new Map(),
     currentTurnToolUseIds: [],
+    turnStartedAt: Date.now(),
   };
 }
 
@@ -722,6 +725,7 @@ export async function handleMessageComplete(
     userMessageInterface: deps.turnInterfaceContext.userMessageInterface,
     assistantMessageInterface:
       deps.turnInterfaceContext.assistantMessageInterface,
+    sentAt: state.turnStartedAt,
   };
   const assistantMsg = await addMessage(
     deps.ctx.conversationId,

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -247,6 +247,7 @@ export function enqueueMessage(
     turnInterfaceContext,
     isInteractive: options?.isInteractive,
     displayContent,
+    sentAt: Date.now(),
   });
   if (!accepted) {
     onEvent({

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -335,6 +335,7 @@ export async function drainQueue(
         ...(Object.keys(drainImageSourcePaths).length > 0
           ? { imageSourcePaths: drainImageSourcePaths }
           : {}),
+        sentAt: next.sentAt,
       };
       const cleanUserMsg = createUserMessage(next.content, next.attachments);
       const llmUserMsg = enrichMessageWithSourcePaths(
@@ -455,7 +456,7 @@ export async function drainQueue(
       resolvedContent,
       next.attachments,
       next.requestId,
-      next.metadata,
+      { ...next.metadata, sentAt: next.sentAt },
       next.displayContent,
     );
   } catch (err) {

--- a/assistant/src/daemon/conversation-queue-manager.ts
+++ b/assistant/src/daemon/conversation-queue-manager.ts
@@ -31,6 +31,8 @@ export interface QueuedMessage {
   isInteractive?: boolean;
   /** Original user message text to persist to DB when recording intent stripping produced a different `content`. */
   displayContent?: string;
+  /** Wall-clock time (ms since epoch) when the message was enqueued, used as the display timestamp. */
+  sentAt: number;
 }
 
 /**

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -418,6 +418,19 @@ export function handleListMessages(
     }
     const rendered = renderHistoryContent(content);
 
+    // Extract sentAt from metadata for display timestamps. When a message
+    // was queued or its persistence was delayed (long assistant generation),
+    // sentAt captures the actual event time. Falls back to createdAt.
+    let sentAt: number | undefined;
+    if (msg.metadata) {
+      try {
+        const meta = JSON.parse(msg.metadata);
+        if (typeof meta.sentAt === "number") sentAt = meta.sentAt;
+      } catch {
+        // Ignore malformed metadata
+      }
+    }
+
     // Strip <no_response/> markers from assistant messages so web/API
     // clients never see the raw sentinel. Only assistant messages produce
     // this marker; user messages are left untouched.
@@ -450,6 +463,7 @@ export function handleListMessages(
         role: msg.role,
         text: rendered.text.replace(NO_RESPONSE_INLINE_RE, "").trim(),
         timestamp: msg.createdAt,
+        sentAt,
         toolCalls: rendered.toolCalls,
         toolCallsBeforeText: rendered.toolCallsBeforeText,
         textSegments: filteredSegments,
@@ -466,6 +480,7 @@ export function handleListMessages(
       role: msg.role,
       text: rendered.text,
       timestamp: msg.createdAt,
+      sentAt,
       toolCalls: rendered.toolCalls,
       toolCallsBeforeText: rendered.toolCallsBeforeText,
       textSegments: rendered.textSegments,
@@ -542,11 +557,14 @@ export function handleListMessages(
       prevAssistantTimestamp = msgTimestamp;
     }
 
+    // Use sentAt (actual event time) for the display timestamp when
+    // available, falling back to createdAt (persistence time).
+    const displayTimestamp = m.sentAt ?? m.timestamp;
     return {
       id: m.id ?? "",
       role: m.role,
       content: m.text,
-      timestamp: new Date(m.timestamp).toISOString(),
+      timestamp: new Date(displayTimestamp).toISOString(),
       attachments: msgAttachments,
       ...(m.toolCalls.length > 0 ? { toolCalls: m.toolCalls } : {}),
       ...(interfaces ? { interfaces } : {}),


### PR DESCRIPTION
## Summary
- Store `sentAt` in message metadata capturing the actual event time — enqueue time for queued user messages, turn start time for assistant messages
- History API returns `sentAt` as the display timestamp when available, falling back to `createdAt` for existing messages
- No client changes or schema migration required — `sentAt` is stored in the existing passthrough metadata JSON

## Original prompt
Fix message timestamps — queued user messages get timestamped at dequeue time instead of send time, and assistant response timestamps change after app restart because server persists at generation-complete time rather than streaming-start time.