### PR TITLE
fix: suppress web_search_tool_result guard false positive in window-manager

### DIFF
--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -915,7 +915,7 @@ function serializeMessagesToContentBlocks(messages: Message[]): ContentBlock[] {
           textLines.length = 0;
         }
         blocks.push(block);
-      } else if (block.type === "tool_result") {
+      } else if (block.type === "tool_result") { // guard:allow-tool-result-only — web_search_tool_result handled by serializeBlock via else branch
         // Extract images from tool_result contentBlocks before serializing.
         const collectedImages: ImageContent[] = [];
         textLines.push(serializeToolResultBlock(block, collectedImages));


### PR DESCRIPTION
## Summary
- The `web_search_tool_result` structural guard test flagged `context/window-manager.ts:918` for having a raw `tool_result` type check without also handling `web_search_tool_result`
- The `web_search_tool_result` case is intentionally handled by the generic `serializeBlock()` else branch (which serializes it correctly), not by `serializeToolResultBlock()` (which extracts images from `contentBlocks` — irrelevant for web search results)
- Added `guard:allow-tool-result-only` annotation to suppress the false positive

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23760706351/job/69227195023