### PR TITLE
fix(memory): move sparse embedding after early-return in MMR

### DIFF
--- a/assistant/src/memory/search/mmr.ts
+++ b/assistant/src/memory/search/mmr.ts
@@ -51,9 +51,6 @@ export function applyMMR(
   candidates: TieredCandidate[],
   penalty: number,
 ): TieredCandidate[] {
-  // Pre-compute sparse embeddings for all candidates
-  const embeddings = candidates.map((c) => generateSparseEmbedding(c.text));
-
   // Separate items from non-items
   const items: { index: number; candidate: TieredCandidate }[] = [];
   const nonItems: TieredCandidate[] = [];
@@ -70,6 +67,12 @@ export function applyMMR(
   // If no items or no penalty, pass through in original order
   if (items.length === 0 || penalty === 0) {
     return candidates;
+  }
+
+  // Pre-compute sparse embeddings only for items (not segments, summaries, media)
+  const embeddings = new Map<number, SparseEmbedding>();
+  for (const item of items) {
+    embeddings.set(item.index, generateSparseEmbedding(item.candidate.text));
   }
 
   // Greedy MMR selection loop
@@ -104,8 +107,8 @@ export function applyMMR(
       for (const selIdx of selected) {
         const selEmbIdx = items[selIdx]!.index;
         const sim = sparseCosine(
-          embeddings[itemEmbIdx]!,
-          embeddings[selEmbIdx]!,
+          embeddings.get(itemEmbIdx)!,
+          embeddings.get(selEmbIdx)!,
         );
         if (sim > maxSim) maxSim = sim;
       }


### PR DESCRIPTION
Move generateSparseEmbedding calls to after the early-return check in applyMMR, and only compute for items that will be used in MMR calculations. Fixes wasted CPU on no-op paths.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22331" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
