### PR TITLE
fix(macos): skip periodic channel refresh during pagination

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -1921,7 +1921,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
                 try? await Task.sleep(nanoseconds: 30_000_000_000) // 30s
                 guard !Task.isCancelled, let self else { return }
                 guard let vm = self.chatViewModels[localId],
-                      !vm.isAssistantBusy else { continue }
+                      !vm.isAssistantBusy,
+                      !vm.isLoadingMoreMessages,
+                      !vm.isLoadingHistory else { continue }
                 vm.prepareForNotificationCatchUp()
                 self.conversationRestorer.requestReconnectHistory(conversationId: daemonConversationId)
             }


### PR DESCRIPTION
## Summary
- Add `isLoadingMoreMessages` and `isLoadingHistory` checks to periodic channel refresh guard
- Prevents conflicting history requests during Load more pagination

Addressed in follow-up to #22441

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
