### PR TITLE
Track managed assistant maintenance mode inside SettingsStore

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -250,6 +250,30 @@ public final class SettingsStore: ObservableObject {
         "brave": "Brave",
     ]
 
+    // MARK: - Managed Assistant Maintenance Mode State
+
+    /// Current maintenance-mode payload for the selected managed assistant.
+    /// `nil` when not in a managed context or when the state has not yet been loaded.
+    @Published var managedAssistantMaintenanceMode: PlatformAssistantMaintenanceMode?
+
+    /// `true` while a maintenance-mode refresh is in flight.
+    @Published var maintenanceModeRefreshing: Bool = false
+
+    /// `true` while an enter-maintenance-mode request is in flight.
+    @Published var maintenanceModeEntering: Bool = false
+
+    /// `true` while an exit-maintenance-mode request is in flight.
+    @Published var maintenanceModeExiting: Bool = false
+
+    /// Non-nil when the most recent refresh failed.
+    @Published var maintenanceModeRefreshError: String?
+
+    /// Non-nil when the most recent enter-maintenance-mode call failed.
+    @Published var maintenanceModeEnterError: String?
+
+    /// Non-nil when the most recent exit-maintenance-mode call failed.
+    @Published var maintenanceModeExitError: String?
+
     // MARK: - Platform Config State
 
     @Published var platformBaseUrl: String = ""
@@ -331,6 +355,10 @@ public final class SettingsStore: ObservableObject {
     private var pendingIngressUrl: String?
     private var routingSourceRefreshTask: Task<Void, Never>?
     private var yourOwnOAuthConnectPollingTask: Task<Void, Never>?
+
+    /// Tracks the last observed `connectedAssistantId` so the UserDefaults change
+    /// subscription can avoid spurious re-fetches on unrelated key changes.
+    private var _lastObservedConnectedAssistantId: String? = UserDefaults.standard.string(forKey: "connectedAssistantId")
 
     /// Last model reported by the daemon — used to skip redundant model_set calls
     /// that would otherwise reinitialize providers and evict idle conversations.
@@ -561,6 +589,51 @@ public final class SettingsStore: ObservableObject {
         }
 
         // Twilio config is now handled via HTTP — no callback wiring needed.
+
+        // Refresh maintenance-mode state when the app returns to the foreground
+        // so the UI stays current if maintenance was toggled elsewhere.
+        NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    await self?.refreshManagedAssistantMaintenanceMode()
+                }
+            }
+            .store(in: &cancellables)
+
+        // Refresh when the connected assistant changes so the state reflects
+        // the newly selected managed assistant rather than the previous one.
+        NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                let newId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+                guard newId != self._lastObservedConnectedAssistantId else { return }
+                self._lastObservedConnectedAssistantId = newId
+                // Reset stale maintenance state immediately before async refresh
+                self.managedAssistantMaintenanceMode = nil
+                self.maintenanceModeRefreshError = nil
+                Task { @MainActor [weak self] in
+                    await self?.refreshManagedAssistantMaintenanceMode()
+                }
+            }
+            .store(in: &cancellables)
+
+        // Refresh after a successful local bootstrap/hatch flow completes so the
+        // maintenance state reflects the freshly hatched assistant.
+        NotificationCenter.default.publisher(for: .localBootstrapCompleted)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    await self?.refreshManagedAssistantMaintenanceMode()
+                }
+            }
+            .store(in: &cancellables)
+
+        // Perform the initial load.
+        Task { @MainActor [weak self] in
+            await self?.refreshManagedAssistantMaintenanceMode()
+        }
 
     }
 
@@ -2380,6 +2453,121 @@ public final class SettingsStore: ObservableObject {
             } catch {
                 log.error("Failed to disconnect managed OAuth connection for \(providerKey): \(error)")
                 managedOAuthError[providerKey] = error.localizedDescription
+            }
+        }
+    }
+
+    // MARK: - Managed Assistant Maintenance Mode Actions
+
+    /// Fetches the current maintenance-mode state for the selected managed assistant
+    /// and updates `managedAssistantMaintenanceMode`.
+    ///
+    /// This is a no-op when the connected assistant is not managed.
+    func refreshManagedAssistantMaintenanceMode() async {
+        guard let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
+              !connectedId.isEmpty,
+              let assistant = LockfileAssistant.loadByName(connectedId),
+              assistant.isManaged else {
+            // Not a managed assistant — clear any stale state.
+            managedAssistantMaintenanceMode = nil
+            return
+        }
+
+        let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") ?? ""
+        guard !orgId.isEmpty else {
+            log.warning("Cannot refresh maintenance mode: no connectedOrganizationId set")
+            return
+        }
+
+        maintenanceModeRefreshing = true
+        maintenanceModeRefreshError = nil
+        defer { maintenanceModeRefreshing = false }
+
+        do {
+            let updated = try await AuthService.shared.refreshAssistant(
+                id: assistant.assistantId,
+                organizationId: orgId
+            )
+            managedAssistantMaintenanceMode = updated.maintenance_mode
+            log.info("Refreshed maintenance mode for assistant \(assistant.assistantId, privacy: .public): enabled=\(updated.maintenance_mode?.enabled ?? false)")
+        } catch {
+            maintenanceModeRefreshError = error.localizedDescription
+            log.error("Failed to refresh maintenance mode for assistant \(assistant.assistantId, privacy: .public): \(error)")
+        }
+    }
+
+    /// Enters maintenance mode for the selected managed assistant.
+    ///
+    /// Sets `maintenanceModeEntering` while the request is in flight and updates
+    /// `managedAssistantMaintenanceMode` on success.
+    func enterManagedAssistantMaintenanceMode() {
+        Task {
+            guard let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
+                  !connectedId.isEmpty,
+                  let assistant = LockfileAssistant.loadByName(connectedId),
+                  assistant.isManaged else {
+                maintenanceModeEnterError = "No managed assistant selected"
+                return
+            }
+
+            let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") ?? ""
+            guard !orgId.isEmpty else {
+                maintenanceModeEnterError = "No organization ID available"
+                return
+            }
+
+            maintenanceModeEntering = true
+            maintenanceModeEnterError = nil
+            defer { maintenanceModeEntering = false }
+
+            do {
+                let updated = try await AuthService.shared.enterMaintenanceMode(
+                    assistantId: assistant.assistantId,
+                    organizationId: orgId
+                )
+                managedAssistantMaintenanceMode = updated.maintenance_mode
+                log.info("Entered maintenance mode for assistant \(assistant.assistantId, privacy: .public)")
+            } catch {
+                maintenanceModeEnterError = error.localizedDescription
+                log.error("Failed to enter maintenance mode for assistant \(assistant.assistantId, privacy: .public): \(error)")
+            }
+        }
+    }
+
+    /// Exits maintenance mode for the selected managed assistant.
+    ///
+    /// Sets `maintenanceModeExiting` while the request is in flight and updates
+    /// `managedAssistantMaintenanceMode` on success.
+    func exitManagedAssistantMaintenanceMode() {
+        Task {
+            guard let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
+                  !connectedId.isEmpty,
+                  let assistant = LockfileAssistant.loadByName(connectedId),
+                  assistant.isManaged else {
+                maintenanceModeExitError = "No managed assistant selected"
+                return
+            }
+
+            let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") ?? ""
+            guard !orgId.isEmpty else {
+                maintenanceModeExitError = "No organization ID available"
+                return
+            }
+
+            maintenanceModeExiting = true
+            maintenanceModeExitError = nil
+            defer { maintenanceModeExiting = false }
+
+            do {
+                let updated = try await AuthService.shared.exitMaintenanceMode(
+                    assistantId: assistant.assistantId,
+                    organizationId: orgId
+                )
+                managedAssistantMaintenanceMode = updated.maintenance_mode
+                log.info("Exited maintenance mode for assistant \(assistant.assistantId, privacy: .public)")
+            } catch {
+                maintenanceModeExitError = error.localizedDescription
+                log.error("Failed to exit maintenance mode for assistant \(assistant.assistantId, privacy: .public): \(error)")
             }
         }
     }

--- a/clients/macos/vellum-assistantTests/SettingsStoreManagedMaintenanceTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreManagedMaintenanceTests.swift
@@ -1,0 +1,473 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+// MARK: - URLProtocol stub for maintenance-mode endpoint calls
+
+private final class MaintenanceStoreURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - Helpers
+
+private func assistantPayload(
+    id: String,
+    maintenanceEnabled: Bool,
+    debugPodName: String? = nil,
+    enteredAt: String? = nil
+) -> Data {
+    let podField: String
+    if let pod = debugPodName {
+        podField = "\"debug_pod_name\": \"\(pod)\""
+    } else {
+        podField = "\"debug_pod_name\": null"
+    }
+    let atField: String
+    if let at = enteredAt {
+        atField = "\"entered_at\": \"\(at)\""
+    } else {
+        atField = "\"entered_at\": null"
+    }
+    return Data("""
+    {
+      "id": "\(id)",
+      "name": "Test Managed Assistant",
+      "status": "running",
+      "maintenance_mode": {
+        "enabled": \(maintenanceEnabled),
+        \(podField),
+        \(atField)
+      }
+    }
+    """.utf8)
+}
+
+// MARK: - Tests
+
+@MainActor
+final class SettingsStoreManagedMaintenanceTests: XCTestCase {
+
+    private let testAssistantId = "maintenance-test-asst-\(UUID().uuidString.prefix(8))"
+    private let testOrgId = "org-test-\(UUID().uuidString.prefix(8))"
+
+    /// Path to the primary lockfile at `~/.vellum.lock.json`.
+    private var primaryLockfilePath: String {
+        LockfilePaths.primaryPath
+    }
+
+    /// Backup of the lockfile contents before the test modifies it.
+    private var lockfileBackup: Data?
+    private var defaultsSuiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+
+        // Backup the existing lockfile so we can restore it in tearDown.
+        let primaryURL = URL(fileURLWithPath: primaryLockfilePath)
+        lockfileBackup = try? Data(contentsOf: primaryURL)
+
+        // Write a managed entry for our test assistant.
+        let lockfileContent: [String: Any] = [
+            "assistants": [
+                [
+                    "assistantId": testAssistantId,
+                    "name": testAssistantId,
+                    "cloud": "vellum",
+                    "runtimeUrl": "https://platform.vellum.ai",
+                    "hatchedAt": "2026-01-01T00:00:00Z",
+                ] as [String: Any]
+            ]
+        ]
+        let data = try! JSONSerialization.data(withJSONObject: lockfileContent)
+        try! data.write(to: primaryURL, options: .atomic)
+
+        // Isolated UserDefaults so we don't pollute the real app state.
+        defaultsSuiteName = "SettingsStoreManagedMaintenanceTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: defaultsSuiteName)!
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+        defaults.set(testAssistantId, forKey: "connectedAssistantId")
+        defaults.set(testOrgId, forKey: "connectedOrganizationId")
+
+        // Register stub network handler and a session token.
+        URLProtocol.registerClass(MaintenanceStoreURLProtocol.self)
+        MaintenanceStoreURLProtocol.requestHandler = nil
+        SessionTokenManager.setToken("stub-session-token")
+    }
+
+    override func tearDown() {
+        URLProtocol.unregisterClass(MaintenanceStoreURLProtocol.self)
+        MaintenanceStoreURLProtocol.requestHandler = nil
+        SessionTokenManager.deleteToken()
+
+        // Restore the original lockfile (or delete it if there was nothing before).
+        let primaryURL = URL(fileURLWithPath: primaryLockfilePath)
+        if let backup = lockfileBackup {
+            try? backup.write(to: primaryURL, options: .atomic)
+        } else {
+            try? FileManager.default.removeItem(at: primaryURL)
+        }
+        lockfileBackup = nil
+
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+        defaults = nil
+        defaultsSuiteName = nil
+
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeStore() -> SettingsStore {
+        // Pass in the isolated UserDefaults via the connectedAssistantId / connectedOrganizationId
+        // that were already set in setUp(). SettingsStore reads from UserDefaults.standard, so we
+        // mirror those values there for the duration of each test.
+        UserDefaults.standard.set(testAssistantId, forKey: "connectedAssistantId")
+        UserDefaults.standard.set(testOrgId, forKey: "connectedOrganizationId")
+        return SettingsStore(settingsClient: MockSettingsClient())
+    }
+
+    private func cleanupStandard() {
+        // Remove the test-specific values from standard UserDefaults.
+        UserDefaults.standard.removeObject(forKey: "connectedAssistantId")
+        UserDefaults.standard.removeObject(forKey: "connectedOrganizationId")
+    }
+
+    private func stubSuccess(
+        id: String? = nil,
+        maintenanceEnabled: Bool,
+        debugPodName: String? = nil,
+        enteredAt: String? = nil
+    ) {
+        let assistantId = id ?? testAssistantId
+        MaintenanceStoreURLProtocol.requestHandler = { _ in
+            let url = URL(string: "https://example.com")!
+            let response = HTTPURLResponse(
+                url: url, statusCode: 200, httpVersion: nil, headerFields: nil
+            )!
+            return (response, assistantPayload(
+                id: assistantId,
+                maintenanceEnabled: maintenanceEnabled,
+                debugPodName: debugPodName,
+                enteredAt: enteredAt
+            ))
+        }
+    }
+
+    private func stubFailure(statusCode: Int) {
+        MaintenanceStoreURLProtocol.requestHandler = { request in
+            let url = request.url ?? URL(string: "https://example.com")!
+            let response = HTTPURLResponse(
+                url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil
+            )!
+            return (response, Data("{\"detail\": \"error\"}".utf8))
+        }
+    }
+
+    // MARK: - Initial state
+
+    func testInitialMaintenanceModeStateIsNil() {
+        defer { cleanupStandard() }
+        let store = makeStore()
+
+        XCTAssertNil(store.managedAssistantMaintenanceMode)
+        XCTAssertFalse(store.maintenanceModeRefreshing)
+        XCTAssertFalse(store.maintenanceModeEntering)
+        XCTAssertFalse(store.maintenanceModeExiting)
+        XCTAssertNil(store.maintenanceModeRefreshError)
+        XCTAssertNil(store.maintenanceModeEnterError)
+        XCTAssertNil(store.maintenanceModeExitError)
+    }
+
+    // MARK: - refreshManagedAssistantMaintenanceMode
+
+    func testRefreshSetsMaintenanceModeEnabledFromSuccessResponse() async {
+        defer { cleanupStandard() }
+        stubSuccess(
+            maintenanceEnabled: true,
+            debugPodName: "debug-pod-abc",
+            enteredAt: "2026-03-30T10:00:00Z"
+        )
+
+        let store = makeStore()
+        await store.refreshManagedAssistantMaintenanceMode()
+
+        let mode = try! XCTUnwrap(store.managedAssistantMaintenanceMode)
+        XCTAssertTrue(mode.enabled)
+        XCTAssertEqual(mode.debug_pod_name, "debug-pod-abc")
+        XCTAssertEqual(mode.entered_at, "2026-03-30T10:00:00Z")
+        XCTAssertNil(store.maintenanceModeRefreshError)
+        XCTAssertFalse(store.maintenanceModeRefreshing)
+    }
+
+    func testRefreshSetsMaintenanceModeDisabled() async {
+        defer { cleanupStandard() }
+        stubSuccess(maintenanceEnabled: false)
+
+        let store = makeStore()
+        await store.refreshManagedAssistantMaintenanceMode()
+
+        let mode = try! XCTUnwrap(store.managedAssistantMaintenanceMode)
+        XCTAssertFalse(mode.enabled)
+        XCTAssertNil(mode.debug_pod_name)
+        XCTAssertNil(store.maintenanceModeRefreshError)
+    }
+
+    func testRefreshSetsErrorOnPlatformFailure() async {
+        defer { cleanupStandard() }
+        stubFailure(statusCode: 500)
+
+        let store = makeStore()
+        await store.refreshManagedAssistantMaintenanceMode()
+
+        XCTAssertNil(store.managedAssistantMaintenanceMode)
+        XCTAssertNotNil(store.maintenanceModeRefreshError)
+        XCTAssertFalse(store.maintenanceModeRefreshing)
+    }
+
+    func testRefreshClearsRefreshErrorOnSuccess() async {
+        defer { cleanupStandard() }
+
+        let store = makeStore()
+
+        // First call fails.
+        stubFailure(statusCode: 503)
+        await store.refreshManagedAssistantMaintenanceMode()
+        XCTAssertNotNil(store.maintenanceModeRefreshError)
+
+        // Second call succeeds — error should be cleared.
+        stubSuccess(maintenanceEnabled: false)
+        await store.refreshManagedAssistantMaintenanceMode()
+        XCTAssertNil(store.maintenanceModeRefreshError)
+    }
+
+    func testRefreshIsNoOpWhenNoConnectedAssistantId() async {
+        // Remove the connected assistant ID.
+        UserDefaults.standard.removeObject(forKey: "connectedAssistantId")
+        defer {
+            UserDefaults.standard.removeObject(forKey: "connectedAssistantId")
+            UserDefaults.standard.removeObject(forKey: "connectedOrganizationId")
+        }
+
+        // If refresh were to hit the network, the nil handler would cause an error.
+        MaintenanceStoreURLProtocol.requestHandler = nil
+
+        let store = SettingsStore(settingsClient: MockSettingsClient())
+        await store.refreshManagedAssistantMaintenanceMode()
+
+        XCTAssertNil(store.managedAssistantMaintenanceMode)
+        XCTAssertNil(store.maintenanceModeRefreshError)
+        XCTAssertFalse(store.maintenanceModeRefreshing)
+    }
+
+    // MARK: - enterManagedAssistantMaintenanceMode
+
+    func testEnterMaintenanceModeUpdatesStateOnSuccess() async {
+        defer { cleanupStandard() }
+        stubSuccess(
+            maintenanceEnabled: true,
+            debugPodName: "debug-pod-enter",
+            enteredAt: "2026-03-30T15:00:00Z"
+        )
+
+        let store = makeStore()
+        store.enterManagedAssistantMaintenanceMode()
+
+        let completed = expectation(description: "enter done")
+        let task = Task {
+            var ticks = 0
+            while store.maintenanceModeEntering && ticks < 200 {
+                await Task.yield()
+                ticks += 1
+            }
+            completed.fulfill()
+        }
+        await fulfillment(of: [completed], timeout: 5)
+        task.cancel()
+
+        let mode = try! XCTUnwrap(store.managedAssistantMaintenanceMode)
+        XCTAssertTrue(mode.enabled)
+        XCTAssertEqual(mode.debug_pod_name, "debug-pod-enter")
+        XCTAssertNil(store.maintenanceModeEnterError)
+        XCTAssertFalse(store.maintenanceModeEntering)
+    }
+
+    func testEnterMaintenanceModeStoresErrorOnFailure() async {
+        defer { cleanupStandard() }
+        stubFailure(statusCode: 409)
+
+        let store = makeStore()
+        store.enterManagedAssistantMaintenanceMode()
+
+        let completed = expectation(description: "enter done with error")
+        let task = Task {
+            var ticks = 0
+            while store.maintenanceModeEntering && ticks < 200 {
+                await Task.yield()
+                ticks += 1
+            }
+            completed.fulfill()
+        }
+        await fulfillment(of: [completed], timeout: 5)
+        task.cancel()
+
+        XCTAssertNotNil(store.maintenanceModeEnterError)
+        XCTAssertFalse(store.maintenanceModeEntering)
+    }
+
+    // MARK: - exitManagedAssistantMaintenanceMode
+
+    func testExitMaintenanceModeUpdatesStateOnSuccess() async {
+        defer { cleanupStandard() }
+        stubSuccess(maintenanceEnabled: false)
+
+        let store = makeStore()
+        // Seed an active maintenance state.
+        store.managedAssistantMaintenanceMode = PlatformAssistantMaintenanceMode(
+            enabled: true,
+            entered_at: "2026-03-30T10:00:00Z",
+            debug_pod_name: "debug-pod-old"
+        )
+
+        store.exitManagedAssistantMaintenanceMode()
+
+        let completed = expectation(description: "exit done")
+        let task = Task {
+            var ticks = 0
+            while store.maintenanceModeExiting && ticks < 200 {
+                await Task.yield()
+                ticks += 1
+            }
+            completed.fulfill()
+        }
+        await fulfillment(of: [completed], timeout: 5)
+        task.cancel()
+
+        let mode = try! XCTUnwrap(store.managedAssistantMaintenanceMode)
+        XCTAssertFalse(mode.enabled)
+        XCTAssertNil(store.maintenanceModeExitError)
+        XCTAssertFalse(store.maintenanceModeExiting)
+    }
+
+    func testExitMaintenanceModeStoresErrorOnFailure() async {
+        defer { cleanupStandard() }
+        stubFailure(statusCode: 409)
+
+        let store = makeStore()
+        store.exitManagedAssistantMaintenanceMode()
+
+        let completed = expectation(description: "exit done with error")
+        let task = Task {
+            var ticks = 0
+            while store.maintenanceModeExiting && ticks < 200 {
+                await Task.yield()
+                ticks += 1
+            }
+            completed.fulfill()
+        }
+        await fulfillment(of: [completed], timeout: 5)
+        task.cancel()
+
+        XCTAssertNotNil(store.maintenanceModeExitError)
+        XCTAssertFalse(store.maintenanceModeExiting)
+    }
+
+    // MARK: - Error cleared on next action
+
+    func testEnterClearsPreviousEnterError() async {
+        defer { cleanupStandard() }
+
+        let store = makeStore()
+
+        // First call fails.
+        stubFailure(statusCode: 500)
+        store.enterManagedAssistantMaintenanceMode()
+        let firstDone = expectation(description: "first enter done")
+        let task1 = Task {
+            var ticks = 0
+            while store.maintenanceModeEntering && ticks < 200 {
+                await Task.yield()
+                ticks += 1
+            }
+            firstDone.fulfill()
+        }
+        await fulfillment(of: [firstDone], timeout: 5)
+        task1.cancel()
+        XCTAssertNotNil(store.maintenanceModeEnterError)
+
+        // Second call succeeds — error should be cleared.
+        stubSuccess(maintenanceEnabled: true)
+        store.enterManagedAssistantMaintenanceMode()
+        let secondDone = expectation(description: "second enter done")
+        let task2 = Task {
+            var ticks = 0
+            while store.maintenanceModeEntering && ticks < 200 {
+                await Task.yield()
+                ticks += 1
+            }
+            secondDone.fulfill()
+        }
+        await fulfillment(of: [secondDone], timeout: 5)
+        task2.cancel()
+        XCTAssertNil(store.maintenanceModeEnterError)
+    }
+
+    func testExitClearsPreviousExitError() async {
+        defer { cleanupStandard() }
+
+        let store = makeStore()
+
+        // First call fails.
+        stubFailure(statusCode: 500)
+        store.exitManagedAssistantMaintenanceMode()
+        let firstDone = expectation(description: "first exit done")
+        let task1 = Task {
+            var ticks = 0
+            while store.maintenanceModeExiting && ticks < 200 {
+                await Task.yield()
+                ticks += 1
+            }
+            firstDone.fulfill()
+        }
+        await fulfillment(of: [firstDone], timeout: 5)
+        task1.cancel()
+        XCTAssertNotNil(store.maintenanceModeExitError)
+
+        // Second call succeeds — error should be cleared.
+        stubSuccess(maintenanceEnabled: false)
+        store.exitManagedAssistantMaintenanceMode()
+        let secondDone = expectation(description: "second exit done")
+        let task2 = Task {
+            var ticks = 0
+            while store.maintenanceModeExiting && ticks < 200 {
+                await Task.yield()
+                ticks += 1
+            }
+            secondDone.fulfill()
+        }
+        await fulfillment(of: [secondDone], timeout: 5)
+        task2.cancel()
+        XCTAssertNil(store.maintenanceModeExitError)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `managedAssistantMaintenanceMode` (plus loading/error fields) as `@Published` state on `SettingsStore`, providing a single source of truth for the selected managed assistant's maintenance-mode payload.
- Adds `refreshManagedAssistantMaintenanceMode()`, `enterManagedAssistantMaintenanceMode()`, and `exitManagedAssistantMaintenanceMode()` that delegate to the PR 1 `AuthService` helpers and update local observable state on success.
- Refreshes maintenance state on app foreground, after successful hatch/bootstrap, and when the selected assistant changes so chat and settings surfaces stay current without their own polling.

Part of plan: assistant-debug-pods.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
