### PR TITLE
ci: add feature flag registry / LaunchDarkly sync check

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -138,6 +138,24 @@ jobs:
           path: assistant/.test-durations
           key: test-durations-${{ github.run_id }}
 
+  feature-flag-sync-check:
+    name: Feature Flag Sync Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.9'
+
+      - name: Check registry flags exist in LaunchDarkly
+        run: bun run meta/feature-flags/check-launchdarkly-sync.ts
+        env:
+          PLATFORM_API_URL: ${{ secrets.PLATFORM_API_URL }}
+
   openapi-check:
     name: OpenAPI Spec Check
     runs-on: ubuntu-latest
@@ -170,7 +188,7 @@ jobs:
 
   notify-assistant:
     name: Slack Notification (Assistant)
-    needs: [lint, typecheck, test]
+    needs: [lint, typecheck, test, feature-flag-sync-check]
     if: always()
     continue-on-error: true
     runs-on: ubuntu-latest
@@ -183,11 +201,11 @@ jobs:
         run: |
           GITHUB_USER="${{ github.actor }}"
 
-          if [[ "${{ needs.lint.result }}" == "failure" || "${{ needs.typecheck.result }}" == "failure" || "${{ needs.test.result }}" == "failure" ]]; then
+          if [[ "${{ needs.lint.result }}" == "failure" || "${{ needs.typecheck.result }}" == "failure" || "${{ needs.test.result }}" == "failure" || "${{ needs.feature-flag-sync-check.result }}" == "failure" ]]; then
             STATUS="failure"
-          elif [[ "${{ needs.lint.result }}" == "cancelled" || "${{ needs.typecheck.result }}" == "cancelled" || "${{ needs.test.result }}" == "cancelled" ]]; then
+          elif [[ "${{ needs.lint.result }}" == "cancelled" || "${{ needs.typecheck.result }}" == "cancelled" || "${{ needs.test.result }}" == "cancelled" || "${{ needs.feature-flag-sync-check.result }}" == "cancelled" ]]; then
             STATUS="cancelled"
-          elif [[ "${{ needs.lint.result }}" == "skipped" || "${{ needs.typecheck.result }}" == "skipped" || "${{ needs.test.result }}" == "skipped" ]]; then
+          elif [[ "${{ needs.lint.result }}" == "skipped" || "${{ needs.typecheck.result }}" == "skipped" || "${{ needs.test.result }}" == "skipped" || "${{ needs.feature-flag-sync-check.result }}" == "skipped" ]]; then
             STATUS="skipped"
           else
             STATUS="success"

--- a/.github/workflows/pr-assistant.yaml
+++ b/.github/workflows/pr-assistant.yaml
@@ -209,6 +209,24 @@ jobs:
       - name: Check OpenAPI spec is up to date
         run: bun run generate:openapi -- --check
 
+  feature-flag-sync-check:
+    name: Feature Flag Sync Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.9'
+
+      - name: Check registry flags exist in LaunchDarkly
+        run: bun run meta/feature-flags/check-launchdarkly-sync.ts
+        env:
+          PLATFORM_API_URL: ${{ secrets.PLATFORM_API_URL }}
+
   lint-bundled-skills:
     name: Lint Bundled Skills
     runs-on: ubuntu-latest

--- a/meta/feature-flags/check-launchdarkly-sync.ts
+++ b/meta/feature-flags/check-launchdarkly-sync.ts
@@ -1,0 +1,90 @@
+/**
+ * Standalone Bun script that validates every feature flag key in the local
+ * registry exists in LaunchDarkly (via the platform's public feature-flags
+ * endpoint).
+ *
+ * Usage:
+ *   PLATFORM_API_URL=https://... bun run meta/feature-flags/check-launchdarkly-sync.ts
+ *
+ * Exit codes:
+ *   0 — all registry flags found in LaunchDarkly
+ *   1 — missing flags, missing env var, or API error
+ */
+
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+
+// ---------------------------------------------------------------------------
+// 1. Validate environment
+// ---------------------------------------------------------------------------
+
+const baseUrl = process.env.PLATFORM_API_URL;
+if (!baseUrl) {
+  console.error('Error: PLATFORM_API_URL environment variable is required but not set.');
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// 2. Load local registry
+// ---------------------------------------------------------------------------
+
+interface RegistryFlag {
+  key: string;
+  [k: string]: unknown;
+}
+
+interface Registry {
+  flags: RegistryFlag[];
+}
+
+const registryPath = join(import.meta.dirname ?? __dirname, 'feature-flag-registry.json');
+const registryRaw = await readFile(registryPath, 'utf-8');
+const registry: Registry = JSON.parse(registryRaw);
+const registryKeys = new Set(registry.flags.map((f) => f.key));
+
+// ---------------------------------------------------------------------------
+// 3. Fetch flags from the platform API
+// ---------------------------------------------------------------------------
+
+const apiUrl = `${baseUrl.replace(/\/+$/, '')}/v1/feature-flags/`;
+
+let response: Response;
+try {
+  response = await fetch(apiUrl, { signal: AbortSignal.timeout(10_000) });
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`Error: Failed to reach the platform API at ${apiUrl}`);
+  console.error(`  ${message}`);
+  process.exit(1);
+}
+
+if (!response.ok) {
+  const body = await response.text().catch(() => '(unable to read response body)');
+  console.error(`Error: Platform API returned HTTP ${response.status}`);
+  console.error(`  ${body}`);
+  process.exit(1);
+}
+
+interface ApiResponse {
+  flags: { key: string; [k: string]: unknown }[];
+}
+
+const apiData: ApiResponse = await response.json();
+const apiKeys = new Set(apiData.flags.map((f) => f.key));
+
+// ---------------------------------------------------------------------------
+// 4. Compare
+// ---------------------------------------------------------------------------
+
+const missingKeys = [...registryKeys].filter((k) => !apiKeys.has(k));
+
+if (missingKeys.length === 0) {
+  console.log(`\u2713 All ${registryKeys.size} registry flags found in LaunchDarkly`);
+  process.exit(0);
+} else {
+  const list = missingKeys.map((k) => `  - ${k}`).join('\n');
+  console.error(
+    `\u2717 ${missingKeys.length} registry flag${missingKeys.length === 1 ? '' : 's'} not found in LaunchDarkly:\n${list}`,
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- Add standalone Bun script that validates all feature flag keys in the registry exist in LaunchDarkly via the platform API
- Add feature-flag-sync-check job to both PR and main CI workflows
- Script uses zero external dependencies (Bun builtins only)

Part of plan: ff-launchdarkly-sync-ci.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
