### PR TITLE
fix: check for active git processes before removing index.lock

### DIFF
--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -1,4 +1,4 @@
-import { execFile } from "node:child_process";
+import { execFile, spawnSync } from "node:child_process";
 import {
   existsSync,
   readFileSync,
@@ -258,20 +258,41 @@ export class WorkspaceGitService {
   }
 
   /**
-   * Remove `.git/index.lock` if it exists.
+   * Remove `.git/index.lock` if it exists and no external process holds it.
    *
    * This method is always called inside the mutex, so no git operation from
-   * our code can be concurrently holding the lock. Any lock file present is
-   * stale — left behind by a crashed process or an external command that
-   * has already exited.
+   * our code can be concurrently holding the lock. However, an external git
+   * process (user running `git add`, IDE tooling, etc.) could legitimately
+   * hold the lock. We use `lsof` to check — if any process has the file
+   * open, we leave it alone. If no process holds it, it's stale (crashed
+   * process) and safe to remove.
    */
   private cleanStaleLockFile(): void {
     const lockPath = join(this.workspaceDir, ".git", "index.lock");
+    if (!existsSync(lockPath)) {
+      return;
+    }
+
+    try {
+      const result = spawnSync("lsof", ["-t", lockPath], {
+        timeout: 3000,
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+      if (result.status === 0 && result.stdout?.length > 0) {
+        log.debug("index.lock held by an active process, skipping removal");
+        return;
+      }
+    } catch {
+      // lsof unavailable or errored — fall through to remove.
+      // On platforms without lsof this degrades to unconditional removal,
+      // which is the same as the previous behavior.
+    }
+
     try {
       unlinkSync(lockPath);
       log.debug("Removed stale index.lock");
     } catch {
-      // File doesn't exist or can't be removed — move on.
+      // File was removed between check and unlink, or can't be removed — move on.
     }
   }
 


### PR DESCRIPTION
Instead of unconditionally removing index.lock, use lsof to check if an external git process holds the lock before removal. If a process has the file open, skip removal to prevent concurrent index corruption. Falls back to unconditional removal on platforms without lsof.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
