### PR TITLE
fix(memory): add explicit ORDER BY rowid to serendipity probe query

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -1176,6 +1176,7 @@ function sampleSerendipityItems(
           .select(columns)
           .from(memoryItems)
           .where(and(baseConditions, sql`rowid >= ${randomRowid}`))
+          .orderBy(sql`rowid`)
           .limit(1)
           .get();
         if (row && !seen.has(row.id)) {


### PR DESCRIPTION
Add ORDER BY rowid to the rowid-probe sampling query to guarantee correctness per SQLite spec.\n\nAddresses feedback from #22236.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
