### PR TITLE
feat: add outlook_unsubscribe tool for mailing list opt-out

### DIFF
--- a/assistant/src/__tests__/outlook-unsubscribe.test.ts
+++ b/assistant/src/__tests__/outlook-unsubscribe.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type { OutlookMessage } from "../messaging/providers/outlook/types.js";
+import type { ToolContext } from "../tools/types.js";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockGetMessageWithHeaders =
+  mock<(conn: unknown, messageId: string) => Promise<OutlookMessage>>();
+const mockSendMessage =
+  mock<(conn: unknown, payload: unknown) => Promise<void>>();
+const mockResolveOAuthConnection =
+  mock<(provider: string, opts?: unknown) => Promise<unknown>>();
+const mockResolveRequestAddress =
+  mock<
+    (
+      hostname: string,
+      resolveHost: unknown,
+      allowPrivate: boolean,
+    ) => Promise<{ addresses: string[]; blockedAddress?: string }>
+  >();
+const mockPinnedHttpsRequest =
+  mock<(target: URL, address: string, opts?: unknown) => Promise<number>>();
+
+mock.module("../messaging/providers/outlook/client.js", () => ({
+  getMessageWithHeaders: mockGetMessageWithHeaders,
+  sendMessage: mockSendMessage,
+}));
+
+mock.module("../oauth/connection-resolver.js", () => ({
+  resolveOAuthConnection: mockResolveOAuthConnection,
+}));
+
+mock.module("../tools/network/url-safety.js", () => ({
+  isPrivateOrLocalHost: (hostname: string) =>
+    hostname === "localhost" || hostname === "127.0.0.1",
+  resolveHostAddresses: mock(() => Promise.resolve([])),
+  resolveRequestAddress: mockResolveRequestAddress,
+}));
+
+mock.module("../config/bundled-skills/gmail/tools/shared.js", () => ({
+  pinnedHttpsRequest: mockPinnedHttpsRequest,
+  ok: (content: string) => ({ content, isError: false }),
+  err: (message: string) => ({ content: message, isError: true }),
+}));
+
+mock.module("../config/bundled-skills/outlook/tools/shared.js", () => ({
+  pinnedHttpsRequest: mockPinnedHttpsRequest,
+  resolveRequestAddress: mockResolveRequestAddress,
+  ok: (content: string) => ({ content, isError: false }),
+  err: (message: string) => ({ content: message, isError: true }),
+}));
+
+// Import after mocks are set up
+const { run } =
+  await import("../config/bundled-skills/outlook/tools/outlook-unsubscribe.js");
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const fakeConnection = { id: "outlook-conn-1", providerKey: "outlook" };
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    triggeredBySurfaceAction: true,
+    conversationId: "conv-1",
+    ...overrides,
+  } as ToolContext;
+}
+
+function makeMessage(
+  headers: { name: string; value: string }[] = [],
+): OutlookMessage {
+  return {
+    id: "msg-1",
+    conversationId: "conv-1",
+    subject: "Newsletter",
+    bodyPreview: "",
+    body: { contentType: "text", content: "" },
+    toRecipients: [],
+    ccRecipients: [],
+    receivedDateTime: new Date().toISOString(),
+    isRead: true,
+    hasAttachments: false,
+    parentFolderId: "inbox",
+    categories: [],
+    flag: { flagStatus: "notFlagged" },
+    internetMessageHeaders: headers,
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("outlook_unsubscribe", () => {
+  test("rejects when not triggered by surface action", async () => {
+    const result = await run(
+      { message_id: "msg-1", confidence: 0.9 },
+      makeContext({ triggeredBySurfaceAction: false }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("surface action");
+  });
+
+  test("returns error when message_id is missing", async () => {
+    const result = await run({}, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("message_id is required");
+  });
+
+  test("returns error when no List-Unsubscribe header", async () => {
+    mockResolveOAuthConnection.mockResolvedValueOnce(fakeConnection);
+    mockGetMessageWithHeaders.mockResolvedValueOnce(makeMessage([]));
+
+    const result = await run(
+      { message_id: "msg-1", confidence: 0.9 },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("No List-Unsubscribe header found");
+  });
+
+  test("HTTPS POST unsubscribe with List-Unsubscribe-Post header", async () => {
+    mockResolveOAuthConnection.mockResolvedValueOnce(fakeConnection);
+    mockGetMessageWithHeaders.mockResolvedValueOnce(
+      makeMessage([
+        {
+          name: "List-Unsubscribe",
+          value: "<https://mail.example.com/unsubscribe?id=123>",
+        },
+        {
+          name: "List-Unsubscribe-Post",
+          value: "List-Unsubscribe=One-Click-Unsubscribe",
+        },
+      ]),
+    );
+    mockResolveRequestAddress.mockResolvedValueOnce({
+      addresses: ["93.184.216.34"],
+    });
+    mockPinnedHttpsRequest.mockResolvedValueOnce(200);
+
+    const result = await run(
+      { message_id: "msg-1", confidence: 0.9 },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain(
+      "Successfully unsubscribed via HTTPS POST",
+    );
+  });
+
+  test("HTTPS GET unsubscribe without List-Unsubscribe-Post header", async () => {
+    mockResolveOAuthConnection.mockResolvedValueOnce(fakeConnection);
+    mockGetMessageWithHeaders.mockResolvedValueOnce(
+      makeMessage([
+        {
+          name: "List-Unsubscribe",
+          value: "<https://mail.example.com/unsubscribe?id=456>",
+        },
+      ]),
+    );
+    mockResolveRequestAddress.mockResolvedValueOnce({
+      addresses: ["93.184.216.34"],
+    });
+    mockPinnedHttpsRequest.mockResolvedValueOnce(200);
+
+    const result = await run(
+      { message_id: "msg-1", confidence: 0.9 },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Successfully unsubscribed via HTTPS GET");
+  });
+
+  test("mailto fallback sends unsubscribe email via Outlook", async () => {
+    mockResolveOAuthConnection.mockResolvedValueOnce(fakeConnection);
+    mockGetMessageWithHeaders.mockResolvedValueOnce(
+      makeMessage([
+        {
+          name: "List-Unsubscribe",
+          value: "<mailto:unsub@example.com>",
+        },
+      ]),
+    );
+    mockSendMessage.mockResolvedValueOnce(undefined);
+
+    const result = await run(
+      { message_id: "msg-1", confidence: 0.9 },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain(
+      "Unsubscribe email sent to unsub@example.com",
+    );
+    expect(mockSendMessage).toHaveBeenCalledWith(fakeConnection, {
+      message: {
+        subject: "Unsubscribe",
+        body: { contentType: "text", content: "" },
+        toRecipients: [{ emailAddress: { address: "unsub@example.com" } }],
+      },
+    });
+  });
+
+  test("DNS rebinding protection blocks private addresses", async () => {
+    mockResolveOAuthConnection.mockResolvedValueOnce(fakeConnection);
+    mockGetMessageWithHeaders.mockResolvedValueOnce(
+      makeMessage([
+        {
+          name: "List-Unsubscribe",
+          value: "<https://evil.example.com/unsubscribe>",
+        },
+      ]),
+    );
+    mockResolveRequestAddress.mockResolvedValueOnce({
+      addresses: [],
+      blockedAddress: "192.168.1.1",
+    });
+
+    const result = await run(
+      { message_id: "msg-1", confidence: 0.9 },
+      makeContext(),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      "Unsubscribe URL resolves to a private or local address",
+    );
+  });
+
+  test("prefers HTTPS over mailto when both present", async () => {
+    mockResolveOAuthConnection.mockResolvedValueOnce(fakeConnection);
+    mockGetMessageWithHeaders.mockResolvedValueOnce(
+      makeMessage([
+        {
+          name: "List-Unsubscribe",
+          value:
+            "<mailto:unsub@example.com>, <https://mail.example.com/unsubscribe>",
+        },
+      ]),
+    );
+    mockResolveRequestAddress.mockResolvedValueOnce({
+      addresses: ["93.184.216.34"],
+    });
+    mockPinnedHttpsRequest.mockResolvedValueOnce(200);
+
+    const result = await run(
+      { message_id: "msg-1", confidence: 0.9 },
+      makeContext(),
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Successfully unsubscribed via HTTPS");
+  });
+});

--- a/assistant/src/config/bundled-skills/outlook/TOOLS.json
+++ b/assistant/src/config/bundled-skills/outlook/TOOLS.json
@@ -1,1 +1,35 @@
-[]
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "outlook_unsubscribe",
+      "description": "Unsubscribe from a mailing list by following the List-Unsubscribe header on an Outlook message. Include a confidence score (0-1).",
+      "category": "outlook",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "message_id": {
+            "type": "string",
+            "description": "An Outlook message ID from the mailing list to unsubscribe from"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Outlook account to use. Required when multiple Outlook accounts are connected. If omitted, uses the most recently connected account."
+          }
+        },
+        "required": ["message_id", "confidence"]
+      },
+      "executor": "tools/outlook-unsubscribe.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/outlook/tools/outlook-unsubscribe.ts
+++ b/assistant/src/config/bundled-skills/outlook/tools/outlook-unsubscribe.ts
@@ -1,0 +1,129 @@
+import {
+  getMessageWithHeaders,
+  sendMessage,
+} from "../../../../messaging/providers/outlook/client.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
+import {
+  isPrivateOrLocalHost,
+  resolveHostAddresses,
+} from "../../../../tools/network/url-safety.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import {
+  err,
+  ok,
+  pinnedHttpsRequest,
+  resolveRequestAddress,
+} from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
+  if (!context.triggeredBySurfaceAction) {
+    return err(
+      "This tool requires user confirmation via a surface action. Present results in a selection table with action buttons and wait for the user to click before proceeding.",
+    );
+  }
+
+  const messageId = input.message_id as string;
+
+  if (!messageId) {
+    return err("message_id is required.");
+  }
+
+  try {
+    const connection = await resolveOAuthConnection("outlook", {
+      account,
+    });
+    const message = await getMessageWithHeaders(connection, messageId);
+    const headers = message.internetMessageHeaders ?? [];
+    const unsubHeader = headers.find(
+      (h) => h.name.toLowerCase() === "list-unsubscribe",
+    )?.value;
+
+    if (!unsubHeader) {
+      return err(
+        "No List-Unsubscribe header found. Manual unsubscribe may be required.",
+      );
+    }
+
+    const httpsMatch = unsubHeader.match(/<(https:\/\/[^>]+)>/);
+    const mailtoMatch = unsubHeader.match(/<mailto:([^>]+)>/);
+    const postHeader = headers.find(
+      (h) => h.name.toLowerCase() === "list-unsubscribe-post",
+    )?.value;
+
+    if (httpsMatch) {
+      const url = httpsMatch[1];
+      let parsed: URL;
+      let validatedAddresses: string[];
+      try {
+        parsed = new URL(url);
+        if (parsed.protocol !== "https:") {
+          return err("Unsubscribe URL must use HTTPS.");
+        }
+        if (isPrivateOrLocalHost(parsed.hostname)) {
+          return err("Unsubscribe URL points to a private or local address.");
+        }
+        const { addresses, blockedAddress } = await resolveRequestAddress(
+          parsed.hostname,
+          resolveHostAddresses,
+          false,
+        );
+        if (blockedAddress) {
+          return err("Unsubscribe URL resolves to a private or local address.");
+        }
+        if (addresses.length === 0) {
+          return err("Unable to resolve unsubscribe URL hostname.");
+        }
+        validatedAddresses = addresses;
+      } catch {
+        return err("Invalid unsubscribe URL.");
+      }
+
+      const method = postHeader ? "POST" : "GET";
+      const reqOpts = postHeader
+        ? {
+            method: "POST" as const,
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+            body: postHeader,
+          }
+        : undefined;
+
+      let lastStatus = 0;
+      for (const address of validatedAddresses) {
+        try {
+          lastStatus = await pinnedHttpsRequest(parsed, address, reqOpts);
+          if (lastStatus >= 200 && lastStatus < 400) {
+            return ok(`Successfully unsubscribed via HTTPS ${method}.`);
+          }
+        } catch {
+          continue;
+        }
+      }
+      return err(`Unsubscribe request failed: ${lastStatus}`);
+    }
+
+    if (mailtoMatch) {
+      const mailtoAddr = mailtoMatch[1].split("?")[0];
+      await sendMessage(connection, {
+        message: {
+          subject: "Unsubscribe",
+          body: { contentType: "text", content: "" },
+          toRecipients: [{ emailAddress: { address: mailtoAddr } }],
+        },
+      });
+      return ok(`Unsubscribe email sent to ${mailtoAddr}.`);
+    }
+
+    return err(
+      "No supported unsubscribe method found (requires https: or mailto: URL).",
+    );
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -107,6 +107,8 @@ import * as messagingSend from "./bundled-skills/messaging/tools/messaging-send.
 import * as messagingSenderDigest from "./bundled-skills/messaging/tools/messaging-sender-digest.js";
 // ── notifications ──────────────────────────────────────────────────────────────
 import * as sendNotification from "./bundled-skills/notifications/tools/send-notification.js";
+// ── outlook ───────────────────────────────────────────────────────────────────
+import * as outlookUnsubscribe from "./bundled-skills/outlook/tools/outlook-unsubscribe.js";
 // ── phone-calls ────────────────────────────────────────────────────────────────
 import * as callEnd from "./bundled-skills/phone-calls/tools/call-end.js";
 import * as callStart from "./bundled-skills/phone-calls/tools/call-start.js";
@@ -286,6 +288,9 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["messaging:tools/messaging-draft.ts", messagingDraft],
   ["messaging:tools/messaging-sender-digest.ts", messagingSenderDigest],
   ["messaging:tools/messaging-archive-by-sender.ts", messagingArchiveBySender],
+
+  // outlook
+  ["outlook:tools/outlook-unsubscribe.ts", outlookUnsubscribe],
 
   // notifications
   ["notifications:tools/send-notification.ts", sendNotification],


### PR DESCRIPTION
## Summary
- Add outlook_unsubscribe tool with HTTPS and mailto unsubscribe support
- Includes DNS rebinding protection via shared url-safety utilities
- Parses List-Unsubscribe from Outlook's internetMessageHeaders format
- Register tool in bundled-tool-registry.ts and TOOLS.json

Part of plan: outlook-email-gmail-parity.md (PR 8 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
