### PR TITLE
fix: VTabs pill radius, workspace file view chrome, file header background

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -246,5 +246,6 @@ struct FileContentHeaderBar<Trailing: View>: View {
         }
         .padding(.horizontal, VSpacing.md)
         .padding(.vertical, VSpacing.sm)
+        .background(VColor.surfaceOverlay)
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -754,13 +754,6 @@ private struct WorkspaceFileViewer: View {
                 emptyState
             }
         }
-        .background(VColor.surfaceOverlay)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.xl)
-                .strokeBorder(VColor.borderDisabled, lineWidth: 2)
-                .allowsHitTesting(false)
-        )
     }
 
     private var emptyState: some View {

--- a/clients/shared/DesignSystem/Components/Navigation/VTabs.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VTabs.swift
@@ -140,7 +140,7 @@ private struct PillSegment: View {
             .frame(maxWidth: .infinity)
             .frame(height: 28)
             .background(
-                RoundedRectangle(cornerRadius: VRadius.sm)
+                RoundedRectangle(cornerRadius: VRadius.md)
                     .fill(segmentBackground)
                     .shadow(color: isSelected ? VColor.auxBlack.opacity(0.08) : .clear, radius: 2, x: 0, y: 1)
             )


### PR DESCRIPTION
## Summary
- VTabs pill: match container and segment radius to VRadius.md (8pt), use surfaceBase container
- Workspace: remove extra bordered card wrapper from right pane (FileContentView handles its own chrome)
- FileContentHeaderBar: add surfaceOverlay background

## Test plan
- [ ] VTabs pill segments have matching 8pt radius on container and segments
- [ ] Workspace file viewer has no double container/border
- [ ] File header bar has surfaceOverlay background
- [ ] Skill detail file viewer still looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
