### PR TITLE
Exclude textLength from AssistantActivitySnapshot equality to reduce per-token objectWillChange

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -50,6 +50,14 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         let completedToolCallCount: Int
         let surfaceCount: Int
         let isStreaming: Bool
+
+        static func == (lhs: Self, rhs: Self) -> Bool {
+            lhs.messageId == rhs.messageId
+                && lhs.toolCallCount == rhs.toolCallCount
+                && lhs.completedToolCallCount == rhs.completedToolCallCount
+                && lhs.surfaceCount == rhs.surfaceCount
+                && lhs.isStreaming == rhs.isStreaming
+        }
     }
     /// Tracks the number of rows already fetched from the daemon so pagination
     /// offsets stay correct even when the client filters out some conversations.


### PR DESCRIPTION
## Summary
- Add explicit `==` on `AssistantActivitySnapshot` that excludes `textLength` from comparison
- `textLength` stays in the struct for non-equality uses but no longer drives `.removeDuplicates()`
- Reduces ConversationManager `objectWillChange` emissions from per-token to per-structural-change during streaming

Part of plan: scroll-upstream-fix.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
