### PR TITLE
fix: scope skill memory pruning to skill-prefixed subjects only

### DIFF
--- a/assistant/src/__tests__/skill-memory.test.ts
+++ b/assistant/src/__tests__/skill-memory.test.ts
@@ -427,6 +427,40 @@ describe("seedCatalogSkillMemories", () => {
     expect(afterItems[0].status).toBe("deleted");
   });
 
+  test("does not prune non-skill capability memories", async () => {
+    // Pre-insert a non-skill capability memory directly into the DB
+    const db = getDb();
+    const now = Date.now();
+    db.insert(memoryItems)
+      .values({
+        id: "cli-doctor-item",
+        kind: "capability",
+        subject: "cli:doctor",
+        statement: "The doctor command diagnoses issues.",
+        status: "active",
+        confidence: 1.0,
+        importance: 0.7,
+        fingerprint: "cli-doctor-fp",
+        sourceType: "extraction",
+        scopeId: "default",
+        firstSeenAt: now,
+        lastSeenAt: now,
+      })
+      .run();
+
+    // Seed with empty catalog — skill pruner runs but should skip cli:* items
+    mockResolveCatalog = async () => [];
+    await seedCatalogSkillMemories();
+
+    const item = db
+      .select()
+      .from(memoryItems)
+      .where(eq(memoryItems.subject, "cli:doctor"))
+      .get();
+    expect(item).toBeDefined();
+    expect(item!.status).toBe("active");
+  });
+
   test("does not throw when resolveCatalog rejects", async () => {
     mockResolveCatalog = async () => {
       throw new Error("Network failure");

--- a/assistant/src/skills/skill-memory.ts
+++ b/assistant/src/skills/skill-memory.ts
@@ -208,6 +208,7 @@ export async function seedCatalogSkillMemories(): Promise<void> {
 
     const now = Date.now();
     for (const item of allCapabilities) {
+      if (!item.subject.startsWith("skill:")) continue;
       const itemSkillId = item.subject.replace("skill:", "");
       if (!catalogIds.has(itemSkillId)) {
         db.update(memoryItems)


### PR DESCRIPTION
## Summary
- Add a startsWith('skill:') guard in the skill memory pruning loop to prevent cross-contamination with other capability memory prefixes (e.g. cli:*)
- Add test verifying non-skill capability items survive skill memory seeding

Part of plan: cli-command-memories.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22355" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
