### PR TITLE
Narrow NOW.md strip prefix to injected marker

### DIFF
--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -527,7 +527,7 @@ export function injectNowScratchpad(
 /** Strip `<NOW.md>` blocks injected by `injectNowScratchpad`. */
 export function stripNowScratchpad(messages: Message[]): Message[] {
   return stripUserTextBlocksByPrefix(messages, [
-    "<NOW.md",
+    "<NOW.md Always keep this up to date>",
     "<now_scratchpad>", // backward-compat: strip legacy blocks from pre-rename history
   ]);
 }
@@ -1055,7 +1055,7 @@ const RUNTIME_INJECTION_PREFIXES = [
   "<active_workspace>",
   "<active_dynamic_page>",
   "<non_interactive_context>",
-  "<NOW.md",
+  "<NOW.md Always keep this up to date>",
   "<now_scratchpad>", // backward-compat: strip legacy blocks from pre-rename history
   "<transport_hints>",
 ];


### PR DESCRIPTION
## Summary
- Narrow the strip prefix from `<NOW.md` to the exact injected tag `<NOW.md Always keep this up to date>` in both `stripNowScratchpad` and `RUNTIME_INJECTION_PREFIXES`
- Prevents silent content loss when users reference or paste text starting with `<NOW.md`
- Legacy `<now_scratchpad>` backward-compat stripping is unchanged

## Test plan
- [x] Existing tests still pass (assertions use `toContain('<NOW.md')` which matches the full tag)
- [x] Verified the prefix now matches the exact injected opening tag from `injectNowScratchpad`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
