### PR TITLE
fix(security): remove dangerouslySkipPermissions config field and HTTP endpoints

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -1855,47 +1855,6 @@ paths:
               required:
                 - provider
               additionalProperties: false
-  /v1/config/permissions/skip:
-    get:
-      operationId: config_permissions_skip_get
-      summary: Get permission-skip flag
-      description: Return whether dangerouslySkipPermissions is enabled.
-      tags:
-        - config
-      responses:
-        "200":
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  enabled:
-                    type: boolean
-                required:
-                  - enabled
-                additionalProperties: false
-    put:
-      operationId: config_permissions_skip_put
-      summary: Set permission-skip flag
-      description: Enable or disable dangerouslySkipPermissions.
-      tags:
-        - config
-      responses:
-        "200":
-          description: Successful response
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                enabled:
-                  type: boolean
-              required:
-                - enabled
-              additionalProperties: false
   /v1/config/platform:
     get:
       operationId: config_platform_get

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -421,7 +421,6 @@ describe("AssistantConfigSchema", () => {
     const result = AssistantConfigSchema.parse({});
     expect(result.permissions).toEqual({
       mode: "workspace",
-      dangerouslySkipPermissions: false,
     });
   });
 
@@ -1129,7 +1128,6 @@ describe("loadConfig with schema validation", () => {
     const config = loadConfig();
     expect(config.permissions).toEqual({
       mode: "workspace",
-      dangerouslySkipPermissions: false,
     });
   });
 

--- a/assistant/src/config/schemas/security.ts
+++ b/assistant/src/config/schemas/security.ts
@@ -79,12 +79,6 @@ export const PermissionsConfigSchema = z
       .describe(
         "Permission mode — 'strict' requires explicit approval for all operations, 'workspace' allows operations within the workspace",
       ),
-    dangerouslySkipPermissions: z
-      .boolean({
-        error: "permissions.dangerouslySkipPermissions must be a boolean",
-      })
-      .default(false)
-      .describe("Auto-accept all permission prompts without asking"),
   })
   .describe("Permission enforcement mode for tool operations");
 

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -10,8 +10,6 @@
  * PUT    /v1/model/image-gen            — set image-gen model
  * GET    /v1/config/embeddings          — current embedding config
  * PUT    /v1/config/embeddings          — set embedding provider/model
- * GET    /v1/config/permissions/skip    — dangerouslySkipPermissions status
- * PUT    /v1/config/permissions/skip    — toggle dangerouslySkipPermissions
  * GET    /v1/config                     — full raw workspace config
  * PATCH  /v1/config                     — deep-merge partial config
  * GET    /v1/conversations/search       — search conversations
@@ -24,7 +22,6 @@ import { z } from "zod";
 
 import {
   deepMergeOverwrite,
-  getConfig,
   loadRawConfig,
   saveRawConfig,
 } from "../../config/loader.js";
@@ -113,9 +110,7 @@ function applyStoredProviderToLlmContextResult(
   const mergedSummary = normalized.summary
     ? { ...normalized.summary, provider }
     : { provider };
-  const summary = attachEstimatedCost(
-    mergedSummary as LlmContextSummary,
-  );
+  const summary = attachEstimatedCost(mergedSummary as LlmContextSummary);
   return { ...normalized, summary };
 }
 
@@ -321,57 +316,6 @@ export function conversationQueryRouteDefinitions(
             500,
           );
         }
-      },
-    },
-
-    // ── Permissions config ─────────────────────────────────────────────
-    {
-      endpoint: "config/permissions/skip",
-      method: "GET",
-      policyKey: "config/permissions/skip",
-      summary: "Get permission-skip flag",
-      description: "Return whether dangerouslySkipPermissions is enabled.",
-      tags: ["config"],
-      responseBody: z.object({
-        enabled: z.boolean(),
-      }),
-      handler: () => {
-        const config = getConfig();
-        return Response.json({
-          enabled: config.permissions.dangerouslySkipPermissions,
-        });
-      },
-    },
-    {
-      endpoint: "config/permissions/skip",
-      method: "PUT",
-      policyKey: "config/permissions/skip",
-      summary: "Set permission-skip flag",
-      description: "Enable or disable dangerouslySkipPermissions.",
-      tags: ["config"],
-      requestBody: z.object({
-        enabled: z.boolean(),
-      }),
-      handler: async ({ req }) => {
-        const body = (await req.json()) as { enabled?: unknown };
-        if (typeof body.enabled !== "boolean") {
-          return httpError(
-            "BAD_REQUEST",
-            "Missing or invalid field: enabled (boolean)",
-            400,
-          );
-        }
-        const raw = loadRawConfig();
-        const permissions: Record<string, unknown> =
-          raw.permissions != null &&
-          typeof raw.permissions === "object" &&
-          !Array.isArray(raw.permissions)
-            ? (raw.permissions as Record<string, unknown>)
-            : {};
-        permissions.dangerouslySkipPermissions = body.enabled;
-        raw.permissions = permissions;
-        saveRawConfig(raw);
-        return Response.json({ enabled: body.enabled });
       },
     },
 

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -137,24 +137,6 @@ export class PermissionChecker {
       }
 
       if (result.decision === "prompt") {
-        // dangerouslySkipPermissions: when enabled, auto-approve all prompts
-        // without user interaction. Deny rules are still respected (they
-        // return before reaching this block).
-        //
-        // Note: unlike guardian auto-approve and temporary overrides below,
-        // this intentionally does NOT check `context.requireFreshApproval`.
-        // The setting is designed to skip ALL interactive prompts
-        // unconditionally — it is an explicit operator opt-out from the
-        // permission system, so requireFreshApproval does not apply.
-        const cfg = getConfig();
-        if (cfg.permissions.dangerouslySkipPermissions) {
-          log.info(
-            { toolName: name, riskLevel },
-            "dangerouslySkipPermissions active — auto-approving without prompt",
-          );
-          return { allowed: true, decision: "dangerously_skip_permissions", riskLevel };
-        }
-
         // Guardian-trust sessions (e.g. scheduled jobs, reminders) should be
         // able to use bundled tools without interactive approval. The guardian
         // is the owner - prompting makes no sense when there is no client.


### PR DESCRIPTION
## Summary
- Remove dangerouslySkipPermissions field from the Zod config schema
- Remove GET/PUT config/permissions/skip runtime API endpoints
- Remove corresponding OpenAPI spec entries
- Remove dangerouslySkipPermissions auto-approve logic from permission-checker
- Update config-schema tests to match

Part of plan: rm-dangerous-skip-perms.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
