### PR TITLE
Improve `oauth connect` error messages for 401/403 platform responses

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { Command } from "commander";
 
@@ -234,10 +234,48 @@ mock.module("../oauth/connection-resolver.js", () => ({
 // Mock platform/client (needed by request.ts)
 // ---------------------------------------------------------------------------
 
+let mockPlatformClientCreate: () => Promise<Record<
+  string,
+  unknown
+> | null> = async () => null;
+
 mock.module("../platform/client.js", () => ({
   VellumPlatformClient: {
-    create: async () => null,
+    create: () => mockPlatformClientCreate(),
   },
+}));
+
+// ---------------------------------------------------------------------------
+// Mock config/loader (needed by isManagedMode in shared.ts)
+// ---------------------------------------------------------------------------
+
+let mockGetConfig: () => Record<string, unknown> = () => ({
+  services: {},
+});
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => mockGetConfig(),
+  loadConfig: () => mockGetConfig(),
+  saveConfig: () => {},
+  invalidateConfigCache: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  applyNestedDefaults: (c: unknown) => c,
+  deepMergeMissing: (a: unknown) => a,
+  deepMergeOverwrite: (a: unknown) => a,
+  mergeDefaultWorkspaceConfig: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+  API_KEY_PROVIDERS: [
+    "anthropic",
+    "openai",
+    "gemini",
+    "ollama",
+    "fireworks",
+    "openrouter",
+    "brave",
+    "perplexity",
+  ],
 }));
 
 mock.module("../util/logger.js", () => ({
@@ -949,5 +987,110 @@ describe("assistant oauth ping <provider-key>", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("No access token");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// oauth connect — managed mode 401/403 error messages
+// ---------------------------------------------------------------------------
+
+describe("assistant oauth connect managed mode — platform 401/403 errors", () => {
+  /**
+   * Helper: create a mock platform client whose `fetch` always returns the
+   * given status code and body text.
+   */
+  function makeMockPlatformClient(status: number, body = "") {
+    return {
+      platformAssistantId: "asst-test-123",
+      fetch: async () =>
+        new Response(body, { status, statusText: `HTTP ${status}` }),
+    };
+  }
+
+  beforeEach(() => {
+    mockWithValidToken = async (_service, cb) => cb("mock-access-token-xyz");
+    mockOrchestrateOAuthConnect = async () => ({
+      success: true,
+      deferred: false,
+      grantedScopes: [],
+    });
+    mockGetAppByProviderAndClientId = () => undefined;
+    mockGetMostRecentAppByProvider = () => undefined;
+    mockGetSecureKey = () => undefined;
+    mockGetCredentialMetadata = () => undefined;
+
+    // Set up managed mode: provider has managedServiceConfigKey, config
+    // returns the matching service with mode "managed".
+    mockGetProvider = () => ({
+      providerKey: "google",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      defaultScopes: "[]",
+      scopePolicy: "{}",
+      extraParams: null,
+      managedServiceConfigKey: "google-oauth",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    mockGetConfig = () => ({
+      services: {
+        "google-oauth": { mode: "managed" },
+      },
+    });
+  });
+
+  afterEach(() => {
+    mockPlatformClientCreate = async () => null;
+    mockGetConfig = () => ({ services: {} });
+  });
+
+  test("401 response includes 'vellum platform connect' suggestion", async () => {
+    mockPlatformClientCreate = async () =>
+      makeMockPlatformClient(401, "Unauthorized");
+    const { exitCode, stdout } = await runCli([
+      "connect",
+      "google",
+      "--no-browser",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Platform returned HTTP 401");
+    expect(parsed.error).toContain("Unauthorized");
+    expect(parsed.error).toContain("vellum platform connect");
+  });
+
+  test("403 response includes 'vellum platform connect' suggestion", async () => {
+    mockPlatformClientCreate = async () =>
+      makeMockPlatformClient(403, "Forbidden");
+    const { exitCode, stdout } = await runCli([
+      "connect",
+      "google",
+      "--no-browser",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Platform returned HTTP 403");
+    expect(parsed.error).toContain("Forbidden");
+    expect(parsed.error).toContain("vellum platform connect");
+  });
+
+  test("500 response does NOT include 'vellum platform connect' suggestion", async () => {
+    mockPlatformClientCreate = async () =>
+      makeMockPlatformClient(500, "Internal Server Error");
+    const { exitCode, stdout } = await runCli([
+      "connect",
+      "google",
+      "--no-browser",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Platform returned HTTP 500");
+    expect(parsed.error).not.toContain("vellum platform connect");
   });
 });

--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -199,9 +199,14 @@ Examples:
 
               if (!response.ok) {
                 const errorText = await response.text().catch(() => "");
-                writeError(
-                  `Platform returned HTTP ${response.status}${errorText ? `: ${errorText}` : ""}`,
-                );
+                const baseMsg = `Platform returned HTTP ${response.status}${errorText ? `: ${errorText}` : ""}`;
+                if (response.status === 401 || response.status === 403) {
+                  writeError(
+                    `${baseMsg}. Your platform session may have expired. Run \`vellum platform connect\` to reconnect.`,
+                  );
+                } else {
+                  writeError(baseMsg);
+                }
                 return;
               }
 

--- a/assistant/src/cli/commands/oauth/shared.ts
+++ b/assistant/src/cli/commands/oauth/shared.ts
@@ -94,9 +94,13 @@ export async function fetchActiveConnections(
 
   if (!response.ok) {
     if (!options?.silent) {
+      const hint =
+        response.status === 401 || response.status === 403
+          ? `. Your platform session may have expired. Run \`vellum platform connect\` to reconnect.`
+          : "";
       writeOutput(cmd, {
         ok: false,
-        error: `Platform returned HTTP ${response.status}`,
+        error: `Platform returned HTTP ${response.status}${hint}`,
       });
       process.exitCode = 1;
     }


### PR DESCRIPTION
## Summary
- Improve 401/403 error handling in `oauth connect` managed mode to suggest running `vellum platform connect`
- Improve 401/403 error handling in `fetchActiveConnections` with the same actionable guidance
- Non-401/403 errors remain unchanged

Part of plan: require-platform-login.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
