### PR TITLE
security: validate vellum-qdrant symlink target before spawning

### DIFF
--- a/assistant/src/__tests__/qdrant-manager.test.ts
+++ b/assistant/src/__tests__/qdrant-manager.test.ts
@@ -5,6 +5,7 @@ import {
   readdirSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
@@ -365,6 +366,61 @@ describe("QdrantManager", () => {
 
       const binaryPath = join(testDataDir, "data", "qdrant", "bin", "qdrant");
       expect(existsSync(binaryPath)).toBe(true);
+    }, 10_000);
+  });
+
+  // ── Symlink Safety ────────────────────────────────────────────
+
+  describe("vellum-qdrant symlink safety", () => {
+    test("ignores pre-existing non-symlink vellum-qdrant file", async () => {
+      const realMarkerPath = join(qdrantDir, "real-executed.txt");
+      const hijackMarkerPath = join(qdrantDir, "hijack-executed.txt");
+
+      placeFakeBinary(`#!/bin/sh\necho real > "${realMarkerPath}"\nexit 1`);
+
+      const hijackPath = join(qdrantBinDir, "vellum-qdrant");
+      writeFileSync(
+        hijackPath,
+        `#!/bin/sh\necho hijack > "${hijackMarkerPath}"\nexit 0`,
+      );
+      chmodSync(hijackPath, 0o755);
+
+      const port = getTestPort();
+      const mgr = new QdrantManager({
+        url: `http://127.0.0.1:${port}`,
+        ...FAST_TIMEOUTS,
+      });
+
+      await expect(mgr.start()).rejects.toThrow("before becoming ready");
+      expect(existsSync(realMarkerPath)).toBe(true);
+      expect(existsSync(hijackMarkerPath)).toBe(false);
+    }, 10_000);
+
+    test("ignores symlink that does not point to real qdrant binary", async () => {
+      const realMarkerPath = join(qdrantDir, "real-executed.txt");
+      const hijackMarkerPath = join(qdrantDir, "hijack-executed.txt");
+
+      placeFakeBinary(`#!/bin/sh\necho real > "${realMarkerPath}"\nexit 1`);
+
+      const evilBinaryPath = join(qdrantBinDir, "evil-qdrant");
+      writeFileSync(
+        evilBinaryPath,
+        `#!/bin/sh\necho hijack > "${hijackMarkerPath}"\nexit 0`,
+      );
+      chmodSync(evilBinaryPath, 0o755);
+
+      const vellumQdrantPath = join(qdrantBinDir, "vellum-qdrant");
+      symlinkSync(evilBinaryPath, vellumQdrantPath);
+
+      const port = getTestPort();
+      const mgr = new QdrantManager({
+        url: `http://127.0.0.1:${port}`,
+        ...FAST_TIMEOUTS,
+      });
+
+      await expect(mgr.start()).rejects.toThrow("before becoming ready");
+      expect(existsSync(realMarkerPath)).toBe(true);
+      expect(existsSync(hijackMarkerPath)).toBe(false);
     }, 10_000);
   });
 });

--- a/assistant/src/memory/qdrant-manager.ts
+++ b/assistant/src/memory/qdrant-manager.ts
@@ -2,8 +2,10 @@ import { createHash } from "node:crypto";
 import {
   chmodSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
+  realpathSync,
   symlinkSync,
   unlinkSync,
   writeFileSync,
@@ -361,14 +363,33 @@ export class QdrantManager {
    */
   private ensureVellumSymlink(binaryPath: string): string {
     const symlinkPath = join(dirname(binaryPath), "vellum-qdrant");
-    if (!existsSync(symlinkPath)) {
+    const expectedTarget = realpathSync(binaryPath);
+
+    if (existsSync(symlinkPath)) {
       try {
-        symlinkSync(binaryPath, symlinkPath);
+        const symlinkStat = lstatSync(symlinkPath);
+        if (symlinkStat.isSymbolicLink()) {
+          const actualTarget = realpathSync(symlinkPath);
+          if (actualTarget === expectedTarget) {
+            return symlinkPath;
+          }
+        }
       } catch {
-        // Fall back to the real binary if symlink creation fails
-        return binaryPath;
+        // Fall back to the real binary if existing symlink cannot be verified
       }
+      log.warn(
+        { symlinkPath },
+        "Existing vellum-qdrant is not a valid symlink to the Qdrant binary; ignoring it",
+      );
+      return binaryPath;
     }
-    return symlinkPath;
+
+    try {
+      symlinkSync(binaryPath, symlinkPath);
+      return symlinkPath;
+    } catch {
+      // Fall back to the real binary if symlink creation fails
+      return binaryPath;
+    }
   }
 }


### PR DESCRIPTION
## Summary

- **Security fix**: `ensureVellumSymlink()` now validates that any existing `vellum-qdrant` is a real symlink pointing to the expected Qdrant binary before returning it as the spawn path. Falls back to the real binary if validation fails.
- Adds `lstatSync` + `realpathSync` validation with a warning log when an invalid `vellum-qdrant` is detected.
- Adds two test cases covering path hijack via regular file and via symlink to a malicious binary.

**Codex finding:** https://chatgpt.com/codex/security/findings/e8d55e7b795c81918dd81ee6093f2359?sev=critical%2Chigh

## Original prompt

Security Fix: Validate vellum-qdrant symlink target before spawning

`ensureVellumSymlink()` in `assistant/src/memory/qdrant-manager.ts` returns any pre-existing `vellum-qdrant` file without validating it points to the real Qdrant binary. Since the binary dir is under the workspace (which is writable by sandboxed tools), an attacker can plant a malicious `vellum-qdrant` that gets executed by `Bun.spawn()` on the next Qdrant start — a sandbox escape with host-level code execution.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22477" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
