### PR TITLE
feat: redesign skill detail page + shared VFileBrowser component

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/FileTreeRowLabel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/FileTreeRowLabel.swift
@@ -11,6 +11,8 @@ struct FileTreeRowLabel: View {
     let fileIcon: VIcon
     var minRowWidth: CGFloat = 0
     var isDimmed: Bool = false
+    var isActive: Bool = false
+    var trailingText: String? = nil
 
     var body: some View {
         HStack(spacing: VSpacing.xs) {
@@ -25,18 +27,34 @@ struct FileTreeRowLabel: View {
 
             // File or folder icon
             VIconView(isDirectory ? .folder : fileIcon, size: 12)
-                .foregroundStyle(isDirectory ? VColor.primaryBase : VColor.contentSecondary)
+                .foregroundStyle(isActive ? VColor.primaryActive : VColor.primaryBase)
 
             // Name label
             Text(name)
-                .font(VFont.bodyMediumLighter)
-                .foregroundStyle(isDimmed ? VColor.contentTertiary : VColor.contentDefault)
+                .font(VFont.bodyMediumDefault)
+                .foregroundStyle(
+                    isDimmed ? VColor.contentTertiary :
+                    isActive ? VColor.contentEmphasized :
+                    VColor.contentSecondary
+                )
                 .fixedSize(horizontal: true, vertical: false)
+
+            // Trailing text (e.g. file size)
+            if let trailingText {
+                Spacer()
+                Text(trailingText)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
         }
         .padding(.leading, CGFloat(depth) * VSpacing.lg + VSpacing.sm)
         .padding(.trailing, VSpacing.sm)
         .padding(.vertical, VSpacing.xs)
         .frame(minWidth: minRowWidth, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.sm)
+                .fill(isActive ? VColor.surfaceActive : Color.clear)
+        )
         .opacity(isDimmed ? 0.6 : 1.0)
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -92,8 +92,7 @@ struct FileContentView: View {
                     VTabs(
                         items: modes.map { (label: viewModeLabel($0), tag: $0) },
                         selection: $viewMode,
-                        style: .pill,
-                        size: .compact
+                        style: .pill
                     )
                     .fixedSize()
                 }
@@ -105,7 +104,7 @@ struct FileContentView: View {
                 }
             }
 
-            Divider().background(VColor.borderBase)
+            Rectangle().fill(VColor.surfaceBase).frame(height: 1)
 
             ZStack(alignment: .topTrailing) {
                 switch viewMode {
@@ -245,7 +244,7 @@ struct FileContentHeaderBar<Trailing: View>: View {
             Spacer()
             trailing
         }
-        .padding(.horizontal, VSpacing.sm)
-        .frame(height: 36)
+        .padding(.horizontal, VSpacing.md)
+        .padding(.vertical, VSpacing.sm)
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -232,8 +232,13 @@ struct FileContentHeaderBar<Trailing: View>: View {
         HStack(spacing: VSpacing.sm) {
             VIconView(icon, size: 12)
                 .foregroundStyle(VColor.primaryBase)
+                .padding(6)
+                .background(
+                    RoundedRectangle(cornerRadius: VRadius.sm)
+                        .fill(VColor.surfaceActive)
+                )
             Text(fileName)
-                .font(VFont.labelDefault)
+                .font(VFont.titleSmall)
                 .foregroundStyle(VColor.contentDefault)
                 .lineLimit(1)
                 .truncationMode(.middle)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
@@ -64,91 +64,38 @@ struct SkillDetailView: View {
 
     // MARK: - File Browser
 
+    private var browserFiles: [VFileBrowserFile] {
+        guard let files = skillsManager.selectedSkillFiles else { return [] }
+        return files.files
+            .filter { !$0.isBinary && $0.content != nil }
+            .map { VFileBrowserFile(
+                id: $0.path, name: $0.name, path: $0.path,
+                size: $0.size, mimeType: $0.mimeType,
+                isBinary: $0.isBinary, content: $0.content,
+                icon: fileIcon(for: $0.mimeType, fileName: $0.name)
+            )}
+    }
+
     @ViewBuilder
     private var skillDetailFileBrowser: some View {
-        HStack(alignment: .top, spacing: VSpacing.xl) {
-            skillFilesSection
-                .frame(width: 280, alignment: .topLeading)
-                .frame(maxHeight: .infinity)
-                .background(
-                    RoundedRectangle(cornerRadius: VRadius.lg)
-                        .fill(VColor.surfaceBase)
+        VFileBrowser(
+            files: browserFiles,
+            selectedPath: $expandedFilePath
+        ) { selectedFile in
+            if let selectedFile,
+               let content = selectedFile.content {
+                FileContentView(
+                    fileName: selectedFile.path,
+                    mimeType: selectedFile.mimeType,
+                    content: .constant(content),
+                    viewMode: $skillFileViewMode,
+                    isActivelyEditing: .constant(false)
                 )
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-
-            skillDetailFileContent
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(
-                    RoundedRectangle(cornerRadius: VRadius.lg)
-                        .fill(VColor.surfaceBase)
+            } else {
+                VEmptyState(
+                    title: hasViewableFiles ? "Select a file to view" : "No viewable files",
+                    icon: VIcon.fileText.rawValue
                 )
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-
-    @ViewBuilder
-    private var skillDetailFileContent: some View {
-        if let selectedPath = expandedFilePath,
-           let filesResponse = skillsManager.selectedSkillFiles,
-           let file = filesResponse.files.first(where: { $0.path == selectedPath }),
-           !file.isBinary,
-           let content = file.content {
-            FileContentView(
-                fileName: file.path,
-                mimeType: file.mimeType,
-                content: .constant(content),
-                viewMode: $skillFileViewMode,
-                isActivelyEditing: .constant(false)
-            )
-        } else {
-            VEmptyState(
-                title: hasViewableFiles ? "Select a file to view" : "No viewable files",
-                icon: VIcon.fileText.rawValue
-            )
-        }
-    }
-
-    @ViewBuilder
-    private var skillFilesSection: some View {
-        if skillsManager.isLoadingSkillFiles || skillsManager.skillFilesError != nil ||
-            (skillsManager.selectedSkillFiles != nil && !skillsManager.selectedSkillFiles!.files.isEmpty) {
-            VStack(alignment: .leading, spacing: 0) {
-                HStack {
-                    Text("Files")
-                        .font(VFont.bodySmallEmphasised)
-                        .foregroundStyle(VColor.contentDefault)
-                    Spacer()
-                }
-                .padding(.horizontal, VSpacing.md)
-                .frame(height: 36)
-
-                Divider().background(VColor.borderBase)
-
-                VStack(spacing: 0) {
-                    if skillsManager.isLoadingSkillFiles {
-                        VStack {
-                            Spacer()
-                            ProgressView()
-                                .frame(maxWidth: .infinity)
-                            Spacer()
-                        }
-                    } else if let error = skillsManager.skillFilesError {
-                        Text(error)
-                            .font(VFont.labelDefault)
-                            .foregroundStyle(VColor.systemNegativeStrong)
-                            .padding(VSpacing.md)
-                    } else if let filesResponse = skillsManager.selectedSkillFiles, !filesResponse.files.isEmpty {
-                        ScrollView(.vertical) {
-                            SkillFileTreeView(
-                                files: filesResponse.files,
-                                selectedFilePath: $expandedFilePath
-                            )
-                            .padding(.vertical, VSpacing.xs)
-                        }
-                    }
-                }
-                .frame(maxHeight: .infinity, alignment: .topLeading)
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
@@ -29,9 +29,9 @@ struct SkillDetailView: View {
                     .font(VFont.bodyMediumLighter)
                     .foregroundStyle(VColor.contentSecondary)
                     .fixedSize(horizontal: false, vertical: true)
+                    .lineSpacing(8)
+                    .frame(maxWidth: 800, alignment: .leading)
             }
-
-            SkillDetailMetaInfo(skill: skill)
             skillDetailFileBrowser
         }
         .onAppear {
@@ -162,48 +162,37 @@ struct SkillDetailTitleRow: View {
     let onDelete: () -> Void
 
     var body: some View {
-        HStack(spacing: VSpacing.sm) {
-            VButton(
-                label: "Back",
-                iconOnly: VIcon.chevronLeft.rawValue,
-                style: .ghost,
-                tooltip: "Back to Skills"
-            ) {
-                onBack()
-            }
+        HStack {
+            HStack(spacing: VSpacing.lg) {
+                VButton(
+                    label: "Back",
+                    iconOnly: VIcon.arrowLeft.rawValue,
+                    style: .outlined,
+                    tooltip: "Back to Skills"
+                ) {
+                    onBack()
+                }
+                .frame(width: 32, height: 32)
 
-            if let emoji = skill.emoji, !emoji.isEmpty {
-                Text(emoji)
-                    .font(.system(size: 16))
-                    .frame(width: 20, height: 20)
-            } else {
-                VIconView(.zap, size: 12)
-                    .foregroundStyle(VColor.contentTertiary)
-                    .frame(width: 20, height: 20)
-            }
+                HStack(spacing: VSpacing.sm) {
+                    if let emoji = skill.emoji, !emoji.isEmpty {
+                        Text(emoji)
+                            .font(.system(size: 20))
+                    }
 
-            Text(skill.name)
-                .font(VFont.titleSmall)
-                .foregroundStyle(VColor.contentDefault)
-                .lineLimit(1)
+                    Text(skill.name)
+                        .font(VFont.titleMedium)
+                        .foregroundStyle(VColor.contentEmphasized)
+                        .lineLimit(1)
+                }
 
-            if skill.updateAvailable {
-                Text("UPDATE")
-                    .font(VFont.labelSmall)
-                    .foregroundStyle(VColor.systemNegativeHover)
+                VSkillTypePill(source: skill.source)
             }
 
             Spacer()
 
-            VSkillTypePill(source: skill.source)
-
             if skill.source == "managed" || skill.source == "clawhub" {
-                VButton(
-                    label: "Delete",
-                    iconOnly: VIcon.trash.rawValue,
-                    style: .dangerGhost,
-                    tooltip: "Uninstall skill"
-                ) {
+                VButton(label: "Remove", style: .dangerOutline) {
                     onDelete()
                 }
             }
@@ -211,48 +200,3 @@ struct SkillDetailTitleRow: View {
     }
 }
 
-// MARK: - Meta Info
-
-struct SkillDetailMetaInfo: View {
-    let skill: SkillInfo
-
-    var body: some View {
-        HStack(spacing: VSpacing.lg) {
-            if let installedVersion = skill.installedVersion, !installedVersion.isEmpty {
-                skillMetaItem(icon: .tag, value: "v\(installedVersion)")
-            }
-
-            if skill.updateAvailable {
-                if let latestVersion = skill.latestVersion, !latestVersion.isEmpty {
-                    skillMetaItem(icon: .circleArrowUp, value: "v\(latestVersion) available", color: VColor.systemNegativeHover)
-                } else {
-                    skillMetaItem(icon: .circleArrowUp, value: "Update available", color: VColor.systemNegativeHover)
-                }
-            }
-
-            if let provenance = skill.provenance,
-               provenance.kind == "third-party",
-               let urlString = provenance.sourceUrl,
-               let url = URL(string: urlString) {
-                Link(destination: url) {
-                    HStack(spacing: VSpacing.xs) {
-                        VIconView(.externalLink, size: 9)
-                        Text("View on \(provenance.provider ?? "source")")
-                            .font(VFont.labelSmall)
-                    }
-                    .foregroundStyle(VColor.contentTertiary)
-                }
-                .buttonStyle(.plain)
-            }
-        }
-    }
-
-    private func skillMetaItem(icon: VIcon, value: String, color: Color = VColor.contentTertiary) -> some View {
-        HStack(spacing: VSpacing.xs) {
-            VIconView(icon, size: 9)
-            Text(value)
-        }
-        .font(VFont.labelSmall)
-        .foregroundStyle(color)
-    }
-}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
@@ -78,24 +78,40 @@ struct SkillDetailView: View {
 
     @ViewBuilder
     private var skillDetailFileBrowser: some View {
-        VFileBrowser(
-            files: browserFiles,
-            selectedPath: $expandedFilePath
-        ) { selectedFile in
-            if let selectedFile,
-               let content = selectedFile.content {
-                FileContentView(
-                    fileName: selectedFile.path,
-                    mimeType: selectedFile.mimeType,
-                    content: .constant(content),
-                    viewMode: $skillFileViewMode,
-                    isActivelyEditing: .constant(false)
-                )
-            } else {
-                VEmptyState(
-                    title: hasViewableFiles ? "Select a file to view" : "No viewable files",
-                    icon: VIcon.fileText.rawValue
-                )
+        if skillsManager.isLoadingSkillFiles {
+            VEmptyState(
+                title: "Loading files...",
+                icon: VIcon.fileText.rawValue
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .overlay { ProgressView().controlSize(.small) }
+        } else if let error = skillsManager.skillFilesError {
+            VEmptyState(
+                title: "Failed to load files",
+                subtitle: error,
+                icon: VIcon.circleAlert.rawValue
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            VFileBrowser(
+                files: browserFiles,
+                selectedPath: $expandedFilePath
+            ) { selectedFile in
+                if let selectedFile,
+                   let content = selectedFile.content {
+                    FileContentView(
+                        fileName: selectedFile.path,
+                        mimeType: selectedFile.mimeType,
+                        content: .constant(content),
+                        viewMode: $skillFileViewMode,
+                        isActivelyEditing: .constant(false)
+                    )
+                } else {
+                    VEmptyState(
+                        title: hasViewableFiles ? "Select a file to view" : "No viewable files",
+                        icon: VIcon.fileText.rawValue
+                    )
+                }
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -412,8 +412,13 @@ private struct WorkspaceTreeSidebar: View {
             handleDrop(providers: providers, targetDir: "", state: state, workspaceClient: workspaceClient)
             return true
         }
-        .background(VColor.surfaceBase)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .background(VColor.surfaceOverlay)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.xl)
+                .strokeBorder(VColor.borderDisabled, lineWidth: 2)
+                .allowsHitTesting(false)
+        )
         .alert("New File", isPresented: $state.showingNewFileAlert) {
             TextField("Filename", text: $state.newItemName)
             Button("Cancel", role: .cancel) {}
@@ -540,6 +545,7 @@ private struct WorkspaceTreeRow: View {
                         .padding(.trailing, VSpacing.sm)
                         .padding(.vertical, VSpacing.xs)
                         .frame(minWidth: minRowWidth, alignment: .leading)
+                        .background(isSelected ? VColor.surfaceActive : Color.clear)
                     } else {
                         // Normal mode: shared label
                         FileTreeRowLabel(
@@ -549,12 +555,13 @@ private struct WorkspaceTreeRow: View {
                             depth: depth,
                             fileIcon: fileIcon(for: entry.mimeType ?? "application/octet-stream", fileName: entry.name),
                             minRowWidth: minRowWidth,
-                            isDimmed: isHiddenPath(entry.path)
+                            isDimmed: isHiddenPath(entry.path),
+                            isActive: state.selectedFilePath == entry.path,
+                            trailingText: entry.isDirectory ? nil : formattedFileSize(entry.size)
                         )
                     }
                 }
                 .contentShape(Rectangle())
-                .background(isSelected ? VColor.surfaceActive : Color.clear)
             }
             .buttonStyle(.plain)
             .onDrop(of: entry.isDirectory && !isHiddenPath(entry.path) ? [.fileURL] : [], isTargeted: .none) { providers in
@@ -748,6 +755,12 @@ private struct WorkspaceFileViewer: View {
             }
         }
         .background(VColor.surfaceOverlay)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.xl)
+                .strokeBorder(VColor.borderDisabled, lineWidth: 2)
+                .allowsHitTesting(false)
+        )
     }
 
     private var emptyState: some View {
@@ -904,6 +917,20 @@ private struct WorkspaceFileViewer: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
+}
+
+// MARK: - File Size Formatter
+
+/// Formats an optional byte count into a human-readable size string.
+private func formattedFileSize(_ bytes: Int?) -> String? {
+    guard let bytes else { return nil }
+    if bytes < 1024 {
+        return "\(bytes) bytes"
+    } else if bytes < 1024 * 1024 {
+        return "\(bytes / 1024) KB"
+    } else {
+        return "\(String(format: "%.1f", Double(bytes) / (1024 * 1024))) MB"
+    }
 }
 
 // MARK: - Hidden Path Helper

--- a/clients/shared/DesignSystem/Components/Display/VFileBrowser.swift
+++ b/clients/shared/DesignSystem/Components/Display/VFileBrowser.swift
@@ -54,7 +54,7 @@ public struct VFileBrowser<ContentPane: View>: View {
     public init(
         files: [VFileBrowserFile],
         selectedPath: Binding<String?>,
-        sidebarWidth: CGFloat = 220,
+        sidebarWidth: CGFloat = 280,
         @ViewBuilder contentPane: @escaping (VFileBrowserFile?) -> ContentPane
     ) {
         self.files = files
@@ -74,7 +74,7 @@ public struct VFileBrowser<ContentPane: View>: View {
     }
 
     public var body: some View {
-        HStack(spacing: VSpacing.md) {
+        HStack(spacing: VSpacing.sm) {
             sidebarPane
             rightPane
         }
@@ -83,13 +83,17 @@ public struct VFileBrowser<ContentPane: View>: View {
     // MARK: - Sidebar Pane
 
     private var sidebarPane: some View {
-        VStack(spacing: VSpacing.sm) {
+        VStack(spacing: VSpacing.xs) {
             VSearchBar(placeholder: "Search files", text: $searchText)
 
             ScrollView {
                 LazyVStack(spacing: 0) {
                     ForEach(filteredFiles) { file in
-                        fileRow(file)
+                        VFileBrowserRow(
+                            file: file,
+                            isActive: selectedPath == file.path,
+                            onSelect: { selectedPath = file.path }
+                        )
                     }
                 }
             }
@@ -104,42 +108,6 @@ public struct VFileBrowser<ContentPane: View>: View {
         )
     }
 
-    // MARK: - File Row
-
-    private func fileRow(_ file: VFileBrowserFile) -> some View {
-        let isActive = selectedPath == file.path
-        return Button {
-            selectedPath = file.path
-        } label: {
-            HStack(spacing: VSpacing.sm) {
-                VIconView(file.icon, size: 14)
-                    .foregroundStyle(VColor.primaryBase)
-
-                Text(file.name)
-                    .font(VFont.bodyMediumDefault)
-                    .foregroundStyle(VColor.contentSecondary)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-
-                Spacer()
-
-                Text(formatFileSize(file.size))
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(VColor.contentTertiary)
-            }
-            .padding(.horizontal, VSpacing.sm)
-            .padding(.vertical, VSpacing.xs)
-            .background(
-                RoundedRectangle(cornerRadius: VRadius.md)
-                    .fill(isActive ? VColor.surfaceActive : Color.clear)
-            )
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(file.name)
-        .accessibilityHint(isActive ? "Selected" : "Tap to select")
-    }
-
     // MARK: - Right Pane
 
     private var rightPane: some View {
@@ -151,6 +119,55 @@ public struct VFileBrowser<ContentPane: View>: View {
                 RoundedRectangle(cornerRadius: VRadius.xl)
                     .strokeBorder(VColor.borderDisabled, lineWidth: 2)
             )
+    }
+}
+
+// MARK: - File Row (with hover state like VNavItem)
+
+private struct VFileBrowserRow: View {
+    let file: VFileBrowserFile
+    let isActive: Bool
+    let onSelect: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(spacing: VSpacing.xs) {
+                VIconView(file.icon, size: VSize.iconDefault)
+                    .foregroundStyle(isActive ? VColor.primaryActive : VColor.primaryBase)
+                    .frame(width: VSize.iconSlot, height: VSize.iconSlot)
+
+                Text(file.name)
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(isActive ? VColor.contentEmphasized : VColor.contentSecondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+
+                Spacer()
+
+                Text(formatFileSize(file.size))
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+            .padding(.leading, VSpacing.xs)
+            .padding(.trailing, VSpacing.sm)
+            .padding(.vertical, VSpacing.xs)
+            .frame(minHeight: VSize.rowMinHeight)
+            .background(
+                isActive ? VColor.surfaceActive :
+                isHovered ? VColor.surfaceBase :
+                Color.clear
+            )
+            .animation(VAnimation.fast, value: isHovered)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+        .pointerCursor()
+        .accessibilityLabel(file.name)
+        .accessibilityHint(isActive ? "Selected" : "Tap to select")
     }
 }
 #endif

--- a/clients/shared/DesignSystem/Components/Display/VFileBrowser.swift
+++ b/clients/shared/DesignSystem/Components/Display/VFileBrowser.swift
@@ -1,0 +1,156 @@
+#if os(macOS)
+import SwiftUI
+
+// MARK: - File Browser Model
+
+public struct VFileBrowserFile: Identifiable {
+    public let id: String
+    public let name: String
+    public let path: String
+    public let size: Int
+    public let mimeType: String
+    public let isBinary: Bool
+    public let content: String?
+    public let icon: VIcon
+
+    public init(
+        id: String,
+        name: String,
+        path: String,
+        size: Int,
+        mimeType: String,
+        isBinary: Bool,
+        content: String?,
+        icon: VIcon
+    ) {
+        self.id = id
+        self.name = name
+        self.path = path
+        self.size = size
+        self.mimeType = mimeType
+        self.isBinary = isBinary
+        self.content = content
+        self.icon = icon
+    }
+}
+
+// MARK: - VFileBrowser
+
+/// A two-pane file browser with a searchable file list on the left and
+/// caller-provided content on the right. Both panes use bordered card
+/// styling matching the Figma spec.
+///
+/// The right pane content is provided via a `@ViewBuilder` closure so
+/// callers in the macOS target can pass `FileContentView` (which lives
+/// in VellumAssistantLib, not the shared module).
+public struct VFileBrowser<ContentPane: View>: View {
+    let files: [VFileBrowserFile]
+    @Binding var selectedPath: String?
+    var sidebarWidth: CGFloat
+    let contentPane: (VFileBrowserFile?) -> ContentPane
+
+    @State private var searchText: String = ""
+
+    public init(
+        files: [VFileBrowserFile],
+        selectedPath: Binding<String?>,
+        sidebarWidth: CGFloat = 220,
+        @ViewBuilder contentPane: @escaping (VFileBrowserFile?) -> ContentPane
+    ) {
+        self.files = files
+        self._selectedPath = selectedPath
+        self.sidebarWidth = sidebarWidth
+        self.contentPane = contentPane
+    }
+
+    private var filteredFiles: [VFileBrowserFile] {
+        if searchText.isEmpty { return files }
+        return files.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+    }
+
+    private var selectedFile: VFileBrowserFile? {
+        guard let path = selectedPath else { return nil }
+        return files.first { $0.path == path }
+    }
+
+    public var body: some View {
+        HStack(spacing: VSpacing.md) {
+            sidebarPane
+            rightPane
+        }
+    }
+
+    // MARK: - Sidebar Pane
+
+    private var sidebarPane: some View {
+        VStack(spacing: VSpacing.sm) {
+            VSearchBar(placeholder: "Search files", text: $searchText)
+
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(filteredFiles) { file in
+                        fileRow(file)
+                    }
+                }
+            }
+        }
+        .padding(VSpacing.md)
+        .frame(width: sidebarWidth)
+        .background(VColor.surfaceOverlay)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.xl)
+                .strokeBorder(VColor.borderDisabled, lineWidth: 2)
+        )
+    }
+
+    // MARK: - File Row
+
+    private func fileRow(_ file: VFileBrowserFile) -> some View {
+        let isActive = selectedPath == file.path
+        return Button {
+            selectedPath = file.path
+        } label: {
+            HStack(spacing: VSpacing.sm) {
+                VIconView(file.icon, size: 14)
+                    .foregroundStyle(VColor.primaryBase)
+
+                Text(file.name)
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+
+                Spacer()
+
+                Text(formatFileSize(file.size))
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, VSpacing.xs)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(isActive ? VColor.surfaceActive : Color.clear)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(file.name)
+        .accessibilityHint(isActive ? "Selected" : "Tap to select")
+    }
+
+    // MARK: - Right Pane
+
+    private var rightPane: some View {
+        contentPane(selectedFile)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(VColor.surfaceOverlay)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.xl)
+                    .strokeBorder(VColor.borderDisabled, lineWidth: 2)
+            )
+    }
+}
+#endif

--- a/clients/shared/DesignSystem/Components/Navigation/VTabs.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VTabs.swift
@@ -92,8 +92,8 @@ public struct VTabs<SelectionValue: Hashable>: View {
         }
         .padding(2)
         .background(
-            RoundedRectangle(cornerRadius: size == .compact ? VRadius.sm + 1 : VRadius.md)
-                .fill(VColor.surfaceActive)
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .fill(VColor.surfaceBase)
         )
         .animation(VAnimation.fast, value: selection)
     }
@@ -127,20 +127,20 @@ private struct PillSegment: View {
         Button(action: action) {
             Group {
                 if let icon {
-                    VIconView(.resolve(icon), size: size == .compact ? 10 : 12)
+                    VIconView(.resolve(icon), size: 12)
                         .foregroundStyle(VColor.contentDefault)
                 } else {
                     Text(label)
-                        .font(size == .compact ? VFont.labelDefault : VFont.bodyMediumLighter)
+                        .font(VFont.bodyMediumDefault)
                         .fixedSize()
-                        .foregroundStyle(isSelected ? selectedTextColor : VColor.contentSecondary)
+                        .foregroundStyle(isSelected ? VColor.contentEmphasized : VColor.contentSecondary)
                 }
             }
-            .padding(.horizontal, icon != nil ? VSpacing.sm : (size == .compact ? VSpacing.sm : VSpacing.lg))
+            .padding(.horizontal, icon != nil ? VSpacing.sm : 10)
             .frame(maxWidth: .infinity)
-            .frame(height: size == .compact ? 24 : 32)
+            .frame(height: 28)
             .background(
-                RoundedRectangle(cornerRadius: size == .compact ? VRadius.sm : VRadius.md - 1)
+                RoundedRectangle(cornerRadius: VRadius.sm)
                     .fill(segmentBackground)
                     .shadow(color: isSelected ? VColor.auxBlack.opacity(0.08) : .clear, radius: 2, x: 0, y: 1)
             )
@@ -151,10 +151,6 @@ private struct PillSegment: View {
         .pointerCursor()
         .accessibilityLabel(label)
         .accessibilityAddTraits(isSelected ? .isSelected : [])
-    }
-
-    private var selectedTextColor: Color {
-        VColor.contentDefault
     }
 
     private var segmentBackground: Color {


### PR DESCRIPTION
## Summary
Redesign the individual skill detail page to match the Figma design and create a shared VFileBrowser two-pane component reusable by both skill detail and workspace views. UI-only changes — no functionality changes.

## PRs merged into feature branch
- #22421: feat: update FileContentHeaderBar with icon pill and 18pt semibold filename
- #22422: feat: update file row styling — icon colors, fonts, and file size display
- #22423: feat: redesign skill detail header — back button, emoji, name, installed badge, description
- #22431: feat: create VFileBrowser — shared two-pane file browser component
- #22433: feat: migrate SkillDetailView to use VFileBrowser component
- #22430: feat: update WorkspacePanel sidebar styling to match VFileBrowser cards

Part of plan: skill-file-browser-redesign.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
