### PR TITLE
Publish SSE events for signal-injected user messages

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -565,6 +565,28 @@ export class DaemonServer {
         params.conversationKey,
       );
       const conversation = await this.getOrCreateConversation(conversationId);
+
+      // Build a hub-publishing sender so events reach SSE clients.
+      const hubSender = (msg: ServerMessage) => {
+        const msgConversationId =
+          "conversationId" in msg &&
+          typeof (msg as { conversationId?: unknown }).conversationId ===
+            "string"
+            ? (msg as { conversationId: string }).conversationId
+            : undefined;
+        const event = buildAssistantEvent(
+          DAEMON_INTERNAL_ASSISTANT_ID,
+          msg,
+          msgConversationId ?? conversationId,
+        );
+        assistantEventHub.publish(event).catch((err) => {
+          log.warn(
+            { err },
+            "assistant-events hub subscriber threw during signal user-message",
+          );
+        });
+      };
+
       if (conversation.isProcessing()) {
         const requestId = crypto.randomUUID();
         const resolvedChannel = resolveTurnChannel(params.sourceChannel);
@@ -572,7 +594,7 @@ export class DaemonServer {
         const result = conversation.enqueueMessage(
           params.content,
           [],
-          () => {},
+          hubSender,
           requestId,
           undefined,
           undefined,
@@ -589,7 +611,7 @@ export class DaemonServer {
         conversationId,
         params.content,
         undefined,
-        undefined,
+        { onEvent: hubSender },
         params.sourceChannel,
         params.sourceInterface,
       );


### PR DESCRIPTION
## Summary
- Wire a hub-publishing `onEvent` callback into the `registerUserMessageCallback` signal handler so agent loop events (text deltas, tool calls, message completions) are published to `assistantEventHub`
- Covers both code paths: direct processing (conversation idle) via `persistAndProcessMessage` options, and queued processing (conversation busy) via `enqueueMessage` sender callback
- Enables real-time UI updates in the desktop app when external processes inject messages via the signal file system

## Original prompt
Wire signal-injected messages to SSE event hub for real-time UI updates. The HTTP POST /v1/messages handler correctly uses `makeHubPublisher` to publish events, but the signal handler was calling `persistAndProcessMessage` without an event callback, and `enqueueMessage` with a no-op `() => {}` sender.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
