### PR TITLE
fix: trigger conversation starters regeneration from batch extraction

### DIFF
--- a/assistant/src/memory/job-handlers/batch-extraction.ts
+++ b/assistant/src/memory/job-handlers/batch-extraction.ts
@@ -31,6 +31,7 @@ import {
   VALID_KINDS,
   VALID_OVERRIDE_CONFIDENCES,
 } from "../items-extractor.js";
+import { maybeEnqueueConversationStartersJob } from "../conversation-starters-cadence.js";
 import { asString } from "../job-utils.js";
 import { enqueueMemoryJob, type MemoryJob } from "../jobs-store.js";
 import { extractTextFromStoredMessageContent } from "../message-content.js";
@@ -738,4 +739,15 @@ export async function batchExtractJob(job: MemoryJob): Promise<void> {
     },
     "Batch extraction completed",
   );
+
+  if (upserted > 0) {
+    try {
+      maybeEnqueueConversationStartersJob(scopeId);
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "Failed to check conversation starters cadence",
+      );
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- The `batch_extract` job handler replaced the older `extract_items` path for memory extraction but didn't carry over the call to `maybeEnqueueConversationStartersJob()`
- This meant conversation starters were never refreshed despite thousands of new memory items being created
- Added the cadence check at the end of `batchExtractJob` when items are upserted, matching the pattern in `items-extractor.ts`

## Original prompt
Ship the batch extraction conversation starters fix that's already staged in the working tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
