### PR TITLE
fix(macos): show context indicator during generation and add hover delay

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -400,9 +400,7 @@ struct ComposerView: View {
     private var composerActionBar: some View {
         HStack(spacing: VSpacing.xs) {
             // Left side
-            if isAssistantBusy && !hasPendingConfirmation {
-                Spacer()
-            } else {
+            if !isAssistantBusy || hasPendingConfirmation {
                 VButton(
                     label: "Attach file",
                     iconOnly: VIcon.paperclip.rawValue,
@@ -412,15 +410,15 @@ struct ComposerView: View {
                 )
 
                 .vTooltip("Attach file")
-
-                VContextWindowIndicator(
-                    fillRatio: contextWindowFillRatio,
-                    tokensUsed: contextWindowTokens,
-                    tokensMax: contextWindowMaxTokens
-                )
-
-                Spacer()
             }
+
+            VContextWindowIndicator(
+                fillRatio: contextWindowFillRatio,
+                tokensUsed: contextWindowTokens,
+                tokensMax: contextWindowMaxTokens
+            )
+
+            Spacer()
 
             // Right side
             if isAssistantBusy && !hasPendingConfirmation {

--- a/clients/shared/DesignSystem/Components/Feedback/VContextWindowIndicator.swift
+++ b/clients/shared/DesignSystem/Components/Feedback/VContextWindowIndicator.swift
@@ -16,6 +16,7 @@ public struct VContextWindowIndicator: View {
     }
 
     @State private var isHovered = false
+    @State private var hoverTask: Task<Void, Never>?
 
     private let ringSize: CGFloat = 16
     private let ringLineWidth: CGFloat = 2
@@ -49,7 +50,16 @@ public struct VContextWindowIndicator: View {
         if let ratio = clampedRatio {
             circularRing(ratio: ratio)
                 .onHover { hovering in
-                    isHovered = hovering
+                    hoverTask?.cancel()
+                    if hovering {
+                        hoverTask = Task {
+                            try? await Task.sleep(nanoseconds: 200_000_000)
+                            guard !Task.isCancelled else { return }
+                            isHovered = true
+                        }
+                    } else {
+                        isHovered = false
+                    }
                 }
                 .popover(isPresented: $isHovered, arrowEdge: .top) {
                     popoverContent


### PR DESCRIPTION
Move VContextWindowIndicator outside the busy-state branch so it stays visible during streaming. Add 200ms hover delay before showing the popover to prevent flashing during mouse traversal.

Addresses feedback from #22282.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
