### PR TITLE
fix: Add featureFlag to remaining test mock provider rows

### DIFF
--- a/assistant/src/__tests__/oauth-apps-routes.test.ts
+++ b/assistant/src/__tests__/oauth-apps-routes.test.ts
@@ -70,6 +70,7 @@ mock.module("../oauth/oauth-store.js", () => ({
           identityBody: null,
           identityFormat: null,
           identityOkField: null,
+          featureFlag: null,
           createdAt: 1735689500000,
           updatedAt: 1735689550000,
         }

--- a/assistant/src/__tests__/oauth-providers-routes.test.ts
+++ b/assistant/src/__tests__/oauth-providers-routes.test.ts
@@ -33,6 +33,7 @@ const mockListProviders = mock(() => [
     identityFormat: null,
     identityOkField: null,
     identityResponsePaths: null,
+    featureFlag: null,
     createdAt: 1735689500000,
     updatedAt: 1735689550000,
   },
@@ -68,6 +69,7 @@ const mockListProviders = mock(() => [
     identityFormat: null,
     identityOkField: null,
     identityResponsePaths: null,
+    featureFlag: null,
     createdAt: 1735689600000,
     updatedAt: 1735689650000,
   },
@@ -148,6 +150,7 @@ describe("GET /v1/oauth/providers", () => {
       "client_id_placeholder",
       "requires_client_secret",
       "supports_managed_mode",
+      "feature_flag",
     ];
 
     for (const provider of body.providers) {

--- a/assistant/src/cli/commands/oauth/__tests__/providers-update.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/providers-update.test.ts
@@ -168,6 +168,7 @@ const sampleProviderRow = {
   identityResponsePaths: null,
   identityFormat: null,
   identityOkField: null,
+  featureFlag: null,
   createdAt: Date.now(),
   updatedAt: Date.now(),
 };


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for oauth-provider-feature-flag.md.

**Gap:** Test files missing featureFlag: null in mock provider rows
**What was expected:** All mock OAuthProviderRow objects should include featureFlag: null
**What was found:** oauth-apps-routes.test.ts and providers-update.test.ts lack the field
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22391" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
