### PR TITLE
Redact secrets in persisted canonical guardian request fields

### DIFF
--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -25,6 +25,7 @@ import {
 } from "../../memory/conversation-title-service.js";
 import * as pendingInteractions from "../../runtime/pending-interactions.js";
 import { getSubagentManager } from "../../subagent/index.js";
+import { redactSecrets } from "../../security/secret-scanner.js";
 import { summarizeToolInput } from "../../tools/tool-input-summary.js";
 import { truncate } from "../../util/truncate.js";
 import type { Conversation } from "../conversation.js";
@@ -102,9 +103,13 @@ export function makeEventSender(params: {
             guardianPrincipalId: trustContext?.guardianPrincipalId ?? undefined,
             toolName: event.toolName,
             commandPreview:
-              summarizeToolInput(event.toolName, inputRecord) || undefined,
+              redactSecrets(
+                summarizeToolInput(event.toolName, inputRecord),
+              ) || undefined,
             riskLevel: event.riskLevel,
-            activityText: activityRaw,
+            activityText: activityRaw
+              ? redactSecrets(activityRaw)
+              : undefined,
             executionTarget: event.executionTarget,
             status: "pending",
             requestCode: generateCanonicalRequestCode(),

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -53,6 +53,7 @@ import { registerConversationUndoCallback } from "../signals/conversation-undo.j
 import { appendEventToStream } from "../signals/event-stream.js";
 import { registerUserMessageCallback } from "../signals/user-message.js";
 import { getSubagentManager } from "../subagent/index.js";
+import { redactSecrets } from "../security/secret-scanner.js";
 import { summarizeToolInput } from "../tools/tool-input-summary.js";
 import { getLogger } from "../util/logger.js";
 import {
@@ -197,9 +198,13 @@ function makePendingInteractionRegistrar(
           guardianPrincipalId: trustContext?.guardianPrincipalId ?? undefined,
           toolName: msg.toolName,
           commandPreview:
-            summarizeToolInput(msg.toolName, inputRecord) || undefined,
+            redactSecrets(
+              summarizeToolInput(msg.toolName, inputRecord),
+            ) || undefined,
           riskLevel: msg.riskLevel,
-          activityText: activityRaw,
+          activityText: activityRaw
+            ? redactSecrets(activityRaw)
+            : undefined,
           executionTarget: msg.executionTarget,
           status: "pending",
           requestCode: generateCanonicalRequestCode(),

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -65,6 +65,7 @@ import { searchConversations } from "../../memory/conversation-queries.js";
 import { getConfiguredProvider } from "../../providers/provider-send-message.js";
 import type { Provider } from "../../providers/types.js";
 import { checkIngressForSecrets } from "../../security/secret-ingress.js";
+import { redactSecrets } from "../../security/secret-scanner.js";
 import { summarizeToolInput } from "../../tools/tool-input-summary.js";
 import { getLogger } from "../../util/logger.js";
 import { silentlyWithLog } from "../../util/silently.js";
@@ -653,9 +654,13 @@ function makeHubPublisher(
           guardianPrincipalId: trustContext?.guardianPrincipalId ?? undefined,
           toolName: msg.toolName,
           commandPreview:
-            summarizeToolInput(msg.toolName, inputRecord) || undefined,
+            redactSecrets(
+              summarizeToolInput(msg.toolName, inputRecord),
+            ) || undefined,
           riskLevel: msg.riskLevel,
-          activityText: activityRaw,
+          activityText: activityRaw
+            ? redactSecrets(activityRaw)
+            : undefined,
           executionTarget: msg.executionTarget,
           status: "pending",
           requestCode: generateCanonicalRequestCode(),

--- a/assistant/src/tools/tool-input-summary.ts
+++ b/assistant/src/tools/tool-input-summary.ts
@@ -1,8 +1,8 @@
 /**
  * Summarizes tool input into a concise string for guardian approval display.
  *
- * The summary is shown only to the guardian who already has full access,
- * so no secret masking is applied.
+ * Returns unredacted text — callers that persist the result (e.g. to the
+ * canonical_guardian_requests table) must apply redactSecrets() before writing.
  */
 
 function truncate(value: string, maxLen: number): string {


### PR DESCRIPTION
## Summary
- Apply `redactSecrets()` to `commandPreview` and `activityText` before persisting to `canonical_guardian_requests` table
- Covers all three call sites: `conversation-routes.ts`, `daemon/server.ts`, `daemon/handlers/conversations.ts`
- Updates `tool-input-summary.ts` doc comment to clarify callers must redact before persisting

## Context
PR #22099 added `commandPreview`/`activityText` fields to canonical guardian requests using `summarizeToolInput()`, which extracts raw command text without secret masking. Since the workspace DB is included in diagnostic log exports (`sqlite3 .dump`), this creates a data-leak path for API tokens embedded in bash commands.

## Test plan
- [ ] Verify `redactSecrets` import resolves correctly in all three files
- [ ] Confirm canonical requests still populate `commandPreview`/`activityText` for non-secret inputs
- [ ] Verify that a bash command containing an API key gets redacted in the persisted row

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
