### PR TITLE
fix: Add feature_flag to oauth-providers-routes test assertions

### DIFF
--- a/assistant/src/__tests__/oauth-providers-routes.test.ts
+++ b/assistant/src/__tests__/oauth-providers-routes.test.ts
@@ -33,6 +33,7 @@ const mockListProviders = mock(() => [
     identityFormat: null,
     identityOkField: null,
     identityResponsePaths: null,
+    featureFlag: null,
     createdAt: 1735689500000,
     updatedAt: 1735689550000,
   },
@@ -68,6 +69,7 @@ const mockListProviders = mock(() => [
     identityFormat: null,
     identityOkField: null,
     identityResponsePaths: null,
+    featureFlag: null,
     createdAt: 1735689600000,
     updatedAt: 1735689650000,
   },
@@ -148,6 +150,7 @@ describe("GET /v1/oauth/providers", () => {
       "client_id_placeholder",
       "requires_client_secret",
       "supports_managed_mode",
+      "feature_flag",
     ];
 
     for (const provider of body.providers) {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-provider-feature-flag.md.

**Gap:** oauth-providers-routes.test.ts not updated for feature_flag
**What was expected:** Test should include feature_flag in expectedKeys and mock rows
**What was found:** Missing feature_flag in expectedKeys array and featureFlag in mock rows
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
