### PR TITLE
fix: replace "daemon" with "assistant" in re-extract CLI text

### DIFF
--- a/assistant/src/cli/commands/memory.ts
+++ b/assistant/src/cli/commands/memory.ts
@@ -280,7 +280,7 @@ re-processes all messages. Existing memories are provided as supersession
 context — the new extraction can supersede old flat-fact memories with
 richer, properly-scored replacements.
 
-Requires the assistant daemon to be running (jobs are processed by the
+Requires the assistant to be running (jobs are processed by the
 background worker).
 
 Examples:
@@ -351,7 +351,7 @@ Examples:
 
         const { jobIds } = requestReextract(targets);
         log.info(
-          `\nQueued ${jobIds.length} re-extraction job(s). The daemon will process them in the background.`,
+          `\nQueued ${jobIds.length} re-extraction job(s). The assistant will process them in the background.`,
         );
       },
     );


### PR DESCRIPTION
## Summary
- Replace "assistant daemon" with "assistant" in re-extract help text
- Replace "The daemon will process" with "The assistant will process" in CLI output
- Addresses review feedback from #22094 per AGENTS.md § User-Facing Terminology
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
