### PR TITLE
fix(messaging): harden Outlook adapter against OData injection and null sender

### DIFF
--- a/assistant/src/messaging/providers/outlook/adapter.ts
+++ b/assistant/src/messaging/providers/outlook/adapter.ts
@@ -33,13 +33,16 @@ function requireConnection(
 }
 
 function mapOutlookMessage(msg: OutlookMessage): Message {
+  const senderEmail = msg.from?.emailAddress?.address ?? "";
+  const senderName = msg.from?.emailAddress?.name || senderEmail || "Unknown";
+
   return {
     id: msg.id,
     conversationId: msg.conversationId,
     sender: {
-      id: msg.from.emailAddress.address,
-      name: msg.from.emailAddress.name || msg.from.emailAddress.address,
-      email: msg.from.emailAddress.address,
+      id: senderEmail,
+      name: senderName,
+      email: senderEmail,
     },
     text: msg.body.contentType === "text" ? msg.body.content : msg.bodyPreview,
     timestamp: new Date(msg.receivedDateTime).getTime(),
@@ -169,7 +172,7 @@ export const outlookMessagingProvider: MessagingProvider = {
   ): Promise<Message[]> {
     const conn = requireConnection(connection);
     const result = await outlook.listMessages(conn, {
-      filter: `conversationId eq '${threadId}'`,
+      filter: `conversationId eq '${threadId.replace(/'/g, "''")}'`,
       top: options?.limit ?? 50,
       orderby: "receivedDateTime asc",
       select: MESSAGE_SELECT_FIELDS,

--- a/assistant/src/messaging/providers/outlook/types.ts
+++ b/assistant/src/messaging/providers/outlook/types.ts
@@ -35,7 +35,7 @@ export interface OutlookMessage {
   subject: string;
   bodyPreview: string;
   body: OutlookItemBody;
-  from: OutlookRecipient;
+  from?: OutlookRecipient;
   toRecipients: OutlookRecipient[];
   ccRecipients: OutlookRecipient[];
   receivedDateTime: string; // ISO 8601


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for outlook-messaging-provider.md.

**Gap 1:** Escape single quotes in threadId when building OData filter in getThreadReplies to prevent query syntax errors.
**Gap 2:** Make from field optional in OutlookMessage type and add null guard in adapter to handle drafts and calendar notifications that lack a sender.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
