### PR TITLE
Require platform connection for `oauth mode set --set`

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -1240,3 +1240,75 @@ describe("requirePlatformConnection", () => {
     expect(process.exitCode).toBe(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// oauth mode — platform connection guard
+// ---------------------------------------------------------------------------
+
+describe("assistant oauth mode", () => {
+  beforeEach(() => {
+    mockWithValidToken = async (_service, cb) => cb("mock-access-token-xyz");
+    mockGetProvider = () => ({
+      providerKey: "google",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      defaultScopes: "[]",
+      scopePolicy: "{}",
+      extraParams: null,
+      managedServiceConfigKey: "google-oauth",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    mockGetConfig = () => ({
+      services: {
+        "google-oauth": { mode: "your-own" },
+      },
+    });
+  });
+
+  afterEach(() => {
+    mockPlatformClientCreate = async () => null;
+    mockGetConfig = () => ({ services: {} });
+    mockGetProvider = () => undefined;
+  });
+
+  test("oauth mode <provider> --set managed fails when not connected to platform", async () => {
+    mockPlatformClientCreate = async () => null;
+    const { exitCode, stdout } = await runCli([
+      "mode",
+      "google",
+      "--set",
+      "managed",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("vellum platform connect");
+  });
+
+  test("oauth mode <provider> --set your-own fails when not connected to platform", async () => {
+    mockPlatformClientCreate = async () => null;
+    const { exitCode, stdout } = await runCli([
+      "mode",
+      "google",
+      "--set",
+      "your-own",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("vellum platform connect");
+  });
+
+  test("oauth mode <provider> (read) succeeds without platform connection", async () => {
+    mockPlatformClientCreate = async () => null;
+    const { exitCode, stdout } = await runCli(["mode", "google", "--json"]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.provider).toBe("google");
+    expect(parsed.mode).toBe("your-own");
+  });
+});

--- a/assistant/src/cli/commands/oauth/mode.ts
+++ b/assistant/src/cli/commands/oauth/mode.ts
@@ -17,6 +17,7 @@ import { shouldOutputJson, writeOutput } from "../../output.js";
 import {
   fetchActiveConnections,
   getManagedServiceConfigKey,
+  requirePlatformConnection,
 } from "./shared.js";
 
 /**
@@ -92,6 +93,12 @@ Examples:
           });
           process.exitCode = 1;
           return;
+        }
+
+        // Require platform connection for mode changes
+        if (opts.set !== undefined) {
+          const connected = await requirePlatformConnection(cmd);
+          if (!connected) return;
         }
 
         const managedKey = getManagedServiceConfigKey(provider);


### PR DESCRIPTION
## Summary
- Add platform connection guard to `oauth mode set` when `--set` flag is used
- Read-only mode queries (`oauth mode <provider>`) work without platform connection
- Clear error message directs users to run `vellum platform connect`

Part of plan: require-platform-login.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
