### PR TITLE
fix(gateway): prevent circuit breaker HALF_OPEN stuck state

### DIFF
--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -553,8 +553,10 @@ export async function uploadAttachment(
 
   // Always check the breaker for fail-fast (OPEN/HALF_OPEN rejection).
   // skipCb only suppresses success/failure accounting so attachment errors
-  // don't trip the breaker.
-  cbBeforeRequest();
+  // don't trip the breaker — but half-open probes must always record their
+  // outcome to avoid getting stuck in HALF_OPEN permanently.
+  const isProbe = cbBeforeRequest();
+  const recordOutcome = !skipCb || isProbe;
 
   const url = `${config.assistantRuntimeBaseUrl}/v1/attachments`;
 
@@ -569,7 +571,7 @@ export async function uploadAttachment(
       signal: AbortSignal.timeout(config.runtimeTimeoutMs),
     });
   } catch (err) {
-    if (!skipCb) cbOnFailure();
+    if (recordOutcome) cbOnFailure();
     throw err;
   }
 
@@ -579,16 +581,16 @@ export async function uploadAttachment(
     // extension, missing fields). Distinguish from transient 5xx/network errors
     // so callers can decide whether to skip or propagate.
     if (response.status >= 400 && response.status < 500) {
-      if (!skipCb) cbOnSuccess();
+      if (recordOutcome) cbOnSuccess();
       throw new AttachmentValidationError(
         `Attachment rejected (${response.status}): ${body}`,
       );
     }
-    if (!skipCb) cbOnFailure();
+    if (recordOutcome) cbOnFailure();
     throw new Error(`Attachment upload failed (${response.status}): ${body}`);
   }
 
-  if (!skipCb) cbOnSuccess();
+  if (recordOutcome) cbOnSuccess();
   return (await response.json()) as UploadAttachmentResponse;
 }
 


### PR DESCRIPTION
## Summary
- Fix circuit breaker getting permanently stuck in HALF_OPEN when a `skipCircuitBreaker` request consumes the probe slot
- Capture `cbBeforeRequest()` return value (`isProbe`) and use `recordOutcome = !skipCb || isProbe` so half-open probe outcomes are always recorded
- Normal `skipCb` requests still suppress success/failure accounting as intended

Addressed in follow-up to #22332

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
