### PR TITLE
feat: add Outlook managed OAuth provider to assistant daemon behind feature flag

### DIFF
--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -51,6 +51,11 @@ export const GoogleOAuthServiceSchema = BaseServiceSchema.extend({
 });
 export type GoogleOAuthService = z.infer<typeof GoogleOAuthServiceSchema>;
 
+export const OutlookOAuthServiceSchema = BaseServiceSchema.extend({
+  mode: ServiceModeSchema.default("your-own"),
+});
+export type OutlookOAuthService = z.infer<typeof OutlookOAuthServiceSchema>;
+
 export const ServicesSchema = z.object({
   inference: InferenceServiceSchema.default(InferenceServiceSchema.parse({})),
   "image-generation": ImageGenerationServiceSchema.default(
@@ -61,6 +66,9 @@ export const ServicesSchema = z.object({
   ),
   "google-oauth": GoogleOAuthServiceSchema.default(
     GoogleOAuthServiceSchema.parse({}),
+  ),
+  "outlook-oauth": OutlookOAuthServiceSchema.default(
+    OutlookOAuthServiceSchema.parse({}),
   ),
 });
 export type Services = z.infer<typeof ServicesSchema>;

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -612,6 +612,51 @@ const PROVIDER_SEED_DATA: Record<
     identityResponsePaths: ["handle", "email"],
   },
 
+  outlook: {
+    providerKey: "outlook",
+    authUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+    tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+    pingUrl: "https://graph.microsoft.com/v1.0/me",
+    baseUrl: "https://graph.microsoft.com",
+    displayName: "Outlook / Microsoft",
+    description: "Email and calendar",
+    dashboardUrl:
+      "https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade",
+    clientIdPlaceholder: "Application (client) ID from Azure portal",
+    defaultScopes: [
+      "openid",
+      "profile",
+      "email",
+      "offline_access",
+      "User.Read",
+      "Mail.Read",
+      "Mail.Send",
+      "Calendars.Read",
+      "Calendars.ReadWrite",
+    ],
+    scopePolicy: {
+      allowAdditionalScopes: true,
+      allowedOptionalScopes: ["Contacts.Read", "Files.Read", "Tasks.ReadWrite"],
+      forbiddenScopes: [],
+    },
+    extraParams: { prompt: "consent" },
+    tokenEndpointAuthMethod: "client_secret_post",
+    callbackTransport: "gateway",
+    managedServiceConfigKey: "outlook-oauth",
+    injectionTemplates: [
+      {
+        hostPattern: "graph.microsoft.com",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
+    ],
+    appType: "App registration",
+    identityUrl: "https://graph.microsoft.com/v1.0/me",
+    identityResponsePaths: ["mail", "userPrincipalName"],
+    featureFlag: "outlook-oauth-integration",
+  },
+
   // Manual-token providers: these don't use OAuth2 flows but need provider
   // rows so that oauth_app and oauth_connection FK chains can reference them.
   // The authUrl/tokenUrl values are placeholders — never used at runtime.

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -360,6 +360,14 @@
       "label": "Fast Mode",
       "description": "Enable Anthropic fast mode for Opus 4.6, delivering up to 2.5x higher output tokens per second at premium pricing",
       "defaultEnabled": false
+    },
+    {
+      "id": "outlook-oauth-integration",
+      "scope": "assistant",
+      "key": "outlook-oauth-integration",
+      "label": "Outlook / Microsoft Integration",
+      "description": "Enable the Outlook / Microsoft OAuth provider for connecting to Microsoft Graph APIs (email, calendar)",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `outlook-oauth-integration` feature flag entry to the feature flag registry with `scope: "assistant"` and `defaultEnabled: false`
- Add Outlook seed provider data to `PROVIDER_SEED_DATA` with Microsoft Graph endpoints, scopes, identity config, and `callbackTransport: "gateway"` for managed mode
- Add `OutlookOAuthServiceSchema` to services config schema with `"outlook-oauth"` key matching the seed provider's `managedServiceConfigKey`

Part of plan: managed-oauth-outlook.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
