### PR TITLE
feat(outlook-calendar): add RSVP tool

### DIFF
--- a/assistant/src/config/bundled-skills/outlook-calendar/tools/outlook-calendar-rsvp.ts
+++ b/assistant/src/config/bundled-skills/outlook-calendar/tools/outlook-calendar-rsvp.ts
@@ -1,0 +1,36 @@
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import * as calendar from "../calendar-client.js";
+import { getCalendarConnection, ok } from "./shared.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  _context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const account = input.account as string | undefined;
+  const eventId = input.event_id as string;
+  const response = input.response as "accepted" | "declined" | "tentative";
+
+  const connection = await getCalendarConnection(account);
+
+  // Fetch the event to get context for the response message
+  const event = await calendar.getEvent(connection, eventId);
+
+  // If the user is the organizer, no RSVP is needed
+  if (event.responseStatus?.response === "organizer") {
+    return ok("You are the organizer of this event. No RSVP needed.");
+  }
+
+  // Send RSVP via the dedicated Microsoft Graph endpoint, notifying the organizer
+  await calendar.rsvpEvent(connection, eventId, response, true);
+
+  const responseLabel =
+    response === "accepted"
+      ? "Accepted"
+      : response === "declined"
+        ? "Declined"
+        : "Tentatively accepted";
+  return ok(`${responseLabel} the event "${event.subject ?? eventId}".`);
+}


### PR DESCRIPTION
## Summary
- Add outlook-calendar-rsvp.ts tool for accepting, declining, or tentatively accepting event invitations
- Uses Microsoft Graph dedicated RSVP endpoints (accept/decline/tentativelyAccept)
- Detects organizer status and returns appropriate message

Part of plan: outlook-cal-gcal-parity.md (PR 7 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22569" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
