### PR TITLE
fix: re-seed skill capability memories on runtime install/enable

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -42,7 +42,10 @@ import {
   removeSkillsIndexEntry,
   validateManagedSkillId,
 } from "../../skills/managed-store.js";
-import { deleteSkillCapabilityMemory } from "../../skills/skill-memory.js";
+import {
+  deleteSkillCapabilityMemory,
+  seedCatalogSkillMemories,
+} from "../../skills/skill-memory.js";
 import { getWorkspaceSkillsDir } from "../../util/platform.js";
 import {
   CONFIG_RELOAD_DEBOUNCE_MS,
@@ -478,6 +481,7 @@ export function enableSkill(
       name: skillId,
       state: "enabled",
     });
+    seedCatalogSkillMemories();
     return { success: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -572,6 +576,7 @@ export async function installSkill(
           "Failed to auto-enable bundled skill",
         );
       }
+      seedCatalogSkillMemories();
       return { success: true };
     }
 
@@ -602,6 +607,7 @@ export async function installSkill(
           );
         }
 
+        seedCatalogSkillMemories();
         return { success: true };
       }
     } catch (err) {
@@ -637,6 +643,7 @@ export async function installSkill(
       log.warn({ err, skillId }, "Failed to auto-enable installed skill");
     }
 
+    seedCatalogSkillMemories();
     return { success: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -1035,6 +1042,7 @@ export async function createSkill(
       );
     }
 
+    seedCatalogSkillMemories();
     return { success: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- Add `seedCatalogSkillMemories()` calls in runtime skill install/enable/create handlers
- Skills added after daemon startup now get capability memories immediately
- Covers all paths: `enableSkill`, `installSkill` (bundled, catalog, clawhub), and `createSkill`

Addressed in follow-up to #22370

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
