### PR TITLE
fix(macos): refresh stale Slack/channel conversations on activation and periodically

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -106,6 +106,13 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             }
             // Subscribe to the new active view model's changes
             subscribeToActiveViewModel()
+
+            // Manage periodic refresh polling for channel conversations.
+            if let activeConversationId {
+                startChannelRefreshIfNeeded(conversationId: activeConversationId)
+            } else {
+                stopChannelRefresh()
+            }
         }
     }
 
@@ -184,6 +191,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
     /// once the associated ChatViewModel finishes its current send/think cycle.
     /// Populated when a notification_intent arrives while the VM is busy.
     private var pendingNotificationCatchUpIds: Set<String> = []
+    /// Periodic task that refreshes the active channel conversation's history.
+    /// Cancelled when switching away from a channel conversation.
+    private var channelRefreshTask: Task<Void, Never>?
     /// Local seen/unread toggles should survive a stale daemon conversation-list
     /// replay until the daemon either acknowledges them or reports a newer reply.
     private var pendingAttentionOverrides: [String: PendingAttentionOverride] = [:]
@@ -894,6 +904,14 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         }
 
         touchVMAccessOrder(id)
+
+        // Channel conversations (Slack, etc.) receive new messages via webhooks
+        // that the client doesn't see in real time. Invalidate the history cache
+        // before activation so loadHistoryIfNeeded fetches fresh data.
+        if conversation.isChannelConversation, let vm = chatViewModels[id], vm.isHistoryLoaded {
+            vm.prepareForChannelRefresh()
+        }
+
         activeConversationId = id
         // Render caches are keyed by content + appearance (text hash +
         // color descriptions), not by conversation — entries from one
@@ -1536,6 +1554,15 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
     func activateConversation(_ id: UUID) {
         let previousActiveId = activeConversationId
         trimPreviousConversationIfNeeded(nextConversationId: id)
+
+        // Channel conversations: invalidate cache before activation so
+        // loadHistoryIfNeeded fetches fresh data from the daemon.
+        if let conversation = conversations.first(where: { $0.id == id }),
+           conversation.isChannelConversation,
+           let vm = chatViewModels[id], vm.isHistoryLoaded {
+            vm.prepareForChannelRefresh()
+        }
+
         activeConversationId = id
 
         // Emit explicit seen signal for user-initiated conversation activation.
@@ -1879,6 +1906,31 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             vmAccessOrder.remove(at: idx)
         }
         log.info("Removed abandoned empty conversation \(previousId)")
+    }
+
+    /// Start a periodic refresh loop for the active conversation if it is a
+    /// channel conversation (Slack, etc.). Cancels any existing refresh task first.
+    private func startChannelRefreshIfNeeded(conversationId localId: UUID) {
+        stopChannelRefresh()
+        guard let conversation = conversations.first(where: { $0.id == localId }),
+              conversation.isChannelConversation,
+              let daemonConversationId = conversation.conversationId else { return }
+
+        channelRefreshTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 30_000_000_000) // 30s
+                guard !Task.isCancelled, let self else { return }
+                guard let vm = self.chatViewModels[localId],
+                      !vm.isAssistantBusy else { continue }
+                vm.prepareForNotificationCatchUp()
+                self.conversationRestorer.requestReconnectHistory(conversationId: daemonConversationId)
+            }
+        }
+    }
+
+    private func stopChannelRefresh() {
+        channelRefreshTask?.cancel()
+        channelRefreshTask = nil
     }
 
     /// Trim the previously active conversation's view model to shed memory before

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1147,6 +1147,15 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         needsReconnectCatchUp = true
     }
 
+    /// Prepare the view model for a channel conversation refresh.
+    /// Resets `isHistoryLoaded` so `loadHistoryIfNeeded` proceeds, and sets
+    /// `needsReconnectCatchUp` so `populateFromHistory` does an atomic
+    /// message replace instead of clearing the array first.
+    public func prepareForChannelRefresh() {
+        needsReconnectCatchUp = true
+        isHistoryLoaded = false
+    }
+
     // MARK: - Deep Link
 
     /// Check for a buffered deep-link message and apply it to `inputText`.


### PR DESCRIPTION
## Summary
- Channel conversations in the desktop app showed stale messages because `isHistoryLoaded` was cached after the first fetch and never invalidated
- Now invalidates the history cache when switching to a channel conversation, triggering a fresh fetch from the daemon
- Adds a 30-second periodic refresh timer for the active channel conversation so new messages appear without switching away
- Uses the existing reconnect catch-up path (`prepareForNotificationCatchUp` + `requestReconnectHistory`) for seamless message replacement with no UI flicker

## Original prompt
Slack conversations in the desktop app don't stay up to date with the actual conversation in Slack. They only refresh on app restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
