### PR TITLE
fix: sort imports in skill-memory test to satisfy lint

### DIFF
--- a/assistant/src/__tests__/skill-memory.test.ts
+++ b/assistant/src/__tests__/skill-memory.test.ts
@@ -64,11 +64,11 @@ import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import { memoryItems, memoryJobs } from "../memory/schema.js";
 import type { CatalogSkill } from "../skills/catalog-install.js";
 import {
-  type SkillCapabilityInput,
   buildCapabilityStatement,
   deleteSkillCapabilityMemory,
   fromCatalogSkill,
   seedCatalogSkillMemories,
+  type SkillCapabilityInput,
   upsertSkillCapabilityMemory,
 } from "../skills/skill-memory.js";
 import { ensureDataDir, getDbPath } from "../util/platform.js";


### PR DESCRIPTION
## Summary
- Sort named imports in `skill-memory.test.ts` to satisfy `simple-import-sort/imports` lint rule (`type SkillCapabilityInput` moved to alphabetical position)

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23761684506/job/69230603198
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
