### PR TITLE
Compact temporal context injection (~50 → ~25 tokens/turn)

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -589,7 +589,7 @@ describe("injectTemporalContext", () => {
   };
 
   const sampleContext =
-    "<temporal_context>\nToday: 2026-02-18 (Wednesday)\nTimezone: UTC\n</temporal_context>";
+    "<temporal_context>\nToday: 2026-02-18 (Wed) 12:00 +00:00\nTZ: UTC\n</temporal_context>";
 
   test("prepends temporal context block to user message", () => {
     const result = injectTemporalContext(baseUserMessage, sampleContext);
@@ -729,7 +729,7 @@ describe("applyRuntimeInjections with temporalContext", () => {
   ];
 
   const sampleContext =
-    "<temporal_context>\nToday: 2026-02-18 (Wednesday)\n</temporal_context>";
+    "<temporal_context>\nToday: 2026-02-18 (Wed) 12:00 +00:00\nTZ: UTC\n</temporal_context>";
 
   test("injects temporal context when provided", () => {
     const result = applyRuntimeInjections(baseMessages, {
@@ -1293,7 +1293,7 @@ describe("applyRuntimeInjections — injection mode", () => {
     workspaceTopLevelContext:
       "<workspace_top_level>\nRoot: /sandbox\n</workspace_top_level>",
     temporalContext:
-      "<temporal_context>\nToday: 2026-03-04 (Tuesday)\n</temporal_context>",
+      "<temporal_context>\nToday: 2026-03-04 (Tue) 12:00 +00:00\nTZ: UTC\n</temporal_context>",
     channelCommandContext: { type: "start" } as const,
     activeSurface: { surfaceId: "sf_1", html: "<div>test</div>" },
     channelCapabilities: {

--- a/assistant/src/__tests__/date-context.test.ts
+++ b/assistant/src/__tests__/date-context.test.ts
@@ -24,9 +24,9 @@ describe("buildTemporalContext", () => {
     expect(result).toEndWith("</temporal_context>");
   });
 
-  test("includes today date and weekday", () => {
+  test("includes today date, weekday, time and offset on one line", () => {
     const result = buildTemporalContext({ nowMs: WED_FEB_18, timeZone: "UTC" });
-    expect(result).toContain("Today: 2026-02-18 (Wednesday)");
+    expect(result).toContain("Today: 2026-02-18 (Wed) 12:00 +00:00");
   });
 
   test("includes timezone", () => {
@@ -34,22 +34,16 @@ describe("buildTemporalContext", () => {
       nowMs: WED_FEB_18,
       timeZone: "America/New_York",
     });
-    expect(result).toContain("Timezone: America/New_York");
+    expect(result).toContain("TZ: America/New_York");
   });
 
-  test("includes current local time as ISO 8601 with offset", () => {
+  test("does not include UTC time, timezone source, or seconds", () => {
     const result = buildTemporalContext({ nowMs: WED_FEB_18, timeZone: "UTC" });
-    expect(result).toContain("Current local time: 2026-02-18T12:00:00+00:00");
-  });
-
-  test("includes current UTC time from assistant host clock", () => {
-    const result = buildTemporalContext({ nowMs: WED_FEB_18, timeZone: "UTC" });
-    expect(result).toContain("Current UTC time: 2026-02-18T12:00:00.000Z");
-  });
-
-  test("includes timezone source", () => {
-    const result = buildTemporalContext({ nowMs: WED_FEB_18, timeZone: "UTC" });
-    expect(result).toContain("Timezone source:");
+    expect(result).not.toContain("Current UTC time");
+    expect(result).not.toContain("Current local time");
+    expect(result).not.toContain("Timezone source:");
+    // No seconds in the time
+    expect(result).not.toContain("12:00:00");
   });
 
   test("does not include week definitions, next weekend, next work week, or horizon dates", () => {
@@ -60,25 +54,25 @@ describe("buildTemporalContext", () => {
     expect(result).not.toContain("Upcoming dates");
   });
 
-  test("uses user timezone when provided and records source metadata", () => {
+  test("uses user timezone when provided", () => {
     const result = buildTemporalContext({
       nowMs: WED_FEB_18,
       hostTimeZone: "UTC",
       userTimeZone: "America/New_York",
     });
-    expect(result).toContain("Timezone: America/New_York");
-    expect(result).toContain("Current local time: 2026-02-18T07:00:00-05:00");
-    expect(result).toContain("Timezone source: user_profile_memory");
+    expect(result).toContain("TZ: America/New_York");
+    expect(result).toContain("Today: 2026-02-18 (Wed) 07:00 -05:00");
+    expect(result).not.toContain("(host fallback)");
   });
 
-  test("shows user timezone only when different from primary timezone", () => {
+  test("shows user TZ only when different from primary timezone", () => {
     // When user timezone equals the primary timezone, omit it
     const sameResult = buildTemporalContext({
       nowMs: WED_FEB_18,
       hostTimeZone: "UTC",
       configuredUserTimeZone: "UTC",
     });
-    expect(sameResult).not.toContain("User timezone:");
+    expect(sameResult).not.toContain("User TZ:");
 
     // When user timezone differs from host, it becomes the primary timezone
     // and the host timezone is shown as a secondary annotation
@@ -87,19 +81,19 @@ describe("buildTemporalContext", () => {
       hostTimeZone: "UTC",
       userTimeZone: "America/New_York",
     });
-    expect(diffResult).toContain("Timezone: America/New_York");
-    expect(diffResult).toContain("Assistant host timezone: UTC");
-    expect(diffResult).not.toContain("User timezone:");
+    expect(diffResult).toContain("TZ: America/New_York");
+    expect(diffResult).toContain("Host TZ: UTC");
+    expect(diffResult).not.toContain("User TZ:");
   });
 
-  test("shows assistant host timezone only when different from primary timezone", () => {
+  test("shows host TZ only when different from primary timezone", () => {
     // When host timezone equals the primary timezone, omit it
     const sameResult = buildTemporalContext({
       nowMs: WED_FEB_18,
       hostTimeZone: "UTC",
       timeZone: "UTC",
     });
-    expect(sameResult).not.toContain("Assistant host timezone:");
+    expect(sameResult).not.toContain("Host TZ:");
 
     // When different, include it
     const diffResult = buildTemporalContext({
@@ -107,7 +101,7 @@ describe("buildTemporalContext", () => {
       hostTimeZone: "UTC",
       userTimeZone: "America/New_York",
     });
-    expect(diffResult).toContain("Assistant host timezone: UTC");
+    expect(diffResult).toContain("Host TZ: UTC");
   });
 
   test("uses configured user timezone when profile timezone is unavailable", () => {
@@ -117,9 +111,9 @@ describe("buildTemporalContext", () => {
       configuredUserTimeZone: "America/Chicago",
       userTimeZone: null,
     });
-    expect(result).toContain("Timezone: America/Chicago");
-    expect(result).toContain("Current local time: 2026-02-18T06:00:00-06:00");
-    expect(result).toContain("Timezone source: user_settings");
+    expect(result).toContain("TZ: America/Chicago");
+    expect(result).toContain("Today: 2026-02-18 (Wed) 06:00 -06:00");
+    expect(result).not.toContain("(host fallback)");
   });
 
   test("configured user timezone takes precedence over profile timezone", () => {
@@ -129,19 +123,17 @@ describe("buildTemporalContext", () => {
       configuredUserTimeZone: "America/Los_Angeles",
       userTimeZone: "America/New_York",
     });
-    expect(result).toContain("Timezone: America/Los_Angeles");
-    expect(result).toContain("Current local time: 2026-02-18T04:00:00-08:00");
-    expect(result).toContain("Timezone source: user_settings");
+    expect(result).toContain("TZ: America/Los_Angeles");
+    expect(result).toContain("Today: 2026-02-18 (Wed) 04:00 -08:00");
   });
 
-  test("falls back to host timezone when user timezone is unavailable", () => {
+  test("falls back to host timezone with (host fallback) suffix", () => {
     const result = buildTemporalContext({
       nowMs: WED_FEB_18,
       hostTimeZone: "UTC",
       userTimeZone: null,
     });
-    expect(result).toContain("Timezone: UTC");
-    expect(result).toContain("Timezone source: assistant_host_fallback");
+    expect(result).toContain("TZ: UTC (host fallback)");
   });
 
   test("accepts UTC/GMT offset-style user timezone values", () => {
@@ -150,9 +142,9 @@ describe("buildTemporalContext", () => {
       hostTimeZone: "UTC",
       userTimeZone: "UTC+2",
     });
-    expect(result).toContain("Timezone: Etc/GMT-2");
-    expect(result).toContain("Current local time: 2026-02-18T14:00:00+02:00");
-    expect(result).toContain("Timezone source: user_profile_memory");
+    expect(result).toContain("TZ: Etc/GMT-2");
+    expect(result).toContain("Today: 2026-02-18 (Wed) 14:00 +02:00");
+    expect(result).not.toContain("(host fallback)");
   });
 
   test("accepts fractional UTC/GMT offset-style user timezone values", () => {
@@ -161,30 +153,30 @@ describe("buildTemporalContext", () => {
       hostTimeZone: "UTC",
       userTimeZone: "UTC+5:30",
     });
-    expect(result).toContain("Timezone: +05:30");
-    expect(result).toContain("Current local time: 2026-02-18T17:30:00+05:30");
-    expect(result).toContain("Timezone source: user_profile_memory");
+    expect(result).toContain("TZ: +05:30");
+    expect(result).toContain("Today: 2026-02-18 (Wed) 17:30 +05:30");
+    expect(result).not.toContain("(host fallback)");
   });
 
-  test("formats midnight hours as 00 (never 24) in local ISO output", () => {
+  test("formats midnight hours as 00 (never 24)", () => {
     const justAfterMidnight = Date.UTC(2026, 1, 19, 0, 5, 0);
     const result = buildTemporalContext({
       nowMs: justAfterMidnight,
       timeZone: "UTC",
     });
-    expect(result).toContain("Current local time: 2026-02-19T00:05:00+00:00");
-    expect(result).not.toContain("T24:05:00");
+    expect(result).toContain("00:05 +00:00");
+    expect(result).not.toContain("24:05");
   });
 
   test("Today line includes full YYYY-MM-DD format with year", () => {
     const result = buildTemporalContext({ nowMs: WED_FEB_18, timeZone: "UTC" });
-    expect(result).toMatch(/Today: \d{4}-\d{2}-\d{2} \(\w+\)/);
+    expect(result).toMatch(/Today: \d{4}-\d{2}-\d{2} \(\w{3}\) \d{2}:\d{2}/);
     expect(result).toContain("2026-02-18");
   });
 
   test("handles year boundary correctly", () => {
     const result = buildTemporalContext({ nowMs: TUE_DEC_29, timeZone: "UTC" });
-    expect(result).toContain("Today: 2026-12-29 (Tuesday)");
+    expect(result).toContain("Today: 2026-12-29 (Tue)");
   });
 });
 
@@ -198,8 +190,7 @@ describe("DST-safe timezone behavior", () => {
       nowMs: WED_FEB_18,
       timeZone: "America/New_York",
     });
-    expect(result).toContain("Today: 2026-02-18 (Wednesday)");
-    expect(result).toContain("Current local time: 2026-02-18T07:00:00-05:00");
+    expect(result).toContain("Today: 2026-02-18 (Wed) 07:00 -05:00");
   });
 
   test("date labels are correct in timezone ahead of UTC", () => {
@@ -209,7 +200,7 @@ describe("DST-safe timezone behavior", () => {
       nowMs: nearMidnight,
       timeZone: "Asia/Tokyo",
     });
-    expect(result).toContain("Today: 2026-02-19 (Thursday)");
+    expect(result).toContain("Today: 2026-02-19 (Thu) 08:00 +09:00");
   });
 
   test("local offset tracks daylight saving changes", () => {
@@ -219,7 +210,7 @@ describe("DST-safe timezone behavior", () => {
       nowMs: summer,
       timeZone: "America/New_York",
     });
-    expect(result).toContain("Current local time: 2026-07-01T08:00:00-04:00");
+    expect(result).toContain("Today: 2026-07-01 (Wed) 08:00 -04:00");
   });
 });
 

--- a/assistant/src/daemon/date-context.ts
+++ b/assistant/src/daemon/date-context.ts
@@ -18,14 +18,14 @@ export interface TemporalContextOptions {
   userTimeZone?: string | null;
 }
 
-const WEEKDAY_NAMES = [
-  "Sunday",
-  "Monday",
-  "Tuesday",
-  "Wednesday",
-  "Thursday",
-  "Friday",
-  "Saturday",
+const WEEKDAY_SHORT = [
+  "Sun",
+  "Mon",
+  "Tue",
+  "Wed",
+  "Thu",
+  "Fri",
+  "Sat",
 ] as const;
 const UTC_GMT_OFFSET_TOKEN_RE = /^(?:UTC|GMT)([+-])(\d{1,2})(?::?(\d{2}))?$/i;
 
@@ -290,30 +290,25 @@ function formatLocalDate(date: Date, timeZone: string): string {
 }
 
 /**
- * Format a Date as local ISO 8601 with timezone offset in the given timezone.
+ * Format HH:MM and UTC offset for the given instant in the given timezone.
  */
-function formatLocalIsoWithOffset(date: Date, timeZone: string): string {
+function formatCompactTimeAndOffset(
+  date: Date,
+  timeZone: string,
+): { time: string; offset: string } {
   const fmt = new Intl.DateTimeFormat("en-US", {
     timeZone,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
     hour: "2-digit",
     minute: "2-digit",
-    second: "2-digit",
     hourCycle: "h23",
     timeZoneName: "shortOffset",
   });
   const parts = fmt.formatToParts(date);
   const get = (t: string) => parts.find((p) => p.type === t)?.value ?? "";
-  const offset = normalizeOffsetToken(get("timeZoneName"));
-  const year = get("year");
-  const month = get("month");
-  const day = get("day");
   const hour = get("hour");
   const minute = get("minute");
-  const second = get("second");
-  return `${year}-${month}-${day}T${hour}:${minute}:${second}${offset}`;
+  const offset = normalizeOffsetToken(get("timeZoneName"));
+  return { time: `${hour}:${minute}`, offset };
 }
 
 /**
@@ -351,22 +346,23 @@ export function buildTemporalContext(
         : "assistant_host_fallback";
   const todayParts = localDateParts(now, timeZone);
   const todayStr = formatLocalDate(now, timeZone);
-  const todayWeekday = WEEKDAY_NAMES[todayParts.weekday];
+  const todayWeekday = WEEKDAY_SHORT[todayParts.weekday];
+  const { time, offset } = formatCompactTimeAndOffset(now, timeZone);
+
+  const tzSuffix =
+    timeZoneSource === "assistant_host_fallback" ? " (host fallback)" : "";
 
   const lines = [
     `<temporal_context>`,
-    `Today: ${todayStr} (${todayWeekday})`,
-    `Timezone: ${timeZone}`,
-    `Current local time: ${formatLocalIsoWithOffset(now, timeZone)}`,
-    `Current UTC time: ${now.toISOString()}`,
-    `Timezone source: ${timeZoneSource}`,
+    `Today: ${todayStr} (${todayWeekday}) ${time} ${offset}`,
+    `TZ: ${timeZone}${tzSuffix}`,
   ];
 
   if (userTimeZone && userTimeZone !== timeZone) {
-    lines.push(`User timezone: ${userTimeZone}`);
+    lines.push(`User TZ: ${userTimeZone}`);
   }
   if (resolvedHostTimeZone !== timeZone) {
-    lines.push(`Assistant host timezone: ${resolvedHostTimeZone}`);
+    lines.push(`Host TZ: ${resolvedHostTimeZone}`);
   }
 
   lines.push(`</temporal_context>`);

--- a/skills/time-based-actions/SKILL.md
+++ b/skills/time-based-actions/SKILL.md
@@ -47,19 +47,18 @@ If you use `send_notification` for any of these, the notification fires immediat
 
 Use the injected `<temporal_context>` block as the authoritative clock source:
 
-- `Current UTC time` is the canonical current instant (from assistant host clock).
-- `Current local time` + `Timezone` are the active local-calendar interpretation.
-- `Timezone source` tells you whether local-time interpretation is user-specific or host fallback. When a `User timezone:` line is present, the user's timezone differs from the primary timezone.
+- `Today:` line contains the date, abbreviated weekday, local time (HH:MM), and UTC offset.
+- `TZ:` line is the IANA timezone identifier. When followed by `(host fallback)`, the timezone was inferred from the assistant host — not the user.
 
-When `Timezone source: assistant_host_fallback` and the request is locale-specific (e.g. "at 3pm", "tomorrow morning", "tonight"), ask once for their timezone and then proceed.
+When `TZ:` shows `(host fallback)` and the request is locale-specific (e.g. "at 3pm", "tomorrow morning", "tonight"), ask once for their timezone and then proceed.
 If the user confirms a timezone, suggest saving it in Settings -> Appearance -> User timezone so future reminders resolve correctly without re-asking.
 
 ## Relative Time Parsing
 
 When the user says "in X minutes/hours", compute the ISO 8601 timestamp yourself:
 
-- Take `Current UTC time` (or `Current local time` in the active `Timezone`)
-- Add the offset
+- Take the time and offset from the `Today:` line (e.g. `23:26 -05:00`)
+- Add the requested offset
 - Format as ISO 8601 with timezone: `2025-03-15T09:05:00-05:00`
 - Pass to `reminder_create` as `fire_at`
 


### PR DESCRIPTION
## Summary
- Merge date + weekday + time + UTC offset into one `Today:` line, eliminating the redundant `Current local time:` field
- Remove `Current UTC time` (derivable from local + offset), `Timezone source` (debug metadata), and seconds precision (stale by model read time)
- Shorten labels: `TZ:`, `User TZ:`, `Host TZ:`. Replace `Timezone source: assistant_host_fallback` with `(host fallback)` suffix on `TZ:` line
- Update time-based-actions SKILL.md to reference new field format

**Before** (~50 tokens/turn):
```
<temporal_context>
Today: 2026-03-29 (Sunday)
Timezone: America/Chicago
Current local time: 2026-03-29T23:26:32-05:00
Current UTC time: 2026-03-30T04:26:32.508Z
Timezone source: user_settings
</temporal_context>
```

**After** (~25 tokens/turn):
```
<temporal_context>
Today: 2026-03-29 (Sun) 23:26 -05:00
TZ: America/Chicago
</temporal_context>
```

## Original prompt
This injected section seems suboptimal - how can we improve it?
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
