### PR TITLE
fix: filter cancelled events in outlook calendar watcher fallback path

### DIFF
--- a/assistant/src/watcher/providers/outlook-calendar.ts
+++ b/assistant/src/watcher/providers/outlook-calendar.ts
@@ -335,7 +335,9 @@ async function fallbackFetch(
 ): Promise<FetchResult> {
   const { items: events, deltaLink } = await initialDeltaQuery(connection);
 
-  const items = events.map((event) => eventToItem(event, "new_calendar_event"));
+  const items = events
+    .filter((event) => !event.isCancelled)
+    .map((event) => eventToItem(event, "new_calendar_event"));
 
   return { items, watermark: deltaLink };
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for outlook-cal-gcal-parity.md.

**Gap:** fallbackFetch does not filter cancelled events
**What was expected:** Cancelled events filtered in fallback path
**What was found:** Only fetchNew path filters isCancelled
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
