### PR TITLE
Fix macOS build: disambiguate ForEach overload with Array() wrapper

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -588,7 +588,7 @@ extension MainWindowView {
                     }
 
                     // Channel conversation sections
-                    ForEach(channelConversationGroups, id: \ChannelConversationGroup.id) { group in
+                    ForEach(Array(channelConversationGroups), id: \ChannelConversationGroup.id) { group in
                         let isCollapsed = sidebar.collapsedChannelSections.contains(group.channel)
                         let sectionHasUnread = isCollapsed &&
                             group.conversations.contains(where: { $0.hasUnseenLatestAssistantMessage })


### PR DESCRIPTION
## Summary
- Wrapped `channelConversationGroups` in `Array()` to force Swift 6.2 to resolve the `ForEach(data, id:)` overload instead of `ForEach(Binding<C>, id:)`.
- Previous attempts (explicit `id: \.id`, then `\ChannelConversationGroup.id`) were insufficient to disambiguate.

## Original prompt
Fix macOS build error: `ForEach(channelConversationGroups, id: \ChannelConversationGroup.id)` causes Swift 6.2 to pick the `Binding<C>` overload.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
