### PR TITLE
Break upstream observation feedback loops causing scroll freeze

### DIFF
--- a/clients/AGENTS.md
+++ b/clients/AGENTS.md
@@ -248,6 +248,16 @@ Programmatic scrolling uses `scrollPosition.scrollTo(id:anchor:)` instead of `Sc
 
 A `SuppressionReasons` OptionSet (`.resize`, `.pagination`, `.expansion`) manages reasons for temporarily suppressing auto-scroll-to-bottom. The `suppressionReasons` property and the derived `isSuppressed` flag are both `@ObservationIgnored` — the view never reads suppression state directly for rendering. Multiple reasons can be active concurrently; `isSuppressed` is true when any reason is set. Manage flags via `beginSuppression(_:)` and `endSuppression(_:)`. Only `.expansion` uses a 200ms auto-timeout Task; `.resize` and `.pagination` manage their lifecycle manually within their task bodies. Check `scrollState.isSuppressed` before issuing any automatic scroll-to-bottom call.
 
+### Upstream Observation Fixes
+
+Three fixes outside the scroll subsystem prevent observation feedback loops that drive excessive scroll-state and body re-evaluation:
+
+- **Pagination cooldown.** The pagination sentinel enforces a 500ms cooldown between completions via `lastPaginationCompletedAt` on `MessageListScrollState`. This prevents a feedback loop where scroll triggers pagination, `displayedMessageCount` changes cause body re-evaluation, content/geometry changes fire the sentinel again, and pagination re-enters. The cooldown ensures rapid pagination completions cannot cascade.
+
+- **Body-level circuit breaker.** When `isThrottled` is true (more than 100 body evaluations in 2 seconds), `derivedState` returns a cached `MessageListDerivedState` instead of recomputing O(n) derived properties. This makes body re-evaluation cheap during any loop regardless of its source — scroll state changes, pagination, or parent cascade (e.g., `ConversationManager` `objectWillChange`). The circuit breaker is a safety net that caps the cost of body evaluations even when the root-cause loop is not scroll-related.
+
+- **AssistantActivitySnapshot equality.** `textLength` is excluded from the `Equatable` conformance of `AssistantActivitySnapshot` so that `.removeDuplicates()` in the assistant activity Combine pipeline filters out per-token streaming deltas. As a result, `handleAssistantMessageArrival` only fires on structural message changes (new message, role change, completion) rather than on every token append. This prevents per-token `objectWillChange` emissions from `ConversationManager`, which would otherwise cascade into `MessageListBody` re-evaluation and scroll-state recomputation on every streamed token.
+
 ### Rules
 
 - **Cancel auto-scroll tasks immediately on user-initiated scroll.** When the user manually scrolls (up, pagination pull, etc.), cancel the debounce/auto-scroll `Task` synchronously inside the scroll callback — before any `await`. Do not rely on the task noticing cancellation at its next sleep boundary; by then the trailing scroll may already have been scheduled, starting a fight with the user's scroll position.

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -233,6 +233,7 @@ final class MessageListScrollState {
     @ObservationIgnored private var bodyEvalTimestamps: [CFAbsoluteTime] = []
     /// When true, scheduleUISync() is suppressed to break a runaway re-evaluation loop.
     @ObservationIgnored private(set) var isThrottled = false
+    @ObservationIgnored var cachedDerivedStateBox: Any?
     @ObservationIgnored private var throttleRecoveryTask: Task<Void, Never>?
 
     /// Called once per MessageListView body evaluation. Trips the circuit
@@ -403,6 +404,7 @@ final class MessageListScrollState {
         // hit a stale cache from the previous conversation.
         cachedLayoutKey = nil
         cachedLayoutMetadata = nil
+        cachedDerivedStateBox = nil
         messageListVersion = 0
         lastKnownRawMessageCount = 0
         lastKnownVisibleMessageCount = 0

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -108,6 +108,10 @@ final class MessageListScrollState {
     /// Tracks whether the pagination sentinel was previously inside the trigger band.
     @ObservationIgnored var wasPaginationTriggerInRange: Bool = false
 
+    /// Timestamp of the last pagination completion, used to enforce a 500ms
+    /// cooldown between successive pagination fires.
+    @ObservationIgnored var lastPaginationCompletedAt: Date = .distantPast
+
     /// The conversation ID currently being displayed. Updated in `reset(for:)`
     /// so closures always read the live value.
     @ObservationIgnored var currentConversationId: UUID?
@@ -394,6 +398,7 @@ final class MessageListScrollState {
         paginationTask = nil
         if _isPaginationInFlight { _isPaginationInFlight = false }
         wasPaginationTriggerInRange = false
+        lastPaginationCompletedAt = .distantPast
         // Invalidate the layout cache so the new conversation doesn't
         // hit a stale cache from the previous conversation.
         cachedLayoutKey = nil

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -461,6 +461,8 @@ final class MessageListScrollState {
         bodyEvalTimestamps.removeAll()
         if _hideScrollIndicators { _hideScrollIndicators = false }
         if _isPaginationInFlight { _isPaginationInFlight = false }
+        cachedDerivedStateBox = nil
+        lastPaginationCompletedAt = .distantPast
         syncUIImmediately()
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -511,8 +511,6 @@ struct MessageListView: View {
             viewportHeight: scrollState.viewportHeight,
             wasInRange: scrollState.wasPaginationTriggerInRange
         )
-        scrollState.wasPaginationTriggerInRange = isInRange
-
         guard shouldFire,
               hasMoreMessages,
               !isLoadingMoreMessages,
@@ -521,7 +519,9 @@ struct MessageListView: View {
 
         guard Date().timeIntervalSince(scrollState.lastPaginationCompletedAt) > 0.5 else { return }
 
-        // Fire pagination
+        // Fire pagination — update edge state only now so guard rejections
+        // (including cooldown) don't consume the one-shot rising edge.
+        scrollState.wasPaginationTriggerInRange = isInRange
         scrollState.isPaginationInFlight = true
         let anchorId = scrollState.cachedFirstVisibleMessageId
         os_signpost(.event, log: PerfSignposts.log, name: "paginationSentinelFired")

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -222,6 +222,11 @@ struct MessageListView: View {
         os_signpost(.begin, log: stallLog, name: "DerivedState.resolve")
         scrollState.recordBodyEvaluation()
 
+        if scrollState.isThrottled, let cached = scrollState.cachedDerivedStateBox as? MessageListDerivedState {
+            os_signpost(.end, log: stallLog, name: "DerivedState.resolve")
+            return cached
+        }
+
         // Compute visible messages first so version tracking and layout
         // both operate on the same filtered set.
         let liveMessages = visibleMessages
@@ -380,6 +385,7 @@ struct MessageListView: View {
             hasMessages: !liveMessages.isEmpty
         )
 
+        scrollState.cachedDerivedStateBox = result
         os_signpost(.end, log: stallLog, name: "DerivedState.resolve")
         return result
     }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -513,6 +513,8 @@ struct MessageListView: View {
               !scrollState.isPaginationInFlight
         else { return }
 
+        guard Date().timeIntervalSince(scrollState.lastPaginationCompletedAt) > 0.5 else { return }
+
         // Fire pagination
         scrollState.isPaginationInFlight = true
         let anchorId = scrollState.cachedFirstVisibleMessageId
@@ -520,9 +522,11 @@ struct MessageListView: View {
         scrollState.paginationTask = Task { [scrollState] in
             defer {
                 if !Task.isCancelled {
+                    scrollState.lastPaginationCompletedAt = Date()
                     scrollState.isPaginationInFlight = false
                     scrollState.paginationTask = nil
                 } else if scrollState.paginationTask == nil {
+                    scrollState.lastPaginationCompletedAt = Date()
                     scrollState.isPaginationInFlight = false
                 }
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -50,6 +50,14 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         let completedToolCallCount: Int
         let surfaceCount: Int
         let isStreaming: Bool
+
+        static func == (lhs: Self, rhs: Self) -> Bool {
+            lhs.messageId == rhs.messageId
+                && lhs.toolCallCount == rhs.toolCallCount
+                && lhs.completedToolCallCount == rhs.completedToolCallCount
+                && lhs.surfaceCount == rhs.surfaceCount
+                && lhs.isStreaming == rhs.isStreaming
+        }
     }
     /// Tracks the number of rows already fetched from the daemon so pagination
     /// offsets stay correct even when the client filters out some conversations.

--- a/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
@@ -366,6 +366,14 @@ final class MessageListScrollStateTests: XCTestCase {
         XCTAssertFalse(state.isThrottled, "Circuit breaker should auto-recover")
     }
 
+    // MARK: - Pagination Cooldown
+
+    func testPaginationCooldownResetOnConversationSwitch() {
+        state.lastPaginationCompletedAt = Date()
+        state.reset(for: UUID())
+        XCTAssertEqual(state.lastPaginationCompletedAt, .distantPast)
+    }
+
     func testScheduleUISyncSuppressedWhenThrottled() async throws {
         for _ in 0...100 {
             state.recordBodyEvaluation()


### PR DESCRIPTION
## Summary
Break three interlocking feedback loops that cause the macOS app to freeze at 99.9% CPU during scrolling, even after the scroll state was decoupled to a single `uiVersion` observed property.

1. **Pagination cooldown**: 500ms timestamp-based cooldown prevents the pagination sentinel from re-firing in a tight loop when `displayedMessageCount` observation cascades cause rapid body re-evaluations
2. **Body-level circuit breaker**: When >100 body evals in 2s (circuit breaker tripped), `derivedState` returns a cached result in O(1) instead of O(n) recomputation — makes re-evaluation cheap during ANY loop regardless of source
3. **AssistantActivitySnapshot equality**: Exclude `textLength` from equality so `.removeDuplicates()` filters per-token streaming deltas, reducing ConversationManager `objectWillChange` emissions from per-token to per-structural-change

## PRs merged into feature branch
- #22405: Add timestamp-based cooldown to pagination sentinel
- #22406: Return cached derivedState when circuit breaker is tripped
- #22407: Exclude textLength from AssistantActivitySnapshot equality to reduce per-token objectWillChange
- #22409: Document upstream observation fixes in AGENTS.md scroll architecture section

Part of plan: scroll-upstream-fix.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
