### PR TITLE
fix: add empty JSON body to enter/exit maintenance mode POST requests

### DIFF
--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -366,6 +366,7 @@ public final class AuthService {
         urlRequest.httpMethod = "POST"
         urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.httpBody = Data("{}".utf8)
         urlRequest.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
 
         if let token = await SessionTokenManager.getTokenAsync() {
@@ -420,6 +421,7 @@ public final class AuthService {
         urlRequest.httpMethod = "POST"
         urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.httpBody = Data("{}".utf8)
         urlRequest.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
 
         if let token = await SessionTokenManager.getTokenAsync() {


### PR DESCRIPTION
## Summary
Addresses review feedback on feature branch PR #22451.

Adds httpBody = Data("{}".utf8) to enterMaintenanceMode and exitMaintenanceMode POST requests. Without a body, setting Content-Type: application/json could cause Django to raise a ParseError when reading request.data on the empty body.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22474" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
