### PR TITLE
fix: add 401 retry to local import path in teleport command

### DIFF
--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -461,7 +461,7 @@ async function importToAssistant(
 
   if (cloud === "local") {
     // Local target
-    const accessToken = await getAccessToken(
+    let accessToken = await getAccessToken(
       entry.runtimeUrl,
       entry.assistantId,
       entry.assistantId,
@@ -484,6 +484,35 @@ async function importToAssistant(
             signal: AbortSignal.timeout(120_000),
           },
         );
+
+        // Retry once with a fresh token on 401
+        if (response.status === 401) {
+          let refreshedToken: string | null = null;
+          try {
+            const freshToken = await leaseGuardianToken(
+              entry.runtimeUrl,
+              entry.assistantId,
+            );
+            refreshedToken = freshToken.accessToken;
+          } catch {
+            // If token refresh fails, fall through to the error handler below
+          }
+          if (refreshedToken) {
+            accessToken = refreshedToken;
+            response = await fetch(
+              `${entry.runtimeUrl}/v1/migrations/import-preflight`,
+              {
+                method: "POST",
+                headers: {
+                  Authorization: `Bearer ${accessToken}`,
+                  "Content-Type": "application/octet-stream",
+                },
+                body: new Blob([bundleData]),
+                signal: AbortSignal.timeout(120_000),
+              },
+            );
+          }
+        }
       } catch (err) {
         if (err instanceof Error && err.name === "TimeoutError") {
           console.error("Error: Preflight request timed out after 2 minutes.");
@@ -521,6 +550,32 @@ async function importToAssistant(
         body: new Blob([bundleData]),
         signal: AbortSignal.timeout(120_000),
       });
+
+      // Retry once with a fresh token on 401
+      if (response.status === 401) {
+        let refreshedToken: string | null = null;
+        try {
+          const freshToken = await leaseGuardianToken(
+            entry.runtimeUrl,
+            entry.assistantId,
+          );
+          refreshedToken = freshToken.accessToken;
+        } catch {
+          // If token refresh fails, fall through to the error handler below
+        }
+        if (refreshedToken) {
+          accessToken = refreshedToken;
+          response = await fetch(`${entry.runtimeUrl}/v1/migrations/import`, {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              "Content-Type": "application/octet-stream",
+            },
+            body: new Blob([bundleData]),
+            signal: AbortSignal.timeout(120_000),
+          });
+        }
+      }
     } catch (err) {
       if (err instanceof Error && err.name === "TimeoutError") {
         console.error("Error: Import request timed out after 2 minutes.");


### PR DESCRIPTION
Adds a single token refresh retry on 401 to the local import path (both preflight and actual import) in the teleport command, matching the existing retry pattern in the export path. This prevents false failures when a cached guardian token expires between export and import.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
