### PR TITLE
fix: validate granularity, fix locale and iOS hourly formatting

### DIFF
--- a/assistant/src/runtime/routes/usage-routes.ts
+++ b/assistant/src/runtime/routes/usage-routes.ts
@@ -117,7 +117,14 @@ export function usageRouteDefinitions(): RouteDefinition[] {
       handler: ({ url }) => {
         const range = parseTimeRange(url);
         if (range instanceof Response) return range;
-        const granularity = url.searchParams.get("granularity");
+        const granularity = url.searchParams.get("granularity") ?? "daily";
+        if (granularity !== "daily" && granularity !== "hourly") {
+          return httpError(
+            "BAD_REQUEST",
+            `Invalid "granularity" value: "${granularity}". Must be one of: daily, hourly`,
+            400,
+          );
+        }
         const buckets =
           granularity === "hourly"
             ? getUsageHourBuckets(range)

--- a/clients/ios/Views/UsageDashboardView.swift
+++ b/clients/ios/Views/UsageDashboardView.swift
@@ -99,7 +99,7 @@ struct UsageDashboardView: View {
                 } else {
                     ForEach(daily.buckets, id: \.date) { bucket in
                         HStack {
-                            Text(bucket.date)
+                            Text(Self.formatBucketLabel(bucket.date, isHourly: isHourly))
                                 .font(.footnote.monospaced())
                             Spacer()
                             Text(UsageFormatting.formatCost(bucket.totalEstimatedCostUsd))
@@ -172,5 +172,47 @@ struct UsageDashboardView: View {
         }
     }
 
+    // MARK: - Formatters
+
+    private static let shortDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "MMM d"
+        f.timeZone = TimeZone(identifier: "UTC")!
+        return f
+    }()
+
+    private static let isoDateParser: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(identifier: "UTC")!
+        return f
+    }()
+
+    private static let isoHourParser: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd HH:mm"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(identifier: "UTC")!
+        return f
+    }()
+
+    private static let shortHourFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "ha"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(identifier: "UTC")!
+        return f
+    }()
+
+    private static func formatBucketLabel(_ dateString: String, isHourly: Bool) -> String {
+        if isHourly {
+            guard let date = isoHourParser.date(from: dateString) else { return dateString }
+            return shortHourFormatter.string(from: date).lowercased()
+        } else {
+            guard let date = isoDateParser.date(from: dateString) else { return dateString }
+            return shortDateFormatter.string(from: date)
+        }
+    }
 }
 #endif

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -247,6 +247,7 @@ struct UsageDashboardPanel: View {
     private static let shortHourFormatter: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "ha"
+        f.locale = Locale(identifier: "en_US_POSIX")
         f.timeZone = TimeZone(identifier: "UTC")!
         return f
     }()


### PR DESCRIPTION
Validate granularity parameter in usage route, add en_US_POSIX locale to shortHourFormatter, and format hourly labels on iOS.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22340" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
