### PR TITLE
Add circuit breaker to auto-recover from scroll re-evaluation loops

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -198,6 +198,41 @@ final class MessageListScrollState {
     /// without relying on `.defaultScrollAnchor`.
     @ObservationIgnored var scrollToEdge: ((_ edge: Edge) -> Void)?
 
+    // MARK: - Circuit Breaker
+
+    /// Rolling window of body evaluation timestamps for loop detection.
+    @ObservationIgnored private var bodyEvalTimestamps: [CFAbsoluteTime] = []
+    /// When true, scheduleUISync() is suppressed to break a runaway re-evaluation loop.
+    @ObservationIgnored private(set) var isThrottled = false
+    @ObservationIgnored private var throttleRecoveryTask: Task<Void, Never>?
+
+    /// Called once per MessageListView body evaluation. Trips the circuit
+    /// breaker when >100 evaluations occur in 2 seconds, suppressing
+    /// `scheduleUISync()` for 500ms to break the loop.
+    func recordBodyEvaluation() {
+        let now = CFAbsoluteTimeGetCurrent()
+        bodyEvalTimestamps.append(now)
+        // Trim entries older than 2 seconds.
+        let cutoff = now - 2.0
+        if let firstValid = bodyEvalTimestamps.firstIndex(where: { $0 >= cutoff }) {
+            bodyEvalTimestamps.removeFirst(firstValid)
+        }
+
+        if bodyEvalTimestamps.count > 100 && !isThrottled {
+            isThrottled = true
+            os_log(.fault, "Scroll re-evaluation loop detected: %d evals in 2s — throttling for 500ms",
+                   bodyEvalTimestamps.count)
+            throttleRecoveryTask?.cancel()
+            throttleRecoveryTask = Task { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: 500_000_000)
+                guard let self, !Task.isCancelled else { return }
+                self.isThrottled = false
+                self.bodyEvalTimestamps.removeAll()
+                self.throttleRecoveryTask = nil
+            }
+        }
+    }
+
     // MARK: - Debounced UI Sync
 
     @ObservationIgnored private var uiSyncTask: Task<Void, Never>?
@@ -206,6 +241,7 @@ final class MessageListScrollState {
     /// (e.g. during rapid scrolling near bottom) coalesces into at most one
     /// view re-evaluation per frame instead of one per scroll event.
     private func scheduleUISync() {
+        guard !isThrottled else { return }
         uiSyncTask?.cancel()
         uiSyncTask = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: 16_000_000) // ~1 frame at 60Hz
@@ -355,6 +391,10 @@ final class MessageListScrollState {
         highlightDismissTask = nil
         scrollIndicatorRestoreTask?.cancel()
         scrollIndicatorRestoreTask = nil
+        throttleRecoveryTask?.cancel()
+        throttleRecoveryTask = nil
+        isThrottled = false
+        bodyEvalTimestamps.removeAll()
         if hideScrollIndicators { hideScrollIndicators = false }
         if isPaginationInFlight { isPaginationInFlight = false }
     }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -216,6 +216,7 @@ struct MessageListView: View {
     /// SwiftUI's `.equatable()` diffing sees every mutation.
     private var derivedState: MessageListDerivedState {
         os_signpost(.begin, log: stallLog, name: "DerivedState.resolve")
+        scrollState.recordBodyEvaluation()
 
         // Compute visible messages first so version tracking and layout
         // both operate on the same filtered set.

--- a/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
@@ -317,4 +317,34 @@ final class MessageListScrollStateTests: XCTestCase {
         XCTAssertEqual(state.tailSpacerHeight, 0,
                        "Should be 0 when viewport height is not finite")
     }
+
+    // MARK: - Circuit Breaker
+
+    func testCircuitBreakerTripsAfterRapidEvaluations() {
+        for _ in 0...100 {
+            state.recordBodyEvaluation()
+        }
+        XCTAssertTrue(state.isThrottled, "Circuit breaker should be active")
+    }
+
+    func testCircuitBreakerRecovery() async throws {
+        for _ in 0...100 {
+            state.recordBodyEvaluation()
+        }
+        XCTAssertTrue(state.isThrottled)
+        try await Task.sleep(nanoseconds: 600_000_000)
+        XCTAssertFalse(state.isThrottled, "Circuit breaker should auto-recover")
+    }
+
+    func testScheduleUISyncSuppressedWhenThrottled() async throws {
+        for _ in 0...100 {
+            state.recordBodyEvaluation()
+        }
+        XCTAssertTrue(state.isThrottled)
+        state.detach()
+        XCTAssertFalse(state.isFollowingBottom)
+        try await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertFalse(state.showScrollToLatest,
+                       "showScrollToLatest should NOT update while throttled")
+    }
 }


### PR DESCRIPTION
## Summary
- Add body evaluation circuit breaker that trips after >100 evaluations in 2 seconds
- When tripped, suppresses scheduleUISync() for 500ms to break any residual re-evaluation loop
- Auto-recovers after 500ms so normal operation resumes
- Safety net that makes any future loop TEMPORARY instead of PERMANENT

Part of plan: scroll-decouple-freeze-fix.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
