### PR TITLE
Add nullable feature_flag column to oauth_providers table

### DIFF
--- a/assistant/src/__tests__/oauth-provider-serializer.test.ts
+++ b/assistant/src/__tests__/oauth-provider-serializer.test.ts
@@ -41,6 +41,7 @@ function makeRow(overrides: Partial<OAuthProviderRow> = {}): OAuthProviderRow {
     identityResponsePaths: null,
     identityFormat: null,
     identityOkField: null,
+    featureFlag: null,
     createdAt: now,
     updatedAt: now,
     ...overrides,

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -98,6 +98,7 @@ import {
   migrateOAuthAppsClientSecretPath,
   migrateOAuthProvidersBehaviorColumns,
   migrateOAuthProvidersDisplayMetadata,
+  migrateOAuthProvidersFeatureFlag,
   migrateOAuthProvidersManagedServiceConfigKey,
   migrateOAuthProvidersPingConfig,
   migrateOAuthProvidersPingUrl,
@@ -539,6 +540,9 @@ export function initializeDb(): void {
 
   // 98. Add llm_call_count column to llm_usage_events for accurate LLM call counting
   migrateUsageLlmCallCount(database);
+
+  // 99. Add feature_flag column to oauth_providers for feature-flag gating
+  migrateOAuthProvidersFeatureFlag(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/201-oauth-providers-feature-flag.ts
+++ b/assistant/src/memory/migrations/201-oauth-providers-feature-flag.ts
@@ -1,0 +1,11 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+export function migrateOAuthProvidersFeatureFlag(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  try {
+    raw.exec(`ALTER TABLE oauth_providers ADD COLUMN feature_flag TEXT`);
+  } catch {
+    // Column already exists — nothing to do.
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -140,6 +140,7 @@ export { migrateOAuthProvidersBehaviorColumns } from "./197-oauth-providers-beha
 export { migrateDropSetupSkillIdColumn } from "./198-drop-setup-skill-id-column.js";
 export { migrateGuardianRequestEnrichmentColumns } from "./199-guardian-request-enrichment-columns.js";
 export { migrateUsageLlmCallCount } from "./200-usage-llm-call-count.js";
+export { migrateOAuthProvidersFeatureFlag } from "./201-oauth-providers-feature-flag.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/oauth.ts
+++ b/assistant/src/memory/schema/oauth.ts
@@ -38,6 +38,7 @@ export const oauthProviders = sqliteTable("oauth_providers", {
   identityResponsePaths: text("identity_response_paths"),
   identityFormat: text("identity_format"),
   identityOkField: text("identity_ok_field"),
+  featureFlag: text("feature_flag"),
   createdAt: integer("created_at").notNull(),
   updatedAt: integer("updated_at").notNull(),
 });

--- a/assistant/src/oauth/__tests__/identity-verifier.test.ts
+++ b/assistant/src/oauth/__tests__/identity-verifier.test.ts
@@ -60,6 +60,7 @@ function makeProviderRow(
     identityResponsePaths: null,
     identityFormat: null,
     identityOkField: null,
+    featureFlag: null,
     createdAt: now,
     updatedAt: now,
     ...rest,

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -95,6 +95,7 @@ export function seedProviders(
     identityResponsePaths?: string[];
     identityFormat?: string;
     identityOkField?: string;
+    featureFlag?: string;
   }>,
 ): void {
   const db = getDb();
@@ -138,6 +139,7 @@ export function seedProviders(
       : null;
     const identityFormat = p.identityFormat ?? null;
     const identityOkField = p.identityOkField ?? null;
+    const featureFlag = p.featureFlag ?? null;
 
     db.insert(oauthProviders)
       .values({
@@ -172,6 +174,7 @@ export function seedProviders(
         identityResponsePaths,
         identityFormat,
         identityOkField,
+        featureFlag,
         createdAt: now,
         updatedAt: now,
       })
@@ -206,6 +209,7 @@ export function seedProviders(
           identityResponsePaths,
           identityFormat,
           identityOkField,
+          featureFlag,
           updatedAt: now,
         },
       })
@@ -270,6 +274,7 @@ export function registerProvider(params: {
   identityResponsePaths?: string[];
   identityFormat?: string;
   identityOkField?: string;
+  featureFlag?: string;
 }): OAuthProviderRow {
   const db = getDb();
   const now = Date.now();
@@ -321,6 +326,7 @@ export function registerProvider(params: {
       : null,
     identityFormat: params.identityFormat ?? null,
     identityOkField: params.identityOkField ?? null,
+    featureFlag: params.featureFlag ?? null,
     createdAt: now,
     updatedAt: now,
   };
@@ -376,6 +382,7 @@ export function updateProvider(
     identityResponsePaths: string[];
     identityFormat: string;
     identityOkField: string;
+    featureFlag: string;
   }>,
 ): OAuthProviderRow | undefined {
   const existing = getProvider(providerKey);
@@ -430,6 +437,7 @@ export function updateProvider(
     set.identityFormat = params.identityFormat;
   if (params.identityOkField !== undefined)
     set.identityOkField = params.identityOkField;
+  if (params.featureFlag !== undefined) set.featureFlag = params.featureFlag;
 
   db.update(oauthProviders)
     .set(set)


### PR DESCRIPTION
## Summary
- Add feature_flag TEXT column to Drizzle schema for oauth_providers
- Create idempotent migration (201) to ALTER TABLE ADD COLUMN
- Wire migration into db-init.ts startup sequence
- Update oauth-store registerProvider, seedProviders, updateProvider to handle featureFlag
- Add featureFlag to test helpers for type safety

Part of plan: oauth-provider-feature-flag.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22383" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
