### PR TITLE
fix: open settings window for all settings-navigation actions in ThreadWindow

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
@@ -206,9 +206,11 @@ private struct ThreadWindowContentView: View {
                     onForkFromMessage: (conversation?.isChannelConversation ?? false) ? nil : { daemonMessageId in onFork(daemonMessageId) },
                     onAddFunds: {
                         settingsStore.pendingSettingsTab = .billing
+                        AppDelegate.shared?.showSettingsWindow(nil)
                     },
                     onOpenModelsAndServices: {
                         settingsStore.pendingSettingsTab = .modelsAndServices
+                        AppDelegate.shared?.showSettingsWindow(nil)
                     },
                     maintenanceMode: settingsStore.managedAssistantMaintenanceMode,
                     isMaintenanceModeExiting: settingsStore.maintenanceModeExiting,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for assistant-debug-pods.md.

**Gap:** onAddFunds and onOpenModelsAndServices in ThreadWindow missing showSettingsWindow call
**What was expected:** All three settings-navigation closures in ThreadWindowContentView open the settings window
**What was found:** Only onOpenSSHSettings was fixed; onAddFunds and onOpenModelsAndServices still only set pendingSettingsTab
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22459" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
