### PR TITLE
fix: Use content blocks format for cross-posted outbound messages

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
@@ -238,7 +238,7 @@ export async function run(
           const crossPosted = await addMessage(
             binding.conversationId,
             "assistant",
-            text,
+            JSON.stringify([{ type: "text", text }]),
             { automated: true, crossPostedFrom: context.conversationId },
             { skipIndexing: true },
           );


### PR DESCRIPTION
## Summary
- Cross-posted messages now use `JSON.stringify([{ type: "text", text }])` content blocks format instead of plain text
- Aligns with every other `addMessage` callsite in the codebase (relay-server, agent-loop-handlers, call-conversation-messages, etc.)
- Ensures downstream consumers (context window loading, search, disk view) see a consistent content format

Addresses review feedback from #21976.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
