### PR TITLE
fix: allow disclosure sections to expand in read-only conversations

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -536,6 +536,7 @@ struct AssistantProgressView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .environment(\.isEnabled, true)
         .padding(.horizontal, VSpacing.sm)
         .padding(.vertical, VSpacing.xs)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -857,6 +858,7 @@ private struct StepDetailRow: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .environment(\.isEnabled, true)
             .padding(.leading, VSpacing.sm)
             .padding(.trailing, VSpacing.xs)
             .padding(.vertical, VSpacing.xs)

--- a/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
@@ -57,6 +57,7 @@ struct ThinkingBlockView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .environment(\.isEnabled, true)
         .pointerCursor()
     }
 }


### PR DESCRIPTION
## Summary
- **Problem**: In read-only conversations (channel conversations from Slack, etc.), the "Thought process" and "Completed N step" collapsed sections couldn't be expanded because `.disabled(!isInteractionEnabled)` on `MessageListView` disabled all interactive elements.
- **Fix**: Add `.environment(\.isEnabled, true)` to the three disclosure header buttons (`ThinkingBlockView`, `AssistantProgressView` headerRow, `StepDetailRow`) to re-enable them while keeping tool confirmation and guardian action buttons correctly disabled.
- Also fixes the pointer cursor (hand icon) on these headers, since `PointerCursorModifier` reads `@Environment(\.isEnabled)`.

## Original prompt
it (from plan: allow disclosure sections to expand in read-only conversations)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22374" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
