### PR TITLE
fix: update stale comments in MessageListScrollState for single uiVersion architecture

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -6,14 +6,14 @@ import VellumAssistantShared
 // MARK: - MessageListScrollState
 
 /// Replaces `MessageListScrollCoordinator` (ObservableObject) with an
-/// `@Observable` class that only triggers SwiftUI view re-evaluations for
-/// 4 properties that legitimately drive UI changes. All scroll-frequency
+/// `@Observable` class where a single `uiVersion` counter is the ONLY
+/// property that triggers SwiftUI view re-evaluations. All scroll-frequency
 /// state is `@ObservationIgnored` to prevent the cascading re-render
 /// feedback loops that caused the old coordinator to freeze the app.
 @Observable @MainActor
 final class MessageListScrollState {
 
-    // MARK: - Observed Properties (trigger view updates)
+    // MARK: - UI State (single uiVersion observation)
 
     @ObservationIgnored private var _isFollowingBottom = true
 


### PR DESCRIPTION
## Summary
Fixes stale documentation found during plan review for scroll-single-observed-prop.md.

**Gap 1:** Class-level doc comment still referenced '4 properties' — updated to describe single uiVersion architecture.
**Gap 2:** MARK section header 'Observed Properties' was stale — updated to reflect that only uiVersion is observed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22354" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
