### PR TITLE
feat: add outlook_draft, outlook_send_draft, and outlook_forward tools

### DIFF
--- a/assistant/src/__tests__/outlook-compose-tools.test.ts
+++ b/assistant/src/__tests__/outlook-compose-tools.test.ts
@@ -1,0 +1,325 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { OAuthConnection } from "../oauth/connection.js";
+import type { ToolContext } from "../tools/types.js";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const createDraftMock = mock(
+  async (_conn: OAuthConnection, _draft: Record<string, unknown>) => ({
+    id: "draft-new-1",
+    subject: "Test",
+    body: { contentType: "text", content: "hello" },
+    toRecipients: [],
+    ccRecipients: [],
+  }),
+);
+
+const createReplyDraftMock = mock(
+  async (_conn: OAuthConnection, _msgId: string, _comment?: string) => ({
+    id: "draft-reply-1",
+    subject: "Re: Test",
+    body: { contentType: "text", content: "reply" },
+    toRecipients: [{ emailAddress: { address: "original@example.com" } }],
+    ccRecipients: [],
+  }),
+);
+
+const patchMessageMock = mock(
+  async (
+    _conn: OAuthConnection,
+    _msgId: string,
+    _fields: Record<string, unknown>,
+  ) => ({
+    id: "draft-reply-1",
+  }),
+);
+
+const sendDraftMock = mock(
+  async (_conn: OAuthConnection, _msgId: string) => {},
+);
+
+const createForwardDraftMock = mock(
+  async (
+    _conn: OAuthConnection,
+    _msgId: string,
+    _to?: unknown[],
+    _comment?: string,
+  ) => ({
+    id: "draft-fwd-1",
+    subject: "Fwd: Test",
+    body: { contentType: "text", content: "forwarded" },
+    toRecipients: [],
+    ccRecipients: [],
+  }),
+);
+
+const fakeConnection = {
+  id: "conn-1",
+  providerKey: "microsoft",
+  accountInfo: "user@outlook.com",
+} as unknown as OAuthConnection;
+
+mock.module("../messaging/providers/outlook/client.js", () => ({
+  createDraft: createDraftMock,
+  createReplyDraft: createReplyDraftMock,
+  patchMessage: patchMessageMock,
+  sendDraft: sendDraftMock,
+  createForwardDraft: createForwardDraftMock,
+}));
+
+mock.module("../oauth/connection-resolver.js", () => ({
+  resolveOAuthConnection: async () => fakeConnection,
+}));
+
+// Import tools after mocks are set up
+import { run as runDraft } from "../config/bundled-skills/outlook/tools/outlook-draft.js";
+import { run as runForward } from "../config/bundled-skills/outlook/tools/outlook-forward.js";
+import { run as runSendDraft } from "../config/bundled-skills/outlook/tools/outlook-send-draft.js";
+
+const baseContext: ToolContext = {
+  workingDir: "/tmp",
+  conversationId: "conv-1",
+  trustClass: "guardian" as const,
+};
+
+// ── outlook_draft ────────────────────────────────────────────────────────────
+
+describe("outlook_draft", () => {
+  beforeEach(() => {
+    createDraftMock.mockClear();
+    createReplyDraftMock.mockClear();
+    patchMessageMock.mockClear();
+  });
+
+  test("creates a new draft with to, subject, body", async () => {
+    const result = await runDraft(
+      { to: "alice@example.com", subject: "Hello", body: "Hi there" },
+      baseContext,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Draft created (ID: draft-new-1)");
+    expect(createDraftMock).toHaveBeenCalledTimes(1);
+    const [conn, draft] = createDraftMock.mock.calls[0];
+    expect(conn).toBe(fakeConnection);
+    expect(draft).toMatchObject({
+      subject: "Hello",
+      body: { contentType: "text", content: "Hi there" },
+    });
+  });
+
+  test("creates a new draft with cc and bcc", async () => {
+    const result = await runDraft(
+      {
+        to: "alice@example.com",
+        subject: "Hello",
+        body: "Hi",
+        cc: "bob@example.com",
+        bcc: "charlie@example.com",
+      },
+      baseContext,
+    );
+
+    expect(result.isError).toBe(false);
+    const [, draft] = createDraftMock.mock.calls[0];
+    expect(draft.ccRecipients).toEqual([
+      { emailAddress: { address: "bob@example.com" } },
+    ]);
+    expect(draft.bccRecipients).toEqual([
+      { emailAddress: { address: "charlie@example.com" } },
+    ]);
+  });
+
+  test("creates a reply draft when in_reply_to is provided", async () => {
+    const result = await runDraft(
+      {
+        to: "alice@example.com",
+        subject: "Re: Hello",
+        body: "Thanks!",
+        in_reply_to: "msg-original-1",
+      },
+      baseContext,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Draft created (ID: draft-reply-1)");
+    expect(createReplyDraftMock).toHaveBeenCalledTimes(1);
+    const [, msgId, comment] = createReplyDraftMock.mock.calls[0];
+    expect(msgId).toBe("msg-original-1");
+    expect(comment).toBe("Thanks!");
+    // Should patch recipients since to is specified
+    expect(patchMessageMock).toHaveBeenCalledTimes(1);
+    const [, patchMsgId] = patchMessageMock.mock.calls[0];
+    expect(patchMsgId).toBe("draft-reply-1");
+  });
+
+  test("patches reply draft with custom cc and bcc", async () => {
+    const result = await runDraft(
+      {
+        to: "alice@example.com",
+        subject: "Re: Hello",
+        body: "Thanks!",
+        in_reply_to: "msg-original-1",
+        cc: "bob@example.com",
+        bcc: "secret@example.com",
+      },
+      baseContext,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(patchMessageMock).toHaveBeenCalledTimes(1);
+    const [, , patchFields] = patchMessageMock.mock.calls[0];
+    expect(patchFields.toRecipients).toEqual([
+      { emailAddress: { address: "alice@example.com" } },
+    ]);
+    expect(patchFields.ccRecipients).toEqual([
+      { emailAddress: { address: "bob@example.com" } },
+    ]);
+    expect(patchFields.bccRecipients).toEqual([
+      { emailAddress: { address: "secret@example.com" } },
+    ]);
+  });
+
+  test("returns error when to is missing", async () => {
+    const result = await runDraft(
+      { subject: "Hello", body: "Hi" },
+      baseContext,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("to is required");
+  });
+
+  test("returns error when subject is missing", async () => {
+    const result = await runDraft(
+      { to: "alice@example.com", body: "Hi" },
+      baseContext,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("subject is required");
+  });
+
+  test("returns error when body is missing", async () => {
+    const result = await runDraft(
+      { to: "alice@example.com", subject: "Hello" },
+      baseContext,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("body is required");
+  });
+});
+
+// ── outlook_send_draft ───────────────────────────────────────────────────────
+
+describe("outlook_send_draft", () => {
+  beforeEach(() => {
+    sendDraftMock.mockClear();
+  });
+
+  test("sends a draft when triggered by surface action", async () => {
+    const result = await runSendDraft(
+      { draft_id: "draft-1", confidence: 0.9 },
+      { ...baseContext, triggeredBySurfaceAction: true },
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe("Draft sent.");
+    expect(sendDraftMock).toHaveBeenCalledTimes(1);
+    const [, draftId] = sendDraftMock.mock.calls[0];
+    expect(draftId).toBe("draft-1");
+  });
+
+  test("rejects when not triggered by surface action", async () => {
+    const result = await runSendDraft(
+      { draft_id: "draft-1", confidence: 0.9 },
+      baseContext,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("surface action");
+    expect(sendDraftMock).not.toHaveBeenCalled();
+  });
+
+  test("returns error when draft_id is missing", async () => {
+    const result = await runSendDraft(
+      { confidence: 0.9 },
+      { ...baseContext, triggeredBySurfaceAction: true },
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("draft_id is required");
+  });
+});
+
+// ── outlook_forward ──────────────────────────────────────────────────────────
+
+describe("outlook_forward", () => {
+  beforeEach(() => {
+    createForwardDraftMock.mockClear();
+  });
+
+  test("creates a forward draft", async () => {
+    const result = await runForward(
+      { message_id: "msg-1", to: "bob@example.com", confidence: 0.9 },
+      baseContext,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Forward draft created (ID: draft-fwd-1)");
+    expect(createForwardDraftMock).toHaveBeenCalledTimes(1);
+    const [, msgId, toList] = createForwardDraftMock.mock.calls[0];
+    expect(msgId).toBe("msg-1");
+    expect(toList).toEqual([{ emailAddress: { address: "bob@example.com" } }]);
+  });
+
+  test("creates a forward draft with comment", async () => {
+    const result = await runForward(
+      {
+        message_id: "msg-1",
+        to: "bob@example.com",
+        comment: "FYI",
+        confidence: 0.9,
+      },
+      baseContext,
+    );
+
+    expect(result.isError).toBe(false);
+    const [, , , fwdComment] = createForwardDraftMock.mock.calls[0];
+    expect(fwdComment).toBe("FYI");
+  });
+
+  test("creates a forward draft with multiple recipients", async () => {
+    const result = await runForward(
+      {
+        message_id: "msg-1",
+        to: "bob@example.com, carol@example.com",
+        confidence: 0.9,
+      },
+      baseContext,
+    );
+
+    expect(result.isError).toBe(false);
+    const [, , toList] = createForwardDraftMock.mock.calls[0];
+    expect(toList).toEqual([
+      { emailAddress: { address: "bob@example.com" } },
+      { emailAddress: { address: "carol@example.com" } },
+    ]);
+  });
+
+  test("returns error when message_id is missing", async () => {
+    const result = await runForward(
+      { to: "bob@example.com", confidence: 0.9 },
+      baseContext,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("message_id is required");
+  });
+
+  test("returns error when to is missing", async () => {
+    const result = await runForward(
+      { message_id: "msg-1", confidence: 0.9 },
+      baseContext,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("to is required");
+  });
+});

--- a/assistant/src/config/bundled-skills/outlook/TOOLS.json
+++ b/assistant/src/config/bundled-skills/outlook/TOOLS.json
@@ -1,1 +1,119 @@
-[]
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "outlook_draft",
+      "description": "Create a draft email in Outlook. The draft will appear in Outlook Drafts for user review. Use in_reply_to with an Outlook message ID to create a reply draft.",
+      "category": "outlook",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "to": {
+            "type": "string",
+            "description": "Recipient email address (comma-separated for multiple)"
+          },
+          "subject": {
+            "type": "string",
+            "description": "Email subject line"
+          },
+          "body": {
+            "type": "string",
+            "description": "Email body (plain text)"
+          },
+          "in_reply_to": {
+            "type": "string",
+            "description": "Outlook message ID to reply to. Creates a reply draft that preserves the conversation thread."
+          },
+          "cc": {
+            "type": "string",
+            "description": "CC recipients (comma-separated email addresses)"
+          },
+          "bcc": {
+            "type": "string",
+            "description": "BCC recipients (comma-separated email addresses)"
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Outlook account to use. Required when multiple Outlook accounts are connected. If omitted, uses the most recently connected account."
+          }
+        },
+        "required": ["to", "subject", "body"]
+      },
+      "executor": "tools/outlook-draft.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "outlook_send_draft",
+      "description": "Send an existing Outlook draft. Only use when the user has reviewed and explicitly approved sending.",
+      "category": "outlook",
+      "risk": "high",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "draft_id": {
+            "type": "string",
+            "description": "Outlook draft message ID to send"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Outlook account to use. Required when multiple Outlook accounts are connected. If omitted, uses the most recently connected account."
+          }
+        },
+        "required": ["draft_id", "confidence"]
+      },
+      "executor": "tools/outlook-send-draft.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "outlook_forward",
+      "description": "Create a draft forwarding an Outlook message to another recipient, preserving attachments. Microsoft Graph handles attachment forwarding natively.",
+      "category": "outlook",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "message_id": {
+            "type": "string",
+            "description": "Outlook message ID to forward"
+          },
+          "to": {
+            "type": "string",
+            "description": "Recipient email address (comma-separated for multiple)"
+          },
+          "comment": {
+            "type": "string",
+            "description": "Optional text to include with the forwarded message"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Outlook account to use. Required when multiple Outlook accounts are connected. If omitted, uses the most recently connected account."
+          }
+        },
+        "required": ["message_id", "to", "confidence"]
+      },
+      "executor": "tools/outlook-forward.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/outlook/tools/outlook-draft.ts
+++ b/assistant/src/config/bundled-skills/outlook/tools/outlook-draft.ts
@@ -1,0 +1,84 @@
+import {
+  createDraft,
+  createReplyDraft,
+  patchMessage,
+} from "../../../../messaging/providers/outlook/client.js";
+import type { OutlookRecipient } from "../../../../messaging/providers/outlook/types.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+function toRecipients(csv: string | undefined): OutlookRecipient[] | undefined {
+  if (!csv) return undefined;
+  return csv
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((address) => ({ emailAddress: { address } }));
+}
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
+  const to = input.to as string;
+  const subject = input.subject as string;
+  const body = input.body as string;
+  const inReplyTo = input.in_reply_to as string | undefined;
+  const cc = input.cc as string | undefined;
+  const bcc = input.bcc as string | undefined;
+
+  if (!to) return err("to is required.");
+  if (!subject) return err("subject is required.");
+  if (!body) return err("body is required.");
+
+  try {
+    const connection = await resolveOAuthConnection("microsoft", {
+      account,
+    });
+
+    if (inReplyTo) {
+      // Create a reply draft, then optionally patch recipients
+      const draft = await createReplyDraft(connection, inReplyTo, body);
+
+      const toList = toRecipients(to);
+      const ccList = toRecipients(cc);
+      const bccList = toRecipients(bcc);
+
+      const patch: Record<string, unknown> = {};
+      if (toList) patch.toRecipients = toList;
+      if (ccList) patch.ccRecipients = ccList;
+      if (bccList) patch.bccRecipients = bccList;
+
+      if (Object.keys(patch).length > 0) {
+        await patchMessage(connection, draft.id, patch);
+      }
+
+      return ok(
+        `Draft created (ID: ${draft.id}). It will appear in your Outlook Drafts folder. Tell me to send it when ready.`,
+      );
+    }
+
+    const toRecipientsList = toRecipients(to) ?? [];
+    const ccRecipientsList = toRecipients(cc);
+    const bccRecipientsList = toRecipients(bcc);
+
+    const draft = await createDraft(connection, {
+      subject,
+      body: { contentType: "text", content: body },
+      toRecipients: toRecipientsList,
+      ccRecipients: ccRecipientsList,
+      bccRecipients: bccRecipientsList,
+    });
+
+    return ok(
+      `Draft created (ID: ${draft.id}). It will appear in your Outlook Drafts folder. Tell me to send it when ready.`,
+    );
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/outlook/tools/outlook-forward.ts
+++ b/assistant/src/config/bundled-skills/outlook/tools/outlook-forward.ts
@@ -1,0 +1,49 @@
+import { createForwardDraft } from "../../../../messaging/providers/outlook/client.js";
+import type { OutlookRecipient } from "../../../../messaging/providers/outlook/types.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+function toRecipients(csv: string): OutlookRecipient[] {
+  return csv
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((address) => ({ emailAddress: { address } }));
+}
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
+  const messageId = input.message_id as string;
+  const to = input.to as string;
+  const comment = input.comment as string | undefined;
+
+  if (!messageId) return err("message_id is required.");
+  if (!to) return err("to is required.");
+
+  try {
+    const connection = await resolveOAuthConnection("microsoft", {
+      account,
+    });
+
+    const toRecipientsList = toRecipients(to);
+    const draft = await createForwardDraft(
+      connection,
+      messageId,
+      toRecipientsList,
+      comment,
+    );
+
+    return ok(
+      `Forward draft created (ID: ${draft.id}). Review in Outlook Drafts, then tell me to send it.`,
+    );
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/outlook/tools/outlook-send-draft.ts
+++ b/assistant/src/config/bundled-skills/outlook/tools/outlook-send-draft.ts
@@ -1,0 +1,32 @@
+import { sendDraft } from "../../../../messaging/providers/outlook/client.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { err, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
+  const draftId = input.draft_id as string;
+  if (!draftId) return err("draft_id is required.");
+
+  if (!context.triggeredBySurfaceAction) {
+    return err(
+      "This tool requires user confirmation via a surface action. Present the draft details with a send button and wait for the user to click before proceeding.",
+    );
+  }
+
+  try {
+    const connection = await resolveOAuthConnection("microsoft", {
+      account,
+    });
+    await sendDraft(connection, draftId);
+    return ok("Draft sent.");
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -107,6 +107,10 @@ import * as messagingSend from "./bundled-skills/messaging/tools/messaging-send.
 import * as messagingSenderDigest from "./bundled-skills/messaging/tools/messaging-sender-digest.js";
 // ── notifications ──────────────────────────────────────────────────────────────
 import * as sendNotification from "./bundled-skills/notifications/tools/send-notification.js";
+// ── outlook ───────────────────────────────────────────────────────────────────
+import * as outlookDraft from "./bundled-skills/outlook/tools/outlook-draft.js";
+import * as outlookForward from "./bundled-skills/outlook/tools/outlook-forward.js";
+import * as outlookSendDraft from "./bundled-skills/outlook/tools/outlook-send-draft.js";
 // ── phone-calls ────────────────────────────────────────────────────────────────
 import * as callEnd from "./bundled-skills/phone-calls/tools/call-end.js";
 import * as callStart from "./bundled-skills/phone-calls/tools/call-start.js";
@@ -289,6 +293,11 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
 
   // notifications
   ["notifications:tools/send-notification.ts", sendNotification],
+
+  // outlook
+  ["outlook:tools/outlook-draft.ts", outlookDraft],
+  ["outlook:tools/outlook-send-draft.ts", outlookSendDraft],
+  ["outlook:tools/outlook-forward.ts", outlookForward],
 
   // phone-calls
   ["phone-calls:tools/call-start.ts", callStart],

--- a/assistant/src/messaging/providers/outlook/client.ts
+++ b/assistant/src/messaging/providers/outlook/client.ts
@@ -278,6 +278,22 @@ export async function markMessageRead(
   );
 }
 
+/** Patch arbitrary fields on a message (e.g. to update recipients on a draft). */
+export async function patchMessage(
+  connection: OAuthConnection,
+  messageId: string,
+  fields: Record<string, unknown>,
+): Promise<OutlookMessage> {
+  return request<OutlookMessage>(
+    connection,
+    `/v1.0/me/messages/${encodeURIComponent(messageId)}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify(fields),
+    },
+  );
+}
+
 /** Move a message to a different folder (e.g. for archiving). */
 export async function moveMessage(
   connection: OAuthConnection,


### PR DESCRIPTION
## Summary
- Add outlook_draft tool for creating email drafts (including reply drafts)
- Add outlook_send_draft tool for sending existing drafts (high-risk, requires surface action)
- Add outlook_forward tool for creating forward drafts preserving attachments
- Register all three tools in bundled-tool-registry.ts and TOOLS.json

Part of plan: outlook-email-gmail-parity.md (PR 7 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
