### PR TITLE
fix: preserve segment rows when Qdrant cleanup fails

### DIFF
--- a/assistant/src/cli/commands/memory.ts
+++ b/assistant/src/cli/commands/memory.ts
@@ -175,6 +175,9 @@ Examples:
         );
       } else {
         log.info(`Removed ${result.removed} short segment(s).`);
+        if (result.failed > 0) {
+          log.warn(`${result.failed} segment(s) skipped — Qdrant deletion failed. Re-run when Qdrant is available.`);
+        }
       }
     });
 

--- a/assistant/src/memory/admin.ts
+++ b/assistant/src/memory/admin.ts
@@ -119,6 +119,7 @@ export async function queryMemory(query: string, conversationId: string) {
 
 export interface CleanupShortSegmentsResult {
   removed: number;
+  failed: number;
   dryRunCount?: number;
 }
 
@@ -139,18 +140,20 @@ export async function cleanupShortSegments(
     .all();
 
   if (opts?.dryRun) {
-    return { removed: 0, dryRunCount: shortSegments.length };
+    return { removed: 0, failed: 0, dryRunCount: shortSegments.length };
   }
 
   let removed = 0;
+  let failed = 0;
   for (const row of shortSegments) {
-    // Delete the Qdrant embedding first (best-effort via circuit breaker)
     try {
       const qdrant = getQdrantClient();
       await withQdrantBreaker(() => qdrant.deleteByTarget("segment", row.id));
-    } catch {
-      // Qdrant may not be running or the vector may not exist — continue
-      // with SQLite deletion regardless
+    } catch (err) {
+      // Keep the SQLite row so the target ID is preserved for retry
+      log.warn({ segmentId: row.id, err }, "Qdrant deletion failed — skipping SQLite deletion to preserve target ID");
+      failed++;
+      continue;
     }
 
     db.delete(memorySegments)
@@ -159,8 +162,8 @@ export async function cleanupShortSegments(
     removed++;
   }
 
-  log.info({ removed, threshold: MIN_SEGMENT_CHARS }, "Cleaned up short segments");
-  return { removed };
+  log.info({ removed, failed, threshold: MIN_SEGMENT_CHARS }, "Cleaned up short segments");
+  return { removed, failed };
 }
 
 // ── Re-extraction ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Stop deleting SQLite segment rows when Qdrant vector deletion fails — preserves the target ID for retry
- Track and report failed deletions in `CleanupShortSegmentsResult.failed`
- CLI `cleanup-segments` command now warns when segments were skipped due to Qdrant errors

Addresses review feedback from #22116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
