### PR TITLE
fix: wrap attachment image grid to prevent wide message bubbles

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -72,7 +72,7 @@ private struct InlineToolCallImageView: View {
 
 // MARK: - Attachment Image Grid (async)
 
-/// Renders image attachments in a horizontal grid.
+/// Renders image attachments in a wrapping grid.
 ///
 /// NSImage(data:) must never be called during SwiftUI view body evaluation or
 /// layout measurement — doing so triggers re-entrant AppKit constraint
@@ -100,19 +100,22 @@ private struct AttachmentImageGrid<Fallback: View>: View {
     /// Single images render at full width; multiple images use a compact grid.
     private var isSingleImage: Bool { imageAttachments.count == 1 }
 
+    private static let gridColumns = [
+        GridItem(.adaptive(minimum: 160, maximum: 160), spacing: VSpacing.sm)
+    ]
+
     @available(macOS, deprecated: 13.0)
     var body: some View {
-        HStack(spacing: VSpacing.sm) {
-            ForEach(imageAttachments, id: \.id) { attachment in
-                Group {
-                    if let nsImage = loadedImages[attachment.id] {
-                        Group {
-                            if isSingleImage {
-                                singleImageContent(nsImage)
-                            } else {
-                                gridImageContent(nsImage)
-                            }
+        let content = ForEach(imageAttachments, id: \.id) { attachment in
+            Group {
+                if let nsImage = loadedImages[attachment.id] {
+                    Group {
+                        if isSingleImage {
+                            singleImageContent(nsImage)
+                        } else {
+                            gridImageContent(nsImage)
                         }
+                    }
                         .onTapGesture {
                             onTap(attachment, nsImage)
                         }
@@ -251,6 +254,14 @@ private struct AttachmentImageGrid<Fallback: View>: View {
                     // placeholder instead of showing the filename/download affordance.
                     failedIds.insert(attachment.id)
                 }
+            }
+        }
+
+        if isSingleImage {
+            content
+        } else {
+            LazyVGrid(columns: Self.gridColumns, alignment: .leading, spacing: VSpacing.sm) {
+                content
             }
         }
     }


### PR DESCRIPTION
## Summary
- Replace the horizontal `HStack` in `AttachmentImageGrid` with a `LazyVGrid` using adaptive 160pt columns
- Multi-image attachments now wrap into rows that respect the bubble's max width instead of stretching infinitely wide
- Single-image rendering is unchanged (still uses full-width layout)

## Original prompt
the user messages are too wide sometimes - I think it's when they have a lot of attachments. The screenshot shows a message with ~9 image thumbnails in a horizontal row that's stretching the message bubble too wide. Need to constrain the max width of user message bubbles or make the attachment grid wrap.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
