### PR TITLE
fix: use host execution for bundled avatar skill tools

### DIFF
--- a/assistant/src/config/bundled-skills/settings/TOOLS.json
+++ b/assistant/src/config/bundled-skills/settings/TOOLS.json
@@ -108,7 +108,7 @@
         "required": ["image_path"]
       },
       "executor": "tools/avatar-update.ts",
-      "execution_target": "sandbox"
+      "execution_target": "host"
     },
     {
       "name": "remove_avatar",
@@ -125,7 +125,7 @@
         }
       },
       "executor": "tools/avatar-remove.ts",
-      "execution_target": "sandbox"
+      "execution_target": "host"
     },
     {
       "name": "get_avatar",
@@ -142,7 +142,7 @@
         }
       },
       "executor": "tools/avatar-get.ts",
-      "execution_target": "sandbox"
+      "execution_target": "host"
     }
   ]
 }

--- a/assistant/src/tools/skills/skill-script-runner.ts
+++ b/assistant/src/tools/skills/skill-script-runner.ts
@@ -40,7 +40,7 @@ export async function runSkillToolScript(
   context: ToolContext,
   options?: RunSkillToolScriptOptions,
 ): Promise<ToolExecutionResult> {
-  if (options?.target === "sandbox") {
+  if (options?.target === "sandbox" && !options?.bundled) {
     return runSkillToolScriptSandbox(skillDir, executorPath, input, context, {
       timeoutMs: options.timeoutMs,
       expectedSkillVersionHash: options.expectedSkillVersionHash,


### PR DESCRIPTION
## Summary
- Changed `set_avatar`, `remove_avatar`, and `get_avatar` from `execution_target: "sandbox"` to `"host"` in settings TOOLS.json — sandbox spawns a child process that can't resolve relative imports in the compiled binary, and would also break event hub notifications even if it could
- Added defensive guard in `skill-script-runner.ts`: bundled tools now always use the pre-imported registry (host execution) even if marked sandbox, preventing this class of failure for future tools

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
