### PR TITLE
fix: make 402 billing errors retryable to handle transient balance miscalculation

### DIFF
--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -443,12 +443,12 @@ describe("classifyConversationError", () => {
       expect(result.errorCategory).toBe("provider_not_configured");
     });
 
-    it("classifies ProviderError with 402 as credits_exhausted (non-retryable)", () => {
+    it("classifies ProviderError with 402 as credits_exhausted (retryable)", () => {
       const err = new ProviderError("Payment Required", "anthropic", 402);
       const result = classifyConversationError(err, baseCtx);
       expect(result.code).toBe("PROVIDER_BILLING");
       expect(result.errorCategory).toBe("credits_exhausted");
-      expect(result.retryable).toBe(false);
+      expect(result.retryable).toBe(true);
     });
 
     it("classifies ProviderError with 400 as PROVIDER_API (retryable)", () => {

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -242,7 +242,7 @@ function classifyCore(
         code: "PROVIDER_BILLING",
         userMessage:
           "You've run out of credits. Add funds to continue using the assistant.",
-        retryable: false,
+        retryable: true,
         errorCategory: "credits_exhausted",
       };
     }

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -241,7 +241,7 @@ function classifyCore(
       return {
         code: "PROVIDER_BILLING",
         userMessage:
-          "Your balance appears depleted. If you recently added funds, wait a minute and retry.",
+          "You've run out of credits. Add funds to continue using the assistant. If you recently topped up, it may take a minute to update.",
         retryable: true,
         errorCategory: "credits_exhausted",
       };

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -241,7 +241,7 @@ function classifyCore(
       return {
         code: "PROVIDER_BILLING",
         userMessage:
-          "You've run out of credits. Add funds to continue using the assistant.",
+          "Your balance appears depleted. If you recently added funds, wait a minute and retry.",
         retryable: true,
         errorCategory: "credits_exhausted",
       };

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -40,9 +40,18 @@ function isRetryableStreamError(error: unknown): boolean {
   return RETRYABLE_STREAM_PATTERNS.some((p) => error.message.includes(p));
 }
 
+/** 402 billing errors may be transient when effective balance is briefly miscalculated. */
+function isBillingError(error: unknown): boolean {
+  return error instanceof ProviderError && error.statusCode === 402;
+}
+
+/** Max retries for billing errors — keep low to avoid hammering when genuinely depleted. */
+const BILLING_MAX_RETRIES = 1;
+
 function isRetryableError(error: unknown): boolean {
   if (error instanceof ProviderError && error.statusCode !== undefined) {
     if (error.statusCode === 429 || error.statusCode >= 500) return true;
+    if (error.statusCode === 402) return true;
   }
   if (isRetryableStreamError(error)) return true;
   return isRetryableNetworkError(error);
@@ -67,7 +76,8 @@ function normalizeSendMessageOptions(
   const needsThinkingStrip =
     providerName !== "anthropic" && config.thinking !== undefined;
   const needsEffortStrip =
-    !EFFORT_SUPPORTED_PROVIDERS.has(providerName) && config.effort !== undefined;
+    !EFFORT_SUPPORTED_PROVIDERS.has(providerName) &&
+    config.effort !== undefined;
   const needsSpeedStrip =
     providerName !== "anthropic" && config.speed !== undefined;
 
@@ -146,6 +156,12 @@ export class RetryProvider implements Provider {
         lastError = error;
 
         if (attempt < DEFAULT_MAX_RETRIES && isRetryableError(error)) {
+          // Billing errors get fewer retries to avoid hammering when genuinely depleted.
+          const maxRetries = isBillingError(error)
+            ? BILLING_MAX_RETRIES
+            : DEFAULT_MAX_RETRIES;
+          if (attempt >= maxRetries) throw error;
+
           // Prefer server-provided Retry-After; fall back to exponential backoff.
           const retryAfter =
             error instanceof ProviderError ? error.retryAfterMs : undefined;
@@ -161,13 +177,15 @@ export class RetryProvider implements Provider {
                   error.statusCode !== undefined &&
                   error.statusCode >= 500
                 ? `server_error_${error.statusCode}`
-                : isRetryableStreamError(error)
-                  ? "stream_corruption"
-                  : "network_error";
+                : isBillingError(error)
+                  ? "billing_402"
+                  : isRetryableStreamError(error)
+                    ? "stream_corruption"
+                    : "network_error";
           log.warn(
             {
               attempt: attempt + 1,
-              maxRetries: DEFAULT_MAX_RETRIES,
+              maxRetries: maxRetries,
               delay,
               retryAfterHeader: retryAfter !== undefined,
               errorType,

--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -210,10 +210,10 @@ struct CreditsExhaustedBanner: View {
     var body: some View {
         HStack(spacing: VSpacing.xl) {
             VStack(alignment: .leading, spacing: 2) {
-                Text("💰  Your balance has run out")
+                Text("💰  Your balance appears depleted")
                     .font(VFont.bodySmallEmphasised)
                     .foregroundStyle(VColor.contentEmphasized)
-                Text("Add funds to pick up where you left off.")
+                Text("Add funds to continue. If you just topped up, it may take a minute to update — try again shortly.")
                     .font(VFont.bodyMediumDefault)
                     .foregroundStyle(VColor.contentSecondary)
             }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -210,10 +210,10 @@ struct CreditsExhaustedBanner: View {
     var body: some View {
         HStack(spacing: VSpacing.xl) {
             VStack(alignment: .leading, spacing: 2) {
-                Text("💰  Your balance appears depleted")
+                Text("💰  Your balance has run out")
                     .font(VFont.bodySmallEmphasised)
                     .foregroundStyle(VColor.contentEmphasized)
-                Text("Add funds to continue. If you just topped up, it may take a minute to update — try again shortly.")
+                Text("Add funds to pick up where you left off. If you recently topped up, it may take a minute to update.")
                     .font(VFont.bodyMediumDefault)
                     .foregroundStyle(VColor.contentSecondary)
             }

--- a/clients/shared/Features/Chat/ChatConversationError.swift
+++ b/clients/shared/Features/Chat/ChatConversationError.swift
@@ -60,7 +60,7 @@ public enum ConversationErrorCategory: Equatable, Sendable {
         case .providerApi:
             return "This is usually temporary — click Retry, or check your API key in Settings if it persists."
         case .providerBilling:
-            return "Click Retry — if the error persists, add credits to your account."
+            return "This may be temporary — try again, or add credits to your account if it persists."
         case .providerOrdering:
             return "This is usually temporary — click Retry to continue."
         case .providerWebSearch:

--- a/clients/shared/Features/Chat/ChatConversationError.swift
+++ b/clients/shared/Features/Chat/ChatConversationError.swift
@@ -60,7 +60,7 @@ public enum ConversationErrorCategory: Equatable, Sendable {
         case .providerApi:
             return "This is usually temporary — click Retry, or check your API key in Settings if it persists."
         case .providerBilling:
-            return "Please add credits to your account or update your API key in Settings."
+            return "Click Retry — if the error persists, add credits to your account."
         case .providerOrdering:
             return "This is usually temporary — click Retry to continue."
         case .providerWebSearch:

--- a/clients/shared/Features/Chat/ChatConversationError.swift
+++ b/clients/shared/Features/Chat/ChatConversationError.swift
@@ -60,7 +60,7 @@ public enum ConversationErrorCategory: Equatable, Sendable {
         case .providerApi:
             return "This is usually temporary — click Retry, or check your API key in Settings if it persists."
         case .providerBilling:
-            return "This may be temporary — try again, or add credits to your account if it persists."
+            return "If you recently added funds, it may take a minute to update. Try again shortly, or add credits."
         case .providerOrdering:
             return "This is usually temporary — click Retry to continue."
         case .providerWebSearch:

--- a/clients/shared/Features/Chat/ChatConversationError.swift
+++ b/clients/shared/Features/Chat/ChatConversationError.swift
@@ -60,7 +60,7 @@ public enum ConversationErrorCategory: Equatable, Sendable {
         case .providerApi:
             return "This is usually temporary — click Retry, or check your API key in Settings if it persists."
         case .providerBilling:
-            return "If you recently added funds, it may take a minute to update. Try again shortly, or add credits."
+            return "Please add credits to your account. If you recently topped up, it may take a minute to update — try again shortly."
         case .providerOrdering:
             return "This is usually temporary — click Retry to continue."
         case .providerWebSearch:

--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -222,14 +222,13 @@ public final class EventStreamClient {
                     userMessage: message,
                     retryable: false
                 )))
-            case .insufficientBalance(let detail, let failedContent):
+            case .insufficientBalance(let detail, _):
                 self.broadcastMessage(.conversationError(ConversationErrorMessage(
                     conversationId: conversationId,
                     code: .providerBilling,
                     userMessage: detail,
                     retryable: true,
-                    errorCategory: "credits_exhausted",
-                    failedMessageContent: failedContent
+                    errorCategory: "credits_exhausted"
                 )))
             case .error(_, let message, _):
                 self.broadcastMessage(.conversationError(ConversationErrorMessage(

--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -264,7 +264,7 @@ public final class EventStreamClient {
                         self.broadcastMessage(.conversationError(ConversationErrorMessage(
                             conversationId: "",
                             code: .providerBilling,
-                            userMessage: "Your balance has run out. Add funds to continue using the assistant.",
+                            userMessage: "Your balance appears depleted. If you recently added funds, it may take a minute to update.",
                             retryable: false,
                             errorCategory: "credits_exhausted"
                         )))

--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -222,13 +222,14 @@ public final class EventStreamClient {
                     userMessage: message,
                     retryable: false
                 )))
-            case .insufficientBalance(let detail, _):
+            case .insufficientBalance(let detail, let failedContent):
                 self.broadcastMessage(.conversationError(ConversationErrorMessage(
                     conversationId: conversationId,
                     code: .providerBilling,
                     userMessage: detail,
                     retryable: true,
-                    errorCategory: "credits_exhausted"
+                    errorCategory: "credits_exhausted",
+                    failedMessageContent: failedContent
                 )))
             case .error(_, let message, _):
                 self.broadcastMessage(.conversationError(ConversationErrorMessage(
@@ -265,7 +266,7 @@ public final class EventStreamClient {
                             conversationId: "",
                             code: .providerBilling,
                             userMessage: "Your balance has run out. Add funds to continue using the assistant.",
-                            retryable: true,
+                            retryable: false,
                             errorCategory: "credits_exhausted"
                         )))
                     }

--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -227,7 +227,7 @@ public final class EventStreamClient {
                     conversationId: conversationId,
                     code: .providerBilling,
                     userMessage: detail,
-                    retryable: false,
+                    retryable: true,
                     errorCategory: "credits_exhausted"
                 )))
             case .error(_, let message, _):
@@ -265,7 +265,7 @@ public final class EventStreamClient {
                             conversationId: "",
                             code: .providerBilling,
                             userMessage: "Your balance has run out. Add funds to continue using the assistant.",
-                            retryable: false,
+                            retryable: true,
                             errorCategory: "credits_exhausted"
                         )))
                     }

--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -264,7 +264,7 @@ public final class EventStreamClient {
                         self.broadcastMessage(.conversationError(ConversationErrorMessage(
                             conversationId: "",
                             code: .providerBilling,
-                            userMessage: "Your balance appears depleted. If you recently added funds, it may take a minute to update.",
+                            userMessage: "Your balance has run out. Add funds to continue using the assistant. If you recently topped up, it may take a minute to update.",
                             retryable: false,
                             errorCategory: "credits_exhausted"
                         )))

--- a/clients/shared/Network/MessageClient.swift
+++ b/clients/shared/Network/MessageClient.swift
@@ -133,7 +133,7 @@ public struct MessageClient: MessageClientProtocol {
                 return .error(statusCode: 422, message: "Failed to send message (HTTP 422)", failedMessageContent: content)
             } else if response.statusCode == 402 {
                 let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any]
-                let detail = (json?["detail"] as? String) ?? "Insufficient balance. Please add funds to continue."
+                let detail = (json?["detail"] as? String) ?? "Your balance appears depleted. If you recently added funds, wait a minute and retry."
                 log.warning("Send message blocked by billing guard (402)")
                 return .insufficientBalance(detail: detail, failedMessageContent: content)
             } else {

--- a/clients/shared/Network/MessageClient.swift
+++ b/clients/shared/Network/MessageClient.swift
@@ -133,7 +133,7 @@ public struct MessageClient: MessageClientProtocol {
                 return .error(statusCode: 422, message: "Failed to send message (HTTP 422)", failedMessageContent: content)
             } else if response.statusCode == 402 {
                 let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any]
-                let detail = (json?["detail"] as? String) ?? "Your balance appears depleted. If you recently added funds, wait a minute and retry."
+                let detail = (json?["detail"] as? String) ?? "Insufficient balance. Please add funds to continue."
                 log.warning("Send message blocked by billing guard (402)")
                 return .insufficientBalance(detail: detail, failedMessageContent: content)
             } else {


### PR DESCRIPTION
## Summary
- Adds automatic retry (1 attempt) for HTTP 402 in the daemon's RetryProvider, so transient effective-balance miscalculations resolve transparently
- Marks `credits_exhausted` errors as retryable across the daemon and client, enabling the Retry button in the chat UI
- Updates the billing-error recovery suggestion to guide users toward Retry first

## Original prompt
--safe https://linear.app/vellum/issue/LUM-406/false-out-of-credits-402-error-when-effective-balance-is-miscalculated
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
