### PR TITLE
feat(messaging): add Microsoft Graph API response types for Outlook

### DIFF
--- a/assistant/knip.json
+++ b/assistant/knip.json
@@ -3,7 +3,8 @@
     "src/**/*.test.ts",
     "src/**/__tests__/**/*.ts",
     "scripts/**/*.ts",
-    "src/daemon/main.ts"
+    "src/daemon/main.ts",
+    "src/messaging/providers/*/types.ts"
   ],
   "project": ["src/**/*.ts", "src/**/*.tsx", "scripts/**/*.ts"],
   "ignoreDependencies": [

--- a/assistant/src/messaging/providers/outlook/types.ts
+++ b/assistant/src/messaging/providers/outlook/types.ts
@@ -1,0 +1,82 @@
+/** Minimal Outlook message reference from list endpoint */
+export interface OutlookMessageRef {
+  id: string;
+  conversationId: string;
+}
+
+/** Outlook message list/search response (paginated) */
+export interface OutlookMessageListResponse {
+  value?: OutlookMessage[];
+  "@odata.nextLink"?: string;
+  "@odata.count"?: number;
+}
+
+/** Email address in Microsoft Graph format */
+export interface OutlookEmailAddress {
+  name?: string;
+  address: string;
+}
+
+/** Recipient wrapper containing an email address */
+export interface OutlookRecipient {
+  emailAddress: OutlookEmailAddress;
+}
+
+/** Message body with content type */
+export interface OutlookItemBody {
+  contentType: "text" | "html";
+  content: string;
+}
+
+/** Full Outlook message from Microsoft Graph */
+export interface OutlookMessage {
+  id: string;
+  conversationId: string;
+  subject: string;
+  bodyPreview: string;
+  body: OutlookItemBody;
+  from: OutlookRecipient;
+  toRecipients: OutlookRecipient[];
+  ccRecipients: OutlookRecipient[];
+  receivedDateTime: string; // ISO 8601
+  isRead: boolean;
+  hasAttachments: boolean;
+  parentFolderId: string;
+  categories: string[];
+  flag: {
+    flagStatus: "notFlagged" | "flagged" | "complete";
+  };
+}
+
+/** Outlook mail folder */
+export interface OutlookMailFolder {
+  id: string;
+  displayName: string;
+  totalItemCount?: number;
+  unreadItemCount?: number;
+  parentFolderId?: string;
+  childFolderCount?: number;
+}
+
+/** Outlook mail folder list response */
+export interface OutlookMailFolderListResponse {
+  value?: OutlookMailFolder[];
+}
+
+/** Payload for sending a message via Microsoft Graph */
+export interface OutlookSendMessagePayload {
+  message: {
+    subject: string;
+    body: OutlookItemBody;
+    toRecipients: OutlookRecipient[];
+    ccRecipients?: OutlookRecipient[];
+  };
+  saveToSentItems?: boolean;
+}
+
+/** Microsoft Graph user profile */
+export interface OutlookUserProfile {
+  displayName: string;
+  mail: string;
+  userPrincipalName: string;
+}


### PR DESCRIPTION
## Summary
- Add TypeScript interfaces for Microsoft Graph Mail API responses (messages, folders, recipients, profiles)
- Types cover list, get, search, send, folder list, and profile operations
- Modeled after existing Gmail types pattern

Part of plan: outlook-messaging-provider.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
