### PR TITLE
fix: address self-review gaps for OAuth transport plan

### DIFF
--- a/assistant/src/__tests__/oauth-connect-orchestrator.test.ts
+++ b/assistant/src/__tests__/oauth-connect-orchestrator.test.ts
@@ -95,7 +95,6 @@ type ProviderRow = {
   defaultScopes: string;
   scopePolicy: string;
   extraParams: string | null;
-  callbackTransport: string | null;
   pingUrl: string | null;
   pingMethod: string | null;
   pingHeaders: string | null;
@@ -171,7 +170,6 @@ function makeProviderRow(
     scopePolicy:
       '{"allowAdditionalScopes":false,"allowedOptionalScopes":[],"forbiddenScopes":[]}',
     extraParams: null,
-    callbackTransport: null,
     pingUrl: null,
     pingMethod: null,
     pingHeaders: null,

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -221,6 +221,11 @@ const PROVIDER_SEED_DATA: Record<
       allowedOptionalScopes: [],
       forbiddenScopes: [],
     },
+    // client_secret_basic is safe with loopback: the token exchange is a
+    // server-side HTTP call from the assistant process to Twitter's token
+    // endpoint — the client secret is never exposed to the browser. The
+    // callback transport only affects where the browser redirects with the
+    // authorization code.
     tokenEndpointAuthMethod: "client_secret_basic",
     loopbackPort: 17335,
     injectionTemplates: [

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -3126,6 +3126,11 @@ export function buildSchema(): Record<string, unknown> {
               type: "array",
               items: { type: "string" },
             },
+            callback_transport: {
+              type: "string",
+              enum: ["loopback", "gateway"],
+              description: "OAuth callback transport. Defaults to loopback.",
+            },
           },
         },
         OAuthConnectDeferredResponse: {


### PR DESCRIPTION
## Summary
Fixes 3 gaps identified during plan self-review:

- Add `callback_transport` to gateway OpenAPI schema (`OAuthConnectRequest`)
- Add server-side token exchange safety comment to Twitter provider
- Remove stale `callbackTransport` field from test mock ProviderRow type

Part of plan: dynamic-oauth-transport.md (review fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
