### PR TITLE
Add estimated cost to LLM Context Inspector overview

### DIFF
--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -48,9 +48,13 @@ import { deleteQueuedMessage } from "../../daemon/handlers/conversations.js";
 import { getAssistantMessageIdsInTurn } from "../../memory/conversation-crud.js";
 import { getRequestLogsByMessageId } from "../../memory/llm-request-log-store.js";
 import { getMemoryRecallLogByMessageIds } from "../../memory/memory-recall-log-store.js";
+import { resolvePricingForUsage } from "../../util/pricing.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
-import { normalizeLlmContextPayloads } from "./llm-context-normalization.js";
+import {
+  type LlmContextSummary,
+  normalizeLlmContextPayloads,
+} from "./llm-context-normalization.js";
 
 const validProviderSet = new Set<string>(VALID_INFERENCE_PROVIDERS);
 const validEmbeddingProviderSet = new Set<string>(
@@ -71,20 +75,48 @@ type LlmContextRouteResult = Omit<LlmContextNormalizationResult, "summary"> & {
   summary?: LlmContextSummaryResponse;
 };
 
+function attachEstimatedCost(summary: LlmContextSummary): LlmContextSummary {
+  const { provider, model, inputTokens, outputTokens } = summary;
+  if (!model || inputTokens == null || outputTokens == null) {
+    return summary;
+  }
+
+  const cacheCreation = summary.cacheCreationInputTokens ?? 0;
+  const cacheRead = summary.cacheReadInputTokens ?? 0;
+  const directInputTokens = Math.max(
+    inputTokens - cacheCreation - cacheRead,
+    0,
+  );
+
+  const result = resolvePricingForUsage(provider, model, {
+    directInputTokens,
+    outputTokens,
+    cacheCreationInputTokens: cacheCreation,
+    cacheReadInputTokens: cacheRead,
+    anthropicCacheCreation: null,
+  });
+
+  return { ...summary, estimatedCostUsd: result.estimatedCostUsd };
+}
+
 function applyStoredProviderToLlmContextResult(
   normalized: LlmContextNormalizationResult,
   provider: string | null,
 ): LlmContextRouteResult {
   if (!provider) {
-    return normalized as LlmContextRouteResult;
+    const summary = normalized.summary
+      ? attachEstimatedCost(normalized.summary)
+      : undefined;
+    return { ...normalized, summary } as LlmContextRouteResult;
   }
 
-  return {
-    ...normalized,
-    summary: normalized.summary
-      ? { ...normalized.summary, provider }
-      : { provider },
-  };
+  const mergedSummary = normalized.summary
+    ? { ...normalized.summary, provider }
+    : { provider };
+  const summary = attachEstimatedCost(
+    mergedSummary as LlmContextSummary,
+  );
+  return { ...normalized, summary };
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/routes/llm-context-normalization.ts
+++ b/assistant/src/runtime/routes/llm-context-normalization.ts
@@ -18,6 +18,7 @@ export interface LlmContextSummary {
   responseToolCallCount?: number;
   responsePreview?: string;
   toolCallNames?: string[];
+  estimatedCostUsd?: number | null;
 }
 
 export interface LlmContextSection {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorSummaryFormatters.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorSummaryFormatters.swift
@@ -52,6 +52,7 @@ struct MessageInspectorOverviewContent: Equatable {
                 created: summary.cacheCreationInputTokens,
                 read: summary.cacheReadInputTokens
             )),
+            .init(label: "Estimated cost", value: MessageInspectorSummaryFormatters.formatCost(summary.estimatedCostUsd)),
             .init(label: "Request messages", value: MessageInspectorSummaryFormatters.formatCount(summary.requestMessageCount)),
             .init(label: "Tool count", value: MessageInspectorSummaryFormatters.formatCount(summary.requestToolCount)),
         ]
@@ -68,6 +69,11 @@ enum MessageInspectorSummaryFormatters {
     static func formatCount(_ value: Int?) -> String {
         guard let value else { return missingValue }
         return Self.numberFormatter.string(from: NSNumber(value: value)) ?? "\(value)"
+    }
+
+    static func formatCost(_ value: Double?) -> String {
+        guard let value else { return missingValue }
+        return costFormatter.string(from: NSNumber(value: value)) ?? String(format: "$%.4f", value)
     }
 
     static func formatCacheTokens(created: Int?, read: Int?) -> String {
@@ -200,6 +206,15 @@ enum MessageInspectorSummaryFormatters {
     private static let numberFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
+        return formatter
+    }()
+
+    private static let costFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = "USD"
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 4
         return formatter
     }()
 }

--- a/clients/shared/Network/LLMContextClient.swift
+++ b/clients/shared/Network/LLMContextClient.swift
@@ -25,6 +25,7 @@ public struct LLMCallSummary: Codable, Sendable, Equatable {
     public let responsePreview: String?
     public let toolCallNames: [String]?
     public let durationMs: Int?
+    public let estimatedCostUsd: Double?
 
     public init(
         title: String? = nil,
@@ -44,7 +45,8 @@ public struct LLMCallSummary: Codable, Sendable, Equatable {
         responseToolCallCount: Int? = nil,
         responsePreview: String? = nil,
         toolCallNames: [String]? = nil,
-        durationMs: Int? = nil
+        durationMs: Int? = nil,
+        estimatedCostUsd: Double? = nil
     ) {
         self.title = title
         self.subtitle = subtitle
@@ -64,6 +66,7 @@ public struct LLMCallSummary: Codable, Sendable, Equatable {
         self.responsePreview = responsePreview
         self.toolCallNames = toolCallNames
         self.durationMs = durationMs
+        self.estimatedCostUsd = estimatedCostUsd
     }
 
     /// String form of the normalized summary when the payload uses text.


### PR DESCRIPTION
## Summary
- Compute estimated cost (USD) from the normalized token summary using the existing pricing catalog in the LLM context API route
- Add `estimatedCostUsd` field to the `LlmContextSummary` (TS) and `LLMCallSummary` (Swift) models
- Display the cost as a new "Estimated cost" row in the Usage section of the inspector's Overview tab, formatted as USD currency

## Original prompt
Can you add the cost here too? (referring to the LLM Context Inspector Usage section)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
