### PR TITLE
fix: strip channel formatting in plain-text guardian decision normalizer

### DIFF
--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -1460,6 +1460,36 @@ describe("routing invariant: expired requests are excluded from pending discover
     expect(resolvedExpired!.status).toBe("pending");
   });
 
+  test("backtick-wrapped plain-text approve is normalized and applied", async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: "tool_approval",
+      sourceType: "channel",
+      conversationId: "conv-1",
+      guardianExternalUserId: "guardian-1",
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      requestCode: "FMT001",
+      toolName: "shell",
+      expiresAt: Date.now() + 60_000,
+    });
+    registerPendingToolApprovalInteraction(req.id, "conv-1", "shell");
+
+    const result = await routeGuardianReply(
+      replyCtx({
+        messageText: "`approve`",
+        conversationId: "conv-guardian-conversation",
+        pendingRequestIds: [req.id],
+        approvalConversationGenerator: undefined,
+      }),
+    );
+
+    expect(result.consumed).toBe(true);
+    expect(result.type).toBe("canonical_decision_applied");
+    expect(result.decisionApplied).toBe(true);
+
+    const resolved = getCanonicalGuardianRequest(req.id);
+    expect(resolved!.status).toBe("approved");
+  });
+
   test("all expired hinted requests means no pending found — not consumed", async () => {
     const expired1 = createCanonicalGuardianRequest({
       kind: "tool_approval",

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -754,6 +754,7 @@ const EXPLICIT_REJECT_PHRASES: ReadonlySet<string> = new Set([
 
 function normalizeDecisionPhrase(text: string): string {
   return text
+    .replace(/[`*_~]/g, "")
     .trim()
     .toLowerCase()
     .replace(/[.!?]+$/g, "")


### PR DESCRIPTION
## Summary
- Add formatting character stripping to `normalizeDecisionPhrase()` in guardian reply router
- Add test for backtick-wrapped plain-text approval decision

Part of plan: fix-guardian-reply-fmt.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22357" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
