### PR TITLE
fix: remove dead animation modifier from MaintenanceModeBanner in ChatView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -369,7 +369,6 @@ struct ChatView: View {
                 .frame(maxWidth: VSpacing.chatColumnMaxWidth - 2 * VSpacing.xl)
                 .frame(maxWidth: .infinity)
                 .padding(.bottom, -VSpacing.sm)
-                .animation(VAnimation.fast, value: mode.enabled)
             }
 
             if isReadonly {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for assistant-debug-pods.md.

**Gap:** Dead .animation(VAnimation.fast, value: mode.enabled) code in ChatView
**What was expected:** MaintenanceModeBanner follows the same pattern as CreditsExhaustedBanner/MissingApiKeyBanner — no animation modifier on the banner
**What was found:** .animation(VAnimation.fast, value: mode.enabled) was applied but mode.enabled is always true while the view exists
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22453" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
