### PR TITLE
fix: stop threading Slack DM replies for non-threaded messages

### DIFF
--- a/gateway/src/__tests__/slack-normalize.test.ts
+++ b/gateway/src/__tests__/slack-normalize.test.ts
@@ -326,6 +326,32 @@ describe("normalizeSlackMessageEdit", () => {
     expect(result!.threadTs).toBe("1700000000.000100");
   });
 
+  test("DM edit without thread_ts omits threadTs", () => {
+    const config = makeConfig();
+    const event = makeMessageChangedEvent({ channel_type: "im" });
+    const result = normalizeSlackMessageEdit(event, "evt-dm-edit-1", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.threadTs).toBeUndefined();
+  });
+
+  test("DM edit with thread_ts preserves threadTs", () => {
+    const config = makeConfig();
+    const event = makeMessageChangedEvent({
+      channel_type: "im",
+      message: {
+        user: "U_USER123",
+        text: "edited hello world",
+        ts: "1700000000.000100",
+        thread_ts: "1700000000.000050",
+      },
+    });
+    const result = normalizeSlackMessageEdit(event, "evt-dm-edit-2", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.threadTs).toBe("1700000000.000050");
+  });
+
   test("DM edits use default assistant when channel is not in routing table", () => {
     const config = makeConfig({
       unmappedPolicy: "reject",

--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -260,6 +260,26 @@ describe("normalizeSlackReactionAdded", () => {
   });
 });
 
+describe("DM threading", () => {
+  it("non-threaded DM has no threadTs", () => {
+    const config = makeConfig();
+    const event = makeDmEvent();
+    const result = normalizeSlackDirectMessage(event, "evt-dm-1", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.threadTs).toBeUndefined();
+  });
+
+  it("threaded DM preserves threadTs", () => {
+    const config = makeConfig();
+    const event = makeDmEvent({ thread_ts: "1700000000.000050" });
+    const result = normalizeSlackDirectMessage(event, "evt-dm-2", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.threadTs).toBe("1700000000.000050");
+  });
+});
+
 // --- Attachment extraction tests ---
 
 function makeSlackFile(overrides?: Partial<SlackFile>): SlackFile {

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -379,7 +379,7 @@ export function normalizeSlackDirectMessage(
       raw: event as unknown as Record<string, unknown>,
     },
     routing,
-    threadTs: event.thread_ts ?? event.ts,
+    ...(event.thread_ts ? { threadTs: event.thread_ts } : {}),
     channel: event.channel,
     ...(slackFiles ? { slackFiles } : {}),
   };
@@ -754,8 +754,9 @@ export function normalizeSlackMessageEdit(
       raw: event as unknown as Record<string, unknown>,
     },
     routing,
-    // Fall back to the original message ts, not the wrapper event ts
-    threadTs: edited.thread_ts ?? edited.ts,
+    // For DMs without a thread, omit threadTs so the reply goes directly in conversation.
+    // For channels (or DMs already in a thread), fall back to edited.ts.
+    ...(isDm && !edited.thread_ts ? {} : { threadTs: edited.thread_ts ?? edited.ts }),
     channel: event.channel,
   };
 }


### PR DESCRIPTION
## Summary
- Omits `threadTs` for non-threaded DM messages so replies go directly in conversation
- Applies same fix to DM edits (`normalizeSlackMessageEdit`)
- Adds tests for both threaded and non-threaded DM normalization paths
- Channel messages and app mentions are completely unaffected

Part of plan: fix-slack-dm-threading.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
