### PR TITLE
fix(macos): scope usage_update context window state to active conversation

### DIFF
--- a/assistant/src/__tests__/conversation-usage.test.ts
+++ b/assistant/src/__tests__/conversation-usage.test.ts
@@ -202,6 +202,7 @@ describe("recordUsage", () => {
     expect(onEventMessages).toEqual([
       {
         type: "usage_update",
+        conversationId: "conv-usage-1",
         inputTokens: 3_420_218,
         outputTokens: 11_768,
         totalInputTokens: 3_420_218,

--- a/assistant/src/daemon/conversation-usage.ts
+++ b/assistant/src/daemon/conversation-usage.ts
@@ -175,6 +175,7 @@ export function recordUsage(
   );
   onEvent({
     type: "usage_update",
+    conversationId: ctx.conversationId,
     inputTokens,
     outputTokens,
     totalInputTokens: ctx.usageStats.inputTokens,

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -335,6 +335,7 @@ export interface UndoComplete {
 
 export interface UsageUpdate {
   type: "usage_update";
+  conversationId: string;
   inputTokens: number;
   outputTokens: number;
   totalInputTokens: number;

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -245,6 +245,7 @@ final class ChatActionHandler {
             vm.handleGuardianActionDecisionResponse(response)
 
         case .usageUpdate(let update):
+            guard belongsToConversation(update.conversationId) else { return }
             if let tokens = update.contextWindowTokens {
                 vm.contextWindowTokens = tokens
             }

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -4862,6 +4862,7 @@ public struct UsageStats: Codable, Sendable {
 
 public struct UsageUpdate: Codable, Sendable {
     public let type: String
+    public let conversationId: String?
     public let inputTokens: Int
     public let outputTokens: Int
     public let totalInputTokens: Int
@@ -4871,12 +4872,13 @@ public struct UsageUpdate: Codable, Sendable {
     public let contextWindowTokens: Int?
     public let contextWindowMaxTokens: Int?
 
-    public init(type: String, inputTokens: Int, outputTokens: Int,
+    public init(type: String, conversationId: String? = nil, inputTokens: Int, outputTokens: Int,
                 totalInputTokens: Int, totalOutputTokens: Int,
                 estimatedCost: Double, model: String,
                 contextWindowTokens: Int? = nil,
                 contextWindowMaxTokens: Int? = nil) {
         self.type = type
+        self.conversationId = conversationId
         self.inputTokens = inputTokens
         self.outputTokens = outputTokens
         self.totalInputTokens = totalInputTokens


### PR DESCRIPTION
Add conversation ID filter to usage_update handling so background conversations don't overwrite the foreground chat's context-window fill ratio.

- Add `conversationId` field to `UsageUpdate` wire type (TS interface + Swift struct)
- Include `conversationId` in server-side usage_update emission
- Add `belongsToConversation` guard in ChatActionHandler's usageUpdate case
- Update test assertion to include conversationId
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
