### PR TITLE
fix: update capabilities test to match expanded Outlook adapter capabilities

### DIFF
--- a/assistant/src/__tests__/outlook-messaging-provider.test.ts
+++ b/assistant/src/__tests__/outlook-messaging-provider.test.ts
@@ -681,7 +681,16 @@ describe("Outlook messaging provider", () => {
     test("has correct capabilities", () => {
       expect(outlookMessagingProvider.capabilities.has("threads")).toBe(true);
       expect(outlookMessagingProvider.capabilities.has("folders")).toBe(true);
-      expect(outlookMessagingProvider.capabilities.has("archive")).toBe(false);
+      expect(outlookMessagingProvider.capabilities.has("archive")).toBe(true);
+      expect(outlookMessagingProvider.capabilities.has("categories")).toBe(
+        true,
+      );
+      expect(outlookMessagingProvider.capabilities.has("drafts_native")).toBe(
+        true,
+      );
+      expect(outlookMessagingProvider.capabilities.has("unsubscribe")).toBe(
+        true,
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
Update Outlook messaging provider test to assert the new capabilities (archive, categories, drafts_native, unsubscribe) that were added to the adapter.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
