### PR TITLE
fix: restore session token after test instead of deleting it

### DIFF
--- a/clients/shared/Tests/PlatformAssistantMaintenanceDecodingTests.swift
+++ b/clients/shared/Tests/PlatformAssistantMaintenanceDecodingTests.swift
@@ -38,11 +38,15 @@ private final class MaintenanceModeURLProtocol: URLProtocol {
 @MainActor
 final class PlatformAssistantMaintenanceDecodingTests: XCTestCase {
     private let decoder = JSONDecoder()
+    private var previousToken: String?
 
     override func setUp() {
         super.setUp()
         MaintenanceModeURLProtocol.requestHandler = nil
         URLProtocol.registerClass(MaintenanceModeURLProtocol.self)
+        // Save any existing token so we can restore it in tearDown, preventing
+        // a test-abort from leaving a bogus token in the real credential store.
+        previousToken = SessionTokenManager.getToken()
         // Provide a token so network-path tests reach the stub handler rather than
         // short-circuiting with authenticationRequired before any request is made.
         SessionTokenManager.setToken("test-session-token")
@@ -51,7 +55,13 @@ final class PlatformAssistantMaintenanceDecodingTests: XCTestCase {
     override func tearDown() {
         URLProtocol.unregisterClass(MaintenanceModeURLProtocol.self)
         MaintenanceModeURLProtocol.requestHandler = nil
-        SessionTokenManager.deleteToken()
+        // Restore the credential store to its pre-test state.
+        if let token = previousToken {
+            SessionTokenManager.setToken(token)
+        } else {
+            SessionTokenManager.deleteToken()
+        }
+        previousToken = nil
         super.tearDown()
     }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for assistant-debug-pods.md.

**Gap:** Test session token bleeds into real credential store
**What was expected:** Tests must not leave a bogus or missing token in the production credential store if a run aborts
**What was found:** setUp wrote a hardcoded test token; tearDown deleted instead of restoring the previous value
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
