### PR TITLE
fix(macos): enable copy & LLM inspector for read-only conversations

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -614,7 +614,7 @@ struct ActiveChatViewWrapper: View {
                     allowedDomains: settingsStore.mediaEmbedVideoAllowlistDomains
                 ),
                 onMicrophoneToggle: onMicrophoneToggle,
-                onForkFromMessage: { [conversationManager] daemonMessageId in
+                onForkFromMessage: isReadonly ? nil : { [conversationManager] daemonMessageId in
                     Task { @MainActor in
                         await conversationManager.forkConversation(throughDaemonMessageId: daemonMessageId)
                     }
@@ -635,7 +635,7 @@ struct ActiveChatViewWrapper: View {
                 anchorMessageId: $anchorMessageId,
                 highlightedMessageId: $highlightedMessageId,
                 conversationId: conversationId,
-                isInteractionEnabled: inspectorMessageId == nil && !isReadonly,
+                isInteractionEnabled: inspectorMessageId == nil,
                 isReadonly: isReadonly,
                 isBootstrapping: isBootstrapping,
                 isBootstrapTimedOut: isBootstrapTimedOut,

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
@@ -203,7 +203,7 @@ private struct ThreadWindowContentView: View {
                         allowedDomains: settingsStore.mediaEmbedVideoAllowlistDomains
                     ),
                     onMicrophoneToggle: {},
-                    onForkFromMessage: { daemonMessageId in onFork(daemonMessageId) },
+                    onForkFromMessage: (conversation?.isChannelConversation ?? false) ? nil : { daemonMessageId in onFork(daemonMessageId) },
                     onAddFunds: {
                         settingsStore.pendingSettingsTab = .billing
                     },
@@ -212,7 +212,7 @@ private struct ThreadWindowContentView: View {
                     },
                     anchorMessageId: $anchorMessageId,
                     highlightedMessageId: $highlightedMessageId,
-                    isInteractionEnabled: !(conversation?.isChannelConversation ?? false),
+                    isInteractionEnabled: true,
                     isReadonly: conversation?.isChannelConversation ?? false,
                     watchSession: ambientAgent.activeWatchSession
                 )


### PR DESCRIPTION
## Summary
- Decouple `isReadonly` from `isInteractionEnabled` so hover menus (copy, inspect, TTS) work in read-only channel conversations
- Nil out `onForkFromMessage` callback when readonly to keep fork disabled as a mutating action
- Fix applies to both `PanelCoordinator` (main view) and `ThreadWindow` (thread panels)

## Original prompt
I still want to be able to copy messages and open the LLM call inspector for readonly conversations
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22413" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
