### PR TITLE
fix: static stored property in generic AttachmentImageGrid

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -100,9 +100,9 @@ private struct AttachmentImageGrid<Fallback: View>: View {
     /// Single images render at full width; multiple images use a compact grid.
     private var isSingleImage: Bool { imageAttachments.count == 1 }
 
-    private static let gridColumns = [
-        GridItem(.adaptive(minimum: 160, maximum: 160), spacing: VSpacing.sm)
-    ]
+    private var gridColumns: [GridItem] {
+        [GridItem(.adaptive(minimum: 160, maximum: 160), spacing: VSpacing.sm)]
+    }
 
     @available(macOS, deprecated: 13.0)
     var body: some View {
@@ -259,7 +259,7 @@ private struct AttachmentImageGrid<Fallback: View>: View {
         if isSingleImage {
             content
         } else {
-            LazyVGrid(columns: Self.gridColumns, alignment: .leading, spacing: VSpacing.sm) {
+            LazyVGrid(columns: gridColumns, alignment: .leading, spacing: VSpacing.sm) {
                 content
             }
         }


### PR DESCRIPTION
## Summary
- Convert `gridColumns` from `static let` to a computed instance property in `AttachmentImageGrid<Fallback>` to fix Swift compiler error "static stored properties not supported in generic types"
- Update reference from `Self.gridColumns` to `gridColumns`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23756715932/job/69213280148
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
