### PR TITLE
fix(memory): re-apply min-score filter after MMR and fix diagnostic ordering

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -594,7 +594,11 @@ export async function buildMemoryRecall(
   const filtered = filterByMinScore(allCandidates);
 
   // ── Step 5b: MMR diversity ranking ─────────────────────────────
-  const diversified = applyMMR(filtered, MMR_PENALTY);
+  const mmrRanked = applyMMR(filtered, MMR_PENALTY);
+
+  // MMR rewrites finalScore, so re-enforce the min-score threshold to
+  // drop candidates whose adjusted score fell below the cutoff.
+  const diversified = filterByMinScore(mmrRanked);
 
   // ── Step 5c: Enrich candidates with source labels ──────────────
   enrichSourceLabels(diversified);


### PR DESCRIPTION
Re-enforce min-score threshold after MMR reranking to drop candidates whose adjusted score fell below the cutoff. The diagnostic sort fix was already present in the codebase.\n\nAddresses feedback from #22203.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
