### PR TITLE
fix: align telemetry route schema and preserve watermark IDs on opt-out

### DIFF
--- a/assistant/src/runtime/routes/telemetry-routes.ts
+++ b/assistant/src/runtime/routes/telemetry-routes.ts
@@ -58,10 +58,19 @@ export function telemetryRouteDefinitions(): RouteDefinition[] {
       requestBody: z.object({
         event_name: z.string().describe("Event name: app_open or hatch"),
       }),
-      responseBody: z.object({
-        id: z.string().describe("Event ID"),
-        event_name: z.string(),
-      }),
+      responseBody: z.union([
+        z.object({
+          id: z.string().describe("Event ID"),
+          event_name: z.string(),
+        }),
+        z.object({
+          skipped: z
+            .literal(true)
+            .describe(
+              "Event skipped due to usage data collection being disabled",
+            ),
+        }),
+      ]),
       handler: async ({ req }) => handleRecordLifecycleEvent(req),
     },
   ];

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -97,13 +97,15 @@ export class UsageTelemetryReporter {
       // skip the flush and advance watermarks so events recorded during the
       // opt-out window are never sent retroactively.
       if (!getConfig().collectUsageData) {
+        // Advance only the timestamp watermarks. Leave the ID watermarks
+        // untouched so the compound-cursor branch stays active — setting them
+        // to "" would make the truthy check fail, falling back to a
+        // timestamp-only `gt(createdAt, watermark)` query that silently drops
+        // events created in the same millisecond as the opt-out watermark.
         const now = String(Date.now());
         setMemoryCheckpoint(CHECKPOINT_KEY_WATERMARK, now);
-        setMemoryCheckpoint(CHECKPOINT_KEY_WATERMARK_ID, "");
         setMemoryCheckpoint(CHECKPOINT_KEY_TURN_WATERMARK, now);
-        setMemoryCheckpoint(CHECKPOINT_KEY_TURN_WATERMARK_ID, "");
         setMemoryCheckpoint(CHECKPOINT_KEY_LIFECYCLE_WATERMARK, now);
-        setMemoryCheckpoint(CHECKPOINT_KEY_LIFECYCLE_WATERMARK_ID, "");
         return;
       }
 


### PR DESCRIPTION
## Summary
- Update lifecycle route `responseBody` schema to `z.union()` covering both `{ id, event_name }` (recorded) and `{ skipped: true }` (opted out) response shapes, fixing OpenAPI contract drift.
- Stop resetting `*_last_reported_id` watermark checkpoints to `""` when collection is disabled — empty string is falsy and disables the compound-cursor query branch, causing silent telemetry loss for events created in the same millisecond as the opt-out watermark.

Addresses review feedback from #22001.