### PR TITLE
fix: clear stale maintenance error state on assistant/org switch

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -609,6 +609,8 @@ public final class SettingsStore: ObservableObject {
                 // Reset stale maintenance state immediately before async refresh
                 self.managedAssistantMaintenanceMode = nil
                 self.maintenanceModeRefreshError = nil
+                self.maintenanceModeEnterError = nil
+                self.maintenanceModeExitError = nil
                 Task { @MainActor [weak self] in
                     await self?.refreshManagedAssistantMaintenanceMode()
                 }
@@ -624,6 +626,8 @@ public final class SettingsStore: ObservableObject {
                 guard let self else { return }
                 self.managedAssistantMaintenanceMode = nil
                 self.maintenanceModeRefreshError = nil
+                self.maintenanceModeEnterError = nil
+                self.maintenanceModeExitError = nil
                 Task { @MainActor [weak self] in
                     await self?.refreshManagedAssistantMaintenanceMode()
                 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for assistant-debug-pods.md.

**Gap:** Stale enter/exit error fields not cleared on assistant switch in SettingsStore
**What was expected:** Error fields reset when switching to a different managed assistant
**What was found:** Old error text from a previous assistant persisted until the user triggered a new action
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22457" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
