### PR TITLE
fix(macos): hide Show less button during unread auto-expansion

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -631,15 +631,15 @@ extension MainWindowView {
                                     .padding(.bottom, SidebarLayoutMetrics.listRowGap)
                             }
 
-                            if group.conversations.count > 3 {
+                            if group.conversations.count > 3, !hasHiddenUnread {
                                 HStack {
                                     VButton(
-                                        label: showAll ? "Show less" : "Show more",
+                                        label: explicitShowAll ? "Show less" : "Show more",
                                         style: .ghost,
                                         size: .compact
                                     ) {
                                         withAnimation(VAnimation.fast) {
-                                            sidebar.showAllChannelConversations[group.channel] = !showAll
+                                            sidebar.showAllChannelConversations[group.channel] = !explicitShowAll
                                         }
                                     }
                                     Spacer()


### PR DESCRIPTION
## Summary
- Fix non-functional Show less button when sidebar is auto-expanded due to hidden unread messages
- Button now only appears when user explicitly expanded the list
- Button label and toggle use `explicitShowAll` instead of merged `showAll` to ensure correct state transitions

Addressed in follow-up to #22338

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
