### PR TITLE
perf: move PTTActivator.fromStored() off main thread (LUM-570)

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -232,7 +232,7 @@ extension AppDelegate {
 
     /// Builds the status item tooltip, appending PTT key info when enabled.
     private func menuBarTooltip() -> String {
-        let activator = PTTActivator.fromStored()
+        let activator = PTTActivator.cached
         guard activator.kind != .none else { return "Vellum" }
         return "Vellum — hold \(activator.displayName) to talk"
     }

--- a/clients/macos/vellum-assistant/App/AppDelegate+Voice.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Voice.swift
@@ -120,9 +120,12 @@ extension AppDelegate {
         // starting monitors so they use the user's stored key, not the default.
         // The background read was kicked off early in launch and is almost
         // certainly complete, so the await typically returns immediately.
+        // Guard: if an activationKeyChanged notification already triggered
+        // restartKeyMonitors(), monitors are already set up — skip the start.
         Task { @MainActor [weak self] in
             await PTTActivator.ensureCacheReady()
-            self?.voiceInput?.start()
+            guard let vi = self?.voiceInput, !vi.hasStarted else { return }
+            vi.start()
         }
 
         // Restart key monitors when the activation key is changed remotely via HTTP

--- a/clients/macos/vellum-assistant/App/AppDelegate+Voice.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Voice.swift
@@ -125,6 +125,7 @@ extension AppDelegate {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor in
+                PTTActivator.refreshCache()
                 self?.voiceInput?.restartKeyMonitors()
             }
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate+Voice.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Voice.swift
@@ -116,7 +116,14 @@ extension AppDelegate {
                 self?.updateMenuBarIcon()
             }
         }
-        voiceInput?.start()
+        // Await the PTT cache (warmed in applicationDidFinishLaunching) before
+        // starting monitors so they use the user's stored key, not the default.
+        // The background read was kicked off early in launch and is almost
+        // certainly complete, so the await typically returns immediately.
+        Task { @MainActor [weak self] in
+            await PTTActivator.ensureCacheReady()
+            self?.voiceInput?.start()
+        }
 
         // Restart key monitors when the activation key is changed remotely via HTTP
         NotificationCenter.default.addObserver(

--- a/clients/macos/vellum-assistant/App/AppDelegate+Voice.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Voice.swift
@@ -125,7 +125,7 @@ extension AppDelegate {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor in
-                PTTActivator.refreshCache()
+                await PTTActivator.refreshCache()
                 self?.voiceInput?.restartKeyMonitors()
             }
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -297,6 +297,7 @@ extension AppDelegate {
         onboarding.onComplete = { [weak self] state in
             OnboardingState.clearPersistedState()
             UserDefaults.standard.set(state.chosenKey.rawValue, forKey: "activationKey")
+            PTTActivator.updateCache(PTTActivator.fromStored())
 
             onboarding.close()
             self?.onboardingWindow = nil
@@ -341,6 +342,7 @@ extension AppDelegate {
         onboarding.onComplete = { [weak self] state in
             OnboardingState.clearPersistedState()
             UserDefaults.standard.set(state.chosenKey.rawValue, forKey: "activationKey")
+            PTTActivator.updateCache(PTTActivator.fromStored())
 
             onboarding.close()
             self?.onboardingWindow = nil
@@ -430,6 +432,7 @@ extension AppDelegate {
         onboarding.onComplete = { [weak self] state in
             OnboardingState.clearPersistedState()
             UserDefaults.standard.set(state.chosenKey.rawValue, forKey: "activationKey")
+            PTTActivator.updateCache(PTTActivator.fromStored())
 
             onboarding.close()
             self?.onboardingWindow = nil

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -298,6 +298,7 @@ extension AppDelegate {
             OnboardingState.clearPersistedState()
             UserDefaults.standard.set(state.chosenKey.rawValue, forKey: "activationKey")
             PTTActivator.updateCache(PTTActivator.fromStored())
+            NotificationCenter.default.post(name: .activationKeyChanged, object: nil)
 
             onboarding.close()
             self?.onboardingWindow = nil
@@ -343,6 +344,7 @@ extension AppDelegate {
             OnboardingState.clearPersistedState()
             UserDefaults.standard.set(state.chosenKey.rawValue, forKey: "activationKey")
             PTTActivator.updateCache(PTTActivator.fromStored())
+            NotificationCenter.default.post(name: .activationKeyChanged, object: nil)
 
             onboarding.close()
             self?.onboardingWindow = nil
@@ -433,6 +435,7 @@ extension AppDelegate {
             OnboardingState.clearPersistedState()
             UserDefaults.standard.set(state.chosenKey.rawValue, forKey: "activationKey")
             PTTActivator.updateCache(PTTActivator.fromStored())
+            NotificationCenter.default.post(name: .activationKeyChanged, object: nil)
 
             onboarding.close()
             self?.onboardingWindow = nil

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -562,6 +562,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         registerSidebarToggleMonitor()
         setupHotKey()
         setupEscapeMonitor()
+        PTTActivator.refreshCache()
         setupVoiceInput()
         setupAmbientAgent()
         setupSurfaceManager()

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -562,8 +562,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         registerSidebarToggleMonitor()
         setupHotKey()
         setupEscapeMonitor()
-        PTTActivator.refreshCache()
-        setupVoiceInput()
+        Task {
+            await PTTActivator.refreshCache()
+            setupVoiceInput()
+        }
         setupAmbientAgent()
         setupSurfaceManager()
         setupToolConfirmationNotifications()

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -339,6 +339,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
         Self.shared = self
 
+        // Kick off the PTT activator UserDefaults read on a background
+        // thread as early as possible so it completes before proceedToApp()
+        // sets up voice input monitors.
+        PTTActivator.warmCache()
+
         // Initialize the chat diagnostics store early so launch session
         // metadata and first events exist even if the app wedges during startup.
         _ = ChatDiagnosticsStore.shared
@@ -562,10 +567,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         registerSidebarToggleMonitor()
         setupHotKey()
         setupEscapeMonitor()
-        Task {
-            await PTTActivator.refreshCache()
-            setupVoiceInput()
-        }
+        setupVoiceInput()
         setupAmbientAgent()
         setupSurfaceManager()
         setupToolConfirmationNotifications()

--- a/clients/macos/vellum-assistant/App/PTTActivator.swift
+++ b/clients/macos/vellum-assistant/App/PTTActivator.swift
@@ -90,6 +90,10 @@ struct PTTActivator: Codable, Equatable {
     /// a previously-started `warmCache()` without launching a second read.
     @MainActor private static var _cacheTask: Task<PTTActivator, Never>?
 
+    /// Generation counter incremented on every cache write. Used by
+    /// `ensureCacheReady()` to discard stale warm-cache results.
+    @MainActor private static var _cacheGeneration: Int = 0
+
     /// Returns the cached activator, falling back to `defaultActivator`
     /// until the cache is populated.
     @MainActor static var cached: PTTActivator {
@@ -105,14 +109,21 @@ struct PTTActivator: Codable, Equatable {
     }
 
     /// Awaits the in-flight cache load (started by `warmCache()`) and
-    /// applies the result. If `warmCache()` was never called, reads
-    /// synchronously on a detached task.
+    /// applies the result **only if** no intervening `updateCache()` or
+    /// `refreshCache()` has already populated a fresher value.
     @MainActor static func ensureCacheReady() async {
         if let task = _cacheTask {
-            _cached = await task.value
+            let gen = _cacheGeneration
+            let result = await task.value
+            // Only apply if no fresher write happened while we were awaiting.
+            if _cacheGeneration == gen {
+                _cached = result
+                _cacheGeneration += 1
+            }
             _cacheTask = nil
-        } else {
+        } else if _cached == nil {
             _cached = await Task.detached { Self.fromStored() }.value
+            _cacheGeneration += 1
         }
     }
 
@@ -122,12 +133,14 @@ struct PTTActivator: Codable, Equatable {
         _cacheTask = nil
         let result = await Task.detached { Self.fromStored() }.value
         _cached = result
+        _cacheGeneration += 1
     }
 
     /// Synchronously updates the cache after a local write (e.g. settings change).
     @MainActor static func updateCache(_ activator: PTTActivator) {
         _cached = activator
         _cacheTask = nil
+        _cacheGeneration += 1
     }
 
     // MARK: - Persistence

--- a/clients/macos/vellum-assistant/App/PTTActivator.swift
+++ b/clients/macos/vellum-assistant/App/PTTActivator.swift
@@ -79,9 +79,36 @@ struct PTTActivator: Codable, Equatable {
         return NSEvent.ModifierFlags(rawValue: raw)
     }
 
+    // MARK: - Cache
+
+    /// In-memory cache populated asynchronously so that the first
+    /// UserDefaults read does not block the main thread during app launch.
+    /// Access via `cached`; mutated only by `refreshCache()`.
+    @MainActor private static var _cached: PTTActivator?
+
+    /// Returns the cached activator, falling back to `defaultActivator`
+    /// until `refreshCache()` completes.
+    @MainActor static var cached: PTTActivator {
+        _cached ?? .defaultActivator
+    }
+
+    /// Reads the stored activator off the main thread and updates the cache.
+    @MainActor static func refreshCache() {
+        Task {
+            let result = await Task.detached { Self.fromStored() }.value
+            _cached = result
+        }
+    }
+
+    /// Synchronously updates the cache after a local write (e.g. settings change).
+    @MainActor static func updateCache(_ activator: PTTActivator) {
+        _cached = activator
+    }
+
     // MARK: - Persistence
 
     /// Read the activator from UserDefaults, handling both legacy strings and JSON.
+    /// Prefer `cached` on the main thread to avoid synchronous I/O during app launch.
     static func fromStored() -> PTTActivator {
         guard let stored = UserDefaults.standard.string(forKey: "activationKey") else {
             return .defaultActivator

--- a/clients/macos/vellum-assistant/App/PTTActivator.swift
+++ b/clients/macos/vellum-assistant/App/PTTActivator.swift
@@ -93,11 +93,10 @@ struct PTTActivator: Codable, Equatable {
     }
 
     /// Reads the stored activator off the main thread and updates the cache.
-    @MainActor static func refreshCache() {
-        Task {
-            let result = await Task.detached { Self.fromStored() }.value
-            _cached = result
-        }
+    /// Callers should `await` to ensure the cache is populated before reading it.
+    @MainActor static func refreshCache() async {
+        let result = await Task.detached { Self.fromStored() }.value
+        _cached = result
     }
 
     /// Synchronously updates the cache after a local write (e.g. settings change).

--- a/clients/macos/vellum-assistant/App/PTTActivator.swift
+++ b/clients/macos/vellum-assistant/App/PTTActivator.swift
@@ -131,9 +131,13 @@ struct PTTActivator: Codable, Equatable {
     /// Used when the activation key is changed remotely.
     @MainActor static func refreshCache() async {
         _cacheTask = nil
+        let gen = _cacheGeneration
         let result = await Task.detached { Self.fromStored() }.value
-        _cached = result
-        _cacheGeneration += 1
+        // Only apply if no fresher write happened while we were awaiting.
+        if _cacheGeneration == gen {
+            _cached = result
+            _cacheGeneration += 1
+        }
     }
 
     /// Synchronously updates the cache after a local write (e.g. settings change).

--- a/clients/macos/vellum-assistant/App/PTTActivator.swift
+++ b/clients/macos/vellum-assistant/App/PTTActivator.swift
@@ -83,18 +83,43 @@ struct PTTActivator: Codable, Equatable {
 
     /// In-memory cache populated asynchronously so that the first
     /// UserDefaults read does not block the main thread during app launch.
-    /// Access via `cached`; mutated only by `refreshCache()`.
+    /// Access via `cached`; mutated only by `refreshCache()` / `updateCache()`.
     @MainActor private static var _cached: PTTActivator?
 
+    /// In-flight cache load task. Stored so `ensureCacheReady()` can await
+    /// a previously-started `warmCache()` without launching a second read.
+    @MainActor private static var _cacheTask: Task<PTTActivator, Never>?
+
     /// Returns the cached activator, falling back to `defaultActivator`
-    /// until `refreshCache()` completes.
+    /// until the cache is populated.
     @MainActor static var cached: PTTActivator {
         _cached ?? .defaultActivator
     }
 
-    /// Reads the stored activator off the main thread and updates the cache.
-    /// Callers should `await` to ensure the cache is populated before reading it.
+    /// Kicks off an async UserDefaults read without blocking the caller.
+    /// Call this as early as possible (e.g. `applicationDidFinishLaunching`)
+    /// so the result is ready by the time `ensureCacheReady()` is awaited.
+    @MainActor static func warmCache() {
+        guard _cacheTask == nil else { return }
+        _cacheTask = Task.detached { Self.fromStored() }
+    }
+
+    /// Awaits the in-flight cache load (started by `warmCache()`) and
+    /// applies the result. If `warmCache()` was never called, reads
+    /// synchronously on a detached task.
+    @MainActor static func ensureCacheReady() async {
+        if let task = _cacheTask {
+            _cached = await task.value
+            _cacheTask = nil
+        } else {
+            _cached = await Task.detached { Self.fromStored() }.value
+        }
+    }
+
+    /// Re-reads UserDefaults off the main thread and updates the cache.
+    /// Used when the activation key is changed remotely.
     @MainActor static func refreshCache() async {
+        _cacheTask = nil
         let result = await Task.detached { Self.fromStored() }.value
         _cached = result
     }
@@ -102,6 +127,7 @@ struct PTTActivator: Codable, Equatable {
     /// Synchronously updates the cache after a local write (e.g. settings change).
     @MainActor static func updateCache(_ activator: PTTActivator) {
         _cached = activator
+        _cacheTask = nil
     }
 
     // MARK: - Persistence

--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -82,6 +82,10 @@ final class VoiceInputManager {
     /// Guards against double-start/double-stop from rapid key events.
     private var isActivatorHeld = false
 
+    /// Whether `start()` has been called (monitors are active).
+    /// Used to guard against duplicate registration from deferred startup.
+    private(set) var hasStarted = false
+
     /// All active event monitors, consolidated for clean teardown.
     private var monitors: [Any] = []
 
@@ -109,6 +113,7 @@ final class VoiceInputManager {
     }
 
     func start() {
+        hasStarted = true
         setupActivationMonitors()
 
         // Cancel any in-flight hold when the user switches apps, to prevent the
@@ -177,6 +182,7 @@ final class VoiceInputManager {
     }
 
     func stop() {
+        hasStarted = false
         for monitor in monitors {
             NSEvent.removeMonitor(monitor)
         }

--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -91,9 +91,9 @@ final class VoiceInputManager {
     private var lastAppSwitchTime: Date = .distantPast
     private var appSwitchObservers: [Any] = []
 
-    /// The current PTT activator, read from UserDefaults.
+    /// The current PTT activator, read from the in-memory cache.
     var activator: PTTActivator {
-        PTTActivator.fromStored()
+        PTTActivator.cached
     }
 
     private let speechRecognizer = SFSpeechRecognizer(locale: Locale(identifier: "en-US"))

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -623,7 +623,7 @@ VStreamingWaveform(
 
     /// Tooltip text for the mic button. Includes the PTT hold hint only when PTT is enabled.
     private var micTooltipText: String {
-        let activator = PTTActivator.fromStored()
+        let activator = PTTActivator.cached
         if activator.kind == .none {
             return "Click to dictate"
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -218,7 +218,7 @@ struct SettingsAppearanceTab: View {
                         .foregroundStyle(VColor.contentSecondary)
                     Spacer()
                     // Read activationKey to establish SwiftUI dependency tracking
-                    let activator = { _ = activationKey; return PTTActivator.fromStored() }()
+                    let activator = { _ = activationKey; return PTTActivator.cached }()
 
                     if isRecordingVoiceInput {
                         VShortcutTag("Press key...")
@@ -234,6 +234,7 @@ struct SettingsAppearanceTab: View {
                             if activator.kind != .none {
                                 VButton(label: "Unbind", style: .outlined) {
                                     PTTActivator.off.store()
+                                    PTTActivator.updateCache(.off)
                                     activationKey = "none"
                                     NotificationCenter.default.post(name: .activationKeyChanged, object: nil)
                                 }
@@ -669,6 +670,7 @@ struct SettingsAppearanceTab: View {
                 .flatMap { String(data: $0, encoding: .utf8) } ?? "fn"
             activationKey = json
         }
+        PTTActivator.updateCache(newActivator)
         NotificationCenter.default.post(name: .activationKeyChanged, object: nil)
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -20,7 +20,7 @@ struct VoiceSettingsView: View {
         // without this, SwiftUI doesn't know the body depends on this
         // @AppStorage value and skips re-rendering when it changes.
         _ = activationKey
-        return PTTActivator.fromStored()
+        return PTTActivator.cached
     }
 
     private var pttEnabled: Bool {
@@ -164,6 +164,7 @@ struct VoiceSettingsView: View {
                 .flatMap { String(data: $0, encoding: .utf8) } ?? "fn"
             activationKey = json
         }
+        PTTActivator.updateCache(newActivator)
         NotificationCenter.default.post(name: .activationKeyChanged, object: nil)
     }
 


### PR DESCRIPTION
## Summary
- Add a static `cached` property and `refreshCache()` method to `PTTActivator` that reads UserDefaults off the main thread via `Task.detached`, avoiding the ~2s app hang from synchronous plist I/O during cold launch
- Replace all production `fromStored()` call sites (VoiceInputManager, MenuBar tooltip, ComposerView, VoiceSettingsView, SettingsAppearanceTab) with `PTTActivator.cached`
- Keep the cache in sync by calling `updateCache()` on local writes and `refreshCache()` on remote changes via `.activationKeyChanged` notification

## Original prompt
--safe https://linear.app/vellum/issue/LUM-570/app-hang-2s-pttactivatorfromstored-called-synchronously-during
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22553" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
