### PR TITLE
fix: add requirePlatformConnection mock to mode.test.ts

### DIFF
--- a/assistant/src/cli/commands/oauth/__tests__/mode.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/mode.test.ts
@@ -34,6 +34,10 @@ let mockSetNestedValueCalls: Array<{
 
 let mockConfigServices: Record<string, unknown> = {};
 
+let mockRequirePlatformConnection: (
+  cmd: unknown,
+) => Promise<boolean> = async () => true;
+
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
@@ -120,6 +124,8 @@ mock.module("../shared.js", () => ({
   isManagedMode: () => false,
   getManagedServiceConfigKey: (key: string) =>
     mockGetManagedServiceConfigKey(key),
+  requirePlatformConnection: (cmd: unknown) =>
+    mockRequirePlatformConnection(cmd),
   requirePlatformClient: async (_cmd: Command) => {
     if (
       !mockPlatformClientResult ||
@@ -244,6 +250,7 @@ describe("assistant oauth mode", () => {
     mockSaveRawConfigCalls = [];
     mockSetNestedValueCalls = [];
     mockConfigServices = {};
+    mockRequirePlatformConnection = async () => true;
     process.exitCode = 0;
   });
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for require-platform-login.md.

**Gap:** mode.test.ts mock missing requirePlatformConnection
**What was expected:** Existing mode tests should pass after the new guard was added
**What was found:** mock.module for shared.js was missing the new export, causing TypeError
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22539" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
