### PR TITLE
fix(memory): preserve user_confirmed on batch dedup updates

### DIFF
--- a/assistant/src/memory/job-handlers/batch-extraction.ts
+++ b/assistant/src/memory/job-handlers/batch-extraction.ts
@@ -462,10 +462,10 @@ export async function batchExtractJob(job: MemoryJob): Promise<void> {
             ? "journal_carry_forward"
             : "extraction";
       const effectiveVerificationState =
-        itemRole === "user" || existing.verificationState === "user_reported"
-          ? "user_reported"
-          : existing.verificationState === "user_confirmed"
-            ? "user_confirmed"
+        existing.verificationState === "user_confirmed"
+          ? "user_confirmed"
+          : itemRole === "user" || existing.verificationState === "user_reported"
+            ? "user_reported"
             : "assistant_inferred";
 
       db.update(memoryItems)


### PR DESCRIPTION
Prevent batch extraction from downgrading user_confirmed memories to user_reported when deduping with a user-role batch item. Reorders the verification-state ternary to check for user_confirmed first, preserving the stronger provenance.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
