### PR TITLE
feat(outlook-calendar): register tools, watcher provider, and regenerate bundled registry

### DIFF
--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -120,6 +120,12 @@ import * as outlookSenderDigest from "./bundled-skills/outlook/tools/outlook-sen
 import * as outlookTrash from "./bundled-skills/outlook/tools/outlook-trash.js";
 import * as outlookUnsubscribe from "./bundled-skills/outlook/tools/outlook-unsubscribe.js";
 import * as outlookVacation from "./bundled-skills/outlook/tools/outlook-vacation.js";
+// ── outlook-calendar ──────────────────────────────────────────────────────────
+import * as outlookCalendarCheckAvailability from "./bundled-skills/outlook-calendar/tools/outlook-calendar-check-availability.js";
+import * as outlookCalendarCreateEvent from "./bundled-skills/outlook-calendar/tools/outlook-calendar-create-event.js";
+import * as outlookCalendarGetEvent from "./bundled-skills/outlook-calendar/tools/outlook-calendar-get-event.js";
+import * as outlookCalendarListEvents from "./bundled-skills/outlook-calendar/tools/outlook-calendar-list-events.js";
+import * as outlookCalendarRsvp from "./bundled-skills/outlook-calendar/tools/outlook-calendar-rsvp.js";
 // ── phone-calls ────────────────────────────────────────────────────────────────
 import * as callEnd from "./bundled-skills/phone-calls/tools/call-end.js";
 import * as callStart from "./bundled-skills/phone-calls/tools/call-start.js";
@@ -273,6 +279,25 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
     calendarCheckAvailability,
   ],
   ["google-calendar:tools/calendar-rsvp.ts", calendarRsvp],
+
+  // outlook-calendar
+  [
+    "outlook-calendar:tools/outlook-calendar-list-events.ts",
+    outlookCalendarListEvents,
+  ],
+  [
+    "outlook-calendar:tools/outlook-calendar-get-event.ts",
+    outlookCalendarGetEvent,
+  ],
+  [
+    "outlook-calendar:tools/outlook-calendar-create-event.ts",
+    outlookCalendarCreateEvent,
+  ],
+  [
+    "outlook-calendar:tools/outlook-calendar-check-availability.ts",
+    outlookCalendarCheckAvailability,
+  ],
+  ["outlook-calendar:tools/outlook-calendar-rsvp.ts", outlookCalendarRsvp],
 
   // image-studio
   ["image-studio:tools/media-generate-image.ts", mediaGenerateImage],

--- a/assistant/src/daemon/providers-setup.ts
+++ b/assistant/src/daemon/providers-setup.ts
@@ -28,6 +28,7 @@ import { gmailProvider } from "../watcher/providers/gmail.js";
 import { googleCalendarProvider } from "../watcher/providers/google-calendar.js";
 import { linearProvider } from "../watcher/providers/linear.js";
 import { outlookProvider } from "../watcher/providers/outlook.js";
+import { outlookCalendarProvider } from "../watcher/providers/outlook-calendar.js";
 const log = getLogger("lifecycle");
 
 export async function initializeProvidersAndTools(
@@ -136,6 +137,7 @@ export async function initializeProvidersAndTools(
 export function registerWatcherProviders(): void {
   registerWatcherProvider(gmailProvider);
   registerWatcherProvider(googleCalendarProvider);
+  registerWatcherProvider(outlookCalendarProvider);
   registerWatcherProvider(githubProvider);
   registerWatcherProvider(linearProvider);
 


### PR DESCRIPTION
## Summary
- Register all 5 Outlook Calendar tools in bundled-tool-registry.ts
- Register outlookCalendarProvider in providers-setup.ts watcher registration

Part of plan: outlook-cal-gcal-parity.md (PR 9 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22570" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
