### PR TITLE
fix: also guard against stale org-ID when committing async refresh result

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2499,11 +2499,16 @@ public final class SettingsStore: ObservableObject {
                 id: assistant.assistantId,
                 organizationId: orgId
             )
-            // Guard against stale responses: only apply the result if the connected
-            // assistant hasn't changed while the request was in flight.
+            // Guard against stale responses: only apply the result if both the connected
+            // assistant and connected organization haven't changed while the request was in flight.
             let currentConnectedId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
             guard currentConnectedId == connectedId else {
                 log.info("Discarding stale maintenance-mode response for assistant \(assistant.assistantId, privacy: .public): assistant changed to '\(currentConnectedId, privacy: .public)' while request was in flight")
+                return
+            }
+            let currentOrgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") ?? ""
+            guard currentOrgId == orgId else {
+                log.info("Discarding stale maintenance-mode response for assistant \(assistant.assistantId, privacy: .public): organization changed to '\(currentOrgId, privacy: .public)' while request was in flight")
                 return
             }
             managedAssistantMaintenanceMode = updated.maintenance_mode


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for assistant-debug-pods.md.

**Gap:** Stale async refresh race guard incomplete — org-ID change not covered
**What was expected:** Both assistantId and organizationId checked for staleness after async refresh
**What was found:** Only connectedAssistantId was snapshotted and re-checked; org-ID change would pass the guard
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
