### PR TITLE
fix: surface maintenance refresh error in SSH settings card

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -810,9 +810,16 @@ struct SettingsDeveloperTab: View {
                 }
             }
         } else {
-            Text("Maintenance status unavailable")
-                .font(VFont.labelDefault)
-                .foregroundStyle(VColor.contentTertiary)
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Maintenance status unavailable")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+                if let refreshError = store.maintenanceModeRefreshError {
+                    Text(refreshError)
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.systemNegativeStrong)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for assistant-debug-pods.md.

**Gap:** maintenanceModeRefreshError stored but never displayed in any UI
**What was expected:** Failed background refreshes show an error message to the user
**What was found:** The @Published property was populated but never read by any view
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
