### PR TITLE
Require platform login for OAuth & service mode CLI commands

### DIFF
--- a/assistant/src/__tests__/config-set-platform-guard.test.ts
+++ b/assistant/src/__tests__/config-set-platform-guard.test.ts
@@ -1,0 +1,301 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let mockPlatformClientCreate: () => Promise<Record<
+  string,
+  unknown
+> | null> = async () => null;
+
+let mockLoadRawConfig: () => Record<string, unknown> = () => ({});
+const mockSaveRawConfigCalls: Array<Record<string, unknown>> = [];
+const mockSetNestedValueCalls: Array<{
+  obj: Record<string, unknown>;
+  key: string;
+  value: unknown;
+}> = [];
+let mockGetNestedValue: (
+  obj: Record<string, unknown>,
+  key: string,
+) => unknown = () => undefined;
+
+// ---------------------------------------------------------------------------
+// Mocks — platform/client (controls requirePlatformConnection)
+// ---------------------------------------------------------------------------
+
+mock.module("../platform/client.js", () => ({
+  VellumPlatformClient: {
+    create: () => mockPlatformClientCreate(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Mocks — config/loader
+// ---------------------------------------------------------------------------
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({ services: {} }),
+  loadConfig: () => ({ services: {} }),
+  saveConfig: () => {},
+  invalidateConfigCache: () => {},
+  loadRawConfig: () => mockLoadRawConfig(),
+  saveRawConfig: (raw: Record<string, unknown>) => {
+    mockSaveRawConfigCalls.push(raw);
+  },
+  applyNestedDefaults: (c: unknown) => c,
+  deepMergeMissing: (a: unknown) => a,
+  deepMergeOverwrite: (a: unknown) => a,
+  mergeDefaultWorkspaceConfig: () => {},
+  getNestedValue: (obj: Record<string, unknown>, key: string) =>
+    mockGetNestedValue(obj, key),
+  setNestedValue: (obj: Record<string, unknown>, key: string, value: unknown) =>
+    mockSetNestedValueCalls.push({ obj, key, value }),
+  API_KEY_PROVIDERS: [
+    "anthropic",
+    "openai",
+    "gemini",
+    "ollama",
+    "fireworks",
+    "openrouter",
+    "brave",
+    "perplexity",
+  ],
+}));
+
+// ---------------------------------------------------------------------------
+// Mocks — util/logger (suppress log output)
+// ---------------------------------------------------------------------------
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mocks — oauth/oauth-store (transitive dep of oauth/shared.ts)
+// ---------------------------------------------------------------------------
+
+mock.module("../oauth/oauth-store.js", () => ({
+  disconnectOAuthProvider: async () => "not-found" as const,
+  getConnection: () => undefined,
+  getConnectionByProvider: () => undefined,
+  listConnections: () => [],
+  deleteConnection: () => false,
+  upsertApp: async () => ({}),
+  getApp: () => undefined,
+  getAppByProviderAndClientId: () => undefined,
+  getMostRecentAppByProvider: () => undefined,
+  listApps: () => [],
+  deleteApp: async () => false,
+  getProvider: () => undefined,
+  listProviders: () => [],
+  registerProvider: () => ({}),
+  updateProvider: () => undefined,
+  deleteProvider: () => false,
+  seedProviders: () => {},
+  getActiveConnection: () => undefined,
+  listActiveConnectionsByProvider: () => [],
+  createConnection: () => ({}),
+  isProviderConnected: () => false,
+  updateConnection: () => ({}),
+}));
+
+// ---------------------------------------------------------------------------
+// Import the module under test (after mocks are registered)
+// ---------------------------------------------------------------------------
+
+const { registerConfigCommand } = await import("../cli/commands/config.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runCli(
+  args: string[],
+): Promise<{ exitCode: number; stdout: string }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = (() => true) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.option("--json", "JSON output");
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerConfigCommand(program);
+    await program.parseAsync(args);
+  } catch {
+    if (process.exitCode === 0) process.exitCode = 1;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return {
+    exitCode,
+    stdout: stdoutChunks.join(""),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("config set — platform connection guard for service mode paths", () => {
+  beforeEach(() => {
+    // Default: not connected to platform
+    mockPlatformClientCreate = async () => null;
+    mockLoadRawConfig = () => ({});
+    mockSaveRawConfigCalls.length = 0;
+    mockSetNestedValueCalls.length = 0;
+    mockGetNestedValue = () => undefined;
+  });
+
+  test("config set services.inference.mode managed — fails when not connected", async () => {
+    const { exitCode, stdout } = await runCli([
+      "node",
+      "assistant",
+      "--json",
+      "config",
+      "set",
+      "services.inference.mode",
+      "managed",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("vellum platform connect");
+    expect(parsed.error).toContain("Not connected");
+    // Config should NOT have been written
+    expect(mockSaveRawConfigCalls).toHaveLength(0);
+    expect(mockSetNestedValueCalls).toHaveLength(0);
+  });
+
+  test("config set services.image-generation.mode your-own — fails when not connected", async () => {
+    const { exitCode, stdout } = await runCli([
+      "node",
+      "assistant",
+      "--json",
+      "config",
+      "set",
+      "services.image-generation.mode",
+      "your-own",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("vellum platform connect");
+    // Config should NOT have been written
+    expect(mockSaveRawConfigCalls).toHaveLength(0);
+    expect(mockSetNestedValueCalls).toHaveLength(0);
+  });
+
+  test("config set calls.enabled true — succeeds without platform connection", async () => {
+    const { exitCode } = await runCli([
+      "node",
+      "assistant",
+      "config",
+      "set",
+      "calls.enabled",
+      "true",
+    ]);
+
+    expect(exitCode).toBe(0);
+    // Config should have been written
+    expect(mockSetNestedValueCalls).toHaveLength(1);
+    expect(mockSetNestedValueCalls[0]!.key).toBe("calls.enabled");
+    expect(mockSetNestedValueCalls[0]!.value).toBe(true);
+    expect(mockSaveRawConfigCalls).toHaveLength(1);
+  });
+
+  test("config get services.inference.mode — works without platform connection", async () => {
+    mockGetNestedValue = (_obj, key) => {
+      if (key === "services.inference.mode") return "your-own";
+      return undefined;
+    };
+
+    const { exitCode } = await runCli([
+      "node",
+      "assistant",
+      "config",
+      "get",
+      "services.inference.mode",
+    ]);
+
+    expect(exitCode).toBe(0);
+    // No writes should have occurred
+    expect(mockSaveRawConfigCalls).toHaveLength(0);
+    expect(mockSetNestedValueCalls).toHaveLength(0);
+  });
+
+  test("config set services.web-search.mode managed — fails when not connected", async () => {
+    const { exitCode, stdout } = await runCli([
+      "node",
+      "assistant",
+      "--json",
+      "config",
+      "set",
+      "services.web-search.mode",
+      "managed",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("vellum platform connect");
+    expect(mockSaveRawConfigCalls).toHaveLength(0);
+  });
+
+  test("config set services.inference.mode managed — succeeds when connected", async () => {
+    mockPlatformClientCreate = async () => ({
+      platformAssistantId: "asst-123",
+      fetch: async () => new Response(),
+    });
+
+    const { exitCode } = await runCli([
+      "node",
+      "assistant",
+      "config",
+      "set",
+      "services.inference.mode",
+      "managed",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(mockSetNestedValueCalls).toHaveLength(1);
+    expect(mockSetNestedValueCalls[0]!.key).toBe("services.inference.mode");
+    expect(mockSetNestedValueCalls[0]!.value).toBe("managed");
+    expect(mockSaveRawConfigCalls).toHaveLength(1);
+  });
+});

--- a/assistant/src/__tests__/config-set-platform-guard.test.ts
+++ b/assistant/src/__tests__/config-set-platform-guard.test.ts
@@ -201,8 +201,8 @@ describe("config set — platform connection guard for service mode paths", () =
     expect(mockSetNestedValueCalls).toHaveLength(0);
   });
 
-  test("config set services.image-generation.mode your-own — fails when not connected", async () => {
-    const { exitCode, stdout } = await runCli([
+  test("config set services.image-generation.mode your-own — succeeds without platform connection", async () => {
+    const { exitCode } = await runCli([
       "node",
       "assistant",
       "--json",
@@ -212,13 +212,14 @@ describe("config set — platform connection guard for service mode paths", () =
       "your-own",
     ]);
 
-    expect(exitCode).toBe(1);
-    const parsed = JSON.parse(stdout);
-    expect(parsed.ok).toBe(false);
-    expect(parsed.error).toContain("vellum platform connect");
-    // Config should NOT have been written
-    expect(mockSaveRawConfigCalls).toHaveLength(0);
-    expect(mockSetNestedValueCalls).toHaveLength(0);
+    expect(exitCode).toBe(0);
+    // Config should have been written — setting to "your-own" doesn't need platform
+    expect(mockSetNestedValueCalls).toHaveLength(1);
+    expect(mockSetNestedValueCalls[0]!.key).toBe(
+      "services.image-generation.mode",
+    );
+    expect(mockSetNestedValueCalls[0]!.value).toBe("your-own");
+    expect(mockSaveRawConfigCalls).toHaveLength(1);
   });
 
   test("config set calls.enabled true — succeeds without platform connection", async () => {

--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -1240,3 +1240,75 @@ describe("requirePlatformConnection", () => {
     expect(process.exitCode).toBe(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// oauth mode — platform connection guard
+// ---------------------------------------------------------------------------
+
+describe("assistant oauth mode", () => {
+  beforeEach(() => {
+    mockWithValidToken = async (_service, cb) => cb("mock-access-token-xyz");
+    mockGetProvider = () => ({
+      providerKey: "google",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      defaultScopes: "[]",
+      scopePolicy: "{}",
+      extraParams: null,
+      managedServiceConfigKey: "google-oauth",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    mockGetConfig = () => ({
+      services: {
+        "google-oauth": { mode: "your-own" },
+      },
+    });
+  });
+
+  afterEach(() => {
+    mockPlatformClientCreate = async () => null;
+    mockGetConfig = () => ({ services: {} });
+    mockGetProvider = () => undefined;
+  });
+
+  test("oauth mode <provider> --set managed fails when not connected to platform", async () => {
+    mockPlatformClientCreate = async () => null;
+    const { exitCode, stdout } = await runCli([
+      "mode",
+      "google",
+      "--set",
+      "managed",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("vellum platform connect");
+  });
+
+  test("oauth mode <provider> --set your-own fails when not connected to platform", async () => {
+    mockPlatformClientCreate = async () => null;
+    const { exitCode, stdout } = await runCli([
+      "mode",
+      "google",
+      "--set",
+      "your-own",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("vellum platform connect");
+  });
+
+  test("oauth mode <provider> (read) succeeds without platform connection", async () => {
+    mockPlatformClientCreate = async () => null;
+    const { exitCode, stdout } = await runCli(["mode", "google", "--json"]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.provider).toBe("google");
+    expect(parsed.mode).toBe("your-own");
+  });
+});

--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { Command } from "commander";
 
@@ -242,6 +242,39 @@ mock.module("../platform/client.js", () => ({
   VellumPlatformClient: {
     create: () => mockPlatformClientCreate(),
   },
+}));
+
+// ---------------------------------------------------------------------------
+// Mock config/loader (needed by isManagedMode in shared.ts)
+// ---------------------------------------------------------------------------
+
+let mockGetConfig: () => Record<string, unknown> = () => ({
+  services: {},
+});
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => mockGetConfig(),
+  loadConfig: () => mockGetConfig(),
+  saveConfig: () => {},
+  invalidateConfigCache: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  applyNestedDefaults: (c: unknown) => c,
+  deepMergeMissing: (a: unknown) => a,
+  deepMergeOverwrite: (a: unknown) => a,
+  mergeDefaultWorkspaceConfig: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+  API_KEY_PROVIDERS: [
+    "anthropic",
+    "openai",
+    "gemini",
+    "ollama",
+    "fireworks",
+    "openrouter",
+    "brave",
+    "perplexity",
+  ],
 }));
 
 mock.module("../util/logger.js", () => ({
@@ -955,6 +988,111 @@ describe("assistant oauth ping <provider-key>", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("No access token");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// oauth connect — managed mode 401/403 error messages
+// ---------------------------------------------------------------------------
+
+describe("assistant oauth connect managed mode — platform 401/403 errors", () => {
+  /**
+   * Helper: create a mock platform client whose `fetch` always returns the
+   * given status code and body text.
+   */
+  function makeMockPlatformClient(status: number, body = "") {
+    return {
+      platformAssistantId: "asst-test-123",
+      fetch: async () =>
+        new Response(body, { status, statusText: `HTTP ${status}` }),
+    };
+  }
+
+  beforeEach(() => {
+    mockWithValidToken = async (_service, cb) => cb("mock-access-token-xyz");
+    mockOrchestrateOAuthConnect = async () => ({
+      success: true,
+      deferred: false,
+      grantedScopes: [],
+    });
+    mockGetAppByProviderAndClientId = () => undefined;
+    mockGetMostRecentAppByProvider = () => undefined;
+    mockGetSecureKey = () => undefined;
+    mockGetCredentialMetadata = () => undefined;
+
+    // Set up managed mode: provider has managedServiceConfigKey, config
+    // returns the matching service with mode "managed".
+    mockGetProvider = () => ({
+      providerKey: "google",
+      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      defaultScopes: "[]",
+      scopePolicy: "{}",
+      extraParams: null,
+      managedServiceConfigKey: "google-oauth",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    mockGetConfig = () => ({
+      services: {
+        "google-oauth": { mode: "managed" },
+      },
+    });
+  });
+
+  afterEach(() => {
+    mockPlatformClientCreate = async () => null;
+    mockGetConfig = () => ({ services: {} });
+  });
+
+  test("401 response includes 'vellum platform connect' suggestion", async () => {
+    mockPlatformClientCreate = async () =>
+      makeMockPlatformClient(401, "Unauthorized");
+    const { exitCode, stdout } = await runCli([
+      "connect",
+      "google",
+      "--no-browser",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Platform returned HTTP 401");
+    expect(parsed.error).toContain("Unauthorized");
+    expect(parsed.error).toContain("vellum platform connect");
+  });
+
+  test("403 response includes 'vellum platform connect' suggestion", async () => {
+    mockPlatformClientCreate = async () =>
+      makeMockPlatformClient(403, "Forbidden");
+    const { exitCode, stdout } = await runCli([
+      "connect",
+      "google",
+      "--no-browser",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Platform returned HTTP 403");
+    expect(parsed.error).toContain("Forbidden");
+    expect(parsed.error).toContain("vellum platform connect");
+  });
+
+  test("500 response does NOT include 'vellum platform connect' suggestion", async () => {
+    mockPlatformClientCreate = async () =>
+      makeMockPlatformClient(500, "Internal Server Error");
+    const { exitCode, stdout } = await runCli([
+      "connect",
+      "google",
+      "--no-browser",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Platform returned HTTP 500");
+    expect(parsed.error).not.toContain("vellum platform connect");
   });
 });
 

--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -88,6 +88,10 @@ let mockGetCredentialMetadata: (
   service: string,
   field: string,
 ) => Record<string, unknown> | undefined = () => undefined;
+let mockPlatformClientCreate: () => Promise<Record<
+  string,
+  unknown
+> | null> = async () => null;
 
 // ---------------------------------------------------------------------------
 // Mock token-manager
@@ -236,7 +240,7 @@ mock.module("../oauth/connection-resolver.js", () => ({
 
 mock.module("../platform/client.js", () => ({
   VellumPlatformClient: {
-    create: async () => null,
+    create: () => mockPlatformClientCreate(),
   },
 }));
 
@@ -260,6 +264,8 @@ mock.module("../util/logger.js", () => ({
 // ---------------------------------------------------------------------------
 
 const { registerOAuthCommand } = await import("../cli/commands/oauth/index.js");
+const { requirePlatformClient, requirePlatformConnection } =
+  await import("../cli/commands/oauth/shared.js");
 
 // ---------------------------------------------------------------------------
 // Test helper
@@ -949,5 +955,150 @@ describe("assistant oauth ping <provider-key>", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("No access token");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requirePlatformClient — improved error messages
+// ---------------------------------------------------------------------------
+
+describe("requirePlatformClient", () => {
+  test("returns error mentioning 'vellum platform connect' when not connected", async () => {
+    mockPlatformClientCreate = async () => null;
+    const stdoutChunks: string[] = [];
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: unknown) => {
+      stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+    process.exitCode = 0;
+
+    try {
+      const cmd = new Command();
+      cmd.option("--json");
+      cmd.parse(["node", "test", "--json"]);
+      const result = await requirePlatformClient(cmd);
+      expect(result).toBeNull();
+      expect(process.exitCode).toBe(1);
+      const output = stdoutChunks.join("");
+      const parsed = JSON.parse(output);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("vellum platform connect");
+      expect(parsed.error).toContain("Not connected");
+    } finally {
+      process.stdout.write = originalWrite;
+      process.exitCode = 0;
+    }
+  });
+
+  test("returns distinct error when connected but missing assistant ID", async () => {
+    mockPlatformClientCreate = async () => ({
+      platformAssistantId: "",
+      fetch: async () => new Response(),
+    });
+    const stdoutChunks: string[] = [];
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: unknown) => {
+      stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+    process.exitCode = 0;
+
+    try {
+      const cmd = new Command();
+      cmd.option("--json");
+      cmd.parse(["node", "test", "--json"]);
+      const result = await requirePlatformClient(cmd);
+      expect(result).toBeNull();
+      expect(process.exitCode).toBe(1);
+      const output = stdoutChunks.join("");
+      const parsed = JSON.parse(output);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("no assistant ID is configured");
+      expect(parsed.error).toContain("registered on the platform");
+    } finally {
+      process.stdout.write = originalWrite;
+      process.exitCode = 0;
+    }
+  });
+
+  test("returns client when connected with assistant ID", async () => {
+    mockPlatformClientCreate = async () => ({
+      platformAssistantId: "asst-123",
+      fetch: async () => new Response(),
+    });
+    process.exitCode = 0;
+
+    const cmd = new Command();
+    cmd.option("--json");
+    cmd.parse(["node", "test", "--json"]);
+    const result = await requirePlatformClient(cmd);
+    expect(result).not.toBeNull();
+    expect(result!.platformAssistantId).toBe("asst-123");
+    expect(process.exitCode).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requirePlatformConnection
+// ---------------------------------------------------------------------------
+
+describe("requirePlatformConnection", () => {
+  test("returns false and writes error when not connected", async () => {
+    mockPlatformClientCreate = async () => null;
+    const stdoutChunks: string[] = [];
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: unknown) => {
+      stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+    process.exitCode = 0;
+
+    try {
+      const cmd = new Command();
+      cmd.option("--json");
+      cmd.parse(["node", "test", "--json"]);
+      const result = await requirePlatformConnection(cmd);
+      expect(result).toBe(false);
+      expect(process.exitCode).toBe(1);
+      const output = stdoutChunks.join("");
+      const parsed = JSON.parse(output);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("vellum platform connect");
+      expect(parsed.error).toContain("Not connected");
+    } finally {
+      process.stdout.write = originalWrite;
+      process.exitCode = 0;
+    }
+  });
+
+  test("returns true when client can be created (even without assistant ID)", async () => {
+    mockPlatformClientCreate = async () => ({
+      platformAssistantId: "",
+      fetch: async () => new Response(),
+    });
+    process.exitCode = 0;
+
+    const cmd = new Command();
+    cmd.option("--json");
+    cmd.parse(["node", "test", "--json"]);
+    const result = await requirePlatformConnection(cmd);
+    expect(result).toBe(true);
+    expect(process.exitCode).toBe(0);
+  });
+
+  test("returns true when client can be created with assistant ID", async () => {
+    mockPlatformClientCreate = async () => ({
+      platformAssistantId: "asst-456",
+      fetch: async () => new Response(),
+    });
+    process.exitCode = 0;
+
+    const cmd = new Command();
+    cmd.option("--json");
+    cmd.parse(["node", "test", "--json"]);
+    const result = await requirePlatformConnection(cmd);
+    expect(result).toBe(true);
+    expect(process.exitCode).toBe(0);
   });
 });

--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -1287,7 +1287,7 @@ describe("assistant oauth mode", () => {
     expect(parsed.error).toContain("vellum platform connect");
   });
 
-  test("oauth mode <provider> --set your-own fails when not connected to platform", async () => {
+  test("oauth mode <provider> --set your-own succeeds without platform connection", async () => {
     mockPlatformClientCreate = async () => null;
     const { exitCode, stdout } = await runCli([
       "mode",
@@ -1296,10 +1296,11 @@ describe("assistant oauth mode", () => {
       "your-own",
       "--json",
     ]);
-    expect(exitCode).toBe(1);
+    // Setting to "your-own" doesn't need platform — it's a local-only operation
+    expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
-    expect(parsed.ok).toBe(false);
-    expect(parsed.error).toContain("vellum platform connect");
+    expect(parsed.ok).toBe(true);
+    expect(parsed.mode).toBe("your-own");
   });
 
   test("oauth mode <provider> (read) succeeds without platform connection", async () => {

--- a/assistant/src/cli/commands/config.ts
+++ b/assistant/src/cli/commands/config.ts
@@ -86,8 +86,8 @@ Examples:
     )
     .action(
       async (key: string, value: string, _opts: unknown, cmd: Command) => {
-        // Require platform connection when setting a service mode
-        if (SERVICE_MODE_PATH_RE.test(key)) {
+        // Require platform connection when setting a service mode to "managed"
+        if (SERVICE_MODE_PATH_RE.test(key) && value === "managed") {
           const connected = await requirePlatformConnection(cmd);
           if (!connected) return;
         }

--- a/assistant/src/cli/commands/config.ts
+++ b/assistant/src/cli/commands/config.ts
@@ -10,6 +10,7 @@ import {
 import { AssistantConfigSchema } from "../../config/schema.js";
 import { getSchemaAtPath } from "../../config/schema-utils.js";
 import { log } from "../logger.js";
+import { requirePlatformConnection } from "./oauth/shared.js";
 
 /**
  * Flatten a nested config object into dotted key paths.
@@ -33,6 +34,9 @@ function flattenConfig(
   }
   return result;
 }
+
+/** Matches config paths like `services.inference.mode`, `services.image-generation.mode`, etc. */
+const SERVICE_MODE_PATH_RE = /^services\.[^.]+\.mode$/;
 
 export function registerConfigCommand(program: Command): void {
   const config = program.command("config").description("Manage configuration");
@@ -80,19 +84,27 @@ Examples:
   $ assistant config set services.inference.provider anthropic
   $ assistant config set calls.enabled true`,
     )
-    .action((key: string, value: string) => {
-      const raw = loadRawConfig();
-      // Try to parse as JSON for booleans/numbers, fall back to string
-      let parsed: unknown = value;
-      try {
-        parsed = JSON.parse(value);
-      } catch {
-        // keep as string
-      }
-      setNestedValue(raw, key, parsed);
-      saveRawConfig(raw);
-      log.info(`Set ${key} = ${JSON.stringify(parsed)}`);
-    });
+    .action(
+      async (key: string, value: string, _opts: unknown, cmd: Command) => {
+        // Require platform connection when setting a service mode
+        if (SERVICE_MODE_PATH_RE.test(key)) {
+          const connected = await requirePlatformConnection(cmd);
+          if (!connected) return;
+        }
+
+        const raw = loadRawConfig();
+        // Try to parse as JSON for booleans/numbers, fall back to string
+        let parsed: unknown = value;
+        try {
+          parsed = JSON.parse(value);
+        } catch {
+          // keep as string
+        }
+        setNestedValue(raw, key, parsed);
+        saveRawConfig(raw);
+        log.info(`Set ${key} = ${JSON.stringify(parsed)}`);
+      },
+    );
 
   config
     .command("get <key>")

--- a/assistant/src/cli/commands/config.ts
+++ b/assistant/src/cli/commands/config.ts
@@ -86,13 +86,6 @@ Examples:
     )
     .action(
       async (key: string, value: string, _opts: unknown, cmd: Command) => {
-        // Require platform connection when setting a service mode to "managed"
-        if (SERVICE_MODE_PATH_RE.test(key) && value === "managed") {
-          const connected = await requirePlatformConnection(cmd);
-          if (!connected) return;
-        }
-
-        const raw = loadRawConfig();
         // Try to parse as JSON for booleans/numbers, fall back to string
         let parsed: unknown = value;
         try {
@@ -100,6 +93,14 @@ Examples:
         } catch {
           // keep as string
         }
+
+        // Require platform connection when setting a service mode to "managed"
+        if (SERVICE_MODE_PATH_RE.test(key) && parsed === "managed") {
+          const connected = await requirePlatformConnection(cmd);
+          if (!connected) return;
+        }
+
+        const raw = loadRawConfig();
         setNestedValue(raw, key, parsed);
         saveRawConfig(raw);
         log.info(`Set ${key} = ${JSON.stringify(parsed)}`);

--- a/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
@@ -127,7 +127,7 @@ mock.module("../shared.js", () => ({
         JSON.stringify({
           ok: false,
           error:
-            "Platform prerequisites not met (not logged in or missing assistant ID)",
+            "Not connected to Vellum platform. Run `vellum platform connect` to connect first.",
         }) + "\n",
       );
       return null;

--- a/assistant/src/cli/commands/oauth/__tests__/disconnect.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/disconnect.test.ts
@@ -162,7 +162,7 @@ mock.module("../shared.js", () => ({
         JSON.stringify({
           ok: false,
           error:
-            "Platform prerequisites not met (not logged in or missing assistant ID)",
+            "Not connected to Vellum platform. Run `vellum platform connect` to connect first.",
         }) + "\n",
       );
       return null;

--- a/assistant/src/cli/commands/oauth/__tests__/mode.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/mode.test.ts
@@ -34,6 +34,10 @@ let mockSetNestedValueCalls: Array<{
 
 let mockConfigServices: Record<string, unknown> = {};
 
+let mockRequirePlatformConnection: (
+  cmd: unknown,
+) => Promise<boolean> = async () => true;
+
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
@@ -120,6 +124,8 @@ mock.module("../shared.js", () => ({
   isManagedMode: () => false,
   getManagedServiceConfigKey: (key: string) =>
     mockGetManagedServiceConfigKey(key),
+  requirePlatformConnection: (cmd: unknown) =>
+    mockRequirePlatformConnection(cmd),
   requirePlatformClient: async (_cmd: Command) => {
     if (
       !mockPlatformClientResult ||
@@ -244,6 +250,7 @@ describe("assistant oauth mode", () => {
     mockSaveRawConfigCalls = [];
     mockSetNestedValueCalls = [];
     mockConfigServices = {};
+    mockRequirePlatformConnection = async () => true;
     process.exitCode = 0;
   });
 

--- a/assistant/src/cli/commands/oauth/__tests__/mode.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/mode.test.ts
@@ -130,7 +130,7 @@ mock.module("../shared.js", () => ({
         JSON.stringify({
           ok: false,
           error:
-            "Platform prerequisites not met (not logged in or missing assistant ID)",
+            "Not connected to Vellum platform. Run `vellum platform connect` to connect first.",
         }) + "\n",
       );
       return null;

--- a/assistant/src/cli/commands/oauth/__tests__/status.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/status.test.ts
@@ -107,7 +107,7 @@ mock.module("../shared.js", () => ({
         JSON.stringify({
           ok: false,
           error:
-            "Platform prerequisites not met (not logged in or missing assistant ID)",
+            "Not connected to Vellum platform. Run `vellum platform connect` to connect first.",
         }) + "\n",
       );
       return null;

--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -199,9 +199,14 @@ Examples:
 
               if (!response.ok) {
                 const errorText = await response.text().catch(() => "");
-                writeError(
-                  `Platform returned HTTP ${response.status}${errorText ? `: ${errorText}` : ""}`,
-                );
+                const baseMsg = `Platform returned HTTP ${response.status}${errorText ? `: ${errorText}` : ""}`;
+                if (response.status === 401 || response.status === 403) {
+                  writeError(
+                    `${baseMsg}. Your platform session may have expired. Run \`vellum platform connect\` to reconnect.`,
+                  );
+                } else {
+                  writeError(baseMsg);
+                }
                 return;
               }
 

--- a/assistant/src/cli/commands/oauth/mode.ts
+++ b/assistant/src/cli/commands/oauth/mode.ts
@@ -95,12 +95,6 @@ Examples:
           return;
         }
 
-        // Require platform connection when switching to managed mode
-        if (opts.set === "managed") {
-          const connected = await requirePlatformConnection(cmd);
-          if (!connected) return;
-        }
-
         const managedKey = getManagedServiceConfigKey(provider);
 
         // -----------------------------------------------------------------
@@ -185,6 +179,12 @@ Examples:
           });
           process.exitCode = 1;
           return;
+        }
+
+        // Require platform connection when switching to managed mode
+        if (newMode === "managed") {
+          const connected = await requirePlatformConnection(cmd);
+          if (!connected) return;
         }
 
         // Read current mode

--- a/assistant/src/cli/commands/oauth/mode.ts
+++ b/assistant/src/cli/commands/oauth/mode.ts
@@ -95,8 +95,8 @@ Examples:
           return;
         }
 
-        // Require platform connection for mode changes
-        if (opts.set !== undefined) {
+        // Require platform connection when switching to managed mode
+        if (opts.set === "managed") {
           const connected = await requirePlatformConnection(cmd);
           if (!connected) return;
         }

--- a/assistant/src/cli/commands/oauth/mode.ts
+++ b/assistant/src/cli/commands/oauth/mode.ts
@@ -17,6 +17,7 @@ import { shouldOutputJson, writeOutput } from "../../output.js";
 import {
   fetchActiveConnections,
   getManagedServiceConfigKey,
+  requirePlatformConnection,
 } from "./shared.js";
 
 /**
@@ -92,6 +93,12 @@ Examples:
           });
           process.exitCode = 1;
           return;
+        }
+
+        // Require platform connection for mode changes
+        if (opts.set !== undefined) {
+          const connected = await requirePlatformConnection(cmd);
+          if (!connected) return;
         }
 
         const managedKey = getManagedServiceConfigKey(provider);

--- a/assistant/src/cli/commands/oauth/shared.ts
+++ b/assistant/src/cli/commands/oauth/shared.ts
@@ -126,9 +126,13 @@ export async function fetchActiveConnections(
 
   if (!response.ok) {
     if (!options?.silent) {
+      const hint =
+        response.status === 401 || response.status === 403
+          ? `. Your platform session may have expired. Run \`vellum platform connect\` to reconnect.`
+          : "";
       writeOutput(cmd, {
         ok: false,
-        error: `Platform returned HTTP ${response.status}`,
+        error: `Platform returned HTTP ${response.status}${hint}`,
       });
       process.exitCode = 1;
     }

--- a/assistant/src/cli/commands/oauth/shared.ts
+++ b/assistant/src/cli/commands/oauth/shared.ts
@@ -59,16 +59,48 @@ export async function requirePlatformClient(
   cmd: Command,
 ): Promise<VellumPlatformClient | null> {
   const client = await VellumPlatformClient.create();
-  if (!client || !client.platformAssistantId) {
+  if (!client) {
     writeOutput(cmd, {
       ok: false,
       error:
-        "Platform prerequisites not met (not logged in or missing assistant ID)",
+        "Not connected to Vellum platform. Run `vellum platform connect` to connect first.",
+    });
+    process.exitCode = 1;
+    return null;
+  }
+  if (!client.platformAssistantId) {
+    writeOutput(cmd, {
+      ok: false,
+      error:
+        "Connected to Vellum platform but no assistant ID is configured. Ensure the assistant is registered on the platform.",
     });
     process.exitCode = 1;
     return null;
   }
   return client;
+}
+
+/**
+ * Verify that the user has connected to the Vellum platform (has stored
+ * credentials). Unlike `requirePlatformClient`, this does NOT require a
+ * platform assistant ID — it only checks that credentials exist.
+ *
+ * Writes an error and sets exitCode=1 when the user is not connected.
+ */
+export async function requirePlatformConnection(
+  cmd: Command,
+): Promise<boolean> {
+  const client = await VellumPlatformClient.create();
+  if (!client) {
+    writeOutput(cmd, {
+      ok: false,
+      error:
+        "Not connected to Vellum platform. Run `vellum platform connect` to connect first.",
+    });
+    process.exitCode = 1;
+    return false;
+  }
+  return true;
 }
 
 /**


### PR DESCRIPTION
## Summary
Adds proactive platform connection guards to CLI commands that configure platform-managed features, ensuring users who aren't logged in get a clear error directing them to run `vellum platform connect` first. Also improves error messages for 401/403 responses from platform API calls.

## PRs merged into feature branch
- #22525: Add `requirePlatformConnection` guard with actionable error messages
- #22526: Improve `oauth connect` error messages for 401/403 platform responses
- #22529: Require platform connection for `oauth mode set --set`
- #22535: Require platform connection for `config set services.*.mode`

Part of plan: require-platform-login.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
