### PR TITLE
Fix import sort order in conversations.ts and server.ts

### DIFF
--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -24,8 +24,8 @@ import {
   UNTITLED_FALLBACK,
 } from "../../memory/conversation-title-service.js";
 import * as pendingInteractions from "../../runtime/pending-interactions.js";
-import { getSubagentManager } from "../../subagent/index.js";
 import { redactSecrets } from "../../security/secret-scanner.js";
+import { getSubagentManager } from "../../subagent/index.js";
 import { summarizeToolInput } from "../../tools/tool-input-summary.js";
 import { truncate } from "../../util/truncate.js";
 import type { Conversation } from "../conversation.js";

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -48,12 +48,12 @@ import { getSigningKeyFingerprint } from "../runtime/auth/token-service.js";
 import { bridgeConfirmationRequestToGuardian } from "../runtime/confirmation-request-guardian-bridge.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { checkIngressForSecrets } from "../security/secret-ingress.js";
+import { redactSecrets } from "../security/secret-scanner.js";
 import { registerCancelCallback } from "../signals/cancel.js";
 import { registerConversationUndoCallback } from "../signals/conversation-undo.js";
 import { appendEventToStream } from "../signals/event-stream.js";
 import { registerUserMessageCallback } from "../signals/user-message.js";
 import { getSubagentManager } from "../subagent/index.js";
-import { redactSecrets } from "../security/secret-scanner.js";
 import { summarizeToolInput } from "../tools/tool-input-summary.js";
 import { getLogger } from "../util/logger.js";
 import {


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint errors in `conversations.ts` and `server.ts` by reordering imports alphabetically

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23728079219/job/69115624785