### PR TITLE
fix(messaging): correct Outlook Graph API paths and remove unimplemented archive capability

### DIFF
--- a/assistant/src/__tests__/outlook-messaging-provider.test.ts
+++ b/assistant/src/__tests__/outlook-messaging-provider.test.ts
@@ -570,7 +570,7 @@ describe("Outlook messaging provider", () => {
     test("has correct capabilities", () => {
       expect(outlookMessagingProvider.capabilities.has("threads")).toBe(true);
       expect(outlookMessagingProvider.capabilities.has("folders")).toBe(true);
-      expect(outlookMessagingProvider.capabilities.has("archive")).toBe(true);
+      expect(outlookMessagingProvider.capabilities.has("archive")).toBe(false);
     });
   });
 });

--- a/assistant/src/messaging/providers/outlook/adapter.ts
+++ b/assistant/src/messaging/providers/outlook/adapter.ts
@@ -62,7 +62,7 @@ export const outlookMessagingProvider: MessagingProvider = {
   id: "outlook",
   displayName: "Outlook",
   credentialService: "outlook",
-  capabilities: new Set(["threads", "folders", "archive"]),
+  capabilities: new Set(["threads", "folders"]),
 
   async testConnection(connection?: OAuthConnection): Promise<ConnectionInfo> {
     const conn = requireConnection(connection);

--- a/assistant/src/messaging/providers/outlook/client.ts
+++ b/assistant/src/messaging/providers/outlook/client.ts
@@ -38,8 +38,8 @@ function isIdempotent(method: string): boolean {
 /**
  * Make an authenticated request to the Microsoft Graph API with retry logic.
  *
- * The OAuth provider's baseUrl is already configured to `https://graph.microsoft.com/v1.0/me`,
- * so paths are relative to `/me` (e.g. `/messages`, `/mailFolders`).
+ * The OAuth provider's baseUrl is `https://graph.microsoft.com`, so all paths
+ * must include the full API version and resource prefix (e.g. `/v1.0/me/messages`).
  */
 async function request<T>(
   connection: OAuthConnection,
@@ -104,8 +104,7 @@ async function request<T>(
 export async function getProfile(
   connection: OAuthConnection,
 ): Promise<OutlookUserProfile> {
-  // The baseUrl already points to /me, so an empty path returns the user profile.
-  return request<OutlookUserProfile>(connection, "");
+  return request<OutlookUserProfile>(connection, "/v1.0/me");
 }
 
 /** List messages, optionally within a specific folder. */
@@ -121,8 +120,8 @@ export async function listMessages(
   },
 ): Promise<OutlookMessageListResponse> {
   const path = options?.folderId
-    ? `/mailFolders/${options.folderId}/messages`
-    : "/messages";
+    ? `/v1.0/me/mailFolders/${options.folderId}/messages`
+    : "/v1.0/me/messages";
 
   const query: Record<string, string> = {};
   if (options?.top !== undefined) query["$top"] = String(options.top);
@@ -150,7 +149,7 @@ export async function getMessage(
 
   return request<OutlookMessage>(
     connection,
-    `/messages/${messageId}`,
+    `/v1.0/me/messages/${messageId}`,
     undefined,
     Object.keys(query).length > 0 ? query : undefined,
   );
@@ -173,7 +172,7 @@ export async function searchMessages(
 
   return request<OutlookMessageListResponse>(
     connection,
-    "/messages",
+    "/v1.0/me/messages",
     undefined,
     query,
   );
@@ -184,7 +183,7 @@ export async function sendMessage(
   connection: OAuthConnection,
   message: OutlookSendMessagePayload,
 ): Promise<void> {
-  await request<void>(connection, "/sendMail", {
+  await request<void>(connection, "/v1.0/me/sendMail", {
     method: "POST",
     body: JSON.stringify(message),
   });
@@ -196,7 +195,7 @@ export async function replyToMessage(
   messageId: string,
   comment: string,
 ): Promise<void> {
-  await request<void>(connection, `/messages/${messageId}/reply`, {
+  await request<void>(connection, `/v1.0/me/messages/${messageId}/reply`, {
     method: "POST",
     body: JSON.stringify({ comment }),
   });
@@ -208,7 +207,7 @@ export async function listMailFolders(
 ): Promise<OutlookMailFolder[]> {
   const resp = await request<OutlookMailFolderListResponse>(
     connection,
-    "/mailFolders",
+    "/v1.0/me/mailFolders",
     undefined,
     { $top: "100" },
   );
@@ -220,7 +219,7 @@ export async function markMessageRead(
   connection: OAuthConnection,
   messageId: string,
 ): Promise<void> {
-  await request<void>(connection, `/messages/${messageId}`, {
+  await request<void>(connection, `/v1.0/me/messages/${messageId}`, {
     method: "PATCH",
     body: JSON.stringify({ isRead: true }),
   });
@@ -232,10 +231,14 @@ export async function moveMessage(
   messageId: string,
   destinationFolderId: string,
 ): Promise<OutlookMessage> {
-  return request<OutlookMessage>(connection, `/messages/${messageId}/move`, {
-    method: "POST",
-    body: JSON.stringify({ destinationId: destinationFolderId }),
-  });
+  return request<OutlookMessage>(
+    connection,
+    `/v1.0/me/messages/${messageId}/move`,
+    {
+      method: "POST",
+      body: JSON.stringify({ destinationId: destinationFolderId }),
+    },
+  );
 }
 
 /** Max concurrent individual getMessage requests for batch fetching. */


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for outlook-messaging-provider.md.

**Gap 1:** Client paths were relative to /me but the OAuth baseUrl is https://graph.microsoft.com, so all API calls would hit wrong URLs. Fixed by prefixing all paths with /v1.0/me.
**Gap 2:** Adapter declared archive capability without implementing archiveByQuery. Removed archive from capabilities.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
