### PR TITLE
feat: show app update availability inline after coordinated upgrade attempt

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -40,6 +40,9 @@ struct AssistantUpgradeSection: View {
     /// Whether the healthz fetch has completed (regardless of success/failure).
     var healthzLoaded: Bool = false
 
+    /// The update manager to observe for reactive Sparkle status updates.
+    @ObservedObject var updateManager: UpdateManager
+
     @State private var availableReleases: [AssistantRelease] = []
     @State private var selectedVersion: String?
     @State private var isLoadingReleases = false
@@ -56,6 +59,8 @@ struct AssistantUpgradeSection: View {
     @State private var escalationTask: Task<Void, Never>?
     @State private var dockerUpgradeTask: Task<Void, Never>?
     @State private var backwardReleasesEnabled = false
+    /// Whether a Sparkle check was triggered as part of the coordinated upgrade flow.
+    @State private var sparkleCheckTriggered = false
     private let featureFlagClient = FeatureFlagClient()
 
     private var latestRelease: AssistantRelease? {
@@ -365,6 +370,20 @@ struct AssistantUpgradeSection: View {
                     .foregroundStyle(VColor.systemPositiveStrong)
             }
 
+            if sparkleCheckTriggered && successMessage != nil {
+                if updateManager.isUpdateAvailable {
+                    VInlineMessage(
+                        "An app update is available. Follow the Sparkle dialog to install it, or use Check for Updates in the menu bar.",
+                        tone: .info
+                    )
+                } else {
+                    VInlineMessage(
+                        "App update check complete. If the update dialog was dismissed, use Check for Updates in the menu bar to try again.",
+                        tone: .info
+                    )
+                }
+            }
+
             if isServiceGroupUpdateInProgress && !isUpgrading && (topology == .managed || topology == .docker) {
                 HStack(spacing: VSpacing.sm) {
                     ProgressView()
@@ -519,6 +538,7 @@ struct AssistantUpgradeSection: View {
             successMessage = isRollback ? "Rollback complete." : "Upgrade complete."
             if !isRollback && isAppBehindTarget {
                 successMessage! += " Checking for app update…"
+                sparkleCheckTriggered = true
                 AppDelegate.shared?.updateManager.checkForUpdates()
             }
             AppDelegate.shared?.updateManager.clearServiceGroupFlags()
@@ -560,6 +580,7 @@ struct AssistantUpgradeSection: View {
                 : "Upgrade initiated. The assistant may be briefly unavailable."
             if !isRollback && isAppBehindTarget {
                 successMessage! += " Checking for app update in the background…"
+                sparkleCheckTriggered = true
                 // Use background check (no modal) — the managed upgrade only means
                 // the platform accepted the request, not that the service group has
                 // restarted. A modal Sparkle dialog would be premature here.
@@ -616,6 +637,7 @@ struct AssistantUpgradeSection: View {
         errorMessage = nil
         successMessage = nil
         showFeedbackOption = false
+        sparkleCheckTriggered = false
     }
 
     private func guidanceForError(_ error: VellumCli.CliError) -> String {

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -541,8 +541,10 @@ struct AssistantUpgradeSection: View {
             if !isRollback && isAppBehindTarget {
                 successMessage! += " Checking for app update…"
                 sparkleCheckTriggered = true
-                AppDelegate.shared?.updateManager.checkForUpdates()
-                sparkleCheckCompleted = true
+                Task {
+                    _ = await AppDelegate.shared?.updateManager.checkForUpdatesAsync()
+                    sparkleCheckCompleted = true
+                }
             }
             AppDelegate.shared?.updateManager.clearServiceGroupFlags()
             showFeedbackOption = false

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -61,6 +61,8 @@ struct AssistantUpgradeSection: View {
     @State private var backwardReleasesEnabled = false
     /// Whether a Sparkle check was triggered as part of the coordinated upgrade flow.
     @State private var sparkleCheckTriggered = false
+    /// Whether the triggered Sparkle check has actually finished resolving.
+    @State private var sparkleCheckCompleted = false
     private let featureFlagClient = FeatureFlagClient()
 
     private var latestRelease: AssistantRelease? {
@@ -370,7 +372,7 @@ struct AssistantUpgradeSection: View {
                     .foregroundStyle(VColor.systemPositiveStrong)
             }
 
-            if sparkleCheckTriggered && successMessage != nil {
+            if sparkleCheckTriggered && sparkleCheckCompleted && successMessage != nil {
                 if updateManager.isUpdateAvailable {
                     VInlineMessage(
                         "An app update is available. Follow the Sparkle dialog to install it, or use Check for Updates in the menu bar.",
@@ -540,6 +542,7 @@ struct AssistantUpgradeSection: View {
                 successMessage! += " Checking for app update…"
                 sparkleCheckTriggered = true
                 AppDelegate.shared?.updateManager.checkForUpdates()
+                sparkleCheckCompleted = true
             }
             AppDelegate.shared?.updateManager.clearServiceGroupFlags()
             showFeedbackOption = false
@@ -586,6 +589,7 @@ struct AssistantUpgradeSection: View {
                 // restarted. A modal Sparkle dialog would be premature here.
                 Task {
                     _ = await AppDelegate.shared?.updateManager.checkForUpdatesAsync()
+                    sparkleCheckCompleted = true
                 }
             }
             AppDelegate.shared?.updateManager.clearServiceGroupFlags()
@@ -638,6 +642,7 @@ struct AssistantUpgradeSection: View {
         successMessage = nil
         showFeedbackOption = false
         sparkleCheckTriggered = false
+        sparkleCheckCompleted = false
     }
 
     private func guidanceForError(_ error: VellumCli.CliError) -> String {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -60,7 +60,7 @@ struct SettingsGeneralTab: View {
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             accountSection
-            if !lockfileAssistants.isEmpty {
+            if !lockfileAssistants.isEmpty, let updateManager = AppDelegate.shared?.updateManager {
                 AssistantUpgradeSection(
                     currentVersion: connectionManager?.assistantVersion ?? healthz?.version,
                     topology: topology,
@@ -70,7 +70,8 @@ struct SettingsGeneralTab: View {
                     sparkleUpdateVersion: sparkleUpdateVersion,
                     isServiceGroupUpdateInProgress: isServiceGroupUpdateInProgress,
                     updateStatusMessage: updateStatusMessage,
-                    healthzLoaded: healthzLoaded
+                    healthzLoaded: healthzLoaded,
+                    updateManager: updateManager
                 )
             }
             if MacOSClientFeatureFlagManager.shared.isEnabled("mobile-pairing") {


### PR DESCRIPTION
## Summary
- Add `sparkleCheckTriggered` state flag to track when a coordinated Sparkle check was initiated
- Show inline `VInlineMessage` in settings after coordinated upgrade with guidance about app update status
- Observe `UpdateManager.isUpdateAvailable` reactively via `@ObservedObject` to update the inline message as Sparkle resolves
- Reset the flag in `clearMessages()` so it clears when starting a new operation

Part of plan: coord-upgrade-app-svc.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
