### PR TITLE
fix(macos): guard pagination cooldown against cancelled task race

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -526,6 +526,7 @@ struct MessageListView: View {
         scrollState.wasPaginationTriggerInRange = isInRange
         scrollState.isPaginationInFlight = true
         let anchorId = scrollState.cachedFirstVisibleMessageId
+        let taskConversationId = scrollState.currentConversationId
         os_signpost(.event, log: PerfSignposts.log, name: "paginationSentinelFired")
         scrollState.paginationTask = Task { [scrollState] in
             defer {
@@ -533,7 +534,8 @@ struct MessageListView: View {
                     scrollState.lastPaginationCompletedAt = Date()
                     scrollState.isPaginationInFlight = false
                     scrollState.paginationTask = nil
-                } else if scrollState.paginationTask == nil {
+                } else if scrollState.paginationTask == nil,
+                          scrollState.currentConversationId == taskConversationId {
                     scrollState.lastPaginationCompletedAt = Date()
                     scrollState.isPaginationInFlight = false
                 }


### PR DESCRIPTION
## Summary
- Capture conversation ID at pagination task creation time
- In the cancelled task's defer block, only write `lastPaginationCompletedAt` if the conversation hasn't changed
- Prevents the cancelled task from overwriting the intentional `.distantPast` reset done by `reset(for:)`
- Fixes first pagination being blocked after conversation switch

Addressed in follow-up to #22405

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
