### PR TITLE
Add /compact slash command for forced context compaction

### DIFF
--- a/assistant/src/__tests__/conversation-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-slash-commands.test.ts
@@ -36,6 +36,7 @@ describe("resolveSlash /commands interface-aware help", () => {
     );
     expect(lines).toEqual([
       "/commands — List all available commands",
+      "/compact — Force context compaction immediately",
       "/models — List all available models",
       "/status — Show conversation status and context usage",
       "/btw — Ask a side question while the assistant is working",
@@ -53,6 +54,7 @@ describe("resolveSlash /commands interface-aware help", () => {
     );
     expect(lines).toEqual([
       "/commands — List all available commands",
+      "/compact — Force context compaction immediately",
       "/models — List all available models",
       "/status — Show conversation status and context usage",
       "/btw — Ask a side question while the assistant is working",
@@ -66,6 +68,7 @@ describe("resolveSlash /commands interface-aware help", () => {
     );
     expect(lines).toEqual([
       "/commands — List all available commands",
+      "/compact — Force context compaction immediately",
       "/models — List all available models",
       "/status — Show conversation status and context usage",
       "/btw — Ask a side question while the assistant is working",
@@ -76,6 +79,7 @@ describe("resolveSlash /commands interface-aware help", () => {
     const lines = await resolveCommandsLines(makeSlashContext());
     expect(lines).toEqual([
       "/commands — List all available commands",
+      "/compact — Force context compaction immediately",
       "/models — List all available models",
       "/pair — Generate pairing info for connecting a mobile device",
       "/status — Show conversation status and context usage",
@@ -86,6 +90,7 @@ describe("resolveSlash /commands interface-aware help", () => {
     const lines = await resolveCommandsLines();
     expect(lines).toEqual([
       "/commands — List all available commands",
+      "/compact — Force context compaction immediately",
       "/models — List all available models",
       "/pair — Generate pairing info for connecting a mobile device",
     ]);

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -26,6 +26,7 @@ import {
 } from "../memory/conversation-crud.js";
 import { extractPreferences } from "../notifications/preference-extractor.js";
 import { createPreference } from "../notifications/preferences-store.js";
+import type { ContextWindowResult } from "../context/window-manager.js";
 import type { Message } from "../providers/types.js";
 import { routeGuardianReply } from "../runtime/guardian-reply-router.js";
 import { getLogger } from "../util/logger.js";
@@ -46,6 +47,20 @@ import type { TraceEmitter } from "./trace-emitter.js";
 import { resolveVerificationSessionIntent } from "./verification-session-intent.js";
 
 const log = getLogger("conversation-process");
+
+/** Format the result of a forced compaction into a user-facing message. */
+export function formatCompactResult(result: ContextWindowResult): string {
+  const fmt = (n: number) => n.toLocaleString("en-US");
+  if (!result.compacted) {
+    return `Context compaction skipped — ${result.reason ?? "nothing to compact"}.`;
+  }
+  const saved = result.previousEstimatedInputTokens - result.estimatedInputTokens;
+  return [
+    "Context Compacted\n",
+    `Tokens:   ${fmt(result.previousEstimatedInputTokens)} → ${fmt(result.estimatedInputTokens)} (${fmt(saved)} saved)`,
+    `Messages: ${fmt(result.compactedMessages)} compacted`,
+  ].join("\n");
+}
 
 /** Build a model_info event with fresh config data. */
 export async function buildModelInfoEvent(): Promise<ServerMessage> {
@@ -139,6 +154,8 @@ export interface ProcessConversationContext {
     requestId?: string,
     statusText?: string,
   ): void;
+  /** Force context compaction regardless of threshold/cooldown. */
+  forceCompact(): Promise<ContextWindowResult>;
 }
 
 function resolveQueuedTurnContext(
@@ -420,6 +437,82 @@ export async function drainQueue(
       next.onEvent({ type: "error", message });
     }
     // Continue draining regardless of success/failure
+    await drainQueue(conversation);
+    return;
+  }
+
+  // /compact — force context compaction, persist exchange, continue draining.
+  if (slashResult.kind === "compact") {
+    try {
+      const drainProvenance = provenanceFromTrustContext(
+        conversation.trustContext,
+      );
+      const drainChannelMeta = {
+        ...drainProvenance,
+        ...(queuedTurnCtx
+          ? {
+              userMessageChannel: queuedTurnCtx.userMessageChannel,
+              assistantMessageChannel: queuedTurnCtx.assistantMessageChannel,
+            }
+          : {}),
+        ...(queuedInterfaceCtx
+          ? {
+              userMessageInterface: queuedInterfaceCtx.userMessageInterface,
+              assistantMessageInterface:
+                queuedInterfaceCtx.assistantMessageInterface,
+            }
+          : {}),
+        sentAt: next.sentAt,
+      };
+      const cleanUserMsg = createUserMessage(next.content, next.attachments);
+      await addMessage(
+        conversation.conversationId,
+        "user",
+        JSON.stringify(cleanUserMsg.content),
+        drainChannelMeta,
+      );
+      conversation.messages.push(cleanUserMsg);
+
+      conversation.emitActivityState(
+        "thinking",
+        "context_compacting",
+        "assistant_turn",
+        next.requestId,
+      );
+      const result = await conversation.forceCompact();
+      const responseText = formatCompactResult(result);
+
+      const assistantMsg = createAssistantMessage(responseText);
+      await addMessage(
+        conversation.conversationId,
+        "assistant",
+        JSON.stringify(assistantMsg.content),
+        drainChannelMeta,
+      );
+      conversation.messages.push(assistantMsg);
+
+      next.onEvent({ type: "assistant_text_delta", text: responseText });
+      conversation.traceEmitter.emit(
+        "message_complete",
+        "Compact slash command handled",
+        { requestId: next.requestId, status: "success" },
+      );
+      next.onEvent({
+        type: "message_complete",
+        conversationId: conversation.conversationId,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.error(
+        {
+          err,
+          conversationId: conversation.conversationId,
+          requestId: next.requestId,
+        },
+        "Failed to execute /compact",
+      );
+      next.onEvent({ type: "error", message });
+    }
     await drainQueue(conversation);
     return;
   }
@@ -773,6 +866,66 @@ export async function processMessage(
         requestId,
         status: "success",
       },
+    );
+    onEvent({
+      type: "message_complete",
+      conversationId: conversation.conversationId,
+    });
+    return persisted.id;
+  }
+
+  // /compact — force context compaction, persist exchange, return message ID.
+  if (slashResult.kind === "compact") {
+    const pmTurnCtx = conversation.getTurnChannelContext();
+    const pmInterfaceCtx = conversation.getTurnInterfaceContext();
+    const pmProvenance = provenanceFromTrustContext(conversation.trustContext);
+    const pmChannelMeta = {
+      ...pmProvenance,
+      ...(pmTurnCtx
+        ? {
+            userMessageChannel: pmTurnCtx.userMessageChannel,
+            assistantMessageChannel: pmTurnCtx.assistantMessageChannel,
+          }
+        : {}),
+      ...(pmInterfaceCtx
+        ? {
+            userMessageInterface: pmInterfaceCtx.userMessageInterface,
+            assistantMessageInterface: pmInterfaceCtx.assistantMessageInterface,
+          }
+        : {}),
+    };
+    const cleanUserMsg = createUserMessage(content, attachments);
+    const persisted = await addMessage(
+      conversation.conversationId,
+      "user",
+      JSON.stringify(cleanUserMsg.content),
+      pmChannelMeta,
+    );
+    conversation.messages.push(cleanUserMsg);
+
+    conversation.emitActivityState(
+      "thinking",
+      "context_compacting",
+      "assistant_turn",
+      requestId,
+    );
+    const result = await conversation.forceCompact();
+    const responseText = formatCompactResult(result);
+
+    const assistantMsg = createAssistantMessage(responseText);
+    await addMessage(
+      conversation.conversationId,
+      "assistant",
+      JSON.stringify(assistantMsg.content),
+      pmChannelMeta,
+    );
+    conversation.messages.push(assistantMsg);
+
+    onEvent({ type: "assistant_text_delta", text: responseText });
+    conversation.traceEmitter.emit(
+      "message_complete",
+      "Compact slash command handled",
+      { requestId, status: "success" },
     );
     onEvent({
       type: "message_complete",

--- a/assistant/src/daemon/conversation-slash.ts
+++ b/assistant/src/daemon/conversation-slash.ts
@@ -16,7 +16,8 @@ import type { PairingStore } from "./pairing-store.js";
 
 export type SlashResolution =
   | { kind: "passthrough"; content: string }
-  | { kind: "unknown"; message: string; qrFilename?: string };
+  | { kind: "unknown"; message: string; qrFilename?: string }
+  | { kind: "compact" };
 
 // ── /pair command — module-level pairing context ────────────────────
 
@@ -129,6 +130,7 @@ function resolveStatusCommand(context: SlashContext): SlashResolution {
 function resolveCommandsList(context?: SlashContext): string[] {
   const fallbackLines = [
     "/commands — List all available commands",
+    "/compact — Force context compaction immediately",
     "/models — List all available models",
     "/pair — Generate pairing info for connecting a mobile device",
   ];
@@ -141,6 +143,7 @@ function resolveCommandsList(context?: SlashContext): string[] {
   if (context.userMessageInterface === "macos") {
     return [
       "/commands — List all available commands",
+      "/compact — Force context compaction immediately",
       "/models — List all available models",
       "/status — Show conversation status and context usage",
       "/btw — Ask a side question while the assistant is working",
@@ -152,6 +155,7 @@ function resolveCommandsList(context?: SlashContext): string[] {
   if (context.userMessageInterface === "ios") {
     return [
       "/commands — List all available commands",
+      "/compact — Force context compaction immediately",
       "/models — List all available models",
       "/status — Show conversation status and context usage",
       "/btw — Ask a side question while the assistant is working",
@@ -161,6 +165,7 @@ function resolveCommandsList(context?: SlashContext): string[] {
 
   return [
     "/commands — List all available commands",
+    "/compact — Force context compaction immediately",
     "/models — List all available models",
     "/status — Show conversation status and context usage",
     "/btw — Ask a side question while the assistant is working",
@@ -168,8 +173,9 @@ function resolveCommandsList(context?: SlashContext): string[] {
 }
 
 /**
- * Resolve built-in slash commands (/models, /status, /commands, /pair).
- * Returns `unknown` with a deterministic message, or the (possibly rewritten) content.
+ * Resolve built-in slash commands (/models, /status, /commands, /compact, /pair).
+ * Returns `unknown` with a deterministic message, `compact` for forced compaction,
+ * or the (possibly rewritten) content as `passthrough`.
  */
 export async function resolveSlash(
   content: string,
@@ -208,6 +214,11 @@ export async function resolveSlash(
   // Handle /pair command
   const pairResult = resolvePairCommand(content, context);
   if (pairResult) return pairResult;
+
+  // Handle /compact command
+  if (trimmed === "/compact") {
+    return { kind: "compact" };
+  }
 
   // Handle /status command
   if (trimmed === "/status") {

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -24,7 +24,10 @@ import type {
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
 import type { Speed } from "../config/schemas/inference.js";
-import { ContextWindowManager } from "../context/window-manager.js";
+import {
+  ContextWindowManager,
+  type ContextWindowResult,
+} from "../context/window-manager.js";
 import type { CesClient } from "../credential-execution/client.js";
 import { EventBus } from "../events/bus.js";
 import type { AssistantDomainEvents } from "../events/domain-events.js";
@@ -880,6 +883,20 @@ export class Conversation {
       ...(statusText ? { statusText } : {}),
     } as ServerMessage;
     this.sendToClient(msg);
+  }
+
+  async forceCompact(): Promise<ContextWindowResult> {
+    const result = await this.contextWindowManager.maybeCompact(
+      this.messages,
+      this.abortController?.signal ?? undefined,
+      { force: true, lastCompactedAt: this.contextCompactedAt ?? undefined },
+    );
+    if (result.compacted) {
+      this.messages = result.messages;
+      this.contextCompactedMessageCount += result.compactedPersistedMessages;
+      this.contextCompactedAt = Date.now();
+    }
+    return result;
   }
 
   setChannelCapabilities(caps: ChannelCapabilities | null): void {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -68,6 +68,7 @@ import {
 } from "./conversation.js";
 import { ConversationEvictor } from "./conversation-evictor.js";
 import { resolveChannelCapabilities } from "./conversation-runtime-assembly.js";
+import { formatCompactResult } from "./conversation-process.js";
 import { resolveSlash, type SlashContext } from "./conversation-slash.js";
 import { undoLastMessage } from "./handlers/conversations.js";
 import { parseIdentityFields } from "./handlers/identity.js";
@@ -1165,6 +1166,54 @@ export class DaemonServer {
         "assistant",
         JSON.stringify(assistantMsg.content),
         serverChannelMeta,
+      );
+      conversation.getMessages().push(assistantMsg);
+      return { messageId: persisted.id };
+    }
+
+    if (slashResult.kind === "compact") {
+      const serverTurnCtx = conversation.getTurnChannelContext();
+      const serverProvenance = provenanceFromTrustContext(
+        conversation.trustContext,
+      );
+      const compactChannelMeta = {
+        ...serverProvenance,
+        ...(serverTurnCtx
+          ? {
+              userMessageChannel: serverTurnCtx.userMessageChannel,
+              assistantMessageChannel: serverTurnCtx.assistantMessageChannel,
+            }
+          : {}),
+        ...(serverInterfaceCtx
+          ? {
+              userMessageInterface: serverInterfaceCtx.userMessageInterface,
+              assistantMessageInterface:
+                serverInterfaceCtx.assistantMessageInterface,
+            }
+          : {}),
+      };
+      const cleanMsg = createUserMessage(content, attachments);
+      const persisted = await addMessage(
+        conversationId,
+        "user",
+        JSON.stringify(cleanMsg.content),
+        compactChannelMeta,
+      );
+      conversation.getMessages().push(cleanMsg);
+
+      conversation.emitActivityState(
+        "thinking",
+        "context_compacting",
+        "assistant_turn",
+      );
+      const result = await conversation.forceCompact();
+      const responseText = formatCompactResult(result);
+      const assistantMsg = createAssistantMessage(responseText);
+      await addMessage(
+        conversationId,
+        "assistant",
+        JSON.stringify(assistantMsg.content),
+        compactChannelMeta,
       );
       conversation.getMessages().push(assistantMsg);
       return { messageId: persisted.id };

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -22,6 +22,7 @@ import { isHttpAuthDisabled } from "../../config/env.js";
 import { getConfig } from "../../config/loader.js";
 import {
   buildModelInfoEvent,
+  formatCompactResult,
   isModelSlashCommand,
 } from "../../daemon/conversation-process.js";
 import {
@@ -1325,6 +1326,74 @@ export async function handleSendMessage(
     } finally {
       // No-op for the slash-command early-return path (handled inside
       // setTimeout above), but still needed for error paths.
+      if (!cleanupDeferred && conversation.processing) {
+        conversation.processing = false;
+        silentlyWithLog(conversation.drainQueue(), "error-path queue drain");
+      }
+    }
+  }
+
+  if (slashResult.kind === "compact") {
+    conversation.processing = true;
+    let cleanupDeferred = false;
+    try {
+      const provenance = provenanceFromTrustContext(conversation.trustContext);
+      const channelMeta = {
+        ...provenance,
+        userMessageChannel: sourceChannel,
+        assistantMessageChannel: sourceChannel,
+        userMessageInterface: sourceInterface,
+        assistantMessageInterface: sourceInterface,
+      };
+      const cleanMsg = createUserMessage(rawContent, attachments);
+      const persisted = await addMessage(
+        mapping.conversationId,
+        "user",
+        JSON.stringify(cleanMsg.content),
+        channelMeta,
+      );
+      conversation.getMessages().push(cleanMsg);
+
+      conversation.emitActivityState(
+        "thinking",
+        "context_compacting",
+        "assistant_turn",
+      );
+      const result = await conversation.forceCompact();
+      const responseText = formatCompactResult(result);
+
+      const assistantMsg = createAssistantMessage(responseText);
+      await addMessage(
+        mapping.conversationId,
+        "assistant",
+        JSON.stringify(assistantMsg.content),
+        channelMeta,
+      );
+      conversation.getMessages().push(assistantMsg);
+
+      const response = Response.json(
+        {
+          accepted: true,
+          messageId: persisted.id,
+          conversationId: mapping.conversationId,
+        },
+        { status: 202 },
+      );
+
+      const conversationId = mapping.conversationId;
+      setTimeout(() => {
+        onEvent({ type: "assistant_text_delta", text: responseText });
+        onEvent({
+          type: "message_complete",
+          conversationId,
+        });
+        conversation.processing = false;
+        silentlyWithLog(conversation.drainQueue(), "compact-command queue drain");
+      }, 0);
+
+      cleanupDeferred = true;
+      return response;
+    } finally {
       if (!cleanupDeferred && conversation.processing) {
         conversation.processing = false;
         silentlyWithLog(conversation.drainQueue(), "error-path queue drain");


### PR DESCRIPTION
## Summary
- Adds `/compact` slash command that forces immediate context compaction, bypassing threshold and cooldown checks
- Implemented across all message entry paths: conversation-process (drainQueue + processMessage), legacy server endpoint, and runtime conversation routes
- Displays before/after token counts and number of messages compacted in the response

## Original prompt
add a "/compact" command to the vellum app to force compaction to run immediately
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
