### PR TITLE
Fix missing anthropicCacheCreation in fast mode pricing tests

### DIFF
--- a/assistant/src/__tests__/conversation-usage.test.ts
+++ b/assistant/src/__tests__/conversation-usage.test.ts
@@ -94,6 +94,7 @@ describe("recordUsage", () => {
       outputTokens: 1_000_000,
       cacheCreationInputTokens: 0,
       cacheReadInputTokens: 0,
+      anthropicCacheCreation: null,
       speed: "fast",
     };
     const expectedPricing = resolvePricingForUsageWithOverrides(

--- a/assistant/src/__tests__/pricing.test.ts
+++ b/assistant/src/__tests__/pricing.test.ts
@@ -301,6 +301,7 @@ describe("fast mode pricing", () => {
       outputTokens: 1_000_000,
       cacheCreationInputTokens: 0,
       cacheReadInputTokens: 0,
+      anthropicCacheCreation: null,
       speed: "fast",
     };
 
@@ -317,6 +318,7 @@ describe("fast mode pricing", () => {
       outputTokens: 1_000_000,
       cacheCreationInputTokens: 0,
       cacheReadInputTokens: 0,
+      anthropicCacheCreation: null,
       speed: "standard",
     };
 
@@ -332,6 +334,7 @@ describe("fast mode pricing", () => {
       outputTokens: 1_000_000,
       cacheCreationInputTokens: 0,
       cacheReadInputTokens: 0,
+      anthropicCacheCreation: null,
       speed: null,
     };
 
@@ -379,6 +382,7 @@ describe("fast mode pricing", () => {
       outputTokens: 1_000_000,
       cacheCreationInputTokens: 0,
       cacheReadInputTokens: 0,
+      anthropicCacheCreation: null,
       speed: "fast",
     };
 


### PR DESCRIPTION
## Summary
- Add `anthropicCacheCreation: null` to 5 PricingUsage literals in fast mode pricing tests that were missing the required field
- Fixes type check CI failure: `TS2741: Property 'anthropicCacheCreation' is missing`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23728079219/job/69115624786
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
