### PR TITLE
fix(gateway): honor circuit breaker fail-fast for skipped requests

### DIFF
--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -551,7 +551,10 @@ export async function uploadAttachment(
 ): Promise<UploadAttachmentResponse> {
   const skipCb = opts?.skipCircuitBreaker === true;
 
-  if (!skipCb) cbBeforeRequest();
+  // Always check the breaker for fail-fast (OPEN/HALF_OPEN rejection).
+  // skipCb only suppresses success/failure accounting so attachment errors
+  // don't trip the breaker.
+  cbBeforeRequest();
 
   const url = `${config.assistantRuntimeBaseUrl}/v1/attachments`;
 


### PR DESCRIPTION
Still call cbBeforeRequest() for skipCircuitBreaker requests to get fail-fast during outages, but skip success/failure accounting so attachment errors don't trip the breaker.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
