### PR TITLE
fix: remove extraneous closing brace in AttachmentImageGrid

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -255,7 +255,6 @@ private struct AttachmentImageGrid<Fallback: View>: View {
                     failedIds.insert(attachment.id)
                 }
             }
-        }
 
         if isSingleImage {
             content


### PR DESCRIPTION
## Summary
- Removes a leftover `}` from the `HStack` wrapper that was deleted in #22314 but whose closing brace was not removed, causing a Swift compilation error (`extraneous '}' at top level`) that breaks the macOS build.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23756287104/job/69211804050
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
