### PR TITLE
fix(memory): skip oversized recall candidates instead of aborting scan

### DIFF
--- a/assistant/src/memory/search/formatting.ts
+++ b/assistant/src/memory/search/formatting.ts
@@ -121,7 +121,7 @@ export function buildMemoryInjection(params: {
     if (remainingTokens <= 0) break;
     const line = renderCandidate(c);
     const tokens = estimateTextTokens(line);
-    if (tokens > remainingTokens) break;
+    if (tokens > remainingTokens) continue;
     lines.push(line);
     remainingTokens -= tokens;
   }
@@ -146,7 +146,7 @@ export function buildMemoryInjection(params: {
       if (echoesBudget <= 0) break;
       const line = renderCandidate(c);
       const tokens = estimateTextTokens(line);
-      if (tokens > echoesBudget) break;
+      if (tokens > echoesBudget) continue;
       echoLines.push(line);
       echoesBudget -= tokens;
       remainingTokens -= tokens;


### PR DESCRIPTION
## Summary
- Change `break` to `continue` in the recall budget loop so oversized candidates are skipped rather than terminating the scan
- Apply the same fix to the echoes (serendipity) budget loop for consistency
- Addresses P1 feedback from #22040: under tight budgets, one large memory could block all remaining smaller candidates

## Test plan
- [ ] Verify that when a high-score candidate exceeds the token budget, smaller candidates after it are still included
- [ ] Verify echoes section behaves the same way

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
