### PR TITLE
Regenerate stale openapi.yaml

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6376,17 +6376,27 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                    description: Event ID
-                  event_name:
-                    type: string
-                required:
-                  - id
-                  - event_name
-                additionalProperties: false
+                anyOf:
+                  - type: object
+                    properties:
+                      id:
+                        type: string
+                        description: Event ID
+                      event_name:
+                        type: string
+                    required:
+                      - id
+                      - event_name
+                    additionalProperties: false
+                  - type: object
+                    properties:
+                      skipped:
+                        type: boolean
+                        const: true
+                        description: Event skipped due to usage data collection being disabled
+                    required:
+                      - skipped
+                    additionalProperties: false
       requestBody:
         required: true
         content:


### PR DESCRIPTION
## Summary
- Regenerate `openapi.yaml` to match current route definitions (adds `anyOf` response schema for usage event endpoint)

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23728079219/job/69115624798
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
