### PR TITLE
Add ContextWindowIndicator view — 2px color-coded context fill bar

### DIFF
--- a/clients/shared/DesignSystem/Components/Feedback/ContextWindowIndicator.swift
+++ b/clients/shared/DesignSystem/Components/Feedback/ContextWindowIndicator.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+/// A 2px-tall progress bar showing context window fill level.
+/// Hidden when `fillRatio` is nil (no usage data yet).
+public struct ContextWindowIndicator: View {
+    public let fillRatio: Double?
+
+    public init(fillRatio: Double?) {
+        self.fillRatio = fillRatio
+    }
+
+    private var barColor: Color {
+        guard let ratio = fillRatio else { return .clear }
+        if ratio >= 0.8 { return VColor.systemNegativeStrong }
+        if ratio >= 0.6 { return VColor.systemMidStrong }
+        return VColor.contentTertiary
+    }
+
+    public var body: some View {
+        if let ratio = fillRatio, ratio > 0 {
+            GeometryReader { geo in
+                Rectangle()
+                    .fill(barColor.opacity(0.7))
+                    .frame(width: geo.size.width * ratio, height: 2)
+            }
+            .frame(height: 2)
+            .background(VColor.borderDisabled.opacity(0.2))
+            .help("Context: \(Int((fillRatio ?? 0) * 100))% used")
+            .accessibilityLabel("Context window \(Int((fillRatio ?? 0) * 100)) percent used")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add new `ContextWindowIndicator` SwiftUI view component
- 2px color-coded progress bar: grey < 60%, amber 60-80%, red >= 80% (matching compaction threshold)
- Hidden when no data available, with tooltip and VoiceOver support
- Uses existing VColor design tokens

Part of plan: context-window-usage-indicator.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
