### PR TITLE
OAuth provider feature flag gating

### DIFF
--- a/assistant/src/__tests__/oauth-apps-routes.test.ts
+++ b/assistant/src/__tests__/oauth-apps-routes.test.ts
@@ -70,6 +70,7 @@ mock.module("../oauth/oauth-store.js", () => ({
           identityBody: null,
           identityFormat: null,
           identityOkField: null,
+          featureFlag: null,
           createdAt: 1735689500000,
           updatedAt: 1735689550000,
         }

--- a/assistant/src/__tests__/oauth-provider-serializer.test.ts
+++ b/assistant/src/__tests__/oauth-provider-serializer.test.ts
@@ -192,6 +192,7 @@ describe("serializeProviderSummary", () => {
       client_id_placeholder: "your-client-id.apps.googleusercontent.com",
       requires_client_secret: true,
       supports_managed_mode: true,
+      feature_flag: null,
     });
   });
 

--- a/assistant/src/__tests__/oauth-provider-serializer.test.ts
+++ b/assistant/src/__tests__/oauth-provider-serializer.test.ts
@@ -41,6 +41,7 @@ function makeRow(overrides: Partial<OAuthProviderRow> = {}): OAuthProviderRow {
     identityResponsePaths: null,
     identityFormat: null,
     identityOkField: null,
+    featureFlag: null,
     createdAt: now,
     updatedAt: now,
     ...overrides,

--- a/assistant/src/__tests__/oauth-provider-visibility.test.ts
+++ b/assistant/src/__tests__/oauth-provider-visibility.test.ts
@@ -1,0 +1,149 @@
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../security/secure-keys.js", () => ({
+  deleteSecureKeyAsync: () => Promise.resolve("deleted" as const),
+  setSecureKeyAsync: () => Promise.resolve(true),
+  getSecureKeyAsync: () => Promise.resolve(undefined),
+}));
+
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
+import type { AssistantConfig } from "../config/schema.js";
+import { initializeDb, resetDb, resetTestTables } from "../memory/db.js";
+import { listProviders, seedProviders } from "../oauth/oauth-store.js";
+import { isProviderVisible } from "../oauth/provider-visibility.js";
+
+initializeDb();
+
+/** Create a minimal AssistantConfig for testing. */
+function makeConfig(): AssistantConfig {
+  return {} as AssistantConfig;
+}
+
+beforeEach(() => {
+  resetTestTables("oauth_connections", "oauth_apps", "oauth_providers");
+  _setOverridesForTesting({});
+});
+
+afterEach(() => {
+  _setOverridesForTesting({});
+});
+
+afterAll(() => {
+  resetDb();
+});
+
+describe("isProviderVisible", () => {
+  test("returns true when featureFlag is null", () => {
+    seedProviders([
+      {
+        providerKey: "no-flag-provider",
+        authUrl: "https://example.com/auth",
+        tokenUrl: "https://example.com/token",
+        defaultScopes: ["read"],
+        scopePolicy: {},
+      },
+    ]);
+
+    const providers = listProviders();
+    const provider = providers.find(
+      (p) => p.providerKey === "no-flag-provider",
+    );
+    expect(provider).toBeDefined();
+    expect(provider!.featureFlag).toBeNull();
+
+    const config = makeConfig();
+    expect(isProviderVisible(provider!, config)).toBe(true);
+  });
+
+  test("returns true when featureFlag is set and the flag is enabled", () => {
+    _setOverridesForTesting({ "test-gate": true });
+
+    seedProviders([
+      {
+        providerKey: "gated-provider",
+        authUrl: "https://example.com/auth",
+        tokenUrl: "https://example.com/token",
+        defaultScopes: ["read"],
+        scopePolicy: {},
+        featureFlag: "test-gate",
+      },
+    ]);
+
+    const providers = listProviders();
+    const provider = providers.find((p) => p.providerKey === "gated-provider");
+    expect(provider).toBeDefined();
+    expect(provider!.featureFlag).toBe("test-gate");
+
+    const config = makeConfig();
+    expect(isProviderVisible(provider!, config)).toBe(true);
+  });
+
+  test("returns false when featureFlag is set and the flag is disabled", () => {
+    _setOverridesForTesting({ "test-gate": false });
+
+    seedProviders([
+      {
+        providerKey: "gated-provider",
+        authUrl: "https://example.com/auth",
+        tokenUrl: "https://example.com/token",
+        defaultScopes: ["read"],
+        scopePolicy: {},
+        featureFlag: "test-gate",
+      },
+    ]);
+
+    const providers = listProviders();
+    const provider = providers.find((p) => p.providerKey === "gated-provider");
+    expect(provider).toBeDefined();
+
+    const config = makeConfig();
+    expect(isProviderVisible(provider!, config)).toBe(false);
+  });
+
+  test("listProviders returns all providers but isProviderVisible filters gated ones when flag is disabled", () => {
+    _setOverridesForTesting({ "test-gate": false });
+
+    seedProviders([
+      {
+        providerKey: "visible-provider",
+        authUrl: "https://example.com/auth",
+        tokenUrl: "https://example.com/token",
+        defaultScopes: ["read"],
+        scopePolicy: {},
+      },
+      {
+        providerKey: "gated-provider",
+        authUrl: "https://gated.example.com/auth",
+        tokenUrl: "https://gated.example.com/token",
+        defaultScopes: ["read"],
+        scopePolicy: {},
+        featureFlag: "test-gate",
+      },
+    ]);
+
+    const allProviders = listProviders();
+    expect(allProviders).toHaveLength(2);
+
+    const config = makeConfig();
+    const visibleProviders = allProviders.filter((p) =>
+      isProviderVisible(p, config),
+    );
+    expect(visibleProviders).toHaveLength(1);
+    expect(visibleProviders[0]!.providerKey).toBe("visible-provider");
+  });
+});

--- a/assistant/src/__tests__/oauth-providers-routes.test.ts
+++ b/assistant/src/__tests__/oauth-providers-routes.test.ts
@@ -33,6 +33,7 @@ const mockListProviders = mock(() => [
     identityFormat: null,
     identityOkField: null,
     identityResponsePaths: null,
+    featureFlag: null,
     createdAt: 1735689500000,
     updatedAt: 1735689550000,
   },
@@ -68,6 +69,7 @@ const mockListProviders = mock(() => [
     identityFormat: null,
     identityOkField: null,
     identityResponsePaths: null,
+    featureFlag: null,
     createdAt: 1735689600000,
     updatedAt: 1735689650000,
   },
@@ -148,6 +150,7 @@ describe("GET /v1/oauth/providers", () => {
       "client_id_placeholder",
       "requires_client_secret",
       "supports_managed_mode",
+      "feature_flag",
     ];
 
     for (const provider of body.providers) {

--- a/assistant/src/cli/commands/oauth/__tests__/providers-update.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/providers-update.test.ts
@@ -168,6 +168,7 @@ const sampleProviderRow = {
   identityResponsePaths: null,
   identityFormat: null,
   identityOkField: null,
+  featureFlag: null,
   createdAt: Date.now(),
   updatedAt: Date.now(),
 };

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -637,6 +637,15 @@ Examples:
             return;
           }
 
+          if (!isProviderVisible(existing, loadConfig())) {
+            writeOutput(cmd, {
+              ok: false,
+              error: `Provider "${providerKey}" not found. Run 'assistant oauth providers list' to see all registered providers.`,
+            });
+            process.exitCode = 1;
+            return;
+          }
+
           // Block updates to built-in providers
           if (SEEDED_PROVIDER_KEYS.has(providerKey)) {
             writeOutput(cmd, {
@@ -768,6 +777,15 @@ Examples:
         try {
           const provider = getProvider(providerKey);
           if (!provider) {
+            writeOutput(cmd, {
+              ok: false,
+              error: `Provider not found: "${providerKey}". Run 'assistant oauth providers list' to see all registered providers.`,
+            });
+            process.exitCode = 1;
+            return;
+          }
+
+          if (!isProviderVisible(provider, loadConfig())) {
             writeOutput(cmd, {
               ok: false,
               error: `Provider not found: "${providerKey}". Run 'assistant oauth providers list' to see all registered providers.`,

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -15,6 +15,7 @@ import {
   updateProvider,
 } from "../../../oauth/oauth-store.js";
 import { serializeProvider } from "../../../oauth/provider-serializer.js";
+import { isProviderVisible } from "../../../oauth/provider-visibility.js";
 import { SEEDED_PROVIDER_KEYS } from "../../../oauth/seed-providers.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
@@ -123,7 +124,12 @@ Examples:
         cmd: Command,
       ) => {
         try {
-          let rows = listProviders().map(parseProviderRow);
+          const config = loadConfig();
+          let allProviders = listProviders();
+          allProviders = allProviders.filter((r) =>
+            isProviderVisible(r, config),
+          );
+          let rows = allProviders.map(parseProviderRow);
 
           if (opts.providerKey) {
             const needles = opts.providerKey
@@ -183,6 +189,15 @@ Examples:
         const row = getProvider(providerKey);
 
         if (!row) {
+          writeOutput(cmd, {
+            ok: false,
+            error: `Provider not found: "${providerKey}". Run 'assistant oauth providers list' to see all registered providers. To register a custom provider, run 'assistant oauth providers register --help'.`,
+          });
+          process.exitCode = 1;
+          return;
+        }
+
+        if (!isProviderVisible(row, loadConfig())) {
           writeOutput(cmd, {
             ok: false,
             error: `Provider not found: "${providerKey}". Run 'assistant oauth providers list' to see all registered providers. To register a custom provider, run 'assistant oauth providers register --help'.`,

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -98,6 +98,7 @@ import {
   migrateOAuthAppsClientSecretPath,
   migrateOAuthProvidersBehaviorColumns,
   migrateOAuthProvidersDisplayMetadata,
+  migrateOAuthProvidersFeatureFlag,
   migrateOAuthProvidersManagedServiceConfigKey,
   migrateOAuthProvidersPingConfig,
   migrateOAuthProvidersPingUrl,
@@ -539,6 +540,9 @@ export function initializeDb(): void {
 
   // 98. Add llm_call_count column to llm_usage_events for accurate LLM call counting
   migrateUsageLlmCallCount(database);
+
+  // 99. Add feature_flag column to oauth_providers for feature-flag gating
+  migrateOAuthProvidersFeatureFlag(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/201-oauth-providers-feature-flag.ts
+++ b/assistant/src/memory/migrations/201-oauth-providers-feature-flag.ts
@@ -1,0 +1,11 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+export function migrateOAuthProvidersFeatureFlag(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  try {
+    raw.exec(`ALTER TABLE oauth_providers ADD COLUMN feature_flag TEXT`);
+  } catch {
+    // Column already exists — nothing to do.
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -140,6 +140,7 @@ export { migrateOAuthProvidersBehaviorColumns } from "./197-oauth-providers-beha
 export { migrateDropSetupSkillIdColumn } from "./198-drop-setup-skill-id-column.js";
 export { migrateGuardianRequestEnrichmentColumns } from "./199-guardian-request-enrichment-columns.js";
 export { migrateUsageLlmCallCount } from "./200-usage-llm-call-count.js";
+export { migrateOAuthProvidersFeatureFlag } from "./201-oauth-providers-feature-flag.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/oauth.ts
+++ b/assistant/src/memory/schema/oauth.ts
@@ -38,6 +38,7 @@ export const oauthProviders = sqliteTable("oauth_providers", {
   identityResponsePaths: text("identity_response_paths"),
   identityFormat: text("identity_format"),
   identityOkField: text("identity_ok_field"),
+  featureFlag: text("feature_flag"),
   createdAt: integer("created_at").notNull(),
   updatedAt: integer("updated_at").notNull(),
 });

--- a/assistant/src/oauth/__tests__/identity-verifier.test.ts
+++ b/assistant/src/oauth/__tests__/identity-verifier.test.ts
@@ -60,6 +60,7 @@ function makeProviderRow(
     identityResponsePaths: null,
     identityFormat: null,
     identityOkField: null,
+    featureFlag: null,
     createdAt: now,
     updatedAt: now,
     ...rest,

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -48,7 +48,7 @@ export type OAuthConnectionRow = typeof oauthConnections.$inferSelect;
  * pingUrl, pingMethod, pingHeaders, pingBody, managedServiceConfigKey,
  * loopbackPort, injectionTemplates, appType, setupNotes,
  * identityUrl, identityMethod, identityHeaders, identityBody,
- * identityResponsePaths, identityFormat, identityOkField)
+ * identityResponsePaths, identityFormat, identityOkField, featureFlag)
  * and display metadata (displayName, description, dashboardUrl,
  * clientIdPlaceholder, requiresClientSecret) propagate to existing
  * installations on every startup, while user-customizable fields

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -95,6 +95,7 @@ export function seedProviders(
     identityResponsePaths?: string[];
     identityFormat?: string;
     identityOkField?: string;
+    featureFlag?: string;
   }>,
 ): void {
   const db = getDb();
@@ -138,6 +139,7 @@ export function seedProviders(
       : null;
     const identityFormat = p.identityFormat ?? null;
     const identityOkField = p.identityOkField ?? null;
+    const featureFlag = p.featureFlag ?? null;
 
     db.insert(oauthProviders)
       .values({
@@ -172,6 +174,7 @@ export function seedProviders(
         identityResponsePaths,
         identityFormat,
         identityOkField,
+        featureFlag,
         createdAt: now,
         updatedAt: now,
       })
@@ -206,6 +209,7 @@ export function seedProviders(
           identityResponsePaths,
           identityFormat,
           identityOkField,
+          featureFlag,
           updatedAt: now,
         },
       })
@@ -270,6 +274,7 @@ export function registerProvider(params: {
   identityResponsePaths?: string[];
   identityFormat?: string;
   identityOkField?: string;
+  featureFlag?: string;
 }): OAuthProviderRow {
   const db = getDb();
   const now = Date.now();
@@ -321,6 +326,7 @@ export function registerProvider(params: {
       : null,
     identityFormat: params.identityFormat ?? null,
     identityOkField: params.identityOkField ?? null,
+    featureFlag: params.featureFlag ?? null,
     createdAt: now,
     updatedAt: now,
   };
@@ -376,6 +382,7 @@ export function updateProvider(
     identityResponsePaths: string[];
     identityFormat: string;
     identityOkField: string;
+    featureFlag: string;
   }>,
 ): OAuthProviderRow | undefined {
   const existing = getProvider(providerKey);
@@ -430,6 +437,7 @@ export function updateProvider(
     set.identityFormat = params.identityFormat;
   if (params.identityOkField !== undefined)
     set.identityOkField = params.identityOkField;
+  if (params.featureFlag !== undefined) set.featureFlag = params.featureFlag;
 
   db.update(oauthProviders)
     .set(set)

--- a/assistant/src/oauth/provider-serializer.ts
+++ b/assistant/src/oauth/provider-serializer.ts
@@ -31,6 +31,7 @@ export interface SerializedProviderSummary {
   client_id_placeholder: string | null;
   requires_client_secret: boolean;
   supports_managed_mode: boolean;
+  feature_flag: string | null;
 }
 
 /**
@@ -87,6 +88,7 @@ function _serializeProvider(
       : null,
     identityFormat: row.identityFormat ?? null,
     identityOkField: row.identityOkField ?? null,
+    featureFlag: row.featureFlag ?? null,
     redirectUri:
       options?.redirectUri !== undefined ? options.redirectUri : null,
     createdAt: new Date(row.createdAt).toISOString(),
@@ -112,5 +114,6 @@ export function serializeProviderSummary(
     client_id_placeholder: row.clientIdPlaceholder ?? null,
     requires_client_secret: !!(row.requiresClientSecret ?? 1),
     supports_managed_mode: !!row.managedServiceConfigKey,
+    feature_flag: row.featureFlag ?? null,
   };
 }

--- a/assistant/src/oauth/provider-visibility.ts
+++ b/assistant/src/oauth/provider-visibility.ts
@@ -1,0 +1,16 @@
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import type { AssistantConfig } from "../config/schema.js";
+import type { OAuthProviderRow } from "./oauth-store.js";
+
+/**
+ * Return true if the provider should be visible to external consumers
+ * (CLI, gateway API). A provider is hidden when it declares a featureFlag
+ * and that flag is currently disabled.
+ */
+export function isProviderVisible(
+  row: OAuthProviderRow,
+  config: AssistantConfig,
+): boolean {
+  if (!row.featureFlag) return true;
+  return isAssistantFeatureFlagEnabled(row.featureFlag, config);
+}

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -59,6 +59,7 @@ const PROVIDER_SEED_DATA: Record<
     identityResponsePaths?: string[];
     identityFormat?: string;
     identityOkField?: string;
+    featureFlag?: string;
   }
 > = {
   google: {

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -9,7 +9,7 @@ import { seedProviders } from "./oauth-store.js";
  * pingUrl, pingMethod, pingHeaders, pingBody, managedServiceConfigKey,
  * loopbackPort, injectionTemplates, appType, setupNotes,
  * identityUrl, identityMethod, identityHeaders, identityBody,
- * identityResponsePaths, identityFormat, identityOkField)
+ * identityResponsePaths, identityFormat, identityOkField, featureFlag)
  * and display metadata (displayName,
  * description, dashboardUrl, clientIdPlaceholder, requiresClientSecret)
  * are overwritten on subsequent startups — user-customizable

--- a/assistant/src/runtime/routes/oauth-providers.ts
+++ b/assistant/src/runtime/routes/oauth-providers.ts
@@ -6,8 +6,10 @@
  * runtime auth middleware.
  */
 
+import { loadConfig } from "../../config/loader.js";
 import { getProvider, listProviders } from "../../oauth/oauth-store.js";
 import { serializeProviderSummary } from "../../oauth/provider-serializer.js";
+import { isProviderVisible } from "../../oauth/provider-visibility.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 
@@ -22,7 +24,9 @@ export function oauthProvidersRouteDefinitions(): RouteDefinition[] {
       method: "GET",
       handler: ({ url }) => {
         const rows = listProviders();
-        let serialized = rows
+        const config = loadConfig();
+        const visibleRows = rows.filter((r) => isProviderVisible(r, config));
+        let serialized = visibleRows
           .map((row) => serializeProviderSummary(row))
           .filter((s): s is NonNullable<typeof s> => s !== null);
 
@@ -46,6 +50,14 @@ export function oauthProvidersRouteDefinitions(): RouteDefinition[] {
       handler: ({ params }) => {
         const row = getProvider(params.providerKey);
         if (!row) {
+          return httpError(
+            "NOT_FOUND",
+            `No OAuth provider registered for "${params.providerKey}"`,
+            404,
+          );
+        }
+
+        if (!isProviderVisible(row, loadConfig())) {
           return httpError(
             "NOT_FOUND",
             `No OAuth provider registered for "${params.providerKey}"`,


### PR DESCRIPTION
## Summary
Add a nullable `feature_flag` column to the `oauth_providers` table. When a provider has a `feature_flag` value set and the corresponding assistant feature flag is disabled, the provider is hidden from the CLI `assistant oauth providers` commands and the gateway `GET /v1/oauth/providers` API — effectively pretending it doesn't exist at the external interface layer while preserving internal access for OAuth flow operations.

## PRs merged into feature branch
- #22383: Add nullable feature_flag column to oauth_providers table
- #22386: Add featureFlag support to OAuth store CRUD and seed providers
- #22387: Filter OAuth providers from CLI and gateway when feature flag is disabled

Part of plan: oauth-provider-feature-flag.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
