### PR TITLE
fix(security): remove dangerouslySkipPermissions from test mock configs

### DIFF
--- a/assistant/src/__tests__/require-fresh-approval.test.ts
+++ b/assistant/src/__tests__/require-fresh-approval.test.ts
@@ -60,7 +60,6 @@ const mockConfig = {
   },
   permissions: {
     mode: "workspace" as const,
-    dangerouslySkipPermissions: false,
   },
 };
 

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -34,7 +34,6 @@ const mockConfig = {
   },
   permissions: {
     mode: "workspace" as const,
-    dangerouslySkipPermissions: false,
   },
 };
 

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -52,7 +52,6 @@ const mockConfig = {
   },
   permissions: {
     mode: "workspace" as const,
-    dangerouslySkipPermissions: false,
   },
 };
 


### PR DESCRIPTION
## Summary
- Remove stale dangerouslySkipPermissions: false from mock config objects in 3 test files
- Mock configs now match the updated schema (permissions only has mode field)

Part of plan: rm-dangerous-skip-perms.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
