### PR TITLE
fix: deduplicate @AppStorage in MessageCellView (LUM-575)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -674,6 +674,7 @@ struct MessageListView: View {
                         isConfirmationRenderedInline: state.isConfirmationRenderedInlineByIndex.contains(index),
                         hasPrecedingAssistant: state.hasPrecedingAssistantByIndex.contains(index),
                         hasUserMessage: state.hasUserMessage,
+                        hasEverSentMessage: hasEverSentMessage,
                         activePendingRequestId: state.activePendingRequestId,
                         latestAssistantId: state.latestAssistantId,
                         anchoredThinkingIndex: state.anchoredThinkingIndex,
@@ -1213,6 +1214,7 @@ private struct MessageCellView: View, Equatable {
             && lhs.isConfirmationRenderedInline == rhs.isConfirmationRenderedInline
             && lhs.hasPrecedingAssistant == rhs.hasPrecedingAssistant
             && lhs.hasUserMessage == rhs.hasUserMessage
+            && lhs.hasEverSentMessage == rhs.hasEverSentMessage
             && lhs.activePendingRequestId == rhs.activePendingRequestId
             && lhs.latestAssistantId == rhs.latestAssistantId
             && lhs.anchoredThinkingIndex == rhs.anchoredThinkingIndex
@@ -1239,6 +1241,7 @@ private struct MessageCellView: View, Equatable {
     let isConfirmationRenderedInline: Bool
     let hasPrecedingAssistant: Bool
     let hasUserMessage: Bool
+    let hasEverSentMessage: Bool
     let activePendingRequestId: String?
     let latestAssistantId: UUID?
     let anchoredThinkingIndex: Int?
@@ -1285,8 +1288,6 @@ private struct MessageCellView: View, Equatable {
         }
         return hasher.finalize()
     }
-
-    @AppStorage("hasEverSentMessage") private var hasEverSentMessage: Bool = false
 
     private func modelListView(for msg: ChatMessage) -> some View {
         ModelListBubble(currentModel: selectedModel, configuredProviders: configuredProviders, providerCatalog: providerCatalog)


### PR DESCRIPTION
## Summary
- Removed duplicate `@AppStorage("hasEverSentMessage")` from `MessageCellView` — the parent `MessageListView` already owns this storage and now passes it down as a `let` property
- Added the property to `MessageCellView`'s `Equatable` conformance so SwiftUI diffing accounts for it
- Eliminates redundant UserDefaults observation in every message cell, reducing unnecessary SwiftUI re-evaluations

## Original prompt
--safe https://linear.app/vellum/issue/LUM-575/duplicate-appstorage-in-messagelistview-and-messagecellview
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22552" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
