### PR TITLE
fix: drain queue after /compact processing lock release

### DIFF
--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -936,6 +936,7 @@ export async function processMessage(
       return persisted.id;
     } finally {
       conversation.processing = false;
+      await drainQueue(conversation);
     }
   }
 


### PR DESCRIPTION
## Summary
- Add drainQueue call in the finally block of the /compact handler
- Prevents messages queued during compaction from being stranded

Addressed in follow-up to #22259

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
