### PR TITLE
fix: open settings window when Open SSH Settings is clicked from ThreadWindow

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
@@ -217,6 +217,7 @@ private struct ThreadWindowContentView: View {
                     },
                     onOpenSSHSettings: {
                         settingsStore.pendingSettingsTab = .developer
+                        AppDelegate.shared?.showSettingsWindow(nil)
                     },
                     anchorMessageId: $anchorMessageId,
                     highlightedMessageId: $highlightedMessageId,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for assistant-debug-pods.md.

**Gap:** onOpenSSHSettings in ThreadWindow silently sets tab without opening settings window
**What was expected:** Clicking Open SSH Settings from a popped-out thread window opens the Settings window at the Developer tab
**What was found:** Only pendingSettingsTab was set; no navigation to open the settings window was performed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
