### PR TITLE
Fix macOS build: add explicit closure type to disambiguate ForEach overload

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -588,7 +588,7 @@ extension MainWindowView {
                     }
 
                     // Channel conversation sections
-                    ForEach(Array(channelConversationGroups), id: \ChannelConversationGroup.id) { group in
+                    ForEach(Array(channelConversationGroups), id: \ChannelConversationGroup.id) { (group: ChannelConversationGroup) in
                         let isCollapsed = sidebar.collapsedChannelSections.contains(group.channel)
                         let sectionHasUnread = isCollapsed &&
                             group.conversations.contains(where: { $0.hasUnseenLatestAssistantMessage })


### PR DESCRIPTION
## Summary
- Add explicit `(group: ChannelConversationGroup)` type annotation on the `ForEach` closure parameter in the sidebar channel sections
- Previous fixes (explicit key path root type, `Array()` wrapping) were insufficient — Swift 6.2 still picked the `Binding<C>` overload
- The explicit closure parameter type forces the compiler to resolve to the correct `ForEach(Data, id:, content:)` initializer

## Original prompt
Fix macOS build error: `ForEach(Array(channelConversationGroups), id:)` cannot convert to `Binding<C>` — Swift picks wrong overload
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
