### PR TITLE
fix(teleport): stop source before hatch, retire only after successful import

### DIFF
--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -130,9 +130,25 @@ mock.module("../lib/hatch-local.js", () => ({
 const hatchDockerMock = mock(async () => {});
 const retireDockerMock = mock(async () => {});
 
+const sleepContainersMock = mock(async () => {});
+const dockerResourceNamesMock = mock((name: string) => ({
+  assistantContainer: `${name}-assistant`,
+  gatewayContainer: `${name}-gateway`,
+  cesContainer: `${name}-ces`,
+  network: `${name}-net`,
+}));
+
 mock.module("../lib/docker.js", () => ({
   hatchDocker: hatchDockerMock,
   retireDocker: retireDockerMock,
+  sleepContainers: sleepContainersMock,
+  dockerResourceNames: dockerResourceNamesMock,
+}));
+
+const stopProcessByPidFileMock = mock(async () => true);
+
+mock.module("../lib/process.js", () => ({
+  stopProcessByPidFile: stopProcessByPidFileMock,
 }));
 
 const retireLocalMock = mock(async () => {});
@@ -249,6 +265,10 @@ beforeEach(() => {
   retireDockerMock.mockResolvedValue(undefined);
   retireLocalMock.mockReset();
   retireLocalMock.mockResolvedValue(undefined);
+  sleepContainersMock.mockReset();
+  sleepContainersMock.mockResolvedValue(undefined);
+  stopProcessByPidFileMock.mockReset();
+  stopProcessByPidFileMock.mockResolvedValue(true);
 
   // Mock process.exit to throw so we can catch it
   exitMock = mock((code?: number) => {
@@ -710,10 +730,17 @@ describe("resolveOrHatchTarget", () => {
 // ---------------------------------------------------------------------------
 
 describe("auto-retire", () => {
-  test("local -> docker: retireLocal called before hatch, removeAssistantEntry called", async () => {
+  test("local -> docker: stops source before hatch, retires after import", async () => {
     setArgv("--from", "my-local", "--docker");
 
-    const localEntry = makeEntry("my-local", { cloud: "local" });
+    const localEntry = makeEntry("my-local", {
+      cloud: "local",
+      resources: {
+        instanceDir: "/home/test",
+        pidFile: "/home/test/.vellum/assistant.pid",
+        signingKey: "key",
+      },
+    });
     const dockerEntry = makeEntry("new-docker", { cloud: "docker" });
 
     findAssistantByNameMock.mockImplementation((name: string) => {
@@ -734,6 +761,9 @@ describe("auto-retire", () => {
 
     try {
       await teleport();
+      // Source should be stopped (slept) before hatch
+      expect(stopProcessByPidFileMock).toHaveBeenCalled();
+      // Retire happens after successful import
       expect(retireLocalMock).toHaveBeenCalledWith("my-local", localEntry);
       expect(removeAssistantEntryMock).toHaveBeenCalledWith("my-local");
     } finally {
@@ -741,7 +771,7 @@ describe("auto-retire", () => {
     }
   });
 
-  test("docker -> local: retireDocker called before hatch, removeAssistantEntry called", async () => {
+  test("docker -> local: sleeps containers before hatch, retires after import", async () => {
     setArgv("--from", "my-docker", "--local");
 
     const dockerEntry = makeEntry("my-docker", { cloud: "docker" });
@@ -764,6 +794,9 @@ describe("auto-retire", () => {
 
     try {
       await teleport();
+      // Docker source should be slept (containers stopped) before hatch
+      expect(sleepContainersMock).toHaveBeenCalled();
+      // Retire happens after successful import
       expect(retireDockerMock).toHaveBeenCalledWith("my-docker");
       expect(removeAssistantEntryMock).toHaveBeenCalledWith("my-docker");
     } finally {

--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -739,6 +739,10 @@ describe("auto-retire", () => {
         instanceDir: "/home/test",
         pidFile: "/home/test/.vellum/assistant.pid",
         signingKey: "key",
+        daemonPort: 7821,
+        gatewayPort: 7830,
+        qdrantPort: 6333,
+        cesPort: 8090,
       },
     });
     const dockerEntry = makeEntry("new-docker", { cloud: "docker" });

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -21,10 +21,17 @@ import {
   platformImportPreflight,
   platformImportBundle,
 } from "../lib/platform-client.js";
-import { hatchDocker, retireDocker } from "../lib/docker.js";
+import {
+  hatchDocker,
+  retireDocker,
+  sleepContainers,
+  dockerResourceNames,
+} from "../lib/docker.js";
 import { hatchLocal } from "../lib/hatch-local.js";
 import { retireLocal } from "../lib/retire-local.js";
 import { validateAssistantName } from "../lib/retire-archive.js";
+import { stopProcessByPidFile } from "../lib/process.js";
+import { join } from "node:path";
 
 function printHelp(): void {
   console.log(
@@ -1087,28 +1094,27 @@ export async function teleport(): Promise<void> {
   console.log(`Exporting from ${from} (${fromCloud})...`);
   const bundleData = await exportFromAssistant(fromEntry, fromCloud);
 
-  // Auto-retire source BEFORE hatching target to free up ports.
-  // For local<->docker transfers, both bind the same default ports (7830, etc.),
-  // so the source must be retired first to avoid "address already in use" errors.
+  // For local<->docker transfers, stop (sleep) the source to free up ports
+  // before hatching the target. We do NOT retire yet — if hatch or import
+  // fails, the user can recover by running `vellum wake <source>`.
   const sourceIsLocalOrDocker = fromCloud === "local" || fromCloud === "docker";
   const targetIsLocalOrDocker = targetEnv === "local" || targetEnv === "docker";
-
-  if (sourceIsLocalOrDocker && targetIsLocalOrDocker) {
-    if (!keepSource) {
-      console.log(`Retiring source assistant '${from}'...`);
-      if (fromCloud === "docker") {
-        await retireDocker(fromEntry.assistantId);
-      } else {
-        await retireLocal(fromEntry.assistantId, fromEntry);
-      }
-      removeAssistantEntry(fromEntry.assistantId);
-      console.log(`Source assistant '${from}' retired.`);
-    } else {
-      console.log(`Source assistant '${from}' kept (--keep-source).`);
+  if (sourceIsLocalOrDocker && targetIsLocalOrDocker && !keepSource) {
+    console.log(`Stopping source assistant '${from}' to free ports...`);
+    if (fromCloud === "docker") {
+      const res = dockerResourceNames(fromEntry.assistantId);
+      await sleepContainers(res);
+    } else if (fromEntry.resources) {
+      const pidFile = fromEntry.resources.pidFile;
+      const vellumDir = join(fromEntry.resources.instanceDir, ".vellum");
+      const gatewayPidFile = join(vellumDir, "gateway.pid");
+      await stopProcessByPidFile(pidFile, "assistant");
+      await stopProcessByPidFile(gatewayPidFile, "gateway", undefined, 7000);
     }
+    console.log(`Source assistant '${from}' stopped.`);
   }
 
-  // Resolve or hatch target (after source is retired to avoid port conflicts)
+  // Resolve or hatch target (after source is stopped to avoid port conflicts)
   const toEntry = await resolveOrHatchTarget(targetEnv, targetName);
   const toCloud = resolveCloud(toEntry);
 
@@ -1126,6 +1132,22 @@ export async function teleport(): Promise<void> {
   // Import to target
   console.log(`Importing to ${toEntry.assistantId} (${toCloud})...`);
   await importToAssistant(toEntry, toCloud, bundleData, false);
+
+  // Retire source after successful import
+  if (sourceIsLocalOrDocker && targetIsLocalOrDocker) {
+    if (!keepSource) {
+      console.log(`Retiring source assistant '${from}'...`);
+      if (fromCloud === "docker") {
+        await retireDocker(fromEntry.assistantId);
+      } else {
+        await retireLocal(fromEntry.assistantId, fromEntry);
+      }
+      removeAssistantEntry(fromEntry.assistantId);
+      console.log(`Source assistant '${from}' retired.`);
+    } else {
+      console.log(`Source assistant '${from}' kept (--keep-source).`);
+    }
+  }
 
   // Success summary
   console.log(`Teleport complete: ${from} → ${toEntry.assistantId}`);


### PR DESCRIPTION
## Summary
- Stop (sleep) the source assistant before hatching the target to free ports, but don't retire it yet
- Retire the source only after successful import — if hatch or import fails, the user can recover with `vellum wake`
- For local sources: stop daemon and gateway processes via PID files
- For docker sources: stop containers via `sleepContainers`

This makes the teleport flow safe against failures: export → stop source → hatch target → import → retire source. Previously, the source was fully retired before hatch/import, meaning a failure left users with a retired source and no successful transfer.

## Original prompt
address the open feedback from this PR: https://github.com/vellum-ai/vellum-assistant/pull/22410
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
