### PR TITLE
Fix signing key persistence: use lockfile instead of .vellum/ directory

### DIFF
--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -1,12 +1,14 @@
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 
-import { resolveTargetAssistant } from "../lib/assistant-config.js";
+import {
+  resolveTargetAssistant,
+  saveAssistantEntry,
+} from "../lib/assistant-config.js";
 import { dockerResourceNames, wakeContainers } from "../lib/docker.js";
 import { isProcessAlive, stopProcessByPidFile } from "../lib/process";
 import {
   generateLocalSigningKey,
-  loadExistingSigningKey,
   isAssistantWatchModeAvailable,
   isGatewayWatchModeAvailable,
   startLocalDaemon,
@@ -108,7 +110,14 @@ export async function wake(): Promise<void> {
     }
   }
 
-  const signingKey = loadExistingSigningKey(resources) ?? generateLocalSigningKey();
+  // Reuse the lockfile-persisted signing key so client actor tokens survive
+  // daemon/gateway restarts. Generate and persist a new one only on first wake.
+  let signingKey = resources.signingKey;
+  if (!signingKey) {
+    signingKey = generateLocalSigningKey();
+    entry.resources = { ...resources, signingKey };
+    saveAssistantEntry(entry);
+  }
 
   if (!daemonRunning) {
     await startLocalDaemon(watch, resources, { foreground, signingKey });

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -43,6 +43,9 @@ export interface LocalInstanceResources {
   cesPort: number;
   /** Absolute path to the daemon PID file */
   pidFile: string;
+  /** Persisted HMAC signing key (hex). Survives daemon/gateway restarts so
+   *  client actor tokens remain valid across `wake` cycles. */
+  signingKey?: string;
   [key: string]: unknown;
 }
 

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -207,39 +207,6 @@ export function generateLocalSigningKey(): string {
   return randomBytes(32).toString("hex");
 }
 
-/**
- * Load an existing signing key from disk for use during `wake`.
- *
- * Checks the known persisted key locations (workspace/deprecated/ and
- * the legacy ~/.vellum/protected/ path). Returns the hex-encoded key if
- * found, or undefined if no key exists on disk.
- *
- * `wake` should prefer this over `generateLocalSigningKey()` so that
- * existing actor tokens (held by connected clients) remain valid across
- * daemon/gateway restarts.
- */
-export function loadExistingSigningKey(
-  resources?: LocalInstanceResources,
-): string | undefined {
-  const instanceDir = resources?.instanceDir ?? join(homedir(), ".vellum");
-  const candidates = [
-    join(instanceDir, ".vellum", "workspace", "deprecated", "actor-token-signing-key"),
-    join(homedir(), ".vellum", "protected", "actor-token-signing-key"),
-  ];
-  for (const keyPath of candidates) {
-    if (!existsSync(keyPath)) continue;
-    try {
-      const raw = readFileSync(keyPath);
-      if (raw.length === 32) {
-        return raw.toString("hex");
-      }
-    } catch {
-      // Fall through to next candidate
-    }
-  }
-  return undefined;
-}
-
 type DaemonStartOptions = {
   foreground?: boolean;
   defaultWorkspaceConfigPath?: string;


### PR DESCRIPTION
## Summary
- Removed `loadExistingSigningKey` which violated the CLI boundary rule in `cli/AGENTS.md` (CLI must never read from `.vellum/` directories — the signing key is literally the canonical example)
- The removed function also didn't work: the daemon doesn't persist env-var-provided keys to disk, so the lookup always returned `undefined` after the first transition
- Instead, persist the signing key in `LocalInstanceResources.signingKey` in the lockfile — the CLI's own state — so it survives `wake` restarts
- On first wake, generates a key and saves it to the lockfile; subsequent wakes reuse it

## Test plan
- [ ] `vellum wake` generates and persists a signing key on first run
- [ ] Subsequent `vellum wake` reuses the persisted key (check lockfile)
- [ ] Connected clients remain authenticated across daemon/gateway restarts

Addresses review feedback from #22160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
