### PR TITLE
fix(memory): add journal carry-forward dedup and fix checkpoint key mismatch

### DIFF
--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -128,6 +128,32 @@ export function upsertDebouncedJob(
   }
 }
 
+/**
+ * Check whether a pending or running `journal_carry_forward` job already
+ * exists for the given filename + userSlug.  Used to prevent duplicate
+ * enqueues while a carry-forward job is still in flight.
+ */
+export function hasActiveCarryForwardJob(
+  filename: string,
+  userSlug: string,
+): boolean {
+  const db = getDb();
+  return (
+    db
+      .select({ id: memoryJobs.id })
+      .from(memoryJobs)
+      .where(
+        and(
+          eq(memoryJobs.type, "journal_carry_forward"),
+          inArray(memoryJobs.status, ["pending", "running"]),
+          sql`json_extract(${memoryJobs.payload}, '$.filename') = ${filename}`,
+          sql`json_extract(${memoryJobs.payload}, '$.userSlug') = ${userSlug}`,
+        ),
+      )
+      .get() != null
+  );
+}
+
 export function enqueueCleanupStaleSupersededItemsJob(
   retentionMs?: number,
 ): string {

--- a/assistant/src/prompts/journal-context.ts
+++ b/assistant/src/prompts/journal-context.ts
@@ -2,7 +2,10 @@ import { readdirSync, readFileSync, statSync } from "node:fs";
 import { basename, join } from "node:path";
 
 import { getMemoryCheckpoint } from "../memory/checkpoints.js";
-import { enqueueMemoryJob } from "../memory/jobs-store.js";
+import {
+  enqueueMemoryJob,
+  hasActiveCarryForwardJob,
+} from "../memory/jobs-store.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir } from "../util/platform.js";
 
@@ -83,10 +86,11 @@ export function buildJournalContext(
   // Wrapped in try-catch so DB errors never break journal context rendering.
   if (rotatingOut.length > 0 && userSlug != null) {
     try {
-      const safeSlug = basename(userSlug);
+      const safeSlug = basename(userSlug) || "unknown";
       for (const entry of rotatingOut) {
         const checkpointKey = `journal_carry_forward:${safeSlug}:${entry.filename}`;
         if (getMemoryCheckpoint(checkpointKey) != null) continue;
+        if (hasActiveCarryForwardJob(entry.filename, safeSlug)) continue;
 
         let content: string;
         try {


### PR DESCRIPTION
## Summary
- Add `hasActiveCarryForwardJob()` dedup check before enqueuing carry-forward jobs, preventing duplicate LLM extraction calls when multiple prompt renders occur before the first job completes
- Align slug fallback in enqueuer (`basename(userSlug) || "unknown"`) to match handler's `userSlug || "unknown"`, fixing checkpoint key mismatch when userSlug is empty string

Addresses feedback from #22222.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
