### PR TITLE
fix(macos): restore read-only gating for message actions without blocking scroll

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -386,6 +386,7 @@ struct ChatView: View {
                 conversationId: conversationId,
                 anchorMessageId: $anchorMessageId,
                 highlightedMessageId: $highlightedMessageId,
+                isInteractionEnabled: isInteractionEnabled,
                 containerWidth: containerWidth
             )
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -109,6 +109,9 @@ struct MessageListView: View {
     @Binding var highlightedMessageId: UUID?
     /// Measured width of the chat container, used to detect sidebar/split resizes
     /// and stabilize scroll position during layout width changes.
+    /// When false, disables interactive controls (buttons, actions) inside the
+    /// message list while keeping scrolling and text selection functional.
+    var isInteractionEnabled: Bool = true
     var containerWidth: CGFloat = 0
     @AppStorage("hasEverSentMessage") private var hasEverSentMessage: Bool = false
     @AppStorage("completedConversationCount") private var completedConversationCount: Int = 0
@@ -744,6 +747,7 @@ struct MessageListView: View {
                     }
                 }
                 .textSelection(.enabled)
+                .disabled(!isInteractionEnabled)
                 .padding(.horizontal, VSpacing.xl)
                 .padding(.top, VSpacing.md)
                 .padding(.bottom, VSpacing.md)


### PR DESCRIPTION
## Summary
- Add `isInteractionEnabled` property to `MessageListView`
- Apply `.disabled(!isInteractionEnabled)` to the `LazyVStack` content inside the `ScrollView`, not the outer `mainContentStack`
- This disables interactive controls (confirmation allow/deny, surface actions, guardian actions) in read-only conversations while keeping scrolling and text selection functional
- Addresses review feedback on #22131: the original fix removed the blanket `.disabled()` to fix scrolling but also unblocked side-effecting actions in the message list

## Test plan
- [ ] Open a read-only channel conversation
- [ ] Verify scrolling works (trackpad, mouse wheel)
- [ ] Verify confirmation buttons and surface action buttons are non-interactive
- [ ] Verify text selection still works in read-only mode