### PR TITLE
fix: increase VNavItem trailing icon size from 10pt to 13pt

### DIFF
--- a/clients/shared/DesignSystem/Core/Navigation/VNavItem.swift
+++ b/clients/shared/DesignSystem/Core/Navigation/VNavItem.swift
@@ -144,7 +144,7 @@ public struct VNavItemTrailingIcon: View {
     }
 
     public var body: some View {
-        VIconView(.resolve(icon), size: 10)
+        VIconView(.resolve(icon), size: 13)
             .foregroundStyle(iconColor)
             .rotationEffect(rotation)
             .animation(VAnimation.fast, value: rotation)


### PR DESCRIPTION
## Summary
- Increase trailing icon (chevron) in VNavItem from 10pt to 13pt for better visibility

## Test plan
- [ ] Preferences row chevron is visibly larger

🤖 Generated with [Claude Code](https://claude.com/claude-code)