### PR TITLE
fix: correct follow-up action name in SKILL.md from 'flag' to 'track'

### DIFF
--- a/assistant/src/config/bundled-skills/outlook/SKILL.md
+++ b/assistant/src/config/bundled-skills/outlook/SKILL.md
@@ -169,7 +169,7 @@ Scan tools (`outlook_sender_digest`, `outlook_outreach_scan`) return a `scan_id`
 
 ### Manage Follow-ups
 
-1. User says "flag this email for follow-up" - call `outlook_follow_up` with `action: "flag"` and the message ID
+1. User says "flag this email for follow-up" - call `outlook_follow_up` with `action: "track"` and the message ID
 2. User says "what emails am I tracking?" - call `outlook_follow_up` with `action: "list"` to show all flagged messages
 3. User says "mark that as done" - call `outlook_follow_up` with `action: "complete"` to clear the flag
 


### PR DESCRIPTION
## Summary
Fix SKILL.md to reference the correct action name 'track' instead of 'flag' for the outlook_follow_up tool.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
