### PR TITLE
fix: align kindCounts with semantic search and add backwards compat fallback

### DIFF
--- a/assistant/src/runtime/routes/memory-item-routes.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.ts
@@ -235,62 +235,64 @@ export async function handleListMemoryItems(url: URL): Promise<Response> {
 
   const db = getDb();
 
-  // ── Kind counts (shared across all code paths) ─────────────────────
-  // Respects status/search filters but NOT kind filter, so the sidebar
-  // can show totals for every kind simultaneously.
-  const kindCountConditions = [];
-  if (statusParam && statusParam !== "all") {
-    kindCountConditions.push(eq(memoryItems.status, statusParam));
-  }
-  if (searchParam) {
-    kindCountConditions.push(
-      or(
-        like(memoryItems.subject, `%${searchParam}%`),
-        like(memoryItems.statement, `%${searchParam}%`),
-      )!,
-    );
-  }
-  const kindCountWhere =
-    kindCountConditions.length > 0 ? and(...kindCountConditions) : undefined;
-  const kindCountRows = db
-    .select({ kind: memoryItems.kind, count: count() })
-    .from(memoryItems)
-    .where(kindCountWhere)
-    .groupBy(memoryItems.kind)
-    .all();
-  const kindCounts: Record<string, number> = {};
-  for (const row of kindCountRows) {
-    kindCounts[row.kind] = row.count;
-  }
-
   // ── Semantic search path ────────────────────────────────────────────
   // When a search query is present, try Qdrant hybrid search first.
   // Falls back to SQL LIKE when embeddings / Qdrant are unavailable.
   if (searchParam) {
+    // Search WITHOUT kind filter so we can compute cross-kind counts.
+    // Kind filtering is applied post-hoc while preserving relevance order.
     const semanticResult = await searchItemsSemantic(
       searchParam,
-      limitParam + offsetParam,
-      kindParam,
+      10_000,
+      null,
       statusParam,
     );
 
     if (semanticResult && semanticResult.ids.length > 0) {
-      // Slice for pagination
-      const pageIds = semanticResult.ids.slice(
-        offsetParam,
-        offsetParam + limitParam,
-      );
+      // Compute kindCounts from all semantic matches (no kind filter)
+      const kindCountRows = db
+        .select({ kind: memoryItems.kind, count: count() })
+        .from(memoryItems)
+        .where(inArray(memoryItems.id, semanticResult.ids))
+        .groupBy(memoryItems.kind)
+        .all();
+      const semanticKindCounts: Record<string, number> = {};
+      for (const row of kindCountRows) {
+        semanticKindCounts[row.kind] = row.count;
+      }
+
+      // Apply kind filter while preserving semantic relevance ordering
+      let filteredIds = semanticResult.ids;
+      if (kindParam) {
+        const kindIdSet = new Set(
+          db
+            .select({ id: memoryItems.id })
+            .from(memoryItems)
+            .where(
+              and(
+                inArray(memoryItems.id, semanticResult.ids),
+                eq(memoryItems.kind, kindParam),
+              ),
+            )
+            .all()
+            .map((r) => r.id),
+        );
+        filteredIds = semanticResult.ids.filter((id) => kindIdSet.has(id));
+      }
+
+      const total = filteredIds.length;
+      const pageIds = filteredIds.slice(offsetParam, offsetParam + limitParam);
 
       if (pageIds.length === 0) {
         return Response.json({
           items: [],
-          total: semanticResult.total,
-          kindCounts,
+          total,
+          kindCounts: semanticKindCounts,
         });
       }
 
-      // Re-apply the same DB-side filters used in the SQL path as defense-
-      // in-depth against stale Qdrant payloads leaking deleted/mismatched rows.
+      // Re-apply DB-side filters as defense-in-depth against stale Qdrant
+      // payloads leaking deleted/mismatched rows.
       const hydrationConditions = [inArray(memoryItems.id, pageIds)];
       if (statusParam && statusParam !== "all") {
         hydrationConditions.push(eq(memoryItems.status, statusParam));
@@ -320,11 +322,39 @@ export async function handleListMemoryItems(url: URL): Promise<Response> {
 
       return Response.json({
         items: enrichedItems,
-        total: semanticResult.total,
-        kindCounts,
+        total,
+        kindCounts: semanticKindCounts,
       });
     }
     // semanticResult was null (Qdrant unavailable) or empty — fall through to SQL
+  }
+
+  // ── Kind counts for SQL path ───────────────────────────────────────
+  // Respects status/search filters but NOT kind filter, so the sidebar
+  // can show totals for every kind simultaneously.
+  const kindCountConditions = [];
+  if (statusParam && statusParam !== "all") {
+    kindCountConditions.push(eq(memoryItems.status, statusParam));
+  }
+  if (searchParam) {
+    kindCountConditions.push(
+      or(
+        like(memoryItems.subject, `%${searchParam}%`),
+        like(memoryItems.statement, `%${searchParam}%`),
+      )!,
+    );
+  }
+  const kindCountWhere =
+    kindCountConditions.length > 0 ? and(...kindCountConditions) : undefined;
+  const sqlKindCountRows = db
+    .select({ kind: memoryItems.kind, count: count() })
+    .from(memoryItems)
+    .where(kindCountWhere)
+    .groupBy(memoryItems.kind)
+    .all();
+  const kindCounts: Record<string, number> = {};
+  for (const row of sqlKindCountRows) {
+    kindCounts[row.kind] = row.count;
   }
 
   // ── SQL path (default or fallback) ──────────────────────────────────

--- a/clients/shared/Features/Memory/MemoryItemsStore.swift
+++ b/clients/shared/Features/Memory/MemoryItemsStore.swift
@@ -37,7 +37,17 @@ public final class MemoryItemsStore {
         if let response {
             items = response.items
             total = response.total
-            kindCounts = response.kindCounts ?? [:]
+            if let serverCounts = response.kindCounts {
+                kindCounts = serverCounts
+            } else {
+                // Backwards compat: derive counts from loaded items when
+                // the server doesn't return kindCounts (older versions).
+                var derived: [String: Int] = [:]
+                for item in response.items {
+                    derived[item.kind, default: 0] += 1
+                }
+                kindCounts = derived
+            }
         }
         isLoading = false
     }


### PR DESCRIPTION
## Summary
- When Qdrant semantic search is used, compute `kindCounts` from the semantic result IDs via `GROUP BY` instead of using SQL `LIKE` — ensures sidebar badge counts match the displayed items
- Search is now done WITHOUT kind filter first (to compute cross-kind counts), then kind-filtered post-hoc while preserving semantic relevance ordering
- Added backwards compat fallback in Swift `MemoryItemsStore`: when `kindCounts` is nil (older server versions), derive counts from the loaded items instead of showing all zeros

Addresses review feedback on #22325.

## Test plan
- [ ] Search memories with Qdrant enabled — verify sidebar kind counts match displayed items
- [ ] Search memories with Qdrant disabled (SQL fallback) — verify counts still work
- [ ] Connect updated client to older server — verify badges show counts derived from items instead of 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
