### PR TITLE
Wire ContextWindowIndicator into ChatView, PanelCoordinator, and ThreadWindow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -93,6 +93,7 @@ struct ChatView: View {
     var activePendingRequestId: String?
     var isInteractionEnabled: Bool = true
     var isReadonly: Bool = false
+    var contextWindowFillRatio: Double? = nil
     /// When set, scroll to this message ID and clear the binding.
     @Binding var anchorMessageId: UUID?
     /// Message ID to visually highlight after an anchor scroll completes.
@@ -345,6 +346,7 @@ struct ChatView: View {
     @ViewBuilder
     private var activeConversationContent: some View {
         VStack(spacing: 0) {
+            ContextWindowIndicator(fillRatio: contextWindowFillRatio)
             MessageListView(
                 messages: messages,
                 isSending: isSending,

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -776,6 +776,7 @@ struct ActiveChatViewWrapper: View {
             activePendingRequestId: viewModel.activePendingRequestId,
             isInteractionEnabled: inspectorMessageId == nil && !isReadonly,
             isReadonly: isReadonly,
+            contextWindowFillRatio: viewModel.contextWindowFillRatio,
             anchorMessageId: $anchorMessageId,
             highlightedMessageId: $highlightedMessageId,
             btwResponse: viewModel.btwResponse,

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
@@ -329,6 +329,7 @@ private struct ThreadWindowContentView: View {
             activePendingRequestId: viewModel.activePendingRequestId,
             isInteractionEnabled: !(conversation?.isChannelConversation ?? false),
             isReadonly: conversation?.isChannelConversation ?? false,
+            contextWindowFillRatio: viewModel.contextWindowFillRatio,
             anchorMessageId: $anchorMessageId,
             highlightedMessageId: $highlightedMessageId,
             creditsExhaustedError: viewModel.errorManager.conversationError?.isCreditsExhausted == true ? viewModel.errorManager.conversationError : nil,


### PR DESCRIPTION
## Summary
- Add `contextWindowFillRatio` property to `ChatView`
- Insert `ContextWindowIndicator` bar at the top of the active conversation content, above `MessageListView`
- Wire the fill ratio from `ChatViewModel` through `PanelCoordinator` and `ThreadWindow`

Part of plan: context-window-usage-indicator.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
