### PR TITLE
Add `requirePlatformConnection` guard with actionable error messages

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -88,6 +88,10 @@ let mockGetCredentialMetadata: (
   service: string,
   field: string,
 ) => Record<string, unknown> | undefined = () => undefined;
+let mockPlatformClientCreate: () => Promise<Record<
+  string,
+  unknown
+> | null> = async () => null;
 
 // ---------------------------------------------------------------------------
 // Mock token-manager
@@ -236,7 +240,7 @@ mock.module("../oauth/connection-resolver.js", () => ({
 
 mock.module("../platform/client.js", () => ({
   VellumPlatformClient: {
-    create: async () => null,
+    create: () => mockPlatformClientCreate(),
   },
 }));
 
@@ -260,6 +264,8 @@ mock.module("../util/logger.js", () => ({
 // ---------------------------------------------------------------------------
 
 const { registerOAuthCommand } = await import("../cli/commands/oauth/index.js");
+const { requirePlatformClient, requirePlatformConnection } =
+  await import("../cli/commands/oauth/shared.js");
 
 // ---------------------------------------------------------------------------
 // Test helper
@@ -949,5 +955,150 @@ describe("assistant oauth ping <provider-key>", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("No access token");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requirePlatformClient — improved error messages
+// ---------------------------------------------------------------------------
+
+describe("requirePlatformClient", () => {
+  test("returns error mentioning 'vellum platform connect' when not connected", async () => {
+    mockPlatformClientCreate = async () => null;
+    const stdoutChunks: string[] = [];
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: unknown) => {
+      stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+    process.exitCode = 0;
+
+    try {
+      const cmd = new Command();
+      cmd.option("--json");
+      cmd.parse(["node", "test", "--json"]);
+      const result = await requirePlatformClient(cmd);
+      expect(result).toBeNull();
+      expect(process.exitCode).toBe(1);
+      const output = stdoutChunks.join("");
+      const parsed = JSON.parse(output);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("vellum platform connect");
+      expect(parsed.error).toContain("Not connected");
+    } finally {
+      process.stdout.write = originalWrite;
+      process.exitCode = 0;
+    }
+  });
+
+  test("returns distinct error when connected but missing assistant ID", async () => {
+    mockPlatformClientCreate = async () => ({
+      platformAssistantId: "",
+      fetch: async () => new Response(),
+    });
+    const stdoutChunks: string[] = [];
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: unknown) => {
+      stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+    process.exitCode = 0;
+
+    try {
+      const cmd = new Command();
+      cmd.option("--json");
+      cmd.parse(["node", "test", "--json"]);
+      const result = await requirePlatformClient(cmd);
+      expect(result).toBeNull();
+      expect(process.exitCode).toBe(1);
+      const output = stdoutChunks.join("");
+      const parsed = JSON.parse(output);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("no assistant ID is configured");
+      expect(parsed.error).toContain("registered on the platform");
+    } finally {
+      process.stdout.write = originalWrite;
+      process.exitCode = 0;
+    }
+  });
+
+  test("returns client when connected with assistant ID", async () => {
+    mockPlatformClientCreate = async () => ({
+      platformAssistantId: "asst-123",
+      fetch: async () => new Response(),
+    });
+    process.exitCode = 0;
+
+    const cmd = new Command();
+    cmd.option("--json");
+    cmd.parse(["node", "test", "--json"]);
+    const result = await requirePlatformClient(cmd);
+    expect(result).not.toBeNull();
+    expect(result!.platformAssistantId).toBe("asst-123");
+    expect(process.exitCode).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requirePlatformConnection
+// ---------------------------------------------------------------------------
+
+describe("requirePlatformConnection", () => {
+  test("returns false and writes error when not connected", async () => {
+    mockPlatformClientCreate = async () => null;
+    const stdoutChunks: string[] = [];
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: unknown) => {
+      stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+    process.exitCode = 0;
+
+    try {
+      const cmd = new Command();
+      cmd.option("--json");
+      cmd.parse(["node", "test", "--json"]);
+      const result = await requirePlatformConnection(cmd);
+      expect(result).toBe(false);
+      expect(process.exitCode).toBe(1);
+      const output = stdoutChunks.join("");
+      const parsed = JSON.parse(output);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("vellum platform connect");
+      expect(parsed.error).toContain("Not connected");
+    } finally {
+      process.stdout.write = originalWrite;
+      process.exitCode = 0;
+    }
+  });
+
+  test("returns true when client can be created (even without assistant ID)", async () => {
+    mockPlatformClientCreate = async () => ({
+      platformAssistantId: "",
+      fetch: async () => new Response(),
+    });
+    process.exitCode = 0;
+
+    const cmd = new Command();
+    cmd.option("--json");
+    cmd.parse(["node", "test", "--json"]);
+    const result = await requirePlatformConnection(cmd);
+    expect(result).toBe(true);
+    expect(process.exitCode).toBe(0);
+  });
+
+  test("returns true when client can be created with assistant ID", async () => {
+    mockPlatformClientCreate = async () => ({
+      platformAssistantId: "asst-456",
+      fetch: async () => new Response(),
+    });
+    process.exitCode = 0;
+
+    const cmd = new Command();
+    cmd.option("--json");
+    cmd.parse(["node", "test", "--json"]);
+    const result = await requirePlatformConnection(cmd);
+    expect(result).toBe(true);
+    expect(process.exitCode).toBe(0);
   });
 });

--- a/assistant/src/cli/commands/oauth/shared.ts
+++ b/assistant/src/cli/commands/oauth/shared.ts
@@ -59,16 +59,48 @@ export async function requirePlatformClient(
   cmd: Command,
 ): Promise<VellumPlatformClient | null> {
   const client = await VellumPlatformClient.create();
-  if (!client || !client.platformAssistantId) {
+  if (!client) {
     writeOutput(cmd, {
       ok: false,
       error:
-        "Platform prerequisites not met (not logged in or missing assistant ID)",
+        "Not connected to Vellum platform. Run `vellum platform connect` to connect first.",
+    });
+    process.exitCode = 1;
+    return null;
+  }
+  if (!client.platformAssistantId) {
+    writeOutput(cmd, {
+      ok: false,
+      error:
+        "Connected to Vellum platform but no assistant ID is configured. Ensure the assistant is registered on the platform.",
     });
     process.exitCode = 1;
     return null;
   }
   return client;
+}
+
+/**
+ * Verify that the user has connected to the Vellum platform (has stored
+ * credentials). Unlike `requirePlatformClient`, this does NOT require a
+ * platform assistant ID — it only checks that credentials exist.
+ *
+ * Writes an error and sets exitCode=1 when the user is not connected.
+ */
+export async function requirePlatformConnection(
+  cmd: Command,
+): Promise<boolean> {
+  const client = await VellumPlatformClient.create();
+  if (!client) {
+    writeOutput(cmd, {
+      ok: false,
+      error:
+        "Not connected to Vellum platform. Run `vellum platform connect` to connect first.",
+    });
+    process.exitCode = 1;
+    return false;
+  }
+  return true;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add new `requirePlatformConnection()` guard function that checks platform credentials exist (lighter than `requirePlatformClient` — no assistant ID required)
- Improve `requirePlatformClient()` to differentiate between 'not connected' and 'missing assistant ID' errors
- Both error messages now direct users to run `vellum platform connect`

Part of plan: require-platform-login.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22525" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
