### PR TITLE
fix(memory): use isAbortError pattern in HyDE expansion

### DIFF
--- a/assistant/src/memory/query-expansion.ts
+++ b/assistant/src/memory/query-expansion.ts
@@ -73,7 +73,7 @@ export async function expandQueryWithHyDE(
 
     return entries;
   } catch (err) {
-    if (err instanceof DOMException && err.name === "AbortError") throw err;
+    if (err instanceof Error && (err.name === "AbortError" || err.name === "APIUserAbortError")) throw err;
     log.warn(
       { err: err instanceof Error ? err.message : String(err) },
       "HyDE query expansion failed",

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -284,7 +284,8 @@ async function runHyDESearch(
   let hypotheticalDocs: string[];
   try {
     hypotheticalDocs = await expandQueryWithHyDE(query, config, signal);
-  } catch {
+  } catch (err) {
+    if (isAbortError(err)) throw err;
     // expandQueryWithHyDE already catches internally, but be defensive
     hypotheticalDocs = [];
   }


### PR DESCRIPTION
## Summary
- Replace ineffective `instanceof DOMException` abort guard with the existing `isAbortError()` pattern in `query-expansion.ts`
- Propagate abort errors through `runHyDESearch` caller in `retriever.ts` instead of swallowing them

Addressed in follow-up to #22249

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
