### PR TITLE
Fix table cell content truncation in markdown tables

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
@@ -394,8 +394,7 @@ struct MarkdownTableView: View {
         return Text(attributed)
             .font(VFont.bodyMediumLighter)
             .foregroundStyle(VColor.contentDefault)
-            // lineLimit(nil) ensures text wraps within the column width
-            // instead of truncating with "..." on a single line.
             .lineLimit(nil)
+            .fixedSize(horizontal: false, vertical: true)
     }
 }


### PR DESCRIPTION
## Summary
- Add `.fixedSize(horizontal: false, vertical: true)` to table cell text views so long content wraps instead of truncating with "..."
- Matches the pattern already used by regular text segments in `MarkdownSegmentView` (line 59)

## Original prompt
Instead of truncating here, let's just show the full content in each table
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
