### PR TITLE
Add optional contextWindowTokens/contextWindowMaxTokens to usage_update event

### DIFF
--- a/assistant/src/daemon/conversation-usage.ts
+++ b/assistant/src/daemon/conversation-usage.ts
@@ -126,6 +126,7 @@ export function recordUsage(
   cacheReadInputTokens = 0,
   rawResponse?: unknown,
   llmCallCount = 1,
+  contextWindow?: { tokens: number; maxTokens: number },
 ): void {
   if (inputTokens <= 0 && outputTokens <= 0) return;
 
@@ -180,6 +181,10 @@ export function recordUsage(
     totalOutputTokens: ctx.usageStats.outputTokens,
     estimatedCost,
     model,
+    ...(contextWindow && {
+      contextWindowTokens: contextWindow.tokens,
+      contextWindowMaxTokens: contextWindow.maxTokens,
+    }),
   });
 
   // Dual-write: persist per-turn usage event to the new ledger table

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -341,6 +341,8 @@ export interface UsageUpdate {
   totalOutputTokens: number;
   estimatedCost: number;
   model: string;
+  contextWindowTokens?: number;
+  contextWindowMaxTokens?: number;
 }
 
 export interface UsageResponse {


### PR DESCRIPTION
## Summary
- Add optional `contextWindowTokens` and `contextWindowMaxTokens` fields to the `UsageUpdate` SSE event type
- Thread a `contextWindow` parameter through `recordUsage()` so callers can include context window fill data
- Existing callers that don't pass context window data continue working unchanged (fields are optional)

Part of plan: context-window-usage-indicator.md (PR 1 of 5)