### PR TITLE
fix: clear maintenanceModeRefreshError on non-managed early return

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2496,6 +2496,7 @@ public final class SettingsStore: ObservableObject {
               assistant.isManaged else {
             // Not a managed assistant — clear any stale state.
             managedAssistantMaintenanceMode = nil
+            maintenanceModeRefreshError = nil
             return
         }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for assistant-debug-pods.md.

**Gap:** maintenanceModeRefreshError not cleared on non-managed early return
**What was expected:** All early-return paths clear both managedAssistantMaintenanceMode and maintenanceModeRefreshError
**What was found:** Early non-managed return set mode to nil but left refresh error stale
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22468" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
