### PR TITLE
Remove unnecessary token exchange comments from seed providers

### DIFF
--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -221,11 +221,6 @@ const PROVIDER_SEED_DATA: Record<
       allowedOptionalScopes: [],
       forbiddenScopes: [],
     },
-    // client_secret_basic is safe with loopback: the token exchange is a
-    // server-side HTTP call from the assistant process to Twitter's token
-    // endpoint — the client secret is never exposed to the browser. The
-    // callback transport only affects where the browser redirects with the
-    // authorization code.
     tokenEndpointAuthMethod: "client_secret_basic",
     loopbackPort: 17335,
     injectionTemplates: [
@@ -631,11 +626,6 @@ const PROVIDER_SEED_DATA: Record<
       forbiddenScopes: [],
     },
     extraParams: { prompt: "consent" },
-    // client_secret_post is safe with loopback: the token exchange is a
-    // server-side HTTP call from the assistant process to Microsoft's token
-    // endpoint — the client secret is never exposed to the browser. The
-    // callback transport only affects where the browser redirects with the
-    // authorization code.
     tokenEndpointAuthMethod: "client_secret_post",
     loopbackPort: 17334,
     managedServiceConfigKey: "outlook-oauth",


### PR DESCRIPTION
## Summary
- Remove obvious comments explaining that OAuth token exchange is server-side (Twitter and Outlook)

Part of plan: dynamic-oauth-transport.md (review fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
