### PR TITLE
fix: set fresh sentAt on slash command assistant replies

### DIFF
--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -380,7 +380,7 @@ export async function drainQueue(
         conversation.conversationId,
         "assistant",
         JSON.stringify(assistantMsg.content),
-        drainChannelMeta,
+        { ...drainChannelMeta, sentAt: Date.now() },
       );
       conversation.messages.push(assistantMsg);
 
@@ -487,7 +487,7 @@ export async function drainQueue(
         conversation.conversationId,
         "assistant",
         JSON.stringify(assistantMsg.content),
-        drainChannelMeta,
+        { ...drainChannelMeta, sentAt: Date.now() },
       );
       conversation.messages.push(assistantMsg);
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -561,6 +561,10 @@ export function handleListMessages(
 
     // Use sentAt (actual event time) for the display timestamp when
     // available, falling back to createdAt (persistence time).
+    // Note: clients use this display timestamp as their pagination cursor
+    // after memory-pressure trimming, while server-side pagination filters
+    // on createdAt. The mismatch is benign — it may return slightly extra
+    // data on a page boundary but never loses messages.
     const displayTimestamp = m.sentAt ?? m.timestamp;
     return {
       id: m.id ?? "",


### PR DESCRIPTION
## Summary
- Set `sentAt: Date.now()` on assistant message metadata in both the "unknown" and "compact" slash command handlers so replies get their own wall-clock timestamp instead of reusing the user's enqueue time.
- Document the benign pagination cursor mismatch (client uses display timestamp, server uses `createdAt`) — may return slightly extra data on page boundaries but never loses messages.

## Test plan
- [ ] Send `/status` or `/models` queued behind a long turn; verify the assistant reply timestamp reflects when the reply was produced, not when the user command was enqueued.
- [ ] Verify message history pagination still works correctly after memory-pressure trimming.

Addresses feedback from #22209.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
