### PR TITLE
Fix macOS build: replace channel group tuple with Identifiable struct

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -2,6 +2,12 @@ import SwiftUI
 import UniformTypeIdentifiers
 import VellumAssistantShared
 
+struct ChannelConversationGroup: Identifiable {
+    var id: String { channel }
+    let channel: String
+    let conversations: [ConversationModel]
+}
+
 // MARK: - Sidebar Content
 
 extension MainWindowView {
@@ -65,7 +71,7 @@ extension MainWindowView {
 
     /// All channel-bound conversations, grouped by originChannel.
     /// Sorted alphabetically by channel name for stable sidebar ordering.
-    var channelConversationGroups: [(channel: String, conversations: [ConversationModel])] {
+    var channelConversationGroups: [ChannelConversationGroup] {
         let channelConversations = conversationManager.visibleConversations.filter { $0.isChannelConversation }
         var grouped: [String: [ConversationModel]] = [:]
         for conversation in channelConversations {
@@ -73,7 +79,7 @@ extension MainWindowView {
             grouped[channel, default: []].append(conversation)
         }
         return grouped.keys.sorted().map { key in
-            (channel: key, conversations: grouped[key]!)
+            ChannelConversationGroup(channel: key, conversations: grouped[key]!)
         }
     }
 
@@ -582,7 +588,7 @@ extension MainWindowView {
                     }
 
                     // Channel conversation sections
-                    ForEach(channelConversationGroups, id: \.channel) { group in
+                    ForEach(channelConversationGroups) { group in
                         let isCollapsed = sidebar.collapsedChannelSections.contains(group.channel)
                         let sectionHasUnread = isCollapsed &&
                             group.conversations.contains(where: { $0.hasUnseenLatestAssistantMessage })


### PR DESCRIPTION
## Summary
- The Swift 6 type checker in Xcode 26.2 cannot infer types for `ForEach` with named tuple arrays `[(channel: String, conversations: [ConversationModel])]` when the closure body is complex, causing cascading type errors on `main`.
- Replaced the tuple with a proper `ChannelConversationGroup` struct conforming to `Identifiable`, and simplified the `ForEach` call to use the protocol conformance.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23729327425/job/69119578507
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
