### PR TITLE
fix(memory): prevent unhandled promise rejection from rawSearchPromise

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -275,6 +275,8 @@ async function runHyDESearch(
     scopeIds,
     sparseVector,
   );
+  // Suppress unhandled rejection if Qdrant rejects before we await
+  rawSearchPromise.catch(() => {});
 
   // Attempt HyDE expansion — returns [] on any failure
   let hypotheticalDocs: string[];


### PR DESCRIPTION
Attach .catch() to rawSearchPromise at creation to prevent crash when Qdrant rejects before the promise is awaited.\n\nAddresses feedback from #22204.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
