### PR TITLE
Add timestamp-based cooldown to pagination sentinel

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -108,6 +108,10 @@ final class MessageListScrollState {
     /// Tracks whether the pagination sentinel was previously inside the trigger band.
     @ObservationIgnored var wasPaginationTriggerInRange: Bool = false
 
+    /// Timestamp of the last pagination completion, used to enforce a 500ms
+    /// cooldown between successive pagination fires.
+    @ObservationIgnored var lastPaginationCompletedAt: Date = .distantPast
+
     /// The conversation ID currently being displayed. Updated in `reset(for:)`
     /// so closures always read the live value.
     @ObservationIgnored var currentConversationId: UUID?
@@ -394,6 +398,7 @@ final class MessageListScrollState {
         paginationTask = nil
         if _isPaginationInFlight { _isPaginationInFlight = false }
         wasPaginationTriggerInRange = false
+        lastPaginationCompletedAt = .distantPast
         // Invalidate the layout cache so the new conversation doesn't
         // hit a stale cache from the previous conversation.
         cachedLayoutKey = nil

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -513,6 +513,8 @@ struct MessageListView: View {
               !scrollState.isPaginationInFlight
         else { return }
 
+        guard Date().timeIntervalSince(scrollState.lastPaginationCompletedAt) > 0.5 else { return }
+
         // Fire pagination
         scrollState.isPaginationInFlight = true
         let anchorId = scrollState.cachedFirstVisibleMessageId
@@ -520,9 +522,11 @@ struct MessageListView: View {
         scrollState.paginationTask = Task { [scrollState] in
             defer {
                 if !Task.isCancelled {
+                    scrollState.lastPaginationCompletedAt = Date()
                     scrollState.isPaginationInFlight = false
                     scrollState.paginationTask = nil
                 } else if scrollState.paginationTask == nil {
+                    scrollState.lastPaginationCompletedAt = Date()
                     scrollState.isPaginationInFlight = false
                 }
             }

--- a/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
@@ -366,6 +366,14 @@ final class MessageListScrollStateTests: XCTestCase {
         XCTAssertFalse(state.isThrottled, "Circuit breaker should auto-recover")
     }
 
+    // MARK: - Pagination Cooldown
+
+    func testPaginationCooldownResetOnConversationSwitch() {
+        state.lastPaginationCompletedAt = Date()
+        state.reset(for: UUID())
+        XCTAssertEqual(state.lastPaginationCompletedAt, .distantPast)
+    }
+
     func testScheduleUISyncSuppressedWhenThrottled() async throws {
         for _ in 0...100 {
             state.recordBodyEvaluation()


### PR DESCRIPTION
## Summary
- Add `lastPaginationCompletedAt` timestamp on MessageListScrollState to enforce 500ms cooldown between pagination completions
- Pagination sentinel guard chain now rejects re-fires within 500ms of last completion, breaking the scroll-up feedback loop
- Conversation switch resets cooldown so pagination isn't blocked when switching conversations

Part of plan: scroll-upstream-fix.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
