### PR TITLE
fix(cli): persist signing key in recover command and update AGENTS.md

### DIFF
--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -45,7 +45,7 @@ Every command must have high-quality `--help` output. Follow the same standards 
 
 The CLI must **never** read from or write to the `.vellum/` directory (e.g. `~/.vellum/protected/`, `<instanceDir>/.vellum/`). That directory structure is an **assistant daemon / gateway implementation detail**. The CLI's job is to spawn those processes and pass configuration via environment variables — not to reach into their internal storage.
 
-For example, the signing key used for JWT auth between the daemon and gateway is passed as the `ACTOR_TOKEN_SIGNING_KEY` env var. The CLI generates an ephemeral key (`generateLocalSigningKey()` in `lib/local.ts`) and passes it to both `startLocalDaemon` and `startGateway`. It does **not** read or write key files on disk — each process manages its own persistence.
+For example, the signing key used for JWT auth between the daemon and gateway is persisted in the lockfile (`resources.signingKey`) so that client actor tokens survive daemon/gateway restarts. On first start (or when the key is missing), the CLI generates a new key via `generateLocalSigningKey()` in `lib/local.ts`, saves it to the lockfile entry, and passes it to both `startLocalDaemon` and `startGateway` as the `ACTOR_TOKEN_SIGNING_KEY` env var. The CLI does **not** read or write to the `.vellum/` directory for signing keys — it uses the lockfile instead.
 
 ## Docker Volume Management
 

--- a/cli/src/commands/recover.ts
+++ b/cli/src/commands/recover.ts
@@ -70,8 +70,12 @@ export async function recover(): Promise<void> {
   unlinkSync(archivePath);
   unlinkSync(metadataPath);
 
-  // 7. Start daemon + gateway (same as wake)
+  // 7. Persist signing key so it survives daemon/gateway restarts (same as wake)
   const signingKey = generateLocalSigningKey();
+  entry.resources = { ...entry.resources, signingKey };
+  saveAssistantEntry(entry);
+
+  // 8. Start daemon + gateway
   await startLocalDaemon(false, entry.resources, { signingKey });
   await startGateway(false, entry.resources, { signingKey });
 


### PR DESCRIPTION
Persist the signing key to the lockfile in the recover command (matching the wake fix from #22233) and update cli/AGENTS.md to reflect the new lockfile persistence pattern.

Addresses feedback from #22233.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
