### PR TITLE
fix(macos): restrict throttled parse reuse to matching text prefix

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -102,7 +102,8 @@ extension ChatBubble {
         // large messages with tables.
         if isStreaming,
            text.count > streamingParseThrottleThreshold,
-           let last = lastStreamingSegments {
+           let last = lastStreamingSegments,
+           text.hasPrefix(last.text) {
             let now = ProcessInfo.processInfo.systemUptime
             if now - lastStreamingParseTime < streamingParseThrottleInterval {
                 return last.value


### PR DESCRIPTION
## Summary
- Fix cross-contamination bug in streaming markdown parse throttle where different text groups could render each other's cached segments
- Add `text.hasPrefix(last.text)` guard so the throttle only reuses results when the current text is an extension of the previously parsed text

Addresses review feedback from #22035.

## Test plan
- [ ] Stream a long message containing multiple text groups (e.g. interleaved code blocks and prose) and verify each group renders its own content
- [ ] Stream a large message with tables and verify throttle still prevents CPU spikes
- [ ] Verify no visual glitches during streaming of normal single-group messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
