### PR TITLE
fix: strip channel formatting delimiters in guardian reply code parser

### DIFF
--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -616,6 +616,127 @@ describe("routing invariant: code-only messages return clarification", () => {
 });
 
 // ===========================================================================
+// SECTION 4b: Channel formatting delimiters stripped from code parser
+// ===========================================================================
+
+describe("routing invariant: channel formatting delimiters stripped from code parser", () => {
+  beforeEach(() => resetTables());
+
+  test("backtick-wrapped code + approve is parsed correctly", async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: "tool_approval",
+      sourceType: "channel",
+      conversationId: "conv-1",
+      guardianExternalUserId: "guardian-1",
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      requestCode: "A1B2C3",
+      toolName: "shell",
+      inputDigest: "sha256:abc",
+      expiresAt: Date.now() + 60_000,
+    });
+    registerPendingToolApprovalInteraction(req.id, "conv-1", "shell");
+
+    const result = await routeGuardianReply(
+      replyCtx({
+        messageText: "`A1B2C3 approve`",
+        conversationId: "conv-1",
+      }),
+    );
+
+    expect(result.consumed).toBe(true);
+    expect(result.type).toBe("canonical_decision_applied");
+    expect(result.decisionApplied).toBe(true);
+
+    const resolved = getCanonicalGuardianRequest(req.id);
+    expect(resolved!.status).toBe("approved");
+  });
+
+  test("bold+backtick code + reject is parsed correctly", async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: "tool_approval",
+      sourceType: "channel",
+      conversationId: "conv-1",
+      guardianExternalUserId: "guardian-1",
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      requestCode: "D4E5F6",
+      expiresAt: Date.now() + 60_000,
+    });
+    registerPendingToolApprovalInteraction(req.id, "conv-1", "shell");
+
+    const result = await routeGuardianReply(
+      replyCtx({
+        messageText: "*`D4E5F6 reject`*",
+        conversationId: "conv-1",
+      }),
+    );
+
+    expect(result.consumed).toBe(true);
+    expect(result.type).toBe("canonical_decision_applied");
+    expect(result.decisionApplied).toBe(true);
+
+    const resolved = getCanonicalGuardianRequest(req.id);
+    expect(resolved!.status).toBe("denied");
+  });
+
+  test("backtick-wrapped code only returns clarification", async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: "tool_approval",
+      sourceType: "channel",
+      conversationId: "conv-1",
+      guardianExternalUserId: "guardian-1",
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      requestCode: "A1B2C3",
+      toolName: "shell",
+      questionText: "Run shell command: ls -la",
+      expiresAt: Date.now() + 60_000,
+    });
+
+    const result = await routeGuardianReply(
+      replyCtx({
+        messageText: "`A1B2C3`",
+        conversationId: "conv-1",
+      }),
+    );
+
+    expect(result.consumed).toBe(true);
+    expect(result.type).toBe("code_only_clarification");
+    expect(result.decisionApplied).toBe(false);
+
+    const unchanged = getCanonicalGuardianRequest(req.id);
+    expect(unchanged!.status).toBe("pending");
+  });
+
+  test("asterisk-wrapped code + approve is parsed correctly", async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: "tool_approval",
+      sourceType: "channel",
+      conversationId: "conv-1",
+      guardianExternalUserId: "guardian-1",
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      requestCode: "A1B2C3",
+      toolName: "shell",
+      inputDigest: "sha256:abc",
+      expiresAt: Date.now() + 60_000,
+    });
+    registerPendingToolApprovalInteraction(req.id, "conv-1", "shell");
+
+    const result = await routeGuardianReply(
+      replyCtx({
+        messageText: "*A1B2C3 approve*",
+        conversationId: "conv-1",
+      }),
+    );
+
+    expect(result.consumed).toBe(true);
+    expect(result.type).toBe("canonical_decision_applied");
+    expect(result.decisionApplied).toBe(true);
+
+    const resolved = getCanonicalGuardianRequest(req.id);
+    expect(resolved!.status).toBe("approved");
+  });
+});
+
+// ===========================================================================
 // SECTION 5: Disambiguation with multiple pending requests stays fail-closed
 // ===========================================================================
 

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -155,8 +155,11 @@ function parseRequestCode(
   text: string,
   scopeConversationId?: string,
 ): CodeParseResult | null {
+  // Strip common channel formatting delimiters (backticks, bold, italic,
+  // strikethrough) that messaging platforms wrap around inline code.
+  const cleaned = text.replace(/[`*_~]/g, "").trim();
   // Request codes are 6 hex chars (A-F, 0-9), uppercase
-  const upper = text.toUpperCase();
+  const upper = cleaned.toUpperCase();
   const match = upper.match(/^([A-F0-9]{6})(?:\s|$)/);
   if (!match) return null;
 
@@ -185,7 +188,7 @@ function parseRequestCode(
     return null;
   }
 
-  const remainingText = text.slice(code.length).trim();
+  const remainingText = cleaned.slice(code.length).trim();
   return { request, remainingText };
 }
 


### PR DESCRIPTION
## Summary
- Strip common channel formatting delimiters (backticks, asterisks, underscores, tildes) from message text in `parseRequestCode()` before regex matching
- Update `remainingText` derivation to use cleaned text for correct offset calculation
- Add tests for backtick-wrapped, bold-wrapped, and mixed-formatting code replies

Part of plan: fix-guardian-reply-fmt.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22358" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
