### PR TITLE
Add maintenance-mode fields and actions to the shared platform auth client

### DIFF
--- a/clients/shared/App/Auth/AuthModels.swift
+++ b/clients/shared/App/Auth/AuthModels.swift
@@ -125,19 +125,45 @@ public struct PaginatedOrganizationsResponse: Codable, Sendable {
 
 // MARK: - Platform Assistant API Models
 
+public struct PlatformAssistantMaintenanceMode: Codable, Sendable {
+    /// Whether maintenance mode is currently active for this assistant.
+    public let enabled: Bool
+    /// ISO 8601 timestamp of when maintenance mode was entered, or `nil` if not currently active.
+    public let entered_at: String?
+    /// Name of the debug pod that has the assistant's workspace PVC mounted, or `nil` when not active.
+    public let debug_pod_name: String?
+
+    public init(enabled: Bool, entered_at: String? = nil, debug_pod_name: String? = nil) {
+        self.enabled = enabled
+        self.entered_at = entered_at
+        self.debug_pod_name = debug_pod_name
+    }
+}
+
 public struct PlatformAssistant: Codable, Sendable {
     public let id: String
     public let name: String?
     public let description: String?
     public let created_at: String?
     public let status: String?
+    /// Present when the platform includes maintenance-mode state in the assistant payload.
+    /// `nil` when the field is absent (e.g. older platform versions or endpoints that omit it).
+    public let maintenance_mode: PlatformAssistantMaintenanceMode?
 
-    public init(id: String, name: String? = nil, description: String? = nil, created_at: String? = nil, status: String? = nil) {
+    public init(
+        id: String,
+        name: String? = nil,
+        description: String? = nil,
+        created_at: String? = nil,
+        status: String? = nil,
+        maintenance_mode: PlatformAssistantMaintenanceMode? = nil
+    ) {
         self.id = id
         self.name = name
         self.description = description
         self.created_at = created_at
         self.status = status
+        self.maintenance_mode = maintenance_mode
     }
 }
 

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -346,6 +346,138 @@ public final class AuthService {
         }
     }
 
+    // MARK: - Maintenance Mode
+
+    /// Enter maintenance mode for a managed assistant.
+    ///
+    /// On success the platform pauses the normal assistant pod and mounts the workspace PVC
+    /// into a debug pod. Returns the updated `PlatformAssistant` with a populated
+    /// `maintenance_mode` field.
+    public func enterMaintenanceMode(
+        assistantId: String,
+        organizationId: String
+    ) async throws -> PlatformAssistant {
+        let urlString = "\(baseURL)/v1/assistants/\(assistantId)/enter-maintenance-mode/"
+        guard let url = URL(string: urlString) else {
+            throw PlatformAPIError.invalidURL
+        }
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
+
+        if let token = await SessionTokenManager.getTokenAsync() {
+            urlRequest.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        } else {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: urlRequest)
+        } catch {
+            throw PlatformAPIError.networkError(error.localizedDescription)
+        }
+
+        let httpResponse = response as? HTTPURLResponse
+        let statusCode = httpResponse?.statusCode ?? 0
+
+        log.debug("Platform request POST assistants/\(assistantId)/enter-maintenance-mode/ -> \(statusCode)")
+
+        if statusCode == 401 || statusCode == 403 {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        guard (200..<300).contains(statusCode) else {
+            let detail = String(data: data, encoding: .utf8)
+            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
+        }
+
+        do {
+            return try JSONDecoder().decode(PlatformAssistant.self, from: data)
+        } catch {
+            throw PlatformAPIError.decodingError(error.localizedDescription)
+        }
+    }
+
+    /// Exit maintenance mode for a managed assistant.
+    ///
+    /// On success the platform tears down the debug pod and resumes the normal assistant pod.
+    /// Returns the updated `PlatformAssistant` with `maintenance_mode.enabled == false`.
+    public func exitMaintenanceMode(
+        assistantId: String,
+        organizationId: String
+    ) async throws -> PlatformAssistant {
+        let urlString = "\(baseURL)/v1/assistants/\(assistantId)/exit-maintenance-mode/"
+        guard let url = URL(string: urlString) else {
+            throw PlatformAPIError.invalidURL
+        }
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
+
+        if let token = await SessionTokenManager.getTokenAsync() {
+            urlRequest.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        } else {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: urlRequest)
+        } catch {
+            throw PlatformAPIError.networkError(error.localizedDescription)
+        }
+
+        let httpResponse = response as? HTTPURLResponse
+        let statusCode = httpResponse?.statusCode ?? 0
+
+        log.debug("Platform request POST assistants/\(assistantId)/exit-maintenance-mode/ -> \(statusCode)")
+
+        if statusCode == 401 || statusCode == 403 {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        guard (200..<300).contains(statusCode) else {
+            let detail = String(data: data, encoding: .utf8)
+            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
+        }
+
+        do {
+            return try JSONDecoder().decode(PlatformAssistant.self, from: data)
+        } catch {
+            throw PlatformAPIError.decodingError(error.localizedDescription)
+        }
+    }
+
+    /// Re-fetch a managed assistant's current detail from the platform.
+    ///
+    /// Convenience used after a maintenance-mode mutation to get the freshest state without
+    /// callers having to inline the `getAssistant` + result-unwrap pattern.
+    /// Throws `PlatformAPIError.serverError(statusCode: 404, ...)` when the assistant is not
+    /// found, and `PlatformAPIError.authenticationRequired` on 403/401.
+    public func refreshAssistant(
+        id: String,
+        organizationId: String
+    ) async throws -> PlatformAssistant {
+        let result = try await getAssistant(id: id, organizationId: organizationId)
+        switch result {
+        case .found(let assistant):
+            return assistant
+        case .notFound:
+            throw PlatformAPIError.serverError(statusCode: 404, detail: "Assistant not found")
+        case .accessDenied:
+            throw PlatformAPIError.authenticationRequired
+        }
+    }
+
     // MARK: - Self-Hosted Local Registration
 
     /// Ensure a self-hosted local assistant registration exists on the platform.

--- a/clients/shared/Tests/PlatformAssistantMaintenanceDecodingTests.swift
+++ b/clients/shared/Tests/PlatformAssistantMaintenanceDecodingTests.swift
@@ -1,0 +1,286 @@
+import XCTest
+
+@testable import VellumAssistantShared
+
+// MARK: - URLProtocol stub for maintenance-mode network calls
+
+private final class MaintenanceModeURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - Tests
+
+@MainActor
+final class PlatformAssistantMaintenanceDecodingTests: XCTestCase {
+    private let decoder = JSONDecoder()
+
+    override func setUp() {
+        super.setUp()
+        MaintenanceModeURLProtocol.requestHandler = nil
+        URLProtocol.registerClass(MaintenanceModeURLProtocol.self)
+        // Provide a token so network-path tests reach the stub handler rather than
+        // short-circuiting with authenticationRequired before any request is made.
+        SessionTokenManager.setToken("test-session-token")
+    }
+
+    override func tearDown() {
+        URLProtocol.unregisterClass(MaintenanceModeURLProtocol.self)
+        MaintenanceModeURLProtocol.requestHandler = nil
+        SessionTokenManager.deleteToken()
+        super.tearDown()
+    }
+
+    // MARK: - PlatformAssistant decoding with maintenance_mode present
+
+    func testDecodesAssistantWithMaintenanceModeEnabled() throws {
+        let data = Data(
+            """
+            {
+              "id": "asst-123",
+              "name": "My Assistant",
+              "status": "running",
+              "maintenance_mode": {
+                "enabled": true,
+                "entered_at": "2026-03-30T12:00:00Z",
+                "debug_pod_name": "debug-asst-123-abc"
+              }
+            }
+            """.utf8
+        )
+
+        let assistant = try decoder.decode(PlatformAssistant.self, from: data)
+        let maintenance = try XCTUnwrap(assistant.maintenance_mode)
+
+        XCTAssertEqual(assistant.id, "asst-123")
+        XCTAssertTrue(maintenance.enabled)
+        XCTAssertEqual(maintenance.entered_at, "2026-03-30T12:00:00Z")
+        XCTAssertEqual(maintenance.debug_pod_name, "debug-asst-123-abc")
+    }
+
+    func testDecodesAssistantWithMaintenanceModeDisabled() throws {
+        let data = Data(
+            """
+            {
+              "id": "asst-456",
+              "name": "Another Assistant",
+              "status": "running",
+              "maintenance_mode": {
+                "enabled": false,
+                "entered_at": null,
+                "debug_pod_name": null
+              }
+            }
+            """.utf8
+        )
+
+        let assistant = try decoder.decode(PlatformAssistant.self, from: data)
+        let maintenance = try XCTUnwrap(assistant.maintenance_mode)
+
+        XCTAssertFalse(maintenance.enabled)
+        XCTAssertNil(maintenance.entered_at)
+        XCTAssertNil(maintenance.debug_pod_name)
+    }
+
+    func testDecodesAssistantWithMaintenanceModeAbsent() throws {
+        let data = Data(
+            """
+            {
+              "id": "asst-789",
+              "name": "Legacy Assistant",
+              "status": "running"
+            }
+            """.utf8
+        )
+
+        let assistant = try decoder.decode(PlatformAssistant.self, from: data)
+
+        XCTAssertEqual(assistant.id, "asst-789")
+        XCTAssertNil(assistant.maintenance_mode)
+    }
+
+    func testDecodesAssistantPreservesExistingFieldsWithMaintenanceMode() throws {
+        let data = Data(
+            """
+            {
+              "id": "asst-full",
+              "name": "Full Assistant",
+              "description": "A complete assistant payload",
+              "created_at": "2025-01-15T09:00:00Z",
+              "status": "provisioned",
+              "maintenance_mode": {
+                "enabled": true,
+                "entered_at": "2026-03-30T08:30:00Z",
+                "debug_pod_name": "debug-asst-full-xyz"
+              }
+            }
+            """.utf8
+        )
+
+        let assistant = try decoder.decode(PlatformAssistant.self, from: data)
+
+        XCTAssertEqual(assistant.id, "asst-full")
+        XCTAssertEqual(assistant.name, "Full Assistant")
+        XCTAssertEqual(assistant.description, "A complete assistant payload")
+        XCTAssertEqual(assistant.created_at, "2025-01-15T09:00:00Z")
+        XCTAssertEqual(assistant.status, "provisioned")
+        let maintenance = try XCTUnwrap(assistant.maintenance_mode)
+        XCTAssertTrue(maintenance.enabled)
+        XCTAssertEqual(maintenance.debug_pod_name, "debug-asst-full-xyz")
+    }
+
+    // MARK: - PlatformAssistantMaintenanceMode standalone decoding
+
+    func testDecodeMaintenanceModeWithOnlyRequiredField() throws {
+        let data = Data(
+            """
+            {
+              "enabled": false
+            }
+            """.utf8
+        )
+
+        let mode = try decoder.decode(PlatformAssistantMaintenanceMode.self, from: data)
+        XCTAssertFalse(mode.enabled)
+        XCTAssertNil(mode.entered_at)
+        XCTAssertNil(mode.debug_pod_name)
+    }
+
+    // MARK: - AuthService error mapping for enter/exit routes
+
+    func testEnterMaintenanceModeNon2xxMapsToServerError() async {
+        MaintenanceModeURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 409,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data("{\"detail\": \"Already in maintenance mode\"}".utf8))
+        }
+
+        do {
+            _ = try await AuthService.shared.enterMaintenanceMode(
+                assistantId: "asst-123",
+                organizationId: "org-1"
+            )
+            XCTFail("Expected serverError to be thrown")
+        } catch let error as PlatformAPIError {
+            if case .serverError(let statusCode, _) = error {
+                XCTAssertEqual(statusCode, 409)
+            } else {
+                XCTFail("Expected .serverError, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testExitMaintenanceModeNon2xxMapsToServerError() async {
+        MaintenanceModeURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 409,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data("{\"detail\": \"Not in maintenance mode\"}".utf8))
+        }
+
+        do {
+            _ = try await AuthService.shared.exitMaintenanceMode(
+                assistantId: "asst-123",
+                organizationId: "org-1"
+            )
+            XCTFail("Expected serverError to be thrown")
+        } catch let error as PlatformAPIError {
+            if case .serverError(let statusCode, _) = error {
+                XCTAssertEqual(statusCode, 409)
+            } else {
+                XCTFail("Expected .serverError, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testEnterMaintenanceModeUnauthenticatedMapsToAuthRequired() async {
+        MaintenanceModeURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 401,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data("{\"detail\": \"Not authenticated\"}".utf8))
+        }
+
+        do {
+            _ = try await AuthService.shared.enterMaintenanceMode(
+                assistantId: "asst-123",
+                organizationId: "org-1"
+            )
+            XCTFail("Expected authenticationRequired to be thrown")
+        } catch let error as PlatformAPIError {
+            if case .authenticationRequired = error {
+                // expected
+            } else {
+                XCTFail("Expected .authenticationRequired, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testExitMaintenanceModeForbiddenMapsToAuthRequired() async {
+        MaintenanceModeURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 403,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data("{\"detail\": \"Forbidden\"}".utf8))
+        }
+
+        do {
+            _ = try await AuthService.shared.exitMaintenanceMode(
+                assistantId: "asst-789",
+                organizationId: "org-2"
+            )
+            XCTFail("Expected authenticationRequired to be thrown")
+        } catch let error as PlatformAPIError {
+            if case .authenticationRequired = error {
+                // expected
+            } else {
+                XCTFail("Expected .authenticationRequired, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Extends `PlatformAssistant` with an optional `maintenance_mode` field (a new `PlatformAssistantMaintenanceMode` model with `enabled`, `entered_at`, and `debug_pod_name`) that matches Django's serialized response shape without breaking existing managed-assistant decoding.
- Adds `enterMaintenanceMode(assistantId:organizationId:)` and `exitMaintenanceMode(assistantId:organizationId:)` to `AuthService`, sharing the same `X-Session-Token` + `Vellum-Organization-Id` authentication model used by the rest of the managed-assistant API.
- Adds a `refreshAssistant(id:organizationId:)` convenience helper for re-fetching assistant detail after a mutation, plus decoding and error-mapping tests in `PlatformAssistantMaintenanceDecodingTests`.

Part of plan: assistant-debug-pods.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
