### PR TITLE
feat: update FileContentHeaderBar with icon pill and 18pt semibold filename

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -232,8 +232,13 @@ struct FileContentHeaderBar<Trailing: View>: View {
         HStack(spacing: VSpacing.sm) {
             VIconView(icon, size: 12)
                 .foregroundStyle(VColor.primaryBase)
+                .padding(6)
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.sm)
+                        .fill(VColor.surfaceActive)
+                )
             Text(fileName)
-                .font(VFont.labelDefault)
+                .font(VFont.titleSmall)
                 .foregroundStyle(VColor.contentDefault)
                 .lineLimit(1)
                 .truncationMode(.middle)


### PR DESCRIPTION
## Summary
- Wrap file icon in surfaceActive pill background with rounded corners
- Change filename font to titleSmall (16pt medium) for bolder display
- Keep existing trailing content slot (VTabs) unchanged

Part of plan: skill-file-browser-redesign.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
