### PR TITLE
fix: remove stale permissions reference from conversation-query-routes header

### DIFF
--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -1,6 +1,6 @@
 /**
  * HTTP route definitions for model configuration, embedding configuration,
- * permissions configuration, conversation search, message content, LLM
+ * conversation search, message content, LLM
  * context inspection, and queued message deletion.
  *
  * These routes expose conversation query functionality over the HTTP API.


### PR DESCRIPTION
## Summary
Remove stale 'permissions configuration' mention from file header comment after endpoints were removed.

Fixes gap from self-review of rm-dangerous-skip-perms.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
