### PR TITLE
Move context indicator to composer toolbar with rich hover popover

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -94,6 +94,8 @@ struct ChatView: View {
     var isInteractionEnabled: Bool = true
     var isReadonly: Bool = false
     var contextWindowFillRatio: Double? = nil
+    var contextWindowTokens: Int? = nil
+    var contextWindowMaxTokens: Int? = nil
     /// When set, scroll to this message ID and clear the binding.
     @Binding var anchorMessageId: UUID?
     /// Message ID to visually highlight after an anchor scroll completes.
@@ -346,7 +348,6 @@ struct ChatView: View {
     @ViewBuilder
     private var activeConversationContent: some View {
         VStack(spacing: 0) {
-            ContextWindowIndicator(fillRatio: contextWindowFillRatio)
             MessageListView(
                 messages: messages,
                 isSending: isSending,
@@ -451,7 +452,10 @@ struct ChatView: View {
                     onDictateToggle: onDictateToggle,
                     onVoiceModeToggle: onVoiceModeToggle,
                     conversationId: conversationId,
-                    isInteractionEnabled: isInteractionEnabled
+                    isInteractionEnabled: isInteractionEnabled,
+                    contextWindowFillRatio: contextWindowFillRatio,
+                    contextWindowTokens: contextWindowTokens,
+                    contextWindowMaxTokens: contextWindowMaxTokens
                 )
             }
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
@@ -28,6 +28,9 @@ struct ComposerSection: View {
     var onVoiceModeToggle: (() -> Void)? = nil
     var conversationId: UUID?
     var isInteractionEnabled: Bool = true
+    var contextWindowFillRatio: Double? = nil
+    var contextWindowTokens: Int? = nil
+    var contextWindowMaxTokens: Int? = nil
 
     var body: some View {
         VStack(spacing: 0) {
@@ -63,7 +66,10 @@ struct ComposerSection: View {
                 onVoiceModeToggle: onVoiceModeToggle,
                 placeholderText: isAssistantBusy ? "Working on it..." : "What would you like to do?",
                 conversationId: conversationId,
-                isInteractionEnabled: isInteractionEnabled
+                isInteractionEnabled: isInteractionEnabled,
+                contextWindowFillRatio: contextWindowFillRatio,
+                contextWindowTokens: contextWindowTokens,
+                contextWindowMaxTokens: contextWindowMaxTokens
             )
         }
         .background(

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -62,6 +62,9 @@ struct ComposerView: View {
     var composerCompactHeight: CGFloat = 38
     var conversationId: UUID?
     var isInteractionEnabled: Bool = true
+    var contextWindowFillRatio: Double? = nil
+    var contextWindowTokens: Int? = nil
+    var contextWindowMaxTokens: Int? = nil
 
     @Environment(\.cmdEnterToSend) private var cmdEnterToSend
     #if os(macOS)
@@ -409,6 +412,12 @@ struct ComposerView: View {
                 )
 
                 .vTooltip("Attach file")
+
+                ContextWindowIndicator(
+                    fillRatio: contextWindowFillRatio,
+                    tokensUsed: contextWindowTokens,
+                    tokensMax: contextWindowMaxTokens
+                )
 
                 Spacer()
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -777,6 +777,8 @@ struct ActiveChatViewWrapper: View {
             isInteractionEnabled: inspectorMessageId == nil && !isReadonly,
             isReadonly: isReadonly,
             contextWindowFillRatio: viewModel.contextWindowFillRatio,
+            contextWindowTokens: viewModel.contextWindowTokens,
+            contextWindowMaxTokens: viewModel.contextWindowMaxTokens,
             anchorMessageId: $anchorMessageId,
             highlightedMessageId: $highlightedMessageId,
             btwResponse: viewModel.btwResponse,

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
@@ -330,6 +330,8 @@ private struct ThreadWindowContentView: View {
             isInteractionEnabled: !(conversation?.isChannelConversation ?? false),
             isReadonly: conversation?.isChannelConversation ?? false,
             contextWindowFillRatio: viewModel.contextWindowFillRatio,
+            contextWindowTokens: viewModel.contextWindowTokens,
+            contextWindowMaxTokens: viewModel.contextWindowMaxTokens,
             anchorMessageId: $anchorMessageId,
             highlightedMessageId: $highlightedMessageId,
             creditsExhaustedError: viewModel.errorManager.conversationError?.isCreditsExhausted == true ? viewModel.errorManager.conversationError : nil,

--- a/clients/shared/DesignSystem/Components/Feedback/ContextWindowIndicator.swift
+++ b/clients/shared/DesignSystem/Components/Feedback/ContextWindowIndicator.swift
@@ -1,32 +1,97 @@
 import SwiftUI
 
-/// A 2px-tall progress bar showing context window fill level.
+/// A small circular ring indicator showing context window fill level.
+/// Designed to sit in the composer toolbar area. On hover, shows a rich
+/// popover with percentage, token counts, and compaction note.
 /// Hidden when `fillRatio` is nil (no usage data yet).
 public struct ContextWindowIndicator: View {
     public let fillRatio: Double?
+    public let tokensUsed: Int?
+    public let tokensMax: Int?
 
-    public init(fillRatio: Double?) {
+    public init(fillRatio: Double?, tokensUsed: Int? = nil, tokensMax: Int? = nil) {
         self.fillRatio = fillRatio
+        self.tokensUsed = tokensUsed
+        self.tokensMax = tokensMax
     }
 
-    private var barColor: Color {
+    @State private var isHovered = false
+
+    private let ringSize: CGFloat = 16
+    private let ringLineWidth: CGFloat = 2
+
+    private var ringColor: Color {
         guard let ratio = fillRatio else { return .clear }
         if ratio >= 0.8 { return VColor.systemNegativeStrong }
         if ratio >= 0.6 { return VColor.systemMidStrong }
         return VColor.contentTertiary
     }
 
+    private var percentText: String {
+        guard let ratio = fillRatio else { return "0%" }
+        return "\(Int(ratio * 100))%"
+    }
+
+    /// Formats a token count as "148k" style.
+    private static func formatTokens(_ count: Int) -> String {
+        if count >= 1000 {
+            return "\(count / 1000)k"
+        }
+        return "\(count)"
+    }
+
     public var body: some View {
         if let ratio = fillRatio, ratio > 0 {
-            GeometryReader { geo in
-                Rectangle()
-                    .fill(barColor.opacity(0.7))
-                    .frame(width: geo.size.width * ratio, height: 2)
-            }
-            .frame(height: 2)
-            .background(VColor.borderDisabled.opacity(0.2))
-            .help("Context: \(Int((fillRatio ?? 0) * 100))% used")
-            .accessibilityLabel("Context window \(Int((fillRatio ?? 0) * 100)) percent used")
+            circularRing(ratio: ratio)
+                .onHover { hovering in
+                    isHovered = hovering
+                }
+                .popover(isPresented: $isHovered, arrowEdge: .top) {
+                    popoverContent
+                }
+                .accessibilityLabel("Context window \(Int((fillRatio ?? 0) * 100)) percent used")
         }
+    }
+
+    @ViewBuilder
+    private func circularRing(ratio: Double) -> some View {
+        ZStack {
+            // Track ring
+            Circle()
+                .stroke(VColor.contentTertiary.opacity(0.2), lineWidth: ringLineWidth)
+                .frame(width: ringSize, height: ringSize)
+
+            // Fill ring
+            Circle()
+                .trim(from: 0, to: CGFloat(min(ratio, 1.0)))
+                .stroke(ringColor, style: StrokeStyle(lineWidth: ringLineWidth, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+                .frame(width: ringSize, height: ringSize)
+        }
+        .frame(width: ringSize, height: ringSize)
+    }
+
+    @ViewBuilder
+    private var popoverContent: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Context window:")
+                .font(VFont.bodySmallDefault)
+                .foregroundStyle(VColor.contentSecondary)
+
+            Text("\(percentText) full")
+                .font(VFont.bodyMediumEmphasised)
+                .foregroundStyle(ringColor)
+
+            if let used = tokensUsed, let max = tokensMax {
+                Text("\(Self.formatTokens(used)) / \(Self.formatTokens(max)) tokens used")
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+            }
+
+            Text("Vellum automatically\ncompacts its context.")
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentTertiary)
+        }
+        .padding(VSpacing.md)
     }
 }


### PR DESCRIPTION
## Summary
- Replace 2px progress bar with a small circular ring indicator in the composer toolbar area
- Add rich popover on hover showing percentage, token counts, and compaction note
- Wire token count data through ChatView, PanelCoordinator, and ThreadWindow

## Original prompt
Move context window indicator to the composer area (near attachment button) and show a tooltip when moused over with percentage, token counts, and compaction info.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
