### PR TITLE
fix: include configured MCP server names in mcp-setup capability memory

### DIFF
--- a/assistant/src/skills/skill-memory.ts
+++ b/assistant/src/skills/skill-memory.ts
@@ -207,7 +207,22 @@ export function seedCatalogSkillMemories(): void {
     const catalogIds = new Set<string>();
     for (const { summary } of enabled) {
       catalogIds.add(summary.id);
-      upsertSkillCapabilityMemory(summary.id, fromSkillSummary(summary));
+      const input = fromSkillSummary(summary);
+
+      // Enrich mcp-setup description with configured server names
+      if (summary.id === "mcp-setup") {
+        const servers = config.mcp?.servers;
+        if (servers) {
+          const names = Object.keys(servers).filter(
+            (name) => servers[name]?.enabled !== false,
+          );
+          if (names.length > 0) {
+            input.description += ` Configured: ${names.join(", ")}`;
+          }
+        }
+      }
+
+      upsertSkillCapabilityMemory(summary.id, input);
     }
 
     // Prune stale capability memories for skills no longer in the enabled set


### PR DESCRIPTION
## Summary
Special-cases the `mcp-setup` skill in `seedCatalogSkillMemories()` to include configured MCP server names in the capability memory description, restoring the dynamic context that was previously provided by the deleted `getMcpSetupDescription()`.

**Gap:** mcp-setup skill loses dynamic description with configured server names
**What was expected:** Capability memory includes configured MCP server names
**What was found:** Only static SKILL.md description was used
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
