### PR TITLE
fix(security): remove dangerouslySkipPermissions from macOS client

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -119,31 +119,6 @@ struct SettingsDeveloperTab: View {
                 revokeAssistantApiKeySection
             }
 
-            // Dangerously Skip Permissions
-            SettingsCard(title: "Dangerously Skip Permissions", subtitle: "Auto-accept all permission prompts without asking. The assistant will never pause for approval — use with caution.") {
-                let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId })
-                let isDisabled = (assistant?.isRemote ?? false) && !(assistant?.isDocker ?? false)
-                HStack(alignment: .top, spacing: VSpacing.sm) {
-                    VToggle(isOn: Binding(
-                        get: { store.dangerouslySkipPermissions },
-                        set: { store.setDangerouslySkipPermissions($0) }
-                    ))
-                    .accessibilityLabel("Dangerously Skip Permissions")
-                    .disabled(isDisabled)
-                    .padding(.top, 2)
-                    VStack(alignment: .leading, spacing: VSpacing.xs) {
-                        Text("Skip all permission prompts")
-                            .font(VFont.bodyMediumLighter)
-                            .foregroundStyle(VColor.contentSecondary)
-                        Text(isDisabled
-                            ? "This setting cannot be changed for remote assistants."
-                            : "When enabled, tools execute immediately without asking for approval. Explicit deny rules are still respected.")
-                            .font(VFont.labelDefault)
-                            .foregroundStyle(VColor.contentTertiary)
-                    }
-                }
-            }
-
             // Permission Simulator
             if let model = testerModel {
                 ToolPermissionTesterView(model: model)
@@ -157,9 +132,6 @@ struct SettingsDeveloperTab: View {
             sentryTestingSection
         }
         .onAppear {
-            // Fetch skip-permissions state for Docker assistants
-            store.refreshDangerouslySkipPermissions()
-
             // Assistant info setup
             lockfileAssistants = LockfileAssistant.loadAll()
             selectedAssistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -92,12 +92,6 @@ public final class SettingsStore: ObservableObject {
     @Published var mediaEmbedVideoAllowlistDomains: [String]
     @Published var userTimezone: String?
 
-    // MARK: - Permissions Settings
-
-    @Published var dangerouslySkipPermissions: Bool
-    /// Monotonic counter to ignore stale rollback responses from rapid toggles.
-    private var skipPermissionsToggleGeneration: UInt = 0
-
     // MARK: - Telegram Integration State
 
     @Published var telegramHasBotToken: Bool = false
@@ -440,9 +434,6 @@ public final class SettingsStore: ObservableObject {
         self.mediaEmbedsEnabledSince = mediaSettings.enabledSince
         self.mediaEmbedVideoAllowlistDomains = mediaSettings.domains
         self.userTimezone = Self.loadUserTimezone(config: emptyConfig)
-
-        // Permissions default to false until daemon provides config
-        self.dangerouslySkipPermissions = false
 
         // Service modes use defaults until daemon provides config
         loadServiceModes(config: emptyConfig)
@@ -957,17 +948,6 @@ public final class SettingsStore: ObservableObject {
                 self.embeddingEnabled = status.enabled
                 self.embeddingDegraded = status.degraded
             }
-        }
-    }
-
-    /// Fetches the current dangerouslySkipPermissions state from the daemon
-    /// over HTTP. Only meaningful for Docker assistants where the config lives
-    /// inside the container and cannot be read from the host filesystem.
-    func refreshDangerouslySkipPermissions() {
-        guard isCurrentAssistantDocker else { return }
-        Task { @MainActor in
-            guard let enabled = await settingsClient.fetchDangerouslySkipPermissions() else { return }
-            self.dangerouslySkipPermissions = enabled
         }
     }
 
@@ -2934,19 +2914,6 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
-    func setDangerouslySkipPermissions(_ enabled: Bool) {
-        skipPermissionsToggleGeneration &+= 1
-        let requestGeneration = skipPermissionsToggleGeneration
-        dangerouslySkipPermissions = enabled
-        Task { @MainActor in
-            let success = await settingsClient.setDangerouslySkipPermissions(enabled)
-            if !success, self.skipPermissionsToggleGeneration == requestGeneration {
-                // Revert optimistic toggle on failure only if no newer toggle has fired
-                self.dangerouslySkipPermissions = !enabled
-            }
-        }
-    }
-
     /// Replaces the video-embed domain allowlist, normalizing the input and
     /// persisting the result to the workspace config.
     func setMediaEmbedVideoAllowlistDomains(_ domains: [String]) {
@@ -3081,9 +3048,6 @@ public final class SettingsStore: ObservableObject {
         self.mediaEmbedsEnabledSince = mediaSettings.enabledSince
         self.mediaEmbedVideoAllowlistDomains = mediaSettings.domains
         self.userTimezone = Self.loadUserTimezone(config: config)
-
-        let permissionsConfig = config["permissions"] as? [String: Any]
-        self.dangerouslySkipPermissions = (permissionsConfig?["dangerouslySkipPermissions"] as? Bool) ?? false
 
         if let services = config["services"] as? [String: Any],
            let webSearch = services["web-search"] as? [String: Any],

--- a/clients/macos/vellum-assistantTests/MockSettingsClient.swift
+++ b/clients/macos/vellum-assistantTests/MockSettingsClient.swift
@@ -32,10 +32,6 @@ final class MockSettingsClient: SettingsClientProtocol {
     var setEmbeddingConfigResponse: EmbeddingConfigMessage?
     var telegramConfigResponse: TelegramConfigResponseMessage?
     var setTelegramConfigResponse: TelegramConfigResponseMessage?
-    var fetchDangerouslySkipPermissionsResponse: Bool?
-    var setDangerouslySkipPermissionsResponse: Bool = true
-    var fetchDangerouslySkipPermissionsCallCount = 0
-    var setDangerouslySkipPermissionsCalls: [Bool] = []
     var setSlackWebhookConfigResponse: Bool = true
     var channelVerificationResponses: [String: ChannelVerificationSessionResponseMessage] = [:]
     var sendChannelVerificationSessionResponse: ChannelVerificationSessionResponseMessage?
@@ -104,16 +100,6 @@ final class MockSettingsClient: SettingsClientProtocol {
     func setTelegramConfig(action: String, botToken: String?, commands: [TelegramConfigRequestCommand]?) async -> TelegramConfigResponseMessage? {
         setTelegramConfigCalls.append((action: action, botToken: botToken, commands: commands))
         return setTelegramConfigResponse
-    }
-
-    func fetchDangerouslySkipPermissions() async -> Bool? {
-        fetchDangerouslySkipPermissionsCallCount += 1
-        return fetchDangerouslySkipPermissionsResponse
-    }
-
-    func setDangerouslySkipPermissions(_ enabled: Bool) async -> Bool {
-        setDangerouslySkipPermissionsCalls.append(enabled)
-        return setDangerouslySkipPermissionsResponse
     }
 
     func setSlackWebhookConfig(action: String, webhookUrl: String?) async -> Bool {

--- a/clients/shared/Network/SettingsClient.swift
+++ b/clients/shared/Network/SettingsClient.swift
@@ -18,8 +18,6 @@ public protocol SettingsClientProtocol {
     func setEmbeddingConfig(provider: String, model: String?) async -> EmbeddingConfigMessage?
     func fetchTelegramConfig() async -> TelegramConfigResponseMessage?
     func setTelegramConfig(action: String, botToken: String?, commands: [TelegramConfigRequestCommand]?) async -> TelegramConfigResponseMessage?
-    func fetchDangerouslySkipPermissions() async -> Bool?
-    func setDangerouslySkipPermissions(_ enabled: Bool) async -> Bool
     func setSlackWebhookConfig(action: String, webhookUrl: String?) async -> Bool
     func fetchChannelVerificationStatus(channel: String) async -> ChannelVerificationSessionResponseMessage?
     func sendChannelVerificationSession(
@@ -238,43 +236,6 @@ public struct SettingsClient: SettingsClientProtocol {
         } catch {
             log.error("setTelegramConfig error: \(error.localizedDescription, privacy: .public)")
             return nil
-        }
-    }
-
-    public func fetchDangerouslySkipPermissions() async -> Bool? {
-        do {
-            let response = try await GatewayHTTPClient.get(
-                path: "config/permissions/skip", timeout: 10
-            )
-            guard response.isSuccess else {
-                log.error("fetchDangerouslySkipPermissions failed (HTTP \(response.statusCode))")
-                return nil
-            }
-            guard let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
-                  let enabled = json["enabled"] as? Bool else {
-                return nil
-            }
-            return enabled
-        } catch {
-            log.error("fetchDangerouslySkipPermissions error: \(error.localizedDescription, privacy: .public)")
-            return nil
-        }
-    }
-
-    public func setDangerouslySkipPermissions(_ enabled: Bool) async -> Bool {
-        do {
-            let body: [String: Any] = ["enabled": enabled]
-            let response = try await GatewayHTTPClient.put(
-                path: "config/permissions/skip", json: body, timeout: 10
-            )
-            guard response.isSuccess else {
-                log.error("setDangerouslySkipPermissions failed (HTTP \(response.statusCode))")
-                return false
-            }
-            return true
-        } catch {
-            log.error("setDangerouslySkipPermissions error: \(error.localizedDescription, privacy: .public)")
-            return false
         }
     }
 

--- a/clients/shared/Tests/ChatViewModelSlashCommandTests.swift
+++ b/clients/shared/Tests/ChatViewModelSlashCommandTests.swift
@@ -33,10 +33,6 @@ final class ChatViewModelSlashCommandTests: XCTestCase {
             commands: [TelegramConfigRequestCommand]?
         ) async -> TelegramConfigResponseMessage? { nil }
 
-        func fetchDangerouslySkipPermissions() async -> Bool? { nil }
-
-        func setDangerouslySkipPermissions(_ enabled: Bool) async -> Bool { false }
-
         func setSlackWebhookConfig(action: String, webhookUrl: String?) async -> Bool { false }
 
         func fetchChannelVerificationStatus(channel: String) async -> ChannelVerificationSessionResponseMessage? { nil }


### PR DESCRIPTION
## Summary
- Remove the Dangerously Skip Permissions toggle from Settings Developer tab
- Remove all SettingsStore properties, methods, and initialization for the feature
- Remove SettingsClient protocol methods and implementations
- Remove all mock/test stubs

Part of plan: rm-dangerous-skip-perms.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22480" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
