### PR TITLE
style: use VSpacing.xs between sidebar header buttons

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationsHeader.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationsHeader.swift
@@ -22,19 +22,21 @@ struct SidebarConversationsHeader: View {
                 .font(.system(size: 13, weight: .medium))
                 .foregroundStyle(VColor.contentDefault)
             Spacer()
-            if hasUnseenConversations {
-                VButton(
-                    label: "Mark all as seen",
-                    iconOnly: VIcon.circleCheck.rawValue,
-                    style: .ghost,
-                    tooltip: "Mark all as seen",
-                    action: onMarkAllSeen
-                )
-                .disabled(isLoading)
+            HStack(spacing: VSpacing.xs) {
+                if hasUnseenConversations {
+                    VButton(
+                        label: "Mark all as seen",
+                        iconOnly: VIcon.circleCheck.rawValue,
+                        style: .ghost,
+                        tooltip: "Mark all as seen",
+                        action: onMarkAllSeen
+                    )
+                    .disabled(isLoading)
+                }
+                VButton(label: "New conversation", iconOnly: VIcon.squarePen.rawValue, style: .ghost, tooltip: newChatTooltip, action: onNewConversation)
+                    .disabled(isLoading)
+                    .opacity(isLoading ? 0.4 : 1)
             }
-            VButton(label: "New conversation", iconOnly: VIcon.squarePen.rawValue, style: .ghost, tooltip: newChatTooltip, action: onNewConversation)
-                .disabled(isLoading)
-                .opacity(isLoading ? 0.4 : 1)
         }
         .padding(.leading, 0)
         .padding(.trailing, 0)


### PR DESCRIPTION
## Summary
- Wrap the mark-all-seen and new-conversation buttons in an inner `HStack(spacing: VSpacing.xs)` so their gap is an explicit 4pt instead of SwiftUI's default ~8pt
- The new conversation button stays pinned to the trailing edge — no position change

## Original prompt
make the spacing between mark all as seen and new conversation button 4pt, using the VSpacing.xs. position of the new conversation button shouldnt move at all
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
