### PR TITLE
feat: show hourly usage trend when viewing Today

### DIFF
--- a/assistant/src/memory/llm-usage-store.ts
+++ b/assistant/src/memory/llm-usage-store.ts
@@ -148,9 +148,11 @@ export interface UsageTotals {
   unpricedEventCount: number;
 }
 
-/** A single day bucket with its aggregate totals. */
+export type UsageGranularity = "daily" | "hourly";
+
+/** A single time bucket with its aggregate totals. */
 export interface UsageDayBucket {
-  /** ISO date string (YYYY-MM-DD) in UTC. */
+  /** ISO date string: "YYYY-MM-DD" (daily) or "YYYY-MM-DD HH:00" (hourly), UTC. */
   date: string;
   /** Direct input tokens only; cache traffic is tracked separately in totals. */
   totalInputTokens: number;
@@ -251,6 +253,37 @@ export function getUsageDayBuckets(range: UsageTimeRange): UsageDayBucket[] {
       COALESCE(SUM(output_tokens), 0)                        AS total_output_tokens,
       COALESCE(SUM(estimated_cost_usd), 0)                   AS total_estimated_cost_usd,
       COALESCE(SUM(COALESCE(llm_call_count, 1)), 0)          AS event_count
+    FROM llm_usage_events
+    WHERE created_at >= ?1 AND created_at <= ?2
+    GROUP BY date
+    ORDER BY date ASC
+    `,
+    range.from,
+    range.to,
+  );
+  return rows.map((r) => ({
+    date: r.date,
+    totalInputTokens: r.total_input_tokens,
+    totalOutputTokens: r.total_output_tokens,
+    totalEstimatedCostUsd: r.total_estimated_cost_usd ?? 0,
+    eventCount: r.event_count,
+  }));
+}
+
+/**
+ * Return per-hour aggregates (UTC) within the given time range, ordered ascending.
+ *
+ * Each bucket key is a "YYYY-MM-DD HH:00" string.
+ */
+export function getUsageHourBuckets(range: UsageTimeRange): UsageDayBucket[] {
+  const rows = rawAll<DayBucketRow>(
+    /*sql*/ `
+    SELECT
+      strftime('%Y-%m-%d %H:00', created_at / 1000, 'unixepoch')  AS date,
+      COALESCE(SUM(input_tokens), 0)                               AS total_input_tokens,
+      COALESCE(SUM(output_tokens), 0)                              AS total_output_tokens,
+      COALESCE(SUM(estimated_cost_usd), 0)                         AS total_estimated_cost_usd,
+      COALESCE(SUM(COALESCE(llm_call_count, 1)), 0)                AS event_count
     FROM llm_usage_events
     WHERE created_at >= ?1 AND created_at <= ?2
     GROUP BY date

--- a/assistant/src/runtime/routes/usage-routes.ts
+++ b/assistant/src/runtime/routes/usage-routes.ts
@@ -11,6 +11,7 @@ import { z } from "zod";
 import {
   getUsageDayBuckets,
   getUsageGroupBreakdown,
+  getUsageHourBuckets,
   getUsageTotals,
 } from "../../memory/llm-usage-store.js";
 import { httpError } from "../http-errors.js";
@@ -104,14 +105,23 @@ export function usageRouteDefinitions(): RouteDefinition[] {
           schema: { type: "integer" },
           description: "End epoch millis (required)",
         },
+        {
+          name: "granularity",
+          schema: { type: "string", enum: ["daily", "hourly"] },
+          description: 'Bucket granularity: "daily" (default) or "hourly"',
+        },
       ],
       responseBody: z.object({
-        buckets: z.array(z.unknown()).describe("Daily usage bucket objects"),
+        buckets: z.array(z.unknown()).describe("Usage bucket objects"),
       }),
       handler: ({ url }) => {
         const range = parseTimeRange(url);
         if (range instanceof Response) return range;
-        const buckets = getUsageDayBuckets(range);
+        const granularity = url.searchParams.get("granularity");
+        const buckets =
+          granularity === "hourly"
+            ? getUsageHourBuckets(range)
+            : getUsageDayBuckets(range);
         return Response.json({ buckets });
       },
     },

--- a/clients/ios/Tests/UsageDashboardViewTests.swift
+++ b/clients/ios/Tests/UsageDashboardViewTests.swift
@@ -208,7 +208,7 @@ final class UsageDashboardViewTests: XCTestCase {
 @MainActor
 private final class NilUsageClient: UsageClientProtocol {
     func fetchUsageTotals(from: Int, to: Int) async -> UsageTotalsResponse? { nil }
-    func fetchUsageDaily(from: Int, to: Int) async -> UsageDailyResponse? { nil }
+    func fetchUsageDaily(from: Int, to: Int, granularity: String) async -> UsageDailyResponse? { nil }
     func fetchUsageBreakdown(from: Int, to: Int, groupBy: String) async -> UsageBreakdownResponse? { nil }
 }
 
@@ -228,7 +228,7 @@ private final class StubUsageClient: UsageClientProtocol {
         )
     }
 
-    func fetchUsageDaily(from: Int, to: Int) async -> UsageDailyResponse? {
+    func fetchUsageDaily(from: Int, to: Int, granularity: String) async -> UsageDailyResponse? {
         UsageDailyResponse(buckets: [
             UsageDayBucket(date: "2026-03-04", totalInputTokens: 600, totalOutputTokens: 300, totalEstimatedCostUsd: 0.0025, eventCount: 2),
             UsageDayBucket(date: "2026-03-05", totalInputTokens: 400, totalOutputTokens: 200, totalEstimatedCostUsd: 0.0017, eventCount: 1),

--- a/clients/ios/Views/UsageDashboardView.swift
+++ b/clients/ios/Views/UsageDashboardView.swift
@@ -79,11 +79,12 @@ struct UsageDashboardView: View {
         }
     }
 
-    // MARK: - Daily Trend
+    // MARK: - Trend
 
     @ViewBuilder
     private var dailyTrendSection: some View {
-        Section("Daily Trend") {
+        let isHourly = store.isHourlyGranularity
+        Section(isHourly ? "Hourly Trend" : "Daily Trend") {
             switch store.dailyState {
             case .idle, .loading:
                 HStack {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -139,11 +139,12 @@ struct UsageDashboardPanel: View {
         }
     }
 
-    // MARK: - Daily Trend Section
+    // MARK: - Trend Section
 
     @ViewBuilder
     func dailySection(store: UsageDashboardStore) -> some View {
-        SettingsCard(title: "Daily Trend") {
+        let isHourly = store.isHourlyGranularity
+        SettingsCard(title: isHourly ? "Hourly Trend" : "Daily Trend") {
             switch store.dailyState {
             case .idle, .loading:
                 // Skeleton matching bar chart layout
@@ -160,12 +161,12 @@ struct UsageDashboardPanel: View {
             case .loaded(let daily):
                 if daily.buckets.isEmpty {
                     VEmptyState(
-                        title: "No daily data",
+                        title: isHourly ? "No hourly data" : "No daily data",
                         subtitle: "No usage recorded in this time range",
                         icon: "calendar"
                     )
                 } else {
-                    dailyBarChart(daily.buckets)
+                    trendBarChart(daily.buckets, isHourly: isHourly)
                 }
             case .failed(let message):
                 errorRow(message) { refreshTask?.cancel(); refreshTask = Task { await store.refresh() } }
@@ -175,11 +176,13 @@ struct UsageDashboardPanel: View {
 
     private let barChartHeight: CGFloat = 140
     private let maxBarWidth: CGFloat = 40
+    private let hourlyBarWidth: CGFloat = 28
 
     @ViewBuilder
-    private func dailyBarChart(_ buckets: [UsageDayBucket]) -> some View {
+    private func trendBarChart(_ buckets: [UsageDayBucket], isHourly: Bool) -> some View {
         let sorted = buckets.sorted { $0.date < $1.date }
         let maxCost = buckets.map(\.totalEstimatedCostUsd).max() ?? 1.0
+        let barWidth = isHourly ? hourlyBarWidth : maxBarWidth
 
         ScrollView(.horizontal, showsIndicators: false) {
             VStack(alignment: .leading, spacing: VSpacing.xs) {
@@ -191,24 +194,24 @@ struct UsageDashboardPanel: View {
                             Spacer(minLength: 0)
                             RoundedRectangle(cornerRadius: VRadius.xs)
                                 .fill(VColor.systemPositiveStrong)
-                                .frame(width: maxBarWidth, height: max(2, barChartHeight * fraction))
+                                .frame(width: barWidth, height: max(2, barChartHeight * fraction))
                         }
                     }
                 }
                 .frame(height: barChartHeight)
 
-                // Cost + date labels — left-aligned
+                // Cost + date/time labels — left-aligned
                 HStack(alignment: .top, spacing: VSpacing.xs) {
                     ForEach(sorted, id: \.date) { bucket in
                         VStack(spacing: VSpacing.xxs) {
                             Text(formatCost(bucket.totalEstimatedCostUsd))
                                 .font(VFont.labelSmall)
                                 .foregroundStyle(VColor.contentSecondary)
-                            Text(formatShortDate(bucket.date))
+                            Text(formatBucketLabel(bucket.date, isHourly: isHourly))
                                 .font(VFont.labelSmall)
                                 .foregroundStyle(VColor.contentTertiary)
                         }
-                        .frame(width: maxBarWidth)
+                        .frame(width: barWidth)
                         .lineLimit(1)
                     }
                 }
@@ -225,7 +228,7 @@ struct UsageDashboardPanel: View {
         return f
     }()
 
-    private static let isoParser: DateFormatter = {
+    private static let isoDateParser: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "yyyy-MM-dd"
         f.locale = Locale(identifier: "en_US_POSIX")
@@ -233,10 +236,29 @@ struct UsageDashboardPanel: View {
         return f
     }()
 
-    /// Formats a date string (e.g. "2026-03-15") to a short label (e.g. "Mar 15").
-    private func formatShortDate(_ dateString: String) -> String {
-        guard let date = Self.isoParser.date(from: dateString) else { return dateString }
-        return Self.shortDateFormatter.string(from: date)
+    private static let isoHourParser: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd HH:mm"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(identifier: "UTC")!
+        return f
+    }()
+
+    private static let shortHourFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "ha"
+        f.timeZone = TimeZone(identifier: "UTC")!
+        return f
+    }()
+
+    private func formatBucketLabel(_ dateString: String, isHourly: Bool) -> String {
+        if isHourly {
+            guard let date = Self.isoHourParser.date(from: dateString) else { return dateString }
+            return Self.shortHourFormatter.string(from: date).lowercased()
+        } else {
+            guard let date = Self.isoDateParser.date(from: dateString) else { return dateString }
+            return Self.shortDateFormatter.string(from: date)
+        }
     }
 
     // MARK: - Breakdown Section

--- a/clients/macos/vellum-assistantTests/UsageDashboardPanelTests.swift
+++ b/clients/macos/vellum-assistantTests/UsageDashboardPanelTests.swift
@@ -484,7 +484,7 @@ private final class MockPanelClient: UsageClientProtocol {
         return stubbedTotals
     }
 
-    func fetchUsageDaily(from: Int, to: Int) async -> UsageDailyResponse? {
+    func fetchUsageDaily(from: Int, to: Int, granularity: String) async -> UsageDailyResponse? {
         lastDailyFrom = from
         return stubbedDaily
     }

--- a/clients/macos/vellum-assistantTests/UsageDashboardStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/UsageDashboardStoreTests.swift
@@ -24,7 +24,7 @@ private final class MockUsageClient: UsageClientProtocol {
         return stubbedTotals
     }
 
-    func fetchUsageDaily(from: Int, to: Int) async -> UsageDailyResponse? {
+    func fetchUsageDaily(from: Int, to: Int, granularity: String) async -> UsageDailyResponse? {
         lastDailyFrom = from
         lastDailyTo = to
         return stubbedDaily
@@ -362,7 +362,7 @@ private final class DelayedMockUsageClient: UsageClientProtocol {
         }
     }
 
-    func fetchUsageDaily(from: Int, to: Int) async -> UsageDailyResponse? {
+    func fetchUsageDaily(from: Int, to: Int, granularity: String) async -> UsageDailyResponse? {
         await withCheckedContinuation { continuation in
             dailyContinuations.append(continuation)
         }

--- a/clients/shared/Features/Usage/UsageDashboardStore.swift
+++ b/clients/shared/Features/Usage/UsageDashboardStore.swift
@@ -6,7 +6,7 @@ import Foundation
 @MainActor
 public protocol UsageClientProtocol {
     func fetchUsageTotals(from: Int, to: Int) async -> UsageTotalsResponse?
-    func fetchUsageDaily(from: Int, to: Int) async -> UsageDailyResponse?
+    func fetchUsageDaily(from: Int, to: Int, granularity: String) async -> UsageDailyResponse?
     func fetchUsageBreakdown(from: Int, to: Int, groupBy: String) async -> UsageBreakdownResponse?
 }
 
@@ -31,9 +31,9 @@ public struct UsageClient: UsageClientProtocol {
         return result?.0
     }
 
-    public func fetchUsageDaily(from: Int, to: Int) async -> UsageDailyResponse? {
+    public func fetchUsageDaily(from: Int, to: Int, granularity: String = "daily") async -> UsageDailyResponse? {
         let result: (UsageDailyResponse?, GatewayHTTPClient.Response)? = try? await GatewayHTTPClient.get(
-            path: "usage/daily?from=\(from)&to=\(to)", timeout: 10
+            path: "usage/daily?from=\(from)&to=\(to)&granularity=\(granularity)", timeout: 10
         )
         return result?.0
     }
@@ -163,6 +163,9 @@ public final class UsageDashboardStore {
     public var breakdownState: UsageLoadingState<UsageBreakdownResponse> = .idle
     public var selectedGroupBy: UsageGroupByDimension = .model
 
+    /// Whether the current daily data uses hourly granularity (true when range is "Today").
+    public var isHourlyGranularity: Bool { selectedRange == .today }
+
     // MARK: - Dependencies
 
     private var client: any UsageClientProtocol = UsageClient()
@@ -212,8 +215,9 @@ public final class UsageDashboardStore {
         dailyState = .loading
         breakdownState = .loading
 
+        let granularity = isHourlyGranularity ? "hourly" : "daily"
         async let totalsResult = client.fetchUsageTotals(from: range.from, to: range.to)
-        async let dailyResult = client.fetchUsageDaily(from: range.from, to: range.to)
+        async let dailyResult = client.fetchUsageDaily(from: range.from, to: range.to, granularity: granularity)
         async let breakdownResult = client.fetchUsageBreakdown(
             from: range.from, to: range.to, groupBy: selectedGroupBy.rawValue
         )


### PR DESCRIPTION
## Summary
- Backend: added `getUsageHourBuckets()` in `llm-usage-store.ts` that groups usage events by hour (UTC). The `/v1/usage/daily` endpoint now accepts an optional `granularity=hourly` query param.
- Swift clients: `UsageDashboardStore` passes `granularity=hourly` when the selected range is `.today`. The macOS bar chart shows compact hour labels (e.g. "2pm") and the section title changes to "Hourly Trend".
- iOS trend section title also updates dynamically.

## Original prompt
When I'm looking at the daily trend in this view, I want the graph to show the hour by hour usage
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
