### PR TITLE
fix: update stale comment referencing removed skills catalog

### DIFF
--- a/assistant/src/__tests__/no-domain-routing-in-prompt-guard.test.ts
+++ b/assistant/src/__tests__/no-domain-routing-in-prompt-guard.test.ts
@@ -5,7 +5,8 @@ import { describe, expect, test } from "bun:test";
 /**
  * Guard test: domain-specific routing sections must NOT appear in the system
  * prompt source file. Routing cues now live in skill frontmatter
- * (`activation-hints` / `avoid-when`) and are projected into the skills catalog.
+ * (`activation-hints` / `avoid-when`) and are seeded as capability memories
+ * for semantic discovery.
  *
  * If this test fails, you are re-introducing hardcoded routing into the system
  * prompt. Instead, add `activation-hints` to the skill's SKILL.md frontmatter.


### PR DESCRIPTION
## Summary
Updates the docstring in no-domain-routing-in-prompt-guard.test.ts to reference capability memories instead of the removed skills catalog.

**Gap:** Stale comment referencing removed skills catalog
**What was expected:** Comment reflects current architecture (capability memories)
**What was found:** Comment still references 'skills catalog'
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
