### PR TITLE
fix(memory): correct NULL-importance handling in serendipity filter

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -1077,9 +1077,10 @@ function filterInContextItems(
  * then selects up to `count` items with probability proportional to their
  * importance value (importance-weighted sampling).
  *
- * Only items with importance >= MIN_SERENDIPITY_IMPORTANCE are eligible,
- * so only genuinely significant memories (decisions, personal moments,
- * turning points) surface as echoes.
+ * Items with importance >= MIN_SERENDIPITY_IMPORTANCE are eligible, as are
+ * legacy items with NULL importance (not yet backfilled). This ensures
+ * genuinely significant memories and pre-importance-era items can both
+ * surface as echoes.
  */
 const MIN_SERENDIPITY_IMPORTANCE = 0.7;
 
@@ -1106,7 +1107,7 @@ function sampleSerendipityItems(
       ? inArray(memoryItems.scopeId, scopeIds)
       : eq(memoryItems.scopeId, "default");
 
-    const importanceFloor = sql`COALESCE(${memoryItems.importance}, 0.5) >= ${MIN_SERENDIPITY_IMPORTANCE}`;
+    const importanceFloor = sql`(${memoryItems.importance} >= ${MIN_SERENDIPITY_IMPORTANCE} OR ${memoryItems.importance} IS NULL)`;
 
     const baseConditions =
       existingItemIds.length > 0


### PR DESCRIPTION
Fix serendipity filter so NULL-importance legacy items actually pass the threshold. The previous `COALESCE(importance, 0.5) >= 0.7` was a no-op for NULL rows since 0.5 < 0.7. Changed to explicit `OR importance IS NULL` clause, and updated the doc comment to reflect the intended behavior.

Addresses feedback from #22221.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
