### PR TITLE
fix(security): add directory allowlist for file-backed attachment uploads

### DIFF
--- a/assistant/src/runtime/routes/attachment-routes.test.ts
+++ b/assistant/src/runtime/routes/attachment-routes.test.ts
@@ -1,0 +1,64 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
+
+const testWorkspaceDir = mkdtempSync(
+  join(tmpdir(), "attachment-routes-workspace-"),
+);
+const testHomeDir = mkdtempSync(join(tmpdir(), "attachment-routes-home-"));
+
+const attachmentsDir = join(testWorkspaceDir, "data", "attachments");
+const recordingsDir = join(
+  testHomeDir,
+  "Library/Application Support/vellum-assistant/recordings",
+);
+const outsideDir = mkdtempSync(join(tmpdir(), "attachment-routes-outside-"));
+
+const originalHome = process.env.HOME;
+process.env.HOME = testHomeDir;
+
+mock.module("../../util/platform.js", () => ({
+  getWorkspaceDir: () => testWorkspaceDir,
+}));
+
+import { resolveAllowedFileBackedAttachmentPath } from "./attachment-routes.js";
+
+beforeAll(() => {
+  mkdirSync(attachmentsDir, { recursive: true });
+  mkdirSync(recordingsDir, { recursive: true });
+});
+
+afterAll(() => {
+  process.env.HOME = originalHome;
+  rmSync(testWorkspaceDir, { recursive: true, force: true });
+  rmSync(testHomeDir, { recursive: true, force: true });
+  rmSync(outsideDir, { recursive: true, force: true });
+});
+
+describe("resolveAllowedFileBackedAttachmentPath", () => {
+  test("allows files in workspace attachments directory", () => {
+    const attachmentFile = join(attachmentsDir, "sample.txt");
+    writeFileSync(attachmentFile, "ok");
+
+    expect(resolveAllowedFileBackedAttachmentPath(attachmentFile)).toBe(
+      attachmentFile,
+    );
+  });
+
+  test("allows files in recordings directory", () => {
+    const recordingFile = join(recordingsDir, "recording.mov");
+    writeFileSync(recordingFile, "ok");
+
+    expect(resolveAllowedFileBackedAttachmentPath(recordingFile)).toBe(
+      recordingFile,
+    );
+  });
+
+  test("rejects files outside allowed directories", () => {
+    const outsideFile = join(outsideDir, "secret.txt");
+    writeFileSync(outsideFile, "secret");
+
+    expect(resolveAllowedFileBackedAttachmentPath(outsideFile)).toBeNull();
+  });
+});

--- a/assistant/src/runtime/routes/attachment-routes.test.ts
+++ b/assistant/src/runtime/routes/attachment-routes.test.ts
@@ -1,4 +1,10 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
@@ -66,10 +72,35 @@ describe("resolveAllowedFileBackedAttachmentPath", () => {
     expect(resolveAllowedFileBackedAttachmentPath(convFile)).toBe(convFile);
   });
 
+  test("rejects files in conversation dir outside attachments subdir", () => {
+    const convDir = join(conversationsDir, "conv-456");
+    mkdirSync(convDir, { recursive: true });
+    const metaFile = join(convDir, "meta.json");
+    writeFileSync(metaFile, "{}");
+
+    expect(resolveAllowedFileBackedAttachmentPath(metaFile)).toBeNull();
+  });
+
   test("rejects files outside allowed directories", () => {
     const outsideFile = join(outsideDir, "secret.txt");
     writeFileSync(outsideFile, "secret");
 
     expect(resolveAllowedFileBackedAttachmentPath(outsideFile)).toBeNull();
+  });
+
+  test("rejects path traversal via '..' segments", () => {
+    const traversalPath = join(attachmentsDir, "..", "..", "secret.txt");
+
+    expect(resolveAllowedFileBackedAttachmentPath(traversalPath)).toBeNull();
+  });
+
+  test("rejects symlinks inside allowed dir pointing outside", () => {
+    const outsideFile = join(outsideDir, "linked-secret.txt");
+    writeFileSync(outsideFile, "secret");
+
+    const symlinkPath = join(attachmentsDir, "sneaky-link.txt");
+    symlinkSync(outsideFile, symlinkPath);
+
+    expect(resolveAllowedFileBackedAttachmentPath(symlinkPath)).toBeNull();
   });
 });

--- a/assistant/src/runtime/routes/attachment-routes.test.ts
+++ b/assistant/src/runtime/routes/attachment-routes.test.ts
@@ -9,6 +9,7 @@ const testWorkspaceDir = mkdtempSync(
 const testHomeDir = mkdtempSync(join(tmpdir(), "attachment-routes-home-"));
 
 const attachmentsDir = join(testWorkspaceDir, "data", "attachments");
+const conversationsDir = join(testWorkspaceDir, "conversations");
 const recordingsDir = join(
   testHomeDir,
   "Library/Application Support/vellum-assistant/recordings",
@@ -26,6 +27,7 @@ import { resolveAllowedFileBackedAttachmentPath } from "./attachment-routes.js";
 
 beforeAll(() => {
   mkdirSync(attachmentsDir, { recursive: true });
+  mkdirSync(conversationsDir, { recursive: true });
   mkdirSync(recordingsDir, { recursive: true });
 });
 
@@ -53,6 +55,15 @@ describe("resolveAllowedFileBackedAttachmentPath", () => {
     expect(resolveAllowedFileBackedAttachmentPath(recordingFile)).toBe(
       recordingFile,
     );
+  });
+
+  test("allows files in conversation attachments directory", () => {
+    const convAttachDir = join(conversationsDir, "conv-123", "attachments");
+    mkdirSync(convAttachDir, { recursive: true });
+    const convFile = join(convAttachDir, "photo.jpg");
+    writeFileSync(convFile, "ok");
+
+    expect(resolveAllowedFileBackedAttachmentPath(convFile)).toBe(convFile);
   });
 
   test("rejects files outside allowed directories", () => {

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -1,7 +1,8 @@
 /**
  * Route handlers for attachment upload, download, and deletion.
  */
-import { existsSync, statSync } from "node:fs";
+import { existsSync, realpathSync, statSync } from "node:fs";
+import { join, resolve, sep } from "node:path";
 
 import { z } from "zod";
 
@@ -11,11 +12,53 @@ import {
   getFilePathForAttachment,
   validateAttachmentUpload,
 } from "../../memory/attachments-store.js";
+import { getWorkspaceDir } from "../../util/platform.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 
 /** 150 MB — base64-encoded 100 MB attachment ≈ 134 MB plus JSON wrapper overhead. */
 const MAX_UPLOAD_BODY_BYTES = 150 * 1024 * 1024;
+
+function resolveCanonicalPath(filePath: string): string {
+  try {
+    return realpathSync(filePath);
+  } catch {
+    return resolve(filePath);
+  }
+}
+
+function isPathWithinDirectory(filePath: string, allowedDir: string): boolean {
+  return filePath === allowedDir || filePath.startsWith(allowedDir + sep);
+}
+
+function resolveAllowedAttachmentDirectories(): string[] {
+  const workspaceAttachmentsDir = join(
+    getWorkspaceDir(),
+    "data",
+    "attachments",
+  );
+  const recordingsDir = join(
+    process.env.HOME ?? "",
+    "Library/Application Support/vellum-assistant/recordings",
+  );
+  return [workspaceAttachmentsDir, recordingsDir].map((dir) => {
+    try {
+      return realpathSync(dir);
+    } catch {
+      return resolve(dir);
+    }
+  });
+}
+
+export function resolveAllowedFileBackedAttachmentPath(
+  filePath: string,
+): string | null {
+  const resolvedPath = resolveCanonicalPath(filePath);
+  const allowedDirs = resolveAllowedAttachmentDirectories();
+  return allowedDirs.some((dir) => isPathWithinDirectory(resolvedPath, dir))
+    ? resolvedPath
+    : null;
+}
 
 export async function handleUploadAttachment(req: Request): Promise<Response> {
   const rawBody = await req.arrayBuffer();
@@ -56,14 +99,22 @@ export async function handleUploadAttachment(req: Request): Promise<Response> {
   // This supports retry of file-backed attachments (e.g. recordings) where the
   // client no longer holds the inline data but the file still exists on disk.
   if (filePath && typeof filePath === "string" && (!data || data === "")) {
-    if (!existsSync(filePath)) {
+    const resolvedPath = resolveAllowedFileBackedAttachmentPath(filePath);
+    if (!resolvedPath) {
+      return httpError(
+        "BAD_REQUEST",
+        "filePath is outside allowed upload directories",
+        400,
+      );
+    }
+    if (!existsSync(resolvedPath)) {
       return httpError("BAD_REQUEST", "filePath does not exist on disk", 400);
     }
-    const sizeBytes = statSync(filePath).size;
+    const sizeBytes = statSync(resolvedPath).size;
     attachment = attachmentsStore.uploadFileBackedAttachment(
       filename,
       mimeType,
-      filePath,
+      resolvedPath,
       sizeBytes,
     );
   } else {
@@ -172,11 +223,15 @@ export function handleGetAttachmentContent(
   // Check for file-backed attachment
   const filePath = getFilePathForAttachment(attachmentId);
   if (filePath) {
-    if (!existsSync(filePath)) {
+    const resolvedPath = resolveAllowedFileBackedAttachmentPath(filePath);
+    if (!resolvedPath) {
+      return httpError("NOT_FOUND", "Attachment content not found", 404);
+    }
+    if (!existsSync(resolvedPath)) {
       return httpError("NOT_FOUND", "Recording file not found on disk", 404);
     }
 
-    const file = Bun.file(filePath);
+    const file = Bun.file(resolvedPath);
     const rangeHeader = req.headers.get("Range");
 
     if (rangeHeader) {

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -37,20 +37,41 @@ function resolveAllowedAttachmentDirectories(): string[] {
     "data",
     "attachments",
   );
-  const conversationsDir = join(getWorkspaceDir(), "conversations");
   const recordingsDir = join(
     process.env.HOME ?? "",
     "Library/Application Support/vellum-assistant/recordings",
   );
-  return [workspaceAttachmentsDir, conversationsDir, recordingsDir].map(
-    (dir) => {
-      try {
-        return realpathSync(dir);
-      } catch {
-        return resolve(dir);
-      }
-    },
-  );
+  return [workspaceAttachmentsDir, recordingsDir].map((dir) => {
+    try {
+      return realpathSync(dir);
+    } catch {
+      return resolve(dir);
+    }
+  });
+}
+
+/**
+ * Check if a resolved path is inside a conversation attachments subdirectory.
+ * Matches: <conversationsDir>/<conversationId>/attachments/...
+ */
+function isConversationAttachmentPath(resolvedPath: string): boolean {
+  const conversationsDir = join(getWorkspaceDir(), "conversations");
+  let resolvedConversationsDir: string;
+  try {
+    resolvedConversationsDir = realpathSync(conversationsDir);
+  } catch {
+    resolvedConversationsDir = resolve(conversationsDir);
+  }
+
+  if (!isPathWithinDirectory(resolvedPath, resolvedConversationsDir)) {
+    return false;
+  }
+
+  // Extract the relative path after conversations/ and verify it contains
+  // an "attachments" segment: <conversationId>/attachments/...
+  const relativePath = resolvedPath.slice(resolvedConversationsDir.length + 1);
+  const segments = relativePath.split(sep);
+  return segments.length >= 3 && segments[1] === "attachments";
 }
 
 export function resolveAllowedFileBackedAttachmentPath(
@@ -58,9 +79,13 @@ export function resolveAllowedFileBackedAttachmentPath(
 ): string | null {
   const resolvedPath = resolveCanonicalPath(filePath);
   const allowedDirs = resolveAllowedAttachmentDirectories();
-  return allowedDirs.some((dir) => isPathWithinDirectory(resolvedPath, dir))
-    ? resolvedPath
-    : null;
+  if (allowedDirs.some((dir) => isPathWithinDirectory(resolvedPath, dir))) {
+    return resolvedPath;
+  }
+  if (isConversationAttachmentPath(resolvedPath)) {
+    return resolvedPath;
+  }
+  return null;
 }
 
 export async function handleUploadAttachment(req: Request): Promise<Response> {
@@ -219,15 +244,17 @@ export function handleGetAttachmentContent(
   attachmentId: string,
   req: Request,
 ): Response {
+  // Check for file-backed attachment first so we can skip hydration — file-backed
+  // content is served directly from disk via Bun.file, not from the hydrated base64.
+  const filePath = getFilePathForAttachment(attachmentId);
+  const isFileBacked = !!filePath;
+
   const attachment = attachmentsStore.getAttachmentById(attachmentId, {
-    hydrateFileData: true,
+    hydrateFileData: !isFileBacked,
   });
   if (!attachment) {
     return httpError("NOT_FOUND", "Attachment not found", 404);
   }
-
-  // Check for file-backed attachment
-  const filePath = getFilePathForAttachment(attachmentId);
   if (filePath) {
     const resolvedPath = resolveAllowedFileBackedAttachmentPath(filePath);
     if (!resolvedPath) {

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -229,7 +229,9 @@ function handleGetAttachment(attachmentId: string): Response {
     mimeType: attachment.mimeType,
     sizeBytes: attachment.sizeBytes,
     kind: attachment.kind,
-    data: attachment.dataBase64,
+    // Return null for file-backed attachments so the gateway's hydration check
+    // (payload.data == null) triggers a fetch from the /content endpoint.
+    data: isFileBacked ? null : attachment.dataBase64,
     // Signal to clients that they should fetch content via the /content endpoint
     ...(isFileBacked ? { fileBacked: true } : {}),
   });

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -37,17 +37,20 @@ function resolveAllowedAttachmentDirectories(): string[] {
     "data",
     "attachments",
   );
+  const conversationsDir = join(getWorkspaceDir(), "conversations");
   const recordingsDir = join(
     process.env.HOME ?? "",
     "Library/Application Support/vellum-assistant/recordings",
   );
-  return [workspaceAttachmentsDir, recordingsDir].map((dir) => {
-    try {
-      return realpathSync(dir);
-    } catch {
-      return resolve(dir);
-    }
-  });
+  return [workspaceAttachmentsDir, conversationsDir, recordingsDir].map(
+    (dir) => {
+      try {
+        return realpathSync(dir);
+      } catch {
+        return resolve(dir);
+      }
+    },
+  );
 }
 
 export function resolveAllowedFileBackedAttachmentPath(

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -184,16 +184,19 @@ export async function handleDeleteAttachment(req: Request): Promise<Response> {
 }
 
 function handleGetAttachment(attachmentId: string): Response {
+  // Use the file_path column to detect file-backed attachments, not string
+  // truthiness of dataBase64 (which would also match valid zero-byte uploads).
+  const isFileBacked = !!getFilePathForAttachment(attachmentId);
+
+  // Skip hydrating file data for file-backed attachments — clients should
+  // fetch content via GET /attachments/:id/content (which validates the path
+  // against the directory allowlist).
   const attachment = attachmentsStore.getAttachmentById(attachmentId, {
-    hydrateFileData: true,
+    hydrateFileData: !isFileBacked,
   });
   if (!attachment) {
     return httpError("NOT_FOUND", "Attachment not found", 404);
   }
-
-  // Use the file_path column to detect file-backed attachments, not string
-  // truthiness of dataBase64 (which would also match valid zero-byte uploads).
-  const isFileBacked = !!getFilePathForAttachment(attachmentId);
 
   return Response.json({
     id: attachment.id,


### PR DESCRIPTION
## Summary

- Add `resolveAllowedFileBackedAttachmentPath()` to validate file-backed attachment paths against an allowlist of two directories: workspace attachments (`data/attachments`) and recordings (`~/Library/Application Support/vellum-assistant/recordings`)
- Guard both the upload handler (`POST /attachments`) and content endpoint (`GET /attachments/:id/content`) with the allowlist check, using `realpathSync` to prevent symlink traversal
- Add unit tests verifying allowed paths are accepted and paths outside the allowlist are rejected

Codex finding: https://chatgpt.com/codex/security/findings/e9c459e630508191b3aeb4a351f9a7f6?sev=critical%2Chigh

## Original prompt

Security fix: Add directory allowlist validation to file-backed attachment uploads

The file-backed attachment upload path (`POST /attachments` with `filePath` and no `data`) accepts arbitrary file paths and stores them verbatim. The content endpoint (`GET /attachments/:id/content`) then streams the file directly from disk via `Bun.file()`. This enables arbitrary file read on the runtime host for any authenticated client with `attachments.write` + `attachments.read` scopes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
