### PR TITLE
fix: clear new state in cancelAll() and fix cooldown edge consumption

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -461,6 +461,8 @@ final class MessageListScrollState {
         bodyEvalTimestamps.removeAll()
         if _hideScrollIndicators { _hideScrollIndicators = false }
         if _isPaginationInFlight { _isPaginationInFlight = false }
+        cachedDerivedStateBox = nil
+        lastPaginationCompletedAt = .distantPast
         syncUIImmediately()
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -511,8 +511,6 @@ struct MessageListView: View {
             viewportHeight: scrollState.viewportHeight,
             wasInRange: scrollState.wasPaginationTriggerInRange
         )
-        scrollState.wasPaginationTriggerInRange = isInRange
-
         guard shouldFire,
               hasMoreMessages,
               !isLoadingMoreMessages,
@@ -521,7 +519,9 @@ struct MessageListView: View {
 
         guard Date().timeIntervalSince(scrollState.lastPaginationCompletedAt) > 0.5 else { return }
 
-        // Fire pagination
+        // Fire pagination — update edge state only now so guard rejections
+        // (including cooldown) don't consume the one-shot rising edge.
+        scrollState.wasPaginationTriggerInRange = isInRange
         scrollState.isPaginationInFlight = true
         let anchorId = scrollState.cachedFirstVisibleMessageId
         os_signpost(.event, log: PerfSignposts.log, name: "paginationSentinelFired")


### PR DESCRIPTION
## Summary
Fixes three gaps from plan review for scroll-upstream-fix.md.

**Gap 1:** cancelAll() now clears cachedDerivedStateBox
**Gap 2:** cancelAll() now resets lastPaginationCompletedAt
**Gap 3:** wasPaginationTriggerInRange is now updated only when pagination fires, not before guards
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
