### PR TITLE
fix(teleport): reject same-env transfers before hatching to avoid orphaned assistants

### DIFF
--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -500,6 +500,66 @@ describe("same-environment rejection", () => {
     }
   });
 
+  test("same-env rejection happens before hatching (no orphaned assistants)", async () => {
+    setArgv("--from", "my-local", "--local");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    await expect(teleport()).rejects.toThrow("process.exit:1");
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Cannot teleport between two local assistants"),
+    );
+    // Crucially: no hatch should have been called — the early guard fires first
+    expect(hatchLocalMock).not.toHaveBeenCalled();
+    expect(hatchDockerMock).not.toHaveBeenCalled();
+    expect(hatchAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("same-env rejection before hatching for docker", async () => {
+    setArgv("--from", "my-docker", "--docker");
+
+    const dockerEntry = makeEntry("my-docker", { cloud: "docker" });
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-docker") return dockerEntry;
+      return null;
+    });
+
+    await expect(teleport()).rejects.toThrow("process.exit:1");
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Cannot teleport between two docker assistants"),
+    );
+    expect(hatchLocalMock).not.toHaveBeenCalled();
+    expect(hatchDockerMock).not.toHaveBeenCalled();
+    expect(hatchAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("same-env rejection before hatching for platform (vellum cloud)", async () => {
+    setArgv("--from", "my-cloud", "--platform");
+
+    const platformEntry = makeEntry("my-cloud", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-cloud") return platformEntry;
+      return null;
+    });
+
+    await expect(teleport()).rejects.toThrow("process.exit:1");
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Cannot teleport between two platform assistants",
+      ),
+    );
+    expect(hatchLocalMock).not.toHaveBeenCalled();
+    expect(hatchDockerMock).not.toHaveBeenCalled();
+    expect(hatchAssistantMock).not.toHaveBeenCalled();
+  });
+
   test("flag says docker but resolved target is local -> uses resolved cloud", async () => {
     // User passes --docker but the named target is actually a local assistant
     setArgv("--from", "src", "--docker", "misidentified");

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -993,6 +993,16 @@ export async function teleport(): Promise<void> {
 
   const fromCloud = resolveCloud(fromEntry);
 
+  // Early same-environment guard — compare source cloud against the CLI flag
+  // BEFORE exporting or hatching, to avoid creating orphaned assistants.
+  const normalizedSourceEnv = fromCloud === "vellum" ? "platform" : fromCloud;
+  if (normalizedSourceEnv === targetEnv) {
+    console.error(
+      `Cannot teleport between two ${targetEnv} assistants. Teleport transfers data across different environments.`,
+    );
+    process.exit(1);
+  }
+
   // Export from source
   console.log(`Exporting from ${from} (${fromCloud})...`);
   const bundleData = await exportFromAssistant(fromEntry, fromCloud);
@@ -1001,8 +1011,9 @@ export async function teleport(): Promise<void> {
   const toEntry = await resolveOrHatchTarget(targetEnv, targetName);
   const toCloud = resolveCloud(toEntry);
 
-  // Same-environment rejection — uses resolved clouds, not CLI flag
-  const normalizedSourceEnv = fromCloud === "vellum" ? "platform" : fromCloud;
+  // Post-hatch same-environment safety net — uses resolved clouds in case
+  // the resolved target cloud differs from the CLI flag (e.g., --docker
+  // targeting a name that is actually a local entry).
   const normalizedTargetEnv = toCloud === "vellum" ? "platform" : toCloud;
   if (normalizedSourceEnv === normalizedTargetEnv) {
     console.error(


### PR DESCRIPTION
## Summary
- Add early same-environment guard before export/hatch to prevent orphaned assistants
- Keep post-hatch check as safety net for edge case where resolved cloud differs from flag
- Verify hatched assistant name is logged before import attempt

Part of plan: teleport-all-environments.md (fix round 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
