### PR TITLE
fix: sort imports in cli-memory test

### DIFF
--- a/assistant/src/__tests__/cli-memory.test.ts
+++ b/assistant/src/__tests__/cli-memory.test.ts
@@ -58,13 +58,13 @@ mock.module("../config/loader.js", () => ({
   invalidateConfigCache: () => {},
 }));
 
-import { getDb, initializeDb, resetDb } from "../memory/db.js";
-import { memoryItems, memoryJobs } from "../memory/schema.js";
 import {
   buildCliCapabilityStatement,
   seedCliCommandMemories,
   upsertCliCapabilityMemory,
 } from "../cli/cli-memory.js";
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import { memoryItems, memoryJobs } from "../memory/schema.js";
 import { ensureDataDir, getDbPath } from "../util/platform.js";
 
 ensureDataDir();


### PR DESCRIPTION
## Summary
- Reorder imports in `assistant/src/__tests__/cli-memory.test.ts` to satisfy `simple-import-sort/imports` lint rule

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23761422952/job/69229704597