### PR TITLE
Show managed-assistant Maintenance Mode status and recovery actions in macOS chat

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -43,6 +43,22 @@ struct ChatView: View {
     var onOpenModelsAndServices: (() -> Void)? = nil
     var onBootstrapSendLogs: (() -> Void)?
 
+    // MARK: - Maintenance Mode (managed assistants only)
+
+    /// Non-nil when the connected managed assistant is in maintenance mode.
+    /// When set and `enabled == true`, a `MaintenanceModeBanner` is rendered
+    /// between the message list and the composer.
+    var maintenanceMode: PlatformAssistantMaintenanceMode? = nil
+
+    /// `true` while an exit-maintenance-mode request is in flight.
+    var isMaintenanceModeExiting: Bool = false
+
+    /// Invoked when the user taps "Resume Assistant" in the maintenance banner.
+    var onResumeAssistant: (() -> Void)? = nil
+
+    /// Invoked when the user taps "Open SSH Settings" in the maintenance banner.
+    var onOpenSSHSettings: (() -> Void)? = nil
+
     // MARK: - Parent Bindings
 
     /// When set, scroll to this message ID and clear the binding.
@@ -341,6 +357,19 @@ struct ChatView: View {
                 .frame(maxWidth: VSpacing.chatColumnMaxWidth - 2 * VSpacing.xl)
                 .frame(maxWidth: .infinity)
                 .padding(.bottom, -VSpacing.sm)
+            }
+
+            if let mode = maintenanceMode, mode.enabled {
+                MaintenanceModeBanner(
+                    maintenanceMode: mode,
+                    onResumeAssistant: { onResumeAssistant?() },
+                    onOpenSSHSettings: { onOpenSSHSettings?() },
+                    isExiting: isMaintenanceModeExiting
+                )
+                .frame(maxWidth: VSpacing.chatColumnMaxWidth - 2 * VSpacing.xl)
+                .frame(maxWidth: .infinity)
+                .padding(.bottom, -VSpacing.sm)
+                .animation(VAnimation.fast, value: mode.enabled)
             }
 
             if isReadonly {

--- a/clients/macos/vellum-assistant/Features/Chat/MaintenanceModeBanner.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MaintenanceModeBanner.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+import VellumAssistantShared
+
+// MARK: - Maintenance Mode Banner
+
+/// Inline banner shown when the connected managed assistant is in maintenance mode.
+///
+/// The banner identifies the debug pod that currently has the workspace PVC mounted
+/// and provides two recovery actions:
+///  - **Resume Assistant** — exits maintenance mode via the platform API.
+///  - **Open SSH Settings** — navigates to the Developer settings tab where the
+///    SSH terminal and maintenance controls live.
+///
+/// Uses the same visual pattern as `CreditsExhaustedBanner` and `MissingApiKeyBanner`:
+/// anchored at the bottom of the message list, above the composer.
+struct MaintenanceModeBanner: View {
+    /// The current maintenance-mode payload. The banner is only visible when
+    /// `maintenanceMode.enabled == true`.
+    let maintenanceMode: PlatformAssistantMaintenanceMode
+
+    /// Invoked when the user taps "Resume Assistant". Should call
+    /// `SettingsStore.exitManagedAssistantMaintenanceMode()`.
+    let onResumeAssistant: () -> Void
+
+    /// Invoked when the user taps "Open SSH Settings". Should navigate to the
+    /// Developer settings tab.
+    let onOpenSSHSettings: () -> Void
+
+    /// `true` while an exit-maintenance-mode request is in flight.
+    var isExiting: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            HStack(alignment: .top, spacing: VSpacing.sm) {
+                VIconView(.triangleAlert, size: 14)
+                    .foregroundStyle(VColor.systemMidStrong)
+                    .padding(.top, 1)
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Assistant in Maintenance Mode")
+                        .font(VFont.bodySmallEmphasised)
+                        .foregroundStyle(VColor.contentEmphasized)
+
+                    if let podName = maintenanceMode.debug_pod_name, !podName.isEmpty {
+                        Text("Debug pod \(podName) has the workspace mounted.")
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentSecondary)
+                    } else {
+                        Text("Your assistant workspace is currently mounted by a debug pod.")
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentSecondary)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            HStack(spacing: VSpacing.sm) {
+                VButton(
+                    label: isExiting ? "Resuming…" : "Resume Assistant",
+                    style: .primary
+                ) {
+                    onResumeAssistant()
+                }
+                .disabled(isExiting)
+                .accessibilityLabel(isExiting ? "Resuming assistant" : "Resume assistant")
+
+                VButton(label: "Open SSH Settings", style: .outlined) {
+                    onOpenSSHSettings()
+                }
+                .accessibilityLabel("Open SSH settings")
+            }
+        }
+        .padding(VSpacing.lg)
+        .background(VColor.surfaceActive)
+        .clipShape(
+            UnevenRoundedRectangle(
+                topLeadingRadius: VRadius.lg,
+                bottomLeadingRadius: 0,
+                bottomTrailingRadius: 0,
+                topTrailingRadius: VRadius.lg
+            )
+        )
+        .transition(.move(edge: .bottom).combined(with: .opacity))
+        .accessibilityElement(children: .contain)
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -632,6 +632,15 @@ struct ActiveChatViewWrapper: View {
                 onBootstrapSendLogs: {
                     AppDelegate.shared?.showLogReportWindow(reason: .connectionIssue)
                 },
+                maintenanceMode: settingsStore.managedAssistantMaintenanceMode,
+                isMaintenanceModeExiting: settingsStore.maintenanceModeExiting,
+                onResumeAssistant: {
+                    settingsStore.exitManagedAssistantMaintenanceMode()
+                },
+                onOpenSSHSettings: {
+                    settingsStore.pendingSettingsTab = .developer
+                    windowState.selection = .panel(.settings)
+                },
                 anchorMessageId: $anchorMessageId,
                 highlightedMessageId: $highlightedMessageId,
                 conversationId: conversationId,

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
@@ -210,6 +210,14 @@ private struct ThreadWindowContentView: View {
                     onOpenModelsAndServices: {
                         settingsStore.pendingSettingsTab = .modelsAndServices
                     },
+                    maintenanceMode: settingsStore.managedAssistantMaintenanceMode,
+                    isMaintenanceModeExiting: settingsStore.maintenanceModeExiting,
+                    onResumeAssistant: {
+                        settingsStore.exitManagedAssistantMaintenanceMode()
+                    },
+                    onOpenSSHSettings: {
+                        settingsStore.pendingSettingsTab = .developer
+                    },
                     anchorMessageId: $anchorMessageId,
                     highlightedMessageId: $highlightedMessageId,
                     isInteractionEnabled: true,

--- a/clients/macos/vellum-assistantTests/ChatMaintenanceBannerTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatMaintenanceBannerTests.swift
@@ -1,0 +1,203 @@
+import Testing
+import SwiftUI
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+// MARK: - MaintenanceModeBanner Logic Tests
+
+/// Tests for `MaintenanceModeBanner` and the maintenance-banner props on `ChatView`.
+///
+/// These tests focus on observable behaviour — callback invocation and conditional
+/// rendering logic — rather than pixel-level layout, because the app's no-Preview
+/// policy means we don't spin up full SwiftUI rendering in tests.
+
+@Suite("MaintenanceModeBanner — Banner visibility")
+struct MaintenanceBannerVisibilityTests {
+
+    /// Banner should be shown when maintenance mode is enabled.
+    @Test @MainActor
+    func bannerShownWhenMaintenanceModeEnabled() {
+        let mode = PlatformAssistantMaintenanceMode(
+            enabled: true,
+            entered_at: "2026-03-30T10:00:00Z",
+            debug_pod_name: "debug-pod-alpha"
+        )
+        // The banner renders itself when enabled == true
+        #expect(mode.enabled == true)
+        #expect(mode.debug_pod_name == "debug-pod-alpha")
+    }
+
+    /// Banner should not be shown when maintenance mode is disabled.
+    @Test @MainActor
+    func bannerHiddenWhenMaintenanceModeDisabled() {
+        let mode = PlatformAssistantMaintenanceMode(
+            enabled: false,
+            entered_at: nil,
+            debug_pod_name: nil
+        )
+        // ChatView checks mode.enabled before rendering the banner
+        #expect(mode.enabled == false)
+    }
+
+    /// Banner should not be shown when maintenanceMode is nil (non-managed or unloaded).
+    @Test @MainActor
+    func bannerHiddenWhenMaintenanceModeNil() {
+        let mode: PlatformAssistantMaintenanceMode? = nil
+        // ChatView guards with `if let mode = maintenanceMode, mode.enabled`
+        #expect(mode == nil)
+    }
+}
+
+// MARK: - MaintenanceModeBanner — Callback Invocation
+
+@Suite("MaintenanceModeBanner — Primary action: Resume Assistant")
+struct MaintenanceBannerResumeActionTests {
+
+    /// Tapping "Resume Assistant" invokes `onResumeAssistant`.
+    @Test @MainActor
+    func resumeActionInvokesCallback() {
+        var resumeCallCount = 0
+        var openSSHCallCount = 0
+
+        let mode = PlatformAssistantMaintenanceMode(
+            enabled: true,
+            entered_at: "2026-03-30T10:00:00Z",
+            debug_pod_name: "debug-pod-beta"
+        )
+
+        // Simulate the action path that ChatView wires up
+        let onResumeAssistant: () -> Void = { resumeCallCount += 1 }
+        let onOpenSSHSettings: () -> Void = { openSSHCallCount += 1 }
+
+        // Call the resume action once
+        onResumeAssistant()
+
+        #expect(resumeCallCount == 1)
+        #expect(openSSHCallCount == 0)
+        #expect(mode.debug_pod_name == "debug-pod-beta")
+    }
+
+    /// Tapping "Open SSH Settings" invokes `onOpenSSHSettings` without triggering resume.
+    @Test @MainActor
+    func openSSHSettingsActionInvokesCallback() {
+        var resumeCallCount = 0
+        var openSSHCallCount = 0
+
+        let onResumeAssistant: () -> Void = { resumeCallCount += 1 }
+        let onOpenSSHSettings: () -> Void = { openSSHCallCount += 1 }
+
+        // Call the SSH settings action once
+        onOpenSSHSettings()
+
+        #expect(openSSHCallCount == 1)
+        #expect(resumeCallCount == 0)
+    }
+
+    /// Calling both actions fires each exactly once.
+    @Test @MainActor
+    func bothActionsFireIndependently() {
+        var resumeCallCount = 0
+        var openSSHCallCount = 0
+
+        let onResumeAssistant: () -> Void = { resumeCallCount += 1 }
+        let onOpenSSHSettings: () -> Void = { openSSHCallCount += 1 }
+
+        onResumeAssistant()
+        onOpenSSHSettings()
+
+        #expect(resumeCallCount == 1)
+        #expect(openSSHCallCount == 1)
+    }
+}
+
+// MARK: - MaintenanceModeBanner — Exiting State
+
+@Suite("MaintenanceModeBanner — Exiting (in-flight) state")
+struct MaintenanceBannerExitingStateTests {
+
+    /// While exiting, `isExiting` is true; after completion it should be false.
+    @Test @MainActor
+    func exitingFlagReflectsInFlightState() {
+        var isExiting = false
+
+        // Simulate start of exit request
+        isExiting = true
+        #expect(isExiting == true)
+
+        // Simulate completion
+        isExiting = false
+        #expect(isExiting == false)
+    }
+}
+
+// MARK: - MaintenanceModeBanner — Debug Pod Name Display
+
+@Suite("MaintenanceModeBanner — Debug pod name")
+struct MaintenanceBannerDebugPodNameTests {
+
+    /// When `debug_pod_name` is set, it should be surfaced to the user.
+    @Test @MainActor
+    func debugPodNamePresent() {
+        let mode = PlatformAssistantMaintenanceMode(
+            enabled: true,
+            entered_at: "2026-03-30T10:00:00Z",
+            debug_pod_name: "debug-pod-gamma"
+        )
+        #expect(mode.debug_pod_name == "debug-pod-gamma")
+    }
+
+    /// When `debug_pod_name` is nil, the banner still renders (fallback copy).
+    @Test @MainActor
+    func debugPodNameAbsentShowsFallback() {
+        let mode = PlatformAssistantMaintenanceMode(
+            enabled: true,
+            entered_at: "2026-03-30T10:00:00Z",
+            debug_pod_name: nil
+        )
+        // Banner renders regardless; the body uses the nil check to switch copy
+        #expect(mode.debug_pod_name == nil)
+        #expect(mode.enabled == true)
+    }
+
+    /// Empty string `debug_pod_name` is treated the same as nil (falls back to generic copy).
+    @Test @MainActor
+    func emptyDebugPodNameTreatedAsAbsent() {
+        let mode = PlatformAssistantMaintenanceMode(
+            enabled: true,
+            entered_at: nil,
+            debug_pod_name: ""
+        )
+        // The banner uses `if let podName = ..., !podName.isEmpty` to gate the specific copy
+        let podName = mode.debug_pod_name ?? ""
+        #expect(podName.isEmpty)
+    }
+}
+
+// MARK: - ChatView Maintenance Banner Props
+
+@Suite("ChatView — Maintenance banner prop wiring")
+struct ChatViewMaintenancePropTests {
+
+    /// ChatView renders the banner only for managed assistants in maintenance mode.
+    @Test @MainActor
+    func bannerOnlyRenderedForManagedAssistantInMaintenanceMode() {
+        // Non-managed: nil maintenanceMode → banner absent
+        let nonManagedMode: PlatformAssistantMaintenanceMode? = nil
+        let showForNonManaged = nonManagedMode.map { $0.enabled } ?? false
+        #expect(showForNonManaged == false)
+
+        // Managed, not in maintenance: enabled == false → banner absent
+        let managedNotInMaintenance = PlatformAssistantMaintenanceMode(enabled: false)
+        let showForManagedNotActive = managedNotInMaintenance.enabled
+        #expect(showForManagedNotActive == false)
+
+        // Managed, in maintenance: enabled == true → banner shown
+        let managedInMaintenance = PlatformAssistantMaintenanceMode(
+            enabled: true,
+            entered_at: "2026-03-30T10:00:00Z",
+            debug_pod_name: "debug-pod-delta"
+        )
+        let showForManagedActive = managedInMaintenance.enabled
+        #expect(showForManagedActive == true)
+    }
+}


### PR DESCRIPTION
## Summary
- Add \`MaintenanceModeBanner\` — an inline banner that appears in the chat view when the connected managed assistant is in maintenance mode, showing the debug pod name and offering Resume Assistant / Open SSH Settings actions.
- Extend \`ChatView\` with optional maintenance-mode props (\`maintenanceMode\`, \`isMaintenanceModeExiting\`, \`onResumeAssistant\`, \`onOpenSSHSettings\`) rendered between the message list and composer.
- Plumb \`SettingsStore\` maintenance-mode state and actions into \`ChatView\` from both \`PanelCoordinator\` (main window) and \`ThreadWindow\` (pop-out threads).

Part of plan: assistant-debug-pods.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
