### PR TITLE
fix: add missing fields to delta query select for watcher compatibility

### DIFF
--- a/assistant/src/messaging/providers/outlook/client.ts
+++ b/assistant/src/messaging/providers/outlook/client.ts
@@ -602,7 +602,8 @@ export async function listMessagesDelta(
     `/v1.0/me/mailFolders/${encodeURIComponent(folderId)}/messages/delta`,
     undefined,
     {
-      $select: "id,subject,from,receivedDateTime,isRead,parentFolderId",
+      $select:
+        "id,subject,from,receivedDateTime,isRead,parentFolderId,conversationId,bodyPreview,hasAttachments",
       $top: "50",
     },
   );


### PR DESCRIPTION
## Summary
Add conversationId, bodyPreview, and hasAttachments to the $select fields in listMessagesDelta so the Outlook watcher can populate these fields in watcher event payloads.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22549" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
