### PR TITLE
fix: restore session token in tearDown for SettingsStore and DeveloperTab tests

### DIFF
--- a/clients/macos/vellum-assistantTests/SettingsDeveloperTabMaintenanceTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsDeveloperTabMaintenanceTests.swift
@@ -66,6 +66,7 @@ final class SettingsDeveloperTabMaintenanceTests: XCTestCase {
 
     private var lockfileBackup: Data?
     private var primaryLockfilePath: String { LockfilePaths.primaryPath }
+    private var previousToken: String?
 
     override func setUp() {
         super.setUp()
@@ -92,13 +93,21 @@ final class SettingsDeveloperTabMaintenanceTests: XCTestCase {
 
         URLProtocol.registerClass(DevTabMaintenanceURLProtocol.self)
         DevTabMaintenanceURLProtocol.requestHandler = nil
+        // Save any existing token so we can restore it in tearDown, preventing
+        // the test run from destroying the developer's real session token.
+        previousToken = SessionTokenManager.getToken()
         SessionTokenManager.setToken("stub-session-token")
     }
 
     override func tearDown() {
         URLProtocol.unregisterClass(DevTabMaintenanceURLProtocol.self)
         DevTabMaintenanceURLProtocol.requestHandler = nil
-        SessionTokenManager.deleteToken()
+        if let token = previousToken {
+            SessionTokenManager.setToken(token)
+        } else {
+            SessionTokenManager.deleteToken()
+        }
+        previousToken = nil
 
         let primaryURL = URL(fileURLWithPath: primaryLockfilePath)
         if let backup = lockfileBackup {

--- a/clients/macos/vellum-assistantTests/SettingsStoreManagedMaintenanceTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreManagedMaintenanceTests.swift
@@ -80,6 +80,7 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
     private var lockfileBackup: Data?
     private var defaultsSuiteName: String!
     private var defaults: UserDefaults!
+    private var previousToken: String?
 
     override func setUp() {
         super.setUp()
@@ -113,13 +114,21 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
         // Register stub network handler and a session token.
         URLProtocol.registerClass(MaintenanceStoreURLProtocol.self)
         MaintenanceStoreURLProtocol.requestHandler = nil
+        // Save any existing token so we can restore it in tearDown, preventing
+        // the test run from destroying the developer's real session token.
+        previousToken = SessionTokenManager.getToken()
         SessionTokenManager.setToken("stub-session-token")
     }
 
     override func tearDown() {
         URLProtocol.unregisterClass(MaintenanceStoreURLProtocol.self)
         MaintenanceStoreURLProtocol.requestHandler = nil
-        SessionTokenManager.deleteToken()
+        if let token = previousToken {
+            SessionTokenManager.setToken(token)
+        } else {
+            SessionTokenManager.deleteToken()
+        }
+        previousToken = nil
 
         // Restore the original lockfile (or delete it if there was nothing before).
         let primaryURL = URL(fileURLWithPath: primaryLockfilePath)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for assistant-debug-pods.md.

**Gap:** Session token isolation incomplete — two test files still destroy real session token in tearDown
**What was expected:** All test files that write a test token in setUp must restore the previous token in tearDown
**What was found:** SettingsStoreManagedMaintenanceTests and SettingsDeveloperTabMaintenanceTests called deleteToken() unconditionally
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22464" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
