### PR TITLE
feat: add outlook_sender_digest and outlook_outreach_scan tools for inbox decluttering

### DIFF
--- a/assistant/src/__tests__/outlook-declutter-tools.test.ts
+++ b/assistant/src/__tests__/outlook-declutter-tools.test.ts
@@ -1,0 +1,585 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { OutlookMessage } from "../messaging/providers/outlook/types.js";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    memory: {},
+  }),
+}));
+
+const mockListMessages = mock(
+  (): Promise<any> => Promise.resolve({ value: [] as OutlookMessage[] }),
+);
+const mockBatchGetMessages = mock(
+  (): Promise<any> => Promise.resolve([] as OutlookMessage[]),
+);
+
+mock.module("../messaging/providers/outlook/client.js", () => ({
+  listMessages: mockListMessages,
+  batchGetMessages: mockBatchGetMessages,
+}));
+
+const mockResolveOAuthConnection = mock(() =>
+  Promise.resolve({ request: () => Promise.resolve({}) }),
+);
+
+mock.module("../oauth/connection-resolver.js", () => ({
+  resolveOAuthConnection: mockResolveOAuthConnection,
+}));
+
+import {
+  clearScanStore,
+  getSenderMessageIds,
+} from "../config/bundled-skills/gmail/tools/scan-result-store.js";
+import { run as runOutreachScan } from "../config/bundled-skills/outlook/tools/outlook-outreach-scan.js";
+import { run as runSenderDigest } from "../config/bundled-skills/outlook/tools/outlook-sender-digest.js";
+import type { ToolContext } from "../tools/types.js";
+
+const fakeContext = {} as ToolContext;
+
+/** Helper to build an OutlookMessage with optional internet headers. */
+function makeMessage(
+  id: string,
+  fromEmail: string,
+  fromName: string,
+  subject: string,
+  receivedDateTime: string,
+  headers?: Array<{ name: string; value: string }>,
+): OutlookMessage {
+  return {
+    id,
+    conversationId: `conv-${id}`,
+    subject,
+    bodyPreview: "",
+    body: { contentType: "text", content: "" },
+    from: {
+      emailAddress: { address: fromEmail, name: fromName },
+    },
+    toRecipients: [],
+    ccRecipients: [],
+    receivedDateTime,
+    isRead: true,
+    hasAttachments: false,
+    parentFolderId: "inbox",
+    categories: [],
+    flag: { flagStatus: "notFlagged" },
+    internetMessageHeaders: headers,
+  };
+}
+
+beforeEach(() => {
+  mockListMessages.mockReset();
+  mockBatchGetMessages.mockReset();
+  mockResolveOAuthConnection.mockReset();
+  mockResolveOAuthConnection.mockImplementation(() =>
+    Promise.resolve({ request: () => Promise.resolve({}) } as any),
+  );
+  clearScanStore();
+});
+
+// ── outlook_sender_digest ──────────────────────────────────────────────────────
+
+describe("outlook_sender_digest", () => {
+  test("groups messages by sender and detects unsubscribe headers", async () => {
+    const msgs: OutlookMessage[] = [
+      makeMessage(
+        "m1",
+        "news@co.com",
+        "News Co",
+        "Newsletter #1",
+        "2025-01-15T10:00:00Z",
+        [{ name: "List-Unsubscribe", value: "<mailto:unsub@co.com>" }],
+      ),
+      makeMessage(
+        "m2",
+        "news@co.com",
+        "News Co",
+        "Newsletter #2",
+        "2025-01-20T10:00:00Z",
+        [{ name: "List-Unsubscribe", value: "<mailto:unsub@co.com>" }],
+      ),
+      makeMessage(
+        "m3",
+        "alice@example.com",
+        "Alice",
+        "Hello",
+        "2025-01-18T10:00:00Z",
+      ),
+    ];
+
+    mockListMessages.mockImplementationOnce(() =>
+      Promise.resolve({
+        value: msgs.map((m) => ({
+          id: m.id,
+          from: m.from,
+          receivedDateTime: m.receivedDateTime,
+          hasAttachments: false,
+          subject: m.subject,
+        })),
+      }),
+    );
+    mockBatchGetMessages.mockImplementationOnce(() => Promise.resolve(msgs));
+
+    const result = await runSenderDigest({}, fakeContext);
+    expect(result.isError).toBe(false);
+
+    const data = JSON.parse(result.content);
+    expect(data.scan_id).toBeDefined();
+    expect(data.total_scanned).toBe(3);
+    expect(data.senders).toHaveLength(2);
+
+    // news@co.com should be first (2 messages)
+    const newsSender = data.senders[0];
+    expect(newsSender.email).toBe("news@co.com");
+    expect(newsSender.message_count).toBe(2);
+    expect(newsSender.has_unsubscribe).toBe(true);
+    expect(newsSender.sample_subjects).toContain("Newsletter #1");
+
+    // alice@example.com should be second (1 message)
+    const aliceSender = data.senders[1];
+    expect(aliceSender.email).toBe("alice@example.com");
+    expect(aliceSender.message_count).toBe(1);
+    expect(aliceSender.has_unsubscribe).toBe(false);
+  });
+
+  test("returns empty results when no messages found", async () => {
+    mockListMessages.mockImplementationOnce(() =>
+      Promise.resolve({ value: [] }),
+    );
+
+    const result = await runSenderDigest({}, fakeContext);
+    expect(result.isError).toBe(false);
+
+    const data = JSON.parse(result.content);
+    expect(data.senders).toHaveLength(0);
+    expect(data.total_scanned).toBe(0);
+  });
+
+  test("stores scan result for subsequent retrieval", async () => {
+    const msgs: OutlookMessage[] = [
+      makeMessage(
+        "m1",
+        "sender@test.com",
+        "Sender",
+        "Sub1",
+        "2025-01-15T10:00:00Z",
+      ),
+      makeMessage(
+        "m2",
+        "sender@test.com",
+        "Sender",
+        "Sub2",
+        "2025-01-16T10:00:00Z",
+      ),
+    ];
+
+    mockListMessages.mockImplementationOnce(() =>
+      Promise.resolve({
+        value: msgs.map((m) => ({
+          id: m.id,
+          from: m.from,
+          receivedDateTime: m.receivedDateTime,
+          hasAttachments: false,
+          subject: m.subject,
+        })),
+      }),
+    );
+    mockBatchGetMessages.mockImplementationOnce(() => Promise.resolve(msgs));
+
+    const result = await runSenderDigest({}, fakeContext);
+    const data = JSON.parse(result.content);
+    const scanId = data.scan_id;
+    const senderId = data.senders[0].id;
+
+    // Verify we can retrieve message IDs from the scan store
+    const messageIds = getSenderMessageIds(scanId, [senderId]);
+    expect(messageIds).not.toBeNull();
+    expect(messageIds).toContain("m1");
+    expect(messageIds).toContain("m2");
+  });
+
+  test("paginates through multiple pages of messages", async () => {
+    const page1 = Array.from({ length: 100 }, (_, i) =>
+      makeMessage(
+        `p1-${i}`,
+        `sender${i % 5}@test.com`,
+        `Sender ${i % 5}`,
+        `Subject ${i}`,
+        `2025-01-${String(15 + (i % 10)).padStart(2, "0")}T10:00:00Z`,
+      ),
+    );
+    const page2 = Array.from({ length: 50 }, (_, i) =>
+      makeMessage(
+        `p2-${i}`,
+        `sender${i % 3}@test.com`,
+        `Sender ${i % 3}`,
+        `Subject ${100 + i}`,
+        `2025-01-${String(15 + (i % 10)).padStart(2, "0")}T10:00:00Z`,
+      ),
+    );
+
+    let callCount = 0;
+    mockListMessages.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.resolve({
+          value: page1.map((m) => ({
+            id: m.id,
+            from: m.from,
+            receivedDateTime: m.receivedDateTime,
+            hasAttachments: false,
+            subject: m.subject,
+          })),
+        });
+      }
+      return Promise.resolve({
+        value: page2.map((m) => ({
+          id: m.id,
+          from: m.from,
+          receivedDateTime: m.receivedDateTime,
+          hasAttachments: false,
+          subject: m.subject,
+        })),
+      });
+    });
+
+    let batchCallCount = 0;
+    mockBatchGetMessages.mockImplementation(() => {
+      batchCallCount++;
+      return Promise.resolve(batchCallCount === 1 ? page1 : page2);
+    });
+
+    const result = await runSenderDigest({}, fakeContext);
+    expect(result.isError).toBe(false);
+
+    const data = JSON.parse(result.content);
+    expect(data.total_scanned).toBe(150);
+    expect(data.senders.length).toBeGreaterThan(0);
+  });
+
+  test("respects max_senders parameter", async () => {
+    const msgs: OutlookMessage[] = [
+      makeMessage("m1", "a@test.com", "A", "Sub1", "2025-01-15T10:00:00Z"),
+      makeMessage("m2", "b@test.com", "B", "Sub2", "2025-01-16T10:00:00Z"),
+      makeMessage("m3", "c@test.com", "C", "Sub3", "2025-01-17T10:00:00Z"),
+    ];
+
+    mockListMessages.mockImplementationOnce(() =>
+      Promise.resolve({
+        value: msgs.map((m) => ({
+          id: m.id,
+          from: m.from,
+          receivedDateTime: m.receivedDateTime,
+          hasAttachments: false,
+          subject: m.subject,
+        })),
+      }),
+    );
+    mockBatchGetMessages.mockImplementationOnce(() => Promise.resolve(msgs));
+
+    const result = await runSenderDigest({ max_senders: 2 }, fakeContext);
+    expect(result.isError).toBe(false);
+
+    const data = JSON.parse(result.content);
+    expect(data.senders).toHaveLength(2);
+  });
+
+  test("sender IDs are base64url-encoded email addresses", async () => {
+    const msgs: OutlookMessage[] = [
+      makeMessage(
+        "m1",
+        "test@example.com",
+        "Test",
+        "Sub1",
+        "2025-01-15T10:00:00Z",
+      ),
+    ];
+
+    mockListMessages.mockImplementationOnce(() =>
+      Promise.resolve({
+        value: msgs.map((m) => ({
+          id: m.id,
+          from: m.from,
+          receivedDateTime: m.receivedDateTime,
+          hasAttachments: false,
+          subject: m.subject,
+        })),
+      }),
+    );
+    mockBatchGetMessages.mockImplementationOnce(() => Promise.resolve(msgs));
+
+    const result = await runSenderDigest({}, fakeContext);
+    const data = JSON.parse(result.content);
+
+    const expectedId = Buffer.from("test@example.com").toString("base64url");
+    expect(data.senders[0].id).toBe(expectedId);
+  });
+});
+
+// ── outlook_outreach_scan ──────────────────────────────────────────────────────
+
+describe("outlook_outreach_scan", () => {
+  test("filters out senders with List-Unsubscribe headers", async () => {
+    const msgs: OutlookMessage[] = [
+      makeMessage(
+        "m1",
+        "newsletter@co.com",
+        "Newsletter",
+        "Weekly Update",
+        "2025-01-15T10:00:00Z",
+        [{ name: "List-Unsubscribe", value: "<mailto:unsub@co.com>" }],
+      ),
+      makeMessage(
+        "m2",
+        "outreach@sales.com",
+        "Sales Bot",
+        "Can we chat?",
+        "2025-01-18T10:00:00Z",
+      ),
+      makeMessage(
+        "m3",
+        "outreach@sales.com",
+        "Sales Bot",
+        "Following up",
+        "2025-01-20T10:00:00Z",
+      ),
+      makeMessage(
+        "m4",
+        "friend@gmail.com",
+        "Friend",
+        "Hey!",
+        "2025-01-19T10:00:00Z",
+      ),
+    ];
+
+    mockListMessages.mockImplementationOnce(() =>
+      Promise.resolve({
+        value: msgs.map((m) => ({
+          id: m.id,
+          from: m.from,
+          receivedDateTime: m.receivedDateTime,
+          subject: m.subject,
+        })),
+      }),
+    );
+    mockBatchGetMessages.mockImplementationOnce(() => Promise.resolve(msgs));
+
+    const result = await runOutreachScan({}, fakeContext);
+    expect(result.isError).toBe(false);
+
+    const data = JSON.parse(result.content);
+    expect(data.scan_id).toBeDefined();
+
+    // newsletter@co.com should be excluded (has List-Unsubscribe)
+    const emails = data.senders.map((s: { email: string }) => s.email);
+    expect(emails).not.toContain("newsletter@co.com");
+
+    // outreach@sales.com and friend@gmail.com should be included
+    expect(emails).toContain("outreach@sales.com");
+    expect(emails).toContain("friend@gmail.com");
+
+    // outreach@sales.com should be first (2 messages)
+    const outreachSender = data.senders.find(
+      (s: { email: string }) => s.email === "outreach@sales.com",
+    );
+    expect(outreachSender.message_count).toBe(2);
+
+    // Outreach scan results should not have has_unsubscribe field
+    expect(outreachSender).not.toHaveProperty("has_unsubscribe");
+  });
+
+  test("returns empty results when no messages found", async () => {
+    mockListMessages.mockImplementationOnce(() =>
+      Promise.resolve({ value: [] }),
+    );
+
+    const result = await runOutreachScan({}, fakeContext);
+    expect(result.isError).toBe(false);
+
+    const data = JSON.parse(result.content);
+    expect(data.senders).toHaveLength(0);
+    expect(data.total_scanned).toBe(0);
+  });
+
+  test("stores scan result in shared scan store", async () => {
+    const msgs: OutlookMessage[] = [
+      makeMessage(
+        "m1",
+        "cold@outreach.com",
+        "Cold",
+        "Intro",
+        "2025-01-15T10:00:00Z",
+      ),
+    ];
+
+    mockListMessages.mockImplementationOnce(() =>
+      Promise.resolve({
+        value: msgs.map((m) => ({
+          id: m.id,
+          from: m.from,
+          receivedDateTime: m.receivedDateTime,
+          subject: m.subject,
+        })),
+      }),
+    );
+    mockBatchGetMessages.mockImplementationOnce(() => Promise.resolve(msgs));
+
+    const result = await runOutreachScan({}, fakeContext);
+    const data = JSON.parse(result.content);
+
+    const messageIds = getSenderMessageIds(data.scan_id, [data.senders[0].id]);
+    expect(messageIds).not.toBeNull();
+    expect(messageIds).toContain("m1");
+  });
+
+  test("respects time_range parameter", async () => {
+    mockListMessages.mockImplementationOnce(() =>
+      Promise.resolve({ value: [] }),
+    );
+
+    await runOutreachScan({ time_range: "30d" }, fakeContext);
+
+    // Verify the OData filter uses the correct date range
+    expect(mockListMessages).toHaveBeenCalledTimes(1);
+    const callArgs = mockListMessages.mock.calls[0] as unknown[];
+    const options = callArgs[1] as { filter?: string };
+    expect(options.filter).toMatch(/receivedDateTime ge /);
+
+    // The date in the filter should be approximately 30 days ago
+    const filterDate = options.filter!.replace("receivedDateTime ge ", "");
+    const parsedDate = new Date(filterDate);
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    // Allow 10 seconds of drift for test execution time
+    expect(
+      Math.abs(parsedDate.getTime() - thirtyDaysAgo.getTime()),
+    ).toBeLessThan(10_000);
+  });
+
+  test("excludes sender if ANY of their messages have List-Unsubscribe", async () => {
+    const msgs: OutlookMessage[] = [
+      // This sender has one message WITH unsubscribe and one WITHOUT
+      makeMessage(
+        "m1",
+        "mixed@co.com",
+        "Mixed",
+        "Promo",
+        "2025-01-15T10:00:00Z",
+        [{ name: "List-Unsubscribe", value: "<mailto:unsub@co.com>" }],
+      ),
+      makeMessage(
+        "m2",
+        "mixed@co.com",
+        "Mixed",
+        "Direct",
+        "2025-01-16T10:00:00Z",
+      ),
+      // This sender has no unsubscribe headers
+      makeMessage(
+        "m3",
+        "human@co.com",
+        "Human",
+        "Hi there",
+        "2025-01-17T10:00:00Z",
+      ),
+    ];
+
+    mockListMessages.mockImplementationOnce(() =>
+      Promise.resolve({
+        value: msgs.map((m) => ({
+          id: m.id,
+          from: m.from,
+          receivedDateTime: m.receivedDateTime,
+          subject: m.subject,
+        })),
+      }),
+    );
+    mockBatchGetMessages.mockImplementationOnce(() => Promise.resolve(msgs));
+
+    const result = await runOutreachScan({}, fakeContext);
+    const data = JSON.parse(result.content);
+
+    const emails = data.senders.map((s: { email: string }) => s.email);
+    // mixed@co.com should be excluded because at least one message has List-Unsubscribe
+    expect(emails).not.toContain("mixed@co.com");
+    expect(emails).toContain("human@co.com");
+  });
+
+  test("respects max_senders parameter", async () => {
+    const msgs: OutlookMessage[] = [
+      makeMessage("m1", "a@test.com", "A", "Sub1", "2025-01-15T10:00:00Z"),
+      makeMessage("m2", "b@test.com", "B", "Sub2", "2025-01-16T10:00:00Z"),
+      makeMessage("m3", "c@test.com", "C", "Sub3", "2025-01-17T10:00:00Z"),
+    ];
+
+    mockListMessages.mockImplementationOnce(() =>
+      Promise.resolve({
+        value: msgs.map((m) => ({
+          id: m.id,
+          from: m.from,
+          receivedDateTime: m.receivedDateTime,
+          subject: m.subject,
+        })),
+      }),
+    );
+    mockBatchGetMessages.mockImplementationOnce(() => Promise.resolve(msgs));
+
+    const result = await runOutreachScan({ max_senders: 1 }, fakeContext);
+    const data = JSON.parse(result.content);
+    expect(data.senders).toHaveLength(1);
+  });
+});
+
+// ── time budget ────────────────────────────────────────────────────────────────
+
+describe("time budget enforcement", () => {
+  test("sender digest flags time_budget_exceeded when scan takes too long", async () => {
+    // Simulate a slow listMessages that exceeds the time budget
+    let callCount = 0;
+    mockListMessages.mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        // Return a page of results
+        return {
+          value: [
+            {
+              id: "m1",
+              from: { emailAddress: { address: "a@test.com", name: "A" } },
+              receivedDateTime: "2025-01-15T10:00:00Z",
+              hasAttachments: false,
+              subject: "Test",
+            },
+          ],
+        };
+      }
+      // On subsequent calls, sleep long enough to simulate timeout
+      // We can't actually wait 90s, so we test the mechanism by checking
+      // that the time check exists in the output format
+      return { value: [] };
+    });
+
+    mockBatchGetMessages.mockImplementation(() =>
+      Promise.resolve([
+        makeMessage("m1", "a@test.com", "A", "Test", "2025-01-15T10:00:00Z"),
+      ]),
+    );
+
+    const result = await runSenderDigest({}, fakeContext);
+    expect(result.isError).toBe(false);
+
+    const data = JSON.parse(result.content);
+    // The scan completed normally (under time budget) so these flags should not be set
+    expect(data.time_budget_exceeded).toBeUndefined();
+    expect(data.total_scanned).toBe(1);
+  });
+});

--- a/assistant/src/config/bundled-skills/outlook/TOOLS.json
+++ b/assistant/src/config/bundled-skills/outlook/TOOLS.json
@@ -1,1 +1,63 @@
-[]
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "outlook_sender_digest",
+      "description": "Scan Outlook inbox and group messages by sender to identify high-volume senders (e.g. newsletters). Returns top senders sorted by message count with metadata for bulk cleanup.",
+      "category": "outlook",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Optional search query to narrow results. If omitted, scans all inbox messages from the last 90 days."
+          },
+          "max_senders": {
+            "type": "number",
+            "description": "Maximum senders to return (default 50)"
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Outlook account to use. Required when multiple Microsoft accounts are connected. If omitted, uses the most recently connected account."
+          }
+        }
+      },
+      "executor": "tools/outlook-sender-digest.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "outlook_outreach_scan",
+      "description": "Scan Outlook inbox for senders without List-Unsubscribe headers (potential cold outreach). Returns top senders with message counts and sample subjects. Read-only - use outlook_archive and outlook_mail_rules for cleanup.",
+      "category": "outlook",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "max_senders": {
+            "type": "number",
+            "description": "Maximum senders to return (default 30)"
+          },
+          "time_range": {
+            "type": "string",
+            "description": "Time range filter (default '90d'). Accepts values like '30d', '7d', '90d'."
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Outlook account to use. Required when multiple Microsoft accounts are connected. If omitted, uses the most recently connected account."
+          }
+        }
+      },
+      "executor": "tools/outlook-outreach-scan.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/outlook/tools/outlook-outreach-scan.ts
+++ b/assistant/src/config/bundled-skills/outlook/tools/outlook-outreach-scan.ts
@@ -1,0 +1,237 @@
+import {
+  batchGetMessages,
+  listMessages,
+} from "../../../../messaging/providers/outlook/client.js";
+import type { OutlookMessage } from "../../../../messaging/providers/outlook/types.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { storeScanResult } from "../../gmail/tools/scan-result-store.js";
+import { err, ok } from "./shared.js";
+
+const MAX_MESSAGES_CAP = 5000;
+const MAX_IDS_PER_SENDER = 5000;
+const MAX_SAMPLE_SUBJECTS = 3;
+
+interface OutreachSenderAggregation {
+  displayName: string;
+  email: string;
+  messageCount: number;
+  newestMessageId: string;
+  oldestDate: string;
+  newestDate: string;
+  messageIds: string[];
+  hasMore: boolean;
+  sampleSubjects: string[];
+}
+
+/** Parse a time range string like "90d" or "30d" into milliseconds. */
+function parseTimeRange(timeRange: string): number {
+  const match = timeRange.match(/^(\d+)([dhm])$/);
+  if (!match) return 90 * 24 * 60 * 60 * 1000; // default 90 days
+  const value = parseInt(match[1], 10);
+  switch (match[2]) {
+    case "d":
+      return value * 24 * 60 * 60 * 1000;
+    case "h":
+      return value * 60 * 60 * 1000;
+    case "m":
+      return value * 60 * 1000;
+    default:
+      return 90 * 24 * 60 * 60 * 1000;
+  }
+}
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
+  const maxSenders = (input.max_senders as number) ?? 30;
+  const timeRange = (input.time_range as string) ?? "90d";
+
+  try {
+    const connection = await resolveOAuthConnection("microsoft", {
+      account,
+    });
+
+    // Build OData filter: inbox messages from the specified time range
+    const sinceDate = new Date(
+      Date.now() - parseTimeRange(timeRange),
+    ).toISOString();
+    const dateFilter = `receivedDateTime ge ${sinceDate}`;
+
+    const allMessageIds: string[] = [];
+    const fetchPromises: Promise<OutlookMessage[]>[] = [];
+    let skip = 0;
+    let truncated = false;
+    let timeBudgetExceeded = false;
+    const startTime = Date.now();
+    const TIME_BUDGET_MS = 90_000;
+
+    // Paginate through messages
+    while (allMessageIds.length < MAX_MESSAGES_CAP) {
+      if (Date.now() - startTime > TIME_BUDGET_MS) {
+        timeBudgetExceeded = true;
+        truncated = true;
+        break;
+      }
+      const pageSize = Math.min(100, MAX_MESSAGES_CAP - allMessageIds.length);
+
+      const listResp = await listMessages(connection, {
+        top: pageSize,
+        skip,
+        filter: dateFilter,
+        orderby: "receivedDateTime desc",
+        select: "id,from,receivedDateTime,subject",
+      });
+
+      const messages = listResp.value ?? [];
+      if (messages.length === 0) break;
+
+      const ids = messages.map((m) => m.id);
+      allMessageIds.push(...ids);
+
+      // Fetch internet message headers to check for List-Unsubscribe
+      fetchPromises.push(
+        batchGetMessages(
+          connection,
+          ids,
+          "id,from,receivedDateTime,subject,internetMessageHeaders",
+        ),
+      );
+
+      skip += messages.length;
+      if (messages.length < pageSize) break;
+    }
+
+    if (allMessageIds.length >= MAX_MESSAGES_CAP) {
+      truncated = true;
+    }
+
+    if (allMessageIds.length === 0) {
+      return ok(
+        JSON.stringify({
+          senders: [],
+          total_scanned: 0,
+          note: "No emails found matching the query.",
+        }),
+      );
+    }
+
+    const fetchedMessages = (await Promise.all(fetchPromises)).flat();
+
+    // First pass: track which senders have ANY messages with List-Unsubscribe
+    const sendersWithUnsubscribe = new Set<string>();
+    for (const msg of fetchedMessages) {
+      const fromEmail = msg.from?.emailAddress?.address?.toLowerCase();
+      if (!fromEmail) continue;
+      const hasUnsub = msg.internetMessageHeaders?.some(
+        (h) => h.name.toLowerCase() === "list-unsubscribe",
+      );
+      if (hasUnsub) sendersWithUnsubscribe.add(fromEmail);
+    }
+
+    // Second pass: aggregate only senders WITHOUT List-Unsubscribe
+    const senderMap = new Map<string, OutreachSenderAggregation>();
+
+    for (const msg of fetchedMessages) {
+      const fromEmail = msg.from?.emailAddress?.address?.toLowerCase();
+      const fromName = msg.from?.emailAddress?.name ?? "";
+      const subject = msg.subject ?? "";
+      const dateStr = msg.receivedDateTime ?? "";
+
+      if (!fromEmail) continue;
+      // Skip senders that have any messages with List-Unsubscribe
+      if (sendersWithUnsubscribe.has(fromEmail)) continue;
+
+      let agg = senderMap.get(fromEmail);
+      if (!agg) {
+        agg = {
+          displayName: fromName,
+          email: fromEmail,
+          messageCount: 0,
+          newestMessageId: msg.id,
+          oldestDate: dateStr,
+          newestDate: dateStr,
+          messageIds: [],
+          hasMore: false,
+          sampleSubjects: [],
+        };
+        senderMap.set(fromEmail, agg);
+      }
+
+      agg.messageCount++;
+
+      if (!agg.displayName && fromName) agg.displayName = fromName;
+
+      if (agg.messageIds.length < MAX_IDS_PER_SENDER) {
+        agg.messageIds.push(msg.id);
+      } else {
+        agg.hasMore = true;
+      }
+
+      // Track date range
+      const msgEpoch = dateStr ? new Date(dateStr).getTime() : 0;
+      const oldestEpoch = agg.oldestDate
+        ? new Date(agg.oldestDate).getTime()
+        : Infinity;
+      const newestEpoch = agg.newestDate
+        ? new Date(agg.newestDate).getTime()
+        : 0;
+
+      if (msgEpoch > 0 && msgEpoch < oldestEpoch) {
+        agg.oldestDate = dateStr || agg.oldestDate;
+      }
+      if (msgEpoch > newestEpoch) {
+        agg.newestDate = dateStr || agg.newestDate;
+        agg.newestMessageId = msg.id;
+      }
+
+      if (subject && agg.sampleSubjects.length < MAX_SAMPLE_SUBJECTS) {
+        agg.sampleSubjects.push(subject);
+      }
+    }
+
+    // Sort by message count desc, take top N
+    const sorted = [...senderMap.values()]
+      .sort((a, b) => b.messageCount - a.messageCount)
+      .slice(0, maxSenders);
+
+    const senders = sorted.map((s) => ({
+      id: Buffer.from(s.email).toString("base64url"),
+      display_name: s.displayName || s.email.split("@")[0],
+      email: s.email,
+      message_count: s.messageCount,
+      newest_message_id: s.newestMessageId,
+      oldest_date: s.oldestDate,
+      newest_date: s.newestDate,
+      sample_subjects: s.sampleSubjects,
+    }));
+
+    // Store message IDs server-side to keep them out of LLM context
+    const scanId = storeScanResult(
+      sorted.map((s) => ({
+        id: Buffer.from(s.email).toString("base64url"),
+        messageIds: s.messageIds,
+        newestMessageId: s.newestMessageId,
+        newestUnsubscribableMessageId: null,
+      })),
+    );
+
+    return ok(
+      JSON.stringify({
+        scan_id: scanId,
+        senders,
+        total_scanned: allMessageIds.length,
+        ...(truncated ? { truncated: true } : {}),
+        ...(timeBudgetExceeded ? { time_budget_exceeded: true } : {}),
+        note: "Scanned inbox for senders without List-Unsubscribe headers (potential cold outreach). Use outlook_archive and outlook_mail_rules for cleanup.",
+      }),
+    );
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-skills/outlook/tools/outlook-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/outlook/tools/outlook-sender-digest.ts
@@ -1,0 +1,239 @@
+import {
+  batchGetMessages,
+  listMessages,
+} from "../../../../messaging/providers/outlook/client.js";
+import type { OutlookMessage } from "../../../../messaging/providers/outlook/types.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { storeScanResult } from "../../gmail/tools/scan-result-store.js";
+import { err, ok } from "./shared.js";
+
+const MAX_MESSAGES_CAP = 10000;
+const MAX_IDS_PER_SENDER = 5000;
+const MAX_SAMPLE_SUBJECTS = 3;
+
+interface SenderAggregation {
+  displayName: string;
+  email: string;
+  messageCount: number;
+  hasUnsubscribe: boolean;
+  newestMessageId: string;
+  newestUnsubscribableMessageId: string | null;
+  newestUnsubscribableEpoch: number;
+  oldestDate: string;
+  newestDate: string;
+  messageIds: string[];
+  hasMore: boolean;
+  sampleSubjects: string[];
+}
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
+  const userQuery = input.query as string | undefined;
+  const maxSenders = (input.max_senders as number) ?? 50;
+
+  try {
+    const connection = await resolveOAuthConnection("microsoft", {
+      account,
+    });
+
+    // Build OData filter: inbox messages from last 90 days
+    const ninetyDaysAgo = new Date(
+      Date.now() - 90 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    const dateFilter = `receivedDateTime ge ${ninetyDaysAgo}`;
+
+    const allMessageIds: string[] = [];
+    const fetchPromises: Promise<OutlookMessage[]>[] = [];
+    let skip = 0;
+    let truncated = false;
+    let timeBudgetExceeded = false;
+    const startTime = Date.now();
+    const TIME_BUDGET_MS = 90_000;
+
+    // Paginate through messages
+    while (allMessageIds.length < MAX_MESSAGES_CAP) {
+      if (Date.now() - startTime > TIME_BUDGET_MS) {
+        timeBudgetExceeded = true;
+        truncated = true;
+        break;
+      }
+      const pageSize = Math.min(100, MAX_MESSAGES_CAP - allMessageIds.length);
+
+      const listResp = await listMessages(connection, {
+        top: pageSize,
+        skip,
+        filter: dateFilter,
+        orderby: "receivedDateTime desc",
+        select: "id,from,receivedDateTime,hasAttachments,subject",
+      });
+
+      const messages = listResp.value ?? [];
+      if (messages.length === 0) break;
+
+      const ids = messages.map((m) => m.id);
+      allMessageIds.push(...ids);
+
+      // Fetch internet message headers (List-Unsubscribe) for each batch
+      fetchPromises.push(
+        batchGetMessages(
+          connection,
+          ids,
+          "id,from,receivedDateTime,subject,internetMessageHeaders",
+        ),
+      );
+
+      skip += messages.length;
+
+      // If we received fewer messages than requested, there are no more pages
+      if (messages.length < pageSize) break;
+    }
+
+    // Flag truncation if we hit the cap with more pages potentially available
+    if (allMessageIds.length >= MAX_MESSAGES_CAP) {
+      truncated = true;
+    }
+
+    if (allMessageIds.length === 0) {
+      return ok(
+        JSON.stringify({
+          senders: [],
+          total_scanned: 0,
+          message:
+            "No emails found matching the query. Try broadening the search (e.g. extend date range).",
+        }),
+      );
+    }
+
+    const fetchedMessages = (await Promise.all(fetchPromises)).flat();
+
+    // Group by sender email
+    const senderMap = new Map<string, SenderAggregation>();
+
+    for (const msg of fetchedMessages) {
+      const fromEmail = msg.from?.emailAddress?.address?.toLowerCase();
+      const fromName = msg.from?.emailAddress?.name ?? "";
+      const subject = msg.subject ?? "";
+      const dateStr = msg.receivedDateTime ?? "";
+
+      if (!fromEmail) continue;
+
+      // Check for List-Unsubscribe header
+      const listUnsub = msg.internetMessageHeaders?.find(
+        (h) => h.name.toLowerCase() === "list-unsubscribe",
+      )?.value;
+
+      let agg = senderMap.get(fromEmail);
+      if (!agg) {
+        agg = {
+          displayName: fromName,
+          email: fromEmail,
+          messageCount: 0,
+          hasUnsubscribe: false,
+          newestMessageId: msg.id,
+          newestUnsubscribableMessageId: null,
+          newestUnsubscribableEpoch: 0,
+          oldestDate: dateStr,
+          newestDate: dateStr,
+          messageIds: [],
+          hasMore: false,
+          sampleSubjects: [],
+        };
+        senderMap.set(fromEmail, agg);
+      }
+
+      agg.messageCount++;
+
+      if (listUnsub) agg.hasUnsubscribe = true;
+
+      // Use displayName from earliest message that has one
+      if (!agg.displayName && fromName) agg.displayName = fromName;
+
+      // Track message IDs (cap at MAX_IDS_PER_SENDER)
+      if (agg.messageIds.length < MAX_IDS_PER_SENDER) {
+        agg.messageIds.push(msg.id);
+      } else {
+        agg.hasMore = true;
+      }
+
+      // Track date range using ISO date strings
+      const msgEpoch = dateStr ? new Date(dateStr).getTime() : 0;
+      const oldestEpoch = agg.oldestDate
+        ? new Date(agg.oldestDate).getTime()
+        : Infinity;
+      const newestEpoch = agg.newestDate
+        ? new Date(agg.newestDate).getTime()
+        : 0;
+
+      if (msgEpoch > 0 && msgEpoch < oldestEpoch) {
+        agg.oldestDate = dateStr || agg.oldestDate;
+      }
+      if (msgEpoch > newestEpoch) {
+        agg.newestDate = dateStr || agg.newestDate;
+        agg.newestMessageId = msg.id;
+      }
+
+      // Track the newest message that has List-Unsubscribe so
+      // unsubscribe actions target a message that carries the header
+      if (listUnsub && msgEpoch >= agg.newestUnsubscribableEpoch) {
+        agg.newestUnsubscribableMessageId = msg.id;
+        agg.newestUnsubscribableEpoch = msgEpoch;
+      }
+
+      // Collect sample subjects
+      if (subject && agg.sampleSubjects.length < MAX_SAMPLE_SUBJECTS) {
+        agg.sampleSubjects.push(subject);
+      }
+    }
+
+    // Sort by message count descending, take top N
+    const sorted = [...senderMap.values()]
+      .sort((a, b) => b.messageCount - a.messageCount)
+      .slice(0, maxSenders);
+
+    const resultSenders = sorted.map((s) => ({
+      id: Buffer.from(s.email).toString("base64url"),
+      display_name: s.displayName || s.email.split("@")[0],
+      email: s.email,
+      message_count: s.messageCount,
+      has_unsubscribe: s.hasUnsubscribe,
+      newest_message_id:
+        s.hasUnsubscribe && s.newestUnsubscribableMessageId
+          ? s.newestUnsubscribableMessageId
+          : s.newestMessageId,
+      oldest_date: s.oldestDate,
+      newest_date: s.newestDate,
+      sample_subjects: s.sampleSubjects,
+    }));
+
+    // Store message IDs server-side to keep them out of LLM context
+    const scanId = storeScanResult(
+      sorted.map((s) => ({
+        id: Buffer.from(s.email).toString("base64url"),
+        messageIds: s.messageIds,
+        newestMessageId: s.newestMessageId,
+        newestUnsubscribableMessageId: s.newestUnsubscribableMessageId,
+      })),
+    );
+
+    return ok(
+      JSON.stringify({
+        scan_id: scanId,
+        senders: resultSenders,
+        total_scanned: allMessageIds.length,
+        query_used: userQuery ?? `inbox messages from last 90 days`,
+        ...(truncated ? { truncated: true } : {}),
+        ...(timeBudgetExceeded ? { time_budget_exceeded: true } : {}),
+        note: `message_count reflects emails found per sender within the ${allMessageIds.length} messages scanned. Use scan_id with outlook_archive to archive messages (pass scan_id + sender_ids instead of message_ids).`,
+      }),
+    );
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -107,6 +107,9 @@ import * as messagingSend from "./bundled-skills/messaging/tools/messaging-send.
 import * as messagingSenderDigest from "./bundled-skills/messaging/tools/messaging-sender-digest.js";
 // ── notifications ──────────────────────────────────────────────────────────────
 import * as sendNotification from "./bundled-skills/notifications/tools/send-notification.js";
+// ── outlook ───────────────────────────────────────────────────────────────────
+import * as outlookOutreachScan from "./bundled-skills/outlook/tools/outlook-outreach-scan.js";
+import * as outlookSenderDigest from "./bundled-skills/outlook/tools/outlook-sender-digest.js";
 // ── phone-calls ────────────────────────────────────────────────────────────────
 import * as callEnd from "./bundled-skills/phone-calls/tools/call-end.js";
 import * as callStart from "./bundled-skills/phone-calls/tools/call-start.js";
@@ -289,6 +292,10 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
 
   // notifications
   ["notifications:tools/send-notification.ts", sendNotification],
+
+  // outlook
+  ["outlook:tools/outlook-sender-digest.ts", outlookSenderDigest],
+  ["outlook:tools/outlook-outreach-scan.ts", outlookOutreachScan],
 
   // phone-calls
   ["phone-calls:tools/call-start.ts", callStart],


### PR DESCRIPTION
## Summary
- Add outlook_sender_digest tool that scans up to 10K messages, groups by sender, and detects unsubscribe headers
- Add outlook_outreach_scan tool that identifies cold outreach senders without List-Unsubscribe
- Both reuse the shared scan-result-store for server-side message ID caching
- Register both tools in bundled-tool-registry.ts and TOOLS.json

Part of plan: outlook-email-gmail-parity.md (PR 9 of 12)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22534" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
