### PR TITLE
Set computer-use write tools to medium risk level

### DIFF
--- a/assistant/src/__tests__/computer-use-skill-manifest-regression.test.ts
+++ b/assistant/src/__tests__/computer-use-skill-manifest-regression.test.ts
@@ -52,9 +52,19 @@ describe("computer-use skill manifest regression", () => {
     }
   });
 
-  test("all manifest tools have risk: low", () => {
+  test("read-only tools have risk: low, side-effect tools have risk: medium", () => {
+    const readOnlyTools = new Set([
+      "computer_use_observe",
+      "computer_use_wait",
+      "computer_use_done",
+      "computer_use_respond",
+    ]);
     for (const tool of manifest.tools) {
-      expect(tool.risk).toBe("low");
+      if (readOnlyTools.has(tool.name)) {
+        expect(tool.risk).toBe("low");
+      } else {
+        expect(tool.risk).toBe("medium");
+      }
     }
   });
 

--- a/assistant/src/config/bundled-skills/computer-use/TOOLS.json
+++ b/assistant/src/config/bundled-skills/computer-use/TOOLS.json
@@ -23,7 +23,7 @@
       "name": "computer_use_click",
       "description": "Click an element on screen. Prefer element_id (from the accessibility tree) over x/y coordinates.",
       "category": "computer-use",
-      "risk": "low",
+      "risk": "medium",
       "input_schema": {
         "type": "object",
         "properties": {
@@ -62,7 +62,7 @@
       "name": "computer_use_type_text",
       "description": "Type text at the current cursor position. First click a text field (by element_id) to focus it, then call this tool. If a field shows 'FOCUSED', skip the click.",
       "category": "computer-use",
-      "risk": "low",
+      "risk": "medium",
       "input_schema": {
         "type": "object",
         "properties": {
@@ -88,7 +88,7 @@
       "name": "computer_use_key",
       "description": "Press a key or keyboard shortcut. Supported: enter, tab, escape, backspace, delete, up, down, left, right, space, cmd+a, cmd+c, cmd+v, cmd+z, cmd+tab, cmd+w, shift+tab, option+tab",
       "category": "computer-use",
-      "risk": "low",
+      "risk": "medium",
       "input_schema": {
         "type": "object",
         "properties": {
@@ -114,7 +114,7 @@
       "name": "computer_use_scroll",
       "description": "Scroll within an element by its [ID], or at raw screen coordinates as fallback.",
       "category": "computer-use",
-      "risk": "low",
+      "risk": "medium",
       "input_schema": {
         "type": "object",
         "properties": {
@@ -157,7 +157,7 @@
       "name": "computer_use_drag",
       "description": "Drag from one element or position to another. Use for moving files, resizing windows, rearranging items, or adjusting sliders.",
       "category": "computer-use",
-      "risk": "low",
+      "risk": "medium",
       "input_schema": {
         "type": "object",
         "properties": {
@@ -229,7 +229,7 @@
       "name": "computer_use_open_app",
       "description": "Open or switch to a macOS application by name. Preferred over cmd+tab for switching apps - more reliable and explicit.",
       "category": "computer-use",
-      "risk": "low",
+      "risk": "medium",
       "input_schema": {
         "type": "object",
         "properties": {
@@ -255,7 +255,7 @@
       "name": "computer_use_run_applescript",
       "description": "Run an AppleScript command. Prefer this over click/type when possible - it doesn't move the cursor or interrupt the user. Never use 'do shell script' inside AppleScript (blocked for security).",
       "category": "computer-use",
-      "risk": "low",
+      "risk": "medium",
       "input_schema": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
## Summary
- Changed 7 computer-use tools that produce side effects (click, type_text, key, scroll, drag, open_app, run_applescript) from `"risk": "low"` to `"risk": "medium"`
- Kept 4 read-only tools (observe, wait, done, respond) at `"risk": "low"`

## Original prompt
help me change all commands (i.e. writes) that potentially trigger side effects to be medium. Reads can remain Low risk
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22475" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
