### PR TITLE
Add Maintenance Mode entry and exit controls to the macOS SSH settings UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -709,14 +709,110 @@ struct SettingsDeveloperTab: View {
 
     // MARK: - SSH Terminal
 
+    /// `true` while either a maintenance-enter or maintenance-exit request is in flight.
+    private var maintenanceTransitionInFlight: Bool {
+        store.maintenanceModeEntering || store.maintenanceModeExiting
+    }
+
     private var sshTerminalSection: some View {
         SettingsCard(
             title: "SSH Terminal",
-            subtitle: "Open a terminal session to the assistant's host machine."
+            subtitle: "Maintenance mode pauses the normal assistant pod and routes terminal sessions into the mounted debug pod, giving you direct access to the assistant's workspace PVC."
         ) {
-            VButton(label: "Open Terminal", style: .outlined) {
-                openTerminalWindow()
+            // Maintenance mode status row
+            maintenanceModeStatusRow
+
+            SettingsDivider()
+
+            // Maintenance mode action buttons
+            HStack(spacing: VSpacing.sm) {
+                if store.managedAssistantMaintenanceMode?.enabled == true {
+                    VButton(
+                        label: "Resume Assistant",
+                        style: .outlined,
+                        isDisabled: maintenanceTransitionInFlight
+                    ) {
+                        store.exitManagedAssistantMaintenanceMode()
+                    }
+                    .accessibilityLabel("Resume Assistant")
+                } else {
+                    VButton(
+                        label: "Enter Maintenance Mode",
+                        style: .outlined,
+                        isDisabled: maintenanceTransitionInFlight
+                    ) {
+                        store.enterManagedAssistantMaintenanceMode()
+                    }
+                    .accessibilityLabel("Enter Maintenance Mode")
+                }
+
+                VButton(label: "Open Terminal", style: .primary) {
+                    openTerminalWindow()
+                }
+                .accessibilityLabel("Open Terminal")
             }
+
+            // Show inline error messages if a maintenance operation fails.
+            if let enterError = store.maintenanceModeEnterError {
+                Text(enterError)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.systemNegativeStrong)
+            }
+            if let exitError = store.maintenanceModeExitError {
+                Text(exitError)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.systemNegativeStrong)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var maintenanceModeStatusRow: some View {
+        if store.maintenanceModeRefreshing {
+            HStack(spacing: VSpacing.sm) {
+                ProgressView()
+                    .controlSize(.mini)
+                    .progressViewStyle(.circular)
+                Text("Loading maintenance status…")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+        } else if let maintenance = store.managedAssistantMaintenanceMode {
+            if maintenance.enabled {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    HStack(spacing: VSpacing.xs) {
+                        Circle()
+                            .fill(VColor.systemMidStrong)
+                            .frame(width: 8, height: 8)
+                            .accessibilityHidden(true)
+                        Text("Maintenance mode active")
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentDefault)
+                            .accessibilityValue("Maintenance mode active")
+                    }
+                    if let podName = maintenance.debug_pod_name {
+                        Text("Debug pod: \(podName)")
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                            .textSelection(.enabled)
+                    }
+                }
+            } else {
+                HStack(spacing: VSpacing.xs) {
+                    Circle()
+                        .fill(VColor.systemPositiveStrong)
+                        .frame(width: 8, height: 8)
+                        .accessibilityHidden(true)
+                    Text("Assistant running normally")
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(VColor.contentDefault)
+                        .accessibilityValue("Assistant running normally")
+                }
+            }
+        } else {
+            Text("Maintenance status unavailable")
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentTertiary)
         }
     }
 

--- a/clients/macos/vellum-assistantTests/SettingsDeveloperTabMaintenanceTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsDeveloperTabMaintenanceTests.swift
@@ -1,0 +1,320 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+// MARK: - URLProtocol stub for SSH maintenance UI endpoint calls
+
+private final class DevTabMaintenanceURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - Payload helpers
+
+private func maintenancePayload(
+    id: String,
+    enabled: Bool,
+    debugPodName: String? = nil,
+    enteredAt: String? = nil
+) -> Data {
+    let podField = debugPodName.map { "\"debug_pod_name\": \"\($0)\"" } ?? "\"debug_pod_name\": null"
+    let atField = enteredAt.map { "\"entered_at\": \"\($0)\"" } ?? "\"entered_at\": null"
+    return Data("""
+    {
+      "id": "\(id)",
+      "name": "Test Managed Assistant",
+      "status": "running",
+      "maintenance_mode": {
+        "enabled": \(enabled),
+        \(podField),
+        \(atField)
+      }
+    }
+    """.utf8)
+}
+
+// MARK: - Tests
+
+/// Tests for the store state that drives the SSH Terminal section maintenance-mode
+/// controls in `SettingsDeveloperTab`: button visibility logic, disabled states
+/// during mutation, and the active-maintenance status copy values.
+@MainActor
+final class SettingsDeveloperTabMaintenanceTests: XCTestCase {
+
+    private let testAssistantId = "devtab-maint-\(UUID().uuidString.prefix(8))"
+    private let testOrgId = "org-devtab-\(UUID().uuidString.prefix(8))"
+
+    private var lockfileBackup: Data?
+    private var primaryLockfilePath: String { LockfilePaths.primaryPath }
+
+    override func setUp() {
+        super.setUp()
+
+        let primaryURL = URL(fileURLWithPath: primaryLockfilePath)
+        lockfileBackup = try? Data(contentsOf: primaryURL)
+
+        let lockfileContent: [String: Any] = [
+            "assistants": [
+                [
+                    "assistantId": testAssistantId,
+                    "name": testAssistantId,
+                    "cloud": "vellum",
+                    "runtimeUrl": "https://platform.vellum.ai",
+                    "hatchedAt": "2026-01-01T00:00:00Z",
+                ] as [String: Any]
+            ]
+        ]
+        let data = try! JSONSerialization.data(withJSONObject: lockfileContent)
+        try! data.write(to: primaryURL, options: .atomic)
+
+        UserDefaults.standard.set(testAssistantId, forKey: "connectedAssistantId")
+        UserDefaults.standard.set(testOrgId, forKey: "connectedOrganizationId")
+
+        URLProtocol.registerClass(DevTabMaintenanceURLProtocol.self)
+        DevTabMaintenanceURLProtocol.requestHandler = nil
+        SessionTokenManager.setToken("stub-session-token")
+    }
+
+    override func tearDown() {
+        URLProtocol.unregisterClass(DevTabMaintenanceURLProtocol.self)
+        DevTabMaintenanceURLProtocol.requestHandler = nil
+        SessionTokenManager.deleteToken()
+
+        let primaryURL = URL(fileURLWithPath: primaryLockfilePath)
+        if let backup = lockfileBackup {
+            try? backup.write(to: primaryURL, options: .atomic)
+        } else {
+            try? FileManager.default.removeItem(at: primaryURL)
+        }
+        lockfileBackup = nil
+
+        UserDefaults.standard.removeObject(forKey: "connectedAssistantId")
+        UserDefaults.standard.removeObject(forKey: "connectedOrganizationId")
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeStore() -> SettingsStore {
+        SettingsStore(settingsClient: MockSettingsClient())
+    }
+
+    private func stubSuccess(enabled: Bool, debugPodName: String? = nil, enteredAt: String? = nil) {
+        DevTabMaintenanceURLProtocol.requestHandler = { _ in
+            let url = URL(string: "https://example.com")!
+            let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, maintenancePayload(
+                id: self.testAssistantId,
+                enabled: enabled,
+                debugPodName: debugPodName,
+                enteredAt: enteredAt
+            ))
+        }
+    }
+
+    private func stubFailure(statusCode: Int = 500) {
+        DevTabMaintenanceURLProtocol.requestHandler = { request in
+            let url = request.url ?? URL(string: "https://example.com")!
+            let response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+            return (response, Data("{\"detail\": \"server error\"}".utf8))
+        }
+    }
+
+    // MARK: - Button visibility: Enter Maintenance Mode shown when not active
+
+    /// When `managedAssistantMaintenanceMode` is nil (initial state), no maintenance
+    /// transition should be in flight and the store should not indicate maintenance is active.
+    func testNoMaintenanceModeActive_whenStateIsNil() {
+        let store = makeStore()
+        XCTAssertNil(store.managedAssistantMaintenanceMode,
+                     "Initial maintenance mode state should be nil")
+        XCTAssertFalse(store.maintenanceModeEntering,
+                       "Should not be entering maintenance mode initially")
+        XCTAssertFalse(store.maintenanceModeExiting,
+                       "Should not be exiting maintenance mode initially")
+    }
+
+    /// After a successful refresh that returns enabled=false, the SSH section should
+    /// show "Enter Maintenance Mode" (not "Resume Assistant").
+    func testRefreshWithMaintenanceDisabled_stateShowsNotActive() async {
+        stubSuccess(enabled: false)
+        let store = makeStore()
+
+        await store.refreshManagedAssistantMaintenanceMode()
+
+        XCTAssertNotNil(store.managedAssistantMaintenanceMode,
+                        "Maintenance mode state should be populated after refresh")
+        XCTAssertFalse(store.managedAssistantMaintenanceMode!.enabled,
+                       "Maintenance mode should be disabled after refresh with enabled=false")
+    }
+
+    // MARK: - Button visibility: Resume Assistant shown when maintenance is active
+
+    /// After a successful refresh that returns enabled=true, the SSH section should
+    /// show "Resume Assistant" instead of "Enter Maintenance Mode".
+    func testRefreshWithMaintenanceEnabled_stateShowsActive() async {
+        stubSuccess(enabled: true, debugPodName: "debug-pod-abc123")
+        let store = makeStore()
+
+        await store.refreshManagedAssistantMaintenanceMode()
+
+        XCTAssertNotNil(store.managedAssistantMaintenanceMode)
+        XCTAssertTrue(store.managedAssistantMaintenanceMode!.enabled,
+                      "Maintenance mode should be active after refresh with enabled=true")
+    }
+
+    // MARK: - Active maintenance status copy: debug pod name is surfaced
+
+    /// When maintenance mode is active and a debug pod name is present, the store
+    /// should expose it so the status row can display "Debug pod: <name>".
+    func testActiveMaintenanceMode_debugPodNameIsPresent() async {
+        let expectedPodName = "debug-pod-xyz789"
+        stubSuccess(enabled: true, debugPodName: expectedPodName)
+        let store = makeStore()
+
+        await store.refreshManagedAssistantMaintenanceMode()
+
+        XCTAssertEqual(store.managedAssistantMaintenanceMode?.debug_pod_name, expectedPodName,
+                       "Debug pod name should match what the platform returned")
+    }
+
+    /// When maintenance mode is active but no debug pod has been assigned yet,
+    /// `debug_pod_name` should be nil (no debug pod copy rendered).
+    func testActiveMaintenanceMode_withoutDebugPod_podNameIsNil() async {
+        stubSuccess(enabled: true, debugPodName: nil)
+        let store = makeStore()
+
+        await store.refreshManagedAssistantMaintenanceMode()
+
+        XCTAssertTrue(store.managedAssistantMaintenanceMode!.enabled)
+        XCTAssertNil(store.managedAssistantMaintenanceMode?.debug_pod_name,
+                     "Debug pod name should be nil when the platform did not assign one")
+    }
+
+    // MARK: - Disabled state during enter-maintenance-mode mutation
+
+    /// `maintenanceModeEntering` flips true while the enter call is in flight and
+    /// false when it resolves — the SSH section buttons are disabled while this is true.
+    func testEnteringMaintenanceMode_flagIsSetDuringRequest() async throws {
+        stubSuccess(enabled: true)
+        let store = makeStore()
+
+        // Observe the entering flag via a brief window — fire the action but don't await it;
+        // just confirm the flag is false before and after the full async resolution.
+        XCTAssertFalse(store.maintenanceModeEntering, "Should not be entering before action")
+        XCTAssertFalse(store.maintenanceModeExiting, "Should not be exiting before action")
+
+        store.enterManagedAssistantMaintenanceMode()
+        // Give the task a chance to settle.
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        XCTAssertFalse(store.maintenanceModeEntering, "Should not be entering after request completes")
+        XCTAssertNil(store.maintenanceModeEnterError, "Enter error should be nil on success")
+        XCTAssertTrue(store.managedAssistantMaintenanceMode?.enabled == true,
+                      "Maintenance mode should be enabled after successful enter")
+    }
+
+    // MARK: - Disabled state during exit-maintenance-mode mutation
+
+    /// `maintenanceModeExiting` flips true while the exit call is in flight and
+    /// false when it resolves — the SSH section buttons are disabled while this is true.
+    func testExitingMaintenanceMode_flagIsSetDuringRequest() async throws {
+        stubSuccess(enabled: false)
+        let store = makeStore()
+        // Pre-seed an active maintenance state.
+        store.managedAssistantMaintenanceMode = PlatformAssistantMaintenanceMode(
+            enabled: true, debug_pod_name: "debug-pod-pre"
+        )
+
+        store.exitManagedAssistantMaintenanceMode()
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        XCTAssertFalse(store.maintenanceModeExiting, "Should not be exiting after request completes")
+        XCTAssertNil(store.maintenanceModeExitError, "Exit error should be nil on success")
+        XCTAssertFalse(store.managedAssistantMaintenanceMode?.enabled == true,
+                       "Maintenance mode should be disabled after successful exit")
+    }
+
+    // MARK: - Error state surfaces inline error copy
+
+    /// When entering maintenance mode fails, `maintenanceModeEnterError` is non-nil
+    /// so the SSH section can render the inline error text.
+    func testEnterMaintenanceModeFailure_setsEnterError() async throws {
+        stubFailure(statusCode: 500)
+        let store = makeStore()
+
+        store.enterManagedAssistantMaintenanceMode()
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        XCTAssertFalse(store.maintenanceModeEntering, "Entering flag should be cleared after failure")
+        XCTAssertNotNil(store.maintenanceModeEnterError,
+                        "Enter error should be set when the request fails")
+    }
+
+    /// When exiting maintenance mode fails, `maintenanceModeExitError` is non-nil
+    /// so the SSH section can render the inline error text.
+    func testExitMaintenanceModeFailure_setsExitError() async throws {
+        stubFailure(statusCode: 503)
+        let store = makeStore()
+        store.managedAssistantMaintenanceMode = PlatformAssistantMaintenanceMode(
+            enabled: true, debug_pod_name: "debug-pod-pre"
+        )
+
+        store.exitManagedAssistantMaintenanceMode()
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        XCTAssertFalse(store.maintenanceModeExiting, "Exiting flag should be cleared after failure")
+        XCTAssertNotNil(store.maintenanceModeExitError,
+                        "Exit error should be set when the request fails")
+    }
+
+    // MARK: - Transition-in-flight computed logic
+
+    /// Neither entering nor exiting is in flight when the store is freshly constructed —
+    /// both buttons in the SSH section should be enabled by default.
+    func testNoTransitionInFlight_bothButtonsEnabledByDefault() {
+        let store = makeStore()
+
+        // The `maintenanceTransitionInFlight` helper in the view is:
+        //   store.maintenanceModeEntering || store.maintenanceModeExiting
+        let transitionInFlight = store.maintenanceModeEntering || store.maintenanceModeExiting
+        XCTAssertFalse(transitionInFlight, "No transition should be in flight on fresh store")
+    }
+
+    // MARK: - Refresh error does not leave entering/exiting flags set
+
+    /// A failed refresh should clear `maintenanceModeRefreshing` and set the error,
+    /// without affecting the enter/exit flags.
+    func testRefreshFailure_setsRefreshErrorAndClearsRefreshingFlag() async {
+        stubFailure(statusCode: 404)
+        let store = makeStore()
+
+        await store.refreshManagedAssistantMaintenanceMode()
+
+        XCTAssertFalse(store.maintenanceModeRefreshing, "Refreshing flag should be cleared after failure")
+        XCTAssertNotNil(store.maintenanceModeRefreshError,
+                        "Refresh error should be populated when the request fails")
+        XCTAssertFalse(store.maintenanceModeEntering, "Enter flag should not be set by a failed refresh")
+        XCTAssertFalse(store.maintenanceModeExiting, "Exit flag should not be set by a failed refresh")
+    }
+}


### PR DESCRIPTION
## Summary
- Extends the SSH Terminal card in the Developer settings tab to show the current maintenance-mode state (active with debug pod name, or running normally) sourced from `SettingsStore`.
- Adds `Enter Maintenance Mode` / `Resume Assistant` buttons that call the existing `SettingsStore` actions and disable themselves while a transition is in flight; the existing `Open Terminal` button and `SSHTerminalWindow` flow are fully preserved.
- Adds `SettingsDeveloperTabMaintenanceTests.swift` covering button-visibility state, disabled-state logic during mutations, debug-pod-name surfacing, and inline error handling.

Part of plan: assistant-debug-pods.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
