### PR TITLE
fix: restore thinking indicator for non-threaded Slack DMs

### DIFF
--- a/assistant/src/memory/slack-thread-store.ts
+++ b/assistant/src/memory/slack-thread-store.ts
@@ -79,6 +79,23 @@ export function extractThreadTsFromCallbackUrl(
 }
 
 /**
+ * Extract the messageTs from a Slack reply callback URL, if present.
+ * The gateway encodes messageTs for non-threaded DMs so the runtime
+ * can target the original message for emoji-based indicators.
+ */
+export function extractMessageTsFromCallbackUrl(
+  callbackUrl: string | undefined,
+): string | null {
+  if (!callbackUrl) return null;
+  try {
+    const url = new URL(callbackUrl);
+    return url.searchParams.get("messageTs");
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Extract the channel from a Slack reply callback URL, if present.
  */
 export function extractChannelFromCallbackUrl(

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -15,6 +15,7 @@ import * as deliveryCrud from "../../../memory/delivery-crud.js";
 import * as deliveryStatus from "../../../memory/delivery-status.js";
 import {
   extractChannelFromCallbackUrl,
+  extractMessageTsFromCallbackUrl,
   extractThreadTsFromCallbackUrl,
   setThreadTs,
 } from "../../../memory/slack-thread-store.js";
@@ -328,9 +329,49 @@ export function setSlackThinkingStatus(
   // the correct thread for the Assistants API status.
   const threadTs = extractThreadTsFromCallbackUrl(callbackUrl);
 
-  // If there's no thread context, we can't set a thread status — bail.
+  // For non-threaded DMs, fall back to emoji reaction on the original message.
   if (!threadTs) {
-    return () => {};
+    const messageTs = extractMessageTsFromCallbackUrl(callbackUrl);
+    if (!messageTs) return () => {};
+
+    const addPromise = deliverChannelReply(
+      callbackUrl,
+      {
+        chatId,
+        assistantId,
+        reaction: { action: "add", name: "eyes", messageTs },
+      },
+      mintBearerToken(),
+    ).catch((err) => {
+      log.debug({ err, chatId, messageTs }, "Failed to add Slack eyes reaction");
+    });
+
+    const clearReaction = () => {
+      if (cleared) return;
+      cleared = true;
+      clearTimeout(safetyTimer);
+      void addPromise.then(() =>
+        deliverChannelReply(
+          callbackUrl,
+          {
+            chatId,
+            assistantId,
+            reaction: { action: "remove", name: "eyes", messageTs },
+          },
+          mintBearerToken(),
+        ).catch((err) => {
+          log.debug(
+            { err, chatId, messageTs },
+            "Failed to remove Slack eyes reaction",
+          );
+        }),
+      );
+    };
+
+    const safetyTimer = setTimeout(clearReaction, SLACK_THINKING_MAX_DURATION_MS);
+    (safetyTimer as { unref?: () => void }).unref?.();
+
+    return clearReaction;
   }
 
   // Track the set promise so clear waits for it to settle first,

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1211,6 +1211,10 @@ async function main() {
         const { threadTs, channel } = normalized;
         const params = new URLSearchParams({ channel });
         if (threadTs) params.set("threadTs", threadTs);
+        // For non-threaded DMs, pass the original message ts so the runtime
+        // can target it for emoji-based thinking indicators.
+        const origMessageTs = normalized.event.source.messageId;
+        if (!threadTs && origMessageTs) params.set("messageTs", origMessageTs);
         const replyCallbackUrl = `${config.gatewayInternalBaseUrl}/deliver/slack?${params}`;
 
         // Check if this is a regular thread reply (not an edit or callback action).


### PR DESCRIPTION
## Summary
- After the DM threading fix stopped including `threadTs` for non-threaded DMs, the "is thinking..." indicator silently broke — `setSlackThinkingStatus()` bailed when it found no `threadTs` in the callback URL.
- Gateway now passes `messageTs` (the original message's `ts`) in the callback URL for non-threaded DMs.
- Runtime falls back to eyes emoji reaction on the original message when there's no thread context.

## Original prompt
We used to get cool preview indicators in slack whenever a message was sent to the assistant, but after the changes today that moved everything to main channel replies instead of threaded replies, we don't get them anymore. What happened?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22414" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
