### PR TITLE
fix(teleport): make --dry-run side-effect-free — do not hatch assistants

### DIFF
--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -808,22 +808,37 @@ describe("auto-retire", () => {
     }
   });
 
-  test("dry-run skips retire", async () => {
+  test("dry-run without existing target does not hatch or export", async () => {
     setArgv("--from", "my-local", "--docker", "--dry-run");
 
     const localEntry = makeEntry("my-local", { cloud: "local" });
-    const dockerEntry = makeEntry("new-docker", { cloud: "docker" });
 
     findAssistantByNameMock.mockImplementation((name: string) => {
       if (name === "my-local") return localEntry;
       return null;
     });
 
-    loadAllAssistantsMock.mockImplementation(() => {
-      if (hatchDockerMock.mock.calls.length > 0) {
-        return [localEntry, dockerEntry];
-      }
-      return [localEntry];
+    await teleport();
+
+    // Should NOT hatch, export, import, or retire
+    expect(hatchDockerMock).not.toHaveBeenCalled();
+    expect(hatchLocalMock).not.toHaveBeenCalled();
+    expect(hatchAssistantMock).not.toHaveBeenCalled();
+    expect(retireLocalMock).not.toHaveBeenCalled();
+    expect(retireDockerMock).not.toHaveBeenCalled();
+    expect(removeAssistantEntryMock).not.toHaveBeenCalled();
+  });
+
+  test("dry-run with existing target runs preflight without hatching", async () => {
+    setArgv("--from", "my-local", "--docker", "my-docker", "--dry-run");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    const dockerEntry = makeEntry("my-docker", { cloud: "docker" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-local") return localEntry;
+      if (name === "my-docker") return dockerEntry;
+      return null;
     });
 
     const originalFetch = globalThis.fetch;
@@ -831,6 +846,10 @@ describe("auto-retire", () => {
 
     try {
       await teleport();
+
+      // Should NOT hatch or retire
+      expect(hatchDockerMock).not.toHaveBeenCalled();
+      expect(hatchLocalMock).not.toHaveBeenCalled();
       expect(retireLocalMock).not.toHaveBeenCalled();
       expect(retireDockerMock).not.toHaveBeenCalled();
       expect(removeAssistantEntryMock).not.toHaveBeenCalled();

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -76,8 +76,15 @@ function printHelp(): void {
     "  --keep-source       Do not retire the source after local/docker transfers",
   );
   console.log(
-    "  --dry-run           Preview the transfer without applying changes",
+    "  --dry-run           Preview the transfer without applying changes.",
   );
+  console.log(
+    "                      If the target exists, runs preflight analysis.",
+  );
+  console.log(
+    "                      If the target would be hatched, shows what would happen",
+  );
+  console.log("                      without creating anything.");
   console.log("  --help, -h          Show this help");
   console.log("");
   console.log("Examples:");
@@ -1003,6 +1010,40 @@ export async function teleport(): Promise<void> {
     process.exit(1);
   }
 
+  // Dry-run without an existing target: skip export, hatch, and import —
+  // just report what would happen.
+  if (dryRun) {
+    const existingTarget = targetName ? findAssistantByName(targetName) : null;
+
+    if (existingTarget) {
+      // Target exists — export and run preflight against it
+      const toCloud = resolveCloud(existingTarget);
+      const normalizedTargetEnv = toCloud === "vellum" ? "platform" : toCloud;
+      if (normalizedSourceEnv === normalizedTargetEnv) {
+        console.error(
+          `Cannot teleport between two ${normalizedTargetEnv} assistants. Teleport transfers data across different environments.`,
+        );
+        process.exit(1);
+      }
+
+      console.log(`Exporting from ${from} (${fromCloud})...`);
+      const bundleData = await exportFromAssistant(fromEntry, fromCloud);
+      console.log(`Importing to ${existingTarget.assistantId} (${toCloud})...`);
+      await importToAssistant(existingTarget, toCloud, bundleData, true);
+    } else {
+      // No existing target — just describe what would happen
+      console.log("Dry run summary:");
+      console.log(`  Would export data from: ${from} (${fromCloud})`);
+      console.log(
+        `  Would hatch a new ${targetEnv} assistant${targetName ? ` named '${targetName}'` : ""}`,
+      );
+      console.log(`  Would import data into the new assistant`);
+    }
+
+    console.log(`Dry run complete — no changes were made.`);
+    return;
+  }
+
   // Export from source
   console.log(`Exporting from ${from} (${fromCloud})...`);
   const bundleData = await exportFromAssistant(fromEntry, fromCloud);
@@ -1024,7 +1065,7 @@ export async function teleport(): Promise<void> {
 
   // Import to target
   console.log(`Importing to ${toEntry.assistantId} (${toCloud})...`);
-  await importToAssistant(toEntry, toCloud, bundleData, dryRun);
+  await importToAssistant(toEntry, toCloud, bundleData, false);
 
   // Auto-retire source if applicable (local<->docker, not dry-run, not --keep-source)
   if (!dryRun) {


### PR DESCRIPTION
## Summary
- When `--dry-run` is used and no existing target is found, print what would happen instead of hatching a real assistant
- When `--dry-run` is used with an existing target, export and run preflight as before
- Update help text to document the dry-run behavior
- Replace dry-run test with two tests: one for no-target (no hatch) and one for existing target (preflight only)

Part of plan: teleport-all-environments.md (review fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
