### PR TITLE
Add context window state to UsageUpdate struct and ChatViewModel

### DIFF
--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -244,6 +244,14 @@ final class ChatActionHandler {
         case .guardianActionDecisionResponse(let response):
             vm.handleGuardianActionDecisionResponse(response)
 
+        case .usageUpdate(let update):
+            if let tokens = update.contextWindowTokens {
+                vm.contextWindowTokens = tokens
+            }
+            if let max = update.contextWindowMaxTokens {
+                vm.contextWindowMaxTokens = max
+            }
+
         default:
             break
         }

--- a/clients/shared/Features/Chat/ChatMessageManager.swift
+++ b/clients/shared/Features/Chat/ChatMessageManager.swift
@@ -126,6 +126,8 @@ public final class ChatMessageManager {
     public var assistantActivityReason: String?
     public var assistantStatusText: String?
     public var isCompacting: Bool = false
+    public var contextWindowTokens: Int? = nil
+    public var contextWindowMaxTokens: Int? = nil
     public var pendingQueuedCount: Int = 0
     public var suggestion: String?
     public var isRecording: Bool = false

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -240,6 +240,8 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
                     self.assistantActivityReason = nil
                     self.assistantStatusText = nil
                     self.isCompacting = false
+                    self.contextWindowTokens = nil
+                    self.contextWindowMaxTokens = nil
                     // Streaming message state
                     if let existingId = self.currentAssistantMessageId,
                        let index = self.messages.firstIndex(where: { $0.id == existingId }) {
@@ -315,6 +317,20 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     public var isCompacting: Bool {
         get { messageManager.isCompacting }
         set { messageManager.isCompacting = newValue }
+    }
+    public var contextWindowTokens: Int? {
+        get { messageManager.contextWindowTokens }
+        set { messageManager.contextWindowTokens = newValue }
+    }
+    public var contextWindowMaxTokens: Int? {
+        get { messageManager.contextWindowMaxTokens }
+        set { messageManager.contextWindowMaxTokens = newValue }
+    }
+    public var contextWindowFillRatio: Double? {
+        guard let tokens = contextWindowTokens,
+              let max = contextWindowMaxTokens,
+              max > 0 else { return nil }
+        return min(Double(tokens) / Double(max), 1.0)
     }
     public var activePendingRequestId: String? {
         messageManager.activePendingRequestId

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -4868,8 +4868,14 @@ public struct UsageUpdate: Codable, Sendable {
     public let totalOutputTokens: Int
     public let estimatedCost: Double
     public let model: String
+    public let contextWindowTokens: Int?
+    public let contextWindowMaxTokens: Int?
 
-    public init(type: String, inputTokens: Int, outputTokens: Int, totalInputTokens: Int, totalOutputTokens: Int, estimatedCost: Double, model: String) {
+    public init(type: String, inputTokens: Int, outputTokens: Int,
+                totalInputTokens: Int, totalOutputTokens: Int,
+                estimatedCost: Double, model: String,
+                contextWindowTokens: Int? = nil,
+                contextWindowMaxTokens: Int? = nil) {
         self.type = type
         self.inputTokens = inputTokens
         self.outputTokens = outputTokens
@@ -4877,6 +4883,8 @@ public struct UsageUpdate: Codable, Sendable {
         self.totalOutputTokens = totalOutputTokens
         self.estimatedCost = estimatedCost
         self.model = model
+        self.contextWindowTokens = contextWindowTokens
+        self.contextWindowMaxTokens = contextWindowMaxTokens
     }
 }
 


### PR DESCRIPTION
## Summary
- Add optional `contextWindowTokens` and `contextWindowMaxTokens` fields to Swift `UsageUpdate` struct (backward-compatible)
- Add `contextWindowFillRatio` computed property to `ChatViewModel` for UI display
- Handle `usage_update` events in `ChatActionHandler` to update context window state
- Reset context window state on conversation switch

Part of plan: context-window-usage-indicator.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
