### PR TITLE
Fix macOS build: disambiguate ForEach with explicit key path root type

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -588,7 +588,7 @@ extension MainWindowView {
                     }
 
                     // Channel conversation sections
-                    ForEach(channelConversationGroups, id: \.id) { group in
+                    ForEach(channelConversationGroups, id: \ChannelConversationGroup.id) { group in
                         let isCollapsed = sidebar.collapsedChannelSections.contains(group.channel)
                         let sectionHasUnread = isCollapsed &&
                             group.conversations.contains(where: { $0.hasUnseenLatestAssistantMessage })


### PR DESCRIPTION
## Summary
- The previous fix adding `id: \.id` didn't fully resolve the Swift 6.2 `ForEach` overload ambiguity between the `Data` and `Binding<C>` initializers
- Specifying the explicit root type (`\ChannelConversationGroup.id`) forces the compiler to select the correct non-binding overload

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
