### PR TITLE
fix(memory): scope journal carry-forward checkpoint by user and defer to completion

### DIFF
--- a/assistant/src/memory/job-handlers/journal-carry-forward.ts
+++ b/assistant/src/memory/job-handlers/journal-carry-forward.ts
@@ -15,6 +15,7 @@ import {
 } from "../../providers/provider-send-message.js";
 import { BackendUnavailableError, ProviderError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
+import { setMemoryCheckpoint } from "../checkpoints.js";
 import { getDb } from "../db.js";
 import { computeMemoryFingerprint } from "../fingerprint.js";
 import { asString } from "../job-utils.js";
@@ -229,6 +230,11 @@ export async function journalCarryForwardJob(job: MemoryJob): Promise<void> {
     enqueueMemoryJob("embed_item", { itemId });
     inserted += 1;
   }
+
+  // Write checkpoint only after successful completion so failed jobs can be
+  // re-enqueued on the next prompt render cycle.
+  const checkpointKey = `journal_carry_forward:${userSlug || "unknown"}:${filename}`;
+  setMemoryCheckpoint(checkpointKey, String(Date.now()));
 
   log.info(
     {

--- a/assistant/src/prompts/journal-context.ts
+++ b/assistant/src/prompts/journal-context.ts
@@ -1,10 +1,7 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { basename, join } from "node:path";
 
-import {
-  getMemoryCheckpoint,
-  setMemoryCheckpoint,
-} from "../memory/checkpoints.js";
+import { getMemoryCheckpoint } from "../memory/checkpoints.js";
 import { enqueueMemoryJob } from "../memory/jobs-store.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir } from "../util/platform.js";
@@ -117,7 +114,7 @@ export function buildJournalContext(
     try {
       const safeSlug = basename(userSlug);
       for (const entry of rotatingOut) {
-        const checkpointKey = `journal_carry_forward:${entry.filename}`;
+        const checkpointKey = `journal_carry_forward:${safeSlug}:${entry.filename}`;
         if (getMemoryCheckpoint(checkpointKey) != null) continue;
 
         let content: string;
@@ -133,7 +130,6 @@ export function buildJournalContext(
           filename: entry.filename,
           scopeId: "default",
         });
-        setMemoryCheckpoint(checkpointKey, String(Date.now()));
         log.info(
           { filename: entry.filename, userSlug: safeSlug },
           "Enqueued journal carry-forward job for rotating-out entry",


### PR DESCRIPTION
## Summary
- Include userSlug in carry-forward checkpoint key to prevent cross-user collisions
- Move setMemoryCheckpoint from enqueue site to job handler, so failed jobs can be retried

## Test plan
- [ ] Verify two users with same-named journal entries get independent checkpoints
- [ ] Verify a failed carry-forward job does not leave a checkpoint, allowing re-enqueue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
