### PR TITLE
feat: add VPageContainer and migrate all panels to consistent layout

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -33,8 +33,6 @@ extension MainWindowView {
                 activeSessionId: conversationManager.activeViewModel?.conversationId,
                 onClose: { windowState.selection = nil }
             )
-            .background(VColor.surfaceOverlay)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
         case .generated:
             GeneratedPanel(
                 onClose: { sharing.showSharePicker = false; windowState.closeDynamicPanel() },
@@ -121,8 +119,6 @@ extension MainWindowView {
                 store: usageDashboardStore,
                 onClose: { windowState.selection = nil }
             )
-            .background(VColor.surfaceOverlay)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
         }
     }
 
@@ -444,8 +440,6 @@ extension MainWindowView {
                 activeSessionId: conversationManager.activeViewModel?.conversationId,
                 onClose: { windowState.dismissOverlay() }
             )
-            .background(VColor.surfaceOverlay)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
         case .avatarCustomization:
             AvatarCustomizationPanel(onClose: { windowState.selection = .panel(windowState.avatarCustomizationReturnPanel) })
         case .generated:
@@ -516,14 +510,11 @@ extension MainWindowView {
                 pendingMemoryId: $windowState.pendingMemoryId,
                 pendingSkillId: $windowState.pendingSkillId
             )
-            .background(VColor.surfaceOverlay)
         case .usageDashboard:
             UsageDashboardPanel(
                 store: usageDashboardStore,
                 onClose: { windowState.dismissOverlay() }
             )
-            .background(VColor.surfaceOverlay)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -45,29 +45,13 @@ struct AppsGridView: View {
     private let maxContentWidth: CGFloat = 1400
 
     var body: some View {
-        Group {
+        VPageContainer(title: "Library") {
             if appListManager.apps.isEmpty && sharedApps.isEmpty && hasFetchedShared && hasFetchedLocalApps {
                 noAppsEmptyState
             } else {
-                VStack(alignment: .leading, spacing: 0) {
-                    // Header
-                    HStack(alignment: .center) {
-                        Text("Library")
-                            .font(VFont.titleLarge)
-                            .foregroundStyle(VColor.contentDefault)
-                        Spacer()
-                    }
-                    .padding(.bottom, VSpacing.md)
-
-                    Divider().background(VColor.borderBase)
-
-                    mainContent
-                }
-                .padding(VSpacing.xl)
+                mainContent
             }
         }
-        .background(VColor.surfaceOverlay)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
         .onAppear {
             if !hasFetchedShared { fetchSharedApps() }
             if !hasFetchedLocalApps { refreshLocalAppsFromDaemon() }
@@ -95,7 +79,7 @@ struct AppsGridView: View {
 
     private var mainContent: some View {
         ScrollView {
-            VStack(spacing: VSpacing.xxl) {
+            VStack(spacing: VSpacing.xl) {
                 searchBar
 
                 let pinned = filteredPinnedApps
@@ -131,7 +115,6 @@ struct AppsGridView: View {
             }
             .frame(maxWidth: maxContentWidth)
             .frame(maxWidth: .infinity)
-            .padding(.top, VSpacing.lg)
         }
     }
 
@@ -169,7 +152,7 @@ struct AppsGridView: View {
             )
             onOpenApp(app.id)
         } label: {
-            VStack(alignment: .leading, spacing: VSpacing.xl) {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
                 // Preview thumbnail or icon placeholder — all corners rounded.
                 // Use a sized container with .overlay so .fill images don't overflow.
                 Group {
@@ -277,7 +260,7 @@ struct AppsGridView: View {
 
 
                 // Name + date below the image
-                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
                     Text(app.name)
                         .font(VFont.bodyLargeEmphasised)
                         .foregroundStyle(VColor.contentDefault)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DebugPanel.swift
@@ -21,20 +21,15 @@ struct DebugPanel: View {
     }
 
     var body: some View {
-        VSidePanel(title: "Logs", onClose: onClose, pinnedContent: {
+        VPageContainer(title: "Logs") {
             if let conversationId = activeSessionId {
                 metricsStrip(conversationId: conversationId)
-                Divider().background(VColor.borderBase)
 
-                // Render timeline in pinned area so it owns its own ScrollView
-                // without nesting inside VSidePanel's scrollable content slot.
                 if hasEvents {
                     TraceTimelineView(traceStore: traceStore, conversationId: conversationId)
                 }
             }
 
-            // Empty states live in the pinned (non-scrollable) area so they
-            // stay centered and the panel doesn't scroll when there's nothing.
             if !hasEvents {
                 Spacer()
                 if activeSessionId != nil {
@@ -60,10 +55,6 @@ struct DebugPanel: View {
                 }
                 Spacer()
             }
-        }) {
-            // Content slot intentionally empty when no events — the empty
-            // state is rendered in pinnedContent above to avoid scrolling.
-            EmptyView()
         }
         .onAppear {
             traceStore.isObserved = true

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -50,16 +50,7 @@ struct IntelligencePanel: View {
     private let maxContentWidth: CGFloat = 1100
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            // Header
-            HStack(alignment: .center) {
-                Text("About \(cachedAssistantName)")
-                    .font(VFont.titleLarge)
-                    .foregroundStyle(VColor.contentEmphasized)
-                Spacer()
-            }
-            .padding(.bottom, VSpacing.lg)
-
+        VPageContainer(title: "About \(cachedAssistantName)") {
             // Tab bar
             VTabs(
                 items: visibleTabs.map { (label: $0.rawValue, tag: $0) },
@@ -70,7 +61,6 @@ struct IntelligencePanel: View {
             // Tab content
             tabContent
         }
-        .padding(VSpacing.xl)
         .onChange(of: pendingMemoryId) {
             if pendingMemoryId != nil {
                 withAnimation(VAnimation.fast) { selectedTab = .memories }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -7,18 +7,23 @@ struct UsageDashboardPanel: View {
 
     @State private var refreshTask: Task<Void, Never>?
     @State private var breakdownTask: Task<Void, Never>?
+    @State private var showTimeRangePopover = false
 
     private var allFailed: Bool {
         store.totalsState.isFailed && store.dailyState.isFailed && store.breakdownState.isFailed
     }
 
     var body: some View {
-        VSidePanel(title: "Usage", contentPadding: EdgeInsets(top: 0, leading: 0, bottom: VSpacing.lg, trailing: 0), onClose: onClose, pinnedContent: {
+        VPageContainer(title: "Usage") {
             timeRangeStrip(store: store)
-        }) {
-            if !allFailed {
-                contentView(store: store)
+
+            ScrollView {
+                if !allFailed {
+                    contentView(store: store)
+                        .padding(.bottom, VSpacing.lg)
+                }
             }
+            .layoutPriority(-1)
         }
         .overlay {
             if allFailed {
@@ -67,25 +72,62 @@ struct UsageDashboardPanel: View {
     @ViewBuilder
     private func timeRangeStrip(store: UsageDashboardStore) -> some View {
         HStack {
-            VDropdown(
-                placeholder: "Time range",
-                selection: Binding(
-                    get: { store.selectedRange },
-                    set: { newRange in
-                        refreshTask?.cancel()
-                        breakdownTask?.cancel()
-                        refreshTask = Task { await store.selectRange(newRange) }
-                    }
-                ),
-                options: UsageTimeRange.allCases.map { ($0.rawValue, $0) },
-                size: .small,
-                maxWidth: 160
-            )
+            timeRangeDropdown(store: store)
+                .frame(width: 150)
             Spacer()
         }
-        .frame(maxWidth: 900)
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, VSpacing.lg)
+    }
+
+    private func timeRangeDropdown(store: UsageDashboardStore) -> some View {
+        Button {
+            showTimeRangePopover.toggle()
+        } label: {
+            HStack(spacing: VSpacing.md) {
+                Text(store.selectedRange.rawValue)
+                    .foregroundStyle(VColor.contentDefault)
+                    .font(VFont.bodyMediumLighter)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                VIconView(.chevronDown, size: 13)
+                    .foregroundStyle(VColor.contentTertiary)
+                    .accessibilityHidden(true)
+            }
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, VSpacing.xs)
+            .frame(height: 32)
+            .vInputChrome()
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Time range: \(store.selectedRange.rawValue)")
+        .popover(isPresented: $showTimeRangePopover, arrowEdge: .bottom) {
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(UsageTimeRange.allCases, id: \.self) { range in
+                    Button {
+                        refreshTask?.cancel()
+                        breakdownTask?.cancel()
+                        refreshTask = Task { await store.selectRange(range) }
+                        showTimeRangePopover = false
+                    } label: {
+                        HStack(spacing: VSpacing.sm) {
+                            Text(range.rawValue)
+                                .font(VFont.bodyMediumLighter)
+                                .foregroundStyle(VColor.contentDefault)
+                            Spacer()
+                            if store.selectedRange == range {
+                                VIconView(.check, size: 12)
+                                    .foregroundStyle(VColor.primaryBase)
+                            }
+                        }
+                        .padding(.horizontal, VSpacing.md)
+                        .padding(.vertical, VSpacing.sm)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.vertical, VSpacing.sm)
+            .frame(width: 180)
+        }
     }
 
     // MARK: - Content

--- a/clients/shared/DesignSystem/Components/Layout/VPageContainer.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VPageContainer.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+/// Standard page container for full-width panel pages (Intelligence, Library, Usage, Logs).
+/// Provides a consistent title + child content layout with shared spacing.
+public struct VPageContainer<Content: View>: View {
+    public let title: String
+    @ViewBuilder public let content: () -> Content
+
+    public init(title: String, @ViewBuilder content: @escaping () -> Content) {
+        self.title = title
+        self.content = content
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(title)
+                .font(VFont.titleLarge)
+                .foregroundStyle(VColor.contentEmphasized)
+                .padding(.bottom, VSpacing.lg)
+
+            content()
+        }
+        .padding(VSpacing.xl)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(VColor.surfaceOverlay)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+    }
+}

--- a/clients/shared/DesignSystem/Core/Inputs/VSearchBar.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VSearchBar.swift
@@ -31,7 +31,6 @@ public struct VSearchBar: View {
             }
         }
         .padding(.horizontal, VSpacing.md)
-        .padding(.vertical, VSpacing.xs)
         .frame(height: 32)
         .vInputChrome(isFocused: isFocused)
     }

--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -111,6 +111,7 @@ enum ComponentGalleryCategory: String, CaseIterable, Identifiable {
             return [
                 GalleryComponent("vModal", "VModal", keywords: ["modal", "dialog"], description: "Standardized modal container with title, optional subtitle, scrollable content, and optional footer with navigation actions."),
                 GalleryComponent("vAdaptiveStack", "VAdaptiveStack", keywords: ["adaptive stack", "responsive"], description: "Arranges content horizontally when space allows, falling back to vertical stacking via ViewThatFits.", useInsteadOf: "Raw ViewThatFits { HStack { } VStack { } } in feature code"),
+                GalleryComponent("vPageContainer", "VPageContainer", keywords: ["page container", "panel layout"], description: "Standard page container with title, consistent spacing, surfaceOverlay background, and rounded corners. Use for full-width panel pages."),
                 GalleryComponent("vSidePanel", "VSidePanel", keywords: ["side panel", "drawer"], description: "Side panel with title header, close button, optional pinned content, and scrollable body."),
                 GalleryComponent("vSplitView", "VSplitView", keywords: ["split view", "resizable"], description: "Split layout with main content and a togglable, resizable side panel."),
                 GalleryComponent("vAppWorkspaceDockLayout", "VAppWorkspaceDockLayout", keywords: ["dock", "workspace", "layout"], description: "Workspace layout with a togglable, resizable dock panel and draggable divider."),

--- a/clients/shared/DesignSystem/Gallery/Sections/LayoutGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/LayoutGallerySection.swift
@@ -122,6 +122,25 @@ struct LayoutGallerySection: View {
                 }
             }
 
+            if filter == nil || filter == "vPageContainer" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+                // MARK: - VPageContainer
+                GallerySectionHeader(
+                    title: "VPageContainer",
+                    description: "Standard page container for full-width panel pages. Provides title, consistent spacing, surfaceOverlay background, and rounded corners.",
+                    useInsteadOf: "Manual VStack + title + padding + background"
+                )
+
+                VPageContainer(title: "Page Title") {
+                    Text("Page content goes here. Used by Intelligence, Library, and Usage panels.")
+                        .font(VFont.bodyMediumLighter)
+                        .foregroundStyle(VColor.contentSecondary)
+                }
+                .frame(height: 150)
+            }
+
             if filter == nil || filter == "vSidePanel" {
                 if filter == nil {
                     Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
@@ -298,6 +317,7 @@ extension LayoutGallerySection {
         switch id {
         case "vModal": LayoutGallerySection(filter: "vModal")
         case "vAdaptiveStack": LayoutGallerySection(filter: "vAdaptiveStack")
+        case "vPageContainer": LayoutGallerySection(filter: "vPageContainer")
         case "vSidePanel": LayoutGallerySection(filter: "vSidePanel")
         case "vSplitView": LayoutGallerySection(filter: "vSplitView")
         case "vAppWorkspaceDockLayout": LayoutGallerySection(filter: "vAppWorkspaceDockLayout")


### PR DESCRIPTION
## Summary
- Create `VPageContainer` component with title, consistent spacing, surfaceOverlay background, and rounded corners
- Migrate Intelligence, Library, Usage, and Logs panels to use it
- Remove dividers under panel titles
- Remove duplicate background/clipShape from PanelCoordinator
- Replace Usage `VDropdown` with popover dropdown matching memories/skills filter pattern
- Remove vertical padding from `VSearchBar`
- Add `VPageContainer` to component gallery

## Test plan
- [ ] Intelligence, Library, Usage, and Logs pages all have consistent title spacing and surfaceOverlay background
- [ ] No dividers under titles on any panel
- [ ] Usage time range filter uses popover dropdown, left-aligned
- [ ] Component gallery → Layout → VPageContainer renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22293" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
