### PR TITLE
fix(macos): remove .move transitions from expandable content to fix hitbox offset

### DIFF
--- a/assistant/src/memory/job-handlers/batch-extraction.ts
+++ b/assistant/src/memory/job-handlers/batch-extraction.ts
@@ -33,6 +33,7 @@ import {
   VALID_OVERRIDE_CONFIDENCES,
 } from "../items-extractor.js";
 import { asString } from "../job-utils.js";
+import { maybeEnqueueConversationStartersJob } from "../conversation-starters-cadence.js";
 import { enqueueMemoryJob, type MemoryJob } from "../jobs-store.js";
 import { extractTextFromStoredMessageContent } from "../message-content.js";
 import { withQdrantBreaker } from "../qdrant-circuit-breaker.js";

--- a/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
@@ -24,7 +24,7 @@ struct ThinkingBlockView: View {
                     .textSelection(.enabled)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(VSpacing.sm)
-                    .transition(.opacity.combined(with: .move(edge: .top)))
+                    .transition(.opacity)
             }
         }
         .background(VColor.surfaceOverlay)

--- a/clients/shared/DesignSystem/Core/Display/VDisclosureSection.swift
+++ b/clients/shared/DesignSystem/Core/Display/VDisclosureSection.swift
@@ -79,7 +79,7 @@ public struct VDisclosureSection<Content: View>: View {
             if isExpanded {
                 content()
                     .padding(.top, VSpacing.sm)
-                    .transition(.opacity.combined(with: .move(edge: .top)))
+                    .transition(.opacity)
             }
         }
     }

--- a/clients/shared/Features/Chat/ToolCallChip.swift
+++ b/clients/shared/Features/Chat/ToolCallChip.swift
@@ -253,7 +253,7 @@ public struct ToolCallChip: View {
                     }
                 }
                 .padding(.bottom, VSpacing.sm)
-                .transition(.opacity.combined(with: .move(edge: .top)))
+                .transition(.opacity)
                 .onAppear {
                     // Compute formatted input once when the user first expands,
                     // rather than re-running formatAllToolInput on every render.

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -251,7 +251,7 @@ public struct ToolConfirmationBubble: View {
                         }
                     }
                     .padding(.top, VSpacing.xs)
-                    .transition(.opacity.combined(with: .move(edge: .top)))
+                    .transition(.opacity)
                 }
             }
             .clipped()
@@ -382,7 +382,7 @@ public struct ToolConfirmationBubble: View {
                     }
                 }
                 .textSelection(.enabled)
-                .transition(.opacity.combined(with: .move(edge: .top)))
+                .transition(.opacity)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Remove `.combined(with: .move(edge: .top))` from transitions on expandable content (ThinkingBlockView, VDisclosureSection, ToolCallChip, ToolConfirmationBubble)
- The `.move` geometry transition caused macOS's AppKit-backed NSScrollView to retain stale hit-test coordinates after animation, making messages below the expanded block uninteractable
- The VStack height change already provides visual motion; `.opacity` alone avoids the stale geometry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
