### PR TITLE
fix: clear maintenanceModeRefreshing on assistant/org switch to prevent stuck spinner

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -617,6 +617,7 @@ public final class SettingsStore: ObservableObject {
                 self.maintenanceModeExitError = nil
                 self.maintenanceModeEntering = false
                 self.maintenanceModeExiting = false
+                self.maintenanceModeRefreshing = false
                 Task { @MainActor [weak self] in
                     await self?.refreshManagedAssistantMaintenanceMode()
                 }
@@ -639,6 +640,7 @@ public final class SettingsStore: ObservableObject {
                 self.maintenanceModeExitError = nil
                 self.maintenanceModeEntering = false
                 self.maintenanceModeExiting = false
+                self.maintenanceModeRefreshing = false
                 Task { @MainActor [weak self] in
                     await self?.refreshManagedAssistantMaintenanceMode()
                 }


### PR DESCRIPTION
## Summary
Fixes behavioral regression introduced in plan review for assistant-debug-pods.md.

**Gap:** maintenanceModeRefreshing stuck at true after assistant/org switch mid-refresh
**What was expected:** All three in-flight flags reset when assistant or org changes
**What was found:** Observers cleared Entering/Exiting but not Refreshing; conditional defer skipped it on switch
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
