### PR TITLE
fix(macos): improve Sentry diagnostic visibility in developer tab

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -362,6 +362,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         // can be attached to the scope for the automatic crash event.
         let crashLogURLs = sendDiagnostics ? CrashReporter.pendingCrashLogURLs() : []
 
+        if !sendDiagnostics {
+            log.info("Sentry disabled: user opted out of diagnostics")
+        } else if MetricKitManager.macosDSN.isEmpty {
+            log.warning("Sentry disabled: SENTRY_DSN_MACOS not set in this build")
+        }
+
         if sendDiagnostics && !MetricKitManager.macosDSN.isEmpty {
             let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
             let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
@@ -414,6 +420,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             }
 
             SentryLogReporter.start()
+            log.info("Sentry initialized (env=\(SentryDeviceInfo.sentryEnvironment, privacy: .public), crashedLastRun=\(crashedLastRun, privacy: .public), ipsFiles=\(crashLogURLs.count, privacy: .public))")
         }
 
         // Record this launch so the next session can identify new crashes.

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -66,6 +66,7 @@ struct SettingsDeveloperTab: View {
     @State private var lastSentryStatus: String?
     @State private var sentryDismissTask: Task<Void, Never>?
     @State private var isSentryEnabled: Bool = true
+    @State private var isSentrySdkRunning: Bool = false
 
     @State private var featureFlagSearchText: String = ""
     @State private var featureFlagScopeFilter: String = "all"
@@ -179,6 +180,7 @@ struct SettingsDeveloperTab: View {
             // Sentry setup
             isSentryEnabled = UserDefaults.standard.object(forKey: "sendDiagnostics") as? Bool
                 ?? true
+            isSentrySdkRunning = SentrySDK.isEnabled
         }
         .alert("Retire Assistant", isPresented: $showingRetireConfirmation) {
             Button("Cancel", role: .cancel) {}
@@ -1079,7 +1081,15 @@ struct SettingsDeveloperTab: View {
                 HStack(spacing: VSpacing.xs) {
                     VIconView(.triangleAlert, size: 12)
                         .foregroundStyle(VColor.systemNegativeHover)
-                    Text("Share Diagnostics is disabled. Non-fatal events will be silently dropped unless you enable \"Share Diagnostics\" in the Privacy tab.")
+                    Text("Share Diagnostics is disabled. Events will be silently dropped unless you enable \"Share Diagnostics\" in the Privacy tab.")
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.systemNegativeHover)
+                }
+            } else if !isSentrySdkRunning {
+                HStack(spacing: VSpacing.xs) {
+                    VIconView(.triangleAlert, size: 12)
+                        .foregroundStyle(VColor.systemNegativeHover)
+                    Text("Sentry SDK is not running (DSN missing from this build). Events will be silently dropped.")
                         .font(VFont.labelDefault)
                         .foregroundStyle(VColor.systemNegativeHover)
                 }
@@ -1173,6 +1183,10 @@ struct SettingsDeveloperTab: View {
     private func sendSentryTestEvent(level: SentryLevel, label: String) {
         guard isSentryEnabled else {
             showSentryStatus("Sentry is disabled — \(label) not sent.")
+            return
+        }
+        guard SentrySDK.isEnabled else {
+            showSentryStatus("Sentry SDK is not running (DSN missing?) — \(label) not sent.")
             return
         }
         let event = Event(level: level)


### PR DESCRIPTION
## Summary
- **Investigation**: Confirmed that Sentry crash/fatal event reporting is correctly configured — DSN is embedded in release builds via `LSEnvironment`, `SentrySDK.start()` is called at launch, dSYMs are uploaded in CI, and the SDK's built-in crash handlers are properly installed.
- **Fix**: The developer tab's "Send Test Error/Warning/Message" buttons checked only the user preference (`sendDiagnostics`) but not `SentrySDK.isEnabled`, so they falsely reported events as "sent" when the SDK wasn't actually running (e.g., debug builds without DSN). Now shows accurate status.
- **Diagnostics**: Added startup log lines to confirm whether Sentry initialized, was skipped due to opt-out, or was skipped due to missing DSN — making it easy to diagnose reporting issues via `log stream`.

## Original prompt
--safe investigate if app crashes and fatal events are still getting reported to sentry - macos app
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22294" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
