### PR TITLE
fix(macos): trigger UI sync after scroll throttle recovery

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -229,6 +229,7 @@ final class MessageListScrollState {
                 self.isThrottled = false
                 self.bodyEvalTimestamps.removeAll()
                 self.throttleRecoveryTask = nil
+                self.scheduleUISync()
             }
         }
     }


### PR DESCRIPTION
Add scheduleUISync() at the end of the throttle recovery path to reconcile any state changes suppressed during throttling.

Addresses feedback from #22212.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
