### PR TITLE
Fix window-manager type error for web_search_tool_result

### DIFF
--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -892,10 +892,11 @@ function serializeMessagesToContentBlocks(messages: Message[]): ContentBlock[] {
           textLines.length = 0;
         }
         blocks.push(block);
-      } else if (
-        block.type === "tool_result" ||
-        block.type === "web_search_tool_result"
-      ) {
+      } else if (block.type === "web_search_tool_result") {
+        textLines.push(
+          `web_search_tool_result ${block.tool_use_id}: [opaque]`,
+        );
+      } else if (block.type === "tool_result") {
         // Extract images from tool_result contentBlocks before serializing.
         const collectedImages: ImageContent[] = [];
         textLines.push(serializeToolResultBlock(block, collectedImages));


### PR DESCRIPTION
## Summary
- Split the combined `tool_result || web_search_tool_result` branch into separate cases so `serializeToolResultBlock` (which expects `ToolResultContent`) is only called with `tool_result` blocks
- `web_search_tool_result` is serialized inline since it has opaque content and no `contentBlocks`/`is_error` to process

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23729706945/job/69120677136
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
