### PR TITLE
Security: escalate hooks directory mutations to High risk

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -2017,6 +2017,9 @@ describe("Permission Checker", () => {
     function ensureSkillsDir(): void {
       mkdirSync(join(checkerTestDir, "skills"), { recursive: true });
     }
+    function ensureHooksDir(): void {
+      mkdirSync(join(checkerTestDir, "hooks"), { recursive: true });
+    }
 
     test("file_write to skill directory is High risk", async () => {
       ensureSkillsDir();
@@ -2145,6 +2148,37 @@ describe("Permission Checker", () => {
       const normalPath = "/tmp/some-file.txt";
       const risk = await classifyRisk("file_edit", { path: normalPath });
       expect(risk).toBe(RiskLevel.Low);
+    });
+
+    test("file_write to hooks directory is High risk", async () => {
+      ensureHooksDir();
+      const hookPath = join(
+        checkerTestDir,
+        "hooks",
+        "post-tool-use",
+        "hook.sh",
+      );
+      const risk = await classifyRisk("file_write", { path: hookPath });
+      expect(risk).toBe(RiskLevel.High);
+    });
+
+    test("file_edit of hooks config is High risk", async () => {
+      ensureHooksDir();
+      const configPath = join(checkerTestDir, "hooks", "config.json");
+      const risk = await classifyRisk("file_edit", { path: configPath });
+      expect(risk).toBe(RiskLevel.High);
+    });
+
+    test("file_write to hooks directory prompts as High risk", async () => {
+      ensureHooksDir();
+      const hookPath = join(
+        checkerTestDir,
+        "hooks",
+        "post-tool-use",
+        "hook.sh",
+      );
+      const result = await check("file_write", { path: hookPath }, "/tmp");
+      expect(result.decision).toBe("prompt");
     });
 
     test("host_file_write to non-skill path remains Medium risk (via registry)", async () => {

--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -2181,6 +2181,25 @@ describe("Permission Checker", () => {
       expect(result.decision).toBe("prompt");
     });
 
+    test("host_file_write to hooks directory is High risk", async () => {
+      ensureHooksDir();
+      const hookPath = join(
+        checkerTestDir,
+        "hooks",
+        "post-tool-use",
+        "hook.sh",
+      );
+      const risk = await classifyRisk("host_file_write", { path: hookPath });
+      expect(risk).toBe(RiskLevel.High);
+    });
+
+    test("host_file_edit of hooks config is High risk", async () => {
+      ensureHooksDir();
+      const configPath = join(checkerTestDir, "hooks", "config.json");
+      const risk = await classifyRisk("host_file_edit", { path: configPath });
+      expect(risk).toBe(RiskLevel.High);
+    });
+
     test("host_file_write to non-skill path remains Medium risk (via registry)", async () => {
       const normalPath = "/tmp/some-file.txt";
       const risk = await classifyRisk("host_file_write", { path: normalPath });

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -766,6 +766,17 @@ async function classifyRiskUncached(
     ) {
       return RiskLevel.High;
     }
+    if (filePath) {
+      const normalizedHooksDir = normalizeDirPath(getWorkspaceHooksDir());
+      const normalizedPath = normalizeFilePath(resolve(filePath));
+      const hooksDirNoTrailingSlash = normalizedHooksDir.slice(0, -1);
+      if (
+        normalizedPath === hooksDirNoTrailingSlash ||
+        normalizedPath.startsWith(normalizedHooksDir)
+      ) {
+        return RiskLevel.High;
+      }
+    }
     // Fall through to the tool registry default (Medium) below.
   }
 

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -8,6 +8,7 @@ import { loadSkillCatalog, resolveSkillSelector } from "../config/skills.js";
 import { indexCatalogById } from "../skills/include-graph.js";
 import {
   isSkillSourcePath,
+  normalizeDirPath,
   normalizeFilePath,
 } from "../skills/path-classifier.js";
 import { computeTransitiveSkillVersionHash } from "../skills/transitive-version-hash.js";
@@ -18,6 +19,7 @@ import {
   looksLikePathOnlyInput,
 } from "../tools/network/url-safety.js";
 import { getTool } from "../tools/registry.js";
+import { getWorkspaceHooksDir } from "../util/platform.js";
 import {
   buildShellAllowlistOptions,
   buildShellCommandCandidates,
@@ -706,6 +708,19 @@ async function classifyRiskUncached(
       )
     ) {
       return RiskLevel.High;
+    }
+    if (filePath) {
+      const normalizedHooksDir = normalizeDirPath(getWorkspaceHooksDir());
+      const normalizedPath = normalizeFilePath(
+        resolve(workingDir ?? process.cwd(), filePath),
+      );
+      const hooksDirNoTrailingSlash = normalizedHooksDir.slice(0, -1);
+      if (
+        normalizedPath === hooksDirNoTrailingSlash ||
+        normalizedPath.startsWith(normalizedHooksDir)
+      ) {
+        return RiskLevel.High;
+      }
     }
     return RiskLevel.Low;
   }


### PR DESCRIPTION
## Summary

- Escalate `file_write`/`file_edit` operations targeting the workspace hooks directory (`~/.vellum/workspace/hooks`) to High risk, preventing workspace-mode auto-allow from silently permitting hook mutations
- Hooks execute on the host via `spawn()`, so unguarded writes created a sandbox escape path exploitable via prompt injection
- Follows the same normalization pattern used for skill source path protection

Codex finding: https://chatgpt.com/codex/security/findings/6d9f3e7fb098819191f8f6ba82ffce93?sev=critical%2Chigh

## Original prompt

Security Fix: Escalate hooks directory mutations to High risk. In workspace permission mode, file_write/file_edit targeting workspace hooks paths are classified as Low risk and auto-allowed without prompting. Since hook scripts execute on the host via spawn(), a prompt-injected model can silently write/modify hook scripts to gain host-level code execution. Fix by escalating hooks path mutations to High risk.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
