### PR TITLE
fix: compute context window estimate before stripping injected context

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1587,13 +1587,14 @@ export async function runAgentLoopImpl(
     }
 
     const restoredHistory = [...preRepairMessages, ...newMessages];
-    ctx.messages = stripInjectedContext(restoredHistory);
 
     const postLoopContextEstimate = estimatePromptTokens(
-      ctx.messages,
+      restoredHistory,
       ctx.systemPrompt,
       { providerName: ctx.provider.name, toolTokenBudget },
     );
+
+    ctx.messages = stripInjectedContext(restoredHistory);
 
     emitUsage(
       ctx,


### PR DESCRIPTION
Move postLoopContextEstimate computation to before stripInjectedContext so the emitted contextWindowTokens includes runtime-injected blocks and accurately reflects actual context fill.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22336" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
