### PR TITLE
fix: remove inline code formatting from Slack access request approval instructions

### DIFF
--- a/assistant/src/notifications/adapters/slack.ts
+++ b/assistant/src/notifications/adapters/slack.ts
@@ -153,7 +153,7 @@ export function buildAccessRequestBlocks(
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `Reply *\`${code} approve\`* to grant access or *\`${code} reject\`* to deny.`,
+        text: `Reply *${code} approve* to grant access or *${code} reject* to deny.`,
       },
     });
   }


### PR DESCRIPTION
## Summary
- Remove backtick (inline code) formatting from Slack access request approval instruction text
- Keep bold formatting so codes are still visually prominent

Part of plan: fix-guardian-reply-fmt.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
