### PR TITLE
fix: scan all responses in extractAnthropicSpeed before returning

### DIFF
--- a/assistant/src/__tests__/conversation-usage.test.ts
+++ b/assistant/src/__tests__/conversation-usage.test.ts
@@ -55,6 +55,61 @@ describe("recordUsage", () => {
     updateConversationUsageCalls.length = 0;
   });
 
+  test("applies fast mode pricing when any response has speed: fast", () => {
+    const usageStats = {
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCost: 0,
+    };
+
+    // First response is standard, second is fast — should detect fast
+    const rawResponses = [
+      { usage: { speed: "standard" } },
+      { usage: { speed: "fast" } },
+    ];
+
+    recordUsage(
+      {
+        conversationId: "conv-speed-1",
+        providerName: "anthropic",
+        usageStats,
+      },
+      1_000_000,
+      1_000_000,
+      "claude-opus-4-6",
+      () => {},
+      "main_agent",
+      "req-speed-1",
+      0,
+      0,
+      rawResponses,
+    );
+
+    const events = listUsageEvents();
+    expect(events).toHaveLength(1);
+
+    // With fast mode, pricing should use the 6x multiplier
+    const fastUsage: PricingUsage = {
+      directInputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+      speed: "fast",
+    };
+    const expectedPricing = resolvePricingForUsageWithOverrides(
+      "anthropic",
+      "claude-opus-4-6",
+      fastUsage,
+      [],
+    );
+
+    expect(events[0].estimatedCostUsd).toBe(
+      expectedPricing.estimatedCostUsd ?? null,
+    );
+    // Sanity: fast should be 6x standard ($30 * 6 = $180)
+    expect(expectedPricing.estimatedCostUsd).toBe(180);
+  });
+
   test("stores direct input separately from Anthropic cache usage while keeping live totals combined", () => {
     const usageStats = {
       inputTokens: 0,

--- a/assistant/src/__tests__/pricing.test.ts
+++ b/assistant/src/__tests__/pricing.test.ts
@@ -294,6 +294,102 @@ describe("resolvePricingForUsage", () => {
   });
 });
 
+describe("fast mode pricing", () => {
+  test("applies 6x multiplier when speed is fast", () => {
+    const usage: PricingUsage = {
+      directInputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+      speed: "fast",
+    };
+
+    const result = resolvePricingForUsage("anthropic", "claude-opus-4-6", usage);
+
+    // Base: $5 input + $25 output = $30; fast: $30 * 6 = $180
+    expect(result.pricingStatus).toBe("priced");
+    expect(result.estimatedCostUsd).toBe((5 + 25) * 6);
+  });
+
+  test("does not apply multiplier when speed is standard", () => {
+    const usage: PricingUsage = {
+      directInputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+      speed: "standard",
+    };
+
+    const result = resolvePricingForUsage("anthropic", "claude-opus-4-6", usage);
+
+    expect(result.pricingStatus).toBe("priced");
+    expect(result.estimatedCostUsd).toBe(5 + 25);
+  });
+
+  test("does not apply multiplier when speed is null", () => {
+    const usage: PricingUsage = {
+      directInputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+      speed: null,
+    };
+
+    const result = resolvePricingForUsage("anthropic", "claude-opus-4-6", usage);
+
+    expect(result.pricingStatus).toBe("priced");
+    expect(result.estimatedCostUsd).toBe(5 + 25);
+  });
+
+  test("fast mode multiplier stacks with cache pricing", () => {
+    const usage: PricingUsage = {
+      directInputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      cacheCreationInputTokens: 1_000_000,
+      cacheReadInputTokens: 1_000_000,
+      anthropicCacheCreation: {
+        ephemeral_5m_input_tokens: 1_000_000,
+        ephemeral_1h_input_tokens: 0,
+      },
+      speed: "fast",
+    };
+
+    const standardUsage: PricingUsage = { ...usage, speed: "standard" };
+
+    const fastResult = resolvePricingForUsage(
+      "anthropic",
+      "claude-opus-4-6",
+      usage,
+    );
+    const standardResult = resolvePricingForUsage(
+      "anthropic",
+      "claude-opus-4-6",
+      standardUsage,
+    );
+
+    expect(fastResult.pricingStatus).toBe("priced");
+    expect(standardResult.pricingStatus).toBe("priced");
+    // Fast mode applies 6x to base rates; cache multipliers stack on top
+    expect(fastResult.estimatedCostUsd).toBe(standardResult.estimatedCostUsd! * 6);
+  });
+
+  test("does not apply fast mode multiplier for non-Anthropic providers", () => {
+    const usage: PricingUsage = {
+      directInputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+      speed: "fast",
+    };
+
+    const result = resolvePricingForUsage("openai", "gpt-4o", usage);
+
+    // Should be standard pricing, not 6x
+    expect(result.pricingStatus).toBe("priced");
+    expect(result.estimatedCostUsd).toBe(2.5 + 10);
+  });
+});
+
 describe("resolvePricingForUsageWithOverrides", () => {
   test("uses override pricing for structured Anthropic usage", () => {
     const usage: PricingUsage = {

--- a/assistant/src/daemon/conversation-usage.ts
+++ b/assistant/src/daemon/conversation-usage.ts
@@ -85,13 +85,14 @@ function extractAnthropicSpeed(
   rawResponse: unknown,
 ): "fast" | "standard" | null {
   const responses = Array.isArray(rawResponse) ? rawResponse : [rawResponse];
+  let foundStandard = false;
   for (const response of responses) {
     const rec = asRecord(response);
     const usage = asRecord(rec?.usage);
     if (usage?.speed === "fast") return "fast";
-    if (usage?.speed === "standard") return "standard";
+    if (usage?.speed === "standard") foundStandard = true;
   }
-  return null;
+  return foundStandard ? "standard" : null;
 }
 
 function resolveStructuredPricing(


### PR DESCRIPTION
## Summary
- Fix `extractAnthropicSpeed` to scan all responses before returning, prioritizing 'fast' over 'standard'
- Previously returned immediately on first 'standard' entry, misclassifying mixed `[standard, fast]` arrays
- Add test coverage for fast mode pricing (6x multiplier, cache stacking, non-Anthropic no-op)
- Add test for mixed-speed response array extraction in conversation-usage

Addresses review feedback from #22021.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
