### PR TITLE
fix(gateway): deliver message without attachments on processing error

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1328,8 +1328,20 @@ async function main() {
           } catch (err) {
             log.error(
               { err, channel, threadTs },
-              "Failed to process Slack event",
+              "Failed to process Slack event — delivering message without attachments",
             );
+            handleInbound(config, normalized.event, {
+              replyCallbackUrl,
+              routingOverride: normalized.routing,
+              ...(threadContextHint
+                ? { transportMetadata: { hints: [threadContextHint] } }
+                : {}),
+            }).catch((fwdErr) => {
+              log.error(
+                { err: fwdErr, channel, threadTs },
+                "Failed to forward Slack event to runtime (fallback)",
+              );
+            });
           }
         };
 


### PR DESCRIPTION
Add fallback handleInbound call in the catch block so messages are always delivered even when attachment processing fails.\n\nAddresses feedback from #22199.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
