### PR TITLE
feat: add outlook_trash, outlook_categories, and outlook_follow_up tools

### DIFF
--- a/assistant/src/__tests__/outlook-categories.test.ts
+++ b/assistant/src/__tests__/outlook-categories.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, mock, test } from "bun:test";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockGetMessage = mock(() =>
+  Promise.resolve({ categories: ["Red category"] }),
+);
+const mockUpdateMessageCategories = mock(() => Promise.resolve());
+const mockListMasterCategories = mock(() =>
+  Promise.resolve({
+    value: [
+      { displayName: "Red category", color: "preset0" },
+      { displayName: "Blue category", color: "preset7" },
+    ],
+  }),
+);
+const mockResolveOAuthConnection = mock(() =>
+  Promise.resolve({ id: "conn-1", providerKey: "outlook" }),
+);
+
+mock.module("../messaging/providers/outlook/client.js", () => ({
+  getMessage: mockGetMessage,
+  updateMessageCategories: mockUpdateMessageCategories,
+  listMasterCategories: mockListMasterCategories,
+}));
+
+mock.module("../oauth/connection-resolver.js", () => ({
+  resolveOAuthConnection: mockResolveOAuthConnection,
+}));
+
+import { run } from "../config/bundled-skills/outlook/tools/outlook-categories.js";
+import type { ToolContext } from "../tools/types.js";
+
+const ctx: ToolContext = {
+  workingDir: "/tmp",
+  conversationId: "test-conv",
+};
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("outlook_categories tool", () => {
+  test("returns error when action is missing", async () => {
+    const result = await run({}, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("action is required");
+  });
+
+  test("returns error for unknown action", async () => {
+    const result = await run({ action: "invalid", confidence: 0.9 }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Unknown action "invalid"');
+  });
+
+  // ── add ──────────────────────────────────────────────────────────────────
+
+  describe("add", () => {
+    test("requires message_id", async () => {
+      const result = await run(
+        { action: "add", categories: ["Blue category"], confidence: 0.9 },
+        ctx,
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("message_id is required");
+    });
+
+    test("requires categories", async () => {
+      const result = await run(
+        { action: "add", message_id: "msg-1", confidence: 0.9 },
+        ctx,
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("categories is required");
+    });
+
+    test("merges new categories with existing", async () => {
+      mockGetMessage.mockClear();
+      mockUpdateMessageCategories.mockClear();
+      mockGetMessage.mockImplementationOnce(() =>
+        Promise.resolve({ categories: ["Red category"] }),
+      );
+
+      const result = await run(
+        {
+          action: "add",
+          message_id: "msg-1",
+          categories: ["Blue category"],
+          confidence: 0.9,
+        },
+        ctx,
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toBe("Categories updated.");
+      expect(mockUpdateMessageCategories).toHaveBeenCalledWith(
+        expect.anything(),
+        "msg-1",
+        expect.arrayContaining(["Red category", "Blue category"]),
+      );
+    });
+
+    test("deduplicates when adding existing category", async () => {
+      mockGetMessage.mockClear();
+      mockUpdateMessageCategories.mockClear();
+      mockGetMessage.mockImplementationOnce(() =>
+        Promise.resolve({ categories: ["Red category"] }),
+      );
+
+      await run(
+        {
+          action: "add",
+          message_id: "msg-1",
+          categories: ["Red category"],
+          confidence: 0.9,
+        },
+        ctx,
+      );
+
+      const calledCategories = mockUpdateMessageCategories.mock
+        .calls[0][2] as string[];
+      expect(calledCategories).toHaveLength(1);
+      expect(calledCategories).toContain("Red category");
+    });
+  });
+
+  // ── remove ───────────────────────────────────────────────────────────────
+
+  describe("remove", () => {
+    test("requires message_id", async () => {
+      const result = await run(
+        { action: "remove", categories: ["Red category"], confidence: 0.9 },
+        ctx,
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("message_id is required");
+    });
+
+    test("requires categories", async () => {
+      const result = await run(
+        { action: "remove", message_id: "msg-1", confidence: 0.9 },
+        ctx,
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("categories is required");
+    });
+
+    test("removes specified categories", async () => {
+      mockGetMessage.mockClear();
+      mockUpdateMessageCategories.mockClear();
+      mockGetMessage.mockImplementationOnce(() =>
+        Promise.resolve({ categories: ["Red category", "Blue category"] }),
+      );
+
+      const result = await run(
+        {
+          action: "remove",
+          message_id: "msg-1",
+          categories: ["Red category"],
+          confidence: 0.9,
+        },
+        ctx,
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toBe("Categories updated.");
+      expect(mockUpdateMessageCategories).toHaveBeenCalledWith(
+        expect.anything(),
+        "msg-1",
+        ["Blue category"],
+      );
+    });
+  });
+
+  // ── list_available ───────────────────────────────────────────────────────
+
+  describe("list_available", () => {
+    test("returns available categories as JSON", async () => {
+      mockListMasterCategories.mockClear();
+
+      const result = await run(
+        { action: "list_available", confidence: 0.5 },
+        ctx,
+      );
+
+      expect(result.isError).toBe(false);
+      const parsed = JSON.parse(result.content);
+      expect(parsed).toHaveLength(2);
+      expect(parsed[0].displayName).toBe("Red category");
+    });
+  });
+
+  // ── error handling ───────────────────────────────────────────────────────
+
+  test("returns error on API failure", async () => {
+    mockGetMessage.mockImplementationOnce(() =>
+      Promise.reject(new Error("Graph API 403: Forbidden")),
+    );
+
+    const result = await run(
+      {
+        action: "add",
+        message_id: "msg-bad",
+        categories: ["Test"],
+        confidence: 0.9,
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Graph API 403");
+  });
+});

--- a/assistant/src/__tests__/outlook-categories.test.ts
+++ b/assistant/src/__tests__/outlook-categories.test.ts
@@ -34,6 +34,7 @@ import type { ToolContext } from "../tools/types.js";
 const ctx: ToolContext = {
   workingDir: "/tmp",
   conversationId: "test-conv",
+  trustClass: "guardian",
 };
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -115,8 +116,8 @@ describe("outlook_categories tool", () => {
         ctx,
       );
 
-      const calledCategories = mockUpdateMessageCategories.mock
-        .calls[0][2] as string[];
+      const callArgs = mockUpdateMessageCategories.mock.calls[0] as unknown[];
+      const calledCategories = callArgs[2] as string[];
       expect(calledCategories).toHaveLength(1);
       expect(calledCategories).toContain("Red category");
     });

--- a/assistant/src/__tests__/outlook-follow-up.test.ts
+++ b/assistant/src/__tests__/outlook-follow-up.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, mock, test } from "bun:test";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockUpdateMessageFlag = mock(() => Promise.resolve());
+const mockListMessages = mock(() =>
+  Promise.resolve({
+    value: [
+      {
+        id: "msg-1",
+        conversationId: "conv-1",
+        subject: "Follow up on proposal",
+        from: { emailAddress: { address: "alice@example.com" } },
+        receivedDateTime: "2024-01-15T10:00:00Z",
+      },
+      {
+        id: "msg-2",
+        conversationId: "conv-2",
+        subject: "Pending review",
+        from: { emailAddress: { address: "bob@example.com" } },
+        receivedDateTime: "2024-01-14T09:00:00Z",
+      },
+    ],
+  }),
+);
+const mockResolveOAuthConnection = mock(() =>
+  Promise.resolve({ id: "conn-1", providerKey: "outlook" }),
+);
+
+mock.module("../messaging/providers/outlook/client.js", () => ({
+  updateMessageFlag: mockUpdateMessageFlag,
+  listMessages: mockListMessages,
+}));
+
+mock.module("../oauth/connection-resolver.js", () => ({
+  resolveOAuthConnection: mockResolveOAuthConnection,
+}));
+
+import { run } from "../config/bundled-skills/outlook/tools/outlook-follow-up.js";
+import type { ToolContext } from "../tools/types.js";
+
+const ctx: ToolContext = {
+  workingDir: "/tmp",
+  conversationId: "test-conv",
+};
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("outlook_follow_up tool", () => {
+  test("returns error when action is missing", async () => {
+    const result = await run({}, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("action is required");
+  });
+
+  test("returns error for unknown action", async () => {
+    const result = await run({ action: "invalid", confidence: 0.9 }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Unknown action "invalid"');
+  });
+
+  // ── track ────────────────────────────────────────────────────────────────
+
+  describe("track", () => {
+    test("requires message_id", async () => {
+      const result = await run({ action: "track", confidence: 0.9 }, ctx);
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("message_id is required");
+    });
+
+    test("flags message for follow-up", async () => {
+      mockUpdateMessageFlag.mockClear();
+
+      const result = await run(
+        { action: "track", message_id: "msg-1", confidence: 0.9 },
+        ctx,
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toBe("Message flagged for follow-up.");
+      expect(mockUpdateMessageFlag).toHaveBeenCalledWith(
+        expect.anything(),
+        "msg-1",
+        { flagStatus: "flagged" },
+      );
+    });
+  });
+
+  // ── complete ─────────────────────────────────────────────────────────────
+
+  describe("complete", () => {
+    test("requires message_id", async () => {
+      const result = await run({ action: "complete", confidence: 0.9 }, ctx);
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("message_id is required");
+    });
+
+    test("marks follow-up as complete", async () => {
+      mockUpdateMessageFlag.mockClear();
+
+      const result = await run(
+        { action: "complete", message_id: "msg-1", confidence: 0.9 },
+        ctx,
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toBe("Follow-up marked complete.");
+      expect(mockUpdateMessageFlag).toHaveBeenCalledWith(
+        expect.anything(),
+        "msg-1",
+        { flagStatus: "complete" },
+      );
+    });
+  });
+
+  // ── untrack ──────────────────────────────────────────────────────────────
+
+  describe("untrack", () => {
+    test("requires message_id", async () => {
+      const result = await run({ action: "untrack", confidence: 0.9 }, ctx);
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("message_id is required");
+    });
+
+    test("removes follow-up flag", async () => {
+      mockUpdateMessageFlag.mockClear();
+
+      const result = await run(
+        { action: "untrack", message_id: "msg-1", confidence: 0.9 },
+        ctx,
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toBe("Follow-up flag removed.");
+      expect(mockUpdateMessageFlag).toHaveBeenCalledWith(
+        expect.anything(),
+        "msg-1",
+        { flagStatus: "notFlagged" },
+      );
+    });
+  });
+
+  // ── list ─────────────────────────────────────────────────────────────────
+
+  describe("list", () => {
+    test("returns flagged messages", async () => {
+      mockListMessages.mockClear();
+
+      const result = await run({ action: "list", confidence: 0.5 }, ctx);
+
+      expect(result.isError).toBe(false);
+      const parsed = JSON.parse(result.content);
+      expect(parsed).toHaveLength(2);
+      expect(parsed[0].subject).toBe("Follow up on proposal");
+      expect(parsed[0].from).toBe("alice@example.com");
+      expect(parsed[1].subject).toBe("Pending review");
+
+      expect(mockListMessages).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          filter: "flag/flagStatus eq 'flagged'",
+          top: 50,
+          orderby: "receivedDateTime desc",
+        }),
+      );
+    });
+
+    test("returns message when no flagged messages", async () => {
+      mockListMessages.mockImplementationOnce(() =>
+        Promise.resolve({ value: [] }),
+      );
+
+      const result = await run({ action: "list", confidence: 0.5 }, ctx);
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("No messages are currently flagged");
+    });
+  });
+
+  // ── error handling ───────────────────────────────────────────────────────
+
+  test("returns error on API failure", async () => {
+    mockUpdateMessageFlag.mockImplementationOnce(() =>
+      Promise.reject(new Error("Graph API 500: Internal Server Error")),
+    );
+
+    const result = await run(
+      { action: "track", message_id: "msg-bad", confidence: 0.9 },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Graph API 500");
+  });
+});

--- a/assistant/src/__tests__/outlook-follow-up.test.ts
+++ b/assistant/src/__tests__/outlook-follow-up.test.ts
@@ -42,6 +42,7 @@ import type { ToolContext } from "../tools/types.js";
 const ctx: ToolContext = {
   workingDir: "/tmp",
   conversationId: "test-conv",
+  trustClass: "guardian",
 };
 
 // ── Tests ────────────────────────────────────────────────────────────────────

--- a/assistant/src/__tests__/outlook-trash.test.ts
+++ b/assistant/src/__tests__/outlook-trash.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, mock, test } from "bun:test";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockTrashMessage = mock(() => Promise.resolve({}));
+const mockResolveOAuthConnection = mock(() =>
+  Promise.resolve({ id: "conn-1", providerKey: "outlook" }),
+);
+
+mock.module("../messaging/providers/outlook/client.js", () => ({
+  trashMessage: mockTrashMessage,
+}));
+
+mock.module("../oauth/connection-resolver.js", () => ({
+  resolveOAuthConnection: mockResolveOAuthConnection,
+}));
+
+import { run } from "../config/bundled-skills/outlook/tools/outlook-trash.js";
+import type { ToolContext } from "../tools/types.js";
+
+const ctx: ToolContext = {
+  workingDir: "/tmp",
+  conversationId: "test-conv",
+};
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("outlook_trash tool", () => {
+  test("returns error when message_id is missing", async () => {
+    const result = await run({}, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("message_id is required");
+  });
+
+  test("moves message to Deleted Items", async () => {
+    mockTrashMessage.mockClear();
+    mockResolveOAuthConnection.mockClear();
+
+    const result = await run({ message_id: "msg-123", confidence: 0.9 }, ctx);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe("Message moved to Deleted Items.");
+    expect(mockResolveOAuthConnection).toHaveBeenCalledWith("outlook", {
+      account: undefined,
+    });
+    expect(mockTrashMessage).toHaveBeenCalledTimes(1);
+  });
+
+  test("passes account to connection resolver", async () => {
+    mockResolveOAuthConnection.mockClear();
+
+    await run(
+      {
+        message_id: "msg-456",
+        account: "user@outlook.com",
+        confidence: 0.8,
+      },
+      ctx,
+    );
+
+    expect(mockResolveOAuthConnection).toHaveBeenCalledWith("outlook", {
+      account: "user@outlook.com",
+    });
+  });
+
+  test("returns error on API failure", async () => {
+    mockTrashMessage.mockImplementationOnce(() =>
+      Promise.reject(new Error("Graph API 404: Not found")),
+    );
+
+    const result = await run({ message_id: "msg-bad", confidence: 0.9 }, ctx);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Graph API 404");
+  });
+});

--- a/assistant/src/__tests__/outlook-trash.test.ts
+++ b/assistant/src/__tests__/outlook-trash.test.ts
@@ -21,6 +21,7 @@ import type { ToolContext } from "../tools/types.js";
 const ctx: ToolContext = {
   workingDir: "/tmp",
   conversationId: "test-conv",
+  trustClass: "guardian",
 };
 
 // ── Tests ────────────────────────────────────────────────────────────────────

--- a/assistant/src/config/bundled-skills/outlook/TOOLS.json
+++ b/assistant/src/config/bundled-skills/outlook/TOOLS.json
@@ -1,1 +1,112 @@
-[]
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "outlook_trash",
+      "description": "Move an Outlook message to Deleted Items. Include a confidence score (0-1).",
+      "category": "outlook",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "message_id": {
+            "type": "string",
+            "description": "Outlook message ID to move to Deleted Items"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Outlook account to use. Required when multiple Outlook accounts are connected. If omitted, uses the most recently connected account."
+          }
+        },
+        "required": ["message_id", "confidence"]
+      },
+      "executor": "tools/outlook-trash.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "outlook_categories",
+      "description": "Add, remove, or list available categories on Outlook messages. Include a confidence score (0-1) for add/remove actions.",
+      "category": "outlook",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": ["add", "remove", "list_available"],
+            "description": "Category action"
+          },
+          "message_id": {
+            "type": "string",
+            "description": "Outlook message ID (required for add/remove)"
+          },
+          "categories": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Category names to add or remove"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Outlook account to use. Required when multiple Outlook accounts are connected. If omitted, uses the most recently connected account."
+          }
+        },
+        "required": ["action", "confidence"]
+      },
+      "executor": "tools/outlook-categories.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "outlook_follow_up",
+      "description": "Track, list, untrack, or complete follow-up flags on Outlook messages using the native flag system. Include a confidence score (0-1) for track/complete/untrack actions.",
+      "category": "outlook",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": ["track", "list", "untrack", "complete"],
+            "description": "Follow-up action"
+          },
+          "message_id": {
+            "type": "string",
+            "description": "Outlook message ID (required for track/complete/untrack)"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Outlook account to use. Required when multiple Outlook accounts are connected. If omitted, uses the most recently connected account."
+          }
+        },
+        "required": ["action", "confidence"]
+      },
+      "executor": "tools/outlook-follow-up.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/outlook/tools/outlook-categories.ts
+++ b/assistant/src/config/bundled-skills/outlook/tools/outlook-categories.ts
@@ -1,0 +1,77 @@
+import {
+  getMessage,
+  listMasterCategories,
+  updateMessageCategories,
+} from "../../../../messaging/providers/outlook/client.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
+  const action = input.action as string;
+
+  if (!action) {
+    return err("action is required (add, remove, or list_available).");
+  }
+
+  try {
+    const connection = await resolveOAuthConnection("outlook", {
+      account,
+    });
+
+    switch (action) {
+      case "add": {
+        const messageId = input.message_id as string;
+        if (!messageId) return err("message_id is required for add action.");
+
+        const categories = input.categories as string[] | undefined;
+        if (!categories || categories.length === 0) {
+          return err("categories is required for add action.");
+        }
+
+        const message = await getMessage(connection, messageId, "categories");
+        const existing = message.categories ?? [];
+        const merged = [...new Set([...existing, ...categories])];
+        await updateMessageCategories(connection, messageId, merged);
+        return ok("Categories updated.");
+      }
+
+      case "remove": {
+        const messageId = input.message_id as string;
+        if (!messageId) return err("message_id is required for remove action.");
+
+        const categories = input.categories as string[] | undefined;
+        if (!categories || categories.length === 0) {
+          return err("categories is required for remove action.");
+        }
+
+        const removeSet = new Set(categories);
+        const message = await getMessage(connection, messageId, "categories");
+        const existing = message.categories ?? [];
+        const filtered = existing.filter((c) => !removeSet.has(c));
+        await updateMessageCategories(connection, messageId, filtered);
+        return ok("Categories updated.");
+      }
+
+      case "list_available": {
+        const resp = await listMasterCategories(connection);
+        const categories = resp.value ?? [];
+        return ok(JSON.stringify(categories, null, 2));
+      }
+
+      default:
+        return err(
+          `Unknown action "${action}". Use add, remove, or list_available.`,
+        );
+    }
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/outlook/tools/outlook-follow-up.ts
+++ b/assistant/src/config/bundled-skills/outlook/tools/outlook-follow-up.ts
@@ -1,0 +1,94 @@
+import {
+  listMessages,
+  updateMessageFlag,
+} from "../../../../messaging/providers/outlook/client.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
+  const action = input.action as string;
+
+  if (!action) {
+    return err("action is required (track, list, untrack, or complete).");
+  }
+
+  try {
+    const connection = await resolveOAuthConnection("outlook", {
+      account,
+    });
+
+    switch (action) {
+      case "track": {
+        const messageId = input.message_id as string;
+        if (!messageId) return err("message_id is required for track action.");
+
+        await updateMessageFlag(connection, messageId, {
+          flagStatus: "flagged",
+        });
+        return ok("Message flagged for follow-up.");
+      }
+
+      case "complete": {
+        const messageId = input.message_id as string;
+        if (!messageId)
+          return err("message_id is required for complete action.");
+
+        await updateMessageFlag(connection, messageId, {
+          flagStatus: "complete",
+        });
+        return ok("Follow-up marked complete.");
+      }
+
+      case "untrack": {
+        const messageId = input.message_id as string;
+        if (!messageId)
+          return err("message_id is required for untrack action.");
+
+        await updateMessageFlag(connection, messageId, {
+          flagStatus: "notFlagged",
+        });
+        return ok("Follow-up flag removed.");
+      }
+
+      case "list": {
+        const resp = await listMessages(connection, {
+          filter: "flag/flagStatus eq 'flagged'",
+          top: 50,
+          select:
+            "id,conversationId,subject,bodyPreview,body,from,toRecipients,receivedDateTime,isRead,hasAttachments,parentFolderId,categories,flag",
+          orderby: "receivedDateTime desc",
+        });
+
+        const messages = resp.value ?? [];
+        if (messages.length === 0) {
+          return ok("No messages are currently flagged for follow-up.");
+        }
+
+        const items = messages.map((m) => ({
+          id: m.id,
+          conversationId: m.conversationId,
+          subject: m.subject,
+          from: m.from?.emailAddress?.address ?? "",
+          date: m.receivedDateTime,
+        }));
+
+        return ok(JSON.stringify(items, null, 2));
+      }
+
+      default:
+        return err(
+          `Unknown action "${action}". Use track, list, untrack, or complete.`,
+        );
+    }
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/outlook/tools/outlook-trash.ts
+++ b/assistant/src/config/bundled-skills/outlook/tools/outlook-trash.ts
@@ -1,0 +1,29 @@
+import { trashMessage } from "../../../../messaging/providers/outlook/client.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
+  const messageId = input.message_id as string;
+
+  if (!messageId) {
+    return err("message_id is required.");
+  }
+
+  try {
+    const connection = await resolveOAuthConnection("outlook", {
+      account,
+    });
+    await trashMessage(connection, messageId);
+    return ok("Message moved to Deleted Items.");
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -107,6 +107,10 @@ import * as messagingSend from "./bundled-skills/messaging/tools/messaging-send.
 import * as messagingSenderDigest from "./bundled-skills/messaging/tools/messaging-sender-digest.js";
 // ── notifications ──────────────────────────────────────────────────────────────
 import * as sendNotification from "./bundled-skills/notifications/tools/send-notification.js";
+// ── outlook ───────────────────────────────────────────────────────────────────
+import * as outlookCategories from "./bundled-skills/outlook/tools/outlook-categories.js";
+import * as outlookFollowUp from "./bundled-skills/outlook/tools/outlook-follow-up.js";
+import * as outlookTrash from "./bundled-skills/outlook/tools/outlook-trash.js";
 // ── phone-calls ────────────────────────────────────────────────────────────────
 import * as callEnd from "./bundled-skills/phone-calls/tools/call-end.js";
 import * as callStart from "./bundled-skills/phone-calls/tools/call-start.js";
@@ -250,6 +254,11 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["gmail:tools/gmail-vacation.ts", gmailVacation],
   ["gmail:tools/gmail-sender-digest.ts", gmailSenderDigest],
   ["gmail:tools/gmail-outreach-scan.ts", gmailOutreachScan],
+
+  // outlook
+  ["outlook:tools/outlook-trash.ts", outlookTrash],
+  ["outlook:tools/outlook-categories.ts", outlookCategories],
+  ["outlook:tools/outlook-follow-up.ts", outlookFollowUp],
 
   // google-calendar
   ["google-calendar:tools/calendar-list-events.ts", calendarListEvents],


### PR DESCRIPTION
## Summary
- Add outlook_trash tool for moving messages to Deleted Items
- Add outlook_categories tool for managing message categories (add/remove/list)
- Add outlook_follow_up tool for tracking messages with Outlook's native flag system
- Register all three tools in bundled-tool-registry.ts and TOOLS.json

Part of plan: outlook-email-gmail-parity.md (PR 6 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
