### PR TITLE
fix: Update stale comment and add circuit breaker reset to reset(for:)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -364,6 +364,12 @@ final class MessageListScrollState {
         isAtBottom = true
         hasReceivedScrollEvent = false
         lastContentOffsetY = 0
+        // Clear circuit breaker state so a throttle tripped in the previous
+        // conversation doesn't suppress scheduleUISync() in the new one.
+        throttleRecoveryTask?.cancel()
+        throttleRecoveryTask = nil
+        isThrottled = false
+        bodyEvalTimestamps.removeAll()
         // Hide scroll indicators during the conversation switch grace period
         // to mask LazyVStack content size estimation changes.
         scrollIndicatorRestoreTask?.cancel()

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -120,7 +120,7 @@ struct MessageListView: View {
     /// won't trigger re-renders on frequent `data` progress ticks.
     var taskProgressManager = TaskProgressOverlayManager.shared
     /// Consolidates all scroll-related state with @Observable fine-grained tracking.
-    /// Only 4 properties trigger view re-evaluations: isFollowingBottom,
+    /// Only 4 properties trigger view re-evaluations: showScrollToLatest,
     /// pushToTopMessageId, isPaginationInFlight, hideScrollIndicators.
     @State private var scrollState = MessageListScrollState()
     /// In-flight resize scroll stabilization task; cancelled on each new resize.


### PR DESCRIPTION
## Summary
Fixes two gaps from plan review:
- Update stale comment in MessageListView.swift listing isFollowingBottom as observed (now showScrollToLatest)
- Add circuit breaker cleanup to reset(for:) so throttle state doesn't carry over on conversation switch

Part of plan: scroll-decouple-freeze-fix.md (review fix)