### PR TITLE
feat(outlook-calendar): add SKILL.md, TOOLS.json, and shared helpers

### DIFF
--- a/assistant/src/config/bundled-skills/outlook-calendar/SKILL.md
+++ b/assistant/src/config/bundled-skills/outlook-calendar/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: outlook-calendar
+description: View, create, and manage Outlook Calendar events and check availability
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "📅"
+  vellum:
+    display-name: "Outlook Calendar"
+---
+
+You are an Outlook Calendar assistant with full access to the user's calendar. Use the Outlook Calendar tools to help them view, create, and manage events.
+
+## Connection Setup
+
+Before using any Outlook Calendar tool, verify that Outlook is connected by attempting a lightweight call (e.g., `outlook_calendar_list_events` with a narrow date range). If the call fails with a token/authorization error:
+
+1. **Try connecting directly first.** Run `assistant oauth status outlook`. This will show whether or not the user had previously connected their Outlook account. If so, they are ready to go.
+2. **If no connections are found:** The user needs to either use Vellum's managed Outlook integration or set up their own OAuth app.
+   - Call `skill_load` with `skill: "vellum-oauth-integrations"` with `provider-key: outlook` throughout.
+   - To use `your-own` mode, you will need to call `skill_load` with `skill: outlook-oauth-app-setup`. In this case:
+      - Tell the user Outlook account isn't connected yet and briefly explain what the setup involves, then use `ui_show` with `surface_type: "confirmation"` to ask for permission to start:
+      - **message:** "Ready to set up Outlook Calendar?"
+      - **detail:** "I'll open a few pages in your browser and walk you through setting up Microsoft Azure credentials - registering an app, configuring permissions, and connecting your account. Takes about 5 minutes.\n\n**Your emails stay under your control** — I only ever create drafts. Nothing gets sent without your explicit say-so."
+      - **confirmLabel:** "Get Started"
+      - **cancelLabel:** "Not Now"
+      - If the user confirms, briefly acknowledge (e.g., "Setting up Outlook Calendar now...") and proceed with the setup guide. If they decline, acknowledge and let them know they can set it up later.
+
+## Capabilities
+
+- **List Events**: View upcoming events from any calendar within a date range.
+- **Get Event**: Read full details of a specific calendar event.
+- **Create Event**: Create new events with attendees, location, and description.
+- **Check Availability**: Find free/busy times across calendars to identify open slots for scheduling.
+- **RSVP**: Respond to event invitations (accepted, declined, tentative).
+
+## Scheduling Playbook
+
+When the user wants to schedule something:
+
+1. **Always check availability first** before proposing times. Use `outlook_calendar_check_availability` to find free slots.
+2. Propose 2-3 available time options to the user.
+3. Once the user picks a time, create the event with `outlook_calendar_create_event`.
+4. If adding other attendees, mention that they'll receive an invitation email.
+
+## Date & Time Handling
+
+- Always ask the user for their timezone if it's not already known from context or their profile.
+- Use ISO 8601 format for dates and times (e.g., `2024-01-15T09:00:00-05:00`).
+- For all-day events, use date-only format (e.g., `2024-01-15`).
+- When listing events, display times in the user's local timezone.
+
+## Confidence Scores
+
+Medium-risk tools (create event, RSVP) require a confidence score between 0 and 1. Set this based on how certain you are the action matches the user's intent:
+
+- **0.9-1.0**: User explicitly requested this exact action
+- **0.7-0.8**: Action is strongly implied by context
+- **0.5-0.6**: Reasonable inference but some ambiguity
+- **Below 0.5**: Ask the user to confirm before proceeding

--- a/assistant/src/config/bundled-skills/outlook-calendar/TOOLS.json
+++ b/assistant/src/config/bundled-skills/outlook-calendar/TOOLS.json
@@ -1,0 +1,221 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "outlook_calendar_list_events",
+      "description": "List upcoming Outlook Calendar events within a date range. Returns event summaries, times, and metadata.",
+      "category": "calendar",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "calendar_id": {
+            "type": "string",
+            "description": "Calendar ID to query. If omitted, uses the default calendar."
+          },
+          "time_min": {
+            "type": "string",
+            "description": "Start of time range in ISO 8601 format (e.g. \"2024-01-15T00:00:00Z\"). Defaults to now."
+          },
+          "time_max": {
+            "type": "string",
+            "description": "End of time range in ISO 8601 format (e.g. \"2024-01-22T00:00:00Z\"). Defaults to 7 days from now."
+          },
+          "max_results": {
+            "type": "number",
+            "description": "Maximum number of events to return (default 25, max 250)"
+          },
+          "query": {
+            "type": "string",
+            "description": "OData $filter expression to filter events"
+          },
+          "order_by": {
+            "type": "string",
+            "description": "OData $orderby expression (default \"start/dateTime\")"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Outlook account to use. Required when multiple Outlook accounts are connected. If omitted, uses the most recently connected account."
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        }
+      },
+      "executor": "tools/outlook-calendar-list-events.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "outlook_calendar_get_event",
+      "description": "Get the full details of a single Outlook Calendar event by its ID.",
+      "category": "calendar",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "type": "string",
+            "description": "The Outlook Calendar event ID"
+          },
+          "calendar_id": {
+            "type": "string",
+            "description": "Calendar ID. If omitted, uses the default calendar."
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Outlook account to use. Required when multiple Outlook accounts are connected. If omitted, uses the most recently connected account."
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["event_id"]
+      },
+      "executor": "tools/outlook-calendar-get-event.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "outlook_calendar_create_event",
+      "description": "Create a new Outlook Calendar event. Include a confidence score (0-1) indicating how certain you are this action is correct.",
+      "category": "calendar",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "summary": {
+            "type": "string",
+            "description": "Event title (maps to the Outlook subject field)"
+          },
+          "start": {
+            "type": "string",
+            "description": "Start time in ISO 8601 format (e.g. \"2024-01-15T09:00:00-05:00\") or date for all-day events (\"2024-01-15\")"
+          },
+          "end": {
+            "type": "string",
+            "description": "End time in ISO 8601 format or date for all-day events"
+          },
+          "description": {
+            "type": "string",
+            "description": "Event description or notes"
+          },
+          "location": {
+            "type": "string",
+            "description": "Event location"
+          },
+          "attendees": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Email addresses of attendees to invite"
+          },
+          "timezone": {
+            "type": "string",
+            "description": "IANA timezone (e.g. \"America/New_York\"). Required when start/end don't include timezone offset."
+          },
+          "calendar_id": {
+            "type": "string",
+            "description": "Calendar ID. If omitted, uses the default calendar."
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Outlook account to use. Required when multiple Outlook accounts are connected. If omitted, uses the most recently connected account."
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["summary", "start", "end", "confidence"]
+      },
+      "executor": "tools/outlook-calendar-create-event.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "outlook_calendar_check_availability",
+      "description": "Check free/busy status across one or more schedules to find available time slots.",
+      "category": "calendar",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "time_min": {
+            "type": "string",
+            "description": "Start of time range in ISO 8601 format"
+          },
+          "time_max": {
+            "type": "string",
+            "description": "End of time range in ISO 8601 format"
+          },
+          "schedules": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Email addresses of schedules to check. Defaults to the authenticated user."
+          },
+          "timezone": {
+            "type": "string",
+            "description": "IANA timezone for interpreting results (e.g. \"America/New_York\")"
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Outlook account to use. Required when multiple Outlook accounts are connected. If omitted, uses the most recently connected account."
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["time_min", "time_max"]
+      },
+      "executor": "tools/outlook-calendar-check-availability.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "outlook_calendar_rsvp",
+      "description": "Respond to an Outlook Calendar event invitation (accept, decline, or tentative). Include a confidence score (0-1).",
+      "category": "calendar",
+      "risk": "medium",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "type": "string",
+            "description": "The Outlook Calendar event ID"
+          },
+          "response": {
+            "type": "string",
+            "enum": ["accepted", "declined", "tentative"],
+            "description": "RSVP response"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score (0-1) for this action"
+          },
+          "calendar_id": {
+            "type": "string",
+            "description": "Calendar ID. If omitted, uses the default calendar."
+          },
+          "account": {
+            "type": "string",
+            "description": "Email address of the Outlook account to use. Required when multiple Outlook accounts are connected. If omitted, uses the most recently connected account."
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["event_id", "response", "confidence"]
+      },
+      "executor": "tools/outlook-calendar-rsvp.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/outlook-calendar/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/outlook-calendar/tools/shared.ts
@@ -1,0 +1,17 @@
+import type { OAuthConnection } from "../../../../oauth/connection.js";
+import { resolveOAuthConnection } from "../../../../oauth/connection-resolver.js";
+import type { ToolExecutionResult } from "../../../../tools/types.js";
+
+export function ok(content: string): ToolExecutionResult {
+  return { content, isError: false };
+}
+
+export function err(message: string): ToolExecutionResult {
+  return { content: message, isError: true };
+}
+
+export async function getCalendarConnection(
+  account?: string,
+): Promise<OAuthConnection> {
+  return resolveOAuthConnection("outlook", { account });
+}


### PR DESCRIPTION
## Summary
- Add SKILL.md with Outlook Calendar assistant instructions, connection setup, and scheduling playbook
- Add TOOLS.json with 5 tool definitions (list events, get event, create event, check availability, RSVP)
- Add shared.ts with ok/err helpers and getCalendarConnection using outlook OAuth

Part of plan: outlook-cal-gcal-parity.md (PR 2 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
