### PR TITLE
fix: move CLI symlink install off main thread (LUM-630)

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -584,8 +584,10 @@ extension AppDelegate {
     /// Skipped when dev mode is active (developers manage their own PATH)
     /// or when `vellum` already resolves to a different executable
     /// (avoids overwriting a developer's locally-built binary).
-    func installCLISymlinkIfNeeded() {
-        guard !DevModeManager.shared.isDevMode else { return }
+    /// Installs CLI symlinks if needed. Designed to run off the main thread
+    /// (Process.waitUntilExit internally blocks on a DispatchSemaphore).
+    nonisolated static func installCLISymlinkIfNeeded(isDevMode: Bool) {
+        guard !isDevMode else { return }
 
         guard let execURL = Bundle.main.executableURL else { return }
         let macosDir = execURL.deletingLastPathComponent()
@@ -602,7 +604,7 @@ extension AppDelegate {
     /// is not writable. Skips creation when the destination already exists
     /// as a regular file, already points to the correct target, or the
     /// command resolves elsewhere on PATH (developer's local build).
-    private func installSymlink(commandName: String, target: String) {
+    private nonisolated static func installSymlink(commandName: String, target: String) {
         let fm = FileManager.default
 
         // Candidate directories in priority order: /usr/local/bin (system-wide),

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -474,9 +474,15 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         installFileMenuDelegate()
         setupHotKey()
 
-        // Install CLI symlinks early so they are available before the daemon
-        // starts, regardless of auth or onboarding state.
-        installCLISymlinkIfNeeded()
+        // Install CLI symlinks in the background. installSymlink() spawns
+        // /usr/bin/which via Process.waitUntilExit() which internally blocks
+        // on a DispatchSemaphore — running it on the main thread causes a
+        // ~2s app hang (LUM-630). The symlinks are best-effort and don't
+        // need to complete before the daemon starts.
+        let isDevMode = DevModeManager.shared.isDevMode
+        Task.detached(priority: .utility) {
+            Self.installCLISymlinkIfNeeded(isDevMode: isDevMode)
+        }
 
         let hasAssistants = lockfileHasAssistants()
         log.info("[appLaunch] skipOnboarding=\(skipOnboarding) hasAssistants=\(hasAssistants)")


### PR DESCRIPTION
## Summary
- Move `installCLISymlinkIfNeeded()` from synchronous main-thread execution during `applicationDidFinishLaunching` into a `Task.detached(priority: .utility)` background task
- Convert `installCLISymlinkIfNeeded` and `installSymlink` from instance methods to `nonisolated static` methods so they don't require main actor isolation
- Capture `DevModeManager.shared.isDevMode` on the main actor before dispatching to avoid main-actor access from the background

`Process.waitUntilExit()` (used for `/usr/bin/which`) internally blocks on a `DispatchSemaphore`, which was causing a ~2s app hang on the main thread during launch.

## Original prompt
--safe https://linear.app/vellum/issue/LUM-630/app-hang-2s-dispatchsemaphore-blocks-main-thread-during

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
