### PR TITLE
fix: remove duplicate import in batch-extraction.ts

### DIFF
--- a/assistant/src/memory/job-handlers/batch-extraction.ts
+++ b/assistant/src/memory/job-handlers/batch-extraction.ts
@@ -33,7 +33,6 @@ import {
   VALID_OVERRIDE_CONFIDENCES,
 } from "../items-extractor.js";
 import { asString } from "../job-utils.js";
-import { maybeEnqueueConversationStartersJob } from "../conversation-starters-cadence.js";
 import { enqueueMemoryJob, type MemoryJob } from "../jobs-store.js";
 import { extractTextFromStoredMessageContent } from "../message-content.js";
 import { withQdrantBreaker } from "../qdrant-circuit-breaker.js";


### PR DESCRIPTION
## Summary
- Remove duplicate import of `maybeEnqueueConversationStartersJob` from `conversation-starters-cadence.js` (lines 19 and 36 were identical) that caused a TypeScript `TS2300: Duplicate identifier` error in CI.

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23759413290/job/69222647703
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
