### PR TITLE
fix: cancel directory monitor when transitioning to file monitoring

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3149,6 +3149,8 @@ public final class SettingsStore: ObservableObject {
     private func watchConfigFile() {
         configFileMonitor?.cancel()
         configFileMonitor = nil
+        configDirMonitor?.cancel()
+        configDirMonitor = nil
 
         let path = workspaceConfigURL.path
         let fd = open(path, O_EVTONLY)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-model-change-ui-sync.md.

**Gap:** Directory monitor not cancelled when transitioning to file monitoring
**What was expected:** watchConfigFile() should cancel configDirMonitor to avoid leaked file descriptors
**What was found:** Only configFileMonitor was cancelled, leaving configDirMonitor running indefinitely
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22504" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
