### PR TITLE
fix(context): remove web_search_tool_result from tool_result serializer path

### DIFF
--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -915,10 +915,6 @@ function serializeMessagesToContentBlocks(messages: Message[]): ContentBlock[] {
           textLines.length = 0;
         }
         blocks.push(block);
-      } else if (block.type === "web_search_tool_result") {
-        textLines.push(
-          `web_search_tool_result ${block.tool_use_id}: [opaque]`,
-        );
       } else if (block.type === "tool_result") {
         // Extract images from tool_result contentBlocks before serializing.
         const collectedImages: ImageContent[] = [];


### PR DESCRIPTION
Remove web_search_tool_result from the dedicated branch in serializeMessagesToContentBlocks so it falls through to serializeBlock which handles it correctly without touching opaque content.

Addresses review feedback on #22273.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22347" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
