### PR TITLE
Add /compact to client picker and support signal attachments

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 import {
@@ -81,7 +81,10 @@ import type { SkillOperationContext } from "./handlers/skills.js";
 import { HostBashProxy } from "./host-bash-proxy.js";
 import { HostCuProxy } from "./host-cu-proxy.js";
 import { HostFileProxy } from "./host-file-proxy.js";
-import type { ServerMessage } from "./message-protocol.js";
+import type {
+  ServerMessage,
+  UserMessageAttachment,
+} from "./message-protocol.js";
 
 const log = getLogger("server");
 
@@ -566,6 +569,37 @@ export class DaemonServer {
       );
       const conversation = await this.getOrCreateConversation(conversationId);
 
+      // Register file-backed attachments so they flow through the send
+      // pipeline as images the LLM can see directly.
+      const attachmentIds: string[] = [];
+      const resolvedAttachments: UserMessageAttachment[] = [];
+      if (params.attachments && params.attachments.length > 0) {
+        for (const a of params.attachments) {
+          try {
+            const size = statSync(a.path).size;
+            const stored = attachmentsStore.uploadFileBackedAttachment(
+              a.filename,
+              a.mimeType,
+              a.path,
+              size,
+            );
+            attachmentIds.push(stored.id);
+            resolvedAttachments.push({
+              id: stored.id,
+              filename: a.filename,
+              mimeType: a.mimeType,
+              data: "",
+              filePath: a.path,
+            });
+          } catch (err) {
+            log.warn(
+              { err, path: a.path },
+              "Failed to register signal attachment",
+            );
+          }
+        }
+      }
+
       // Build a hub-publishing sender so events reach SSE clients.
       const hubSender = (msg: ServerMessage) => {
         const msgConversationId =
@@ -593,7 +627,7 @@ export class DaemonServer {
         const resolvedInterface = resolveTurnInterface(params.sourceInterface);
         const result = conversation.enqueueMessage(
           params.content,
-          [],
+          resolvedAttachments,
           hubSender,
           requestId,
           undefined,
@@ -610,7 +644,7 @@ export class DaemonServer {
       await this.persistAndProcessMessage(
         conversationId,
         params.content,
-        undefined,
+        attachmentIds.length > 0 ? attachmentIds : undefined,
         { onEvent: hubSender },
         params.sourceChannel,
         params.sourceInterface,

--- a/assistant/src/signals/user-message.ts
+++ b/assistant/src/signals/user-message.ts
@@ -23,6 +23,18 @@ import { getSignalsDir } from "../util/platform.js";
 
 const log = getLogger("signal:user-message");
 
+// ── Attachment descriptor ───────────────────────────────────────────
+
+/** A file-backed attachment included in a signal payload. */
+export interface SignalAttachment {
+  /** Absolute path to the file on disk. */
+  path: string;
+  /** Display filename (e.g. "f_0001.jpg"). */
+  filename: string;
+  /** MIME type (e.g. "image/jpeg"). */
+  mimeType: string;
+}
+
 // ── Daemon callback registry ─────────────────────────────────────────
 
 type UserMessageCallback = (params: {
@@ -31,6 +43,7 @@ type UserMessageCallback = (params: {
   sourceChannel: string;
   sourceInterface: string;
   bypassSecretCheck?: boolean;
+  attachments?: SignalAttachment[];
 }) => Promise<{ accepted: boolean; error?: string; message?: string }>;
 
 let _sendUserMessage: UserMessageCallback | null = null;
@@ -99,6 +112,11 @@ export async function handleUserMessageSignal(filename: string): Promise<void> {
       interface?: string;
       requestId?: string;
       bypassSecretCheck?: boolean;
+      attachments?: Array<{
+        path?: string;
+        filename?: string;
+        mimeType?: string;
+      }>;
     };
     const { requestId } = parsed;
     parsedRequestId = requestId;
@@ -131,12 +149,31 @@ export async function handleUserMessageSignal(filename: string): Promise<void> {
       return;
     }
 
+    // Validate and normalize attachments
+    const attachments: SignalAttachment[] = [];
+    if (Array.isArray(parsed.attachments)) {
+      for (const a of parsed.attachments) {
+        if (
+          typeof a.path === "string" &&
+          typeof a.filename === "string" &&
+          typeof a.mimeType === "string"
+        ) {
+          attachments.push({
+            path: a.path,
+            filename: a.filename,
+            mimeType: a.mimeType,
+          });
+        }
+      }
+    }
+
     const result = await _sendUserMessage({
       conversationKey: parsed.conversationKey,
       content: parsed.content,
       sourceChannel: parsed.sourceChannel ?? "vellum",
       sourceInterface: parsed.interface ?? "cli",
       bypassSecretCheck: parsed.bypassSecretCheck === true,
+      ...(attachments.length > 0 ? { attachments } : {}),
     });
 
     log.info(

--- a/clients/shared/Features/Chat/SlashCommandCatalog.swift
+++ b/clients/shared/Features/Chat/SlashCommandCatalog.swift
@@ -98,6 +98,15 @@ public enum ChatSlashCommandCatalog {
             sendPathPlatforms: allPlatforms
         ),
         ChatSlashCommandDescriptor(
+            name: "compact",
+            description: "Force context compaction immediately",
+            icon: "arrow.down.right.and.arrow.up.left",
+            selectionBehavior: .autoSend,
+            pickerPlatforms: allPlatforms,
+            helpBubblePlatforms: allPlatforms,
+            sendPathPlatforms: allPlatforms
+        ),
+        ChatSlashCommandDescriptor(
             name: "models",
             description: "List all available models",
             icon: "list.bullet",


### PR DESCRIPTION
## Summary
- **`/compact` command visibility**: Added the `/compact` slash command to the client-side `SlashCommandCatalog.swift` — it was implemented on the daemon but missing from the client picker, so users couldn't discover it.
- **Signal attachments**: Wired file-backed attachment support through the signal user-message pipeline (`user-message.ts` → `server.ts`), so images included in signal payloads are registered as attachments and passed to the LLM.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
