### PR TITLE
Fix iOS build: initialize estimatedCostUsd in LLMCallSummary decoder

### DIFF
--- a/clients/shared/Network/LLMContextClient.swift
+++ b/clients/shared/Network/LLMContextClient.swift
@@ -94,6 +94,7 @@ public struct LLMCallSummary: Codable, Sendable, Equatable {
         responsePreview = container.decodeString(for: ["responsePreview", "responseTextPreview", "response_preview"])
         toolCallNames = container.decodeStringArray(for: ["toolCallNames", "tool_call_names"])
         durationMs = container.decodeInt(for: ["durationMs", "duration_ms", "elapsedMs"])
+        estimatedCostUsd = container.decodeDouble(for: ["estimatedCostUsd", "estimated_cost_usd"])
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -116,6 +117,7 @@ public struct LLMCallSummary: Codable, Sendable, Equatable {
         try container.encodeIfPresent(responsePreview, forKey: "responsePreview")
         try container.encodeIfPresent(toolCallNames, forKey: "toolCallNames")
         try container.encodeIfPresent(durationMs, forKey: "durationMs")
+        try container.encodeIfPresent(estimatedCostUsd, forKey: "estimatedCostUsd")
     }
 }
 
@@ -408,6 +410,16 @@ private extension KeyedDecodingContainer where Key == LLMContextCodingKey {
         return nil
     }
 
+    func decodeDouble(for keys: [String]) -> Double? {
+        for key in keys {
+            guard let codingKey = Key(stringValue: key) else { continue }
+            if let value = try? decodeIfPresent(Double.self, forKey: codingKey) {
+                return value
+            }
+        }
+        return nil
+    }
+
     func decodeBool(for keys: [String]) -> Bool? {
         for key in keys {
             guard let codingKey = Key(stringValue: key) else { continue }
@@ -446,6 +458,11 @@ private extension KeyedEncodingContainer where Key == LLMContextCodingKey {
     }
 
     mutating func encodeIfPresent(_ value: Int?, forKey key: String) throws {
+        guard let value, let codingKey = Key(stringValue: key) else { return }
+        try encode(value, forKey: codingKey)
+    }
+
+    mutating func encodeIfPresent(_ value: Double?, forKey key: String) throws {
         guard let value, let codingKey = Key(stringValue: key) else { return }
         try encode(value, forKey: codingKey)
     }


### PR DESCRIPTION
## Summary
- Add `estimatedCostUsd` decoding in `LLMCallSummary.init(from:)` — the custom decoder was missing this property, causing "Return from initializer without initializing all stored properties"
- Add `estimatedCostUsd` encoding in `encode(to:)` for roundtrip correctness
- Add `decodeDouble` and `encodeIfPresent(Double?)` helpers to the `LLMContextCodingKey` extensions

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23729064524/job/69118794033
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
