### PR TITLE
feat: add attachment, trash, category, flag, and internet-header APIs to Outlook client

### DIFF
--- a/assistant/src/__tests__/outlook-messaging-provider.test.ts
+++ b/assistant/src/__tests__/outlook-messaging-provider.test.ts
@@ -1,5 +1,15 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+// Import client functions directly before mock.module so we get the real implementations
+import {
+  getAttachment,
+  getMessageWithHeaders,
+  listAttachments,
+  listMasterCategories,
+  trashMessage,
+  updateMessageCategories,
+  updateMessageFlag,
+} from "../messaging/providers/outlook/client.js";
 import type { OutlookMailFolder } from "../messaging/providers/outlook/types.js";
 import type { OutlookMessage } from "../messaging/providers/outlook/types.js";
 import type { OAuthConnection } from "../oauth/connection.js";
@@ -571,6 +581,201 @@ describe("Outlook messaging provider", () => {
       expect(outlookMessagingProvider.capabilities.has("threads")).toBe(true);
       expect(outlookMessagingProvider.capabilities.has("folders")).toBe(true);
       expect(outlookMessagingProvider.capabilities.has("archive")).toBe(false);
+    });
+  });
+});
+
+// ── Outlook client function tests ──────────────────────────────────────────
+
+describe("Outlook client functions", () => {
+  function createClientMockConnection(
+    responseBody: unknown = {},
+    status = 200,
+  ): OAuthConnection {
+    return {
+      id: "outlook-conn-1",
+      providerKey: "outlook",
+      accountInfo: "test@outlook.com",
+      request: mock(() =>
+        Promise.resolve({ status, headers: {}, body: responseBody }),
+      ),
+      withToken: <T>(fn: (token: string) => Promise<T>) =>
+        fn("mock-access-token"),
+    };
+  }
+
+  // ── listAttachments ──────────────────────────────────────────────────
+
+  describe("listAttachments", () => {
+    test("returns attachment metadata", async () => {
+      const attachments = {
+        value: [
+          {
+            id: "att-1",
+            name: "file.pdf",
+            contentType: "application/pdf",
+            size: 12345,
+            isInline: false,
+          },
+        ],
+      };
+      const conn = createClientMockConnection(attachments);
+      const result = await listAttachments(conn, "msg-1");
+
+      expect(conn.request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "GET",
+          path: "/v1.0/me/messages/msg-1/attachments",
+          query: { $select: "id,name,contentType,size,isInline" },
+        }),
+      );
+      expect(result.value).toHaveLength(1);
+      expect(result.value![0].name).toBe("file.pdf");
+    });
+  });
+
+  // ── getAttachment ────────────────────────────────────────────────────
+
+  describe("getAttachment", () => {
+    test("returns file content with contentBytes", async () => {
+      const attachment = {
+        id: "att-1",
+        name: "file.pdf",
+        contentType: "application/pdf",
+        size: 12345,
+        isInline: false,
+        contentBytes: "dGVzdCBjb250ZW50",
+      };
+      const conn = createClientMockConnection(attachment);
+      const result = await getAttachment(conn, "msg-1", "att-1");
+
+      expect(conn.request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "GET",
+          path: "/v1.0/me/messages/msg-1/attachments/att-1",
+        }),
+      );
+      expect(result.contentBytes).toBe("dGVzdCBjb250ZW50");
+      expect(result.name).toBe("file.pdf");
+    });
+  });
+
+  // ── trashMessage ─────────────────────────────────────────────────────
+
+  describe("trashMessage", () => {
+    test("calls move with destinationId deleteditems", async () => {
+      const movedMessage = {
+        id: "msg-1",
+        conversationId: "conv-1",
+        subject: "Test",
+        parentFolderId: "deleteditems",
+      };
+      const conn = createClientMockConnection(movedMessage);
+      const result = await trashMessage(conn, "msg-1");
+
+      expect(conn.request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "POST",
+          path: "/v1.0/me/messages/msg-1/move",
+          body: { destinationId: "deleteditems" },
+        }),
+      );
+      expect(result.id).toBe("msg-1");
+    });
+  });
+
+  // ── updateMessageCategories ──────────────────────────────────────────
+
+  describe("updateMessageCategories", () => {
+    test("sends PATCH with categories array", async () => {
+      const conn = createClientMockConnection(undefined, 204);
+      await updateMessageCategories(conn, "msg-1", ["important", "work"]);
+
+      expect(conn.request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "PATCH",
+          path: "/v1.0/me/messages/msg-1",
+          body: { categories: ["important", "work"] },
+        }),
+      );
+    });
+  });
+
+  // ── updateMessageFlag ────────────────────────────────────────────────
+
+  describe("updateMessageFlag", () => {
+    test("sends PATCH with flag object", async () => {
+      const flag = {
+        flagStatus: "flagged" as const,
+        dueDateTime: {
+          dateTime: "2024-12-31T23:59:59",
+          timeZone: "UTC",
+        },
+      };
+      const conn = createClientMockConnection(undefined, 204);
+      await updateMessageFlag(conn, "msg-1", flag);
+
+      expect(conn.request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "PATCH",
+          path: "/v1.0/me/messages/msg-1",
+          body: { flag },
+        }),
+      );
+    });
+  });
+
+  // ── listMasterCategories ─────────────────────────────────────────────
+
+  describe("listMasterCategories", () => {
+    test("returns category list", async () => {
+      const categories = {
+        value: [
+          { displayName: "Red Category", color: "preset0" },
+          { displayName: "Blue Category", color: "preset7" },
+        ],
+      };
+      const conn = createClientMockConnection(categories);
+      const result = await listMasterCategories(conn);
+
+      expect(conn.request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "GET",
+          path: "/v1.0/me/outlook/masterCategories",
+        }),
+      );
+      expect(result.value).toHaveLength(2);
+      expect(result.value![0].displayName).toBe("Red Category");
+    });
+  });
+
+  // ── getMessageWithHeaders ────────────────────────────────────────────
+
+  describe("getMessageWithHeaders", () => {
+    test("includes internetMessageHeaders in select", async () => {
+      const message = {
+        id: "msg-1",
+        subject: "Test",
+        internetMessageHeaders: [
+          { name: "X-Mailer", value: "TestMailer" },
+          { name: "List-Unsubscribe", value: "<mailto:unsub@example.com>" },
+        ],
+      };
+      const conn = createClientMockConnection(message);
+      const result = await getMessageWithHeaders(conn, "msg-1");
+
+      expect(conn.request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "GET",
+          path: "/v1.0/me/messages/msg-1",
+          query: {
+            $select:
+              "id,subject,from,internetMessageHeaders,bodyPreview,body,hasAttachments,receivedDateTime",
+          },
+        }),
+      );
+      expect(result.internetMessageHeaders).toHaveLength(2);
+      expect(result.internetMessageHeaders![0].name).toBe("X-Mailer");
     });
   });
 });

--- a/assistant/src/messaging/providers/outlook/client.ts
+++ b/assistant/src/messaging/providers/outlook/client.ts
@@ -3,9 +3,13 @@ import type {
   OAuthConnectionResponse,
 } from "../../../oauth/connection.js";
 import type {
+  OutlookAttachmentListResponse,
+  OutlookFileAttachment,
   OutlookMailFolder,
   OutlookMailFolderListResponse,
+  OutlookMasterCategoryListResponse,
   OutlookMessage,
+  OutlookMessageFlag,
   OutlookMessageListResponse,
   OutlookSendMessagePayload,
   OutlookUserProfile,
@@ -308,4 +312,102 @@ export async function batchGetMessages(
     results.push(...waveResults);
   }
   return results;
+}
+
+/** List attachments on a message. */
+export async function listAttachments(
+  connection: OAuthConnection,
+  messageId: string,
+): Promise<OutlookAttachmentListResponse> {
+  return request<OutlookAttachmentListResponse>(
+    connection,
+    `/v1.0/me/messages/${encodeURIComponent(messageId)}/attachments`,
+    undefined,
+    { $select: "id,name,contentType,size,isInline" },
+  );
+}
+
+/** Get a single attachment by ID (includes file content). */
+export async function getAttachment(
+  connection: OAuthConnection,
+  messageId: string,
+  attachmentId: string,
+): Promise<OutlookFileAttachment> {
+  return request<OutlookFileAttachment>(
+    connection,
+    `/v1.0/me/messages/${encodeURIComponent(messageId)}/attachments/${encodeURIComponent(attachmentId)}`,
+  );
+}
+
+/** Move a message to the Deleted Items folder. */
+export async function trashMessage(
+  connection: OAuthConnection,
+  messageId: string,
+): Promise<OutlookMessage> {
+  return request<OutlookMessage>(
+    connection,
+    `/v1.0/me/messages/${encodeURIComponent(messageId)}/move`,
+    {
+      method: "POST",
+      body: JSON.stringify({ destinationId: "deleteditems" }),
+    },
+  );
+}
+
+/** Update the categories on a message. */
+export async function updateMessageCategories(
+  connection: OAuthConnection,
+  messageId: string,
+  categories: string[],
+): Promise<void> {
+  await request<void>(
+    connection,
+    `/v1.0/me/messages/${encodeURIComponent(messageId)}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify({ categories }),
+    },
+  );
+}
+
+/** Update the flag on a message. */
+export async function updateMessageFlag(
+  connection: OAuthConnection,
+  messageId: string,
+  flag: OutlookMessageFlag,
+): Promise<void> {
+  await request<void>(
+    connection,
+    `/v1.0/me/messages/${encodeURIComponent(messageId)}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify({ flag }),
+    },
+  );
+}
+
+/** List the user's master categories. */
+export async function listMasterCategories(
+  connection: OAuthConnection,
+): Promise<OutlookMasterCategoryListResponse> {
+  return request<OutlookMasterCategoryListResponse>(
+    connection,
+    "/v1.0/me/outlook/masterCategories",
+  );
+}
+
+/** Get a message with internet message headers included. */
+export async function getMessageWithHeaders(
+  connection: OAuthConnection,
+  messageId: string,
+): Promise<OutlookMessage> {
+  return request<OutlookMessage>(
+    connection,
+    `/v1.0/me/messages/${encodeURIComponent(messageId)}`,
+    undefined,
+    {
+      $select:
+        "id,subject,from,internetMessageHeaders,bodyPreview,body,hasAttachments,receivedDateTime",
+    },
+  );
 }

--- a/assistant/src/messaging/providers/outlook/types.ts
+++ b/assistant/src/messaging/providers/outlook/types.ts
@@ -28,6 +28,12 @@ export interface OutlookItemBody {
   content: string;
 }
 
+/** Internet message header (e.g. List-Unsubscribe, X-Mailer) */
+export interface OutlookInternetMessageHeader {
+  name: string;
+  value: string;
+}
+
 /** Full Outlook message from Microsoft Graph */
 export interface OutlookMessage {
   id: string;
@@ -46,6 +52,7 @@ export interface OutlookMessage {
   flag: {
     flagStatus: "notFlagged" | "flagged" | "complete";
   };
+  internetMessageHeaders?: OutlookInternetMessageHeader[];
 }
 
 /** Outlook mail folder */
@@ -80,4 +87,43 @@ export interface OutlookUserProfile {
   displayName: string;
   mail: string;
   userPrincipalName: string;
+}
+
+/** Outlook attachment metadata */
+export interface OutlookAttachment {
+  id: string;
+  name: string;
+  contentType: string;
+  size: number;
+  isInline: boolean;
+  "@odata.type"?: string;
+}
+
+/** Outlook file attachment with base64-encoded content */
+export interface OutlookFileAttachment extends OutlookAttachment {
+  contentBytes: string;
+}
+
+/** Outlook attachment list response (paginated) */
+export interface OutlookAttachmentListResponse {
+  value?: OutlookAttachment[];
+  "@odata.nextLink"?: string;
+}
+
+/** Outlook message flag with optional due/start dates */
+export interface OutlookMessageFlag {
+  flagStatus: "notFlagged" | "flagged" | "complete";
+  dueDateTime?: { dateTime: string; timeZone: string };
+  startDateTime?: { dateTime: string; timeZone: string };
+}
+
+/** Outlook master category */
+export interface OutlookMasterCategory {
+  displayName: string;
+  color: string;
+}
+
+/** Outlook master category list response */
+export interface OutlookMasterCategoryListResponse {
+  value?: OutlookMasterCategory[];
 }


### PR DESCRIPTION
## Summary
- Add 7 new Microsoft Graph API client functions: listAttachments, getAttachment, trashMessage, updateMessageCategories, updateMessageFlag, listMasterCategories, getMessageWithHeaders
- Add corresponding TypeScript types: OutlookAttachment, OutlookFileAttachment, OutlookMessageFlag, OutlookMasterCategory, OutlookInternetMessageHeader, and response types
- Add unit tests for all new client functions

Part of plan: outlook-email-gmail-parity.md (PR 2 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
