### PR TITLE
feat: add subtitle to VNavItem, polish VModal and avatar sheet

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarManagementSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarManagementSheet.swift
@@ -47,14 +47,12 @@ struct AvatarManagementSheet: View {
             VAvatarImage(image: appearance.fullAvatarImage, size: 120, showBorder: false)
                 .padding(.bottom, VSpacing.xl)
 
-            Divider().background(VColor.borderBase)
-                .padding(.horizontal, -VSpacing.xl)
-
-            VStack(spacing: 0) {
-                actionRow(
-                    icon: "paintbrush",
+            VStack(spacing: VSpacing.sm) {
+                VNavItem(
+                    icon: VIcon.wrench.rawValue,
                     label: "Build a Character",
-                    subtitle: "Build your own character"
+                    subtitle: "Build your own character",
+                    trailingIcon: VIcon.chevronRight.rawValue
                 ) {
                     withAnimation(VAnimation.fast) {
                         if let body = appearance.characterBodyShape,
@@ -76,31 +74,27 @@ struct AvatarManagementSheet: View {
                     }
                 }
 
-                Divider().background(VColor.borderBase)
-
-                actionRow(
-                    icon: "photo",
+                VNavItem(
+                    icon: VIcon.image.rawValue,
                     label: "Upload Image",
-                    subtitle: "Choose an image from your Mac"
+                    subtitle: "Choose an image from your Mac",
+                    trailingIcon: VIcon.chevronRight.rawValue
                 ) {
                     pickImage()
                 }
 
                 if appearance.customAvatarImage != nil {
-                    Divider().background(VColor.borderBase)
-
-                    actionRow(
+                    VNavItem(
                         icon: VIcon.trash.rawValue,
                         label: "Delete Avatar",
-                        subtitle: "Revert to the default avatar",
-                        destructive: true
+                        subtitle: "Revert to the default avatar"
                     ) {
                         appearance.clearCustomAvatar()
                         onClose()
                     }
                 }
             }
-            .padding(.vertical, VSpacing.sm)
+            .padding(.bottom, VSpacing.lg)
         }
     }
 
@@ -128,7 +122,8 @@ struct AvatarManagementSheet: View {
                 .padding(.bottom, VSpacing.lg)
 
             HStack(spacing: VSpacing.md) {
-                VButton(label: "Discard", style: .dangerOutline, isDisabled: !isDirty) {
+                Spacer()
+                VButton(label: "Discard", style: .outlined, isDisabled: !isDirty) {
                     onClose()
                 }
                 VButton(label: "Confirm", style: .primary, isDisabled: draftImage == nil) {
@@ -269,11 +264,7 @@ struct AvatarManagementSheet: View {
         .frame(height: 52)
         .background(
             RoundedRectangle(cornerRadius: VRadius.xl)
-                .fill(VColor.surfaceBase)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.xl)
-                .stroke(VColor.borderBase, lineWidth: 1)
+                .fill(VColor.surfaceOverlay)
         )
         .accessibilityElement(children: .contain)
         .accessibilityLabel(label)

--- a/clients/shared/DesignSystem/Components/Layout/VModal.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VModal.swift
@@ -57,20 +57,9 @@ public struct VModal<Content: View, Footer: View>: View {
 
     public var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            HStack(alignment: .top) {
+            HStack(alignment: .center) {
                 if let backAction {
-                    Button(action: backAction) {
-                        HStack(spacing: VSpacing.xs) {
-                            VIconView(.chevronLeft, size: 10)
-                            Text("Back")
-                                .font(VFont.bodyMediumDefault)
-                        }
-                        .foregroundStyle(VColor.contentSecondary)
-                        .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .pointerCursor()
-                    .accessibilityLabel("Back")
+                    VButton(label: "Back", leftIcon: VIcon.chevronLeft.rawValue, style: .ghost, tintColor: VColor.contentSecondary, action: backAction)
                 } else {
                     titleArea
                 }
@@ -78,43 +67,30 @@ public struct VModal<Content: View, Footer: View>: View {
                 Spacer(minLength: 0)
 
                 if let closeAction {
-                    Button(action: closeAction) {
-                        VIconView(.x, size: 12)
-                            .foregroundStyle(VColor.contentTertiary)
-                            .frame(width: 32, height: 32)
-                            .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .pointerCursor()
-                    .accessibilityLabel("Close")
-                    .padding(.top, -VSpacing.sm)
-                    .padding(.trailing, -VSpacing.sm)
+                    VButton(label: "Close", iconOnly: VIcon.x.rawValue, style: .ghost, tintColor: VColor.contentTertiary, action: closeAction)
                 }
             }
-            .padding(.horizontal, VSpacing.xl)
-            .padding(.top, VSpacing.xl)
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.top, VSpacing.lg)
             .padding(.bottom, VSpacing.lg)
 
             ScrollView {
                 content()
-                    .padding(.horizontal, VSpacing.xl)
-                    .padding(.vertical, VSpacing.xs)
+                    .padding(.horizontal, VSpacing.lg)
                     .frame(maxWidth: .infinity, alignment: .top)
             }
 
             if Footer.self != EmptyView.self {
                 footer()
-                    .padding(.horizontal, VSpacing.xl)
+                    .padding(.horizontal, VSpacing.lg)
                     .padding(.vertical, VSpacing.lg)
             }
         }
         .frame(maxHeight: screenMaxHeight)
         .background(VColor.surfaceLift)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .stroke(VColor.borderBase, lineWidth: 1)
-        )
+        .vShadow(VShadow.modalNear)
+        .vShadow(VShadow.modalFar)
     }
 
     @ViewBuilder

--- a/clients/shared/DesignSystem/Core/Navigation/VNavItem.swift
+++ b/clients/shared/DesignSystem/Core/Navigation/VNavItem.swift
@@ -19,6 +19,7 @@ import SwiftUI
 public struct VNavItem<Trailing: View>: View {
     public let icon: String?
     public let label: String
+    public var subtitle: String?
     public var isActive: Bool
     public var isExpanded: Bool
     public let action: () -> Void
@@ -32,6 +33,7 @@ public struct VNavItem<Trailing: View>: View {
     public init(
         icon: String? = nil,
         label: String,
+        subtitle: String? = nil,
         isActive: Bool = false,
         isExpanded: Bool = true,
         action: @escaping () -> Void,
@@ -39,6 +41,7 @@ public struct VNavItem<Trailing: View>: View {
     ) {
         self.icon = icon
         self.label = label
+        self.subtitle = subtitle
         self.isActive = isActive
         self.isExpanded = isExpanded
         self.action = action
@@ -60,15 +63,24 @@ public struct VNavItem<Trailing: View>: View {
                     .foregroundStyle(iconColor)
                     .frame(width: Self.iconSlotSize, height: Self.iconSlotSize)
             }
-            Text(label)
-                .font(VFont.bodyMediumDefault)
-                .foregroundStyle(textColor)
-                .lineLimit(1)
-                .truncationMode(.tail)
-                .frame(width: isExpanded ? nil : 0, alignment: .leading)
-                .clipped()
-                .opacity(isExpanded ? 1 : 0)
-                .allowsHitTesting(false)
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                Text(label)
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(textColor)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                if let subtitle, isExpanded {
+                    Text(subtitle)
+                        .font(VFont.bodySmallDefault)
+                        .foregroundStyle(VColor.contentTertiary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+            }
+            .frame(width: isExpanded ? nil : 0, alignment: .leading)
+            .clipped()
+            .opacity(isExpanded ? 1 : 0)
+            .allowsHitTesting(false)
             if isExpanded {
                 Spacer()
                 trailing
@@ -101,11 +113,12 @@ public extension VNavItem where Trailing == EmptyView {
     init(
         icon: String? = nil,
         label: String,
+        subtitle: String? = nil,
         isActive: Bool = false,
         isExpanded: Bool = true,
         action: @escaping () -> Void
     ) {
-        self.init(icon: icon, label: label, isActive: isActive, isExpanded: isExpanded, action: action) {
+        self.init(icon: icon, label: label, subtitle: subtitle, isActive: isActive, isExpanded: isExpanded, action: action) {
             EmptyView()
         }
     }
@@ -116,6 +129,7 @@ public extension VNavItem where Trailing == VNavItemTrailingIcon {
     init(
         icon: String? = nil,
         label: String,
+        subtitle: String? = nil,
         isActive: Bool = false,
         trailingIcon: String,
         trailingIconRotation: Angle = .zero,
@@ -123,7 +137,7 @@ public extension VNavItem where Trailing == VNavItemTrailingIcon {
         action: @escaping () -> Void
     ) {
         let active = isActive
-        self.init(icon: icon, label: label, isActive: isActive, isExpanded: isExpanded, action: action) {
+        self.init(icon: icon, label: label, subtitle: subtitle, isActive: isActive, isExpanded: isExpanded, action: action) {
             VNavItemTrailingIcon(
                 icon: trailingIcon,
                 rotation: trailingIconRotation,

--- a/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
@@ -125,6 +125,15 @@ struct NavigationGallerySection: View {
 
                 VCard {
                     VStack(alignment: .leading, spacing: VSpacing.sm) {
+                        Text("With Subtitle").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
+
+                        VNavItem(icon: VIcon.wrench.rawValue, label: "Build a Character", subtitle: "Build your own character") {}
+                        VNavItem(icon: VIcon.image.rawValue, label: "Upload Image", subtitle: "Choose an image from your Mac") {}
+                    }
+                }
+
+                VCard {
+                    VStack(alignment: .leading, spacing: VSpacing.sm) {
                         Text("Without Icon").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
 
                         VNavItem(label: "Overview", isActive: false) {}

--- a/clients/shared/DesignSystem/Tokens/ShadowTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ShadowTokens.swift
@@ -25,6 +25,10 @@ public enum VShadow {
 
     /// Forest glow for accent elements (focused inputs, active buttons)
     public static let accentGlow = Definition(color: VColor.primaryActive.opacity(0.3), radius: 8, x: 0, y: 0)
+
+    /// Modal shadow — dual-layer: subtle near shadow + soft spread
+    public static let modalNear = Definition(color: VColor.auxBlack.opacity(0.1), radius: 1.5, x: 0, y: 1)
+    public static let modalFar  = Definition(color: VColor.auxBlack.opacity(0.1), radius: 6, x: 0, y: 4)
 }
 
 public extension View {


### PR DESCRIPTION
## Summary
- Add optional `subtitle` to VNavItem (bodySmallDefault, contentTertiary)
- VModal: remove border, add modal shadow tokens, use VButton for back/close, center-align header
- Avatar sheet: use VNavItem with subtitles instead of custom actionRow, remove dividers, right-align footer, surfaceOverlay carousel backgrounds
- Add modal shadow tokens (modalNear/modalFar) to VShadow
- Add "With Subtitle" examples to VNavItem gallery

## Test plan
- [ ] Avatar sheet uses VNavItem rows with subtitles and chevrons
- [ ] Modal has box shadow, no border, aligned header
- [ ] Component gallery shows VNavItem subtitle examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22303" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
