### PR TITLE
fix: update stale requirePlatformClient mock error messages

### DIFF
--- a/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
@@ -127,7 +127,7 @@ mock.module("../shared.js", () => ({
         JSON.stringify({
           ok: false,
           error:
-            "Platform prerequisites not met (not logged in or missing assistant ID)",
+            "Not connected to Vellum platform. Run `vellum platform connect` to connect first.",
         }) + "\n",
       );
       return null;

--- a/assistant/src/cli/commands/oauth/__tests__/disconnect.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/disconnect.test.ts
@@ -162,7 +162,7 @@ mock.module("../shared.js", () => ({
         JSON.stringify({
           ok: false,
           error:
-            "Platform prerequisites not met (not logged in or missing assistant ID)",
+            "Not connected to Vellum platform. Run `vellum platform connect` to connect first.",
         }) + "\n",
       );
       return null;

--- a/assistant/src/cli/commands/oauth/__tests__/mode.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/mode.test.ts
@@ -130,7 +130,7 @@ mock.module("../shared.js", () => ({
         JSON.stringify({
           ok: false,
           error:
-            "Platform prerequisites not met (not logged in or missing assistant ID)",
+            "Not connected to Vellum platform. Run `vellum platform connect` to connect first.",
         }) + "\n",
       );
       return null;

--- a/assistant/src/cli/commands/oauth/__tests__/status.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/status.test.ts
@@ -107,7 +107,7 @@ mock.module("../shared.js", () => ({
         JSON.stringify({
           ok: false,
           error:
-            "Platform prerequisites not met (not logged in or missing assistant ID)",
+            "Not connected to Vellum platform. Run `vellum platform connect` to connect first.",
         }) + "\n",
       );
       return null;


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for require-platform-login.md.

**Gap:** Stale error messages in test mocks for requirePlatformClient
**What was expected:** Mock error messages should match the new requirePlatformClient implementation
**What was found:** 4 test files had the old error string
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22538" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
