### PR TITLE
feat: create VFilterDropdown, migrate all filters to VMenu

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -15,7 +15,6 @@ struct AgentPanelContent: View {
     @State private var skillsManager: SkillsManager
     @State private var selectedInstalledSkillId: String?
     @State private var skillToDelete: SkillInfo?
-    @State private var showSkillFilterPopover = false
     @AppStorage("skillsBannerDismissed") private var bannerDismissed = false
 
     init(onInvokeSkill: ((SkillInfo) -> Void)? = nil, onCreateSkill: (() -> Void)? = nil, onSkillsChanged: (() -> Void)? = nil, connectionManager: GatewayConnectionManager, focusedSkillId: Binding<String?> = .constant(nil)) {
@@ -127,63 +126,11 @@ struct AgentPanelContent: View {
     private var filterBar: some View {
         HStack(spacing: VSpacing.sm) {
             VSearchBar(placeholder: "Search Skills", text: $skillsManager.searchQuery)
-            skillFilterDropdown
-                .frame(width: 130)
-        }
-    }
-
-    private var skillFilterDropdown: some View {
-        Button {
-            showSkillFilterPopover.toggle()
-        } label: {
-            HStack(spacing: VSpacing.md) {
-                Text(skillsManager.skillFilter.rawValue)
-                    .foregroundStyle(VColor.contentDefault)
-                    .font(VFont.bodyMediumLighter)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                VIconView(.chevronDown, size: 13)
-                    .foregroundStyle(VColor.contentTertiary)
-                    .accessibilityHidden(true)
-            }
-            .padding(.horizontal, VSpacing.sm)
-            .padding(.vertical, VSpacing.xs)
-            .frame(height: 32)
-            .vInputChrome()
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel("Skill filter: \(skillsManager.skillFilter.rawValue)")
-        .popover(isPresented: $showSkillFilterPopover, arrowEdge: .bottom) {
-            VStack(alignment: .leading, spacing: 0) {
-                ForEach(SkillFilter.allCases, id: \.self) { filter in
-                    Button {
-                        withAnimation(VAnimation.fast) { skillsManager.skillFilter = filter }
-                        showSkillFilterPopover = false
-                    } label: {
-                        HStack(spacing: VSpacing.sm) {
-                            VIconView(filter.icon, size: 14)
-                                .foregroundStyle(VColor.contentDefault)
-                                .frame(width: 20)
-                            Text(filter.rawValue)
-                                .font(VFont.bodyMediumLighter)
-                                .foregroundStyle(VColor.contentDefault)
-                            Spacer()
-                            if skillsManager.skillFilter == filter {
-                                VIconView(.check, size: 12)
-                                    .foregroundStyle(VColor.primaryBase)
-                            }
-                        }
-                        .padding(.horizontal, VSpacing.md)
-                        .padding(.vertical, VSpacing.sm)
-                        .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("\(filter.rawValue) skills")
-                    .accessibilityAddTraits(skillsManager.skillFilter == filter ? .isSelected : [])
-                }
-            }
-            .padding(.vertical, VSpacing.sm)
-            .frame(width: 180)
+            VFilterDropdown(
+                options: SkillFilter.allCases.map { VFilterOption(label: $0.rawValue, value: $0, icon: $0.icon) },
+                selection: $skillsManager.skillFilter,
+                width: 130
+            )
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -72,8 +72,6 @@ struct MemoriesPanel: View {
     @State private var statusFilter: MemoryStatusFilter = .active
     @State private var sortOption: MemorySortOption = .newest
     @State private var searchDebounceTask: Task<Void, Never>?
-    @State private var showStatusFilterPopover = false
-    @State private var showSortPopover = false
 
     init(connectionManager: GatewayConnectionManager, focusedMemoryId: Binding<String?> = .constant(nil)) {
         self.connectionManager = connectionManager
@@ -138,11 +136,26 @@ struct MemoriesPanel: View {
                     }
                 }
 
-            statusFilterDropdown
-                .frame(width: 158)
+            VFilterDropdown(
+                options: MemoryStatusFilter.allCases.map { VFilterOption(label: $0.rawValue, value: $0, icon: $0.icon) },
+                selection: $statusFilter,
+                width: 158,
+                onChange: { newStatus in
+                    store.statusFilter = newStatus.apiValue
+                    Task { await store.loadItems() }
+                }
+            )
 
-            sortFilterDropdown
-                .frame(width: 158)
+            VFilterDropdown(
+                options: MemorySortOption.allCases.map { VFilterOption(label: $0.rawValue, value: $0, icon: $0.icon) },
+                selection: $sortOption,
+                width: 158,
+                onChange: { newSort in
+                    store.sortField = newSort.sortField
+                    store.sortOrder = newSort.sortOrder
+                    Task { await store.loadItems() }
+                }
+            )
 
             VButton(label: "New", icon: VIcon.plus.rawValue, style: .primary) {
                 showCreateSheet = true
@@ -191,124 +204,6 @@ struct MemoriesPanel: View {
         return store.items.filter { $0.kind == kind.rawValue }
     }
 
-    // MARK: - Status Filter Dropdown
-
-    private var statusFilterDropdown: some View {
-        Button {
-            showStatusFilterPopover.toggle()
-        } label: {
-            HStack(spacing: VSpacing.md) {
-                Text(statusFilter.rawValue)
-                    .foregroundStyle(VColor.contentDefault)
-                    .font(VFont.bodyMediumLighter)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                VIconView(.chevronDown, size: 13)
-                    .foregroundStyle(VColor.contentTertiary)
-                    .accessibilityHidden(true)
-            }
-            .padding(.horizontal, VSpacing.sm)
-            .padding(.vertical, VSpacing.xs)
-            .frame(height: 32)
-            .vInputChrome()
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel("Status filter: \(statusFilter.rawValue)")
-        .popover(isPresented: $showStatusFilterPopover, arrowEdge: .bottom) {
-            VStack(alignment: .leading, spacing: 0) {
-                ForEach(MemoryStatusFilter.allCases, id: \.self) { status in
-                    Button {
-                        statusFilter = status
-                        store.statusFilter = status.apiValue
-                        showStatusFilterPopover = false
-                        Task { await store.loadItems() }
-                    } label: {
-                        HStack(spacing: VSpacing.sm) {
-                            VIconView(status.icon, size: 14)
-                                .foregroundStyle(VColor.contentDefault)
-                                .frame(width: 20)
-                            Text(status.rawValue)
-                                .font(VFont.bodyMediumLighter)
-                                .foregroundStyle(VColor.contentDefault)
-                            Spacer()
-                            if statusFilter == status {
-                                VIconView(.check, size: 12)
-                                    .foregroundStyle(VColor.primaryBase)
-                            }
-                        }
-                        .padding(.horizontal, VSpacing.md)
-                        .padding(.vertical, VSpacing.sm)
-                        .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("\(status.rawValue) status")
-                    .accessibilityAddTraits(statusFilter == status ? .isSelected : [])
-                }
-            }
-            .padding(.vertical, VSpacing.sm)
-            .frame(width: 180)
-        }
-    }
-
-    // MARK: - Sort Filter Dropdown
-
-    private var sortFilterDropdown: some View {
-        Button {
-            showSortPopover.toggle()
-        } label: {
-            HStack(spacing: VSpacing.md) {
-                Text(sortOption.rawValue)
-                    .foregroundStyle(VColor.contentDefault)
-                    .font(VFont.bodyMediumLighter)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                VIconView(.chevronDown, size: 13)
-                    .foregroundStyle(VColor.contentTertiary)
-                    .accessibilityHidden(true)
-            }
-            .padding(.horizontal, VSpacing.sm)
-            .padding(.vertical, VSpacing.xs)
-            .frame(height: 32)
-            .vInputChrome()
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel("Sort by: \(sortOption.rawValue)")
-        .popover(isPresented: $showSortPopover, arrowEdge: .bottom) {
-            VStack(alignment: .leading, spacing: 0) {
-                ForEach(MemorySortOption.allCases, id: \.self) { option in
-                    Button {
-                        sortOption = option
-                        store.sortField = option.sortField
-                        store.sortOrder = option.sortOrder
-                        showSortPopover = false
-                        Task { await store.loadItems() }
-                    } label: {
-                        HStack(spacing: VSpacing.sm) {
-                            VIconView(option.icon, size: 14)
-                                .foregroundStyle(VColor.contentDefault)
-                                .frame(width: 20)
-                            Text(option.rawValue)
-                                .font(VFont.bodyMediumLighter)
-                                .foregroundStyle(VColor.contentDefault)
-                            Spacer()
-                            if sortOption == option {
-                                VIconView(.check, size: 12)
-                                    .foregroundStyle(VColor.primaryBase)
-                            }
-                        }
-                        .padding(.horizontal, VSpacing.md)
-                        .padding(.vertical, VSpacing.sm)
-                        .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Sort by \(option.rawValue)")
-                    .accessibilityAddTraits(sortOption == option ? .isSelected : [])
-                }
-            }
-            .padding(.vertical, VSpacing.sm)
-            .frame(width: 200)
-        }
-    }
 
     // MARK: - Content View
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -7,7 +7,6 @@ struct UsageDashboardPanel: View {
 
     @State private var refreshTask: Task<Void, Never>?
     @State private var breakdownTask: Task<Void, Never>?
-    @State private var showTimeRangePopover = false
 
     private var allFailed: Bool {
         store.totalsState.isFailed && store.dailyState.isFailed && store.breakdownState.isFailed
@@ -72,61 +71,20 @@ struct UsageDashboardPanel: View {
     @ViewBuilder
     private func timeRangeStrip(store: UsageDashboardStore) -> some View {
         HStack {
-            timeRangeDropdown(store: store)
-                .frame(width: 150)
-            Spacer()
-        }
-    }
-
-    private func timeRangeDropdown(store: UsageDashboardStore) -> some View {
-        Button {
-            showTimeRangePopover.toggle()
-        } label: {
-            HStack(spacing: VSpacing.md) {
-                Text(store.selectedRange.rawValue)
-                    .foregroundStyle(VColor.contentDefault)
-                    .font(VFont.bodyMediumLighter)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                VIconView(.chevronDown, size: 13)
-                    .foregroundStyle(VColor.contentTertiary)
-                    .accessibilityHidden(true)
-            }
-            .padding(.horizontal, VSpacing.sm)
-            .padding(.vertical, VSpacing.xs)
-            .frame(height: 32)
-            .vInputChrome()
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel("Time range: \(store.selectedRange.rawValue)")
-        .popover(isPresented: $showTimeRangePopover, arrowEdge: .bottom) {
-            VStack(alignment: .leading, spacing: 0) {
-                ForEach(UsageTimeRange.allCases, id: \.self) { range in
-                    Button {
-                        refreshTask?.cancel()
-                        breakdownTask?.cancel()
-                        refreshTask = Task { await store.selectRange(range) }
-                        showTimeRangePopover = false
-                    } label: {
-                        HStack(spacing: VSpacing.sm) {
-                            Text(range.rawValue)
-                                .font(VFont.bodyMediumLighter)
-                                .foregroundStyle(VColor.contentDefault)
-                            Spacer()
-                            if store.selectedRange == range {
-                                VIconView(.check, size: 12)
-                                    .foregroundStyle(VColor.primaryBase)
-                            }
-                        }
-                        .padding(.horizontal, VSpacing.md)
-                        .padding(.vertical, VSpacing.sm)
-                        .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
+            VFilterDropdown(
+                options: UsageTimeRange.allCases.map { VFilterOption(label: $0.rawValue, value: $0) },
+                selection: Binding(
+                    get: { store.selectedRange },
+                    set: { _ in }
+                ),
+                width: 150,
+                onChange: { newRange in
+                    refreshTask?.cancel()
+                    breakdownTask?.cancel()
+                    refreshTask = Task { await store.selectRange(newRange) }
                 }
-            }
-            .padding(.vertical, VSpacing.sm)
-            .frame(width: 180)
+            )
+            Spacer()
         }
     }
 

--- a/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
@@ -43,7 +43,7 @@ public struct VMenu<Content: View>: View {
     }
 
     public var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
             content
         }
         .padding(VSpacing.sm)

--- a/clients/shared/DesignSystem/Core/Inputs/VFilterDropdown.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VFilterDropdown.swift
@@ -1,0 +1,151 @@
+#if os(macOS)
+import SwiftUI
+import AppKit
+
+/// Reusable filter dropdown that shows a VMenu via VMenuPanel.
+///
+/// Renders a trigger button with label + chevron using `.vInputChrome(isFocused:)`
+/// and shows a VMenu below the trigger on click. The trigger shows a focus-style
+/// border while the menu is open.
+///
+/// Usage:
+/// ```swift
+/// VFilterDropdown(
+///     options: [
+///         VFilterOption(label: "All", value: .all, icon: .circle),
+///         VFilterOption(label: "Installed", value: .installed, icon: .circleCheck),
+///     ],
+///     selection: $filter
+/// )
+/// ```
+public struct VFilterOption<T: Hashable>: Identifiable {
+    public let label: String
+    public let value: T
+    public let icon: VIcon?
+
+    public var id: String { label }
+
+    public init(label: String, value: T, icon: VIcon? = nil) {
+        self.label = label
+        self.value = value
+        self.icon = icon
+    }
+}
+
+public struct VFilterDropdown<T: Hashable>: View {
+    public let options: [VFilterOption<T>]
+    @Binding public var selection: T
+    public var width: CGFloat = 150
+    public var menuWidth: CGFloat = 180
+    public var onChange: ((T) -> Void)?
+
+    @State private var isOpen = false
+    @State private var activePanel: VMenuPanel?
+
+    public init(
+        options: [VFilterOption<T>],
+        selection: Binding<T>,
+        width: CGFloat = 150,
+        menuWidth: CGFloat = 180,
+        onChange: ((T) -> Void)? = nil
+    ) {
+        self.options = options
+        self._selection = selection
+        self.width = width
+        self.menuWidth = menuWidth
+        self.onChange = onChange
+    }
+
+    private var selectedLabel: String {
+        options.first { $0.value == selection }?.label ?? ""
+    }
+
+    public var body: some View {
+        Button {
+            if isOpen {
+                activePanel?.close()
+                activePanel = nil
+                isOpen = false
+            } else {
+                showMenu()
+            }
+        } label: {
+            HStack(spacing: VSpacing.md) {
+                Text(selectedLabel)
+                    .foregroundStyle(VColor.contentDefault)
+                    .font(VFont.bodyMediumLighter)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                VIconView(.chevronDown, size: 13)
+                    .foregroundStyle(VColor.contentTertiary)
+                    .accessibilityHidden(true)
+            }
+            .padding(.horizontal, VSpacing.sm)
+            .frame(height: 32)
+            .vInputChrome(isFocused: isOpen)
+        }
+        .buttonStyle(.plain)
+        .frame(width: width)
+        .accessibilityLabel("Filter: \(selectedLabel)")
+        .overlay {
+            GeometryReader { geo in
+                Color.clear
+                    .onAppear { triggerFrame = geo.frame(in: .global) }
+                    .onChange(of: geo.frame(in: .global)) { _, newFrame in
+                        triggerFrame = newFrame
+                    }
+            }
+        }
+    }
+
+    @State private var triggerFrame: CGRect = .zero
+
+    private func showMenu() {
+        guard !isOpen else { return }
+        isOpen = true
+
+        // Resign first responder so text inputs lose focus
+        NSApp.keyWindow?.makeFirstResponder(nil)
+
+        guard let window = NSApp.keyWindow ?? NSApp.windows.first(where: { $0.isVisible }) else {
+            isOpen = false
+            return
+        }
+
+        // Convert trigger frame to screen coordinates — position menu at bottom-left of trigger
+        let triggerInWindow = CGPoint(
+            x: triggerFrame.minX,
+            y: triggerFrame.maxY
+        )
+        let screenPoint = window.convertPoint(toScreen: NSPoint(
+            x: triggerInWindow.x,
+            y: window.frame.height - triggerInWindow.y
+        ))
+
+        let appearance = window.effectiveAppearance
+        activePanel = VMenuPanel.show(at: screenPoint, sourceAppearance: appearance) {
+            VMenu(width: menuWidth) {
+                ForEach(options) { option in
+                    VMenuItem(
+                        icon: option.icon?.rawValue,
+                        label: option.label,
+                        isActive: selection == option.value,
+                        size: .regular
+                    ) {
+                        withAnimation(VAnimation.fast) { selection = option.value }
+                        onChange?(option.value)
+                    } trailing: {
+                        if selection == option.value {
+                            VIconView(.check, size: 12)
+                                .foregroundStyle(VColor.primaryBase)
+                        }
+                    }
+                }
+            }
+        } onDismiss: {
+            isOpen = false
+            activePanel = nil
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Create `VFilterDropdown` component: trigger button with `.vInputChrome` focus state + `VMenuPanel` dropdown
- Migrate Skills (All/Installed), Memories (status + sort), and Usage (time range) filters
- Add xs spacing between VMenu items
- Toggle-to-close: clicking filter while menu is open closes it
- Resign text input focus when filter is clicked

## Test plan
- [ ] Skills filter opens VMenu, selects correctly, closes on click outside/escape/re-click
- [ ] Memories status and sort filters work the same way
- [ ] Usage time range filter works the same way
- [ ] Clicking filter while search is focused removes search focus
- [ ] Menu items have xs spacing between them

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
