### PR TITLE
Document upstream observation fixes in AGENTS.md scroll architecture section

### DIFF
--- a/clients/AGENTS.md
+++ b/clients/AGENTS.md
@@ -248,6 +248,16 @@ Programmatic scrolling uses `scrollPosition.scrollTo(id:anchor:)` instead of `Sc
 
 A `SuppressionReasons` OptionSet (`.resize`, `.pagination`, `.expansion`) manages reasons for temporarily suppressing auto-scroll-to-bottom. The `suppressionReasons` property and the derived `isSuppressed` flag are both `@ObservationIgnored` — the view never reads suppression state directly for rendering. Multiple reasons can be active concurrently; `isSuppressed` is true when any reason is set. Manage flags via `beginSuppression(_:)` and `endSuppression(_:)`. Only `.expansion` uses a 200ms auto-timeout Task; `.resize` and `.pagination` manage their lifecycle manually within their task bodies. Check `scrollState.isSuppressed` before issuing any automatic scroll-to-bottom call.
 
+### Upstream Observation Fixes
+
+Three fixes outside the scroll subsystem prevent observation feedback loops that drive excessive scroll-state and body re-evaluation:
+
+- **Pagination cooldown.** The pagination sentinel enforces a 500ms cooldown between completions via `lastPaginationCompletedAt` on `MessageListScrollState`. This prevents a feedback loop where scroll triggers pagination, `displayedMessageCount` changes cause body re-evaluation, content/geometry changes fire the sentinel again, and pagination re-enters. The cooldown ensures rapid pagination completions cannot cascade.
+
+- **Body-level circuit breaker.** When `isThrottled` is true (more than 100 body evaluations in 2 seconds), `derivedState` returns a cached `MessageListDerivedState` instead of recomputing O(n) derived properties. This makes body re-evaluation cheap during any loop regardless of its source — scroll state changes, pagination, or parent cascade (e.g., `ConversationManager` `objectWillChange`). The circuit breaker is a safety net that caps the cost of body evaluations even when the root-cause loop is not scroll-related.
+
+- **AssistantActivitySnapshot equality.** `textLength` is excluded from the `Equatable` conformance of `AssistantActivitySnapshot` so that `.removeDuplicates()` in the assistant activity Combine pipeline filters out per-token streaming deltas. As a result, `handleAssistantMessageArrival` only fires on structural message changes (new message, role change, completion) rather than on every token append. This prevents per-token `objectWillChange` emissions from `ConversationManager`, which would otherwise cascade into `MessageListBody` re-evaluation and scroll-state recomputation on every streamed token.
+
 ### Rules
 
 - **Cancel auto-scroll tasks immediately on user-initiated scroll.** When the user manually scrolls (up, pagination pull, etc.), cancel the debounce/auto-scroll `Task` synchronously inside the scroll callback — before any `await`. Do not rely on the task noticing cancellation at its next sleep boundary; by then the trailing scroll may already have been scheduled, starting a fight with the user's scroll position.


### PR DESCRIPTION
## Summary
- Document pagination cooldown (500ms between completions via lastPaginationCompletedAt)
- Document body-level circuit breaker (cached derivedState when isThrottled)
- Document AssistantActivitySnapshot equality fix (textLength excluded from comparison)

Part of plan: scroll-upstream-fix.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
