### PR TITLE
fix(macos): fix memory modal state, design token, and escape key

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import VellumAssistantShared
 
@@ -72,6 +73,7 @@ struct MemoriesPanel: View {
     @State private var statusFilter: MemoryStatusFilter = .active
     @State private var sortOption: MemorySortOption = .newest
     @State private var searchDebounceTask: Task<Void, Never>?
+    @State private var escapeMonitor: Any?
 
     init(connectionManager: GatewayConnectionManager, focusedMemoryId: Binding<String?> = .constant(nil)) {
         self.connectionManager = connectionManager
@@ -120,8 +122,11 @@ struct MemoriesPanel: View {
                         store: store,
                         onDismiss: { withAnimation(VAnimation.fast) { selectedItem = nil } }
                     )
+                    .id(selectedItem?.id)
                 }
                 .transition(.opacity)
+                .onAppear { installEscapeMonitor() }
+                .onDisappear { removeEscapeMonitor() }
             }
         }
         .sheet(isPresented: $showCreateSheet) {
@@ -217,6 +222,22 @@ struct MemoriesPanel: View {
         return store.items.filter { $0.kind == kind.rawValue }
     }
 
+    // MARK: - Escape Key
+
+    private func installEscapeMonitor() {
+        escapeMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            guard event.keyCode == 53 else { return event } // 53 = Escape
+            withAnimation(VAnimation.fast) { selectedItem = nil }
+            return nil
+        }
+    }
+
+    private func removeEscapeMonitor() {
+        if let monitor = escapeMonitor {
+            NSEvent.removeMonitor(monitor)
+            escapeMonitor = nil
+        }
+    }
 
     // MARK: - Content View
 


### PR DESCRIPTION
## Summary
- Force memory detail sheet recreation via `.id(selectedItem?.id)` to prevent stale `@State` when switching between memories without `selectedItem` first becoming `nil`
- Add `NSEvent` local monitor for Escape key (keyCode 53) to restore Escape dismissal lost in the sheet-to-overlay migration
- `VColor.auxBlack` design token was already in place (confirmed)

Addresses review feedback on #22319.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22343" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
