### PR TITLE
fix: remove orphaned route policy entries for deleted skip-permissions endpoints

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -349,10 +349,6 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "config/embeddings:GET", scopes: ["settings.read"] },
   { endpoint: "config/embeddings:PUT", scopes: ["settings.write"] },
 
-  // Permissions config
-  { endpoint: "config/permissions/skip:GET", scopes: ["settings.read"] },
-  { endpoint: "config/permissions/skip:PUT", scopes: ["settings.write"] },
-
   // Generic config read/patch
   { endpoint: "config:GET", scopes: ["settings.read"] },
   { endpoint: "config:PATCH", scopes: ["settings.write"] },


### PR DESCRIPTION
## Summary
Remove stale auth policy entries for the deleted config/permissions/skip GET and PUT endpoints.

Fixes gap from self-review of rm-dangerous-skip-perms.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22486" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
