### PR TITLE
fix: honor temporal mode semantics in guardian approval grants and resolver

### DIFF
--- a/assistant/src/__tests__/guardian-decision-primitive-canonical.test.ts
+++ b/assistant/src/__tests__/guardian-decision-primitive-canonical.test.ts
@@ -10,6 +10,8 @@ mock.module("../util/logger.js", () => ({
 
 import {
   applyCanonicalGuardianDecision,
+  GRANT_TTL_10M_MS,
+  GRANT_TTL_MS,
   mintCanonicalRequestGrant,
 } from "../approvals/guardian-decision-primitive.js";
 import type { ActorContext } from "../approvals/guardian-request-resolvers.js";
@@ -391,7 +393,8 @@ describe("applyCanonicalGuardianDecision", () => {
     expect(result.resolverFailed).toBe(true);
   });
 
-  test("preserves approve_10m (not downgraded) and mints grant", async () => {
+  test("preserves approve_10m (not downgraded) and mints grant with 10m TTL", async () => {
+    const before = Date.now();
     const req = createCanonicalGuardianRequest({
       kind: "unknown_kind",
       sourceType: "voice",
@@ -426,9 +429,14 @@ describe("applyCanonicalGuardianDecision", () => {
     expect(grants.length).toBe(1);
     expect(grants[0].toolName).toBe("host_bash");
     expect(grants[0].conversationId).toBe("conv-10m-1");
+
+    // Grant TTL should be ~10 minutes, not the default 5 minutes
+    const grantExpiresAt = grants[0].expiresAt;
+    expect(grantExpiresAt).toBeGreaterThanOrEqual(before + GRANT_TTL_10M_MS);
+    expect(grantExpiresAt).toBeLessThanOrEqual(Date.now() + GRANT_TTL_10M_MS);
   });
 
-  test("preserves approve_conversation (not downgraded) and mints grant", async () => {
+  test("preserves approve_conversation (not downgraded) and mints grant with no wall-clock expiry", async () => {
     const req = createCanonicalGuardianRequest({
       kind: "unknown_kind",
       sourceType: "voice",
@@ -463,6 +471,9 @@ describe("applyCanonicalGuardianDecision", () => {
     expect(grants.length).toBe(1);
     expect(grants[0].toolName).toBe("file_write");
     expect(grants[0].conversationId).toBe("conv-session-1");
+
+    // Conversation-scoped grants have no wall-clock expiry (far-future sentinel)
+    expect(grants[0].expiresAt).toBe(Number.MAX_SAFE_INTEGER);
   });
 
   // ── Expired request ────────────────────────────────────────────────
@@ -633,6 +644,7 @@ describe("mintCanonicalRequestGrant", () => {
       request: req,
       actorChannel: "telegram",
       guardianExternalUserId: "guardian-1",
+      effectiveAction: "approve_once",
     });
 
     expect(result.minted).toBe(true);
@@ -652,6 +664,7 @@ describe("mintCanonicalRequestGrant", () => {
     const result = mintCanonicalRequestGrant({
       request: req,
       actorChannel: "vellum",
+      effectiveAction: "approve_once",
     });
 
     expect(result.minted).toBe(true);
@@ -674,6 +687,7 @@ describe("mintCanonicalRequestGrant", () => {
       request: req,
       actorChannel: "telegram",
       guardianExternalUserId: "guardian-1",
+      effectiveAction: "approve_once",
     });
 
     expect(result.minted).toBe(false);
@@ -692,8 +706,91 @@ describe("mintCanonicalRequestGrant", () => {
       request: req,
       actorChannel: "telegram",
       guardianExternalUserId: "guardian-1",
+      effectiveAction: "approve_once",
     });
 
     expect(result.minted).toBe(false);
+  });
+
+  test("mints grant with 10m TTL for approve_10m action", () => {
+    const before = Date.now();
+    const req = createCanonicalGuardianRequest({
+      kind: "tool_approval",
+      sourceType: "channel",
+      sourceChannel: "telegram",
+      conversationId: "conv-ttl-10m",
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      toolName: "shell",
+      inputDigest: "sha256:ttl-10m",
+    });
+
+    const result = mintCanonicalRequestGrant({
+      request: req,
+      actorChannel: "telegram",
+      guardianExternalUserId: "guardian-1",
+      effectiveAction: "approve_10m",
+    });
+
+    expect(result.minted).toBe(true);
+
+    const db = getDb();
+    const grants = db.select().from(scopedApprovalGrants).all();
+    expect(grants.length).toBe(1);
+    expect(grants[0].expiresAt).toBeGreaterThanOrEqual(before + GRANT_TTL_10M_MS);
+    expect(grants[0].expiresAt).toBeLessThanOrEqual(Date.now() + GRANT_TTL_10M_MS);
+  });
+
+  test("mints grant with no wall-clock expiry for approve_conversation", () => {
+    const req = createCanonicalGuardianRequest({
+      kind: "tool_approval",
+      sourceType: "channel",
+      sourceChannel: "telegram",
+      conversationId: "conv-ttl-conv",
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      toolName: "shell",
+      inputDigest: "sha256:ttl-conv",
+    });
+
+    const result = mintCanonicalRequestGrant({
+      request: req,
+      actorChannel: "telegram",
+      guardianExternalUserId: "guardian-1",
+      effectiveAction: "approve_conversation",
+    });
+
+    expect(result.minted).toBe(true);
+
+    const db = getDb();
+    const grants = db.select().from(scopedApprovalGrants).all();
+    expect(grants.length).toBe(1);
+    expect(grants[0].expiresAt).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  test("mints grant with default 5m TTL for approve_once", () => {
+    const before = Date.now();
+    const req = createCanonicalGuardianRequest({
+      kind: "tool_approval",
+      sourceType: "channel",
+      sourceChannel: "telegram",
+      conversationId: "conv-ttl-once",
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      toolName: "shell",
+      inputDigest: "sha256:ttl-once",
+    });
+
+    const result = mintCanonicalRequestGrant({
+      request: req,
+      actorChannel: "telegram",
+      guardianExternalUserId: "guardian-1",
+      effectiveAction: "approve_once",
+    });
+
+    expect(result.minted).toBe(true);
+
+    const db = getDb();
+    const grants = db.select().from(scopedApprovalGrants).all();
+    expect(grants.length).toBe(1);
+    expect(grants[0].expiresAt).toBeGreaterThanOrEqual(before + GRANT_TTL_MS);
+    expect(grants[0].expiresAt).toBeLessThanOrEqual(Date.now() + GRANT_TTL_MS);
   });
 });

--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -64,6 +64,28 @@ const log = getLogger("guardian-decision-primitive");
 /** TTL for scoped approval grants minted on guardian approve_once decisions. */
 export const GRANT_TTL_MS = 5 * 60 * 1000;
 
+/** TTL for scoped approval grants minted on guardian approve_10m decisions. */
+export const GRANT_TTL_10M_MS = 10 * 60 * 1000;
+
+/**
+ * Compute the grant `expiresAt` timestamp for a given approval action.
+ *
+ * - `approve_10m` → 10 minutes from now
+ * - `approve_conversation` → no wall-clock expiry (far-future sentinel;
+ *   conversation lifecycle manages cleanup)
+ * - All others (`approve_once`, etc.) → 5 minutes from now (default)
+ */
+export function computeGrantExpiresAt(action: ApprovalAction): number {
+  switch (action) {
+    case "approve_10m":
+      return Date.now() + GRANT_TTL_10M_MS;
+    case "approve_conversation":
+      return Number.MAX_SAFE_INTEGER;
+    default:
+      return Date.now() + GRANT_TTL_MS;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Scoped grant minting
 // ---------------------------------------------------------------------------
@@ -82,8 +104,9 @@ export function tryMintToolApprovalGrant(params: {
   approval: GuardianApprovalRequest;
   decisionChannel: ChannelId;
   guardianExternalUserId: string;
+  effectiveAction: ApprovalAction;
 }): void {
-  const { approvalInfo, approval, decisionChannel, guardianExternalUserId } =
+  const { approvalInfo, approval, decisionChannel, guardianExternalUserId, effectiveAction } =
     params;
 
   if (!approvalInfo.toolName) {
@@ -119,7 +142,7 @@ export function tryMintToolApprovalGrant(params: {
     callSessionId: null,
     guardianExternalUserId,
     requesterExternalUserId: approval.requesterExternalUserId,
-    expiresAt: Date.now() + GRANT_TTL_MS,
+    expiresAt: computeGrantExpiresAt(effectiveAction),
   });
 
   if (result.ok) {
@@ -244,6 +267,7 @@ export function applyGuardianDecision(
       approval,
       decisionChannel: actorChannel,
       guardianExternalUserId: effectiveGuardianId,
+      effectiveAction: effectiveDecision.action,
     });
   }
 
@@ -271,8 +295,9 @@ export function mintCanonicalRequestGrant(params: {
   request: CanonicalGuardianRequest;
   actorChannel: string;
   guardianExternalUserId?: string;
+  effectiveAction: ApprovalAction;
 }): { minted: boolean } {
-  const { request, actorChannel, guardianExternalUserId } = params;
+  const { request, actorChannel, guardianExternalUserId, effectiveAction } = params;
 
   if (!request.toolName || !request.inputDigest) {
     return { minted: false };
@@ -289,7 +314,7 @@ export function mintCanonicalRequestGrant(params: {
     callSessionId: request.callSessionId ?? null,
     guardianExternalUserId: guardianExternalUserId ?? null,
     requesterExternalUserId: request.requesterExternalUserId ?? null,
-    expiresAt: Date.now() + GRANT_TTL_MS,
+    expiresAt: computeGrantExpiresAt(effectiveAction),
   });
 
   if (result.ok) {
@@ -580,6 +605,7 @@ export async function applyCanonicalGuardianDecision(
         actorContext.actorExternalUserId ??
         resolved.guardianExternalUserId ??
         undefined,
+      effectiveAction,
     });
     grantMinted = grantResult.minted;
   }

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -26,6 +26,7 @@ import {
 import { addRule } from "../permissions/trust-store.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { mintDaemonDeliveryToken } from "../runtime/auth/token-service.js";
+import type { UserDecision } from "../permissions/types.js";
 import type { ApprovalAction } from "../runtime/channel-approval-types.js";
 import { createOutboundSession } from "../runtime/channel-verification-service.js";
 import { deliverChannelReply } from "../runtime/gateway-client.js";
@@ -231,8 +232,24 @@ const pendingInteractionResolver: GuardianRequestResolver = {
     }
 
     // Map action to the permission system's UserDecision type and notify session.
-    const userDecision =
-      decision.action === "reject" ? ("deny" as const) : ("allow" as const);
+    // Mirrors mapApprovalActionToUserDecision from channel-approvals.ts so
+    // temporal modes (approve_10m, approve_conversation) reach the session with
+    // the correct UserDecision instead of collapsing to plain "allow".
+    let userDecision: UserDecision;
+    switch (decision.action) {
+      case "reject":
+        userDecision = "deny";
+        break;
+      case "approve_10m":
+        userDecision = "allow_10m";
+        break;
+      case "approve_conversation":
+        userDecision = "allow_conversation";
+        break;
+      default:
+        userDecision = "allow";
+        break;
+    }
     resolved.conversation!.handleConfirmationResponse(
       request.id,
       userDecision,


### PR DESCRIPTION
## Summary
- Thread `effectiveAction` through `tryMintToolApprovalGrant` and `mintCanonicalRequestGrant` so grant TTLs match the approval action: `approve_10m` → 10 min, `approve_conversation` → no wall-clock expiry (previously both silently used 5 min)
- Fix `pendingInteractionResolver` in canonical path to map `approve_10m` → `allow_10m` and `approve_conversation` → `allow_conversation` instead of collapsing all non-reject actions to `"allow"`, matching the non-canonical path's `mapApprovalActionToUserDecision`
- Add dedicated `mintCanonicalRequestGrant` tests verifying TTLs per action and update existing temporal mode tests with TTL assertions

Addresses review feedback on #21983.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
