### PR TITLE
fix: validate empty schedules in check-availability and reorder registry entries

### DIFF
--- a/assistant/src/config/bundled-skills/outlook-calendar/tools/outlook-calendar-check-availability.ts
+++ b/assistant/src/config/bundled-skills/outlook-calendar/tools/outlook-calendar-check-availability.ts
@@ -3,7 +3,7 @@ import type {
   ToolExecutionResult,
 } from "../../../../tools/types.js";
 import * as calendar from "../calendar-client.js";
-import { getCalendarConnection, ok } from "./shared.js";
+import { err, getCalendarConnection, ok } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
@@ -22,6 +22,11 @@ export async function run(
       method: "GET",
       path: "/v1.0/me",
     });
+    if (resp.status < 200 || resp.status >= 300) {
+      return err(
+        "Failed to retrieve your Microsoft profile. Cannot determine your email for availability lookup.",
+      );
+    }
     const body = resp.body as Record<string, unknown>;
     const email =
       (body.mail as string | undefined) ??
@@ -29,6 +34,13 @@ export async function run(
     if (email) {
       schedules = [email];
     }
+  }
+
+  if (schedules.length === 0) {
+    return err(
+      "No schedules provided and could not determine your email address from your Microsoft profile. " +
+        "Please provide at least one email address in the schedules parameter.",
+    );
   }
 
   const result = await calendar.getSchedule(connection, {

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -120,7 +120,7 @@ import * as outlookSenderDigest from "./bundled-skills/outlook/tools/outlook-sen
 import * as outlookTrash from "./bundled-skills/outlook/tools/outlook-trash.js";
 import * as outlookUnsubscribe from "./bundled-skills/outlook/tools/outlook-unsubscribe.js";
 import * as outlookVacation from "./bundled-skills/outlook/tools/outlook-vacation.js";
-// ── outlook-calendar ──────────────────────────────────────────────────────────
+// ── outlook-calendar ───────────────────────────────────────────────────────────
 import * as outlookCalendarCheckAvailability from "./bundled-skills/outlook-calendar/tools/outlook-calendar-check-availability.js";
 import * as outlookCalendarCreateEvent from "./bundled-skills/outlook-calendar/tools/outlook-calendar-create-event.js";
 import * as outlookCalendarGetEvent from "./bundled-skills/outlook-calendar/tools/outlook-calendar-get-event.js";
@@ -280,25 +280,6 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ],
   ["google-calendar:tools/calendar-rsvp.ts", calendarRsvp],
 
-  // outlook-calendar
-  [
-    "outlook-calendar:tools/outlook-calendar-list-events.ts",
-    outlookCalendarListEvents,
-  ],
-  [
-    "outlook-calendar:tools/outlook-calendar-get-event.ts",
-    outlookCalendarGetEvent,
-  ],
-  [
-    "outlook-calendar:tools/outlook-calendar-create-event.ts",
-    outlookCalendarCreateEvent,
-  ],
-  [
-    "outlook-calendar:tools/outlook-calendar-check-availability.ts",
-    outlookCalendarCheckAvailability,
-  ],
-  ["outlook-calendar:tools/outlook-calendar-rsvp.ts", outlookCalendarRsvp],
-
   // image-studio
   ["image-studio:tools/media-generate-image.ts", mediaGenerateImage],
 
@@ -341,6 +322,25 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["outlook:tools/outlook-follow-up.ts", outlookFollowUp],
   ["outlook:tools/outlook-unsubscribe.ts", outlookUnsubscribe],
   ["outlook:tools/outlook-attachments.ts", outlookAttachments],
+
+  // outlook-calendar
+  [
+    "outlook-calendar:tools/outlook-calendar-list-events.ts",
+    outlookCalendarListEvents,
+  ],
+  [
+    "outlook-calendar:tools/outlook-calendar-get-event.ts",
+    outlookCalendarGetEvent,
+  ],
+  [
+    "outlook-calendar:tools/outlook-calendar-create-event.ts",
+    outlookCalendarCreateEvent,
+  ],
+  [
+    "outlook-calendar:tools/outlook-calendar-check-availability.ts",
+    outlookCalendarCheckAvailability,
+  ],
+  ["outlook-calendar:tools/outlook-calendar-rsvp.ts", outlookCalendarRsvp],
 
   // phone-calls
   ["phone-calls:tools/call-start.ts", callStart],


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for outlook-cal-gcal-parity.md.

**Gap A:** Check-availability empty schedules validation
- Added status check on the `/v1.0/me` response to return a user-friendly error if the profile lookup fails
- Added validation after the email lookup block: if `schedules` is still empty, return an error instead of sending a bad request to Microsoft Graph
- Added `err` to the import from `./shared.js`

**Gap B:** Registry map entry ordering
- Regenerated `bundled-tool-registry.ts` so `outlook-calendar` entries are placed after `outlook` entries (alphabetical order)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
