### PR TITLE
feat: add Outlook email watcher using Microsoft Graph delta queries

### DIFF
--- a/assistant/src/__tests__/outlook-email-watcher.test.ts
+++ b/assistant/src/__tests__/outlook-email-watcher.test.ts
@@ -1,0 +1,322 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { OutlookDeltaResponse } from "../messaging/providers/outlook/types.js";
+import type { OutlookMessage } from "../messaging/providers/outlook/types.js";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before importing the module under test
+// ---------------------------------------------------------------------------
+
+const mockListMessagesDelta =
+  mock<
+    (
+      connection: unknown,
+      folderId: string,
+      deltaLink?: string,
+    ) => Promise<OutlookDeltaResponse<OutlookMessage>>
+  >();
+
+const mockListMessages =
+  mock<
+    (
+      connection: unknown,
+      options?: Record<string, unknown>,
+    ) => Promise<{ value?: OutlookMessage[] }>
+  >();
+
+mock.module("../messaging/providers/outlook/client.js", () => ({
+  listMessagesDelta: mockListMessagesDelta,
+  listMessages: mockListMessages,
+  OutlookApiError: class OutlookApiError extends Error {
+    status: number;
+    statusText: string;
+    constructor(status: number, statusText: string, message: string) {
+      super(message);
+      this.name = "OutlookApiError";
+      this.status = status;
+      this.statusText = statusText;
+    }
+  },
+}));
+
+const mockResolveOAuthConnection =
+  mock<(providerKey: string) => Promise<unknown>>();
+
+mock.module("../oauth/connection-resolver.js", () => ({
+  resolveOAuthConnection: mockResolveOAuthConnection,
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+// Import module under test after mocks
+const { outlookProvider, DeltaSyncExpiredError } =
+  await import("../watcher/providers/outlook.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const FAKE_CONNECTION = { id: "test-conn" };
+const DELTA_LINK_1 =
+  "https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta?$deltatoken=abc123";
+const DELTA_LINK_2 =
+  "https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta?$deltatoken=def456";
+const NEXT_LINK =
+  "https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta?$skiptoken=page2";
+
+function makeMessage(overrides: Partial<OutlookMessage> = {}): OutlookMessage {
+  return {
+    id: overrides.id ?? "msg-1",
+    conversationId: overrides.conversationId ?? "conv-1",
+    subject: overrides.subject ?? "Test Subject",
+    bodyPreview: overrides.bodyPreview ?? "Preview text",
+    body: overrides.body ?? { contentType: "text", content: "Body text" },
+    from: overrides.from ?? {
+      emailAddress: { name: "Alice", address: "alice@example.com" },
+    },
+    toRecipients: overrides.toRecipients ?? [],
+    ccRecipients: overrides.ccRecipients ?? [],
+    receivedDateTime: overrides.receivedDateTime ?? "2025-06-15T10:00:00.000Z",
+    isRead: overrides.isRead ?? false,
+    hasAttachments: overrides.hasAttachments ?? false,
+    parentFolderId: overrides.parentFolderId ?? "inbox-folder-id",
+    categories: overrides.categories ?? [],
+    flag: overrides.flag ?? { flagStatus: "notFlagged" },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockListMessagesDelta.mockReset();
+  mockListMessages.mockReset();
+  mockResolveOAuthConnection.mockReset();
+  mockResolveOAuthConnection.mockResolvedValue(FAKE_CONNECTION);
+});
+
+describe("Outlook email watcher — getInitialWatermark", () => {
+  test("captures the deltaLink from the initial delta query", async () => {
+    mockListMessagesDelta.mockResolvedValueOnce({
+      value: [],
+      "@odata.deltaLink": DELTA_LINK_1,
+    });
+
+    const watermark = await outlookProvider.getInitialWatermark("outlook");
+
+    expect(watermark).toBe(DELTA_LINK_1);
+    expect(mockListMessagesDelta).toHaveBeenCalledWith(
+      FAKE_CONNECTION,
+      "inbox",
+      undefined,
+    );
+  });
+
+  test("throws when no deltaLink is returned", async () => {
+    mockListMessagesDelta.mockResolvedValueOnce({
+      value: [],
+    });
+
+    await expect(
+      outlookProvider.getInitialWatermark("outlook"),
+    ).rejects.toThrow("without returning a deltaLink");
+  });
+});
+
+describe("Outlook email watcher — fetchNew", () => {
+  test("returns empty items and initial watermark when no watermark provided", async () => {
+    mockListMessagesDelta.mockResolvedValueOnce({
+      value: [],
+      "@odata.deltaLink": DELTA_LINK_1,
+    });
+
+    const result = await outlookProvider.fetchNew(
+      "outlook",
+      null,
+      {},
+      "watcher-1",
+    );
+
+    expect(result.items).toEqual([]);
+    expect(result.watermark).toBe(DELTA_LINK_1);
+  });
+
+  test("returns new messages from delta query", async () => {
+    const msg1 = makeMessage({ id: "msg-1", subject: "Hello" });
+    const msg2 = makeMessage({
+      id: "msg-2",
+      subject: "World",
+      from: {
+        emailAddress: { name: "Bob", address: "bob@example.com" },
+      },
+    });
+
+    mockListMessagesDelta.mockResolvedValueOnce({
+      value: [msg1, msg2],
+      "@odata.deltaLink": DELTA_LINK_2,
+    });
+
+    const result = await outlookProvider.fetchNew(
+      "outlook",
+      DELTA_LINK_1,
+      {},
+      "watcher-1",
+    );
+
+    expect(result.items).toHaveLength(2);
+    expect(result.watermark).toBe(DELTA_LINK_2);
+
+    expect(result.items[0].externalId).toBe("msg-1");
+    expect(result.items[0].eventType).toBe("new_email");
+    expect(result.items[0].summary).toBe("Email from Alice: Hello");
+
+    expect(result.items[1].externalId).toBe("msg-2");
+    expect(result.items[1].summary).toBe("Email from Bob: World");
+  });
+
+  test("returns empty items when delta has no new messages", async () => {
+    mockListMessagesDelta.mockResolvedValueOnce({
+      value: [],
+      "@odata.deltaLink": DELTA_LINK_2,
+    });
+
+    const result = await outlookProvider.fetchNew(
+      "outlook",
+      DELTA_LINK_1,
+      {},
+      "watcher-1",
+    );
+
+    expect(result.items).toEqual([]);
+    expect(result.watermark).toBe(DELTA_LINK_2);
+  });
+
+  test("handles pagination across multiple delta pages", async () => {
+    const msg1 = makeMessage({ id: "msg-1", subject: "Page 1" });
+    const msg2 = makeMessage({ id: "msg-2", subject: "Page 2" });
+
+    // First call returns page 1 with nextLink
+    mockListMessagesDelta.mockResolvedValueOnce({
+      value: [msg1],
+      "@odata.nextLink": NEXT_LINK,
+    });
+
+    // Second call returns page 2 with deltaLink (end of pagination)
+    mockListMessagesDelta.mockResolvedValueOnce({
+      value: [msg2],
+      "@odata.deltaLink": DELTA_LINK_2,
+    });
+
+    const result = await outlookProvider.fetchNew(
+      "outlook",
+      DELTA_LINK_1,
+      {},
+      "watcher-1",
+    );
+
+    expect(result.items).toHaveLength(2);
+    expect(result.items[0].externalId).toBe("msg-1");
+    expect(result.items[1].externalId).toBe("msg-2");
+    expect(result.watermark).toBe(DELTA_LINK_2);
+
+    // First call uses the stored watermark (deltaLink)
+    expect(mockListMessagesDelta).toHaveBeenCalledTimes(2);
+    expect(mockListMessagesDelta.mock.calls[0]).toEqual([
+      FAKE_CONNECTION,
+      "inbox",
+      DELTA_LINK_1,
+    ]);
+    // Second call uses the nextLink
+    expect(mockListMessagesDelta.mock.calls[1]).toEqual([
+      FAKE_CONNECTION,
+      "inbox",
+      NEXT_LINK,
+    ]);
+  });
+
+  test("handles 410 expired sync state with fallback", async () => {
+    // Import the mocked OutlookApiError class
+    const { OutlookApiError } =
+      await import("../messaging/providers/outlook/client.js");
+
+    // Delta query returns 410 Gone
+    mockListMessagesDelta.mockRejectedValueOnce(
+      new OutlookApiError(410, "Gone", "Sync state expired"),
+    );
+
+    // Fallback: listMessages returns recent messages
+    const recentMsg = makeMessage({ id: "recent-1", subject: "Recent Email" });
+    mockListMessages.mockResolvedValueOnce({
+      value: [recentMsg],
+    });
+
+    // After fallback, get fresh deltaLink
+    mockListMessagesDelta.mockResolvedValueOnce({
+      value: [],
+      "@odata.deltaLink": DELTA_LINK_2,
+    });
+
+    const result = await outlookProvider.fetchNew(
+      "outlook",
+      DELTA_LINK_1,
+      {},
+      "watcher-1",
+    );
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].externalId).toBe("recent-1");
+    expect(result.items[0].summary).toBe("Email from Alice: Recent Email");
+    expect(result.watermark).toBe(DELTA_LINK_2);
+
+    // Verify fallback called listMessages with appropriate filter
+    expect(mockListMessages).toHaveBeenCalledTimes(1);
+    const listCallArgs = mockListMessages.mock.calls[0][1] as Record<
+      string,
+      unknown
+    >;
+    expect(listCallArgs.folderId).toBe("inbox");
+    expect(listCallArgs.top).toBe(20);
+    expect(listCallArgs.filter).toMatch(/receivedDateTime ge /);
+  });
+
+  test("empty delta response returns no items with updated watermark", async () => {
+    mockListMessagesDelta.mockResolvedValueOnce({
+      "@odata.deltaLink": DELTA_LINK_2,
+    });
+
+    const result = await outlookProvider.fetchNew(
+      "outlook",
+      DELTA_LINK_1,
+      {},
+      "watcher-1",
+    );
+
+    expect(result.items).toEqual([]);
+    expect(result.watermark).toBe(DELTA_LINK_2);
+  });
+});
+
+describe("DeltaSyncExpiredError", () => {
+  test("has correct name and message", () => {
+    const err = new DeltaSyncExpiredError("sync state lost");
+    expect(err.name).toBe("DeltaSyncExpiredError");
+    expect(err.message).toBe("sync state lost");
+    expect(err).toBeInstanceOf(Error);
+  });
+});
+
+describe("Outlook email watcher — provider metadata", () => {
+  test("has correct id, displayName, and requiredCredentialService", () => {
+    expect(outlookProvider.id).toBe("outlook");
+    expect(outlookProvider.displayName).toBe("Outlook");
+    expect(outlookProvider.requiredCredentialService).toBe("outlook");
+  });
+});

--- a/assistant/src/daemon/providers-setup.ts
+++ b/assistant/src/daemon/providers-setup.ts
@@ -1,9 +1,11 @@
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import {
   setPlatformAssistantId,
   setPlatformBaseUrl,
   setPlatformOrganizationId,
   setPlatformUserId,
 } from "../config/env.js";
+import { getConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/types.js";
 import { setSentryOrganizationId, setSentryUserId } from "../instrument.js";
 import { getMcpServerManager } from "../mcp/manager.js";
@@ -25,6 +27,7 @@ import { githubProvider } from "../watcher/providers/github.js";
 import { gmailProvider } from "../watcher/providers/gmail.js";
 import { googleCalendarProvider } from "../watcher/providers/google-calendar.js";
 import { linearProvider } from "../watcher/providers/linear.js";
+import { outlookProvider } from "../watcher/providers/outlook.js";
 const log = getLogger("lifecycle");
 
 export async function initializeProvidersAndTools(
@@ -135,6 +138,12 @@ export function registerWatcherProviders(): void {
   registerWatcherProvider(googleCalendarProvider);
   registerWatcherProvider(githubProvider);
   registerWatcherProvider(linearProvider);
+
+  const config = getConfig();
+  if (isAssistantFeatureFlagEnabled("outlook-oauth-integration", config)) {
+    registerWatcherProvider(outlookProvider);
+  }
+
   initWatcherEngine();
 }
 

--- a/assistant/src/watcher/providers/outlook.ts
+++ b/assistant/src/watcher/providers/outlook.ts
@@ -1,0 +1,198 @@
+/**
+ * Outlook watcher provider — uses Microsoft Graph delta queries for efficient
+ * change detection.
+ *
+ * On first poll, captures the initial deltaLink as the watermark (start from "now").
+ * Subsequent polls use the deltaLink to detect new messages.
+ * Falls back to listing recent inbox messages if the sync state has expired (410 Gone).
+ */
+
+import {
+  listMessages,
+  listMessagesDelta,
+  OutlookApiError,
+} from "../../messaging/providers/outlook/client.js";
+import type {
+  OutlookDeltaResponse,
+  OutlookMessage,
+} from "../../messaging/providers/outlook/types.js";
+import type { OAuthConnection } from "../../oauth/connection.js";
+import { resolveOAuthConnection } from "../../oauth/connection-resolver.js";
+import { getLogger } from "../../util/logger.js";
+import type {
+  FetchResult,
+  WatcherItem,
+  WatcherProvider,
+} from "../provider-types.js";
+
+const log = getLogger("watcher:outlook");
+
+/** Thrown when Microsoft Graph returns 410 Gone (delta sync state expired). */
+export class DeltaSyncExpiredError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DeltaSyncExpiredError";
+  }
+}
+
+function messageToItem(msg: OutlookMessage): WatcherItem {
+  const from =
+    msg.from?.emailAddress?.name ||
+    msg.from?.emailAddress?.address ||
+    "Unknown";
+  const subject = msg.subject ?? "(no subject)";
+
+  return {
+    externalId: msg.id,
+    eventType: "new_email",
+    summary: `Email from ${from}: ${subject}`,
+    payload: {
+      id: msg.id,
+      conversationId: msg.conversationId,
+      from,
+      fromAddress: msg.from?.emailAddress?.address ?? "",
+      subject,
+      receivedDateTime: msg.receivedDateTime,
+      bodyPreview: msg.bodyPreview ?? "",
+      isRead: msg.isRead ?? false,
+      hasAttachments: msg.hasAttachments ?? false,
+    },
+    timestamp: msg.receivedDateTime
+      ? new Date(msg.receivedDateTime).getTime()
+      : Date.now(),
+  };
+}
+
+/**
+ * Fetch all pages of a delta response, following @odata.nextLink until
+ * a @odata.deltaLink is returned.
+ */
+async function fetchAllDeltaPages(
+  connection: OAuthConnection,
+  folderId: string,
+  deltaLink?: string,
+): Promise<{ messages: OutlookMessage[]; newDeltaLink: string }> {
+  const messages: OutlookMessage[] = [];
+
+  let resp: OutlookDeltaResponse<OutlookMessage>;
+  try {
+    resp = await listMessagesDelta(connection, folderId, deltaLink);
+  } catch (err) {
+    if (err instanceof OutlookApiError && err.status === 410) {
+      throw new DeltaSyncExpiredError(err.message);
+    }
+    throw err;
+  }
+
+  if (resp.value) {
+    messages.push(...resp.value);
+  }
+
+  // Follow pagination until we get a deltaLink
+  while (resp["@odata.nextLink"] && !resp["@odata.deltaLink"]) {
+    try {
+      resp = await listMessagesDelta(
+        connection,
+        folderId,
+        resp["@odata.nextLink"],
+      );
+    } catch (err) {
+      if (err instanceof OutlookApiError && err.status === 410) {
+        throw new DeltaSyncExpiredError(
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+      throw err;
+    }
+    if (resp.value) {
+      messages.push(...resp.value);
+    }
+  }
+
+  const newDeltaLink = resp["@odata.deltaLink"];
+  if (!newDeltaLink) {
+    throw new Error(
+      "Outlook delta query completed without returning a deltaLink",
+    );
+  }
+
+  return { messages, newDeltaLink };
+}
+
+export const outlookProvider: WatcherProvider = {
+  id: "outlook",
+  displayName: "Outlook",
+  requiredCredentialService: "outlook",
+
+  async getInitialWatermark(credentialService: string): Promise<string> {
+    const connection = await resolveOAuthConnection(credentialService);
+    const { newDeltaLink } = await fetchAllDeltaPages(connection, "inbox");
+    return newDeltaLink;
+  },
+
+  async fetchNew(
+    credentialService: string,
+    watermark: string | null,
+    _config: Record<string, unknown>,
+    _watcherKey: string,
+  ): Promise<FetchResult> {
+    const connection = await resolveOAuthConnection(credentialService);
+
+    if (!watermark) {
+      // No watermark — get initial position, return no items
+      const { newDeltaLink } = await fetchAllDeltaPages(connection, "inbox");
+      return { items: [], watermark: newDeltaLink };
+    }
+
+    try {
+      const { messages, newDeltaLink } = await fetchAllDeltaPages(
+        connection,
+        "inbox",
+        watermark,
+      );
+
+      if (messages.length === 0) {
+        return { items: [], watermark: newDeltaLink };
+      }
+
+      const items = messages.map(messageToItem);
+      log.info(
+        { count: items.length, watermark: newDeltaLink },
+        "Outlook: fetched new messages",
+      );
+
+      return { items, watermark: newDeltaLink };
+    } catch (err) {
+      if (err instanceof DeltaSyncExpiredError) {
+        log.warn(
+          "Outlook delta sync state expired, falling back to recent inbox messages",
+        );
+        return fallbackFetch(connection);
+      }
+      throw err;
+    }
+  },
+};
+
+/**
+ * Fallback when sync state expires (410 Gone): list recent inbox messages
+ * from the last day, then get a fresh deltaLink.
+ */
+async function fallbackFetch(
+  connection: OAuthConnection,
+): Promise<FetchResult> {
+  const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  const resp = await listMessages(connection, {
+    folderId: "inbox",
+    top: 20,
+    filter: `receivedDateTime ge ${oneDayAgo}`,
+    orderby: "receivedDateTime desc",
+  });
+
+  const items = (resp.value ?? []).map(messageToItem);
+
+  // Get a fresh deltaLink for the new watermark
+  const { newDeltaLink } = await fetchAllDeltaPages(connection, "inbox");
+
+  return { items, watermark: newDeltaLink };
+}


### PR DESCRIPTION
## Summary
- Add Outlook email watcher provider using Microsoft Graph delta queries for efficient change detection
- Implements WatcherProvider interface with delta link-based watermarks
- Handles 410 sync state expiration with graceful fallback to recent messages
- Register watcher in providers-setup.ts behind outlook-oauth-integration feature flag

Part of plan: outlook-email-gmail-parity.md (PR 11 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
