### PR TITLE
Fix empty base64 data in signal-injected image attachments

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -584,11 +584,12 @@ export class DaemonServer {
               size,
             );
             attachmentIds.push(stored.id);
+            const fileData = readFileSync(a.path).toString("base64");
             resolvedAttachments.push({
               id: stored.id,
               filename: a.filename,
               mimeType: a.mimeType,
-              data: "",
+              data: fileData,
               filePath: a.path,
             });
           } catch (err) {


### PR DESCRIPTION
## Summary
- Signal-injected attachments passed `data: ""` to the enqueue path, causing Anthropic API rejections (`image cannot be empty`) when the conversation was busy
- Now reads file contents into base64 at registration time so both idle and busy paths have valid image data

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
