### PR TITLE
Fix messaging-send cross-post test assertion

### DIFF
--- a/assistant/src/__tests__/messaging-send-tool.test.ts
+++ b/assistant/src/__tests__/messaging-send-tool.test.ts
@@ -195,7 +195,7 @@ describe("messaging-send tool", () => {
     expect(addMessageMock).toHaveBeenCalledWith(
       "bound-conv-99",
       "assistant",
-      "hello from A",
+      JSON.stringify([{ type: "text", text: "hello from A" }]),
       { automated: true, crossPostedFrom: "conv-A" },
       { skipIndexing: true },
     );


### PR DESCRIPTION
## Summary
- Update test expectation in `messaging-send-tool.test.ts` to match the implementation which passes `JSON.stringify([{ type: "text", text }])` instead of a plain string for cross-posted messages.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23728079219/job/69115624780
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
