### PR TITLE
feat: add outlook_rules and outlook_vacation tools for inbox automation

### DIFF
--- a/assistant/src/__tests__/outlook-automation-tools.test.ts
+++ b/assistant/src/__tests__/outlook-automation-tools.test.ts
@@ -1,0 +1,425 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type {
+  OutlookAutoReplySettings,
+  OutlookMessageRule,
+  OutlookMessageRuleListResponse,
+} from "../messaging/providers/outlook/types.js";
+import type { OAuthConnection } from "../oauth/connection.js";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const listMailRulesMock = mock<() => Promise<OutlookMessageRuleListResponse>>();
+const createMailRuleMock =
+  mock<
+    (
+      connection: OAuthConnection,
+      rule: Omit<OutlookMessageRule, "id">,
+    ) => Promise<OutlookMessageRule>
+  >();
+const deleteMailRuleMock =
+  mock<(connection: OAuthConnection, ruleId: string) => Promise<void>>();
+const getAutoReplySettingsMock =
+  mock<() => Promise<OutlookAutoReplySettings>>();
+const updateAutoReplySettingsMock =
+  mock<
+    (
+      connection: OAuthConnection,
+      settings: OutlookAutoReplySettings,
+    ) => Promise<void>
+  >();
+
+mock.module("../messaging/providers/outlook/client.js", () => ({
+  listMailRules: (...args: unknown[]) => listMailRulesMock(...(args as [])),
+  createMailRule: (...args: unknown[]) =>
+    createMailRuleMock(
+      ...(args as [OAuthConnection, Omit<OutlookMessageRule, "id">]),
+    ),
+  deleteMailRule: (...args: unknown[]) =>
+    deleteMailRuleMock(...(args as [OAuthConnection, string])),
+  getAutoReplySettings: (...args: unknown[]) =>
+    getAutoReplySettingsMock(...(args as [])),
+  updateAutoReplySettings: (...args: unknown[]) =>
+    updateAutoReplySettingsMock(
+      ...(args as [OAuthConnection, OutlookAutoReplySettings]),
+    ),
+}));
+
+const fakeConnection = {} as OAuthConnection;
+
+mock.module("../oauth/connection-resolver.js", () => ({
+  resolveOAuthConnection: () => fakeConnection,
+}));
+
+import { run as runRules } from "../config/bundled-skills/outlook/tools/outlook-rules.js";
+import { run as runVacation } from "../config/bundled-skills/outlook/tools/outlook-vacation.js";
+import type { ToolContext } from "../tools/types.js";
+
+const ctx: ToolContext = {
+  workingDir: "/tmp",
+  conversationId: "test-conversation",
+  trustClass: "guardian",
+};
+
+// ── outlook_rules: list ──────────────────────────────────────────────────────
+
+describe("outlook_rules list", () => {
+  test("returns no rules message when list is empty", async () => {
+    listMailRulesMock.mockResolvedValueOnce({ value: [] });
+    const result = await runRules({ action: "list" }, ctx);
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe("No inbox rules configured.");
+  });
+
+  test("returns formatted rule summaries", async () => {
+    listMailRulesMock.mockResolvedValueOnce({
+      value: [
+        {
+          id: "rule-1",
+          displayName: "Archive newsletters",
+          sequence: 1,
+          isEnabled: true,
+          conditions: { senderContains: ["newsletter@"] },
+          actions: { moveToFolder: "archive-folder-id", markAsRead: true },
+        },
+        {
+          id: "rule-2",
+          displayName: "Flag urgent",
+          sequence: 2,
+          isEnabled: false,
+          conditions: { importance: "high" },
+          actions: { markImportance: "high" },
+        },
+      ],
+    });
+
+    const result = await runRules({ action: "list" }, ctx);
+    expect(result.isError).toBe(false);
+
+    const parsed = JSON.parse(result.content);
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0].id).toBe("rule-1");
+    expect(parsed[0].displayName).toBe("Archive newsletters");
+    expect(parsed[0].isEnabled).toBe(true);
+    expect(parsed[0].conditions).toContain("sender contains: newsletter@");
+    expect(parsed[0].actions).toContain("move to folder: archive-folder-id");
+    expect(parsed[0].actions).toContain("mark as read");
+    expect(parsed[1].id).toBe("rule-2");
+    expect(parsed[1].isEnabled).toBe(false);
+  });
+});
+
+// ── outlook_rules: create ────────────────────────────────────────────────────
+
+describe("outlook_rules create", () => {
+  test("creates a rule with conditions and actions", async () => {
+    createMailRuleMock.mockResolvedValueOnce({
+      id: "new-rule-1",
+      displayName: "Auto-archive spam",
+      sequence: 1,
+      isEnabled: true,
+      conditions: { senderContains: ["spam@"] },
+      actions: { moveToFolder: "junk-folder-id" },
+    });
+
+    const result = await runRules(
+      {
+        action: "create",
+        display_name: "Auto-archive spam",
+        from_contains: "spam@",
+        move_to_folder: "junk-folder-id",
+        confidence: 0.95,
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe("Rule created (ID: new-rule-1).");
+    expect(createMailRuleMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects create without display_name", async () => {
+    const result = await runRules(
+      { action: "create", from_contains: "test@", confidence: 0.9 },
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("display_name is required");
+  });
+
+  test("rejects create without conditions", async () => {
+    const result = await runRules(
+      {
+        action: "create",
+        display_name: "Empty rule",
+        move_to_folder: "folder-id",
+        confidence: 0.9,
+      },
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("At least one condition is required");
+  });
+
+  test("handles array conditions", async () => {
+    createMailRuleMock.mockResolvedValueOnce({
+      id: "rule-arr",
+      displayName: "Multi-sender",
+      sequence: 1,
+      isEnabled: true,
+      conditions: { senderContains: ["alice@", "bob@"] },
+      actions: { markAsRead: true },
+    });
+
+    const result = await runRules(
+      {
+        action: "create",
+        display_name: "Multi-sender",
+        from_contains: ["alice@", "bob@"],
+        mark_as_read: true,
+        confidence: 0.9,
+      },
+      ctx,
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Rule created");
+  });
+
+  test("creates rule with forward_to action", async () => {
+    createMailRuleMock.mockResolvedValueOnce({
+      id: "rule-fwd",
+      displayName: "Forward urgent",
+      sequence: 1,
+      isEnabled: true,
+      conditions: { importance: "high" },
+      actions: {
+        forwardTo: [{ emailAddress: { address: "boss@example.com" } }],
+      },
+    });
+
+    const result = await runRules(
+      {
+        action: "create",
+        display_name: "Forward urgent",
+        importance: "high",
+        forward_to: "boss@example.com",
+        confidence: 0.9,
+      },
+      ctx,
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Rule created");
+
+    const callArgs = createMailRuleMock.mock.calls.at(-1)!;
+    const rule = callArgs[1] as Omit<OutlookMessageRule, "id">;
+    expect(rule.actions?.forwardTo).toEqual([
+      { emailAddress: { address: "boss@example.com" } },
+    ]);
+  });
+});
+
+// ── outlook_rules: delete ────────────────────────────────────────────────────
+
+describe("outlook_rules delete", () => {
+  test("deletes a rule by ID", async () => {
+    deleteMailRuleMock.mockResolvedValueOnce(undefined);
+
+    const result = await runRules(
+      { action: "delete", rule_id: "rule-1", confidence: 0.9 },
+      ctx,
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe("Rule deleted.");
+    expect(deleteMailRuleMock).toHaveBeenCalledWith(fakeConnection, "rule-1");
+  });
+
+  test("rejects delete without rule_id", async () => {
+    const result = await runRules({ action: "delete", confidence: 0.9 }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("rule_id is required");
+  });
+});
+
+// ── outlook_rules: errors ────────────────────────────────────────────────────
+
+describe("outlook_rules error handling", () => {
+  test("returns error for missing action", async () => {
+    const result = await runRules({}, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("action is required");
+  });
+
+  test("returns error for unknown action", async () => {
+    const result = await runRules({ action: "unknown" }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Unknown action "unknown"');
+  });
+});
+
+// ── outlook_vacation: get ────────────────────────────────────────────────────
+
+describe("outlook_vacation get", () => {
+  test("returns current auto-reply settings", async () => {
+    const settings: OutlookAutoReplySettings = {
+      status: "disabled",
+      externalAudience: "none",
+    };
+    getAutoReplySettingsMock.mockResolvedValueOnce(settings);
+
+    const result = await runVacation({ action: "get" }, ctx);
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.status).toBe("disabled");
+    expect(parsed.externalAudience).toBe("none");
+  });
+
+  test("returns scheduled settings with messages", async () => {
+    const settings: OutlookAutoReplySettings = {
+      status: "scheduled",
+      externalAudience: "all",
+      internalReplyMessage: "I'm on vacation",
+      externalReplyMessage: "Out of office until Jan 5",
+      scheduledStartDateTime: {
+        dateTime: "2025-01-01T00:00:00",
+        timeZone: "America/New_York",
+      },
+      scheduledEndDateTime: {
+        dateTime: "2025-01-05T00:00:00",
+        timeZone: "America/New_York",
+      },
+    };
+    getAutoReplySettingsMock.mockResolvedValueOnce(settings);
+
+    const result = await runVacation({ action: "get" }, ctx);
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.status).toBe("scheduled");
+    expect(parsed.internalReplyMessage).toBe("I'm on vacation");
+    expect(parsed.scheduledStartDateTime.dateTime).toBe("2025-01-01T00:00:00");
+  });
+});
+
+// ── outlook_vacation: enable ─────────────────────────────────────────────────
+
+describe("outlook_vacation enable", () => {
+  test("enables always-on auto-reply", async () => {
+    updateAutoReplySettingsMock.mockResolvedValueOnce(undefined);
+
+    const result = await runVacation(
+      {
+        action: "enable",
+        internal_message: "I'm currently away from my desk.",
+        confidence: 0.9,
+      },
+      ctx,
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe("Auto-reply enabled.");
+
+    const callArgs = updateAutoReplySettingsMock.mock.calls.at(-1)!;
+    const settings = callArgs[1] as OutlookAutoReplySettings;
+    expect(settings.status).toBe("alwaysEnabled");
+    expect(settings.internalReplyMessage).toBe(
+      "I'm currently away from my desk.",
+    );
+    expect(settings.externalAudience).toBe("none");
+  });
+
+  test("enables scheduled auto-reply with date range", async () => {
+    updateAutoReplySettingsMock.mockResolvedValueOnce(undefined);
+
+    const result = await runVacation(
+      {
+        action: "enable",
+        internal_message: "On vacation until Jan 5.",
+        external_message: "Out of office.",
+        external_audience: "all",
+        start_date: "2025-01-01T00:00:00",
+        end_date: "2025-01-05T00:00:00",
+        time_zone: "America/New_York",
+        confidence: 0.9,
+      },
+      ctx,
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe("Auto-reply enabled.");
+
+    const callArgs = updateAutoReplySettingsMock.mock.calls.at(-1)!;
+    const settings = callArgs[1] as OutlookAutoReplySettings;
+    expect(settings.status).toBe("scheduled");
+    expect(settings.externalAudience).toBe("all");
+    expect(settings.externalReplyMessage).toBe("Out of office.");
+    expect(settings.scheduledStartDateTime).toEqual({
+      dateTime: "2025-01-01T00:00:00",
+      timeZone: "America/New_York",
+    });
+    expect(settings.scheduledEndDateTime).toEqual({
+      dateTime: "2025-01-05T00:00:00",
+      timeZone: "America/New_York",
+    });
+  });
+
+  test("rejects enable without internal_message", async () => {
+    const result = await runVacation(
+      { action: "enable", confidence: 0.9 },
+      ctx,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("internal_message is required");
+  });
+
+  test("uses alwaysEnabled when only start_date provided (no end_date)", async () => {
+    updateAutoReplySettingsMock.mockResolvedValueOnce(undefined);
+
+    const result = await runVacation(
+      {
+        action: "enable",
+        internal_message: "Away",
+        start_date: "2025-01-01T00:00:00",
+        confidence: 0.9,
+      },
+      ctx,
+    );
+    expect(result.isError).toBe(false);
+
+    const callArgs = updateAutoReplySettingsMock.mock.calls.at(-1)!;
+    const settings = callArgs[1] as OutlookAutoReplySettings;
+    expect(settings.status).toBe("alwaysEnabled");
+  });
+});
+
+// ── outlook_vacation: disable ────────────────────────────────────────────────
+
+describe("outlook_vacation disable", () => {
+  test("disables auto-reply", async () => {
+    updateAutoReplySettingsMock.mockResolvedValueOnce(undefined);
+
+    const result = await runVacation(
+      { action: "disable", confidence: 0.9 },
+      ctx,
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe("Auto-reply disabled.");
+
+    const callArgs = updateAutoReplySettingsMock.mock.calls.at(-1)!;
+    const settings = callArgs[1] as OutlookAutoReplySettings;
+    expect(settings.status).toBe("disabled");
+    expect(settings.externalAudience).toBe("none");
+  });
+});
+
+// ── outlook_vacation: errors ─────────────────────────────────────────────────
+
+describe("outlook_vacation error handling", () => {
+  test("returns error for missing action", async () => {
+    const result = await runVacation({}, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("action is required");
+  });
+
+  test("returns error for unknown action", async () => {
+    const result = await runVacation({ action: "unknown" }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Unknown action "unknown"');
+  });
+});

--- a/assistant/src/config/bundled-skills/outlook/TOOLS.json
+++ b/assistant/src/config/bundled-skills/outlook/TOOLS.json
@@ -1,1 +1,158 @@
-[]
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "outlook_rules",
+      "description": "List, create, or delete Outlook inbox message rules for automatic mail processing. Include a confidence score (0-1) for create and delete actions.",
+      "category": "outlook",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": ["list", "create", "delete"],
+            "description": "Rule action"
+          },
+          "display_name": {
+            "type": "string",
+            "description": "Display name for the rule (required for create)"
+          },
+          "from_contains": {
+            "oneOf": [
+              { "type": "string" },
+              { "type": "array", "items": { "type": "string" } }
+            ],
+            "description": "Condition: sender contains (for create)"
+          },
+          "subject_contains": {
+            "oneOf": [
+              { "type": "string" },
+              { "type": "array", "items": { "type": "string" } }
+            ],
+            "description": "Condition: subject contains (for create)"
+          },
+          "body_contains": {
+            "oneOf": [
+              { "type": "string" },
+              { "type": "array", "items": { "type": "string" } }
+            ],
+            "description": "Condition: body contains (for create)"
+          },
+          "has_attachment": {
+            "type": "boolean",
+            "description": "Condition: message has attachment (for create)"
+          },
+          "importance": {
+            "type": "string",
+            "enum": ["low", "normal", "high"],
+            "description": "Condition: message importance level (for create)"
+          },
+          "move_to_folder": {
+            "type": "string",
+            "description": "Action: move to folder ID (for create)"
+          },
+          "delete": {
+            "type": "boolean",
+            "description": "Action: delete message (for create)"
+          },
+          "mark_as_read": {
+            "type": "boolean",
+            "description": "Action: mark as read (for create)"
+          },
+          "mark_importance": {
+            "type": "string",
+            "enum": ["low", "normal", "high"],
+            "description": "Action: set importance level (for create)"
+          },
+          "forward_to": {
+            "oneOf": [
+              { "type": "string" },
+              { "type": "array", "items": { "type": "string" } }
+            ],
+            "description": "Action: forward to email address(es) (for create)"
+          },
+          "stop_processing": {
+            "type": "boolean",
+            "description": "Action: stop processing subsequent rules (for create)"
+          },
+          "rule_id": {
+            "type": "string",
+            "description": "Rule ID (required for delete)"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Outlook account to use. Required when multiple Microsoft accounts are connected. If omitted, uses the most recently connected account."
+          }
+        },
+        "required": ["action"]
+      },
+      "executor": "tools/outlook-rules.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "outlook_vacation",
+      "description": "Get, enable, or disable Outlook automatic reply (out-of-office) settings. Include a confidence score (0-1) for enable and disable actions.",
+      "category": "outlook",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": ["get", "enable", "disable"],
+            "description": "Vacation action"
+          },
+          "internal_message": {
+            "type": "string",
+            "description": "Auto-reply message for internal (same organization) senders (required for enable)"
+          },
+          "external_message": {
+            "type": "string",
+            "description": "Auto-reply message for external senders (for enable)"
+          },
+          "external_audience": {
+            "type": "string",
+            "enum": ["none", "contactsOnly", "all"],
+            "description": "Who receives the external auto-reply: none, contactsOnly, or all (default none)"
+          },
+          "start_date": {
+            "type": "string",
+            "description": "Scheduled start date/time in ISO 8601 format (for enable with schedule)"
+          },
+          "end_date": {
+            "type": "string",
+            "description": "Scheduled end date/time in ISO 8601 format (for enable with schedule)"
+          },
+          "time_zone": {
+            "type": "string",
+            "description": "IANA time zone for scheduled dates (default: system timezone)"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Outlook account to use. Required when multiple Microsoft accounts are connected. If omitted, uses the most recently connected account."
+          }
+        },
+        "required": ["action"]
+      },
+      "executor": "tools/outlook-vacation.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/outlook/tools/outlook-rules.ts
+++ b/assistant/src/config/bundled-skills/outlook/tools/outlook-rules.ts
@@ -1,0 +1,161 @@
+import {
+  createMailRule,
+  deleteMailRule,
+  listMailRules,
+} from "../../../../messaging/providers/outlook/client.js";
+import type {
+  OutlookMessageRuleActions,
+  OutlookMessageRulePredicates,
+} from "../../../../messaging/providers/outlook/types.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
+  const action = input.action as string;
+
+  if (!action) {
+    return err("action is required (list, create, or delete).");
+  }
+
+  try {
+    const connection = await resolveOAuthConnection("microsoft", {
+      account,
+    });
+    switch (action) {
+      case "list": {
+        const resp = await listMailRules(connection);
+        const rules = resp.value ?? [];
+        if (rules.length === 0) {
+          return ok("No inbox rules configured.");
+        }
+        const summary = rules.map((r) => ({
+          id: r.id,
+          displayName: r.displayName,
+          isEnabled: r.isEnabled,
+          conditions: summarizeConditions(r.conditions),
+          actions: summarizeActions(r.actions),
+        }));
+        return ok(JSON.stringify(summary, null, 2));
+      }
+
+      case "create": {
+        const displayName = input.display_name as string;
+        if (!displayName)
+          return err("display_name is required for create action.");
+
+        const conditions: OutlookMessageRulePredicates = {};
+        if (input.from_contains)
+          conditions.senderContains = Array.isArray(input.from_contains)
+            ? (input.from_contains as string[])
+            : [input.from_contains as string];
+        if (input.subject_contains)
+          conditions.subjectContains = Array.isArray(input.subject_contains)
+            ? (input.subject_contains as string[])
+            : [input.subject_contains as string];
+        if (input.body_contains)
+          conditions.bodyContains = Array.isArray(input.body_contains)
+            ? (input.body_contains as string[])
+            : [input.body_contains as string];
+        if (input.has_attachment !== undefined)
+          conditions.hasAttachments = input.has_attachment as boolean;
+        if (input.importance)
+          conditions.importance = input.importance as "low" | "normal" | "high";
+
+        if (Object.keys(conditions).length === 0) {
+          return err(
+            "At least one condition is required (from_contains, subject_contains, body_contains, has_attachment, or importance).",
+          );
+        }
+
+        const actions: OutlookMessageRuleActions = {};
+        if (input.move_to_folder)
+          actions.moveToFolder = input.move_to_folder as string;
+        if (input.delete !== undefined)
+          actions.delete = input.delete as boolean;
+        if (input.mark_as_read !== undefined)
+          actions.markAsRead = input.mark_as_read as boolean;
+        if (input.mark_importance)
+          actions.markImportance = input.mark_importance as
+            | "low"
+            | "normal"
+            | "high";
+        if (input.forward_to) {
+          const emails = Array.isArray(input.forward_to)
+            ? (input.forward_to as string[])
+            : [input.forward_to as string];
+          actions.forwardTo = emails.map((addr) => ({
+            emailAddress: { address: addr },
+          }));
+        }
+        if (input.stop_processing !== undefined)
+          actions.stopProcessingRules = input.stop_processing as boolean;
+
+        const rule = await createMailRule(connection, {
+          displayName,
+          sequence: (input.sequence as number) ?? 1,
+          isEnabled: true,
+          conditions,
+          actions,
+        });
+        return ok(`Rule created (ID: ${rule.id}).`);
+      }
+
+      case "delete": {
+        const ruleId = input.rule_id as string;
+        if (!ruleId) return err("rule_id is required for delete action.");
+
+        await deleteMailRule(connection, ruleId);
+        return ok("Rule deleted.");
+      }
+
+      default:
+        return err(`Unknown action "${action}". Use list, create, or delete.`);
+    }
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}
+
+function summarizeConditions(
+  c: OutlookMessageRulePredicates | undefined,
+): string {
+  if (!c) return "none";
+  const parts: string[] = [];
+  if (c.senderContains?.length)
+    parts.push(`sender contains: ${c.senderContains.join(", ")}`);
+  if (c.subjectContains?.length)
+    parts.push(`subject contains: ${c.subjectContains.join(", ")}`);
+  if (c.bodyContains?.length)
+    parts.push(`body contains: ${c.bodyContains.join(", ")}`);
+  if (c.fromAddresses?.length)
+    parts.push(
+      `from: ${c.fromAddresses.map((a) => a.emailAddress.address).join(", ")}`,
+    );
+  if (c.hasAttachments !== undefined)
+    parts.push(`has attachments: ${c.hasAttachments}`);
+  if (c.importance) parts.push(`importance: ${c.importance}`);
+  return parts.length > 0 ? parts.join("; ") : "none";
+}
+
+function summarizeActions(c: OutlookMessageRuleActions | undefined): string {
+  if (!c) return "none";
+  const parts: string[] = [];
+  if (c.moveToFolder) parts.push(`move to folder: ${c.moveToFolder}`);
+  if (c.delete) parts.push("delete");
+  if (c.markAsRead) parts.push("mark as read");
+  if (c.markImportance) parts.push(`mark importance: ${c.markImportance}`);
+  if (c.forwardTo?.length)
+    parts.push(
+      `forward to: ${c.forwardTo.map((r) => r.emailAddress.address).join(", ")}`,
+    );
+  if (c.stopProcessingRules) parts.push("stop processing rules");
+  return parts.length > 0 ? parts.join("; ") : "none";
+}

--- a/assistant/src/config/bundled-skills/outlook/tools/outlook-vacation.ts
+++ b/assistant/src/config/bundled-skills/outlook/tools/outlook-vacation.ts
@@ -1,0 +1,87 @@
+import {
+  getAutoReplySettings,
+  updateAutoReplySettings,
+} from "../../../../messaging/providers/outlook/client.js";
+import type { OutlookAutoReplySettings } from "../../../../messaging/providers/outlook/types.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
+  const action = input.action as string;
+
+  if (!action) {
+    return err("action is required (get, enable, or disable).");
+  }
+
+  try {
+    const connection = await resolveOAuthConnection("microsoft", {
+      account,
+    });
+    switch (action) {
+      case "get": {
+        const settings = await getAutoReplySettings(connection);
+        return ok(JSON.stringify(settings, null, 2));
+      }
+
+      case "enable": {
+        const internalMessage = input.internal_message as string;
+        if (!internalMessage)
+          return err("internal_message is required when enabling auto-reply.");
+
+        const externalAudience = (input.external_audience as string) ?? "none";
+        const startDate = input.start_date as string | undefined;
+        const endDate = input.end_date as string | undefined;
+        const timeZone =
+          (input.time_zone as string) ??
+          Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+        const isScheduled = !!(startDate && endDate);
+
+        const settings: OutlookAutoReplySettings = {
+          status: isScheduled ? "scheduled" : "alwaysEnabled",
+          externalAudience: externalAudience as "none" | "contactsOnly" | "all",
+          internalReplyMessage: internalMessage,
+        };
+
+        if (input.external_message) {
+          settings.externalReplyMessage = input.external_message as string;
+        }
+
+        if (isScheduled) {
+          settings.scheduledStartDateTime = {
+            dateTime: startDate!,
+            timeZone,
+          };
+          settings.scheduledEndDateTime = {
+            dateTime: endDate!,
+            timeZone,
+          };
+        }
+
+        await updateAutoReplySettings(connection, settings);
+        return ok("Auto-reply enabled.");
+      }
+
+      case "disable": {
+        await updateAutoReplySettings(connection, {
+          status: "disabled",
+          externalAudience: "none",
+        });
+        return ok("Auto-reply disabled.");
+      }
+
+      default:
+        return err(`Unknown action "${action}". Use get, enable, or disable.`);
+    }
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -107,6 +107,9 @@ import * as messagingSend from "./bundled-skills/messaging/tools/messaging-send.
 import * as messagingSenderDigest from "./bundled-skills/messaging/tools/messaging-sender-digest.js";
 // ── notifications ──────────────────────────────────────────────────────────────
 import * as sendNotification from "./bundled-skills/notifications/tools/send-notification.js";
+// ── outlook ───────────────────────────────────────────────────────────────────
+import * as outlookRules from "./bundled-skills/outlook/tools/outlook-rules.js";
+import * as outlookVacation from "./bundled-skills/outlook/tools/outlook-vacation.js";
 // ── phone-calls ────────────────────────────────────────────────────────────────
 import * as callEnd from "./bundled-skills/phone-calls/tools/call-end.js";
 import * as callStart from "./bundled-skills/phone-calls/tools/call-start.js";
@@ -289,6 +292,10 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
 
   // notifications
   ["notifications:tools/send-notification.ts", sendNotification],
+
+  // outlook
+  ["outlook:tools/outlook-rules.ts", outlookRules],
+  ["outlook:tools/outlook-vacation.ts", outlookVacation],
 
   // phone-calls
   ["phone-calls:tools/call-start.ts", callStart],


### PR DESCRIPTION
## Summary
- Add outlook_rules tool for managing inbox message rules (list/create/delete)
- Add outlook_vacation tool for managing auto-reply settings (get/enable/disable with scheduling)
- Register both tools in bundled-tool-registry.ts and TOOLS.json

Part of plan: outlook-email-gmail-parity.md (PR 10 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
