### PR TITLE
fix(macos): sync showAll state with unread auto-expansion

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -614,19 +614,13 @@ extension MainWindowView {
                         .pointerCursor()
 
                         if !isCollapsed {
-                            let showAll = sidebar.showAllChannelConversations[group.channel] ?? false
-                            let displayed: [ConversationModel] = {
-                                if showAll {
-                                    return group.conversations
-                                }
-                                // Auto-expand if any hidden conversation has unread messages.
-                                let visible = Array(group.conversations.prefix(3))
-                                let hidden = group.conversations.dropFirst(3)
-                                if hidden.contains(where: { $0.hasUnseenLatestAssistantMessage }) {
-                                    return group.conversations
-                                }
-                                return visible
-                            }()
+                            let explicitShowAll = sidebar.showAllChannelConversations[group.channel] ?? false
+                            // Auto-expand when any hidden conversation has unread messages.
+                            let hasHiddenUnread = !explicitShowAll
+                                && group.conversations.count > 3
+                                && group.conversations.dropFirst(3).contains(where: { $0.hasUnseenLatestAssistantMessage })
+                            let showAll = explicitShowAll || hasHiddenUnread
+                            let displayed = showAll ? group.conversations : Array(group.conversations.prefix(3))
 
                             ForEach(displayed) { conversation in
                                 makeSidebarRow(conversation: conversation)


### PR DESCRIPTION
## Summary
- Derive `showAll` from both the explicit user toggle and unread message state, so the footer correctly shows "Show less" when unread messages auto-expand the channel conversation list.
- Avoids mutating `@Observable` state during SwiftUI body evaluation by using a derived computation instead.

Addresses review feedback on #22248.

## Test plan
- [ ] Open sidebar with a channel that has >3 conversations and unread messages in hidden ones
- [ ] Verify the footer shows "Show less" (not "Show more") when auto-expanded
- [ ] Verify clicking "Show less" is not a confusing no-op — label stays correct
- [ ] Verify reading all messages causes the list to collapse back to 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
