### PR TITLE
fix: remove dangling cleanupStandard() calls from new staleness tests

### DIFF
--- a/clients/macos/vellum-assistantTests/SettingsStoreManagedMaintenanceTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreManagedMaintenanceTests.swift
@@ -663,7 +663,6 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
     /// Verifies that `enterManagedAssistantMaintenanceMode` does not overwrite
     /// `managedAssistantMaintenanceMode` when `connectedOrganizationId` changes mid-flight.
     func testEnterDiscardsStaleResponseWhenOrgIdChangesMidFlight() async {
-        defer { cleanupStandard() }
 
         let url = URL(string: "https://example.com")!
         let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
@@ -727,7 +726,6 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
     /// Verifies that `exitManagedAssistantMaintenanceMode` does not overwrite
     /// `managedAssistantMaintenanceMode` when `connectedAssistantId` changes mid-flight.
     func testExitDiscardsStaleResponseWhenAssistantIdChangesMidFlight() async {
-        defer { cleanupStandard() }
 
         let url = URL(string: "https://example.com")!
         let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
@@ -799,7 +797,6 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
     /// Verifies that `exitManagedAssistantMaintenanceMode` does not overwrite
     /// `managedAssistantMaintenanceMode` when `connectedOrganizationId` changes mid-flight.
     func testExitDiscardsStaleResponseWhenOrgIdChangesMidFlight() async {
-        defer { cleanupStandard() }
 
         let url = URL(string: "https://example.com")!
         let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!


### PR DESCRIPTION
## Summary
Fixes compile error introduced in plan review for assistant-debug-pods.md.

**Gap:** Three new staleness regression tests call cleanupStandard() which was deleted in a prior fix PR
**What was expected:** Test file compiles — no calls to deleted helpers
**What was found:** defer { cleanupStandard() } in 3 test methods; tearDown already handles cleanup unconditionally
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
