### PR TITLE
fix: regenerate stale openapi.yaml

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6759,7 +6759,7 @@ paths:
                   buckets:
                     type: array
                     items: {}
-                    description: Daily usage bucket objects
+                    description: Usage bucket objects
                 required:
                   - buckets
                 additionalProperties: false
@@ -6776,6 +6776,15 @@ paths:
           schema:
             type: integer
           description: End epoch millis (required)
+        - name: granularity
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - daily
+              - hourly
+          description: 'Bucket granularity: "daily" (default) or "hourly"'
   /v1/usage/totals:
     get:
       operationId: usage_totals_get


### PR DESCRIPTION
## Summary
- Regenerate `openapi.yaml` to include the `granularity` query parameter added in #22315

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23756482168/job/69212447747
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22317" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
