### PR TITLE
Fix hatch signing key not persisted to lockfile

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -829,7 +829,7 @@ async function hatchLocal(
     species,
     hatchedAt: new Date().toISOString(),
     serviceGroupVersion: cliPkg.version ? `v${cliPkg.version}` : undefined,
-    resources,
+    resources: { ...resources, signingKey },
   };
   emitProgress(7, 7, "Saving configuration...");
   if (!restart) {


### PR DESCRIPTION
## Summary
- `hatch` generates a signing key and passes it to daemon/gateway, but saved the lockfile entry **without** the key
- On next `wake`, a new key was generated → JWT signature mismatch → 401 on all runtime proxy requests → "Disconnected from Velissa"
- Persist `signingKey` into lockfile resources (same pattern `wake.ts` already uses on line 118)

## Test plan
- [ ] `vellum hatch` a new local instance, verify `signingKey` appears in `~/.vellum.lock.json` resources
- [ ] Restart via `vellum wake` — confirm the same key is reused (not regenerated)
- [ ] macOS app restart — confirm no "Disconnected" state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
