### PR TITLE
fix(macos): handle thinking-only entries in history reconstruction

### DIFF
--- a/clients/shared/Features/Chat/HistoryReconstructionService.swift
+++ b/clients/shared/Features/Chat/HistoryReconstructionService.swift
@@ -120,7 +120,8 @@ enum HistoryReconstructionService {
                 }
             }
 
-            if item.text.isEmpty && toolCalls.isEmpty && attachments.isEmpty && inlineSurfaces.isEmpty { continue }
+            let hasThinking = item.thinkingSegments?.isEmpty == false
+            if item.text.isEmpty && toolCalls.isEmpty && attachments.isEmpty && inlineSurfaces.isEmpty && !hasThinking { continue }
             let timestamp = Date(timeIntervalSince1970: TimeInterval(item.timestamp) / 1000.0)
 
             var chatMsg: ChatMessage


### PR DESCRIPTION
Move thinkingSegments check above the early-continue guard so messages with only thinking content are not silently dropped.

Addresses feedback from #22064.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
