### PR TITLE
fix: guard defer flag reset against assistant switch race in enter/exit mutations

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2505,9 +2505,15 @@ public final class SettingsStore: ObservableObject {
             return
         }
 
+        let taskAssistantId = connectedId
+
         maintenanceModeRefreshing = true
         maintenanceModeRefreshError = nil
-        defer { maintenanceModeRefreshing = false }
+        defer {
+            if UserDefaults.standard.string(forKey: "connectedAssistantId") == taskAssistantId {
+                maintenanceModeRefreshing = false
+            }
+        }
 
         do {
             let updated = try await AuthService.shared.refreshAssistant(
@@ -2554,9 +2560,15 @@ public final class SettingsStore: ObservableObject {
                 return
             }
 
+            let taskAssistantId = connectedId
+
             maintenanceModeEntering = true
             maintenanceModeEnterError = nil
-            defer { maintenanceModeEntering = false }
+            defer {
+                if UserDefaults.standard.string(forKey: "connectedAssistantId") == taskAssistantId {
+                    maintenanceModeEntering = false
+                }
+            }
 
             do {
                 let updated = try await AuthService.shared.enterMaintenanceMode(
@@ -2605,9 +2617,15 @@ public final class SettingsStore: ObservableObject {
                 return
             }
 
+            let taskAssistantId = connectedId
+
             maintenanceModeExiting = true
             maintenanceModeExitError = nil
-            defer { maintenanceModeExiting = false }
+            defer {
+                if UserDefaults.standard.string(forKey: "connectedAssistantId") == taskAssistantId {
+                    maintenanceModeExiting = false
+                }
+            }
 
             do {
                 let updated = try await AuthService.shared.exitMaintenanceMode(


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for assistant-debug-pods.md.

**Gap:** defer race with Combine sink — old Task clears new assistant's in-flight flag
**What was expected:** defer only resets flag when the assistant hasn't changed
**What was found:** unconditional defer could clear maintenanceModeEntering/Exiting for the new assistant's in-flight operation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22466" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
