### PR TITLE
feat(gateway): fetch DM history context for inbound Slack DMs

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -89,6 +89,7 @@ import {
 } from "./slack/socket-mode.js";
 import { downloadSlackFile } from "./slack/download.js";
 import { fetchThreadContext } from "./slack/thread-context.js";
+import { fetchDmContext } from "./slack/dm-context.js";
 import { handleInbound } from "./handlers/handle-inbound.js";
 import { checkAuthRateLimit } from "./http/middleware/rate-limit.js";
 import {
@@ -1356,6 +1357,17 @@ async function main() {
               log.error(
                 { err, channel, threadTs },
                 "Unhandled error in Slack forward (thread reply)",
+              );
+            });
+        } else if (channel.startsWith("D") && botToken && messageTs && !isEdit && !isCallback) {
+          fetchDmContext(channel, messageTs, botToken)
+            .then((context) => context ?? undefined)
+            .catch(() => undefined)
+            .then((context) => forward(context))
+            .catch((err) => {
+              log.error(
+                { err, channel },
+                "Unhandled error in Slack forward (DM context)",
               );
             });
         } else {

--- a/gateway/src/slack/dm-context.test.ts
+++ b/gateway/src/slack/dm-context.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+type FetchFn = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(
+  async () => new Response(),
+);
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+const { fetchDmContext } = await import("./dm-context.js");
+const { clearUserInfoCache, clearInFlightFetches } =
+  await import("./normalize.js");
+
+function mockSlackApi(
+  historyMessages: Array<{
+    user?: string;
+    text?: string;
+    ts?: string;
+    bot_id?: string;
+    username?: string;
+  }>,
+  userNames: Record<string, string> = {},
+) {
+  fetchMock = mock(async (url: string | URL | Request) => {
+    const urlStr = typeof url === "string" ? url : url.toString();
+    if (urlStr.includes("conversations.history")) {
+      return Response.json({ ok: true, messages: historyMessages });
+    }
+    if (urlStr.includes("users.info")) {
+      const userId = new URL(urlStr).searchParams.get("user");
+      const name = userNames[userId!] ?? userId;
+      return Response.json({
+        ok: true,
+        user: { name: userId, profile: { display_name: name } },
+      });
+    }
+    return Response.json({ ok: false });
+  });
+}
+
+describe("fetchDmContext", () => {
+  beforeEach(() => {
+    clearUserInfoCache();
+    clearInFlightFetches();
+  });
+
+  it("returns formatted context with prior messages", async () => {
+    // Slack returns newest-first; include a bot message
+    mockSlackApi(
+      [
+        {
+          user: "UBOT",
+          text: "Here's what I found",
+          ts: "1000.2",
+          bot_id: "B123",
+        },
+        { user: "U001", text: "Can you look this up?", ts: "1000.1" },
+        { user: "U001", text: "Hey there", ts: "1000.0" },
+      ],
+      { U001: "Alice", UBOT: "Assistant" },
+    );
+
+    const result = await fetchDmContext(
+      "D123",
+      "1000.3", // current message ts, excluded from context
+      "xoxb-test-token",
+    );
+
+    expect(result).toContain(
+      "Recent messages in this DM conversation (3 prior messages)",
+    );
+    // Should be in chronological order (oldest first)
+    const aliceHeyIdx = result!.indexOf("[Alice]: Hey there");
+    const aliceCanIdx = result!.indexOf("[Alice]: Can you look this up?");
+    const botIdx = result!.indexOf("[Assistant]: Here's what I found");
+    expect(aliceHeyIdx).toBeLessThan(aliceCanIdx);
+    expect(aliceCanIdx).toBeLessThan(botIdx);
+  });
+
+  it("excludes the current message", async () => {
+    mockSlackApi(
+      [
+        { user: "U001", text: "This is the current message", ts: "1000.1" },
+        { user: "U002", text: "Earlier message", ts: "1000.0" },
+      ],
+      { U001: "Alice", U002: "Bob" },
+    );
+
+    const result = await fetchDmContext(
+      "D123",
+      "1000.1", // matches first message — should be excluded
+      "xoxb-test-token",
+    );
+
+    expect(result).toContain("1 prior messages");
+    expect(result).toContain("[Bob]: Earlier message");
+    expect(result).not.toContain("This is the current message");
+  });
+
+  it("returns null when no prior messages", async () => {
+    // Only the current message in history
+    mockSlackApi([
+      { user: "U001", text: "Hello!", ts: "1000.0" },
+    ]);
+
+    const result = await fetchDmContext(
+      "D123",
+      "1000.0", // matches the only message
+      "xoxb-test-token",
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null on API error", async () => {
+    fetchMock = mock(async () =>
+      Response.json({ ok: false, error: "channel_not_found" }),
+    );
+
+    const result = await fetchDmContext(
+      "D123",
+      "1000.0",
+      "xoxb-test-token",
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null on HTTP error", async () => {
+    fetchMock = mock(async () => new Response("Server Error", { status: 500 }));
+
+    const result = await fetchDmContext(
+      "D123",
+      "1000.0",
+      "xoxb-test-token",
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("reverses API order to chronological", async () => {
+    // Slack API returns newest-first
+    mockSlackApi(
+      [
+        { user: "U001", text: "Third message", ts: "1000.2" },
+        { user: "U001", text: "Second message", ts: "1000.1" },
+        { user: "U001", text: "First message", ts: "1000.0" },
+      ],
+      { U001: "Alice" },
+    );
+
+    const result = await fetchDmContext(
+      "D123",
+      "9999.0", // current message not in list
+      "xoxb-test-token",
+    );
+
+    // Verify chronological order in output
+    const firstIdx = result!.indexOf("First message");
+    const secondIdx = result!.indexOf("Second message");
+    const thirdIdx = result!.indexOf("Third message");
+    expect(firstIdx).toBeLessThan(secondIdx);
+    expect(secondIdx).toBeLessThan(thirdIdx);
+  });
+});

--- a/gateway/src/slack/dm-context.ts
+++ b/gateway/src/slack/dm-context.ts
@@ -1,0 +1,129 @@
+/**
+ * Fetches recent DM history for inbound Slack direct messages so the
+ * assistant has context about prior messages in the conversation.
+ *
+ * Uses `conversations.history` to retrieve recent messages and formats
+ * them as a human-readable context string suitable for transport hints.
+ */
+
+import { fetchImpl } from "../fetch.js";
+import { getLogger } from "../logger.js";
+import { resolveSlackUser } from "./normalize.js";
+
+const log = getLogger("slack-dm-context");
+
+/** Maximum number of prior messages to include in context. */
+const MAX_CONTEXT_MESSAGES = 10;
+
+/** Timeout for the conversations.history API call. */
+const FETCH_TIMEOUT_MS = 5_000;
+
+interface SlackDmMessage {
+  user?: string;
+  text?: string;
+  ts?: string;
+  bot_id?: string;
+  username?: string;
+}
+
+/**
+ * Fetch recent DM history for a Slack direct-message channel.
+ *
+ * Returns a formatted string containing recent prior messages, or null
+ * if the fetch fails or there are no prior messages.
+ *
+ * @param channel - Slack DM channel ID (starts with "D")
+ * @param currentMessageTs - The current message's ts (excluded from context)
+ * @param botToken - Bot OAuth token for API calls
+ */
+export async function fetchDmContext(
+  channel: string,
+  currentMessageTs: string,
+  botToken: string,
+): Promise<string | null> {
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    const params = new URLSearchParams({
+      channel,
+      limit: "10",
+    });
+
+    const resp = await fetchImpl(
+      `https://slack.com/api/conversations.history?${params.toString()}`,
+      {
+        method: "GET",
+        headers: { Authorization: `Bearer ${botToken}` },
+        signal: controller.signal,
+      },
+    );
+
+    clearTimeout(timeout);
+
+    if (!resp.ok) {
+      log.debug(
+        { status: resp.status, channel },
+        "conversations.history HTTP error",
+      );
+      return null;
+    }
+
+    const data = (await resp.json()) as {
+      ok?: boolean;
+      messages?: SlackDmMessage[];
+      error?: string;
+    };
+
+    if (!data.ok || !data.messages?.length) {
+      log.debug(
+        { error: data.error, channel },
+        "conversations.history returned no messages",
+      );
+      return null;
+    }
+
+    // Exclude the current message from context
+    const priorMessages = data.messages.filter(
+      (msg) => msg.ts !== currentMessageTs,
+    );
+
+    if (priorMessages.length === 0) return null;
+
+    // Slack returns newest-first; reverse to chronological order
+    priorMessages.reverse();
+
+    // Cap at MAX_CONTEXT_MESSAGES (take the most recent N)
+    const contextMessages =
+      priorMessages.length <= MAX_CONTEXT_MESSAGES
+        ? priorMessages
+        : priorMessages.slice(-MAX_CONTEXT_MESSAGES);
+
+    // Resolve user display names (best-effort, uses cache)
+    const formattedMessages = await Promise.all(
+      contextMessages.map(async (msg) => {
+        let authorLabel: string;
+        if (msg.user) {
+          const userInfo = await resolveSlackUser(msg.user, botToken).catch(
+            () => undefined,
+          );
+          authorLabel = userInfo?.displayName ?? msg.user;
+        } else {
+          authorLabel = msg.username ?? "Unknown";
+        }
+
+        const text = msg.text?.trim() || "(no text)";
+        return `[${authorLabel}]: ${text}`;
+      }),
+    );
+
+    return `Recent messages in this DM conversation (${contextMessages.length} prior messages):\n\n${formattedMessages.join("\n\n")}`;
+  } catch (err) {
+    // AbortError from timeout or any other fetch failure — non-fatal
+    log.debug(
+      { err, channel },
+      "Failed to fetch DM context (non-fatal)",
+    );
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Add `gateway/src/slack/dm-context.ts` mirroring the existing thread-context pattern, using `conversations.history` to fetch recent DM messages
- Wire it into the Slack event handler in `gateway/src/index.ts` for DM channels (`channel.startsWith('D')`)
- Includes unit tests following the thread-context.test.ts pattern

Part of plan: slack-dm-context.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22377" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
