### PR TITLE
fix: apply redactSecrets to tool grant request questionText

### DIFF
--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -11,6 +11,7 @@ import { getTaskRunRules } from "../tasks/ephemeral-permissions.js";
 import { getLogger } from "../util/logger.js";
 import { getAllTools, getTool } from "./registry.js";
 import { isSideEffectTool } from "./side-effects.js";
+import { redactSecrets } from "../security/secret-scanner.js";
 import { summarizeToolInput } from "./tool-input-summary.js";
 import type {
   ExecutionTarget,
@@ -33,7 +34,7 @@ function buildToolGrantQuestionText(
     context.requesterIdentifier ||
     context.requesterExternalUserId ||
     "A trusted contact";
-  const inputSummary = summarizeToolInput(toolName, input);
+  const inputSummary = redactSecrets(summarizeToolInput(toolName, input));
   return inputSummary
     ? `${senderLabel} wants to use "${toolName}": ${inputSummary}`
     : `${senderLabel} is requesting permission to use "${toolName}"`;


### PR DESCRIPTION
Apply redactSecrets() to the questionText field in the tool grant request path, completing the coverage started in #22231.

Addresses feedback from #22231.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
