### PR TITLE
fix: use publishAssistantEvent for signal SSE events

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -609,17 +609,7 @@ export class DaemonServer {
             "string"
             ? (msg as { conversationId: string }).conversationId
             : undefined;
-        const event = buildAssistantEvent(
-          DAEMON_INTERNAL_ASSISTANT_ID,
-          msg,
-          msgConversationId ?? conversationId,
-        );
-        assistantEventHub.publish(event).catch((err) => {
-          log.warn(
-            { err },
-            "assistant-events hub subscriber threw during signal user-message",
-          );
-        });
+        this.publishAssistantEvent(msg, msgConversationId ?? conversationId);
       };
 
       if (conversation.isProcessing()) {


### PR DESCRIPTION
Replace direct assistantEventHub.publish with publishAssistantEvent in the signal hubSender, restoring hub chain serialization and file-based event stream writes for CLI consumers.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
