### PR TITLE
fix: hydrate signal attachments only for queue path and add validation

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -576,6 +576,17 @@ export class DaemonServer {
       if (params.attachments && params.attachments.length > 0) {
         for (const a of params.attachments) {
           try {
+            const validation = attachmentsStore.validateAttachmentUpload(
+              a.filename,
+              a.mimeType,
+            );
+            if (!validation.ok) {
+              log.warn(
+                { error: validation.error, path: a.path },
+                "Signal attachment rejected by validation",
+              );
+              continue;
+            }
             const size = statSync(a.path).size;
             const stored = attachmentsStore.uploadFileBackedAttachment(
               a.filename,
@@ -584,12 +595,11 @@ export class DaemonServer {
               size,
             );
             attachmentIds.push(stored.id);
-            const fileData = readFileSync(a.path).toString("base64");
             resolvedAttachments.push({
               id: stored.id,
               filename: a.filename,
               mimeType: a.mimeType,
-              data: fileData,
+              data: "",
               filePath: a.path,
             });
           } catch (err) {
@@ -613,6 +623,13 @@ export class DaemonServer {
       };
 
       if (conversation.isProcessing()) {
+        // Hydrate file data now — the queue path won't re-read from
+        // the attachment store, so base64 content must be inline.
+        for (const att of resolvedAttachments) {
+          if (att.filePath && !att.data) {
+            att.data = readFileSync(att.filePath).toString("base64");
+          }
+        }
         const requestId = crypto.randomUUID();
         const resolvedChannel = resolveTurnChannel(params.sourceChannel);
         const resolvedInterface = resolveTurnInterface(params.sourceInterface);


### PR DESCRIPTION
## Summary
- Move `readFileSync` base64 hydration into the `isProcessing()` queue branch so file data is only read when it will be enqueued (the non-queue path hydrates later via `getAttachmentsByIds`).
- Add `validateAttachmentUpload` call for signal attachments, matching the HTTP upload route's MIME type and dangerous extension checks.

Addresses review feedback from #22285.

## Test plan
- [ ] Send a signal message with an image attachment while conversation is idle — attachment flows through `persistAndProcessMessage` path without eager file read
- [ ] Send a signal message with an image attachment while conversation is processing — attachment is hydrated with base64 data before enqueuing
- [ ] Send a signal message with a dangerous file extension (e.g. `.exe`) — attachment is rejected with a validation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
