### PR TITLE
fix(gateway): enforce scope checks on OAuth proxy routes

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -726,13 +726,15 @@ async function main() {
     {
       path: "/v1/oauth/providers",
       method: "GET",
-      auth: "edge",
+      auth: "edge-scoped",
+      scope: "settings.read",
       handler: (req) => oauthProvidersProxy.handleListProviders(req),
     },
     {
       path: /^\/v1\/oauth\/providers\/([^/]+)\/?$/,
       method: "GET",
-      auth: "edge",
+      auth: "edge-scoped",
+      scope: "settings.read",
       handler: (req, params) =>
         oauthProvidersProxy.handleGetProvider(req, params[0]),
     },
@@ -741,39 +743,45 @@ async function main() {
     {
       path: "/v1/oauth/apps",
       method: "GET",
-      auth: "edge",
+      auth: "edge-scoped",
+      scope: "settings.read",
       handler: (req) => oauthAppsProxy.handleListApps(req),
     },
     {
       path: "/v1/oauth/apps",
       method: "POST",
-      auth: "edge",
+      auth: "edge-scoped",
+      scope: "settings.write",
       handler: (req) => oauthAppsProxy.handleCreateApp(req),
     },
     {
       path: /^\/v1\/oauth\/apps\/([^/]+)\/?$/,
       method: "DELETE",
-      auth: "edge",
+      auth: "edge-scoped",
+      scope: "settings.write",
       handler: (req, params) => oauthAppsProxy.handleDeleteApp(req, params[0]),
     },
     {
       path: /^\/v1\/oauth\/apps\/([^/]+)\/connections\/?$/,
       method: "GET",
-      auth: "edge",
+      auth: "edge-scoped",
+      scope: "settings.read",
       handler: (req, params) =>
         oauthAppsProxy.handleListConnections(req, params[0]),
     },
     {
       path: /^\/v1\/oauth\/connections\/([^/]+)\/?$/,
       method: "DELETE",
-      auth: "edge",
+      auth: "edge-scoped",
+      scope: "settings.write",
       handler: (req, params) =>
         oauthAppsProxy.handleDeleteConnection(req, params[0]),
     },
     {
       path: /^\/v1\/oauth\/apps\/([^/]+)\/connect\/?$/,
       method: "POST",
-      auth: "edge",
+      auth: "edge-scoped",
+      scope: "settings.write",
       handler: (req, params) => oauthAppsProxy.handleConnect(req, params[0]),
     },
 


### PR DESCRIPTION
## Summary

- **Security fix**: OAuth app, connection, and provider proxy routes were using `auth: "edge"` (JWT-only, no scope enforcement) while the proxy replaces the caller's token with a `gateway_service_v1` service token that includes `settings.write`. This allowed low-privilege edge tokens (e.g., `ui_page_v1` with only `settings.read`) to perform OAuth app creation, deletion, and connection management — a privilege escalation.
- **Fix**: Changed all 8 OAuth proxy routes from `auth: "edge"` to `auth: "edge-scoped"` with appropriate scope requirements (`settings.read` for GET, `settings.write` for POST/DELETE), matching the pattern already used by admin, feature flag, and privacy config routes.

Codex finding: https://chatgpt.com/codex/security/findings/d5039d7db26c81918007b6e2091cbeb5?sev=critical%2Chigh

## Original prompt

Fix privilege escalation in gateway OAuth proxy routes. The OAuth app/connection proxy routes in `gateway/src/index.ts` use `auth: "edge"` which only validates JWT presence without enforcing scopes. The proxy strips the caller's Authorization header and replaces it with a gateway service token (`gateway_service_v1`) that includes `settings.write`, allowing any valid edge JWT to perform privileged OAuth management actions. Switch all OAuth routes to `auth: "edge-scoped"` with appropriate scope values.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
