### PR TITLE
fix: clean up identity panel — remove edit buttons, use body small, fix divider

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -62,38 +62,13 @@ struct IdentityPanel: View {
                     VStack(spacing: 0) {
                         VStack(spacing: 0) {
                             // Intro heading — show daemon-generated text, fall back to static name
-                            if isEditingName {
-                                inlineEditField(
-                                    text: $editingNameText,
-                                    placeholder: "Enter a name",
-                                    font: VFont.titleMedium,
-                                    isSaving: isSavingIdentityField,
-                                    onSave: { saveIdentityField(field: "Name", value: editingNameText) },
-                                    onCancel: { isEditingName = false }
-                                )
-                                .padding(.top, VSpacing.xxl)
-                                .padding(.horizontal, VSpacing.lg)
-                            } else {
-                                HStack(spacing: VSpacing.xs) {
-                                    Text(introText ?? (hasRealName ? "I'm \(assistantDisplayName)!" : "I need a name!"))
-                                        .font(VFont.titleMedium)
-                                        .foregroundStyle(VColor.contentDefault)
-                                        .multilineTextAlignment(.center)
-
-                                    VButton(
-                                        label: "Edit name",
-                                        iconOnly: VIcon.pencil.rawValue,
-                                        style: .ghost,
-                                        size: .compact
-                                    ) {
-                                        editingNameText = hasRealName ? assistantDisplayName : ""
-                                        isEditingName = true
-                                    }
-                                }
+                            Text(introText ?? (hasRealName ? "I'm \(assistantDisplayName)!" : assistantDisplayName))
+                                .font(VFont.titleMedium)
+                                .foregroundStyle(VColor.contentDefault)
+                                .multilineTextAlignment(.center)
                                 .frame(maxWidth: .infinity, alignment: .center)
                                 .padding(.top, VSpacing.xxl)
                                 .padding(.horizontal, VSpacing.lg)
-                            }
 
                             Spacer()
 
@@ -117,12 +92,12 @@ struct IdentityPanel: View {
 
                             // Update Avatar button
                             VButton(label: "Update Avatar", style: .outlined) { showAvatarSheet = true }
-                                .padding(.top, VSpacing.md)
+                                .padding(.top, VSpacing.xxl)
 
                             Spacer()
 
                             // Divider
-                            Divider().background(VColor.borderBase)
+                            Rectangle().fill(VColor.surfaceOverlay).frame(height: 2)
 
                             // Role + Hatched date
                             VStack(alignment: .leading, spacing: VSpacing.lg) {
@@ -130,35 +105,7 @@ struct IdentityPanel: View {
                                     remoteIdentity?.role.nilIfEmpty,
                                     identity?.role
                                 ])
-                                if isEditingRole {
-                                    VStack(alignment: .leading, spacing: VSpacing.xxs) {
-                                        Text("Role")
-                                            .font(VFont.labelDefault)
-                                            .foregroundStyle(VColor.contentTertiary)
-                                        inlineEditField(
-                                            text: $editingRoleText,
-                                            placeholder: "Enter a role",
-                                            font: VFont.labelDefault,
-                                            isSaving: isSavingIdentityField,
-                                            onSave: { saveIdentityField(field: "Role", value: editingRoleText) },
-                                            onCancel: { isEditingRole = false }
-                                        )
-                                    }
-                                } else {
-                                    HStack(spacing: VSpacing.xs) {
-                                        identityInfoRow(label: "Role", value: role ?? "Not set")
-                                        Spacer()
-                                        VButton(
-                                            label: "Edit role",
-                                            iconOnly: VIcon.pencil.rawValue,
-                                            style: .ghost,
-                                            size: .compact
-                                        ) {
-                                            editingRoleText = role ?? ""
-                                            isEditingRole = true
-                                        }
-                                    }
-                                }
+                                identityInfoRow(label: "Role", value: role ?? "Not set")
                                 if let date = metadata?.createdAt {
                                     identityInfoRow(label: "Hatched", value: formatHatchedDate(date))
                                 }
@@ -451,10 +398,10 @@ struct IdentityPanel: View {
     private func identityInfoRow(label: String, value: String) -> some View {
         VStack(alignment: .leading, spacing: VSpacing.xxs) {
             Text(label)
-                .font(VFont.bodyMediumLighter)
+                .font(VFont.bodySmallDefault)
                 .foregroundStyle(VColor.contentTertiary)
             Text(value)
-                .font(VFont.bodyMediumEmphasised)
+                .font(VFont.bodySmallEmphasised)
                 .foregroundStyle(VColor.contentEmphasized)
         }
     }


### PR DESCRIPTION
## Summary
- Remove name and role edit buttons (pencil + inline edit) from identity panel
- Use bodySmallDefault/bodySmallEmphasised for Role and Hatched date
- Change divider above Role to 2px surfaceOverlay color
- Increase avatar-to-button spacing to xxl (32pt)

## Test plan
- [ ] Identity panel shows name as read-only (no pencil icon)
- [ ] Role and Hatched date use smaller body text
- [ ] Divider is subtle 2px surfaceOverlay
- [ ] Update Avatar button has more space from avatar

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
