### PR TITLE
fix(memory): preserve sourceMessageRole and use compound cursor in batch extraction

### DIFF
--- a/assistant/src/memory/job-handlers/batch-extraction.ts
+++ b/assistant/src/memory/job-handlers/batch-extraction.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, or, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { estimateTextTokens } from "../../context/token-estimator.js";
@@ -97,12 +97,14 @@ export async function batchExtractJob(job: MemoryJob): Promise<void> {
   if (lastExtractedMessageId) {
     // Get the createdAt of the last extracted message so we can find messages after it
     const lastMsg = db
-      .select({ createdAt: messages.createdAt })
+      .select({ id: messages.id, createdAt: messages.createdAt })
       .from(messages)
       .where(eq(messages.id, lastExtractedMessageId))
       .get();
 
     if (lastMsg) {
+      // Compound cursor: createdAt > X OR (createdAt = X AND id > Y)
+      // Avoids skipping messages that share the same timestamp as the checkpoint
       unextractedMessages = db
         .select({
           id: messages.id,
@@ -114,10 +116,16 @@ export async function batchExtractJob(job: MemoryJob): Promise<void> {
         .where(
           and(
             eq(messages.conversationId, conversationId),
-            gt(messages.createdAt, lastMsg.createdAt),
+            or(
+              gt(messages.createdAt, lastMsg.createdAt),
+              and(
+                eq(messages.createdAt, lastMsg.createdAt),
+                gt(messages.id, lastMsg.id),
+              ),
+            ),
           ),
         )
-        .orderBy(asc(messages.createdAt))
+        .orderBy(asc(messages.createdAt), asc(messages.id))
         .all();
     } else {
       // Checkpoint references a deleted message — fetch all
@@ -476,6 +484,7 @@ export async function batchExtractJob(job: MemoryJob): Promise<void> {
           fingerprint: item.fingerprint,
           sourceType: "extraction",
           verificationState: "assistant_inferred",
+          sourceMessageRole: lastMessage.role,
           scopeId,
           firstSeenAt: lastMessage.createdAt,
           lastSeenAt: seenAt,


### PR DESCRIPTION
## Summary
- **P1 fix**: Set `sourceMessageRole: lastMessage.role` when inserting new batch-extracted memory items. Previously left null, which meant `invalidateAssistantInferredItemsForConversation` (filters on `source_message_role = 'assistant'`) could not invalidate stale batch-extracted items after task/schedule failures.
- **P2 fix**: Replace `gt(messages.createdAt, lastMsg.createdAt)` with a compound cursor `(createdAt > X OR (createdAt = X AND id > Y))` to avoid permanently skipping messages that share the same timestamp as the checkpoint message.

Addresses review feedback from #22044.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
