### PR TITLE
Filter OAuth providers from CLI and gateway when feature flag is disabled

### DIFF
--- a/assistant/src/__tests__/oauth-provider-visibility.test.ts
+++ b/assistant/src/__tests__/oauth-provider-visibility.test.ts
@@ -1,0 +1,149 @@
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../security/secure-keys.js", () => ({
+  deleteSecureKeyAsync: () => Promise.resolve("deleted" as const),
+  setSecureKeyAsync: () => Promise.resolve(true),
+  getSecureKeyAsync: () => Promise.resolve(undefined),
+}));
+
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
+import type { AssistantConfig } from "../config/schema.js";
+import { initializeDb, resetDb, resetTestTables } from "../memory/db.js";
+import { listProviders, seedProviders } from "../oauth/oauth-store.js";
+import { isProviderVisible } from "../oauth/provider-visibility.js";
+
+initializeDb();
+
+/** Create a minimal AssistantConfig for testing. */
+function makeConfig(): AssistantConfig {
+  return {} as AssistantConfig;
+}
+
+beforeEach(() => {
+  resetTestTables("oauth_connections", "oauth_apps", "oauth_providers");
+  _setOverridesForTesting({});
+});
+
+afterEach(() => {
+  _setOverridesForTesting({});
+});
+
+afterAll(() => {
+  resetDb();
+});
+
+describe("isProviderVisible", () => {
+  test("returns true when featureFlag is null", () => {
+    seedProviders([
+      {
+        providerKey: "no-flag-provider",
+        authUrl: "https://example.com/auth",
+        tokenUrl: "https://example.com/token",
+        defaultScopes: ["read"],
+        scopePolicy: {},
+      },
+    ]);
+
+    const providers = listProviders();
+    const provider = providers.find(
+      (p) => p.providerKey === "no-flag-provider",
+    );
+    expect(provider).toBeDefined();
+    expect(provider!.featureFlag).toBeNull();
+
+    const config = makeConfig();
+    expect(isProviderVisible(provider!, config)).toBe(true);
+  });
+
+  test("returns true when featureFlag is set and the flag is enabled", () => {
+    _setOverridesForTesting({ "test-gate": true });
+
+    seedProviders([
+      {
+        providerKey: "gated-provider",
+        authUrl: "https://example.com/auth",
+        tokenUrl: "https://example.com/token",
+        defaultScopes: ["read"],
+        scopePolicy: {},
+        featureFlag: "test-gate",
+      },
+    ]);
+
+    const providers = listProviders();
+    const provider = providers.find((p) => p.providerKey === "gated-provider");
+    expect(provider).toBeDefined();
+    expect(provider!.featureFlag).toBe("test-gate");
+
+    const config = makeConfig();
+    expect(isProviderVisible(provider!, config)).toBe(true);
+  });
+
+  test("returns false when featureFlag is set and the flag is disabled", () => {
+    _setOverridesForTesting({ "test-gate": false });
+
+    seedProviders([
+      {
+        providerKey: "gated-provider",
+        authUrl: "https://example.com/auth",
+        tokenUrl: "https://example.com/token",
+        defaultScopes: ["read"],
+        scopePolicy: {},
+        featureFlag: "test-gate",
+      },
+    ]);
+
+    const providers = listProviders();
+    const provider = providers.find((p) => p.providerKey === "gated-provider");
+    expect(provider).toBeDefined();
+
+    const config = makeConfig();
+    expect(isProviderVisible(provider!, config)).toBe(false);
+  });
+
+  test("listProviders returns all providers but isProviderVisible filters gated ones when flag is disabled", () => {
+    _setOverridesForTesting({ "test-gate": false });
+
+    seedProviders([
+      {
+        providerKey: "visible-provider",
+        authUrl: "https://example.com/auth",
+        tokenUrl: "https://example.com/token",
+        defaultScopes: ["read"],
+        scopePolicy: {},
+      },
+      {
+        providerKey: "gated-provider",
+        authUrl: "https://gated.example.com/auth",
+        tokenUrl: "https://gated.example.com/token",
+        defaultScopes: ["read"],
+        scopePolicy: {},
+        featureFlag: "test-gate",
+      },
+    ]);
+
+    const allProviders = listProviders();
+    expect(allProviders).toHaveLength(2);
+
+    const config = makeConfig();
+    const visibleProviders = allProviders.filter((p) =>
+      isProviderVisible(p, config),
+    );
+    expect(visibleProviders).toHaveLength(1);
+    expect(visibleProviders[0]!.providerKey).toBe("visible-provider");
+  });
+});

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -15,6 +15,7 @@ import {
   updateProvider,
 } from "../../../oauth/oauth-store.js";
 import { serializeProvider } from "../../../oauth/provider-serializer.js";
+import { isProviderVisible } from "../../../oauth/provider-visibility.js";
 import { SEEDED_PROVIDER_KEYS } from "../../../oauth/seed-providers.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
@@ -123,7 +124,12 @@ Examples:
         cmd: Command,
       ) => {
         try {
-          let rows = listProviders().map(parseProviderRow);
+          const config = loadConfig();
+          let allProviders = listProviders();
+          allProviders = allProviders.filter((r) =>
+            isProviderVisible(r, config),
+          );
+          let rows = allProviders.map(parseProviderRow);
 
           if (opts.providerKey) {
             const needles = opts.providerKey
@@ -183,6 +189,15 @@ Examples:
         const row = getProvider(providerKey);
 
         if (!row) {
+          writeOutput(cmd, {
+            ok: false,
+            error: `Provider not found: "${providerKey}". Run 'assistant oauth providers list' to see all registered providers. To register a custom provider, run 'assistant oauth providers register --help'.`,
+          });
+          process.exitCode = 1;
+          return;
+        }
+
+        if (!isProviderVisible(row, loadConfig())) {
           writeOutput(cmd, {
             ok: false,
             error: `Provider not found: "${providerKey}". Run 'assistant oauth providers list' to see all registered providers. To register a custom provider, run 'assistant oauth providers register --help'.`,

--- a/assistant/src/oauth/provider-visibility.ts
+++ b/assistant/src/oauth/provider-visibility.ts
@@ -1,0 +1,16 @@
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import type { AssistantConfig } from "../config/schema.js";
+import type { OAuthProviderRow } from "./oauth-store.js";
+
+/**
+ * Return true if the provider should be visible to external consumers
+ * (CLI, gateway API). A provider is hidden when it declares a featureFlag
+ * and that flag is currently disabled.
+ */
+export function isProviderVisible(
+  row: OAuthProviderRow,
+  config: AssistantConfig,
+): boolean {
+  if (!row.featureFlag) return true;
+  return isAssistantFeatureFlagEnabled(row.featureFlag, config);
+}

--- a/assistant/src/runtime/routes/oauth-providers.ts
+++ b/assistant/src/runtime/routes/oauth-providers.ts
@@ -6,8 +6,10 @@
  * runtime auth middleware.
  */
 
+import { loadConfig } from "../../config/loader.js";
 import { getProvider, listProviders } from "../../oauth/oauth-store.js";
 import { serializeProviderSummary } from "../../oauth/provider-serializer.js";
+import { isProviderVisible } from "../../oauth/provider-visibility.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 
@@ -22,7 +24,9 @@ export function oauthProvidersRouteDefinitions(): RouteDefinition[] {
       method: "GET",
       handler: ({ url }) => {
         const rows = listProviders();
-        let serialized = rows
+        const config = loadConfig();
+        const visibleRows = rows.filter((r) => isProviderVisible(r, config));
+        let serialized = visibleRows
           .map((row) => serializeProviderSummary(row))
           .filter((s): s is NonNullable<typeof s> => s !== null);
 
@@ -46,6 +50,14 @@ export function oauthProvidersRouteDefinitions(): RouteDefinition[] {
       handler: ({ params }) => {
         const row = getProvider(params.providerKey);
         if (!row) {
+          return httpError(
+            "NOT_FOUND",
+            `No OAuth provider registered for "${params.providerKey}"`,
+            404,
+          );
+        }
+
+        if (!isProviderVisible(row, loadConfig())) {
           return httpError(
             "NOT_FOUND",
             `No OAuth provider registered for "${params.providerKey}"`,


### PR DESCRIPTION
## Summary
- Create provider-visibility.ts helper with isProviderVisible() function
- Gate CLI providers list and get commands behind feature flag check
- Gate gateway GET /v1/oauth/providers and GET /v1/oauth/providers/:key endpoints
- Add comprehensive tests for visibility filtering scenarios

Part of plan: oauth-provider-feature-flag.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22387" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
