### PR TITLE
fix: add MailboxSettings.ReadWrite scope for Outlook vacation tool

### DIFF
--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -619,6 +619,7 @@ const PROVIDER_SEED_DATA: Record<
       "Mail.Send",
       "Calendars.Read",
       "Calendars.ReadWrite",
+      "MailboxSettings.ReadWrite",
     ],
     scopePolicy: {
       allowAdditionalScopes: true,


### PR DESCRIPTION
## Summary
Add MailboxSettings.ReadWrite to the Outlook OAuth provider's default scopes. This is required by the outlook_vacation tool to read and update auto-reply settings via Microsoft Graph.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22547" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
