### PR TITLE
fix(teleport): retire source before hatching target, wait for docker readiness, warn on platform name

### DIFF
--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -615,7 +615,7 @@ describe("resolveOrHatchTarget", () => {
     const result = await resolveOrHatchTarget("docker", "new-one");
     expect(hatchDockerMock).toHaveBeenCalledWith(
       "vellum",
-      true,
+      false,
       "new-one",
       false,
       {},
@@ -710,7 +710,7 @@ describe("resolveOrHatchTarget", () => {
 // ---------------------------------------------------------------------------
 
 describe("auto-retire", () => {
-  test("local -> docker: retireLocal and removeAssistantEntry called on source after import", async () => {
+  test("local -> docker: retireLocal called before hatch, removeAssistantEntry called", async () => {
     setArgv("--from", "my-local", "--docker");
 
     const localEntry = makeEntry("my-local", { cloud: "local" });
@@ -741,7 +741,7 @@ describe("auto-retire", () => {
     }
   });
 
-  test("docker -> local: retireDocker and removeAssistantEntry called on source after import", async () => {
+  test("docker -> local: retireDocker called before hatch, removeAssistantEntry called", async () => {
     setArgv("--from", "my-docker", "--local");
 
     const dockerEntry = makeEntry("my-docker", { cloud: "docker" });

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -764,14 +764,22 @@ export async function resolveOrHatchTarget(
       return existing;
     }
 
-    // Name not found — will hatch. Validate the name first.
-    try {
-      validateAssistantName(targetName);
-    } catch {
-      console.error(
-        "Error: Target name contains invalid characters (path separators or traversal segments are not allowed).",
+    // Name not found — will hatch.
+    if (targetEnv === "platform") {
+      // Platform API doesn't accept custom names — warn and ignore
+      console.log(
+        `Note: Platform assistants receive a server-assigned ID. The name '${targetName}' will not be used.`,
       );
-      process.exit(1);
+    } else {
+      // Validate the name before passing to hatch
+      try {
+        validateAssistantName(targetName);
+      } catch {
+        console.error(
+          "Error: Target name contains invalid characters (path separators or traversal segments are not allowed).",
+        );
+        process.exit(1);
+      }
     }
   }
 
@@ -793,7 +801,7 @@ export async function resolveOrHatchTarget(
 
   if (targetEnv === "docker") {
     const beforeIds = new Set(loadAllAssistants().map((e) => e.assistantId));
-    await hatchDocker("vellum", true, targetName ?? null, false, {});
+    await hatchDocker("vellum", false, targetName ?? null, false, {});
     const entry = targetName
       ? findAssistantByName(targetName)
       : (loadAllAssistants().find((e) => !beforeIds.has(e.assistantId)) ??
@@ -1079,7 +1087,28 @@ export async function teleport(): Promise<void> {
   console.log(`Exporting from ${from} (${fromCloud})...`);
   const bundleData = await exportFromAssistant(fromEntry, fromCloud);
 
-  // Resolve or hatch target
+  // Auto-retire source BEFORE hatching target to free up ports.
+  // For local<->docker transfers, both bind the same default ports (7830, etc.),
+  // so the source must be retired first to avoid "address already in use" errors.
+  const sourceIsLocalOrDocker = fromCloud === "local" || fromCloud === "docker";
+  const targetIsLocalOrDocker = targetEnv === "local" || targetEnv === "docker";
+
+  if (sourceIsLocalOrDocker && targetIsLocalOrDocker) {
+    if (!keepSource) {
+      console.log(`Retiring source assistant '${from}'...`);
+      if (fromCloud === "docker") {
+        await retireDocker(fromEntry.assistantId);
+      } else {
+        await retireLocal(fromEntry.assistantId, fromEntry);
+      }
+      removeAssistantEntry(fromEntry.assistantId);
+      console.log(`Source assistant '${from}' retired.`);
+    } else {
+      console.log(`Source assistant '${from}' kept (--keep-source).`);
+    }
+  }
+
+  // Resolve or hatch target (after source is retired to avoid port conflicts)
   const toEntry = await resolveOrHatchTarget(targetEnv, targetName);
   const toCloud = resolveCloud(toEntry);
 
@@ -1097,28 +1126,6 @@ export async function teleport(): Promise<void> {
   // Import to target
   console.log(`Importing to ${toEntry.assistantId} (${toCloud})...`);
   await importToAssistant(toEntry, toCloud, bundleData, false);
-
-  // Auto-retire source if applicable (local<->docker, not dry-run, not --keep-source)
-  if (!dryRun) {
-    const sourceIsLocalOrDocker =
-      fromCloud === "local" || fromCloud === "docker";
-    const targetIsLocalOrDocker = toCloud === "local" || toCloud === "docker";
-
-    if (sourceIsLocalOrDocker && targetIsLocalOrDocker) {
-      if (!keepSource) {
-        console.log(`Retiring source assistant '${from}'...`);
-        if (fromCloud === "docker") {
-          await retireDocker(fromEntry.assistantId);
-        } else {
-          await retireLocal(fromEntry.assistantId, fromEntry);
-        }
-        removeAssistantEntry(fromEntry.assistantId);
-        console.log(`Source assistant '${from}' retired.`);
-      } else {
-        console.log(`Source assistant '${from}' kept (--keep-source).`);
-      }
-    }
-  }
 
   // Success summary
   console.log(`Teleport complete: ${from} → ${toEntry.assistantId}`);


### PR DESCRIPTION
## Summary
- Reorder teleport flow: export → retire source → hatch target → import. Previously hatch happened before retire, causing "address already in use" on default port 7830 for local↔docker transfers
- Use `detached: false` for docker hatch so teleport waits for container readiness before importing
- Warn when a name is provided for `--platform` since the API doesn't support custom names

Addresses review feedback on #22410.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
