### PR TITLE
fix(design-system): rename to VContextWindowIndicator, clamp ratio, add gallery

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -413,7 +413,7 @@ struct ComposerView: View {
 
                 .vTooltip("Attach file")
 
-                ContextWindowIndicator(
+                VContextWindowIndicator(
                     fillRatio: contextWindowFillRatio,
                     tokensUsed: contextWindowTokens,
                     tokensMax: contextWindowMaxTokens

--- a/clients/shared/DesignSystem/Components/Feedback/VContextWindowIndicator.swift
+++ b/clients/shared/DesignSystem/Components/Feedback/VContextWindowIndicator.swift
@@ -4,7 +4,7 @@ import SwiftUI
 /// Designed to sit in the composer toolbar area. On hover, shows a rich
 /// popover with percentage, token counts, and compaction note.
 /// Hidden when `fillRatio` is nil (no usage data yet).
-public struct ContextWindowIndicator: View {
+public struct VContextWindowIndicator: View {
     public let fillRatio: Double?
     public let tokensUsed: Int?
     public let tokensMax: Int?
@@ -20,15 +20,20 @@ public struct ContextWindowIndicator: View {
     private let ringSize: CGFloat = 16
     private let ringLineWidth: CGFloat = 2
 
+    private var clampedRatio: Double? {
+        guard let ratio = fillRatio else { return nil }
+        return min(max(ratio, 0), 1)
+    }
+
     private var ringColor: Color {
-        guard let ratio = fillRatio else { return .clear }
+        guard let ratio = clampedRatio else { return .clear }
         if ratio >= 0.8 { return VColor.systemNegativeStrong }
         if ratio >= 0.6 { return VColor.systemMidStrong }
         return VColor.contentTertiary
     }
 
     private var percentText: String {
-        guard let ratio = fillRatio else { return "0%" }
+        guard let ratio = clampedRatio else { return "0%" }
         return "\(Int(ratio * 100))%"
     }
 
@@ -41,7 +46,7 @@ public struct ContextWindowIndicator: View {
     }
 
     public var body: some View {
-        if let ratio = fillRatio, ratio > 0 {
+        if let ratio = clampedRatio {
             circularRing(ratio: ratio)
                 .onHover { hovering in
                     isHovered = hovering
@@ -63,7 +68,7 @@ public struct ContextWindowIndicator: View {
 
             // Fill ring
             Circle()
-                .trim(from: 0, to: CGFloat(min(ratio, 1.0)))
+                .trim(from: 0, to: CGFloat(ratio))
                 .stroke(ringColor, style: StrokeStyle(lineWidth: ringLineWidth, lineCap: .round))
                 .rotationEffect(.degrees(-90))
                 .frame(width: ringSize, height: ringSize)

--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -92,6 +92,7 @@ enum ComponentGalleryCategory: String, CaseIterable, Identifiable {
                 GalleryComponent("vSkeletonBone", "VSkeletonBone", keywords: ["skeleton", "placeholder"], description: "Placeholder bone with shimmer animation for loading skeletons. Compose multiple bones to match the target layout."),
                 GalleryComponent("vSkillTypePill", "VSkillTypePill", keywords: ["skill type", "pill"], description: "Colored pill showing a skill type category."),
                 GalleryComponent("vInfoTooltip", "VInfoTooltip", keywords: ["info", "tooltip"], description: "Info icon with hover tooltip for contextual help text."),
+                GalleryComponent("vContextWindowIndicator", "VContextWindowIndicator", keywords: ["context window", "progress", "ring"], description: "Circular ring showing context window fill level with hover popover."),
             ]
         case .icons:
             return [

--- a/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
@@ -466,6 +466,43 @@ struct FeedbackGallerySection: View {
                 }
             }
 
+            if filter == nil || filter == "vContextWindowIndicator" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+                // MARK: - VContextWindowIndicator
+                GallerySectionHeader(
+                    title: "VContextWindowIndicator",
+                    description: "Circular ring showing context window fill level with hover popover."
+                )
+
+                VCard {
+                    HStack(spacing: VSpacing.xxl) {
+                        VStack(spacing: VSpacing.md) {
+                            Text("nil (hidden)").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                            VContextWindowIndicator(fillRatio: nil)
+                                .frame(width: 16, height: 16)
+                        }
+                        VStack(spacing: VSpacing.md) {
+                            Text("0%").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                            VContextWindowIndicator(fillRatio: 0)
+                        }
+                        VStack(spacing: VSpacing.md) {
+                            Text("30%").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                            VContextWindowIndicator(fillRatio: 0.3)
+                        }
+                        VStack(spacing: VSpacing.md) {
+                            Text("65%").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                            VContextWindowIndicator(fillRatio: 0.65)
+                        }
+                        VStack(spacing: VSpacing.md) {
+                            Text("90%").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                            VContextWindowIndicator(fillRatio: 0.9)
+                        }
+                    }
+                }
+            }
+
             if filter == nil || filter == "vInfoTooltip" {
                 if filter == nil {
                     Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
@@ -507,6 +544,7 @@ extension FeedbackGallerySection {
         case "vSkeletonBone": FeedbackGallerySection(filter: "vSkeletonBone")
         case "vSkillTypePill": FeedbackGallerySection(filter: "vSkillTypePill")
         case "vInfoTooltip": FeedbackGallerySection(filter: "vInfoTooltip")
+        case "vContextWindowIndicator": FeedbackGallerySection(filter: "vContextWindowIndicator")
         default: EmptyView()
         }
     }


### PR DESCRIPTION
Rename ContextWindowIndicator to VContextWindowIndicator (V prefix mandate), clamp fillRatio to 0...1, fix 0% vs nil rendering, and add FeedbackGallerySection entry.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
