### PR TITLE
fix(macos): remove dead lastContentWasToolCall property

### DIFF
--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -466,7 +466,6 @@ final class ChatActionHandler {
         vm.currentAssistantMessageId = nil
         vm.currentTurnUserText = nil
         vm.currentAssistantHasText = false
-        vm.lastContentWasToolCall = false
         // Reset processing messages to sent and drop attachment base64 data
         // for lazy-loadable attachments (sizeBytes != nil means the daemon can
         // re-serve them). Locally-added attachments (sizeBytes == nil) keep their
@@ -518,7 +517,6 @@ final class ChatActionHandler {
         vm.currentAssistantMessageId = nil
         vm.currentTurnUserText = nil
         vm.currentAssistantHasText = false
-        vm.lastContentWasToolCall = false
         vm.discardStreamingBuffer()
         vm.discardPartialOutputBuffer()
     }
@@ -577,7 +575,6 @@ final class ChatActionHandler {
         vm.currentAssistantMessageId = nil
         vm.currentTurnUserText = nil
         vm.currentAssistantHasText = false
-        vm.lastContentWasToolCall = false
         vm.discardStreamingBuffer()
         vm.flushPartialOutputBuffer()
         // Reset processing messages to sent
@@ -681,7 +678,6 @@ final class ChatActionHandler {
             vm.currentAssistantMessageId = nil
             vm.currentTurnUserText = nil
             vm.currentAssistantHasText = false
-            vm.lastContentWasToolCall = false
         }
         if msg.runStillActive != true && vm.pendingQueuedCount == 0 {
             vm.isSending = false
@@ -716,7 +712,6 @@ final class ChatActionHandler {
         vm.currentAssistantMessageId = nil
         vm.currentTurnUserText = nil
         vm.currentAssistantHasText = false
-        vm.lastContentWasToolCall = false
         // Reset processing messages to sent and clear attachment binary payloads.
         // Only clear for lazy-loadable attachments (sizeBytes != nil); locally-created
         // attachments (sizeBytes == nil) can't be re-fetched and need their data preserved.
@@ -777,7 +772,6 @@ final class ChatActionHandler {
         vm.currentAssistantMessageId = nil
         vm.currentTurnUserText = nil
         vm.currentAssistantHasText = false
-        vm.lastContentWasToolCall = false
         if !wasCancelling {
             vm.errorText = err.message
             // When the backend blocks a message for containing secrets,
@@ -995,7 +989,6 @@ final class ChatActionHandler {
         vm.currentAssistantMessageId = nil
         vm.currentTurnUserText = nil
         vm.currentAssistantHasText = false
-        vm.lastContentWasToolCall = false
         vm.flushPartialOutputBuffer()
         // When the user intentionally cancelled, suppress the error.
         // Otherwise, insert an inline error message so errors are visually

--- a/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
@@ -105,7 +105,6 @@ extension ChatViewModel {
                 let segIdx = messages[index].textSegments.count
                 messages[index].textSegments.append(text)
                 messages[index].contentOrder.append(.text(segIdx))
-                lastContentWasToolCall = false
             } else {
                 messages[index].textSegments[messages[index].textSegments.count - 1] += text
             }
@@ -122,7 +121,6 @@ extension ChatViewModel {
             }
             currentAssistantMessageId = msg.id
             messages.append(msg)
-            lastContentWasToolCall = false
         }
     }
 
@@ -226,7 +224,6 @@ extension ChatViewModel {
             currentAssistantMessageId = newMsg.id
             messages.append(newMsg)
         }
-        lastContentWasToolCall = true
     }
 
     /// Handle a `tool_use_start` event: create or update a tool call chip with input data.
@@ -306,7 +303,6 @@ extension ChatViewModel {
             currentAssistantMessageId = newMsg.id
             messages.append(newMsg)
         }
-        lastContentWasToolCall = true
     }
 
     /// Handle a `tool_input_delta` event: update streaming code preview for a tool call.

--- a/clients/shared/Features/Chat/ChatViewModel+SurfaceHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+SurfaceHandling.swift
@@ -381,13 +381,11 @@ extension ChatViewModel {
             let surfIdx = messages[index].inlineSurfaces.count
             messages[index].inlineSurfaces.append(inlineSurface)
             messages[index].contentOrder.append(.surface(surfIdx))
-            lastContentWasToolCall = true
         } else if let lastUserIndex = messages.lastIndex(where: { $0.role == .user }),
                   let idx = messages[lastUserIndex...].lastIndex(where: { $0.role == .assistant }) {
             let surfIdx = messages[idx].inlineSurfaces.count
             messages[idx].inlineSurfaces.append(inlineSurface)
             messages[idx].contentOrder.append(.surface(surfIdx))
-            lastContentWasToolCall = true
         } else {
             var newMsg = ChatMessage(role: .assistant, text: "", isStreaming: true, inlineSurfaces: [inlineSurface])
             newMsg.contentOrder = [.surface(0)]

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -254,7 +254,6 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
                     self.currentAssistantMessageId = nil
                     self.currentTurnUserText = nil
                     self.currentAssistantHasText = false
-                    self.lastContentWasToolCall = false
                     self.discardStreamingBuffer()
                     self.discardPartialOutputBuffer()
                     // Voice state
@@ -602,9 +601,6 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     /// Tracks whether the current assistant message has received any text content.
     /// Used to determine `arrivedBeforeText` for each tool call in the message.
     @ObservationIgnored var currentAssistantHasText: Bool = false
-    /// Tracks whether the last content block was a tool call, so the next text
-    /// delta starts a new segment instead of appending to the previous one.
-    @ObservationIgnored var lastContentWasToolCall: Bool = false
     /// When true, incoming deltas are suppressed until the daemon acknowledges
     /// the cancellation (via `generation_cancelled` or `message_complete`).
     // Public (rather than private) so tests can simulate the
@@ -1962,7 +1958,6 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         surfaceRefetchCoordinator.cancelRefetchTasks()
         currentAssistantMessageId = nil
         currentAssistantHasText = false
-        lastContentWasToolCall = false
 
         if needsReconnectCatchUp {
             // Reconnect catch-up: the SSE stream dropped while a run was

--- a/clients/shared/Features/Chat/MessageSendCoordinator.swift
+++ b/clients/shared/Features/Chat/MessageSendCoordinator.swift
@@ -20,7 +20,6 @@ protocol MessageSendCoordinatorDelegate: AnyObject {
     var currentAssistantMessageId: UUID? { get set }
     var currentTurnUserText: String? { get set }
     var currentAssistantHasText: Bool { get set }
-    var lastContentWasToolCall: Bool { get set }
     var pendingMessageIds: [UUID] { get set }
     var requestIdToMessageId: [String: UUID] { get set }
     var activeRequestIdToMessageId: [String: UUID] { get set }
@@ -627,7 +626,6 @@ final class MessageSendCoordinator {
         delegate.currentAssistantMessageId = nil
         delegate.currentTurnUserText = nil
         delegate.currentAssistantHasText = false
-        delegate.lastContentWasToolCall = false
         delegate.discardStreamingBuffer()
         delegate.discardPartialOutputBuffer()
         messageManager.pendingQueuedCount = 0


### PR DESCRIPTION
Remove write-only lastContentWasToolCall property and all ~14 write sites after PR #22229 replaced its read site with contentOrder.last.\n\nAddresses feedback from #22229.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
