### PR TITLE
Enable 1M context window beta for Anthropic provider

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -986,8 +986,11 @@ export class AnthropicProvider implements Provider {
         speed === "fast" && effectiveModel.includes("opus");
 
       // Collect required betas: extended cache TTL for 1h system prompt caching,
-      // and fast-mode when applicable.
-      const betas: string[] = ["extended-cache-ttl-2025-04-11"];
+      // 1M context window, and fast-mode when applicable.
+      const betas: string[] = [
+        "extended-cache-ttl-2025-04-11",
+        "context-1m-2025-08-07",
+      ];
       if (useFastMode) {
         betas.push("fast-mode-2026-02-01");
       }


### PR DESCRIPTION
## Summary
- Adds `context-1m-2025-08-07` beta header to the Anthropic provider client, unlocking up to 1M input tokens for Claude models
- This is a prerequisite for increasing the default `maxInputTokens` from 200k to 400k+

## Original prompt
Add the `context-1m-2025-08-07` beta header to the Anthropic provider client so the Anthropic API accepts inputs beyond the default 200k context window (up to 1M tokens).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
