### PR TITLE
fix(memory): account for HyDE sparse vectors in telemetry flag

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -453,7 +453,7 @@ export async function buildMemoryRecall(
         hybridCandidates = hydeCandidates.candidates;
         hydeExpanded = hydeCandidates.hydeExpanded;
         hydeDocCount = hydeCandidates.hydeDocCount;
-        sparseVectorUsed = sparseVectorAvailable;
+        sparseVectorUsed = sparseVectorAvailable || hydeExpanded;
       } else {
         // ── Standard path: single raw query search ──
         hybridCandidates = await semanticSearch(


### PR DESCRIPTION
## Summary
- Update `sparseVectorUsed` telemetry to also reflect when HyDE branches generate and use their own sparse vectors
- Previously only derived from `sparseVectorAvailable` (raw query flag), now also accounts for `hydeExpanded`

## Test plan
- [x] Verify emoji-only queries with HyDE enabled report `sparseVectorUsed: true` when HyDE branches use sparse vectors
- [x] Verify standard path behavior is unchanged

Addresses feedback from #22208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
