### PR TITLE
fix(security): remove dangerouslySkipPermissions bypass from permission checker

### DIFF
--- a/assistant/src/__tests__/permission-types.test.ts
+++ b/assistant/src/__tests__/permission-types.test.ts
@@ -15,7 +15,6 @@ describe("isAllowDecision", () => {
     "always_allow",
     "always_allow_high_risk",
     "temporary_override",
-    "dangerously_skip_permissions",
   ];
 
   for (const decision of allowDecisions) {

--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -403,8 +403,7 @@ function mapDecisionToOptionId(
     decision === "allow_conversation" ||
     decision === "always_allow" ||
     decision === "always_allow_high_risk" ||
-    decision === "temporary_override" ||
-    decision === "dangerously_skip_permissions";
+    decision === "temporary_override";
 
   if (isAllow) {
     // Prefer allow_always for persistent decisions, fallback to allow_once

--- a/assistant/src/credential-execution/approval-bridge.ts
+++ b/assistant/src/credential-execution/approval-bridge.ts
@@ -103,7 +103,6 @@ function mapUserDecisionToCesDecision(
         userDecision: decision,
       };
     case "temporary_override":
-    case "dangerously_skip_permissions":
       return {
         grantDecision: "approved",
         ttl: undefined,

--- a/assistant/src/events/domain-events.ts
+++ b/assistant/src/events/domain-events.ts
@@ -25,8 +25,7 @@ export interface ToolDomainEvents {
       | "always_allow_high_risk"
       | "deny"
       | "always_deny"
-      | "temporary_override"
-      | "dangerously_skip_permissions";
+      | "temporary_override";
     riskLevel: string;
     decidedAtMs: number;
   };

--- a/assistant/src/permissions/types.ts
+++ b/assistant/src/permissions/types.ts
@@ -24,8 +24,7 @@ export type UserDecision =
   | "always_allow_high_risk"
   | "deny"
   | "always_deny"
-  | "temporary_override"
-  | "dangerously_skip_permissions";
+  | "temporary_override";
 
 /** Returns true for any allow-variant decision. Centralizes the check to prevent omissions when new allow variants are added. */
 export function isAllowDecision(decision: UserDecision): boolean {
@@ -35,8 +34,7 @@ export function isAllowDecision(decision: UserDecision): boolean {
     decision === "allow_conversation" ||
     decision === "always_allow" ||
     decision === "always_allow_high_risk" ||
-    decision === "temporary_override" ||
-    decision === "dangerously_skip_permissions"
+    decision === "temporary_override"
   );
 }
 

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -137,24 +137,6 @@ export class PermissionChecker {
       }
 
       if (result.decision === "prompt") {
-        // dangerouslySkipPermissions: when enabled, auto-approve all prompts
-        // without user interaction. Deny rules are still respected (they
-        // return before reaching this block).
-        //
-        // Note: unlike guardian auto-approve and temporary overrides below,
-        // this intentionally does NOT check `context.requireFreshApproval`.
-        // The setting is designed to skip ALL interactive prompts
-        // unconditionally — it is an explicit operator opt-out from the
-        // permission system, so requireFreshApproval does not apply.
-        const cfg = getConfig();
-        if (cfg.permissions.dangerouslySkipPermissions) {
-          log.info(
-            { toolName: name, riskLevel },
-            "dangerouslySkipPermissions active — auto-approving without prompt",
-          );
-          return { allowed: true, decision: "dangerously_skip_permissions", riskLevel };
-        }
-
         // Guardian-trust sessions (e.g. scheduled jobs, reminders) should be
         // able to use bundled tools without interactive approval. The guardian
         // is the owner - prompting makes no sense when there is no client.


### PR DESCRIPTION
## Summary
- Remove the dangerouslySkipPermissions bypass block from the permission checker
- Remove the dangerously_skip_permissions decision variant from UserDecision type
- Remove from isAllowDecision() helper and permission-types tests
- Clean up references in client-handler, approval-bridge, and domain-events

Part of plan: rm-dangerous-skip-perms.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
