### PR TITLE
fix(memory): propagate AbortError and cap HyDE expansion entries

### DIFF
--- a/assistant/src/memory/query-expansion.ts
+++ b/assistant/src/memory/query-expansion.ts
@@ -63,7 +63,8 @@ export async function expandQueryWithHyDE(
     const entries = text
       .split("---")
       .map((entry) => entry.trim())
-      .filter((entry) => entry.length > 0);
+      .filter((entry) => entry.length > 0)
+      .slice(0, 3);
 
     if (entries.length === 0) {
       log.warn("No entries parsed from HyDE query expansion response");
@@ -72,6 +73,7 @@ export async function expandQueryWithHyDE(
 
     return entries;
   } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") throw err;
     log.warn(
       { err: err instanceof Error ? err.message : String(err) },
       "HyDE query expansion failed",


### PR DESCRIPTION
Re-throw AbortError in HyDE expansion catch block to avoid wasted compute on cancelled requests, and cap parsed entries at 3 to match the function contract.\n\nAddresses feedback from #22201.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
