### PR TITLE
fix: guard against stale async refresh overwriting new assistant maintenance state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2488,6 +2488,13 @@ public final class SettingsStore: ObservableObject {
                 id: assistant.assistantId,
                 organizationId: orgId
             )
+            // Guard against stale responses: only apply the result if the connected
+            // assistant hasn't changed while the request was in flight.
+            let currentConnectedId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
+            guard currentConnectedId == connectedId else {
+                log.info("Discarding stale maintenance-mode response for assistant \(assistant.assistantId, privacy: .public): assistant changed to '\(currentConnectedId, privacy: .public)' while request was in flight")
+                return
+            }
             managedAssistantMaintenanceMode = updated.maintenance_mode
             log.info("Refreshed maintenance mode for assistant \(assistant.assistantId, privacy: .public): enabled=\(updated.maintenance_mode?.enabled ?? false)")
         } catch {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for assistant-debug-pods.md.

**Gap:** Stale async refresh overwrites new assistant's state (race condition)
**What was expected:** Stale responses for a previous assistant must not overwrite newly switched assistant state
**What was found:** refreshManagedAssistantMaintenanceMode() unconditionally assigned result after await with no staleness check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
