### PR TITLE
fix: sort imports in skill-memory.ts

### DIFF
--- a/assistant/src/skills/skill-memory.ts
+++ b/assistant/src/skills/skill-memory.ts
@@ -3,7 +3,7 @@ import { v4 as uuid } from "uuid";
 
 import { getConfig } from "../config/loader.js";
 import { resolveSkillStates } from "../config/skill-state.js";
-import { type SkillSummary, loadSkillCatalog } from "../config/skills.js";
+import { loadSkillCatalog, type SkillSummary } from "../config/skills.js";
 import { getDb } from "../memory/db.js";
 import { computeMemoryFingerprint } from "../memory/fingerprint.js";
 import { enqueueMemoryJob } from "../memory/jobs-store.js";


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error in `assistant/src/skills/skill-memory.ts` by reordering named imports alphabetically (`loadSkillCatalog` before `type SkillSummary`)

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23761986895/job/69231652472
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22375" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
