### PR TITLE
fix(gateway): prevent attachment failures from tripping inbound circuit breaker

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1287,7 +1287,9 @@ async function main() {
                       slackFile,
                       botToken,
                     );
-                    return uploadAttachment(config, downloaded);
+                    return uploadAttachment(config, downloaded, {
+                      skipCircuitBreaker: true,
+                    });
                   }),
                 );
                 for (const result of results) {
@@ -1333,10 +1335,22 @@ async function main() {
 
         if (isThreadReply && botToken) {
           fetchThreadContext(channel, threadTs, messageTs, botToken)
-            .then((context) => forward(context ?? undefined))
-            .catch(() => forward());
+            .then((context) => context ?? undefined)
+            .catch(() => undefined)
+            .then((context) => forward(context))
+            .catch((err) => {
+              log.error(
+                { err, channel, threadTs },
+                "Unhandled error in Slack forward (thread reply)",
+              );
+            });
         } else {
-          forward();
+          forward().catch((err) => {
+            log.error(
+              { err, channel, threadTs },
+              "Unhandled error in Slack forward",
+            );
+          });
         }
 
         // When an approval button is clicked, store the approval message ts

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -547,8 +547,11 @@ export async function forwardTwilioConnectActionWebhook(
 export async function uploadAttachment(
   config: GatewayConfig,
   input: UploadAttachmentInput,
+  opts?: { skipCircuitBreaker?: boolean },
 ): Promise<UploadAttachmentResponse> {
-  cbBeforeRequest();
+  const skipCb = opts?.skipCircuitBreaker === true;
+
+  if (!skipCb) cbBeforeRequest();
 
   const url = `${config.assistantRuntimeBaseUrl}/v1/attachments`;
 
@@ -563,7 +566,7 @@ export async function uploadAttachment(
       signal: AbortSignal.timeout(config.runtimeTimeoutMs),
     });
   } catch (err) {
-    cbOnFailure();
+    if (!skipCb) cbOnFailure();
     throw err;
   }
 
@@ -573,16 +576,16 @@ export async function uploadAttachment(
     // extension, missing fields). Distinguish from transient 5xx/network errors
     // so callers can decide whether to skip or propagate.
     if (response.status >= 400 && response.status < 500) {
-      cbOnSuccess();
+      if (!skipCb) cbOnSuccess();
       throw new AttachmentValidationError(
         `Attachment rejected (${response.status}): ${body}`,
       );
     }
-    cbOnFailure();
+    if (!skipCb) cbOnFailure();
     throw new Error(`Attachment upload failed (${response.status}): ${body}`);
   }
 
-  cbOnSuccess();
+  if (!skipCb) cbOnSuccess();
   return (await response.json()) as UploadAttachmentResponse;
 }
 


### PR DESCRIPTION
Prevent attachment upload failures from accumulating circuit breaker failures that could block non-attachment inbound traffic.

- Add `skipCircuitBreaker` option to `uploadAttachment()` and use it in Slack Socket Mode handler so attachment failures don't count toward the shared breaker threshold
- Fix potential double message delivery in thread-reply path by separating `fetchThreadContext` error handling from `forward` error handling
- Add `.catch()` to fire-and-forget `forward()` calls to prevent unhandled promise rejections

Addresses feedback from #22198.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
