### PR TITLE
fix(design-system): use clamped ratio in accessibility label

### DIFF
--- a/clients/shared/DesignSystem/Components/Feedback/VContextWindowIndicator.swift
+++ b/clients/shared/DesignSystem/Components/Feedback/VContextWindowIndicator.swift
@@ -64,7 +64,7 @@ public struct VContextWindowIndicator: View {
                 .popover(isPresented: $isHovered, arrowEdge: .top) {
                     popoverContent
                 }
-                .accessibilityLabel("Context window \(Int((fillRatio ?? 0) * 100)) percent used")
+                .accessibilityLabel("Context window \(Int((clampedRatio ?? 0) * 100)) percent used")
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace unclamped fillRatio with clampedRatio in the accessibility label
- VoiceOver now reports the same value as the visual ring

Addressed in follow-up to #22348

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
