### PR TITLE
Decouple scroll follow state from observation with debounced UI sync

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -15,9 +15,11 @@ final class MessageListScrollState {
 
     // MARK: - Observed Properties (trigger view updates)
 
-    /// Whether the viewport is logically following the bottom of the transcript.
-    /// When false (detached), background pin requests are suppressed.
-    var isFollowingBottom = true
+    @ObservationIgnored private var _isFollowingBottom = true
+
+    /// Logical follow state — scroll handlers and callbacks read this.
+    /// Does NOT trigger view re-evaluation (reads @ObservationIgnored backing store).
+    var isFollowingBottom: Bool { _isFollowingBottom }
 
     /// The message ID whose top edge should be pinned to the viewport top
     /// after the user sends a message (push-to-top pattern). `nil` when
@@ -34,11 +36,11 @@ final class MessageListScrollState {
     /// hiding the indicators during the initial layout window masks this.
     var hideScrollIndicators = false
 
-    // MARK: - Computed Properties
+    /// Whether the "Scroll to latest" CTA should be visible.
+    /// Updated via debounced `scheduleUISync()` — at most once per frame.
+    private(set) var showScrollToLatest = false
 
-    /// Whether the "Scroll to latest" CTA should be visible. Replaces the
-    /// `isNearBottom` binding chain from the old coordinator.
-    var showScrollToLatest: Bool { !isFollowingBottom }
+    // MARK: - Computed Properties
 
     /// Height of the tail spacer when it is visible during push-to-top.
     /// Subtracted from content height for overflow and bottom detection
@@ -196,6 +198,26 @@ final class MessageListScrollState {
     /// without relying on `.defaultScrollAnchor`.
     @ObservationIgnored var scrollToEdge: ((_ edge: Edge) -> Void)?
 
+    // MARK: - Debounced UI Sync
+
+    @ObservationIgnored private var uiSyncTask: Task<Void, Never>?
+
+    /// Debounces observed-property updates so rapid oscillation of _isFollowingBottom
+    /// (e.g. during rapid scrolling near bottom) coalesces into at most one
+    /// view re-evaluation per frame instead of one per scroll event.
+    private func scheduleUISync() {
+        uiSyncTask?.cancel()
+        uiSyncTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 16_000_000) // ~1 frame at 60Hz
+            guard let self, !Task.isCancelled else { return }
+            let newValue = !self._isFollowingBottom
+            if self.showScrollToLatest != newValue {
+                self.showScrollToLatest = newValue
+            }
+            self.uiSyncTask = nil
+        }
+    }
+
     // MARK: - Task References
 
     /// In-flight pagination load task.
@@ -242,7 +264,7 @@ final class MessageListScrollState {
         }
 
         // Non-user-initiated requests are gated on follow-state and suppression.
-        guard isFollowingBottom else { return false }
+        guard _isFollowingBottom else { return false }
         guard !isSuppressed else { return false }
 
         if animated {
@@ -257,14 +279,16 @@ final class MessageListScrollState {
 
     /// Transitions to the detached state, suppressing all background pin requests.
     func detach() {
-        guard isFollowingBottom else { return }
-        isFollowingBottom = false
+        guard _isFollowingBottom else { return }
+        _isFollowingBottom = false
+        scheduleUISync()
     }
 
     /// Transitions to the following state, allowing pin requests to proceed.
     func reattach() {
-        guard !isFollowingBottom else { return }
-        isFollowingBottom = true
+        guard !_isFollowingBottom else { return }
+        _isFollowingBottom = true
+        scheduleUISync()
     }
 
     /// Performs a programmatic scroll to the given item ID and anchor point,
@@ -296,7 +320,10 @@ final class MessageListScrollState {
         // Update the live conversation ID so closures read the new value.
         currentConversationId = newConversationId
         // Reset follow state for the new conversation.
-        if !isFollowingBottom { isFollowingBottom = true }
+        if !_isFollowingBottom { _isFollowingBottom = true }
+        // Sync UI immediately for conversation switch (no debounce delay).
+        uiSyncTask?.cancel()
+        if showScrollToLatest { showScrollToLatest = false }
         if pushToTopMessageId != nil { pushToTopMessageId = nil }
         isAtBottom = true
         hasReceivedScrollEvent = false
@@ -316,6 +343,8 @@ final class MessageListScrollState {
     /// Cancel all tasks and clear suppression. Called from `onDisappear`.
     func cancelAll() {
         clearSuppression()
+        uiSyncTask?.cancel()
+        uiSyncTask = nil
         scrollRestoreTask?.cancel()
         scrollRestoreTask = nil
         paginationTask?.cancel()

--- a/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
@@ -152,7 +152,7 @@ final class MessageListScrollPerformanceTests: XCTestCase {
             // Run 100 pin request cycles to get a stable measurement.
             for _ in 0..<100 {
                 scrollState.pinToBottom()
-                scrollState.isFollowingBottom = true
+                scrollState.reattach()
             }
 
             XCTAssertGreaterThan(scrollCallCount, 0)

--- a/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
@@ -60,11 +60,15 @@ final class MessageListScrollStateTests: XCTestCase {
         XCTAssertTrue(state.isFollowingBottom)
     }
 
-    func testRapidDetachCallsDoNotAccumulate() {
+    func testRapidDetachCallsDoNotAccumulate() async throws {
         for _ in 0..<100 {
             state.detach()
         }
         XCTAssertFalse(state.isFollowingBottom)
+        // showScrollToLatest is debounced — not yet updated synchronously.
+        XCTAssertFalse(state.showScrollToLatest)
+        // Wait for the debounced UI sync to fire.
+        try await Task.sleep(nanoseconds: 50_000_000)
         XCTAssertTrue(state.showScrollToLatest)
     }
 
@@ -220,6 +224,7 @@ final class MessageListScrollStateTests: XCTestCase {
         state.reset(for: newId)
 
         XCTAssertTrue(state.isFollowingBottom, "Should restore following state")
+        XCTAssertFalse(state.showScrollToLatest, "Should sync showScrollToLatest immediately on reset")
         XCTAssertFalse(state.isSuppressed, "Should clear suppression")
         XCTAssertFalse(state.isPaginationInFlight, "Should clear pagination flag")
         XCTAssertFalse(state.wasPaginationTriggerInRange, "Should clear trigger range flag")
@@ -270,15 +275,19 @@ final class MessageListScrollStateTests: XCTestCase {
 
     // MARK: - Computed Properties
 
-    func testShowScrollToLatest() {
+    func testShowScrollToLatest() async throws {
         XCTAssertFalse(state.showScrollToLatest,
                        "Should be false when following bottom")
 
         state.detach()
+        // Wait for debounced UI sync.
+        try await Task.sleep(nanoseconds: 50_000_000)
         XCTAssertTrue(state.showScrollToLatest,
                       "Should be true when not following bottom")
 
         state.reattach()
+        // Wait for debounced UI sync.
+        try await Task.sleep(nanoseconds: 50_000_000)
         XCTAssertFalse(state.showScrollToLatest,
                        "Should be false again after reattach")
     }


### PR DESCRIPTION
## Summary
- Split isFollowingBottom into @ObservationIgnored internal state + debounced showScrollToLatest observed property
- Scroll handlers write to internal state at full frequency (zero re-evaluations); UI syncs at most once per frame (16ms)
- Breaks the reactive feedback loop: onScrollGeometryChange → state write → body eval → layout → onScrollGeometryChange

Part of plan: scroll-decouple-freeze-fix.md (PR 1 of 3)