### PR TITLE
Fix thinking delta guards and text segment boundary after thinking

### DIFF
--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -110,6 +110,7 @@ final class ChatActionHandler {
             guard belongsToConversation(delta.conversationId) else { return }
             guard !vm.isCancelling else { break }
             guard !vm.isLoadingHistory else { break }
+            guard !vm.isWorkspaceRefinementInFlight else { break }
             guard MacOSClientFeatureFlagManager.shared.isEnabled("show-thinking-blocks") else { break }
             vm.thinkingDeltaBuffer += delta.thinking
             vm.scheduleThinkingFlush()

--- a/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
@@ -96,7 +96,12 @@ extension ChatViewModel {
         guard !text.isEmpty else { return }
         if let existingId = currentAssistantMessageId,
            let index = messages.firstIndex(where: { $0.id == existingId }) {
-            if lastContentWasToolCall || messages[index].textSegments.isEmpty {
+            let lastWasNonText: Bool = {
+                guard let last = messages[index].contentOrder.last else { return false }
+                if case .text = last { return false }
+                return true  // .toolCall or .thinking
+            }()
+            if lastWasNonText || messages[index].textSegments.isEmpty {
                 let segIdx = messages[index].textSegments.count
                 messages[index].textSegments.append(text)
                 messages[index].contentOrder.append(.text(segIdx))


### PR DESCRIPTION
## Summary
- Add missing `isWorkspaceRefinementInFlight` guard to `assistantThinkingDelta` handler to suppress thinking deltas during workspace refinement (prevents orphaned thinking messages)
- Fix text segment boundary after thinking blocks: replace `lastContentWasToolCall` flag with `contentOrder.last` check so that any non-text content (thinking or tool call) triggers a new text segment, preserving correct interleaving order

Addresses review feedback from #22069.

## Test plan
- [ ] Verify thinking deltas are suppressed during workspace refinement
- [ ] Verify text→thinking→text streams produce correctly interleaved segments in contentOrder

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22229" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
