### PR TITLE
fix: use UserDefaults.publisher(for:) with debounce for maintenance mode refresh

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -78,6 +78,12 @@ extension UserDefaults {
         }
         return string(forKey: "popOutShortcut") ?? ""
     }
+    @objc dynamic var connectedAssistantId: String? {
+        return string(forKey: "connectedAssistantId")
+    }
+    @objc dynamic var connectedOrganizationId: String? {
+        return string(forKey: "connectedOrganizationId")
+    }
 }
 
 // MARK: - Input Monitors

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -356,10 +356,6 @@ public final class SettingsStore: ObservableObject {
     private var routingSourceRefreshTask: Task<Void, Never>?
     private var yourOwnOAuthConnectPollingTask: Task<Void, Never>?
 
-    /// Tracks the last observed `connectedAssistantId` so the UserDefaults change
-    /// subscription can avoid spurious re-fetches on unrelated key changes.
-    private var _lastObservedConnectedAssistantId: String? = UserDefaults.standard.string(forKey: "connectedAssistantId")
-
     /// Last model reported by the daemon — used to skip redundant model_set calls
     /// that would otherwise reinitialize providers and evict idle conversations.
     private var lastDaemonModel: String?
@@ -603,14 +599,29 @@ public final class SettingsStore: ObservableObject {
 
         // Refresh when the connected assistant changes so the state reflects
         // the newly selected managed assistant rather than the previous one.
-        NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)
-            .receive(on: RunLoop.main)
+        // Uses scoped publisher(for:) + debounce per AGENTS.md to avoid
+        // firing on every UserDefaults write app-wide.
+        UserDefaults.standard.publisher(for: \.connectedAssistantId)
+            .debounce(for: .milliseconds(100), scheduler: RunLoop.main)
+            .removeDuplicates()
             .sink { [weak self] _ in
                 guard let self else { return }
-                let newId = UserDefaults.standard.string(forKey: "connectedAssistantId")
-                guard newId != self._lastObservedConnectedAssistantId else { return }
-                self._lastObservedConnectedAssistantId = newId
                 // Reset stale maintenance state immediately before async refresh
+                self.managedAssistantMaintenanceMode = nil
+                self.maintenanceModeRefreshError = nil
+                Task { @MainActor [weak self] in
+                    await self?.refreshManagedAssistantMaintenanceMode()
+                }
+            }
+            .store(in: &cancellables)
+
+        // Refresh when the connected organization changes — switching org without
+        // switching assistant can also leave maintenance state stale.
+        UserDefaults.standard.publisher(for: \.connectedOrganizationId)
+            .debounce(for: .milliseconds(100), scheduler: RunLoop.main)
+            .removeDuplicates()
+            .sink { [weak self] _ in
+                guard let self else { return }
                 self.managedAssistantMaintenanceMode = nil
                 self.maintenanceModeRefreshError = nil
                 Task { @MainActor [weak self] in


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for assistant-debug-pods.md.

**Gap:** UserDefaults.didChangeNotification violates AGENTS.md rule + missing org-ID refresh coverage
**What was expected:** Use publisher(for:) with 100ms debounce per AGENTS.md; also refresh when connectedOrganizationId changes
**What was found:** Used didChangeNotification with manual last-value tracking; only watched connectedAssistantId
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22455" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
