### PR TITLE
refactor: make threadTs optional on NormalizedSlackEvent

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1208,7 +1208,9 @@ async function main() {
       { appToken, botToken, gatewayConfig: config },
       (normalized) => {
         const { threadTs, channel } = normalized;
-        const replyCallbackUrl = `${config.gatewayInternalBaseUrl}/deliver/slack?threadTs=${encodeURIComponent(threadTs)}&channel=${encodeURIComponent(channel)}`;
+        const params = new URLSearchParams({ channel });
+        if (threadTs) params.set("threadTs", threadTs);
+        const replyCallbackUrl = `${config.gatewayInternalBaseUrl}/deliver/slack?${params}`;
 
         // Check if this is a regular thread reply (not an edit or callback action).
         // Edits and callbacks don't benefit from thread context and would just add
@@ -1345,7 +1347,7 @@ async function main() {
           }
         };
 
-        if (isThreadReply && botToken) {
+        if (isThreadReply && botToken && threadTs) {
           fetchThreadContext(channel, threadTs, messageTs, botToken)
             .then((context) => context ?? undefined)
             .catch(() => undefined)

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -291,7 +291,7 @@ export type NormalizedSlackEvent = {
   event: GatewayInboundEvent;
   routing: RouteResult;
   /** Thread timestamp for reply threading. */
-  threadTs: string;
+  threadTs?: string;
   /** Slack channel ID. */
   channel: string;
   /** Original Slack file objects keyed by file ID, for download in the I/O layer. */


### PR DESCRIPTION
## Summary
- Makes `threadTs` optional (`string | undefined`) on `NormalizedSlackEvent` type
- Updates callback URL construction in `index.ts` to conditionally include `threadTs`
- Adds guard for `threadTs` in thread context fetch condition

Part of plan: fix-slack-dm-threading.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
