### PR TITLE
Add featureFlag support to OAuth store CRUD and seed providers

### DIFF
--- a/assistant/src/__tests__/oauth-provider-serializer.test.ts
+++ b/assistant/src/__tests__/oauth-provider-serializer.test.ts
@@ -192,6 +192,7 @@ describe("serializeProviderSummary", () => {
       client_id_placeholder: "your-client-id.apps.googleusercontent.com",
       requires_client_secret: true,
       supports_managed_mode: true,
+      feature_flag: null,
     });
   });
 

--- a/assistant/src/oauth/provider-serializer.ts
+++ b/assistant/src/oauth/provider-serializer.ts
@@ -31,6 +31,7 @@ export interface SerializedProviderSummary {
   client_id_placeholder: string | null;
   requires_client_secret: boolean;
   supports_managed_mode: boolean;
+  feature_flag: string | null;
 }
 
 /**
@@ -87,6 +88,7 @@ function _serializeProvider(
       : null,
     identityFormat: row.identityFormat ?? null,
     identityOkField: row.identityOkField ?? null,
+    featureFlag: row.featureFlag ?? null,
     redirectUri:
       options?.redirectUri !== undefined ? options.redirectUri : null,
     createdAt: new Date(row.createdAt).toISOString(),
@@ -112,5 +114,6 @@ export function serializeProviderSummary(
     client_id_placeholder: row.clientIdPlaceholder ?? null,
     requires_client_secret: !!(row.requiresClientSecret ?? 1),
     supports_managed_mode: !!row.managedServiceConfigKey,
+    feature_flag: row.featureFlag ?? null,
   };
 }

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -59,6 +59,7 @@ const PROVIDER_SEED_DATA: Record<
     identityResponsePaths?: string[];
     identityFormat?: string;
     identityOkField?: string;
+    featureFlag?: string;
   }
 > = {
   google: {


### PR DESCRIPTION
## Summary
- Add optional featureFlag field to seed provider type definition
- Include featureFlag in full provider serialization (_serializeProvider)
- Include feature_flag in summary provider serialization (SerializedProviderSummary)
- Update serializer test to include new feature_flag field

Part of plan: oauth-provider-feature-flag.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
