### PR TITLE
fix(security): classify acp_spawn as high risk to require user approval

### DIFF
--- a/assistant/src/config/bundled-skills/acp/TOOLS.json
+++ b/assistant/src/config/bundled-skills/acp/TOOLS.json
@@ -5,7 +5,7 @@
       "name": "acp_spawn",
       "description": "Spawn an external coding agent (e.g. Claude Code, Codex, Gemini CLI) via ACP to work on a task. The agent runs as a subprocess and streams results back. Use this when you want to delegate a coding task to an external agent that has its own tools, file editing, and terminal access. If ACP is not enabled, follow the setup instructions in SKILL.md to install claude-agent-acp and configure it. The command MUST be 'claude-agent-acp' - NEVER use 'claude', 'claude -p', or 'claude --acp'.",
       "category": "orchestration",
-      "risk": "low",
+      "risk": "high",
       "input_schema": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
## Summary
- Change `acp_spawn` risk level from `"low"` to `"high"` in the ACP bundled skill TOOLS.json
- This ensures spawning an external ACP agent requires explicit user approval, since the spawned agent receives unrestricted host filesystem read/write and terminal capabilities via the ACP client handler
- `acp_status` and `acp_abort` remain low-risk as they are genuinely safe operations

Codex finding: https://chatgpt.com/codex/security/findings/5946696066088191b6fb6c6f3c1dabd5?sev=critical%2Chigh

## Original prompt
Security fix: Change acp_spawn tool risk level from "low" to "high"

The `acp_spawn` bundled skill tool is marked `risk: "low"` in `assistant/src/config/bundled-skills/acp/TOOLS.json:8`, which causes it to be auto-approved without user prompting in non-strict permission modes (per the bundled skill auto-allow logic in `assistant/src/permissions/checker.ts:1074-1088`).

Once spawned, the ACP client handler provides the external agent with unrestricted host capabilities — `readTextFile`, `writeTextFile`, and `createTerminal` (`assistant/src/acp/client-handler.ts:247-298`) — without permission checks. This means a prompt-injected `acp_spawn` can grant an external agent unapproved host file access and command execution.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
