### PR TITLE
Add loopback ports to Outlook and Twitter for desktop OAuth support

### DIFF
--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -227,6 +227,7 @@ const PROVIDER_SEED_DATA: Record<
     },
     tokenEndpointAuthMethod: "client_secret_basic",
     callbackTransport: "gateway",
+    loopbackPort: 17335,
     injectionTemplates: [
       {
         hostPattern: "api.x.com",
@@ -640,8 +641,14 @@ const PROVIDER_SEED_DATA: Record<
       forbiddenScopes: [],
     },
     extraParams: { prompt: "consent" },
+    // client_secret_post is safe with loopback: the token exchange is a
+    // server-side HTTP call from the assistant process to Microsoft's token
+    // endpoint — the client secret is never exposed to the browser. The
+    // callback transport only affects where the browser redirects with the
+    // authorization code.
     tokenEndpointAuthMethod: "client_secret_post",
     callbackTransport: "gateway",
+    loopbackPort: 17334,
     managedServiceConfigKey: "outlook-oauth",
     injectionTemplates: [
       {


### PR DESCRIPTION
## Summary
- Add `loopbackPort: 17334` to Outlook provider seed data
- Add `loopbackPort: 17335` to Twitter provider seed data
- Add comment clarifying client_secret_post works with loopback (token exchange is server-side)

Part of plan: dynamic-oauth-transport.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
