### PR TITLE
Remove anti-repetition system notice from agent loop

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -401,7 +401,7 @@ export class AgentLoop {
         );
 
         // Check if the assistant turn contained any visible text (used for
-        // both the empty-response nudge and the anti-repetition notice).
+        // the empty-response nudge).
         const hasTextBlock = response.content.some(
           (block) => block.type === "text" && block.text.trim().length > 0,
         );
@@ -603,14 +603,6 @@ export class AgentLoop {
           resultBlocks.push({
             type: "text",
             text: "<system_notice>One or more tool calls returned an error. If the error looks recoverable (e.g. missing or invalid parameters), fix the parameters and retry. If the error is clearly unrecoverable (e.g. a service is down, a resource does not exist, or a permission is permanently denied), report it to the user.</system_notice>",
-          });
-        }
-
-        // Remind the LLM not to repeat text it already streamed
-        if (hasTextBlock) {
-          resultBlocks.push({
-            type: "text",
-            text: '<system_notice>Your previous text was already shown to the user in real time. Do not repeat or rephrase it. Do not narrate retries or internal process chatter ("let me try", "that didn\'t work"). Keep working with tools silently unless you need user input, and only send user-facing text when you have concrete progress or final results.</system_notice>',
           });
         }
 


### PR DESCRIPTION
## Summary
- Remove the `<system_notice>` that was injected after every assistant turn containing text, which told the LLM not to repeat or rephrase previously-streamed content
- Update the `hasTextBlock` comment to reflect it's only used for the empty-response nudge now

## Original prompt
Let's get rid of this system notice: `<system_notice>Your previous text was already shown to the user in real time. Do not repeat or rephrase it. Do not narrate retries or internal process chatter ("let me try", "that didn't work"). Keep working with tools silently unless you need user input, and only send user-facing text when you have concrete progress or final results.</system_notice>`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
