### PR TITLE
Persist trust context across conversation eviction

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -928,9 +928,29 @@ export class DaemonServer {
     conversation.setAssistantId(
       options?.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
     );
-    conversation.setTrustContext(options?.trustContext ?? null);
-    conversation.setAuthContext(options?.authContext ?? null);
+    // Only overwrite trust/auth context when explicitly provided. Callers that
+    // don't supply a trust context (e.g. signal-injected messages) should
+    // inherit whatever the conversation already has from a prior session.
+    if (options?.trustContext !== undefined) {
+      conversation.setTrustContext(options.trustContext);
+    }
+    if (options?.authContext !== undefined) {
+      conversation.setAuthContext(options.authContext);
+    }
     await conversation.ensureActorScopedHistory();
+
+    // Persist the conversation's current trust/auth context so it survives
+    // eviction and recreation. The restore path in getOrCreateConversation
+    // reads from storedOptions.trustContext / storedOptions.authContext.
+    const currentTrust = conversation.trustContext;
+    const currentAuth = conversation.authContext;
+    if (currentTrust || currentAuth) {
+      this.conversationOptions.set(conversationId, {
+        ...this.conversationOptions.get(conversationId),
+        ...(currentTrust ? { trustContext: currentTrust } : {}),
+        ...(currentAuth ? { authContext: currentAuth } : {}),
+      });
+    }
     conversation.setChannelCapabilities(
       resolveChannelCapabilities(
         sourceChannel,


### PR DESCRIPTION
## Summary
- Stop unconditionally clearing trust/auth context in `prepareConversationForMessage` — only overwrite when explicitly provided in options, so signal-injected messages inherit the conversation's existing guardian trust
- Persist the conversation's trust/auth context to `conversationOptions` after each message, so it's restored when a conversation is recreated after eviction (the restore path already existed but was never populated)

## Original prompt
Persist trust context in conversationOptions so it survives eviction. The recreation code already restores trust from storedOptions, but nobody ever writes to it. Additionally, `prepareConversationForMessage` was actively clearing trust context when options didn't include one, breaking signal-injected messages even without eviction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
