### PR TITLE
fix(teleport): validate target cloud matches env flag and sanitize target name

### DIFF
--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -560,11 +560,11 @@ describe("same-environment rejection", () => {
     expect(hatchAssistantMock).not.toHaveBeenCalled();
   });
 
-  test("flag says docker but resolved target is local -> uses resolved cloud", async () => {
+  test("flag says docker but resolved target is local -> rejects cloud mismatch", async () => {
     // User passes --docker but the named target is actually a local assistant
     setArgv("--from", "src", "--docker", "misidentified");
 
-    const srcEntry = makeEntry("src", { cloud: "local" });
+    const srcEntry = makeEntry("src", { cloud: "vellum" });
     // Target is actually local despite the --docker flag
     const dstEntry = makeEntry("misidentified", { cloud: "local" });
 
@@ -574,17 +574,10 @@ describe("same-environment rejection", () => {
       return null;
     });
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
-
-    try {
-      await expect(teleport()).rejects.toThrow("process.exit:1");
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Cannot teleport between two local assistants"),
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    await expect(teleport()).rejects.toThrow("process.exit:1");
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("is a local assistant, not docker"),
+    );
   });
 });
 
@@ -682,6 +675,33 @@ describe("resolveOrHatchTarget", () => {
       }),
     );
     expect(result.assistantId).toBe("platform-new-id");
+  });
+
+  test("existing assistant with wrong cloud -> rejects", async () => {
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    await expect(resolveOrHatchTarget("docker", "my-local")).rejects.toThrow(
+      "process.exit:1",
+    );
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("is a local assistant, not docker"),
+    );
+  });
+
+  test("name with path traversal -> rejects before hatching", async () => {
+    findAssistantByNameMock.mockReturnValue(null);
+
+    await expect(
+      resolveOrHatchTarget("docker", "../../../etc/passwd"),
+    ).rejects.toThrow("process.exit:1");
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("invalid characters"),
+    );
+    expect(hatchDockerMock).not.toHaveBeenCalled();
   });
 });
 

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -23,6 +23,7 @@ import {
 import { hatchDocker, retireDocker } from "../lib/docker.js";
 import { hatchLocal } from "../lib/hatch-local.js";
 import { retireLocal } from "../lib/retire-local.js";
+import { validateAssistantName } from "../lib/retire-archive.js";
 
 function printHelp(): void {
   console.log(
@@ -747,8 +748,29 @@ export async function resolveOrHatchTarget(
   if (targetName) {
     const existing = findAssistantByName(targetName);
     if (existing) {
+      // Validate the existing assistant's cloud matches the requested env
+      const existingCloud = resolveCloud(existing);
+      const normalizedExisting =
+        existingCloud === "vellum" ? "platform" : existingCloud;
+      if (normalizedExisting !== targetEnv) {
+        console.error(
+          `Error: Assistant '${targetName}' is a ${normalizedExisting} assistant, not ${targetEnv}. ` +
+            `Use --${normalizedExisting} to target it.`,
+        );
+        process.exit(1);
+      }
       console.log(`Target: ${targetName} (${targetEnv})`);
       return existing;
+    }
+
+    // Name not found — will hatch. Validate the name first.
+    try {
+      validateAssistantName(targetName);
+    } catch {
+      console.error(
+        "Error: Target name contains invalid characters (path separators or traversal segments are not allowed).",
+      );
+      process.exit(1);
     }
   }
 
@@ -1016,9 +1038,16 @@ export async function teleport(): Promise<void> {
     const existingTarget = targetName ? findAssistantByName(targetName) : null;
 
     if (existingTarget) {
-      // Target exists — export and run preflight against it
+      // Target exists — validate cloud matches the flag, then run preflight
       const toCloud = resolveCloud(existingTarget);
       const normalizedTargetEnv = toCloud === "vellum" ? "platform" : toCloud;
+      if (normalizedTargetEnv !== targetEnv) {
+        console.error(
+          `Error: Assistant '${targetName}' is a ${normalizedTargetEnv} assistant, not ${targetEnv}. ` +
+            `Use --${normalizedTargetEnv} to target it.`,
+        );
+        process.exit(1);
+      }
       if (normalizedSourceEnv === normalizedTargetEnv) {
         console.error(
           `Cannot teleport between two ${normalizedTargetEnv} assistants. Teleport transfers data across different environments.`,


### PR DESCRIPTION
## Summary
- Reject existing targets whose cloud doesn't match the environment flag (e.g. `--docker my-local` where `my-local` is actually a local assistant)
- Validate target name with `validateAssistantName` before auto-hatching to prevent path traversal
- Add tests for cloud mismatch rejection and name validation

Addresses review feedback on #22410.

Part of plan: teleport-all-environments.md (review fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
