### PR TITLE
feat(outlook-calendar): add get event tool

### DIFF
--- a/assistant/src/config/bundled-skills/outlook-calendar/tools/outlook-calendar-get-event.ts
+++ b/assistant/src/config/bundled-skills/outlook-calendar/tools/outlook-calendar-get-event.ts
@@ -1,0 +1,18 @@
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import * as calendar from "../calendar-client.js";
+import { getCalendarConnection, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
+  const eventId = input.event_id as string;
+
+  const connection = await getCalendarConnection(account);
+  const event = await calendar.getEvent(connection, eventId);
+  return ok(JSON.stringify(event, null, 2));
+}


### PR DESCRIPTION
## Summary
- Add outlook-calendar-get-event.ts tool that fetches a single Outlook calendar event by ID

Part of plan: outlook-cal-gcal-parity.md (PR 4 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
