### PR TITLE
fix: preserve NULL-importance items in serendipity filter

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, gte, inArray, notInArray, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, notInArray, sql } from "drizzle-orm";
 
 import type { AssistantConfig } from "../config/types.js";
 import { estimateTextTokens } from "../context/token-estimator.js";
@@ -1108,10 +1108,7 @@ function sampleSerendipityItems(
       : eq(memoryItems.scopeId, "default");
 
     let rows;
-    const importanceFloor = gte(
-      memoryItems.importance,
-      MIN_SERENDIPITY_IMPORTANCE,
-    );
+    const importanceFloor = sql`COALESCE(${memoryItems.importance}, 0.5) >= ${MIN_SERENDIPITY_IMPORTANCE}`;
 
     if (existingItemIds.length > 0) {
       rows = db


### PR DESCRIPTION
## Summary
- Fixes backward-compatibility regression from #22093 where `gte(memoryItems.importance, 0.5)` excluded rows with NULL importance
- Uses `COALESCE(importance, 0.5)` to treat NULL as 0.5 (the existing default), preserving legacy rows in echoes sampling
- Removes unused `gte` import

## Test plan
- [ ] Verify legacy memory items (with NULL importance) still appear in `<echoes>` section
- [ ] Verify items with importance < 0.7 are still filtered out
- [ ] Verify items with importance >= 0.7 continue to be sampled
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
