### PR TITLE
Accept `callback_transport` parameter on OAuth connect and plumb through orchestrator

### DIFF
--- a/assistant/src/__tests__/oauth-apps-routes.test.ts
+++ b/assistant/src/__tests__/oauth-apps-routes.test.ts
@@ -89,16 +89,18 @@ mock.module("../oauth/oauth-store.js", () => ({
   ),
 }));
 
+const mockOrchestrateOAuthConnect = mock(() =>
+  Promise.resolve({
+    success: true,
+    deferred: false,
+    grantedScopes: [],
+    accountInfo: null,
+    refreshTokenPresent: false,
+  }),
+);
+
 mock.module("../oauth/connect-orchestrator.js", () => ({
-  orchestrateOAuthConnect: mock(() =>
-    Promise.resolve({
-      success: true,
-      deferred: false,
-      grantedScopes: [],
-      accountInfo: null,
-      refreshTokenPresent: false,
-    }),
-  ),
+  orchestrateOAuthConnect: mockOrchestrateOAuthConnect,
 }));
 
 import { oauthAppsRouteDefinitions } from "../runtime/routes/oauth-apps.js";
@@ -201,5 +203,107 @@ describe("GET /v1/oauth/apps", () => {
     };
 
     expect(body.provider).toBeNull();
+  });
+});
+
+describe("POST /v1/oauth/apps/:appId/connect — callback_transport", () => {
+  function connectRequest(body?: unknown) {
+    return new Request("http://localhost/v1/oauth/apps/app-1/connect", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+  }
+
+  test('callback_transport: "gateway" is accepted and passed through', async () => {
+    mockOrchestrateOAuthConnect.mockClear();
+    const req = connectRequest({ callback_transport: "gateway" });
+    const url = new URL(req.url);
+    const res = await getRoute("POST", "oauth/apps/:appId/connect").handler({
+      req,
+      url,
+      server: null as never,
+      authContext: null as never,
+      params: { appId: "app-1" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockOrchestrateOAuthConnect).toHaveBeenCalledTimes(1);
+    const callArgs = mockOrchestrateOAuthConnect.mock.calls[0]![0] as {
+      callbackTransport: string;
+    };
+    expect(callArgs.callbackTransport).toBe("gateway");
+  });
+
+  test('callback_transport: "loopback" is accepted and passed through', async () => {
+    mockOrchestrateOAuthConnect.mockClear();
+    const req = connectRequest({ callback_transport: "loopback" });
+    const url = new URL(req.url);
+    const res = await getRoute("POST", "oauth/apps/:appId/connect").handler({
+      req,
+      url,
+      server: null as never,
+      authContext: null as never,
+      params: { appId: "app-1" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockOrchestrateOAuthConnect).toHaveBeenCalledTimes(1);
+    const callArgs = mockOrchestrateOAuthConnect.mock.calls[0]![0] as {
+      callbackTransport: string;
+    };
+    expect(callArgs.callbackTransport).toBe("loopback");
+  });
+
+  test('omitting callback_transport defaults to "loopback"', async () => {
+    mockOrchestrateOAuthConnect.mockClear();
+    const req = connectRequest({ scopes: ["email"] });
+    const url = new URL(req.url);
+    const res = await getRoute("POST", "oauth/apps/:appId/connect").handler({
+      req,
+      url,
+      server: null as never,
+      authContext: null as never,
+      params: { appId: "app-1" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockOrchestrateOAuthConnect).toHaveBeenCalledTimes(1);
+    const callArgs = mockOrchestrateOAuthConnect.mock.calls[0]![0] as {
+      callbackTransport: string;
+    };
+    expect(callArgs.callbackTransport).toBe("loopback");
+  });
+
+  test('invalid callback_transport "websocket" returns 400', async () => {
+    mockOrchestrateOAuthConnect.mockClear();
+    const req = connectRequest({ callback_transport: "websocket" });
+    const url = new URL(req.url);
+    const res = await getRoute("POST", "oauth/apps/:appId/connect").handler({
+      req,
+      url,
+      server: null as never,
+      authContext: null as never,
+      params: { appId: "app-1" },
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockOrchestrateOAuthConnect).not.toHaveBeenCalled();
+  });
+
+  test("invalid callback_transport (number) returns 400", async () => {
+    mockOrchestrateOAuthConnect.mockClear();
+    const req = connectRequest({ callback_transport: 123 });
+    const url = new URL(req.url);
+    const res = await getRoute("POST", "oauth/apps/:appId/connect").handler({
+      req,
+      url,
+      server: null as never,
+      authContext: null as never,
+      params: { appId: "app-1" },
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockOrchestrateOAuthConnect).not.toHaveBeenCalled();
   });
 });

--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -358,6 +358,7 @@ Examples:
               service: provider,
               clientId,
               clientSecret,
+              callbackTransport: "loopback",
               isInteractive: opts.browser !== false,
               openUrl: opts.browser !== false ? openInBrowser : undefined,
               ...(opts.scopes ? { requestedScopes: opts.scopes } : {}),

--- a/assistant/src/oauth/connect-orchestrator.ts
+++ b/assistant/src/oauth/connect-orchestrator.ts
@@ -69,6 +69,14 @@ export interface OAuthConnectOptions {
   sendToClient?: (msg: { type: string; [key: string]: unknown }) => void;
 
   /**
+   * Callback transport to use for the OAuth redirect.
+   * - `"loopback"` — start a local HTTP server (desktop clients).
+   * - `"gateway"` — use the public gateway ingress (web clients).
+   * Defaults to `"loopback"` when omitted.
+   */
+  callbackTransport?: "loopback" | "gateway";
+
+  /**
    * Called when the deferred (non-interactive) flow completes — either
    * successfully after tokens are stored, or on failure. Lets callers
    * surface the outcome via SSE events, logs, etc.
@@ -142,9 +150,8 @@ export async function orchestrateOAuthConnect(
   const tokenEndpointAuthMethod = providerRow.tokenEndpointAuthMethod as
     | TokenEndpointAuthMethod
     | undefined;
-  const callbackTransport =
-    (providerRow.callbackTransport as "loopback" | "gateway" | null) ??
-    "loopback";
+  const callbackTransport: "loopback" | "gateway" =
+    options.callbackTransport ?? "loopback";
   const loopbackPort = providerRow.loopbackPort ?? undefined;
 
   // Resolve scopes via the scope policy engine

--- a/assistant/src/runtime/routes/oauth-apps.ts
+++ b/assistant/src/runtime/routes/oauth-apps.ts
@@ -253,7 +253,10 @@ export function oauthAppsRouteDefinitions(): RouteDefinition[] {
           );
         }
 
-        let body: { scopes?: string[] } = {};
+        let body: {
+          scopes?: string[];
+          callback_transport?: "loopback" | "gateway";
+        } = {};
         try {
           const text = await req.text();
           if (text) {
@@ -263,6 +266,19 @@ export function oauthAppsRouteDefinitions(): RouteDefinition[] {
           // No body or invalid JSON — use defaults
         }
 
+        // Validate callback_transport if present
+        if (
+          body.callback_transport !== undefined &&
+          body.callback_transport !== "loopback" &&
+          body.callback_transport !== "gateway"
+        ) {
+          return httpError(
+            "BAD_REQUEST",
+            'callback_transport must be "loopback" or "gateway"',
+            400,
+          );
+        }
+
         const clientSecret = await getAppClientSecret(app);
 
         const result = await orchestrateOAuthConnect({
@@ -270,6 +286,7 @@ export function oauthAppsRouteDefinitions(): RouteDefinition[] {
           clientId: app.clientId,
           clientSecret,
           requestedScopes: body.scopes,
+          callbackTransport: body.callback_transport ?? "loopback",
           isInteractive: false,
         });
 


### PR DESCRIPTION
## Summary
- Add `callback_transport` parameter to `POST /v1/oauth/apps/:appId/connect` API (defaults to `loopback`)
- Plumb through orchestrator so transport is caller-driven instead of provider-driven
- Add explicit `callbackTransport: "loopback"` to CLI connect command

Part of plan: dynamic-oauth-transport.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
