### PR TITLE
Address review feedback on OAuth transport PRs

### DIFF
--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -89,6 +89,14 @@ export function registerConnectCommand(oauth: Command): void {
       `How the OAuth callback is delivered after authorization. Use "loopback" when the assistant runs locally (starts a temporary localhost server to receive the callback — no tunnel or public URL needed). Use "gateway" when the assistant runs on a remote server (routes the callback through the public ingress URL — requires ingress.publicBaseUrl to be configured).`,
       "loopback",
     )
+    .hook("preAction", (thisCommand) => {
+      const transport = thisCommand.opts().callbackTransport;
+      if (transport !== "loopback" && transport !== "gateway") {
+        thisCommand.error(
+          `Invalid --callback-transport value "${transport}". Must be "loopback" or "gateway".`,
+        );
+      }
+    })
     .addHelpText(
       "after",
       `

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -26,10 +26,8 @@ const LOOPBACK_CALLBACK_PATH = "/oauth/callback";
 /**
  * Resolve the redirect URI for a provider based on its loopback port.
  *
- * Transport is now chosen per-flow by the caller (defaulting to loopback),
- * not per-provider. This helper resolves the loopback redirect URI for
- * display purposes. Gateway redirect URIs are resolved dynamically at
- * connect time.
+ * Resolves the loopback redirect URI for display purposes. Gateway
+ * redirect URIs are resolved dynamically at connect time.
  */
 function resolveRedirectUri(loopbackPort: number | null): string | null {
   if (!loopbackPort) {

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -223,6 +223,7 @@ async function handleOAuthConnectStart(body: {
       requestedScopes: body.requestedScopes,
       clientId,
       clientSecret,
+      callbackTransport: "loopback",
       isInteractive: true,
       openUrl: (url: string) => {
         authUrl = url;


### PR DESCRIPTION
## Summary
- Explicitly pass `callbackTransport: "loopback"` in settings-routes.ts `handleOAuthConnectStart`
- Add CLI validation hook to reject invalid `--callback-transport` values
- Fix comment that narrated history instead of describing current state

Part of plan: dynamic-oauth-transport.md (review feedback)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22502" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
