### PR TITLE
fix: persist null trust/auth context to prevent stale restoration after eviction

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -967,15 +967,12 @@ export class DaemonServer {
     // Persist the conversation's current trust/auth context so it survives
     // eviction and recreation. The restore path in getOrCreateConversation
     // reads from storedOptions.trustContext / storedOptions.authContext.
-    const currentTrust = conversation.trustContext;
-    const currentAuth = conversation.authContext;
-    if (currentTrust || currentAuth) {
-      this.conversationOptions.set(conversationId, {
-        ...this.conversationOptions.get(conversationId),
-        ...(currentTrust ? { trustContext: currentTrust } : {}),
-        ...(currentAuth ? { authContext: currentAuth } : {}),
-      });
-    }
+    // Always write — including null — so explicit clearing isn't lost.
+    this.conversationOptions.set(conversationId, {
+      ...this.conversationOptions.get(conversationId),
+      trustContext: conversation.trustContext,
+      authContext: conversation.authContext,
+    });
     conversation.setChannelCapabilities(
       resolveChannelCapabilities(
         sourceChannel,


### PR DESCRIPTION
Always write trust/auth state to conversationOptions including null values, so explicit clearing is reflected and stale context isn't restored after eviction.

Addresses feedback from #22284.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22344" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
