### PR TITLE
fix: increase startup timeout in managed bootstrap test to avoid CI flake

### DIFF
--- a/gateway/src/__tests__/credential-watcher-managed-bootstrap.test.ts
+++ b/gateway/src/__tests__/credential-watcher-managed-bootstrap.test.ts
@@ -76,7 +76,7 @@ async function startGateway(): Promise<void> {
     stdio: ["ignore", "pipe", "pipe"],
   });
 
-  const deadline = Date.now() + 5_000;
+  const deadline = Date.now() + 10_000;
   while (Date.now() < deadline) {
     try {
       const res = await fetch(`http://localhost:${gatewayPort}/healthz`);
@@ -86,7 +86,7 @@ async function startGateway(): Promise<void> {
     }
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
-  throw new Error("Gateway failed to start within 5 seconds");
+  throw new Error("Gateway failed to start within 10 seconds");
 }
 
 function startFakeCes(opts: {
@@ -139,7 +139,7 @@ afterEach(() => {
   cesPort = 0;
 
   if (gatewayProc) {
-    gatewayProc.kill();
+    gatewayProc.kill("SIGKILL");
     gatewayProc = null;
   }
 
@@ -176,7 +176,7 @@ describe("gateway managed credential bootstrap retry", () => {
     }
 
     expect(status).toBe(401);
-  }, 15_000);
+  }, 20_000);
 
   test("keeps retrying until configured credential reads succeed after CES list is already available", async () => {
     mkdirSync(testDir, { recursive: true });
@@ -220,5 +220,5 @@ describe("gateway managed credential bootstrap retry", () => {
     }
 
     expect(status).toBe(401);
-  }, 15_000);
+  }, 20_000);
 });


### PR DESCRIPTION
## Summary
- Increased the `startGateway()` health check deadline from 5s to 10s to accommodate CI resource contention
- Changed `afterEach` cleanup to use `SIGKILL` instead of `SIGTERM` so the previous test's gateway process exits immediately rather than entering a 5-second drain window that overlaps with the next test
- Bumped per-test timeouts from 15s to 20s to match the increased startup timeout

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23761722013/job/69230731635
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22373" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
