### PR TITLE
fix(ios): guard macOS-only homeDirectoryForCurrentUser in GuardianClient

### DIFF
--- a/clients/shared/Network/GuardianClient.swift
+++ b/clients/shared/Network/GuardianClient.swift
@@ -98,7 +98,9 @@ public struct GuardianClient: GuardianClientProtocol {
             // This happens when credentials are wiped (terminal refresh error,
             // daemon instance change) but the lock file persists.
             if response.statusCode == 403 {
+                #if os(macOS)
                 Self.removeBootstrapLockFileIfNeeded(responseData: response.data)
+                #endif
                 log.error("Access token bootstrap failed (HTTP 403)")
                 return false
             }
@@ -127,6 +129,7 @@ public struct GuardianClient: GuardianClientProtocol {
 
     // MARK: - Bootstrap Lock File Recovery
 
+    #if os(macOS)
     /// Removes the `guardian-init.lock` file when the gateway rejects
     /// bootstrap with "Bootstrap already completed". The lock persists
     /// from a prior successful bootstrap, but if the credentials were
@@ -152,6 +155,7 @@ public struct GuardianClient: GuardianClientProtocol {
             log.error("Failed to remove guardian-init.lock: \(error.localizedDescription)")
         }
     }
+    #endif
 
     // MARK: - Response Shapes
 


### PR DESCRIPTION
## Summary
- `GuardianClient.removeBootstrapLockFileIfNeeded` uses `FileManager.default.homeDirectoryForCurrentUser` which is unavailable on iOS
- Wrapped the method definition and its call site in `#if os(macOS)` since bootstrap lock file recovery is a macOS-only concept (no local daemon filesystem on iOS)

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23759413298/job/69222647718
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
