### PR TITLE
Fix macOS build: wrap sidebar displayed-conversations in closure to fix ViewBuilder type error

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -630,19 +630,18 @@ extension MainWindowView {
 
                         if !isCollapsed {
                             let showAll = sidebar.showAllChannelConversations[group.channel] ?? false
-                            let displayed: [ConversationModel]
-                            if showAll {
-                                displayed = group.conversations
-                            } else {
+                            let displayed: [ConversationModel] = {
+                                if showAll {
+                                    return group.conversations
+                                }
                                 // Auto-expand if any hidden conversation has unread messages.
                                 let visible = Array(group.conversations.prefix(3))
                                 let hidden = group.conversations.dropFirst(3)
                                 if hidden.contains(where: { $0.hasUnseenLatestAssistantMessage }) {
-                                    displayed = group.conversations
-                                } else {
-                                    displayed = visible
+                                    return group.conversations
                                 }
-                            }
+                                return visible
+                            }()
 
                             ForEach(displayed) { conversation in
                                 makeSidebarRow(conversation: conversation)


### PR DESCRIPTION
## Summary
- The `if/else` block assigning to `displayed` inside a `@ViewBuilder` context was misinterpreted by Swift as a conditional view builder expression, causing `type '()' cannot conform to 'View'`
- Wrapped the computation in an immediately-invoked closure so Swift treats it as a plain value expression

## Original prompt
fix: ~v/clients/macos (main) ❯❯❯ VELLUM_NO_WATCH=1 ./build.sh run
Building (debug)...
Building for debugging...
/Users/sidd/vocify/vellum-assistant/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift:635:33: error: type '()' cannot conform to 'View'
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
