### PR TITLE
fix(teleport): call setActiveAssistant after platform hatch for consistency

### DIFF
--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -3,6 +3,7 @@ import {
   loadAllAssistants,
   removeAssistantEntry,
   saveAssistantEntry,
+  setActiveAssistant,
 } from "../lib/assistant-config.js";
 import type { AssistantEntry } from "../lib/assistant-config.js";
 import {
@@ -823,6 +824,7 @@ export async function resolveOrHatchTarget(
       hatchedAt: new Date().toISOString(),
     };
     saveAssistantEntry(entry);
+    setActiveAssistant(result.id);
     console.log(`Hatched new platform assistant: ${result.id}`);
     return entry;
   }


### PR DESCRIPTION
## Summary
- Add `setActiveAssistant(result.id)` after platform hatch in `resolveOrHatchTarget` to match the behavior of local and docker hatch paths, which set the active assistant internally

Addresses review feedback on #22410.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
