### PR TITLE
fix(security): remove dangerouslySkipPermissions feature entirely

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -1855,47 +1855,6 @@ paths:
               required:
                 - provider
               additionalProperties: false
-  /v1/config/permissions/skip:
-    get:
-      operationId: config_permissions_skip_get
-      summary: Get permission-skip flag
-      description: Return whether dangerouslySkipPermissions is enabled.
-      tags:
-        - config
-      responses:
-        "200":
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  enabled:
-                    type: boolean
-                required:
-                  - enabled
-                additionalProperties: false
-    put:
-      operationId: config_permissions_skip_put
-      summary: Set permission-skip flag
-      description: Enable or disable dangerouslySkipPermissions.
-      tags:
-        - config
-      responses:
-        "200":
-          description: Successful response
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                enabled:
-                  type: boolean
-              required:
-                - enabled
-              additionalProperties: false
   /v1/config/platform:
     get:
       operationId: config_platform_get

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -421,7 +421,6 @@ describe("AssistantConfigSchema", () => {
     const result = AssistantConfigSchema.parse({});
     expect(result.permissions).toEqual({
       mode: "workspace",
-      dangerouslySkipPermissions: false,
     });
   });
 
@@ -1129,7 +1128,6 @@ describe("loadConfig with schema validation", () => {
     const config = loadConfig();
     expect(config.permissions).toEqual({
       mode: "workspace",
-      dangerouslySkipPermissions: false,
     });
   });
 

--- a/assistant/src/__tests__/permission-types.test.ts
+++ b/assistant/src/__tests__/permission-types.test.ts
@@ -15,7 +15,6 @@ describe("isAllowDecision", () => {
     "always_allow",
     "always_allow_high_risk",
     "temporary_override",
-    "dangerously_skip_permissions",
   ];
 
   for (const decision of allowDecisions) {

--- a/assistant/src/__tests__/require-fresh-approval.test.ts
+++ b/assistant/src/__tests__/require-fresh-approval.test.ts
@@ -60,7 +60,6 @@ const mockConfig = {
   },
   permissions: {
     mode: "workspace" as const,
-    dangerouslySkipPermissions: false,
   },
 };
 

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -34,7 +34,6 @@ const mockConfig = {
   },
   permissions: {
     mode: "workspace" as const,
-    dangerouslySkipPermissions: false,
   },
 };
 

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -52,7 +52,6 @@ const mockConfig = {
   },
   permissions: {
     mode: "workspace" as const,
-    dangerouslySkipPermissions: false,
   },
 };
 

--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -403,8 +403,7 @@ function mapDecisionToOptionId(
     decision === "allow_conversation" ||
     decision === "always_allow" ||
     decision === "always_allow_high_risk" ||
-    decision === "temporary_override" ||
-    decision === "dangerously_skip_permissions";
+    decision === "temporary_override";
 
   if (isAllow) {
     // Prefer allow_always for persistent decisions, fallback to allow_once

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -124,6 +124,10 @@ const DEPRECATED_FIELDS: Record<string, string> = {
     "providerOrder has been removed from the config schema. " +
     "Provider selection is now handled automatically. " +
     "The field will be removed from your config file.",
+  "permissions.dangerouslySkipPermissions":
+    "permissions.dangerouslySkipPermissions has been removed. " +
+    "Permission prompts are now always shown when required. " +
+    "The field will be removed from your config file.",
 };
 
 /**

--- a/assistant/src/config/schemas/security.ts
+++ b/assistant/src/config/schemas/security.ts
@@ -79,12 +79,6 @@ export const PermissionsConfigSchema = z
       .describe(
         "Permission mode — 'strict' requires explicit approval for all operations, 'workspace' allows operations within the workspace",
       ),
-    dangerouslySkipPermissions: z
-      .boolean({
-        error: "permissions.dangerouslySkipPermissions must be a boolean",
-      })
-      .default(false)
-      .describe("Auto-accept all permission prompts without asking"),
   })
   .describe("Permission enforcement mode for tool operations");
 

--- a/assistant/src/credential-execution/approval-bridge.ts
+++ b/assistant/src/credential-execution/approval-bridge.ts
@@ -103,7 +103,6 @@ function mapUserDecisionToCesDecision(
         userDecision: decision,
       };
     case "temporary_override":
-    case "dangerously_skip_permissions":
       return {
         grantDecision: "approved",
         ttl: undefined,

--- a/assistant/src/events/domain-events.ts
+++ b/assistant/src/events/domain-events.ts
@@ -25,8 +25,7 @@ export interface ToolDomainEvents {
       | "always_allow_high_risk"
       | "deny"
       | "always_deny"
-      | "temporary_override"
-      | "dangerously_skip_permissions";
+      | "temporary_override";
     riskLevel: string;
     decidedAtMs: number;
   };

--- a/assistant/src/permissions/types.ts
+++ b/assistant/src/permissions/types.ts
@@ -24,8 +24,7 @@ export type UserDecision =
   | "always_allow_high_risk"
   | "deny"
   | "always_deny"
-  | "temporary_override"
-  | "dangerously_skip_permissions";
+  | "temporary_override";
 
 /** Returns true for any allow-variant decision. Centralizes the check to prevent omissions when new allow variants are added. */
 export function isAllowDecision(decision: UserDecision): boolean {
@@ -35,8 +34,7 @@ export function isAllowDecision(decision: UserDecision): boolean {
     decision === "allow_conversation" ||
     decision === "always_allow" ||
     decision === "always_allow_high_risk" ||
-    decision === "temporary_override" ||
-    decision === "dangerously_skip_permissions"
+    decision === "temporary_override"
   );
 }
 

--- a/assistant/src/prompts/templates/UPDATES.md
+++ b/assistant/src/prompts/templates/UPDATES.md
@@ -10,6 +10,12 @@ _ Format is freeform markdown. Write notes that help the assistant
 _ understand what changed and how it affects behavior, capabilities,
 _ or available tools. Focus on what matters to the user experience.
 
+<!-- vellum-update-release:rm-dangerous-skip-perms -->
+## `dangerouslySkipPermissions` removed
+
+The `permissions.dangerouslySkipPermissions` config option has been removed for security reasons. Permission prompts are now always shown when required — they can no longer be globally suppressed. If your user previously relied on this setting, they will now see permission prompts for sensitive actions. Users with the stale field in their config will see a deprecation warning and the field will be automatically cleaned up.
+<!-- /vellum-update-release:rm-dangerous-skip-perms -->
+
 <!-- vellum-update-release:heartbeat-default -->
 ## Heartbeat now enabled by default
 

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -349,10 +349,6 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "config/embeddings:GET", scopes: ["settings.read"] },
   { endpoint: "config/embeddings:PUT", scopes: ["settings.write"] },
 
-  // Permissions config
-  { endpoint: "config/permissions/skip:GET", scopes: ["settings.read"] },
-  { endpoint: "config/permissions/skip:PUT", scopes: ["settings.write"] },
-
   // Generic config read/patch
   { endpoint: "config:GET", scopes: ["settings.read"] },
   { endpoint: "config:PATCH", scopes: ["settings.write"] },

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -10,8 +10,6 @@
  * PUT    /v1/model/image-gen            — set image-gen model
  * GET    /v1/config/embeddings          — current embedding config
  * PUT    /v1/config/embeddings          — set embedding provider/model
- * GET    /v1/config/permissions/skip    — dangerouslySkipPermissions status
- * PUT    /v1/config/permissions/skip    — toggle dangerouslySkipPermissions
  * GET    /v1/config                     — full raw workspace config
  * PATCH  /v1/config                     — deep-merge partial config
  * GET    /v1/conversations/search       — search conversations
@@ -24,7 +22,6 @@ import { z } from "zod";
 
 import {
   deepMergeOverwrite,
-  getConfig,
   loadRawConfig,
   saveRawConfig,
 } from "../../config/loader.js";
@@ -113,9 +110,7 @@ function applyStoredProviderToLlmContextResult(
   const mergedSummary = normalized.summary
     ? { ...normalized.summary, provider }
     : { provider };
-  const summary = attachEstimatedCost(
-    mergedSummary as LlmContextSummary,
-  );
+  const summary = attachEstimatedCost(mergedSummary as LlmContextSummary);
   return { ...normalized, summary };
 }
 
@@ -321,57 +316,6 @@ export function conversationQueryRouteDefinitions(
             500,
           );
         }
-      },
-    },
-
-    // ── Permissions config ─────────────────────────────────────────────
-    {
-      endpoint: "config/permissions/skip",
-      method: "GET",
-      policyKey: "config/permissions/skip",
-      summary: "Get permission-skip flag",
-      description: "Return whether dangerouslySkipPermissions is enabled.",
-      tags: ["config"],
-      responseBody: z.object({
-        enabled: z.boolean(),
-      }),
-      handler: () => {
-        const config = getConfig();
-        return Response.json({
-          enabled: config.permissions.dangerouslySkipPermissions,
-        });
-      },
-    },
-    {
-      endpoint: "config/permissions/skip",
-      method: "PUT",
-      policyKey: "config/permissions/skip",
-      summary: "Set permission-skip flag",
-      description: "Enable or disable dangerouslySkipPermissions.",
-      tags: ["config"],
-      requestBody: z.object({
-        enabled: z.boolean(),
-      }),
-      handler: async ({ req }) => {
-        const body = (await req.json()) as { enabled?: unknown };
-        if (typeof body.enabled !== "boolean") {
-          return httpError(
-            "BAD_REQUEST",
-            "Missing or invalid field: enabled (boolean)",
-            400,
-          );
-        }
-        const raw = loadRawConfig();
-        const permissions: Record<string, unknown> =
-          raw.permissions != null &&
-          typeof raw.permissions === "object" &&
-          !Array.isArray(raw.permissions)
-            ? (raw.permissions as Record<string, unknown>)
-            : {};
-        permissions.dangerouslySkipPermissions = body.enabled;
-        raw.permissions = permissions;
-        saveRawConfig(raw);
-        return Response.json({ enabled: body.enabled });
       },
     },
 

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -1,6 +1,6 @@
 /**
  * HTTP route definitions for model configuration, embedding configuration,
- * permissions configuration, conversation search, message content, LLM
+ * conversation search, message content, LLM
  * context inspection, and queued message deletion.
  *
  * These routes expose conversation query functionality over the HTTP API.

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -137,24 +137,6 @@ export class PermissionChecker {
       }
 
       if (result.decision === "prompt") {
-        // dangerouslySkipPermissions: when enabled, auto-approve all prompts
-        // without user interaction. Deny rules are still respected (they
-        // return before reaching this block).
-        //
-        // Note: unlike guardian auto-approve and temporary overrides below,
-        // this intentionally does NOT check `context.requireFreshApproval`.
-        // The setting is designed to skip ALL interactive prompts
-        // unconditionally — it is an explicit operator opt-out from the
-        // permission system, so requireFreshApproval does not apply.
-        const cfg = getConfig();
-        if (cfg.permissions.dangerouslySkipPermissions) {
-          log.info(
-            { toolName: name, riskLevel },
-            "dangerouslySkipPermissions active — auto-approving without prompt",
-          );
-          return { allowed: true, decision: "dangerously_skip_permissions", riskLevel };
-        }
-
         // Guardian-trust sessions (e.g. scheduled jobs, reminders) should be
         // able to use bundled tools without interactive approval. The guardian
         // is the owner - prompting makes no sense when there is no client.

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -119,31 +119,6 @@ struct SettingsDeveloperTab: View {
                 revokeAssistantApiKeySection
             }
 
-            // Dangerously Skip Permissions
-            SettingsCard(title: "Dangerously Skip Permissions", subtitle: "Auto-accept all permission prompts without asking. The assistant will never pause for approval — use with caution.") {
-                let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId })
-                let isDisabled = (assistant?.isRemote ?? false) && !(assistant?.isDocker ?? false)
-                HStack(alignment: .top, spacing: VSpacing.sm) {
-                    VToggle(isOn: Binding(
-                        get: { store.dangerouslySkipPermissions },
-                        set: { store.setDangerouslySkipPermissions($0) }
-                    ))
-                    .accessibilityLabel("Dangerously Skip Permissions")
-                    .disabled(isDisabled)
-                    .padding(.top, 2)
-                    VStack(alignment: .leading, spacing: VSpacing.xs) {
-                        Text("Skip all permission prompts")
-                            .font(VFont.bodyMediumLighter)
-                            .foregroundStyle(VColor.contentSecondary)
-                        Text(isDisabled
-                            ? "This setting cannot be changed for remote assistants."
-                            : "When enabled, tools execute immediately without asking for approval. Explicit deny rules are still respected.")
-                            .font(VFont.labelDefault)
-                            .foregroundStyle(VColor.contentTertiary)
-                    }
-                }
-            }
-
             // Permission Simulator
             if let model = testerModel {
                 ToolPermissionTesterView(model: model)
@@ -157,9 +132,6 @@ struct SettingsDeveloperTab: View {
             sentryTestingSection
         }
         .onAppear {
-            // Fetch skip-permissions state for Docker assistants
-            store.refreshDangerouslySkipPermissions()
-
             // Assistant info setup
             lockfileAssistants = LockfileAssistant.loadAll()
             selectedAssistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -310,14 +310,6 @@ public final class SettingsStore: ObservableObject {
             .flatMap { LockfileAssistant.loadByName($0) }?.isRemote ?? false
     }
 
-    /// Whether the connected assistant runs in Docker on the local machine.
-    /// Docker assistants are "remote" for filesystem purposes (workspace is on
-    /// a Docker volume) but support config changes via the HTTP API.
-    private var isCurrentAssistantDocker: Bool {
-        UserDefaults.standard.string(forKey: "connectedAssistantId")
-            .flatMap { LockfileAssistant.loadByName($0) }?.isDocker ?? false
-    }
-
     /// Guards against stale `get` responses overwriting an optimistic
     /// toggle. Set when `setIngressEnabled` fires; cleared once a matching
     /// response arrives.

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -92,12 +92,6 @@ public final class SettingsStore: ObservableObject {
     @Published var mediaEmbedVideoAllowlistDomains: [String]
     @Published var userTimezone: String?
 
-    // MARK: - Permissions Settings
-
-    @Published var dangerouslySkipPermissions: Bool
-    /// Monotonic counter to ignore stale rollback responses from rapid toggles.
-    private var skipPermissionsToggleGeneration: UInt = 0
-
     // MARK: - Telegram Integration State
 
     @Published var telegramHasBotToken: Bool = false
@@ -440,9 +434,6 @@ public final class SettingsStore: ObservableObject {
         self.mediaEmbedsEnabledSince = mediaSettings.enabledSince
         self.mediaEmbedVideoAllowlistDomains = mediaSettings.domains
         self.userTimezone = Self.loadUserTimezone(config: emptyConfig)
-
-        // Permissions default to false until daemon provides config
-        self.dangerouslySkipPermissions = false
 
         // Service modes use defaults until daemon provides config
         loadServiceModes(config: emptyConfig)
@@ -957,17 +948,6 @@ public final class SettingsStore: ObservableObject {
                 self.embeddingEnabled = status.enabled
                 self.embeddingDegraded = status.degraded
             }
-        }
-    }
-
-    /// Fetches the current dangerouslySkipPermissions state from the daemon
-    /// over HTTP. Only meaningful for Docker assistants where the config lives
-    /// inside the container and cannot be read from the host filesystem.
-    func refreshDangerouslySkipPermissions() {
-        guard isCurrentAssistantDocker else { return }
-        Task { @MainActor in
-            guard let enabled = await settingsClient.fetchDangerouslySkipPermissions() else { return }
-            self.dangerouslySkipPermissions = enabled
         }
     }
 
@@ -2934,19 +2914,6 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
-    func setDangerouslySkipPermissions(_ enabled: Bool) {
-        skipPermissionsToggleGeneration &+= 1
-        let requestGeneration = skipPermissionsToggleGeneration
-        dangerouslySkipPermissions = enabled
-        Task { @MainActor in
-            let success = await settingsClient.setDangerouslySkipPermissions(enabled)
-            if !success, self.skipPermissionsToggleGeneration == requestGeneration {
-                // Revert optimistic toggle on failure only if no newer toggle has fired
-                self.dangerouslySkipPermissions = !enabled
-            }
-        }
-    }
-
     /// Replaces the video-embed domain allowlist, normalizing the input and
     /// persisting the result to the workspace config.
     func setMediaEmbedVideoAllowlistDomains(_ domains: [String]) {
@@ -3081,9 +3048,6 @@ public final class SettingsStore: ObservableObject {
         self.mediaEmbedsEnabledSince = mediaSettings.enabledSince
         self.mediaEmbedVideoAllowlistDomains = mediaSettings.domains
         self.userTimezone = Self.loadUserTimezone(config: config)
-
-        let permissionsConfig = config["permissions"] as? [String: Any]
-        self.dangerouslySkipPermissions = (permissionsConfig?["dangerouslySkipPermissions"] as? Bool) ?? false
 
         if let services = config["services"] as? [String: Any],
            let webSearch = services["web-search"] as? [String: Any],

--- a/clients/macos/vellum-assistantTests/MockSettingsClient.swift
+++ b/clients/macos/vellum-assistantTests/MockSettingsClient.swift
@@ -32,10 +32,6 @@ final class MockSettingsClient: SettingsClientProtocol {
     var setEmbeddingConfigResponse: EmbeddingConfigMessage?
     var telegramConfigResponse: TelegramConfigResponseMessage?
     var setTelegramConfigResponse: TelegramConfigResponseMessage?
-    var fetchDangerouslySkipPermissionsResponse: Bool?
-    var setDangerouslySkipPermissionsResponse: Bool = true
-    var fetchDangerouslySkipPermissionsCallCount = 0
-    var setDangerouslySkipPermissionsCalls: [Bool] = []
     var setSlackWebhookConfigResponse: Bool = true
     var channelVerificationResponses: [String: ChannelVerificationSessionResponseMessage] = [:]
     var sendChannelVerificationSessionResponse: ChannelVerificationSessionResponseMessage?
@@ -104,16 +100,6 @@ final class MockSettingsClient: SettingsClientProtocol {
     func setTelegramConfig(action: String, botToken: String?, commands: [TelegramConfigRequestCommand]?) async -> TelegramConfigResponseMessage? {
         setTelegramConfigCalls.append((action: action, botToken: botToken, commands: commands))
         return setTelegramConfigResponse
-    }
-
-    func fetchDangerouslySkipPermissions() async -> Bool? {
-        fetchDangerouslySkipPermissionsCallCount += 1
-        return fetchDangerouslySkipPermissionsResponse
-    }
-
-    func setDangerouslySkipPermissions(_ enabled: Bool) async -> Bool {
-        setDangerouslySkipPermissionsCalls.append(enabled)
-        return setDangerouslySkipPermissionsResponse
     }
 
     func setSlackWebhookConfig(action: String, webhookUrl: String?) async -> Bool {

--- a/clients/shared/Network/SettingsClient.swift
+++ b/clients/shared/Network/SettingsClient.swift
@@ -18,8 +18,6 @@ public protocol SettingsClientProtocol {
     func setEmbeddingConfig(provider: String, model: String?) async -> EmbeddingConfigMessage?
     func fetchTelegramConfig() async -> TelegramConfigResponseMessage?
     func setTelegramConfig(action: String, botToken: String?, commands: [TelegramConfigRequestCommand]?) async -> TelegramConfigResponseMessage?
-    func fetchDangerouslySkipPermissions() async -> Bool?
-    func setDangerouslySkipPermissions(_ enabled: Bool) async -> Bool
     func setSlackWebhookConfig(action: String, webhookUrl: String?) async -> Bool
     func fetchChannelVerificationStatus(channel: String) async -> ChannelVerificationSessionResponseMessage?
     func sendChannelVerificationSession(
@@ -238,43 +236,6 @@ public struct SettingsClient: SettingsClientProtocol {
         } catch {
             log.error("setTelegramConfig error: \(error.localizedDescription, privacy: .public)")
             return nil
-        }
-    }
-
-    public func fetchDangerouslySkipPermissions() async -> Bool? {
-        do {
-            let response = try await GatewayHTTPClient.get(
-                path: "config/permissions/skip", timeout: 10
-            )
-            guard response.isSuccess else {
-                log.error("fetchDangerouslySkipPermissions failed (HTTP \(response.statusCode))")
-                return nil
-            }
-            guard let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
-                  let enabled = json["enabled"] as? Bool else {
-                return nil
-            }
-            return enabled
-        } catch {
-            log.error("fetchDangerouslySkipPermissions error: \(error.localizedDescription, privacy: .public)")
-            return nil
-        }
-    }
-
-    public func setDangerouslySkipPermissions(_ enabled: Bool) async -> Bool {
-        do {
-            let body: [String: Any] = ["enabled": enabled]
-            let response = try await GatewayHTTPClient.put(
-                path: "config/permissions/skip", json: body, timeout: 10
-            )
-            guard response.isSuccess else {
-                log.error("setDangerouslySkipPermissions failed (HTTP \(response.statusCode))")
-                return false
-            }
-            return true
-        } catch {
-            log.error("setDangerouslySkipPermissions error: \(error.localizedDescription, privacy: .public)")
-            return false
         }
     }
 

--- a/clients/shared/Tests/ChatViewModelSlashCommandTests.swift
+++ b/clients/shared/Tests/ChatViewModelSlashCommandTests.swift
@@ -33,10 +33,6 @@ final class ChatViewModelSlashCommandTests: XCTestCase {
             commands: [TelegramConfigRequestCommand]?
         ) async -> TelegramConfigResponseMessage? { nil }
 
-        func fetchDangerouslySkipPermissions() async -> Bool? { nil }
-
-        func setDangerouslySkipPermissions(_ enabled: Bool) async -> Bool { false }
-
         func setSlackWebhookConfig(action: String, webhookUrl: String?) async -> Bool { false }
 
         func fetchChannelVerificationStatus(channel: String) async -> ChannelVerificationSessionResponseMessage? { nil }


### PR DESCRIPTION
## Summary
Removes the `dangerouslySkipPermissions` feature entirely from the codebase. This feature allowed bypassing all permission prompts and was a security liability — the flag lived in the workspace config (`.assistant.json`) where the model could flip it via auto-allowed file writes, creating a privilege escalation vulnerability.

## PRs merged into feature branch
- #22479: fix(security): remove dangerouslySkipPermissions bypass from permission checker
- #22481: fix(security): remove dangerouslySkipPermissions config field and HTTP endpoints
- #22480: fix(security): remove dangerouslySkipPermissions from macOS client
- #22482: fix(security): remove dangerouslySkipPermissions from test mock configs

## What was removed
- Permission checker bypass block that auto-approved all prompts when flag was set
- `dangerously_skip_permissions` decision variant from `UserDecision` type and all consumers
- Config schema field, HTTP API endpoints (`GET/PUT config/permissions/skip`), OpenAPI spec entries
- macOS client UI toggle, SettingsStore properties/methods, SettingsClient protocol methods
- All test mock references

Part of plan: rm-dangerous-skip-perms.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
