### PR TITLE
fix(teleport): fix auto-hatch name discovery, lockfile cleanup, and env check

### DIFF
--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -39,6 +39,16 @@ const saveAssistantEntryMock = spyOn(
   "saveAssistantEntry",
 ).mockImplementation(() => {});
 
+const loadAllAssistantsMock = spyOn(
+  assistantConfig,
+  "loadAllAssistants",
+).mockReturnValue([]);
+
+const removeAssistantEntryMock = spyOn(
+  assistantConfig,
+  "removeAssistantEntry",
+).mockImplementation(() => {});
+
 const loadGuardianTokenMock = mock((_id: string) => ({
   accessToken: "local-token",
   accessTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
@@ -145,6 +155,8 @@ import type { AssistantEntry } from "../lib/assistant-config.js";
 afterAll(() => {
   findAssistantByNameMock.mockRestore();
   saveAssistantEntryMock.mockRestore();
+  loadAllAssistantsMock.mockRestore();
+  removeAssistantEntryMock.mockRestore();
   rmSync(testDir, { recursive: true, force: true });
   delete process.env.VELLUM_LOCKFILE_DIR;
 });
@@ -163,6 +175,10 @@ beforeEach(() => {
   findAssistantByNameMock.mockReturnValue(null);
   saveAssistantEntryMock.mockReset();
   saveAssistantEntryMock.mockImplementation(() => {});
+  loadAllAssistantsMock.mockReset();
+  loadAllAssistantsMock.mockReturnValue([]);
+  removeAssistantEntryMock.mockReset();
+  removeAssistantEntryMock.mockImplementation(() => {});
 
   loadGuardianTokenMock.mockReset();
   loadGuardianTokenMock.mockReturnValue({
@@ -399,49 +415,116 @@ describe("teleport arg parsing", () => {
 // ---------------------------------------------------------------------------
 
 describe("same-environment rejection", () => {
-  test("source local, target local -> error", async () => {
-    setArgv("--from", "src", "--local");
+  test("source local, target local -> error (after resolving target)", async () => {
+    setArgv("--from", "src", "--local", "dst");
+
+    const srcEntry = makeEntry("src", { cloud: "local" });
+    const dstEntry = makeEntry("dst", { cloud: "local" });
+
     findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "src") return makeEntry("src", { cloud: "local" });
+      if (name === "src") return srcEntry;
+      if (name === "dst") return dstEntry;
       return null;
     });
 
-    await expect(teleport()).rejects.toThrow("process.exit:1");
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Cannot teleport between two local assistants"),
-    );
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await expect(teleport()).rejects.toThrow("process.exit:1");
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Cannot teleport between two local assistants"),
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
-  test("source docker, target docker -> error", async () => {
-    setArgv("--from", "src", "--docker");
+  test("source docker, target docker -> error (after resolving target)", async () => {
+    setArgv("--from", "src", "--docker", "dst");
+
+    const srcEntry = makeEntry("src", { cloud: "docker" });
+    const dstEntry = makeEntry("dst", { cloud: "docker" });
+
     findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "src") return makeEntry("src", { cloud: "docker" });
+      if (name === "src") return srcEntry;
+      if (name === "dst") return dstEntry;
       return null;
     });
 
-    await expect(teleport()).rejects.toThrow("process.exit:1");
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Cannot teleport between two docker assistants"),
-    );
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await expect(teleport()).rejects.toThrow("process.exit:1");
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Cannot teleport between two docker assistants",
+        ),
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
-  test("source vellum, target platform -> error", async () => {
-    setArgv("--from", "src", "--platform");
+  test("source vellum, target platform -> error (after resolving target)", async () => {
+    setArgv("--from", "src", "--platform", "dst");
+
+    const srcEntry = makeEntry("src", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const dstEntry = makeEntry("dst", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+
     findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "src")
-        return makeEntry("src", {
-          cloud: "vellum",
-          runtimeUrl: "https://platform.vellum.ai",
-        });
+      if (name === "src") return srcEntry;
+      if (name === "dst") return dstEntry;
       return null;
     });
 
-    await expect(teleport()).rejects.toThrow("process.exit:1");
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining(
-        "Cannot teleport between two platform assistants",
-      ),
-    );
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await expect(teleport()).rejects.toThrow("process.exit:1");
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Cannot teleport between two platform assistants",
+        ),
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("flag says docker but resolved target is local -> uses resolved cloud", async () => {
+    // User passes --docker but the named target is actually a local assistant
+    setArgv("--from", "src", "--docker", "misidentified");
+
+    const srcEntry = makeEntry("src", { cloud: "local" });
+    // Target is actually local despite the --docker flag
+    const dstEntry = makeEntry("misidentified", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "src") return srcEntry;
+      if (name === "misidentified") return dstEntry;
+      return null;
+    });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await expect(teleport()).rejects.toThrow("process.exit:1");
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Cannot teleport between two local assistants"),
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });
 
@@ -487,13 +570,17 @@ describe("resolveOrHatchTarget", () => {
     expect(result).toBe(newEntry);
   });
 
-  test("no name -> hatch local with null name", async () => {
+  test("no name -> hatch local with null name, discovers via diff", async () => {
+    const existingEntry = makeEntry("existing-local", { cloud: "local" });
     const newEntry = makeEntry("auto-generated", { cloud: "local" });
-    findAssistantByNameMock.mockImplementation((name: string) => {
-      if (name === "" && hatchLocalMock.mock.calls.length > 0) {
-        return newEntry;
+
+    // Before hatch: only the existing entry
+    // After hatch: existing + new entry
+    loadAllAssistantsMock.mockImplementation(() => {
+      if (hatchLocalMock.mock.calls.length > 0) {
+        return [existingEntry, newEntry];
       }
-      return null;
+      return [existingEntry];
     });
 
     const result = await resolveOrHatchTarget("local");
@@ -543,7 +630,7 @@ describe("resolveOrHatchTarget", () => {
 // ---------------------------------------------------------------------------
 
 describe("auto-retire", () => {
-  test("local -> docker: retireLocal is called on source after import", async () => {
+  test("local -> docker: retireLocal and removeAssistantEntry called on source after import", async () => {
     setArgv("--from", "my-local", "--docker");
 
     const localEntry = makeEntry("my-local", { cloud: "local" });
@@ -551,10 +638,15 @@ describe("auto-retire", () => {
 
     findAssistantByNameMock.mockImplementation((name: string) => {
       if (name === "my-local") return localEntry;
-      // After hatch, find the new docker entry
-      if (name === "" && hatchDockerMock.mock.calls.length > 0)
-        return dockerEntry;
       return null;
+    });
+
+    // Simulate hatch creating a new docker entry
+    loadAllAssistantsMock.mockImplementation(() => {
+      if (hatchDockerMock.mock.calls.length > 0) {
+        return [localEntry, dockerEntry];
+      }
+      return [localEntry];
     });
 
     const originalFetch = globalThis.fetch;
@@ -563,12 +655,13 @@ describe("auto-retire", () => {
     try {
       await teleport();
       expect(retireLocalMock).toHaveBeenCalledWith("my-local", localEntry);
+      expect(removeAssistantEntryMock).toHaveBeenCalledWith("my-local");
     } finally {
       globalThis.fetch = originalFetch;
     }
   });
 
-  test("docker -> local: retireDocker is called on source after import", async () => {
+  test("docker -> local: retireDocker and removeAssistantEntry called on source after import", async () => {
     setArgv("--from", "my-docker", "--local");
 
     const dockerEntry = makeEntry("my-docker", { cloud: "docker" });
@@ -576,9 +669,14 @@ describe("auto-retire", () => {
 
     findAssistantByNameMock.mockImplementation((name: string) => {
       if (name === "my-docker") return dockerEntry;
-      if (name === "" && hatchLocalMock.mock.calls.length > 0)
-        return localEntry;
       return null;
+    });
+
+    loadAllAssistantsMock.mockImplementation(() => {
+      if (hatchLocalMock.mock.calls.length > 0) {
+        return [dockerEntry, localEntry];
+      }
+      return [dockerEntry];
     });
 
     const originalFetch = globalThis.fetch;
@@ -587,12 +685,13 @@ describe("auto-retire", () => {
     try {
       await teleport();
       expect(retireDockerMock).toHaveBeenCalledWith("my-docker");
+      expect(removeAssistantEntryMock).toHaveBeenCalledWith("my-docker");
     } finally {
       globalThis.fetch = originalFetch;
     }
   });
 
-  test("--keep-source skips retire", async () => {
+  test("--keep-source skips retire and removeAssistantEntry", async () => {
     setArgv("--from", "my-local", "--docker", "--keep-source");
 
     const localEntry = makeEntry("my-local", { cloud: "local" });
@@ -600,9 +699,14 @@ describe("auto-retire", () => {
 
     findAssistantByNameMock.mockImplementation((name: string) => {
       if (name === "my-local") return localEntry;
-      if (name === "" && hatchDockerMock.mock.calls.length > 0)
-        return dockerEntry;
       return null;
+    });
+
+    loadAllAssistantsMock.mockImplementation(() => {
+      if (hatchDockerMock.mock.calls.length > 0) {
+        return [localEntry, dockerEntry];
+      }
+      return [localEntry];
     });
 
     const originalFetch = globalThis.fetch;
@@ -612,6 +716,7 @@ describe("auto-retire", () => {
       await teleport();
       expect(retireLocalMock).not.toHaveBeenCalled();
       expect(retireDockerMock).not.toHaveBeenCalled();
+      expect(removeAssistantEntryMock).not.toHaveBeenCalled();
       expect(consoleLogSpy).toHaveBeenCalledWith(
         expect.stringContaining("kept (--keep-source)"),
       );
@@ -637,6 +742,7 @@ describe("auto-retire", () => {
       await teleport();
       expect(retireLocalMock).not.toHaveBeenCalled();
       expect(retireDockerMock).not.toHaveBeenCalled();
+      expect(removeAssistantEntryMock).not.toHaveBeenCalled();
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -650,9 +756,14 @@ describe("auto-retire", () => {
 
     findAssistantByNameMock.mockImplementation((name: string) => {
       if (name === "my-local") return localEntry;
-      if (name === "" && hatchDockerMock.mock.calls.length > 0)
-        return dockerEntry;
       return null;
+    });
+
+    loadAllAssistantsMock.mockImplementation(() => {
+      if (hatchDockerMock.mock.calls.length > 0) {
+        return [localEntry, dockerEntry];
+      }
+      return [localEntry];
     });
 
     const originalFetch = globalThis.fetch;
@@ -662,6 +773,7 @@ describe("auto-retire", () => {
       await teleport();
       expect(retireLocalMock).not.toHaveBeenCalled();
       expect(retireDockerMock).not.toHaveBeenCalled();
+      expect(removeAssistantEntryMock).not.toHaveBeenCalled();
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -681,9 +793,14 @@ describe("teleport full flow", () => {
 
     findAssistantByNameMock.mockImplementation((name: string) => {
       if (name === "my-local") return localEntry;
-      if (name === "" && hatchDockerMock.mock.calls.length > 0)
-        return dockerEntry;
       return null;
+    });
+
+    loadAllAssistantsMock.mockImplementation(() => {
+      if (hatchDockerMock.mock.calls.length > 0) {
+        return [localEntry, dockerEntry];
+      }
+      return [localEntry];
     });
 
     const originalFetch = globalThis.fetch;
@@ -696,6 +813,7 @@ describe("teleport full flow", () => {
       // Verify sequence: export, hatch, import, retire
       expect(hatchDockerMock).toHaveBeenCalled();
       expect(retireLocalMock).toHaveBeenCalledWith("my-local", localEntry);
+      expect(removeAssistantEntryMock).toHaveBeenCalledWith("my-local");
       expect(consoleLogSpy).toHaveBeenCalledWith(
         expect.stringContaining("Teleport complete"),
       );

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -1,5 +1,7 @@
 import {
   findAssistantByName,
+  loadAllAssistants,
+  removeAssistantEntry,
   saveAssistantEntry,
 } from "../lib/assistant-config.js";
 import type { AssistantEntry } from "../lib/assistant-config.js";
@@ -745,11 +747,13 @@ export async function resolveOrHatchTarget(
 
   // Hatch a new assistant in the target environment
   if (targetEnv === "local") {
+    const beforeIds = new Set(loadAllAssistants().map((e) => e.assistantId));
     await hatchLocal("vellum", targetName ?? null, false, false, false, {});
-    const entry = findAssistantByName(targetName ?? "");
+    const entry = targetName
+      ? findAssistantByName(targetName)
+      : (loadAllAssistants().find((e) => !beforeIds.has(e.assistantId)) ??
+        null);
     if (!entry) {
-      // If no targetName was provided, find the most recently hatched local assistant
-      // by looking up what hatchLocal created
       console.error("Error: Could not find the newly hatched local assistant.");
       process.exit(1);
     }
@@ -758,8 +762,12 @@ export async function resolveOrHatchTarget(
   }
 
   if (targetEnv === "docker") {
+    const beforeIds = new Set(loadAllAssistants().map((e) => e.assistantId));
     await hatchDocker("vellum", true, targetName ?? null, false, {});
-    const entry = findAssistantByName(targetName ?? "");
+    const entry = targetName
+      ? findAssistantByName(targetName)
+      : (loadAllAssistants().find((e) => !beforeIds.has(e.assistantId)) ??
+        null);
     if (!entry) {
       console.error(
         "Error: Could not find the newly hatched docker assistant.",
@@ -985,15 +993,6 @@ export async function teleport(): Promise<void> {
 
   const fromCloud = resolveCloud(fromEntry);
 
-  // Same-environment rejection
-  const normalizedSourceEnv = fromCloud === "vellum" ? "platform" : fromCloud;
-  if (normalizedSourceEnv === targetEnv) {
-    console.error(
-      `Cannot teleport between two ${targetEnv} assistants. Teleport transfers data across different environments.`,
-    );
-    process.exit(1);
-  }
-
   // Export from source
   console.log(`Exporting from ${from} (${fromCloud})...`);
   const bundleData = await exportFromAssistant(fromEntry, fromCloud);
@@ -1001,6 +1000,16 @@ export async function teleport(): Promise<void> {
   // Resolve or hatch target
   const toEntry = await resolveOrHatchTarget(targetEnv, targetName);
   const toCloud = resolveCloud(toEntry);
+
+  // Same-environment rejection — uses resolved clouds, not CLI flag
+  const normalizedSourceEnv = fromCloud === "vellum" ? "platform" : fromCloud;
+  const normalizedTargetEnv = toCloud === "vellum" ? "platform" : toCloud;
+  if (normalizedSourceEnv === normalizedTargetEnv) {
+    console.error(
+      `Cannot teleport between two ${normalizedTargetEnv} assistants. Teleport transfers data across different environments.`,
+    );
+    process.exit(1);
+  }
 
   // Import to target
   console.log(`Importing to ${toEntry.assistantId} (${toCloud})...`);
@@ -1010,8 +1019,7 @@ export async function teleport(): Promise<void> {
   if (!dryRun) {
     const sourceIsLocalOrDocker =
       fromCloud === "local" || fromCloud === "docker";
-    const targetIsLocalOrDocker =
-      targetEnv === "local" || targetEnv === "docker";
+    const targetIsLocalOrDocker = toCloud === "local" || toCloud === "docker";
 
     if (sourceIsLocalOrDocker && targetIsLocalOrDocker) {
       if (!keepSource) {
@@ -1021,6 +1029,7 @@ export async function teleport(): Promise<void> {
         } else {
           await retireLocal(fromEntry.assistantId, fromEntry);
         }
+        removeAssistantEntry(fromEntry.assistantId);
         console.log(`Source assistant '${from}' retired.`);
       } else {
         console.log(`Source assistant '${from}' kept (--keep-source).`);


### PR DESCRIPTION
## Summary
Fixes three gaps from plan review:

1. **Auto-generated name discovery**: After hatching with no target name, diff the lockfile entries to find the newly created assistant instead of searching for empty string
2. **Lockfile cleanup on auto-retire**: Call removeAssistantEntry() after retireLocal/retireDocker to remove zombie lockfile entries
3. **Same-env check uses resolved cloud**: Move same-environment rejection and auto-retire decisions to use resolveCloud(toEntry) instead of the CLI flag value

Part of plan: teleport-all-environments.md (fix round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
