### PR TITLE
Return cached derivedState when circuit breaker is tripped

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -229,6 +229,7 @@ final class MessageListScrollState {
     @ObservationIgnored private var bodyEvalTimestamps: [CFAbsoluteTime] = []
     /// When true, scheduleUISync() is suppressed to break a runaway re-evaluation loop.
     @ObservationIgnored private(set) var isThrottled = false
+    @ObservationIgnored var cachedDerivedStateBox: Any?
     @ObservationIgnored private var throttleRecoveryTask: Task<Void, Never>?
 
     /// Called once per MessageListView body evaluation. Trips the circuit
@@ -398,6 +399,7 @@ final class MessageListScrollState {
         // hit a stale cache from the previous conversation.
         cachedLayoutKey = nil
         cachedLayoutMetadata = nil
+        cachedDerivedStateBox = nil
         messageListVersion = 0
         lastKnownRawMessageCount = 0
         lastKnownVisibleMessageCount = 0

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -222,6 +222,11 @@ struct MessageListView: View {
         os_signpost(.begin, log: stallLog, name: "DerivedState.resolve")
         scrollState.recordBodyEvaluation()
 
+        if scrollState.isThrottled, let cached = scrollState.cachedDerivedStateBox as? MessageListDerivedState {
+            os_signpost(.end, log: stallLog, name: "DerivedState.resolve")
+            return cached
+        }
+
         // Compute visible messages first so version tracking and layout
         // both operate on the same filtered set.
         let liveMessages = visibleMessages
@@ -380,6 +385,7 @@ struct MessageListView: View {
             hasMessages: !liveMessages.isEmpty
         )
 
+        scrollState.cachedDerivedStateBox = result
         os_signpost(.end, log: stallLog, name: "DerivedState.resolve")
         return result
     }


### PR DESCRIPTION
## Summary
- Add type-erased `cachedDerivedStateBox` on MessageListScrollState for caching derivedState
- When `isThrottled` is true, `derivedState` returns cached O(1) result instead of O(n) recomputation
- Cache is cleared on conversation switch via `reset(for:)`
- Circuit breaker recovery (500ms) resumes normal computation automatically

Part of plan: scroll-upstream-fix.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
