### PR TITLE
fix: use server-side kind counts in memories panel sidebar

### DIFF
--- a/assistant/src/runtime/routes/memory-item-routes.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.ts
@@ -235,6 +235,34 @@ export async function handleListMemoryItems(url: URL): Promise<Response> {
 
   const db = getDb();
 
+  // ── Kind counts (shared across all code paths) ─────────────────────
+  // Respects status/search filters but NOT kind filter, so the sidebar
+  // can show totals for every kind simultaneously.
+  const kindCountConditions = [];
+  if (statusParam && statusParam !== "all") {
+    kindCountConditions.push(eq(memoryItems.status, statusParam));
+  }
+  if (searchParam) {
+    kindCountConditions.push(
+      or(
+        like(memoryItems.subject, `%${searchParam}%`),
+        like(memoryItems.statement, `%${searchParam}%`),
+      )!,
+    );
+  }
+  const kindCountWhere =
+    kindCountConditions.length > 0 ? and(...kindCountConditions) : undefined;
+  const kindCountRows = db
+    .select({ kind: memoryItems.kind, count: count() })
+    .from(memoryItems)
+    .where(kindCountWhere)
+    .groupBy(memoryItems.kind)
+    .all();
+  const kindCounts: Record<string, number> = {};
+  for (const row of kindCountRows) {
+    kindCounts[row.kind] = row.count;
+  }
+
   // ── Semantic search path ────────────────────────────────────────────
   // When a search query is present, try Qdrant hybrid search first.
   // Falls back to SQL LIKE when embeddings / Qdrant are unavailable.
@@ -254,7 +282,11 @@ export async function handleListMemoryItems(url: URL): Promise<Response> {
       );
 
       if (pageIds.length === 0) {
-        return Response.json({ items: [], total: semanticResult.total });
+        return Response.json({
+          items: [],
+          total: semanticResult.total,
+          kindCounts,
+        });
       }
 
       // Re-apply the same DB-side filters used in the SQL path as defense-
@@ -289,6 +321,7 @@ export async function handleListMemoryItems(url: URL): Promise<Response> {
       return Response.json({
         items: enrichedItems,
         total: semanticResult.total,
+        kindCounts,
       });
     }
     // semanticResult was null (Qdrant unavailable) or empty — fall through to SQL
@@ -344,7 +377,7 @@ export async function handleListMemoryItems(url: URL): Promise<Response> {
     scopeLabel: resolveScopeLabel(item.scopeId, titleMap),
   }));
 
-  return Response.json({ items: enrichedItems, total });
+  return Response.json({ items: enrichedItems, total, kindCounts });
 }
 
 // ---------------------------------------------------------------------------

--- a/clients/ios/Views/IdentityView.swift
+++ b/clients/ios/Views/IdentityView.swift
@@ -24,7 +24,7 @@ final class IdentityViewModel {
         contactsStore?.contacts.count ?? 0
     }
     var memoriesCount: Int {
-        memoriesStore?.items.count ?? 0
+        memoriesStore?.total ?? 0
     }
 
     @ObservationIgnored private var cancellables: Set<AnyCancellable> = []

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -205,8 +205,10 @@ struct MemoriesPanel: View {
     }
 
     private func kindCount(for kind: MemoryKind?) -> Int {
-        guard let kind else { return store.items.count }
-        return store.items.filter { $0.kind == kind.rawValue }.count
+        guard let kind else {
+            return store.kindCounts.values.reduce(0, +)
+        }
+        return store.kindCounts[kind.rawValue] ?? 0
     }
 
     /// Items filtered by selected kind (client-side only — store always holds all items).

--- a/clients/shared/Features/Memory/MemoryItemPayload.swift
+++ b/clients/shared/Features/Memory/MemoryItemPayload.swift
@@ -76,4 +76,6 @@ public struct MemoryItemPayload: Codable, Identifiable, Hashable, Sendable {
 public struct MemoryItemsListResponse: Codable, Sendable {
     public let items: [MemoryItemPayload]
     public let total: Int
+    /// Server-side count of items per kind (respects status/search filters but not the kind filter).
+    public let kindCounts: [String: Int]?
 }

--- a/clients/shared/Features/Memory/MemoryItemsStore.swift
+++ b/clients/shared/Features/Memory/MemoryItemsStore.swift
@@ -6,6 +6,7 @@ import Foundation
 public final class MemoryItemsStore {
     public var items: [MemoryItemPayload] = []
     public var total: Int = 0
+    public var kindCounts: [String: Int] = [:]
     public var isLoading = false
 
     // Filter state
@@ -36,6 +37,7 @@ public final class MemoryItemsStore {
         if let response {
             items = response.items
             total = response.total
+            kindCounts = response.kindCounts ?? [:]
         }
         isLoading = false
     }


### PR DESCRIPTION
## Summary
- Added `kindCounts` field to `GET /v1/memory-items` response — a `Record<string, number>` with per-kind totals that respects status/search filters but not the kind filter or pagination, so the sidebar can show accurate counts for all kinds simultaneously
- Updated macOS `MemoriesPanel` to use server-side `kindCounts` instead of counting from the (limited) fetched items
- Updated iOS `IdentityView` to use `store.total` instead of `store.items.count` for the memories badge

## Original prompt
are we just pulling 100 memories here? if so update this so the counts are actually correct
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22325" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
