### PR TITLE
feat(messaging): add Outlook MessagingProvider adapter

### DIFF
--- a/assistant/src/daemon/providers-setup.ts
+++ b/assistant/src/daemon/providers-setup.ts
@@ -8,6 +8,7 @@ import type { AssistantConfig } from "../config/types.js";
 import { setSentryOrganizationId, setSentryUserId } from "../instrument.js";
 import { getMcpServerManager } from "../mcp/manager.js";
 import { gmailMessagingProvider } from "../messaging/providers/gmail/adapter.js";
+import { outlookMessagingProvider } from "../messaging/providers/outlook/adapter.js";
 import { slackProvider as slackMessagingProvider } from "../messaging/providers/slack/adapter.js";
 import { telegramBotMessagingProvider } from "../messaging/providers/telegram-bot/adapter.js";
 import { whatsappMessagingProvider } from "../messaging/providers/whatsapp/adapter.js";
@@ -140,6 +141,7 @@ export function registerWatcherProviders(): void {
 export function registerMessagingProviders(): void {
   registerMessagingProvider(slackMessagingProvider);
   registerMessagingProvider(gmailMessagingProvider);
+  registerMessagingProvider(outlookMessagingProvider);
   registerMessagingProvider(telegramBotMessagingProvider);
   registerMessagingProvider(whatsappMessagingProvider);
 }

--- a/assistant/src/messaging/providers/outlook/adapter.ts
+++ b/assistant/src/messaging/providers/outlook/adapter.ts
@@ -1,0 +1,190 @@
+/**
+ * Outlook messaging provider adapter.
+ *
+ * Maps Microsoft Graph API responses to the platform-agnostic messaging types
+ * and implements the MessagingProvider interface.
+ */
+
+import type { OAuthConnection } from "../../../oauth/connection.js";
+import type { MessagingProvider } from "../../provider.js";
+import type {
+  ConnectionInfo,
+  Conversation,
+  HistoryOptions,
+  ListOptions,
+  Message,
+  SearchOptions,
+  SearchResult,
+  SendOptions,
+  SendResult,
+} from "../../provider-types.js";
+import * as outlook from "./client.js";
+import type { OutlookMessage } from "./types.js";
+
+function requireConnection(
+  connection: OAuthConnection | undefined,
+): OAuthConnection {
+  if (!connection) {
+    throw new Error(
+      "Outlook requires an OAuth connection — is the account connected?",
+    );
+  }
+  return connection;
+}
+
+function mapOutlookMessage(msg: OutlookMessage): Message {
+  return {
+    id: msg.id,
+    conversationId: msg.conversationId,
+    sender: {
+      id: msg.from.emailAddress.address,
+      name: msg.from.emailAddress.name || msg.from.emailAddress.address,
+      email: msg.from.emailAddress.address,
+    },
+    text: msg.body.contentType === "text" ? msg.body.content : msg.bodyPreview,
+    timestamp: new Date(msg.receivedDateTime).getTime(),
+    threadId: msg.conversationId,
+    platform: "outlook",
+    hasAttachments: msg.hasAttachments ?? false,
+    metadata: {
+      subject: msg.subject,
+      categories: msg.categories,
+      isRead: msg.isRead,
+      parentFolderId: msg.parentFolderId,
+    },
+  };
+}
+
+const MESSAGE_SELECT_FIELDS =
+  "id,conversationId,subject,bodyPreview,body,from,toRecipients,receivedDateTime,isRead,hasAttachments,parentFolderId,categories,flag";
+
+export const outlookMessagingProvider: MessagingProvider = {
+  id: "outlook",
+  displayName: "Outlook",
+  credentialService: "outlook",
+  capabilities: new Set(["threads", "folders", "archive"]),
+
+  async testConnection(connection?: OAuthConnection): Promise<ConnectionInfo> {
+    const conn = requireConnection(connection);
+    const profile = await outlook.getProfile(conn);
+    return {
+      connected: true,
+      user: profile.mail || profile.userPrincipalName,
+      platform: "outlook",
+    };
+  },
+
+  async listConversations(
+    connection: OAuthConnection | undefined,
+    _options?: ListOptions,
+  ): Promise<Conversation[]> {
+    const conn = requireConnection(connection);
+    const folders = await outlook.listMailFolders(conn);
+    return folders.map((folder) => ({
+      id: folder.id,
+      name: folder.displayName,
+      type: "inbox" as const,
+      platform: "outlook",
+      unreadCount: folder.unreadItemCount ?? 0,
+      lastActivityAt: Date.now(),
+      metadata: {
+        totalItemCount: folder.totalItemCount,
+        childFolderCount: folder.childFolderCount,
+      },
+    }));
+  },
+
+  async getHistory(
+    connection: OAuthConnection | undefined,
+    conversationId: string,
+    options?: HistoryOptions,
+  ): Promise<Message[]> {
+    const conn = requireConnection(connection);
+    const result = await outlook.listMessages(conn, {
+      folderId: conversationId,
+      top: options?.limit ?? 50,
+      orderby: "receivedDateTime desc",
+      select: MESSAGE_SELECT_FIELDS,
+    });
+    return (result.value ?? []).map(mapOutlookMessage);
+  },
+
+  async search(
+    connection: OAuthConnection | undefined,
+    query: string,
+    options?: SearchOptions,
+  ): Promise<SearchResult> {
+    const conn = requireConnection(connection);
+    const result = await outlook.searchMessages(conn, query, {
+      top: options?.count ?? 20,
+    });
+    const messages = result.value ?? [];
+    return {
+      total: result["@odata.count"] ?? messages.length,
+      messages: messages.map(mapOutlookMessage),
+      hasMore: !!result["@odata.nextLink"],
+    };
+  },
+
+  async sendMessage(
+    connection: OAuthConnection | undefined,
+    conversationId: string,
+    text: string,
+    options?: SendOptions,
+  ): Promise<SendResult> {
+    const conn = requireConnection(connection);
+
+    if (options?.inReplyTo) {
+      await outlook.replyToMessage(conn, options.inReplyTo, text);
+      return {
+        id: "",
+        timestamp: Date.now(),
+        conversationId,
+        threadId: options?.threadId,
+      };
+    }
+
+    await outlook.sendMessage(conn, {
+      message: {
+        subject: options?.subject ?? "",
+        body: { contentType: "text", content: text },
+        toRecipients: [{ emailAddress: { address: conversationId } }],
+      },
+    });
+
+    // Microsoft Graph's sendMail returns 202 with no body
+    return {
+      id: "",
+      timestamp: Date.now(),
+      conversationId,
+      threadId: options?.threadId,
+    };
+  },
+
+  async getThreadReplies(
+    connection: OAuthConnection | undefined,
+    _conversationId: string,
+    threadId: string,
+    options?: HistoryOptions,
+  ): Promise<Message[]> {
+    const conn = requireConnection(connection);
+    const result = await outlook.listMessages(conn, {
+      filter: `conversationId eq '${threadId}'`,
+      top: options?.limit ?? 50,
+      orderby: "receivedDateTime asc",
+      select: MESSAGE_SELECT_FIELDS,
+    });
+    return (result.value ?? []).map(mapOutlookMessage);
+  },
+
+  async markRead(
+    connection: OAuthConnection | undefined,
+    _conversationId: string,
+    messageId?: string,
+  ): Promise<void> {
+    const conn = requireConnection(connection);
+    if (messageId) {
+      await outlook.markMessageRead(conn, messageId);
+    }
+  },
+};


### PR DESCRIPTION
## Summary
- Implement MessagingProvider interface for Outlook using Microsoft Graph API client
- Map Outlook messages, folders, and threads to platform-agnostic types
- Support all required operations: test connection, list folders, get history, search, send/reply, mark read, thread replies

Part of plan: outlook-messaging-provider.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
