### PR TITLE
fix: sort imports in batch-extraction.ts

### DIFF
--- a/assistant/src/memory/job-handlers/batch-extraction.ts
+++ b/assistant/src/memory/job-handlers/batch-extraction.ts
@@ -16,6 +16,7 @@ import {
   setMemoryCheckpoint,
 } from "../checkpoints.js";
 import { getConversationMemoryScopeId } from "../conversation-crud.js";
+import { maybeEnqueueConversationStartersJob } from "../conversation-starters-cadence.js";
 import { getDb } from "../db.js";
 import { computeMemoryFingerprint } from "../fingerprint.js";
 import {
@@ -31,7 +32,6 @@ import {
   VALID_KINDS,
   VALID_OVERRIDE_CONFIDENCES,
 } from "../items-extractor.js";
-import { maybeEnqueueConversationStartersJob } from "../conversation-starters-cadence.js";
 import { asString } from "../job-utils.js";
 import { enqueueMemoryJob, type MemoryJob } from "../jobs-store.js";
 import { extractTextFromStoredMessageContent } from "../message-content.js";


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error in `batch-extraction.ts` by moving the `conversation-starters-cadence.js` import to its correct alphabetical position

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23757341825/job/69215448128
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
