### PR TITLE
fix: update AGENTS.md to mention LaunchDarkly requirement for new flags

### DIFF
--- a/meta/feature-flags/AGENTS.md
+++ b/meta/feature-flags/AGENTS.md
@@ -42,6 +42,8 @@ The `id` and `key` fields in `feature-flag-registry.json` **must match** and bot
    bun run meta/feature-flags/sync-bundled-copies.ts
    ```
 
+3. **Create the flag in LaunchDarkly** (via the LaunchDarkly dashboard or API). The CI feature-flag sync check will fail if a flag exists in the registry but not in LaunchDarkly.
+
 ## Creating a Feature Gate
 
 Define a constant using the flag's `id` directly and a predicate function that delegates to the resolver:


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for ff-launchdarkly-sync-ci.md.

**Gap:** AGENTS.md not updated to reflect LaunchDarkly requirement for new flags
**What was expected:** Adding a New Flag section should mention that flags must exist in LaunchDarkly
**What was found:** No mention of LaunchDarkly or CI sync check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
