### PR TITLE
Fix import sort lint errors

### DIFF
--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -17,6 +17,7 @@ import type {
 } from "../channels/types.js";
 import { parseChannelId, parseInterfaceId } from "../channels/types.js";
 import { getConfig } from "../config/loader.js";
+import type { ContextWindowResult } from "../context/window-manager.js";
 import { listPendingRequestsByConversationScope } from "../memory/canonical-guardian-store.js";
 import {
   addMessage,
@@ -26,7 +27,6 @@ import {
 } from "../memory/conversation-crud.js";
 import { extractPreferences } from "../notifications/preference-extractor.js";
 import { createPreference } from "../notifications/preferences-store.js";
-import type { ContextWindowResult } from "../context/window-manager.js";
 import type { Message } from "../providers/types.js";
 import { routeGuardianReply } from "../runtime/guardian-reply-router.js";
 import { getLogger } from "../util/logger.js";

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -67,8 +67,8 @@ import {
   DEFAULT_MEMORY_POLICY,
 } from "./conversation.js";
 import { ConversationEvictor } from "./conversation-evictor.js";
-import { resolveChannelCapabilities } from "./conversation-runtime-assembly.js";
 import { formatCompactResult } from "./conversation-process.js";
+import { resolveChannelCapabilities } from "./conversation-runtime-assembly.js";
 import { resolveSlash, type SlashContext } from "./conversation-slash.js";
 import { undoLastMessage } from "./handlers/conversations.js";
 import { parseIdentityFields } from "./handlers/identity.js";


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint errors in `conversation-process.ts` (moved `ContextWindowResult` import to alphabetical position) and `server.ts` (swapped `conversation-process.js` and `conversation-runtime-assembly.js` imports to alphabetical order).

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23727640236/job/69114375152