### PR TITLE
fix: dismiss memory detail modal on outside click

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -106,12 +106,23 @@ struct MemoriesPanel: View {
             searchDebounceTask?.cancel()
             searchDebounceTask = nil
         }
-        .sheet(item: $selectedItem) { item in
-            MemoryItemDetailSheet(
-                item: item,
-                store: store,
-                onDismiss: { selectedItem = nil }
-            )
+        .overlay {
+            if let item = selectedItem {
+                ZStack {
+                    Color.black.opacity(0.4)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            withAnimation(VAnimation.fast) { selectedItem = nil }
+                        }
+                    MemoryItemDetailSheet(
+                        item: item,
+                        store: store,
+                        onDismiss: { withAnimation(VAnimation.fast) { selectedItem = nil } }
+                    )
+                }
+                .transition(.opacity)
+            }
         }
         .sheet(isPresented: $showCreateSheet) {
             MemoryItemCreateSheet(


### PR DESCRIPTION
## Summary
- Replace `.sheet(item:)` presentation with a custom overlay for the memory detail modal
- Clicking the semi-transparent backdrop behind the modal now dismisses it
- Animated transitions preserved via `withAnimation(VAnimation.fast)` and `.transition(.opacity)`

## Original prompt
clicking outside the modal should close it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
