### PR TITLE
fix: use correct OAuth provider key 'outlook' in all Outlook tools

### DIFF
--- a/assistant/src/config/bundled-skills/outlook/tools/outlook-draft.ts
+++ b/assistant/src/config/bundled-skills/outlook/tools/outlook-draft.ts
@@ -37,7 +37,7 @@ export async function run(
   if (!body) return err("body is required.");
 
   try {
-    const connection = await resolveOAuthConnection("microsoft", {
+    const connection = await resolveOAuthConnection("outlook", {
       account,
     });
 

--- a/assistant/src/config/bundled-skills/outlook/tools/outlook-forward.ts
+++ b/assistant/src/config/bundled-skills/outlook/tools/outlook-forward.ts
@@ -28,7 +28,7 @@ export async function run(
   if (!to) return err("to is required.");
 
   try {
-    const connection = await resolveOAuthConnection("microsoft", {
+    const connection = await resolveOAuthConnection("outlook", {
       account,
     });
 

--- a/assistant/src/config/bundled-skills/outlook/tools/outlook-outreach-scan.ts
+++ b/assistant/src/config/bundled-skills/outlook/tools/outlook-outreach-scan.ts
@@ -53,7 +53,7 @@ export async function run(
   const timeRange = (input.time_range as string) ?? "90d";
 
   try {
-    const connection = await resolveOAuthConnection("microsoft", {
+    const connection = await resolveOAuthConnection("outlook", {
       account,
     });
 

--- a/assistant/src/config/bundled-skills/outlook/tools/outlook-rules.ts
+++ b/assistant/src/config/bundled-skills/outlook/tools/outlook-rules.ts
@@ -26,7 +26,7 @@ export async function run(
   }
 
   try {
-    const connection = await resolveOAuthConnection("microsoft", {
+    const connection = await resolveOAuthConnection("outlook", {
       account,
     });
     switch (action) {

--- a/assistant/src/config/bundled-skills/outlook/tools/outlook-send-draft.ts
+++ b/assistant/src/config/bundled-skills/outlook/tools/outlook-send-draft.ts
@@ -21,7 +21,7 @@ export async function run(
   }
 
   try {
-    const connection = await resolveOAuthConnection("microsoft", {
+    const connection = await resolveOAuthConnection("outlook", {
       account,
     });
     await sendDraft(connection, draftId);

--- a/assistant/src/config/bundled-skills/outlook/tools/outlook-sender-digest.ts
+++ b/assistant/src/config/bundled-skills/outlook/tools/outlook-sender-digest.ts
@@ -39,7 +39,7 @@ export async function run(
   const maxSenders = (input.max_senders as number) ?? 50;
 
   try {
-    const connection = await resolveOAuthConnection("microsoft", {
+    const connection = await resolveOAuthConnection("outlook", {
       account,
     });
 

--- a/assistant/src/config/bundled-skills/outlook/tools/outlook-vacation.ts
+++ b/assistant/src/config/bundled-skills/outlook/tools/outlook-vacation.ts
@@ -22,7 +22,7 @@ export async function run(
   }
 
   try {
-    const connection = await resolveOAuthConnection("microsoft", {
+    const connection = await resolveOAuthConnection("outlook", {
       account,
     });
     switch (action) {


### PR DESCRIPTION
## Summary
Fix 7 Outlook tools that incorrectly used 'microsoft' instead of 'outlook' as the OAuth credential service identifier. This would have caused runtime failures.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
