### PR TITLE
fix: use VColor.auxBlack design token in MemoriesPanel overlay

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -109,7 +109,7 @@ struct MemoriesPanel: View {
         .overlay {
             if let item = selectedItem {
                 ZStack {
-                    Color.black.opacity(0.4)
+                    VColor.auxBlack.opacity(0.4)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                         .contentShape(Rectangle())
                         .onTapGesture {


### PR DESCRIPTION
## Summary
- Replace raw `Color.black.opacity(0.4)` with `VColor.auxBlack.opacity(0.4)` in MemoriesPanel's modal overlay scrim
- Fixes the design token guard CI failure (strict mode violation)

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23757120799/job/69214692482
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
