### PR TITLE
fix: scope guardian reply formatting strip to delimiters only

### DIFF
--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -157,7 +157,7 @@ function parseRequestCode(
 ): CodeParseResult | null {
   // Strip common channel formatting delimiters (backticks, bold, italic,
   // strikethrough) that messaging platforms wrap around inline code.
-  const cleaned = text.replace(/[`*_~]/g, "").trim();
+  const cleaned = text.replace(/^[`*_~]+/, "").replace(/[`*_~]+$/, "").trim();
   // Request codes are 6 hex chars (A-F, 0-9), uppercase
   const upper = cleaned.toUpperCase();
   const match = upper.match(/^([A-F0-9]{6})(?:\s|$)/);


### PR DESCRIPTION
## Summary
- Replace global regex stripping with leading/trailing delimiter stripping
- Preserves underscores, asterisks etc. in guardian answer text content

Addressed in follow-up to #22358

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22510" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
