### PR TITLE
fix: include avoidWhen routing cues in capability memory statements

### DIFF
--- a/assistant/src/__tests__/skill-memory.test.ts
+++ b/assistant/src/__tests__/skill-memory.test.ts
@@ -130,6 +130,32 @@ describe("buildCapabilityStatement", () => {
     expect(result).toContain("needs web data");
   });
 
+  test("includes avoidWhen routing cues when present", () => {
+    const input: SkillCapabilityInput = {
+      id: "test-skill",
+      displayName: "My Skill",
+      description: "A skill for testing",
+      avoidWhen: ["user wants local files only", "offline mode"],
+    };
+    const result = buildCapabilityStatement(input);
+    expect(result).toContain("Avoid when:");
+    expect(result).toContain("user wants local files only");
+    expect(result).toContain("offline mode");
+  });
+
+  test("includes both activationHints and avoidWhen when present", () => {
+    const input: SkillCapabilityInput = {
+      id: "test-skill",
+      displayName: "My Skill",
+      description: "A skill for testing",
+      activationHints: ["user asks to search"],
+      avoidWhen: ["offline mode"],
+    };
+    const result = buildCapabilityStatement(input);
+    expect(result).toContain("Use when: user asks to search.");
+    expect(result).toContain("Avoid when: offline mode.");
+  });
+
   test("works with just name as displayName", () => {
     const input: SkillCapabilityInput = {
       id: "test-skill",
@@ -174,6 +200,19 @@ describe("fromSkillSummary", () => {
     const entry = makeSkillSummary({ activationHints: undefined });
     const input = fromSkillSummary(entry);
     expect(input.activationHints).toBeUndefined();
+  });
+
+  test("maps avoidWhen from SkillSummary", () => {
+    const cues = ["offline mode", "user wants local files only"];
+    const entry = makeSkillSummary({ avoidWhen: cues });
+    const input = fromSkillSummary(entry);
+    expect(input.avoidWhen).toEqual(cues);
+  });
+
+  test("leaves avoidWhen undefined when not present", () => {
+    const entry = makeSkillSummary({ avoidWhen: undefined });
+    const input = fromSkillSummary(entry);
+    expect(input.avoidWhen).toBeUndefined();
   });
 
   test("copies id and description directly", () => {

--- a/assistant/src/skills/skill-memory.ts
+++ b/assistant/src/skills/skill-memory.ts
@@ -22,6 +22,7 @@ export interface SkillCapabilityInput {
   displayName: string;
   description: string;
   activationHints?: string[];
+  avoidWhen?: string[];
 }
 
 /**
@@ -34,6 +35,7 @@ export function fromSkillSummary(entry: SkillSummary): SkillCapabilityInput {
     displayName: entry.displayName,
     description: entry.description,
     activationHints: entry.activationHints,
+    avoidWhen: entry.avoidWhen,
   };
 }
 
@@ -42,11 +44,14 @@ export function fromSkillSummary(entry: SkillSummary): SkillCapabilityInput {
  * Truncated to 500 chars max (matching the limit used by memory item extraction).
  */
 export function buildCapabilityStatement(input: SkillCapabilityInput): string {
-  const { displayName, activationHints } = input;
+  const { displayName, activationHints, avoidWhen } = input;
 
   let statement = `The "${displayName}" skill (${input.id}) is available. ${input.description}.`;
   if (activationHints && activationHints.length > 0) {
     statement += ` Use when: ${activationHints.join("; ")}.`;
+  }
+  if (avoidWhen && avoidWhen.length > 0) {
+    statement += ` Avoid when: ${avoidWhen.join("; ")}.`;
   }
 
   // Truncate to 500 chars max


### PR DESCRIPTION
## Summary
Adds `avoidWhen` to `SkillCapabilityInput` and includes it in capability memory statements, restoring parity with the removed system prompt skills catalog.

**Gap:** avoidWhen routing cues dropped from capability memories
**What was expected:** avoidWhen data surfaced to the model via capability memories
**What was found:** SkillCapabilityInput and buildCapabilityStatement did not include avoidWhen
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
