### PR TITLE
Restrict watch log backfill to the current message's log IDs

### DIFF
--- a/assistant/src/daemon/conversation-notifiers.ts
+++ b/assistant/src/daemon/conversation-notifiers.ts
@@ -22,7 +22,7 @@ import {
   addMessage,
   provenanceFromTrustContext,
 } from "../memory/conversation-crud.js";
-import { backfillMessageIdOnLogs } from "../memory/llm-request-log-store.js";
+import { setMessageIdOnLogs } from "../memory/llm-request-log-store.js";
 import type { Message } from "../providers/types.js";
 import type { WatchSession } from "../tools/watch/watch-state.js";
 import {
@@ -73,27 +73,27 @@ export function registerConversationNotifiers(
   registerWatchCommentaryNotifier(
     conversationId,
     async (_session: WatchSession) => {
-      const commentary = lastCommentaryByConversation.get(conversationId);
-      if (commentary) {
+      const result = lastCommentaryByConversation.get(conversationId);
+      if (result) {
         lastCommentaryByConversation.delete(conversationId);
 
         const msg = await addMessage(
           conversationId,
           "assistant",
-          JSON.stringify([{ type: "text", text: commentary }]),
+          JSON.stringify([{ type: "text", text: result.text }]),
           provenanceFromTrustContext(ctx.trustContext),
         );
-        ctx.messages.push(createAssistantMessage(commentary));
+        ctx.messages.push(createAssistantMessage(result.text));
 
         try {
-          backfillMessageIdOnLogs(conversationId, msg.id);
+          setMessageIdOnLogs(result.logIds, msg.id);
         } catch {
           // non-fatal — message is persisted even if log linkage fails
         }
 
         ctx.sendToClient({
           type: "assistant_text_delta",
-          text: commentary,
+          text: result.text,
           conversationId: conversationId,
         });
         ctx.sendToClient({
@@ -107,27 +107,27 @@ export function registerConversationNotifiers(
   registerWatchCompletionNotifier(
     conversationId,
     async (_session: WatchSession) => {
-      const summary = lastSummaryByConversation.get(conversationId);
-      if (summary) {
+      const result = lastSummaryByConversation.get(conversationId);
+      if (result) {
         lastSummaryByConversation.delete(conversationId);
 
         const msg = await addMessage(
           conversationId,
           "assistant",
-          JSON.stringify([{ type: "text", text: summary }]),
+          JSON.stringify([{ type: "text", text: result.text }]),
           provenanceFromTrustContext(ctx.trustContext),
         );
-        ctx.messages.push(createAssistantMessage(summary));
+        ctx.messages.push(createAssistantMessage(result.text));
 
         try {
-          backfillMessageIdOnLogs(conversationId, msg.id);
+          setMessageIdOnLogs(result.logIds, msg.id);
         } catch {
           // non-fatal — message is persisted even if log linkage fails
         }
 
         ctx.sendToClient({
           type: "assistant_text_delta",
-          text: summary,
+          text: result.text,
           conversationId: conversationId,
         });
         ctx.sendToClient({

--- a/assistant/src/daemon/watch-handler.ts
+++ b/assistant/src/daemon/watch-handler.ts
@@ -21,11 +21,16 @@ import type { WatchObservation } from "./message-protocol.js";
 const log = getLogger("watch-handler");
 
 /**
- * Module-level maps to store commentary/summary text so that session
- * notifier callbacks can retrieve it from the WatchSession's conversationId.
+ * Module-level maps to store commentary/summary text (and associated LLM log
+ * IDs) so that session notifier callbacks can retrieve them from the
+ * WatchSession's conversationId and link logs to the persisted message.
  */
-export const lastCommentaryByConversation = new Map<string, string>();
-export const lastSummaryByConversation = new Map<string, string>();
+export interface WatchResult {
+  text: string;
+  logIds: string[];
+}
+export const lastCommentaryByConversation = new Map<string, WatchResult>();
+export const lastSummaryByConversation = new Map<string, WatchResult>();
 
 export async function handleWatchObservation(
   msg: WatchObservation,
@@ -117,15 +122,15 @@ async function generateCommentary(session: WatchSession): Promise<void> {
       return;
     }
     const lastThree = session.observations.slice(-3);
-    const previousCommentary = lastCommentaryByConversation.get(
+    const previousResult = lastCommentaryByConversation.get(
       session.conversationId,
     );
 
     const userContent = [
       `Focus area: ${session.focusArea}`,
       "",
-      previousCommentary
-        ? `Previous commentary: "${previousCommentary}"`
+      previousResult
+        ? `Previous commentary: "${previousResult.text}"`
         : "No previous commentary yet.",
       "",
       ...lastThree.map(
@@ -165,15 +170,17 @@ async function generateCommentary(session: WatchSession): Promise<void> {
       },
     );
 
+    const logIds: string[] = [];
     if (response.rawRequest && response.rawResponse) {
       try {
-        recordRequestLog(
+        const logId = recordRequestLog(
           session.conversationId,
           JSON.stringify(response.rawRequest),
           JSON.stringify(response.rawResponse),
           undefined,
           response.actualProvider ?? provider.name,
         );
+        logIds.push(logId);
       } catch (err) {
         log.warn({ err }, "Failed to persist watch commentary LLM log");
       }
@@ -182,7 +189,10 @@ async function generateCommentary(session: WatchSession): Promise<void> {
     const commentaryText = extractText(response);
 
     if (commentaryText && commentaryText !== "SKIP") {
-      lastCommentaryByConversation.set(session.conversationId, commentaryText);
+      lastCommentaryByConversation.set(session.conversationId, {
+        text: commentaryText,
+        logIds,
+      });
       fireWatchCommentaryNotifier(session.conversationId, session);
       session.commentaryCount++;
     }
@@ -221,10 +231,10 @@ export async function generateSummary(session: WatchSession): Promise<void> {
         { watchId: session.watchId },
         "Configured provider unavailable for summary generation",
       );
-      lastSummaryByConversation.set(
-        session.conversationId,
-        "[error] Configured provider unavailable. Check your settings.",
-      );
+      lastSummaryByConversation.set(session.conversationId, {
+        text: "[error] Configured provider unavailable. Check your settings.",
+        logIds: [],
+      });
       fireWatchCompletionNotifier(session.conversationId, session);
       return;
     }
@@ -325,15 +335,17 @@ export async function generateSummary(session: WatchSession): Promise<void> {
       },
     );
 
+    const logIds: string[] = [];
     if (response.rawRequest && response.rawResponse) {
       try {
-        recordRequestLog(
+        const logId = recordRequestLog(
           session.conversationId,
           JSON.stringify(response.rawRequest),
           JSON.stringify(response.rawResponse),
           undefined,
           response.actualProvider ?? provider.name,
         );
+        logIds.push(logId);
       } catch (err) {
         log.warn({ err }, "Failed to persist watch summary LLM log");
       }
@@ -352,7 +364,10 @@ export async function generateSummary(session: WatchSession): Promise<void> {
     );
 
     if (summaryText) {
-      lastSummaryByConversation.set(session.conversationId, summaryText);
+      lastSummaryByConversation.set(session.conversationId, {
+        text: summaryText,
+        logIds,
+      });
       log.debug(
         { watchId: session.watchId, conversationId: session.conversationId },
         "Firing completion notifier with summary",
@@ -363,10 +378,10 @@ export async function generateSummary(session: WatchSession): Promise<void> {
         { watchId: session.watchId },
         "Summary was empty from API response",
       );
-      lastSummaryByConversation.set(
-        session.conversationId,
-        "[error] The API returned an empty summary. This may indicate a service issue.",
-      );
+      lastSummaryByConversation.set(session.conversationId, {
+        text: "[error] The API returned an empty summary. This may indicate a service issue.",
+        logIds,
+      });
       fireWatchCompletionNotifier(session.conversationId, session);
     }
   } catch (err) {
@@ -375,10 +390,10 @@ export async function generateSummary(session: WatchSession): Promise<void> {
       "Error generating watch summary — LLM API call failed",
     );
     const message = err instanceof Error ? err.message : String(err);
-    lastSummaryByConversation.set(
-      session.conversationId,
-      `[error] Summary generation failed: ${message}`,
-    );
+    lastSummaryByConversation.set(session.conversationId, {
+      text: `[error] Summary generation failed: ${message}`,
+      logIds: [],
+    });
     fireWatchCompletionNotifier(session.conversationId, session);
   }
 }

--- a/assistant/src/memory/llm-request-log-store.ts
+++ b/assistant/src/memory/llm-request-log-store.ts
@@ -26,11 +26,12 @@ export function recordRequestLog(
   responsePayload: string,
   messageId?: string,
   provider?: string,
-): void {
+): string {
   const db = getDb();
+  const id = uuid();
   db.insert(llmRequestLogs)
     .values({
-      id: uuid(),
+      id,
       conversationId,
       messageId: messageId ?? null,
       provider: provider ?? null,
@@ -39,6 +40,7 @@ export function recordRequestLog(
       createdAt: Date.now(),
     })
     .run();
+  return id;
 }
 
 export function queryRequestLogs(
@@ -80,6 +82,24 @@ export function backfillMessageIdOnLogs(
         isNull(llmRequestLogs.messageId),
       ),
     )
+    .run();
+}
+
+/**
+ * Set `messageId` on specific log rows identified by their IDs.
+ * Unlike `backfillMessageIdOnLogs` (which updates all null-messageId rows
+ * for a conversation), this targets only the given log rows — safe for
+ * concurrent watch/assistant turns.
+ */
+export function setMessageIdOnLogs(
+  logIds: string[],
+  messageId: string,
+): void {
+  if (logIds.length === 0) return;
+  const db = getDb();
+  db.update(llmRequestLogs)
+    .set({ messageId })
+    .where(inArray(llmRequestLogs.id, logIds))
     .run();
 }
 


### PR DESCRIPTION
## Summary
- `backfillMessageIdOnLogs()` in watch notifiers updated **all** null-messageId log rows in the conversation, not just the ones from the current watch response — causing corrupted LLM-call attribution when concurrent turns overlap
- `recordRequestLog()` now returns the log ID so callers can track which logs they created
- Added `setMessageIdOnLogs()` for targeted log-to-message linking by specific log IDs
- Changed `lastCommentaryByConversation` / `lastSummaryByConversation` maps from `Map<string, string>` to `Map<string, WatchResult>` to carry log IDs alongside text
- Watch notifiers now use `setMessageIdOnLogs(result.logIds, msg.id)` instead of the blanket `backfillMessageIdOnLogs(conversationId, msg.id)`

Addresses review feedback on #22173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
