### PR TITLE
Replace per-property observation with single debounced uiVersion counter

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -53,7 +53,17 @@ final class MessageListScrollState {
 
     /// Whether the "Scroll to latest" CTA should be visible.
     /// Updated via debounced `scheduleUISync()` — at most once per frame.
-    private(set) var showScrollToLatest = false
+    @ObservationIgnored private(set) var showScrollToLatest = false
+
+    /// Single observed property — the ONLY thing that triggers SwiftUI view
+    /// re-evaluation from scroll state. Bumped at most once per 16ms frame.
+    private(set) var uiVersion: UInt64 = 0
+
+    /// Snapshot: whether the tail spacer should render.
+    @ObservationIgnored private(set) var showTailSpacer = false
+
+    /// Snapshot: whether scroll indicators should be hidden.
+    @ObservationIgnored private(set) var scrollIndicatorsHidden = false
 
     // MARK: - Computed Properties
 
@@ -262,12 +272,37 @@ final class MessageListScrollState {
         uiSyncTask = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: 16_000_000) // ~1 frame at 60Hz
             guard let self, !Task.isCancelled else { return }
-            let newValue = !self._isFollowingBottom
-            if self.showScrollToLatest != newValue {
-                self.showScrollToLatest = newValue
-            }
+            self.syncUISnapshots()
             self.uiSyncTask = nil
         }
+    }
+
+    /// Computes all snapshot values from internal state and bumps uiVersion
+    /// only if something actually changed.
+    private func syncUISnapshots() {
+        let newShowScrollToLatest = !_isFollowingBottom
+        let newShowTailSpacer = _pushToTopMessageId != nil
+        let newScrollIndicatorsHidden = _hideScrollIndicators
+
+        var changed = false
+        if showScrollToLatest != newShowScrollToLatest {
+            showScrollToLatest = newShowScrollToLatest; changed = true
+        }
+        if showTailSpacer != newShowTailSpacer {
+            showTailSpacer = newShowTailSpacer; changed = true
+        }
+        if scrollIndicatorsHidden != newScrollIndicatorsHidden {
+            scrollIndicatorsHidden = newScrollIndicatorsHidden; changed = true
+        }
+        if changed { uiVersion &+= 1 }
+    }
+
+    /// Synchronous UI sync — bypasses debounce for instant state transitions
+    /// like conversation switches.
+    func syncUIImmediately() {
+        uiSyncTask?.cancel()
+        uiSyncTask = nil
+        syncUISnapshots()
     }
 
     // MARK: - Task References
@@ -373,9 +408,6 @@ final class MessageListScrollState {
         currentConversationId = newConversationId
         // Reset follow state for the new conversation.
         if !_isFollowingBottom { _isFollowingBottom = true }
-        // Sync UI immediately for conversation switch (no debounce delay).
-        uiSyncTask?.cancel()
-        if showScrollToLatest { showScrollToLatest = false }
         if _pushToTopMessageId != nil { _pushToTopMessageId = nil }
         isAtBottom = true
         hasReceivedScrollEvent = false
@@ -390,10 +422,13 @@ final class MessageListScrollState {
         // to mask LazyVStack content size estimation changes.
         scrollIndicatorRestoreTask?.cancel()
         if !_hideScrollIndicators { _hideScrollIndicators = true }
+        // Sync UI immediately for conversation switch (no debounce delay).
+        syncUIImmediately()
         scrollIndicatorRestoreTask = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: 300_000_000) // 300ms
             guard !Task.isCancelled, let self else { return }
             if self._hideScrollIndicators { self._hideScrollIndicators = false }
+            self.syncUIImmediately()
             self.scrollIndicatorRestoreTask = nil
         }
     }
@@ -419,5 +454,6 @@ final class MessageListScrollState {
         bodyEvalTimestamps.removeAll()
         if _hideScrollIndicators { _hideScrollIndicators = false }
         if _isPaginationInFlight { _isPaginationInFlight = false }
+        syncUIImmediately()
     }
 }

--- a/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
@@ -70,6 +70,7 @@ final class MessageListScrollStateTests: XCTestCase {
         // Wait for the debounced UI sync to fire.
         try await Task.sleep(nanoseconds: 50_000_000)
         XCTAssertTrue(state.showScrollToLatest)
+        XCTAssertEqual(state.uiVersion, 1, "Only one uiVersion bump despite 100 detach calls")
     }
 
     // MARK: - Pin Gating
@@ -234,6 +235,9 @@ final class MessageListScrollStateTests: XCTestCase {
         XCTAssertNil(state.pushToTopMessageId, "Should clear pushToTopMessageId")
         XCTAssertTrue(state.hideScrollIndicators,
                       "Should hide scroll indicators during conversation switch")
+        XCTAssertFalse(state.showTailSpacer)
+        XCTAssertTrue(state.scrollIndicatorsHidden)
+        XCTAssertFalse(state.showScrollToLatest)
     }
 
     func testResetClearsLayoutCache() {
@@ -284,6 +288,7 @@ final class MessageListScrollStateTests: XCTestCase {
         try await Task.sleep(nanoseconds: 50_000_000)
         XCTAssertTrue(state.showScrollToLatest,
                       "Should be true when not following bottom")
+        XCTAssertGreaterThan(state.uiVersion, 0)
 
         state.reattach()
         // Wait for debounced UI sync.
@@ -316,6 +321,31 @@ final class MessageListScrollStateTests: XCTestCase {
 
         XCTAssertEqual(state.tailSpacerHeight, 0,
                        "Should be 0 when viewport height is not finite")
+    }
+
+    // MARK: - uiVersion Coalescing
+
+    func testUIVersionCoalescesMultipleChanges() async throws {
+        let vBefore = state.uiVersion
+        state.detach()  // schedules UI sync
+        state.pushToTopMessageId = UUID()  // schedules UI sync (coalesced)
+        state.hideScrollIndicators = true  // schedules UI sync (coalesced)
+        try await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(state.uiVersion, vBefore + 1,
+                       "Multiple changes coalesce into one uiVersion bump")
+        XCTAssertTrue(state.showScrollToLatest)
+        XCTAssertTrue(state.showTailSpacer)
+        XCTAssertTrue(state.scrollIndicatorsHidden)
+    }
+
+    func testSyncUIImmediately() {
+        state.detach()
+        state.pushToTopMessageId = UUID()
+        // Don't await debounce — call immediate sync
+        state.syncUIImmediately()
+        XCTAssertTrue(state.showScrollToLatest)
+        XCTAssertTrue(state.showTailSpacer)
+        XCTAssertGreaterThan(state.uiVersion, 0)
     }
 
     // MARK: - Circuit Breaker


### PR DESCRIPTION
## Summary
- Add single observed `uiVersion` counter — the ONLY thing that triggers SwiftUI view re-evaluation from scroll state
- Add `@ObservationIgnored` snapshot values (`showTailSpacer`, `scrollIndicatorsHidden`) computed during sync
- Make `showScrollToLatest` `@ObservationIgnored` — now updated only during `syncUISnapshots()`
- Expand `scheduleUISync()` to sync all snapshots atomically and only bump `uiVersion` if anything changed
- Add `syncUIImmediately()` for instant state transitions (conversation switches, teardown)
- Update `reset(for:)` and `cancelAll()` to use `syncUIImmediately()`
- Add tests for uiVersion coalescing and syncUIImmediately

Part of plan: scroll-single-observed-prop.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
