### PR TITLE
fix: persist /compact results to DB and add processing lock

### DIFF
--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -876,62 +876,67 @@ export async function processMessage(
 
   // /compact — force context compaction, persist exchange, return message ID.
   if (slashResult.kind === "compact") {
-    const pmTurnCtx = conversation.getTurnChannelContext();
-    const pmInterfaceCtx = conversation.getTurnInterfaceContext();
-    const pmProvenance = provenanceFromTrustContext(conversation.trustContext);
-    const pmChannelMeta = {
-      ...pmProvenance,
-      ...(pmTurnCtx
-        ? {
-            userMessageChannel: pmTurnCtx.userMessageChannel,
-            assistantMessageChannel: pmTurnCtx.assistantMessageChannel,
-          }
-        : {}),
-      ...(pmInterfaceCtx
-        ? {
-            userMessageInterface: pmInterfaceCtx.userMessageInterface,
-            assistantMessageInterface: pmInterfaceCtx.assistantMessageInterface,
-          }
-        : {}),
-    };
-    const cleanUserMsg = createUserMessage(content, attachments);
-    const persisted = await addMessage(
-      conversation.conversationId,
-      "user",
-      JSON.stringify(cleanUserMsg.content),
-      pmChannelMeta,
-    );
-    conversation.messages.push(cleanUserMsg);
+    conversation.processing = true;
+    try {
+      const pmTurnCtx = conversation.getTurnChannelContext();
+      const pmInterfaceCtx = conversation.getTurnInterfaceContext();
+      const pmProvenance = provenanceFromTrustContext(conversation.trustContext);
+      const pmChannelMeta = {
+        ...pmProvenance,
+        ...(pmTurnCtx
+          ? {
+              userMessageChannel: pmTurnCtx.userMessageChannel,
+              assistantMessageChannel: pmTurnCtx.assistantMessageChannel,
+            }
+          : {}),
+        ...(pmInterfaceCtx
+          ? {
+              userMessageInterface: pmInterfaceCtx.userMessageInterface,
+              assistantMessageInterface: pmInterfaceCtx.assistantMessageInterface,
+            }
+          : {}),
+      };
+      const cleanUserMsg = createUserMessage(content, attachments);
+      const persisted = await addMessage(
+        conversation.conversationId,
+        "user",
+        JSON.stringify(cleanUserMsg.content),
+        pmChannelMeta,
+      );
+      conversation.messages.push(cleanUserMsg);
 
-    conversation.emitActivityState(
-      "thinking",
-      "context_compacting",
-      "assistant_turn",
-      requestId,
-    );
-    const result = await conversation.forceCompact();
-    const responseText = formatCompactResult(result);
+      conversation.emitActivityState(
+        "thinking",
+        "context_compacting",
+        "assistant_turn",
+        requestId,
+      );
+      const result = await conversation.forceCompact();
+      const responseText = formatCompactResult(result);
 
-    const assistantMsg = createAssistantMessage(responseText);
-    await addMessage(
-      conversation.conversationId,
-      "assistant",
-      JSON.stringify(assistantMsg.content),
-      pmChannelMeta,
-    );
-    conversation.messages.push(assistantMsg);
+      const assistantMsg = createAssistantMessage(responseText);
+      await addMessage(
+        conversation.conversationId,
+        "assistant",
+        JSON.stringify(assistantMsg.content),
+        pmChannelMeta,
+      );
+      conversation.messages.push(assistantMsg);
 
-    onEvent({ type: "assistant_text_delta", text: responseText });
-    conversation.traceEmitter.emit(
-      "message_complete",
-      "Compact slash command handled",
-      { requestId, status: "success" },
-    );
-    onEvent({
-      type: "message_complete",
-      conversationId: conversation.conversationId,
-    });
-    return persisted.id;
+      onEvent({ type: "assistant_text_delta", text: responseText });
+      conversation.traceEmitter.emit(
+        "message_complete",
+        "Compact slash command handled",
+        { requestId, status: "success" },
+      );
+      onEvent({
+        type: "message_complete",
+        conversationId: conversation.conversationId,
+      });
+      return persisted.id;
+    } finally {
+      conversation.processing = false;
+    }
   }
 
   const resolvedContent = slashResult.content;

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -43,6 +43,7 @@ import {
 import { registerToolTraceListener } from "../events/tool-trace-listener.js";
 import { getHookManager } from "../hooks/manager.js";
 import { resolveCanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
+import { updateConversationContextWindow } from "../memory/conversation-crud.js";
 import { PermissionPrompter } from "../permissions/prompter.js";
 import { SecretPrompter } from "../permissions/secret-prompter.js";
 import { patternMatchesCandidate } from "../permissions/trust-store.js";
@@ -895,6 +896,11 @@ export class Conversation {
       this.messages = result.messages;
       this.contextCompactedMessageCount += result.compactedPersistedMessages;
       this.contextCompactedAt = Date.now();
+      updateConversationContextWindow(
+        this.conversationId,
+        result.summaryText,
+        this.contextCompactedMessageCount,
+      );
     }
     return result;
   }


### PR DESCRIPTION
## Summary
- Added `updateConversationContextWindow()` call inside `forceCompact()` in `conversation.ts` so compaction state (summary text, compacted message count) is persisted to the DB. Previously, `/compact` only updated in-memory fields, meaning compaction was lost on restart.
- Added `conversation.processing = true` lock with `try/finally` cleanup in the `processMessage` compact handler to prevent concurrent messages during the long-running compaction LLM call.

## Test plan
- [ ] Run `/compact` and verify `contextSummary` and `contextCompactedMessageCount` are written to the conversations table
- [ ] Restart daemon after `/compact` and verify compaction state is preserved
- [ ] Send a message during `/compact` via `processMessage` path and verify it gets queued

Addresses feedback from #22214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
