### PR TITLE
fix(auth): correct maintenance mode route URLs

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -39,9 +39,6 @@ func quickInputHotKeyHandler(
 // Using @objc dynamic enables Combine's publisher(for:) key-path KVO without
 // listening to every UserDefaults write app-wide.
 extension UserDefaults {
-    @objc dynamic var connectedAssistantId: String? {
-        string(forKey: "connectedAssistantId")
-    }
     @objc dynamic var globalHotkeyShortcut: String {
         if UserDefaults.standard.object(forKey: "globalHotkeyShortcut") == nil {
             return "cmd+shift+g"

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -357,7 +357,7 @@ public final class AuthService {
         assistantId: String,
         organizationId: String
     ) async throws -> PlatformAssistant {
-        let urlString = "\(baseURL)/v1/assistants/\(assistantId)/enter-maintenance-mode/"
+        let urlString = "\(baseURL)/v1/assistants/\(assistantId)/maintenance-mode/enter/"
         guard let url = URL(string: urlString) else {
             throw PlatformAPIError.invalidURL
         }
@@ -386,7 +386,7 @@ public final class AuthService {
         let httpResponse = response as? HTTPURLResponse
         let statusCode = httpResponse?.statusCode ?? 0
 
-        log.debug("Platform request POST assistants/\(assistantId)/enter-maintenance-mode/ -> \(statusCode)")
+        log.debug("Platform request POST assistants/\(assistantId)/maintenance-mode/enter/ -> \(statusCode)")
 
         if statusCode == 401 || statusCode == 403 {
             throw PlatformAPIError.authenticationRequired
@@ -412,7 +412,7 @@ public final class AuthService {
         assistantId: String,
         organizationId: String
     ) async throws -> PlatformAssistant {
-        let urlString = "\(baseURL)/v1/assistants/\(assistantId)/exit-maintenance-mode/"
+        let urlString = "\(baseURL)/v1/assistants/\(assistantId)/maintenance-mode/exit/"
         guard let url = URL(string: urlString) else {
             throw PlatformAPIError.invalidURL
         }
@@ -441,7 +441,7 @@ public final class AuthService {
         let httpResponse = response as? HTTPURLResponse
         let statusCode = httpResponse?.statusCode ?? 0
 
-        log.debug("Platform request POST assistants/\(assistantId)/exit-maintenance-mode/ -> \(statusCode)")
+        log.debug("Platform request POST assistants/\(assistantId)/maintenance-mode/exit/ -> \(statusCode)")
 
         if statusCode == 401 || statusCode == 403 {
             throw PlatformAPIError.authenticationRequired


### PR DESCRIPTION
## Summary
- Fix 404 errors caused by wrong URL paths for enter/exit maintenance mode
- Change \`/enter-maintenance-mode/\` → \`/maintenance-mode/enter/\`
- Change \`/exit-maintenance-mode/\` → \`/maintenance-mode/exit/\`
- Fix duplicate \`connectedAssistantId\` UserDefaults property that caused compile errors (introduced by merge conflict resolution)

Part of plan: assistant-debug-pods.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22582" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
