### PR TITLE
feat: add outlook_attachments tool for listing and downloading email attachments

### DIFF
--- a/assistant/src/__tests__/outlook-attachments.test.ts
+++ b/assistant/src/__tests__/outlook-attachments.test.ts
@@ -1,0 +1,301 @@
+import { readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { ToolContext } from "../tools/types.js";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockListAttachments = mock(() =>
+  Promise.resolve({
+    value: [
+      {
+        id: "att-1",
+        name: "report.pdf",
+        contentType: "application/pdf",
+        size: 12345,
+        isInline: false,
+      },
+      {
+        id: "att-2",
+        name: "logo.png",
+        contentType: "image/png",
+        size: 5678,
+        isInline: true,
+      },
+    ],
+  }),
+);
+
+const mockGetAttachment = mock(() =>
+  Promise.resolve({
+    id: "att-1",
+    name: "report.pdf",
+    contentType: "application/pdf",
+    size: 12345,
+    isInline: false,
+    // "Hello World" in base64
+    contentBytes: Buffer.from("Hello World").toString("base64"),
+  }),
+);
+
+const mockResolveOAuthConnection = mock(() =>
+  Promise.resolve({ id: "conn-1" }),
+);
+
+mock.module("../../../../messaging/providers/outlook/client.js", () => ({
+  listAttachments: mockListAttachments,
+  getAttachment: mockGetAttachment,
+}));
+
+mock.module("../../../../oauth/connection-resolver.js", () => ({
+  resolveOAuthConnection: mockResolveOAuthConnection,
+}));
+
+// Import after mocking
+const { run } =
+  await import("../config/bundled-skills/outlook/tools/outlook-attachments.js");
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+let testDir: string;
+
+function makeContext(overrides?: Partial<ToolContext>): ToolContext {
+  return {
+    workingDir: testDir,
+    conversationId: "test-conv",
+    ...overrides,
+  } as ToolContext;
+}
+
+beforeEach(async () => {
+  testDir = join(tmpdir(), `outlook-attach-test-${Date.now()}`);
+  await Bun.write(join(testDir, ".keep"), "");
+  mockListAttachments.mockClear();
+  mockGetAttachment.mockClear();
+  mockResolveOAuthConnection.mockClear();
+});
+
+afterEach(async () => {
+  await rm(testDir, { recursive: true, force: true });
+});
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("outlook_attachments", () => {
+  describe("validation", () => {
+    test("returns error when action is missing", async () => {
+      const result = await run({ message_id: "msg-1" }, makeContext());
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("action is required");
+    });
+
+    test("returns error when message_id is missing", async () => {
+      const result = await run({ action: "list" }, makeContext());
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("message_id is required");
+    });
+
+    test("returns error for unknown action", async () => {
+      const result = await run(
+        { action: "delete", message_id: "msg-1" },
+        makeContext(),
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("Unknown action");
+    });
+  });
+
+  describe("list action", () => {
+    test("lists attachments on a message", async () => {
+      const result = await run(
+        { action: "list", message_id: "msg-1" },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      const parsed = JSON.parse(result.content);
+      expect(parsed).toHaveLength(2);
+      expect(parsed[0]).toEqual({
+        attachmentId: "att-1",
+        name: "report.pdf",
+        contentType: "application/pdf",
+        size: 12345,
+        isInline: false,
+      });
+      expect(parsed[1]).toEqual({
+        attachmentId: "att-2",
+        name: "logo.png",
+        contentType: "image/png",
+        size: 5678,
+        isInline: true,
+      });
+    });
+
+    test("returns message when no attachments found", async () => {
+      mockListAttachments.mockResolvedValueOnce({ value: [] });
+
+      const result = await run(
+        { action: "list", message_id: "msg-1" },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("No attachments found");
+    });
+
+    test("passes account to resolveOAuthConnection", async () => {
+      await run(
+        { action: "list", message_id: "msg-1", account: "user@outlook.com" },
+        makeContext(),
+      );
+
+      expect(mockResolveOAuthConnection).toHaveBeenCalledWith("outlook", {
+        account: "user@outlook.com",
+      });
+    });
+
+    test("handles API errors gracefully", async () => {
+      mockListAttachments.mockRejectedValueOnce(new Error("Unauthorized"));
+
+      const result = await run(
+        { action: "list", message_id: "msg-1" },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("Unauthorized");
+    });
+  });
+
+  describe("download action", () => {
+    test("downloads and saves attachment to disk", async () => {
+      const result = await run(
+        {
+          action: "download",
+          message_id: "msg-1",
+          attachment_id: "att-1",
+        },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("Attachment saved to");
+      expect(result.content).toContain("report.pdf");
+      expect(result.content).toContain("11 bytes");
+
+      // Verify file contents
+      const filePath = join(testDir, "report.pdf");
+      const contents = await readFile(filePath, "utf-8");
+      expect(contents).toBe("Hello World");
+    });
+
+    test("returns error when attachment_id is missing", async () => {
+      const result = await run(
+        { action: "download", message_id: "msg-1" },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("attachment_id is required");
+    });
+
+    test("handles API errors during download", async () => {
+      mockGetAttachment.mockRejectedValueOnce(new Error("Not Found"));
+
+      const result = await run(
+        {
+          action: "download",
+          message_id: "msg-1",
+          attachment_id: "att-1",
+        },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("Not Found");
+    });
+
+    test("correctly decodes base64 content", async () => {
+      const binaryContent = Buffer.from([0x00, 0x01, 0x02, 0xff, 0xfe, 0xfd]);
+      mockGetAttachment.mockResolvedValueOnce({
+        id: "att-bin",
+        name: "binary.dat",
+        contentType: "application/octet-stream",
+        size: 6,
+        isInline: false,
+        contentBytes: binaryContent.toString("base64"),
+      });
+
+      const result = await run(
+        {
+          action: "download",
+          message_id: "msg-1",
+          attachment_id: "att-bin",
+        },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      const filePath = join(testDir, "binary.dat");
+      const saved = await readFile(filePath);
+      expect(Buffer.compare(saved, binaryContent)).toBe(0);
+    });
+  });
+
+  describe("path traversal protection", () => {
+    test("strips directory traversal from filename", async () => {
+      mockGetAttachment.mockResolvedValueOnce({
+        id: "att-evil",
+        name: "../../../etc/passwd",
+        contentType: "application/octet-stream",
+        size: 5,
+        isInline: false,
+        contentBytes: Buffer.from("evil").toString("base64"),
+      });
+
+      const result = await run(
+        {
+          action: "download",
+          message_id: "msg-1",
+          attachment_id: "att-evil",
+        },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      // basename("../../../etc/passwd") = "passwd", so file should be saved as "passwd"
+      expect(result.content).toContain("passwd");
+      expect(result.content).not.toContain("../");
+
+      // Verify no file was written outside the working directory
+      const filePath = join(testDir, "passwd");
+      const contents = await readFile(filePath, "utf-8");
+      expect(contents).toBe("evil");
+    });
+
+    test("strips embedded .. sequences from filename", async () => {
+      mockGetAttachment.mockResolvedValueOnce({
+        id: "att-dots",
+        name: "safe..name..txt",
+        contentType: "text/plain",
+        size: 5,
+        isInline: false,
+        contentBytes: Buffer.from("dots").toString("base64"),
+      });
+
+      const result = await run(
+        {
+          action: "download",
+          message_id: "msg-1",
+          attachment_id: "att-dots",
+        },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("safe");
+    });
+  });
+});

--- a/assistant/src/config/bundled-skills/outlook/TOOLS.json
+++ b/assistant/src/config/bundled-skills/outlook/TOOLS.json
@@ -1,1 +1,40 @@
-[]
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "outlook_attachments",
+      "description": "List or download Outlook email attachments. Use action 'list' to enumerate attachments on a message, then 'download' to save a specific attachment to disk.",
+      "category": "outlook",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": ["list", "download"],
+            "description": "List attachments on a message, or download a specific attachment"
+          },
+          "message_id": {
+            "type": "string",
+            "description": "Outlook message ID"
+          },
+          "attachment_id": {
+            "type": "string",
+            "description": "Attachment ID (required for download, from a prior list call)"
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Outlook account to use. Required when multiple Outlook accounts are connected. If omitted, uses the most recently connected account."
+          }
+        },
+        "required": ["action", "message_id"]
+      },
+      "executor": "tools/outlook-attachments.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/outlook/tools/outlook-attachments.ts
+++ b/assistant/src/config/bundled-skills/outlook/tools/outlook-attachments.ts
@@ -1,0 +1,85 @@
+import { writeFile } from "node:fs/promises";
+import { basename, resolve } from "node:path";
+
+import {
+  getAttachment,
+  listAttachments,
+} from "../../../../messaging/providers/outlook/client.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
+  const action = input.action as string;
+  const messageId = input.message_id as string;
+
+  if (!action) return err("action is required.");
+  if (!messageId) return err("message_id is required.");
+
+  if (action === "list") {
+    try {
+      const connection = await resolveOAuthConnection("outlook", {
+        account,
+      });
+      const response = await listAttachments(connection, messageId);
+      const attachments = response.value ?? [];
+
+      if (attachments.length === 0) {
+        return ok("No attachments found on this message.");
+      }
+
+      const result = attachments.map((a) => ({
+        attachmentId: a.id,
+        name: a.name,
+        contentType: a.contentType,
+        size: a.size,
+        isInline: a.isInline,
+      }));
+
+      return ok(JSON.stringify(result, null, 2));
+    } catch (e) {
+      return err(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  if (action === "download") {
+    const attachmentId = input.attachment_id as string;
+
+    if (!attachmentId) return err("attachment_id is required for download.");
+
+    try {
+      const connection = await resolveOAuthConnection("outlook", {
+        account,
+      });
+      const attachment = await getAttachment(
+        connection,
+        messageId,
+        attachmentId,
+      );
+
+      // Outlook returns standard base64 in contentBytes
+      const buffer = Buffer.from(attachment.contentBytes, "base64");
+
+      const outputDir = context.workingDir ?? process.cwd();
+      // Sanitize filename: strip path separators to prevent traversal attacks
+      const safeName = basename(attachment.name).replace(/\.\./g, "_");
+      const outputPath = resolve(outputDir, safeName);
+      if (!outputPath.startsWith(outputDir))
+        return err("Invalid filename: path traversal detected.");
+      await writeFile(outputPath, buffer);
+
+      return ok(`Attachment saved to ${outputPath} (${buffer.length} bytes).`);
+    } catch (e) {
+      return err(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  return err(`Unknown action: ${action}. Expected "list" or "download".`);
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -107,6 +107,8 @@ import * as messagingSend from "./bundled-skills/messaging/tools/messaging-send.
 import * as messagingSenderDigest from "./bundled-skills/messaging/tools/messaging-sender-digest.js";
 // ── notifications ──────────────────────────────────────────────────────────────
 import * as sendNotification from "./bundled-skills/notifications/tools/send-notification.js";
+// ── outlook ───────────────────────────────────────────────────────────────────
+import * as outlookAttachments from "./bundled-skills/outlook/tools/outlook-attachments.js";
 // ── phone-calls ────────────────────────────────────────────────────────────────
 import * as callEnd from "./bundled-skills/phone-calls/tools/call-end.js";
 import * as callStart from "./bundled-skills/phone-calls/tools/call-start.js";
@@ -289,6 +291,9 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
 
   // notifications
   ["notifications:tools/send-notification.ts", sendNotification],
+
+  // outlook
+  ["outlook:tools/outlook-attachments.ts", outlookAttachments],
 
   // phone-calls
   ["phone-calls:tools/call-start.ts", callStart],


### PR DESCRIPTION
## Summary
- Add outlook_attachments tool with list and download actions
- Includes path traversal protection for downloaded filenames
- Register tool in bundled-tool-registry.ts and TOOLS.json

Part of plan: outlook-email-gmail-parity.md (PR 5 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22527" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
