### PR TITLE
fix: preserve timezone offset when creating timed calendar events

### DIFF
--- a/assistant/src/config/bundled-skills/outlook-calendar/tools/outlook-calendar-create-event.ts
+++ b/assistant/src/config/bundled-skills/outlook-calendar/tools/outlook-calendar-create-event.ts
@@ -22,19 +22,29 @@ export async function run(
   // Detect all-day events: if start string does not contain "T", treat as all-day
   const isAllDay = !startRaw.includes("T");
 
+  // Determine the timeZone to send. If the caller provided an explicit IANA
+  // timezone, always use it.  Otherwise, only fall back to UTC when the
+  // dateTime string does NOT already carry an offset (e.g. "-05:00" or "Z").
+  // Sending timeZone: "UTC" alongside a dateTime that contains a different
+  // offset would cause Microsoft Graph to ignore the offset and interpret the
+  // time as UTC, creating events at the wrong wall-clock time.
+  const hasOffset = (dt: string) => /[Zz]|[+-]\d{2}:\d{2}$/.test(dt);
+  const resolveTimeZone = (dt: string) =>
+    timezone ?? (hasOffset(dt) ? undefined : "UTC");
+
   const start = isAllDay
     ? {
         dateTime: `${startRaw}T00:00:00`,
         timeZone: timezone ?? "UTC",
       }
-    : { dateTime: startRaw, timeZone: timezone ?? "UTC" };
+    : { dateTime: startRaw, timeZone: resolveTimeZone(startRaw) };
 
   const end = isAllDay
     ? {
         dateTime: `${endRaw}T00:00:00`,
         timeZone: timezone ?? "UTC",
       }
-    : { dateTime: endRaw, timeZone: timezone ?? "UTC" };
+    : { dateTime: endRaw, timeZone: resolveTimeZone(endRaw) };
 
   const eventBody: Parameters<typeof calendar.createEvent>[1] = {
     subject: summary,

--- a/assistant/src/config/bundled-skills/outlook-calendar/types.ts
+++ b/assistant/src/config/bundled-skills/outlook-calendar/types.ts
@@ -1,7 +1,7 @@
-/** Microsoft Graph date+time pair (always includes time zone). */
+/** Microsoft Graph date+time pair. timeZone may be omitted when dateTime carries an offset. */
 export interface OutlookDateTimeZone {
   dateTime: string;
-  timeZone: string;
+  timeZone?: string;
 }
 
 /** Attendee on a calendar event. */


### PR DESCRIPTION
## Summary
Fixes a bug where providing a timed event with an embedded timezone offset (e.g. `2024-01-15T09:00:00-05:00`) without an explicit `timezone` parameter would default `timeZone` to `UTC`, conflicting with the offset and creating the event at the wrong wall-clock time.

Now, when `timezone` is not provided but the `dateTime` string already contains an offset (`Z`, `+HH:MM`, or `-HH:MM`), `timeZone` is omitted so Microsoft Graph uses the embedded offset. UTC fallback only applies when there is no offset in the dateTime string.

Addresses Codex review feedback on #22571.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
