### PR TITLE
perf: add Equatable to CodeBlockView to skip redundant body evaluations (LUM-626)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -401,7 +401,7 @@ struct MarkdownSegmentView: View, Equatable {
 
 /// Renders a fenced code block with an optional language label and a
 /// hover-revealed copy-to-clipboard button.
-private struct CodeBlockView: View {
+private struct CodeBlockView: View, Equatable {
     let language: String?
     let code: String
     let scaledCodeLabelSize: CGFloat
@@ -411,6 +411,16 @@ private struct CodeBlockView: View {
     let maxContentWidth: CGFloat?
 
     @State private var isHovered = false
+
+    static func == (lhs: CodeBlockView, rhs: CodeBlockView) -> Bool {
+        lhs.language == rhs.language
+            && lhs.code == rhs.code
+            && lhs.scaledCodeLabelSize == rhs.scaledCodeLabelSize
+            && lhs.textColor == rhs.textColor
+            && lhs.mutedTextColor == rhs.mutedTextColor
+            && lhs.codeBackgroundColor == rhs.codeBackgroundColor
+            && lhs.maxContentWidth == rhs.maxContentWidth
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {


### PR DESCRIPTION
## Summary
- Add `Equatable` conformance to `CodeBlockView` so SwiftUI can skip re-evaluating its `body` when the view's inputs haven't changed
- Compare all stored properties (language, code, colors, sizes) but exclude `@State` (isHovered) which is managed by SwiftUI
- During chat streaming, parent views re-render frequently — this prevents expensive code block body re-evaluation when the code content itself hasn't changed

## Original prompt
--safe https://linear.app/vellum/issue/LUM-626/perfmacos-codeblockview-lacks-equatable-re-evaluates-body
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22550" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
