### PR TITLE
fix(macos): add unread auto-expand to channel conversation sections

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -624,7 +624,19 @@ extension MainWindowView {
 
                         if !isCollapsed {
                             let showAll = sidebar.showAllChannelConversations[group.channel] ?? false
-                            let displayed = showAll ? group.conversations : Array(group.conversations.prefix(3))
+                            let displayed: [ConversationModel]
+                            if showAll {
+                                displayed = group.conversations
+                            } else {
+                                // Auto-expand if any hidden conversation has unread messages.
+                                let visible = Array(group.conversations.prefix(3))
+                                let hidden = group.conversations.dropFirst(3)
+                                if hidden.contains(where: { $0.hasUnseenLatestAssistantMessage }) {
+                                    displayed = group.conversations
+                                } else {
+                                    displayed = visible
+                                }
+                            }
 
                             ForEach(displayed) { conversation in
                                 makeSidebarRow(conversation: conversation)


### PR DESCRIPTION
Add auto-expand logic to channel sidebar sections so hidden conversations with unread messages are automatically surfaced, matching the existing background conversation behavior.

Addresses feedback from #21989.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
