### PR TITLE
feat(outlook-calendar): add check availability tool

### DIFF
--- a/assistant/src/config/bundled-skills/outlook-calendar/tools/outlook-calendar-check-availability.ts
+++ b/assistant/src/config/bundled-skills/outlook-calendar/tools/outlook-calendar-check-availability.ts
@@ -1,0 +1,41 @@
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import * as calendar from "../calendar-client.js";
+import { getCalendarConnection, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
+  const timeMin = input.time_min as string;
+  const timeMax = input.time_max as string;
+  let schedules = (input.schedules as string[] | undefined) ?? [];
+  const timezone = (input.timezone as string | undefined) ?? "UTC";
+
+  const connection = await getCalendarConnection(account);
+
+  if (schedules.length === 0) {
+    const resp = await connection.request({
+      method: "GET",
+      path: "/v1.0/me",
+    });
+    const body = resp.body as Record<string, unknown>;
+    const email =
+      (body.mail as string | undefined) ??
+      (body.userPrincipalName as string | undefined);
+    if (email) {
+      schedules = [email];
+    }
+  }
+
+  const result = await calendar.getSchedule(connection, {
+    schedules,
+    startTime: { dateTime: timeMin, timeZone: timezone },
+    endTime: { dateTime: timeMax, timeZone: timezone },
+  });
+
+  return ok(JSON.stringify(result, null, 2));
+}


### PR DESCRIPTION
## Summary
- Add outlook-calendar-check-availability.ts tool that checks free/busy status via Microsoft Graph getSchedule
- Falls back to authenticated user email when no schedules provided

Part of plan: outlook-cal-gcal-parity.md (PR 6 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22566" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
