### PR TITLE
fix: add .dropFirst() to KVO publishers to suppress initial emission on subscription

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -602,6 +602,7 @@ public final class SettingsStore: ObservableObject {
         // Uses scoped publisher(for:) + debounce per AGENTS.md to avoid
         // firing on every UserDefaults write app-wide.
         UserDefaults.standard.publisher(for: \.connectedAssistantId)
+            .dropFirst()
             .debounce(for: .milliseconds(100), scheduler: RunLoop.main)
             .removeDuplicates()
             .sink { [weak self] _ in
@@ -620,6 +621,7 @@ public final class SettingsStore: ObservableObject {
         // Refresh when the connected organization changes — switching org without
         // switching assistant can also leave maintenance state stale.
         UserDefaults.standard.publisher(for: \.connectedOrganizationId)
+            .dropFirst()
             .debounce(for: .milliseconds(100), scheduler: RunLoop.main)
             .removeDuplicates()
             .sink { [weak self] _ in


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for assistant-debug-pods.md.

**Gap:** Missing .dropFirst() on KVO publishers causes duplicate init refresh
**What was expected:** Publishers only fire on actual value changes, not immediately on subscription
**What was found:** KVO publishers emit current value on subscription, triggering redundant refreshes at init
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
