### PR TITLE
fix(gateway): over-fetch DM history to ensure full context window

### DIFF
--- a/gateway/src/slack/dm-context.ts
+++ b/gateway/src/slack/dm-context.ts
@@ -15,6 +15,12 @@ const log = getLogger("slack-dm-context");
 /** Maximum number of prior messages to include in context. */
 const MAX_CONTEXT_MESSAGES = 10;
 
+/**
+ * Over-fetch so the current message (which is filtered out) doesn't
+ * reduce the effective context window below MAX_CONTEXT_MESSAGES.
+ */
+const FETCH_LIMIT = 15;
+
 /** Timeout for the conversations.history API call. */
 const FETCH_TIMEOUT_MS = 5_000;
 
@@ -47,7 +53,7 @@ export async function fetchDmContext(
 
     const params = new URLSearchParams({
       channel,
-      limit: "10",
+      limit: String(FETCH_LIMIT),
     });
 
     const resp = await fetchImpl(


### PR DESCRIPTION
## Summary
- Add `FETCH_LIMIT = 15` constant for the `conversations.history` API call, separate from `MAX_CONTEXT_MESSAGES = 10` output cap
- Mirrors the over-fetch pattern used by `thread-context.ts` (`FETCH_LIMIT = 50` vs `MAX_CONTEXT_MESSAGES = 15`)
- Ensures filtering out the current message doesn't reduce the effective context window below 10

## Original prompt
Fix dm-context.ts to over-fetch from the Slack API like thread-context.ts does. Add a separate FETCH_LIMIT constant (e.g., 15) for the API call, keeping MAX_CONTEXT_MESSAGES = 10 as the output cap. This ensures that after filtering out the current message, we can still return the full 10 context messages.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22385" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
