### PR TITLE
fix: gate outlook calendar watcher behind feature flag

### DIFF
--- a/assistant/src/daemon/providers-setup.ts
+++ b/assistant/src/daemon/providers-setup.ts
@@ -137,13 +137,13 @@ export async function initializeProvidersAndTools(
 export function registerWatcherProviders(): void {
   registerWatcherProvider(gmailProvider);
   registerWatcherProvider(googleCalendarProvider);
-  registerWatcherProvider(outlookCalendarProvider);
   registerWatcherProvider(githubProvider);
   registerWatcherProvider(linearProvider);
 
   const config = getConfig();
   if (isAssistantFeatureFlagEnabled("outlook-oauth-integration", config)) {
     registerWatcherProvider(outlookProvider);
+    registerWatcherProvider(outlookCalendarProvider);
   }
 
   initWatcherEngine();


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for outlook-cal-gcal-parity.md.

**Gap:** Outlook Calendar watcher not gated behind feature flag
**What was expected:** outlookCalendarProvider gated behind outlook-oauth-integration flag
**What was found:** Registered unconditionally
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
