### PR TITLE
fix: guard empty debug_pod_name in SSH settings status row

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -790,7 +790,7 @@ struct SettingsDeveloperTab: View {
                             .foregroundStyle(VColor.contentDefault)
                             .accessibilityValue("Maintenance mode active")
                     }
-                    if let podName = maintenance.debug_pod_name {
+                    if let podName = maintenance.debug_pod_name, !podName.isEmpty {
                         Text("Debug pod: \(podName)")
                             .font(VFont.labelDefault)
                             .foregroundStyle(VColor.contentTertiary)


### PR DESCRIPTION
## Summary
Addresses review feedback on feature branch PR #22451.

Adds !podName.isEmpty guard to SettingsDeveloperTab.swift to match MaintenanceModeBanner.swift's handling of empty debug_pod_name strings — prevents displaying 'Debug pod: ' with no trailing name.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22473" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
