### PR TITLE
Fix duplicate Slack contacts when backfilling externalChatId

### DIFF
--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -259,6 +259,7 @@ export const slackProvider: MessagingProvider = {
           });
           if (existing && !existing.channel.externalChatId) {
             upsertContactChannel({
+              contactId: existing.contact.id,
               sourceChannel: "slack",
               externalUserId: dmUserId,
               externalChatId: conv.id,


### PR DESCRIPTION
## Summary
- Pass `contactId` to `upsertContactChannel` when backfilling `externalChatId` on existing Slack contacts
- Fixes duplicate contact creation when the existing row's address differs from the canonical Slack user ID

Addresses feedback from #22155
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
