### PR TITLE
Compute and emit context window fill in the final usage_update of each agent loop

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1589,6 +1589,12 @@ export async function runAgentLoopImpl(
     const restoredHistory = [...preRepairMessages, ...newMessages];
     ctx.messages = stripInjectedContext(restoredHistory);
 
+    const postLoopContextEstimate = estimatePromptTokens(
+      ctx.messages,
+      ctx.systemPrompt,
+      { providerName: ctx.provider.name, toolTokenBudget },
+    );
+
     emitUsage(
       ctx,
       state.exchangeInputTokens,
@@ -1602,6 +1608,7 @@ export async function runAgentLoopImpl(
       collapseRawResponses(state.exchangeRawResponses),
       state.exchangeProviderName,
       state.exchangeLlmCallCount,
+      { tokens: postLoopContextEstimate, maxTokens: config.contextWindow.maxInputTokens },
     );
 
     void getHookManager().trigger("post-message", {
@@ -1870,6 +1877,7 @@ function emitUsage(
   rawResponse?: unknown,
   providerName?: string,
   llmCallCount = 1,
+  contextWindow?: { tokens: number; maxTokens: number },
 ): void {
   recordUsage(
     {
@@ -1887,6 +1895,7 @@ function emitUsage(
     cacheReadInputTokens,
     rawResponse,
     llmCallCount,
+    contextWindow,
   );
 }
 


### PR DESCRIPTION
## Summary
- Compute context window fill estimate via `estimatePromptTokens` at the end of each agent loop turn
- Pass `contextWindowTokens` and `contextWindowMaxTokens` through the final `emitUsage` call
- Only the main agent loop usage event includes context window data; compaction sub-calls omit it

Part of plan: context-window-usage-indicator.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
