### PR TITLE
feat: coordinated app + service group upgrade for managed/docker topologies

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -40,6 +40,9 @@ struct AssistantUpgradeSection: View {
     /// Whether the healthz fetch has completed (regardless of success/failure).
     var healthzLoaded: Bool = false
 
+    /// The update manager to observe for reactive Sparkle status updates.
+    @ObservedObject var updateManager: UpdateManager
+
     @State private var availableReleases: [AssistantRelease] = []
     @State private var selectedVersion: String?
     @State private var isLoadingReleases = false
@@ -56,6 +59,10 @@ struct AssistantUpgradeSection: View {
     @State private var escalationTask: Task<Void, Never>?
     @State private var dockerUpgradeTask: Task<Void, Never>?
     @State private var backwardReleasesEnabled = false
+    /// Whether a Sparkle check was triggered as part of the coordinated upgrade flow.
+    @State private var sparkleCheckTriggered = false
+    /// Whether the triggered Sparkle check has actually finished resolving.
+    @State private var sparkleCheckCompleted = false
     private let featureFlagClient = FeatureFlagClient()
 
     private var latestRelease: AssistantRelease? {
@@ -365,6 +372,20 @@ struct AssistantUpgradeSection: View {
                     .foregroundStyle(VColor.systemPositiveStrong)
             }
 
+            if sparkleCheckTriggered && sparkleCheckCompleted && successMessage != nil {
+                if updateManager.isUpdateAvailable {
+                    VInlineMessage(
+                        "An app update is available. Follow the Sparkle dialog to install it, or use Check for Updates in the menu bar.",
+                        tone: .info
+                    )
+                } else {
+                    VInlineMessage(
+                        "App update check complete. If the update dialog was dismissed, use Check for Updates in the menu bar to try again.",
+                        tone: .info
+                    )
+                }
+            }
+
             if isServiceGroupUpdateInProgress && !isUpgrading && (topology == .managed || topology == .docker) {
                 HStack(spacing: VSpacing.sm) {
                     ProgressView()
@@ -519,7 +540,11 @@ struct AssistantUpgradeSection: View {
             successMessage = isRollback ? "Rollback complete." : "Upgrade complete."
             if !isRollback && isAppBehindTarget {
                 successMessage! += " Checking for app update…"
-                AppDelegate.shared?.updateManager.checkForUpdates()
+                sparkleCheckTriggered = true
+                Task {
+                    _ = await AppDelegate.shared?.updateManager.checkForUpdatesAsync()
+                    sparkleCheckCompleted = true
+                }
             }
             AppDelegate.shared?.updateManager.clearServiceGroupFlags()
             showFeedbackOption = false
@@ -560,11 +585,13 @@ struct AssistantUpgradeSection: View {
                 : "Upgrade initiated. The assistant may be briefly unavailable."
             if !isRollback && isAppBehindTarget {
                 successMessage! += " Checking for app update in the background…"
+                sparkleCheckTriggered = true
                 // Use background check (no modal) — the managed upgrade only means
                 // the platform accepted the request, not that the service group has
                 // restarted. A modal Sparkle dialog would be premature here.
                 Task {
                     _ = await AppDelegate.shared?.updateManager.checkForUpdatesAsync()
+                    sparkleCheckCompleted = true
                 }
             }
             AppDelegate.shared?.updateManager.clearServiceGroupFlags()
@@ -616,6 +643,8 @@ struct AssistantUpgradeSection: View {
         errorMessage = nil
         successMessage = nil
         showFeedbackOption = false
+        sparkleCheckTriggered = false
+        sparkleCheckCompleted = false
     }
 
     private func guidanceForError(_ error: VellumCli.CliError) -> String {

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -134,6 +134,18 @@ struct AssistantUpgradeSection: View {
         return !VersionCompat.isCompatible(clientVersion: clientVersion, serviceGroupVersion: sgVersion)
     }
 
+    /// Whether the app version is older than the selected target version.
+    /// Used to determine if Sparkle should be triggered after a service group upgrade.
+    private var isAppBehindTarget: Bool {
+        guard let target = effectiveSelectedVersion,
+              let clientVersion = appVersion,
+              let targetParsed = VersionCompat.parse(target),
+              let clientParsed = VersionCompat.parse(clientVersion) else { return false }
+        if targetParsed.major != clientParsed.major { return targetParsed.major > clientParsed.major }
+        if targetParsed.minor != clientParsed.minor { return targetParsed.minor > clientParsed.minor }
+        return targetParsed.patch > clientParsed.patch
+    }
+
     /// Whether the service group version is older than the client version.
     private var isServiceGroupBehind: Bool {
         guard let sgVersion = currentVersion, !sgVersion.isEmpty,
@@ -403,6 +415,8 @@ struct AssistantUpgradeSection: View {
         } message: {
             if isRollback {
                 Text("Rollback to version \(effectiveSelectedVersion ?? "unknown")? The assistant will be briefly unavailable.")
+            } else if isAppBehindTarget {
+                Text("Upgrade to version \(effectiveSelectedVersion ?? "latest")? Both the assistant and the app will be updated. The assistant will be briefly unavailable during the upgrade.")
             } else {
                 Text("Upgrade to version \(effectiveSelectedVersion ?? "latest")? The assistant will be briefly unavailable during the upgrade.")
             }
@@ -503,6 +517,10 @@ struct AssistantUpgradeSection: View {
                 try await cli.upgrade(name: name, version: version)
             }
             successMessage = isRollback ? "Rollback complete." : "Upgrade complete."
+            if !isRollback && isAppBehindTarget {
+                successMessage! += " Checking for app update…"
+                AppDelegate.shared?.updateManager.checkForUpdates()
+            }
             AppDelegate.shared?.updateManager.clearServiceGroupFlags()
             showFeedbackOption = false
             await loadReleasesQuietly()
@@ -540,6 +558,15 @@ struct AssistantUpgradeSection: View {
             successMessage = isRollback
                 ? "Rollback initiated. The assistant may be briefly unavailable."
                 : "Upgrade initiated. The assistant may be briefly unavailable."
+            if !isRollback && isAppBehindTarget {
+                successMessage! += " Checking for app update in the background…"
+                // Use background check (no modal) — the managed upgrade only means
+                // the platform accepted the request, not that the service group has
+                // restarted. A modal Sparkle dialog would be premature here.
+                Task {
+                    _ = await AppDelegate.shared?.updateManager.checkForUpdatesAsync()
+                }
+            }
             AppDelegate.shared?.updateManager.clearServiceGroupFlags()
             showFeedbackOption = false
             // Refresh releases to update UI without clearing success message

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -60,7 +60,7 @@ struct SettingsGeneralTab: View {
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             accountSection
-            if !lockfileAssistants.isEmpty {
+            if !lockfileAssistants.isEmpty, let updateManager = AppDelegate.shared?.updateManager {
                 AssistantUpgradeSection(
                     currentVersion: connectionManager?.assistantVersion ?? healthz?.version,
                     topology: topology,
@@ -70,7 +70,8 @@ struct SettingsGeneralTab: View {
                     sparkleUpdateVersion: sparkleUpdateVersion,
                     isServiceGroupUpdateInProgress: isServiceGroupUpdateInProgress,
                     updateStatusMessage: updateStatusMessage,
-                    healthzLoaded: healthzLoaded
+                    healthzLoaded: healthzLoaded,
+                    updateManager: updateManager
                 )
             }
             if MacOSClientFeatureFlagManager.shared.isEnabled("mobile-pairing") {


### PR DESCRIPTION
## Summary
When upgrading an assistant on managed platform or Docker topology, the macOS Settings "Upgrade" button now updates both the service group (backend) and the macOS client app. Since the app and service group are versioned together, this ensures they stay in sync.

- Adds `isAppBehindTarget` computed property to detect when the macOS app version is older than the upgrade target
- After a successful service group upgrade, triggers a Sparkle background update check if the app also needs updating
- Uses async background check (`checkForUpdatesAsync`) for both managed and Docker paths to correctly track completion
- Shows inline status message in Settings with guidance about the app update
- Updates confirmation dialog to mention both app and service group when both need updating

## PRs merged into feature branch
- #22561: feat: trigger Sparkle app update after service group upgrade for managed/docker topologies
- #22572: feat: show app update availability inline after coordinated upgrade attempt

Part of plan: coord-upgrade-app-svc.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
