### PR TITLE
feat: update file row styling — icon colors, fonts, and file size display

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/FileTreeRowLabel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/FileTreeRowLabel.swift
@@ -11,6 +11,8 @@ struct FileTreeRowLabel: View {
     let fileIcon: VIcon
     var minRowWidth: CGFloat = 0
     var isDimmed: Bool = false
+    var isActive: Bool = false
+    var trailingText: String? = nil
 
     var body: some View {
         HStack(spacing: VSpacing.xs) {
@@ -25,18 +27,34 @@ struct FileTreeRowLabel: View {
 
             // File or folder icon
             VIconView(isDirectory ? .folder : fileIcon, size: 12)
-                .foregroundStyle(isDirectory ? VColor.primaryBase : VColor.contentSecondary)
+                .foregroundStyle(isActive ? VColor.primaryActive : VColor.primaryBase)
 
             // Name label
             Text(name)
-                .font(VFont.bodyMediumLighter)
-                .foregroundStyle(isDimmed ? VColor.contentTertiary : VColor.contentDefault)
+                .font(VFont.bodyMediumDefault)
+                .foregroundStyle(
+                    isDimmed ? VColor.contentTertiary :
+                    isActive ? VColor.contentEmphasized :
+                    VColor.contentSecondary
+                )
                 .fixedSize(horizontal: true, vertical: false)
+
+            // Trailing text (e.g. file size)
+            if let trailingText {
+                Spacer()
+                Text(trailingText)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
         }
         .padding(.leading, CGFloat(depth) * VSpacing.lg + VSpacing.sm)
         .padding(.trailing, VSpacing.sm)
         .padding(.vertical, VSpacing.xs)
         .frame(minWidth: minRowWidth, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.sm)
+                .fill(isActive ? VColor.surfaceActive : Color.clear)
+        )
         .opacity(isDimmed ? 0.6 : 1.0)
     }
 }


### PR DESCRIPTION
## Summary
- Update icon colors to primaryBase/primaryActive
- Add isActive parameter for surfaceActive background highlighting
- Add trailingText parameter for right-aligned file size display
- Update filename to bodyMediumDefault font in contentSecondary

Part of plan: skill-file-browser-redesign.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
