### PR TITLE
fix(recovery-mode): fix decode error + rename Maintenance Mode → Recovery Mode

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -43,15 +43,15 @@ struct ChatView: View {
     var onOpenModelsAndServices: (() -> Void)? = nil
     var onBootstrapSendLogs: (() -> Void)?
 
-    // MARK: - Maintenance Mode (managed assistants only)
+    // MARK: - Recovery Mode (managed assistants only)
 
-    /// Non-nil when the connected managed assistant is in maintenance mode.
-    /// When set and `enabled == true`, a `MaintenanceModeBanner` is rendered
+    /// Non-nil when the connected managed assistant is in recovery mode.
+    /// When set and `enabled == true`, a `RecoveryModeBanner` is rendered
     /// between the message list and the composer.
-    var maintenanceMode: PlatformAssistantMaintenanceMode? = nil
+    var recoveryMode: PlatformAssistantRecoveryMode? = nil
 
-    /// `true` while an exit-maintenance-mode request is in flight.
-    var isMaintenanceModeExiting: Bool = false
+    /// `true` while an exit-recovery-mode request is in flight.
+    var isRecoveryModeExiting: Bool = false
 
     /// Invoked when the user taps "Resume Assistant" in the maintenance banner.
     var onResumeAssistant: (() -> Void)? = nil
@@ -359,12 +359,12 @@ struct ChatView: View {
                 .padding(.bottom, -VSpacing.sm)
             }
 
-            if let mode = maintenanceMode, mode.enabled {
-                MaintenanceModeBanner(
-                    maintenanceMode: mode,
+            if let mode = recoveryMode, mode.enabled {
+                RecoveryModeBanner(
+                    recoveryMode: mode,
                     onResumeAssistant: { onResumeAssistant?() },
                     onOpenSSHSettings: { onOpenSSHSettings?() },
-                    isExiting: isMaintenanceModeExiting
+                    isExiting: isRecoveryModeExiting
                 )
                 .frame(maxWidth: VSpacing.chatColumnMaxWidth - 2 * VSpacing.xl)
                 .frame(maxWidth: .infinity)

--- a/clients/macos/vellum-assistant/Features/Chat/RecoveryModeBanner.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/RecoveryModeBanner.swift
@@ -1,32 +1,32 @@
 import SwiftUI
 import VellumAssistantShared
 
-// MARK: - Maintenance Mode Banner
+// MARK: - Recovery Mode Banner
 
-/// Inline banner shown when the connected managed assistant is in maintenance mode.
+/// Inline banner shown when the connected managed assistant is in recovery mode.
 ///
 /// The banner identifies the debug pod that currently has the workspace PVC mounted
 /// and provides two recovery actions:
-///  - **Resume Assistant** — exits maintenance mode via the platform API.
+///  - **Resume Assistant** — exits recovery mode via the platform API.
 ///  - **Open SSH Settings** — navigates to the Developer settings tab where the
 ///    SSH terminal and maintenance controls live.
 ///
 /// Uses the same visual pattern as `CreditsExhaustedBanner` and `MissingApiKeyBanner`:
 /// anchored at the bottom of the message list, above the composer.
-struct MaintenanceModeBanner: View {
-    /// The current maintenance-mode payload. The banner is only visible when
-    /// `maintenanceMode.enabled == true`.
-    let maintenanceMode: PlatformAssistantMaintenanceMode
+struct RecoveryModeBanner: View {
+    /// The current recovery-mode payload. The banner is only visible when
+    /// `recoveryMode.enabled == true`.
+    let recoveryMode: PlatformAssistantRecoveryMode
 
     /// Invoked when the user taps "Resume Assistant". Should call
-    /// `SettingsStore.exitManagedAssistantMaintenanceMode()`.
+    /// `SettingsStore.exitManagedAssistantRecoveryMode()`.
     let onResumeAssistant: () -> Void
 
     /// Invoked when the user taps "Open SSH Settings". Should navigate to the
     /// Developer settings tab.
     let onOpenSSHSettings: () -> Void
 
-    /// `true` while an exit-maintenance-mode request is in flight.
+    /// `true` while an exit-recovery-mode request is in flight.
     var isExiting: Bool = false
 
     var body: some View {
@@ -38,11 +38,11 @@ struct MaintenanceModeBanner: View {
                     .accessibilityHidden(true)
 
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("Assistant in Maintenance Mode")
+                    Text("Assistant in Recovery Mode")
                         .font(VFont.bodySmallEmphasised)
                         .foregroundStyle(VColor.contentEmphasized)
 
-                    if let podName = maintenanceMode.debug_pod_name, !podName.isEmpty {
+                    if let podName = recoveryMode.debug_pod_name, !podName.isEmpty {
                         Text("Debug pod \(podName) has the workspace mounted.")
                             .font(VFont.bodyMediumDefault)
                             .foregroundStyle(VColor.contentSecondary)

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -632,7 +632,7 @@ struct ActiveChatViewWrapper: View {
                 onBootstrapSendLogs: {
                     AppDelegate.shared?.showLogReportWindow(reason: .connectionIssue)
                 },
-                maintenanceMode: settingsStore.managedAssistantRecoveryMode,
+                recoveryMode: settingsStore.managedAssistantRecoveryMode,
                 isRecoveryModeExiting: settingsStore.recoveryModeExiting,
                 onResumeAssistant: {
                     settingsStore.exitManagedAssistantRecoveryMode()

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -632,10 +632,10 @@ struct ActiveChatViewWrapper: View {
                 onBootstrapSendLogs: {
                     AppDelegate.shared?.showLogReportWindow(reason: .connectionIssue)
                 },
-                maintenanceMode: settingsStore.managedAssistantMaintenanceMode,
-                isMaintenanceModeExiting: settingsStore.maintenanceModeExiting,
+                maintenanceMode: settingsStore.managedAssistantRecoveryMode,
+                isRecoveryModeExiting: settingsStore.recoveryModeExiting,
                 onResumeAssistant: {
-                    settingsStore.exitManagedAssistantMaintenanceMode()
+                    settingsStore.exitManagedAssistantRecoveryMode()
                 },
                 onOpenSSHSettings: {
                     settingsStore.pendingSettingsTab = .developer

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
@@ -212,7 +212,7 @@ private struct ThreadWindowContentView: View {
                         settingsStore.pendingSettingsTab = .modelsAndServices
                         AppDelegate.shared?.showSettingsWindow(nil)
                     },
-                    maintenanceMode: settingsStore.managedAssistantRecoveryMode,
+                    recoveryMode: settingsStore.managedAssistantRecoveryMode,
                     isRecoveryModeExiting: settingsStore.recoveryModeExiting,
                     onResumeAssistant: {
                         settingsStore.exitManagedAssistantRecoveryMode()

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
@@ -212,10 +212,10 @@ private struct ThreadWindowContentView: View {
                         settingsStore.pendingSettingsTab = .modelsAndServices
                         AppDelegate.shared?.showSettingsWindow(nil)
                     },
-                    maintenanceMode: settingsStore.managedAssistantMaintenanceMode,
-                    isMaintenanceModeExiting: settingsStore.maintenanceModeExiting,
+                    maintenanceMode: settingsStore.managedAssistantRecoveryMode,
+                    isRecoveryModeExiting: settingsStore.recoveryModeExiting,
                     onResumeAssistant: {
-                        settingsStore.exitManagedAssistantMaintenanceMode()
+                        settingsStore.exitManagedAssistantRecoveryMode()
                     },
                     onOpenSSHSettings: {
                         settingsStore.pendingSettingsTab = .developer

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -686,39 +686,39 @@ struct SettingsDeveloperTab: View {
 
     /// `true` while either a maintenance-enter or maintenance-exit request is in flight.
     private var maintenanceTransitionInFlight: Bool {
-        store.maintenanceModeEntering || store.maintenanceModeExiting
+        store.recoveryModeEntering || store.recoveryModeExiting
     }
 
     private var sshTerminalSection: some View {
         SettingsCard(
             title: "SSH Terminal",
-            subtitle: "Maintenance mode pauses the normal assistant pod and routes terminal sessions into the mounted debug pod, giving you direct access to the assistant's workspace PVC."
+            subtitle: "Recovery mode pauses the normal assistant pod and routes terminal sessions into the mounted debug pod, giving you direct access to the assistant's workspace PVC."
         ) {
-            // Maintenance mode status row
-            maintenanceModeStatusRow
+            // Recovery mode status row
+            recoveryModeStatusRow
 
             SettingsDivider()
 
-            // Maintenance mode action buttons
+            // Recovery mode action buttons
             HStack(spacing: VSpacing.sm) {
-                if store.managedAssistantMaintenanceMode?.enabled == true {
+                if store.managedAssistantRecoveryMode?.enabled == true {
                     VButton(
                         label: "Resume Assistant",
                         style: .outlined,
                         isDisabled: maintenanceTransitionInFlight
                     ) {
-                        store.exitManagedAssistantMaintenanceMode()
+                        store.exitManagedAssistantRecoveryMode()
                     }
                     .accessibilityLabel("Resume Assistant")
                 } else {
                     VButton(
-                        label: "Enter Maintenance Mode",
+                        label: "Enter Recovery Mode",
                         style: .outlined,
                         isDisabled: maintenanceTransitionInFlight
                     ) {
-                        store.enterManagedAssistantMaintenanceMode()
+                        store.enterManagedAssistantRecoveryMode()
                     }
-                    .accessibilityLabel("Enter Maintenance Mode")
+                    .accessibilityLabel("Enter Recovery Mode")
                 }
 
                 VButton(label: "Open Terminal", style: .primary) {
@@ -728,12 +728,12 @@ struct SettingsDeveloperTab: View {
             }
 
             // Show inline error messages if a maintenance operation fails.
-            if let enterError = store.maintenanceModeEnterError {
+            if let enterError = store.recoveryModeEnterError {
                 Text(enterError)
                     .font(VFont.labelDefault)
                     .foregroundStyle(VColor.systemNegativeStrong)
             }
-            if let exitError = store.maintenanceModeExitError {
+            if let exitError = store.recoveryModeExitError {
                 Text(exitError)
                     .font(VFont.labelDefault)
                     .foregroundStyle(VColor.systemNegativeStrong)
@@ -742,17 +742,17 @@ struct SettingsDeveloperTab: View {
     }
 
     @ViewBuilder
-    private var maintenanceModeStatusRow: some View {
-        if store.maintenanceModeRefreshing {
+    private var recoveryModeStatusRow: some View {
+        if store.recoveryModeRefreshing {
             HStack(spacing: VSpacing.sm) {
                 ProgressView()
                     .controlSize(.mini)
                     .progressViewStyle(.circular)
-                Text("Loading maintenance status…")
+                Text("Loading recovery status…")
                     .font(VFont.labelDefault)
                     .foregroundStyle(VColor.contentTertiary)
             }
-        } else if let maintenance = store.managedAssistantMaintenanceMode {
+        } else if let maintenance = store.managedAssistantRecoveryMode {
             if maintenance.enabled {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     HStack(spacing: VSpacing.xs) {
@@ -760,10 +760,10 @@ struct SettingsDeveloperTab: View {
                             .fill(VColor.systemMidStrong)
                             .frame(width: 8, height: 8)
                             .accessibilityHidden(true)
-                        Text("Maintenance mode active")
+                        Text("Recovery mode active")
                             .font(VFont.bodyMediumDefault)
                             .foregroundStyle(VColor.contentDefault)
-                            .accessibilityValue("Maintenance mode active")
+                            .accessibilityValue("Recovery mode active")
                     }
                     if let podName = maintenance.debug_pod_name, !podName.isEmpty {
                         Text("Debug pod: \(podName)")
@@ -786,10 +786,10 @@ struct SettingsDeveloperTab: View {
             }
         } else {
             VStack(alignment: .leading, spacing: VSpacing.xs) {
-                Text("Maintenance status unavailable")
+                Text("Recovery status unavailable")
                     .font(VFont.labelDefault)
                     .foregroundStyle(VColor.contentTertiary)
-                if let refreshError = store.maintenanceModeRefreshError {
+                if let refreshError = store.recoveryModeRefreshError {
                     Text(refreshError)
                         .font(VFont.labelDefault)
                         .foregroundStyle(VColor.systemNegativeStrong)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -244,29 +244,29 @@ public final class SettingsStore: ObservableObject {
         "brave": "Brave",
     ]
 
-    // MARK: - Managed Assistant Maintenance Mode State
+    // MARK: - Managed Assistant Recovery Mode State
 
-    /// Current maintenance-mode payload for the selected managed assistant.
+    /// Current recovery-mode payload for the selected managed assistant.
     /// `nil` when not in a managed context or when the state has not yet been loaded.
-    @Published var managedAssistantMaintenanceMode: PlatformAssistantMaintenanceMode?
+    @Published var managedAssistantRecoveryMode: PlatformAssistantRecoveryMode?
 
-    /// `true` while a maintenance-mode refresh is in flight.
-    @Published var maintenanceModeRefreshing: Bool = false
+    /// `true` while a recovery-mode refresh is in flight.
+    @Published var recoveryModeRefreshing: Bool = false
 
-    /// `true` while an enter-maintenance-mode request is in flight.
-    @Published var maintenanceModeEntering: Bool = false
+    /// `true` while an enter-recovery-mode request is in flight.
+    @Published var recoveryModeEntering: Bool = false
 
-    /// `true` while an exit-maintenance-mode request is in flight.
-    @Published var maintenanceModeExiting: Bool = false
+    /// `true` while an exit-recovery-mode request is in flight.
+    @Published var recoveryModeExiting: Bool = false
 
     /// Non-nil when the most recent refresh failed.
-    @Published var maintenanceModeRefreshError: String?
+    @Published var recoveryModeRefreshError: String?
 
-    /// Non-nil when the most recent enter-maintenance-mode call failed.
-    @Published var maintenanceModeEnterError: String?
+    /// Non-nil when the most recent enter-recovery-mode call failed.
+    @Published var recoveryModeEnterError: String?
 
-    /// Non-nil when the most recent exit-maintenance-mode call failed.
-    @Published var maintenanceModeExitError: String?
+    /// Non-nil when the most recent exit-recovery-mode call failed.
+    @Published var recoveryModeExitError: String?
 
     // MARK: - Platform Config State
 
@@ -603,13 +603,13 @@ public final class SettingsStore: ObservableObject {
 
         // Twilio config is now handled via HTTP — no callback wiring needed.
 
-        // Refresh maintenance-mode state when the app returns to the foreground
+        // Refresh recovery-mode state when the app returns to the foreground
         // so the UI stays current if maintenance was toggled elsewhere.
         NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
                 Task { @MainActor [weak self] in
-                    await self?.refreshManagedAssistantMaintenanceMode()
+                    await self?.refreshManagedAssistantRecoveryMode()
                 }
             }
             .store(in: &cancellables)
@@ -628,15 +628,15 @@ public final class SettingsStore: ObservableObject {
                 // Also clear in-flight flags so the new assistant's UI starts clean
                 // rather than inheriting a spinner from the previous assistant's
                 // in-progress mutation.
-                self.managedAssistantMaintenanceMode = nil
-                self.maintenanceModeRefreshError = nil
-                self.maintenanceModeEnterError = nil
-                self.maintenanceModeExitError = nil
-                self.maintenanceModeEntering = false
-                self.maintenanceModeExiting = false
-                self.maintenanceModeRefreshing = false
+                self.managedAssistantRecoveryMode = nil
+                self.recoveryModeRefreshError = nil
+                self.recoveryModeEnterError = nil
+                self.recoveryModeExitError = nil
+                self.recoveryModeEntering = false
+                self.recoveryModeExiting = false
+                self.recoveryModeRefreshing = false
                 Task { @MainActor [weak self] in
-                    await self?.refreshManagedAssistantMaintenanceMode()
+                    await self?.refreshManagedAssistantRecoveryMode()
                 }
             }
             .store(in: &cancellables)
@@ -651,15 +651,15 @@ public final class SettingsStore: ObservableObject {
                 guard let self else { return }
                 // Same as the connectedAssistantId sink: clear in-flight flags so
                 // the new context's UI starts clean.
-                self.managedAssistantMaintenanceMode = nil
-                self.maintenanceModeRefreshError = nil
-                self.maintenanceModeEnterError = nil
-                self.maintenanceModeExitError = nil
-                self.maintenanceModeEntering = false
-                self.maintenanceModeExiting = false
-                self.maintenanceModeRefreshing = false
+                self.managedAssistantRecoveryMode = nil
+                self.recoveryModeRefreshError = nil
+                self.recoveryModeEnterError = nil
+                self.recoveryModeExitError = nil
+                self.recoveryModeEntering = false
+                self.recoveryModeExiting = false
+                self.recoveryModeRefreshing = false
                 Task { @MainActor [weak self] in
-                    await self?.refreshManagedAssistantMaintenanceMode()
+                    await self?.refreshManagedAssistantRecoveryMode()
                 }
             }
             .store(in: &cancellables)
@@ -670,14 +670,14 @@ public final class SettingsStore: ObservableObject {
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
                 Task { @MainActor [weak self] in
-                    await self?.refreshManagedAssistantMaintenanceMode()
+                    await self?.refreshManagedAssistantRecoveryMode()
                 }
             }
             .store(in: &cancellables)
 
         // Perform the initial load.
         Task { @MainActor [weak self] in
-            await self?.refreshManagedAssistantMaintenanceMode()
+            await self?.refreshManagedAssistantRecoveryMode()
         }
 
         // Watch workspace config.json for external mutations (e.g. model
@@ -2536,36 +2536,36 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
-    // MARK: - Managed Assistant Maintenance Mode Actions
+    // MARK: - Managed Assistant Recovery Mode Actions
 
-    /// Fetches the current maintenance-mode state for the selected managed assistant
-    /// and updates `managedAssistantMaintenanceMode`.
+    /// Fetches the current recovery-mode state for the selected managed assistant
+    /// and updates `managedAssistantRecoveryMode`.
     ///
     /// This is a no-op when the connected assistant is not managed.
-    func refreshManagedAssistantMaintenanceMode() async {
+    func refreshManagedAssistantRecoveryMode() async {
         guard let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
               !connectedId.isEmpty,
               let assistant = LockfileAssistant.loadByName(connectedId),
               assistant.isManaged else {
             // Not a managed assistant — clear any stale state.
-            managedAssistantMaintenanceMode = nil
-            maintenanceModeRefreshError = nil
+            managedAssistantRecoveryMode = nil
+            recoveryModeRefreshError = nil
             return
         }
 
         let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") ?? ""
         guard !orgId.isEmpty else {
-            log.warning("Cannot refresh maintenance mode: no connectedOrganizationId set")
+            log.warning("Cannot refresh recovery mode: no connectedOrganizationId set")
             return
         }
 
         let taskAssistantId = connectedId
 
-        maintenanceModeRefreshing = true
-        maintenanceModeRefreshError = nil
+        recoveryModeRefreshing = true
+        recoveryModeRefreshError = nil
         defer {
             if UserDefaults.standard.string(forKey: "connectedAssistantId") == taskAssistantId {
-                maintenanceModeRefreshing = false
+                recoveryModeRefreshing = false
             }
         }
 
@@ -2578,132 +2578,132 @@ public final class SettingsStore: ObservableObject {
             // assistant and connected organization haven't changed while the request was in flight.
             let currentConnectedId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
             guard currentConnectedId == connectedId else {
-                log.info("Discarding stale maintenance-mode response for assistant \(assistant.assistantId, privacy: .public): assistant changed to '\(currentConnectedId, privacy: .public)' while request was in flight")
+                log.info("Discarding stale recovery-mode response for assistant \(assistant.assistantId, privacy: .public): assistant changed to '\(currentConnectedId, privacy: .public)' while request was in flight")
                 return
             }
             let currentOrgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") ?? ""
             guard currentOrgId == orgId else {
-                log.info("Discarding stale maintenance-mode response for assistant \(assistant.assistantId, privacy: .public): organization changed to '\(currentOrgId, privacy: .public)' while request was in flight")
+                log.info("Discarding stale recovery-mode response for assistant \(assistant.assistantId, privacy: .public): organization changed to '\(currentOrgId, privacy: .public)' while request was in flight")
                 return
             }
-            managedAssistantMaintenanceMode = updated.maintenance_mode
-            log.info("Refreshed maintenance mode for assistant \(assistant.assistantId, privacy: .public): enabled=\(updated.maintenance_mode?.enabled ?? false)")
+            managedAssistantRecoveryMode = updated.recovery_mode
+            log.info("Refreshed recovery mode for assistant \(assistant.assistantId, privacy: .public): enabled=\(updated.recovery_mode?.enabled ?? false)")
         } catch {
-            maintenanceModeRefreshError = error.localizedDescription
-            log.error("Failed to refresh maintenance mode for assistant \(assistant.assistantId, privacy: .public): \(error)")
+            recoveryModeRefreshError = error.localizedDescription
+            log.error("Failed to refresh recovery mode for assistant \(assistant.assistantId, privacy: .public): \(error)")
         }
     }
 
-    /// Enters maintenance mode for the selected managed assistant.
+    /// Enters recovery mode for the selected managed assistant.
     ///
-    /// Sets `maintenanceModeEntering` while the request is in flight and updates
-    /// `managedAssistantMaintenanceMode` on success.
-    func enterManagedAssistantMaintenanceMode() {
+    /// Sets `recoveryModeEntering` while the request is in flight and updates
+    /// `managedAssistantRecoveryMode` on success.
+    func enterManagedAssistantRecoveryMode() {
         Task {
             guard let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
                   !connectedId.isEmpty,
                   let assistant = LockfileAssistant.loadByName(connectedId),
                   assistant.isManaged else {
-                maintenanceModeEnterError = "No managed assistant selected"
+                recoveryModeEnterError = "No managed assistant selected"
                 return
             }
 
             let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") ?? ""
             guard !orgId.isEmpty else {
-                maintenanceModeEnterError = "No organization ID available"
+                recoveryModeEnterError = "No organization ID available"
                 return
             }
 
             let taskAssistantId = connectedId
 
-            maintenanceModeEntering = true
-            maintenanceModeEnterError = nil
+            recoveryModeEntering = true
+            recoveryModeEnterError = nil
             defer {
                 if UserDefaults.standard.string(forKey: "connectedAssistantId") == taskAssistantId {
-                    maintenanceModeEntering = false
+                    recoveryModeEntering = false
                 }
             }
 
             do {
-                let updated = try await AuthService.shared.enterMaintenanceMode(
+                let updated = try await AuthService.shared.enterRecoveryMode(
                     assistantId: assistant.assistantId,
                     organizationId: orgId
                 )
                 // Guard against stale responses: only apply the result if both the
                 // connected assistant and connected organization haven't changed while
-                // the request was in flight (same pattern as refreshManagedAssistantMaintenanceMode).
+                // the request was in flight (same pattern as refreshManagedAssistantRecoveryMode).
                 let currentConnectedId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
                 guard currentConnectedId == connectedId else {
-                    log.info("Discarding stale enter-maintenance-mode response for assistant \(assistant.assistantId, privacy: .public): assistant changed to '\(currentConnectedId, privacy: .public)' while request was in flight")
+                    log.info("Discarding stale enter-recovery-mode response for assistant \(assistant.assistantId, privacy: .public): assistant changed to '\(currentConnectedId, privacy: .public)' while request was in flight")
                     return
                 }
                 let currentOrgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") ?? ""
                 guard currentOrgId == orgId else {
-                    log.info("Discarding stale enter-maintenance-mode response for assistant \(assistant.assistantId, privacy: .public): organization changed to '\(currentOrgId, privacy: .public)' while request was in flight")
+                    log.info("Discarding stale enter-recovery-mode response for assistant \(assistant.assistantId, privacy: .public): organization changed to '\(currentOrgId, privacy: .public)' while request was in flight")
                     return
                 }
-                managedAssistantMaintenanceMode = updated.maintenance_mode
-                log.info("Entered maintenance mode for assistant \(assistant.assistantId, privacy: .public)")
+                managedAssistantRecoveryMode = updated.recovery_mode
+                log.info("Entered recovery mode for assistant \(assistant.assistantId, privacy: .public)")
             } catch {
-                maintenanceModeEnterError = error.localizedDescription
-                log.error("Failed to enter maintenance mode for assistant \(assistant.assistantId, privacy: .public): \(error)")
+                recoveryModeEnterError = error.localizedDescription
+                log.error("Failed to enter recovery mode for assistant \(assistant.assistantId, privacy: .public): \(error)")
             }
         }
     }
 
-    /// Exits maintenance mode for the selected managed assistant.
+    /// Exits recovery mode for the selected managed assistant.
     ///
-    /// Sets `maintenanceModeExiting` while the request is in flight and updates
-    /// `managedAssistantMaintenanceMode` on success.
-    func exitManagedAssistantMaintenanceMode() {
+    /// Sets `recoveryModeExiting` while the request is in flight and updates
+    /// `managedAssistantRecoveryMode` on success.
+    func exitManagedAssistantRecoveryMode() {
         Task {
             guard let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
                   !connectedId.isEmpty,
                   let assistant = LockfileAssistant.loadByName(connectedId),
                   assistant.isManaged else {
-                maintenanceModeExitError = "No managed assistant selected"
+                recoveryModeExitError = "No managed assistant selected"
                 return
             }
 
             let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") ?? ""
             guard !orgId.isEmpty else {
-                maintenanceModeExitError = "No organization ID available"
+                recoveryModeExitError = "No organization ID available"
                 return
             }
 
             let taskAssistantId = connectedId
 
-            maintenanceModeExiting = true
-            maintenanceModeExitError = nil
+            recoveryModeExiting = true
+            recoveryModeExitError = nil
             defer {
                 if UserDefaults.standard.string(forKey: "connectedAssistantId") == taskAssistantId {
-                    maintenanceModeExiting = false
+                    recoveryModeExiting = false
                 }
             }
 
             do {
-                let updated = try await AuthService.shared.exitMaintenanceMode(
+                let updated = try await AuthService.shared.exitRecoveryMode(
                     assistantId: assistant.assistantId,
                     organizationId: orgId
                 )
                 // Guard against stale responses: only apply the result if both the
                 // connected assistant and connected organization haven't changed while
-                // the request was in flight (same pattern as refreshManagedAssistantMaintenanceMode).
+                // the request was in flight (same pattern as refreshManagedAssistantRecoveryMode).
                 let currentConnectedId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
                 guard currentConnectedId == connectedId else {
-                    log.info("Discarding stale exit-maintenance-mode response for assistant \(assistant.assistantId, privacy: .public): assistant changed to '\(currentConnectedId, privacy: .public)' while request was in flight")
+                    log.info("Discarding stale exit-recovery-mode response for assistant \(assistant.assistantId, privacy: .public): assistant changed to '\(currentConnectedId, privacy: .public)' while request was in flight")
                     return
                 }
                 let currentOrgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") ?? ""
                 guard currentOrgId == orgId else {
-                    log.info("Discarding stale exit-maintenance-mode response for assistant \(assistant.assistantId, privacy: .public): organization changed to '\(currentOrgId, privacy: .public)' while request was in flight")
+                    log.info("Discarding stale exit-recovery-mode response for assistant \(assistant.assistantId, privacy: .public): organization changed to '\(currentOrgId, privacy: .public)' while request was in flight")
                     return
                 }
-                managedAssistantMaintenanceMode = updated.maintenance_mode
-                log.info("Exited maintenance mode for assistant \(assistant.assistantId, privacy: .public)")
+                managedAssistantRecoveryMode = updated.recovery_mode
+                log.info("Exited recovery mode for assistant \(assistant.assistantId, privacy: .public)")
             } catch {
-                maintenanceModeExitError = error.localizedDescription
-                log.error("Failed to exit maintenance mode for assistant \(assistant.assistantId, privacy: .public): \(error)")
+                recoveryModeExitError = error.localizedDescription
+                log.error("Failed to exit recovery mode for assistant \(assistant.assistantId, privacy: .public): \(error)")
             }
         }
     }

--- a/clients/macos/vellum-assistantTests/ChatMaintenanceBannerTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatMaintenanceBannerTests.swift
@@ -3,21 +3,21 @@ import SwiftUI
 @testable import VellumAssistantLib
 @testable import VellumAssistantShared
 
-// MARK: - MaintenanceModeBanner Logic Tests
+// MARK: - RecoveryModeBanner Logic Tests
 
-/// Tests for `MaintenanceModeBanner` and the maintenance-banner props on `ChatView`.
+/// Tests for `RecoveryModeBanner` and the maintenance-banner props on `ChatView`.
 ///
 /// These tests focus on observable behaviour — callback invocation and conditional
 /// rendering logic — rather than pixel-level layout, because the app's no-Preview
 /// policy means we don't spin up full SwiftUI rendering in tests.
 
-@Suite("MaintenanceModeBanner — Banner visibility")
-struct MaintenanceBannerVisibilityTests {
+@Suite("RecoveryModeBanner — Banner visibility")
+struct RecoveryBannerVisibilityTests {
 
-    /// Banner should be shown when maintenance mode is enabled.
+    /// Banner should be shown when recovery mode is enabled.
     @Test @MainActor
-    func bannerShownWhenMaintenanceModeEnabled() {
-        let mode = PlatformAssistantMaintenanceMode(
+    func bannerShownWhenRecoveryModeEnabled() {
+        let mode = PlatformAssistantRecoveryMode(
             enabled: true,
             entered_at: "2026-03-30T10:00:00Z",
             debug_pod_name: "debug-pod-alpha"
@@ -27,10 +27,10 @@ struct MaintenanceBannerVisibilityTests {
         #expect(mode.debug_pod_name == "debug-pod-alpha")
     }
 
-    /// Banner should not be shown when maintenance mode is disabled.
+    /// Banner should not be shown when recovery mode is disabled.
     @Test @MainActor
-    func bannerHiddenWhenMaintenanceModeDisabled() {
-        let mode = PlatformAssistantMaintenanceMode(
+    func bannerHiddenWhenRecoveryModeDisabled() {
+        let mode = PlatformAssistantRecoveryMode(
             enabled: false,
             entered_at: nil,
             debug_pod_name: nil
@@ -39,19 +39,19 @@ struct MaintenanceBannerVisibilityTests {
         #expect(mode.enabled == false)
     }
 
-    /// Banner should not be shown when maintenanceMode is nil (non-managed or unloaded).
+    /// Banner should not be shown when recoveryMode is nil (non-managed or unloaded).
     @Test @MainActor
-    func bannerHiddenWhenMaintenanceModeNil() {
-        let mode: PlatformAssistantMaintenanceMode? = nil
-        // ChatView guards with `if let mode = maintenanceMode, mode.enabled`
+    func bannerHiddenWhenRecoveryModeNil() {
+        let mode: PlatformAssistantRecoveryMode? = nil
+        // ChatView guards with `if let mode = recoveryMode, mode.enabled`
         #expect(mode == nil)
     }
 }
 
-// MARK: - MaintenanceModeBanner — Callback Invocation
+// MARK: - RecoveryModeBanner — Callback Invocation
 
-@Suite("MaintenanceModeBanner — Primary action: Resume Assistant")
-struct MaintenanceBannerResumeActionTests {
+@Suite("RecoveryModeBanner — Primary action: Resume Assistant")
+struct RecoveryBannerResumeActionTests {
 
     /// Tapping "Resume Assistant" invokes `onResumeAssistant`.
     @Test @MainActor
@@ -59,7 +59,7 @@ struct MaintenanceBannerResumeActionTests {
         var resumeCallCount = 0
         var openSSHCallCount = 0
 
-        let mode = PlatformAssistantMaintenanceMode(
+        let mode = PlatformAssistantRecoveryMode(
             enabled: true,
             entered_at: "2026-03-30T10:00:00Z",
             debug_pod_name: "debug-pod-beta"
@@ -110,10 +110,10 @@ struct MaintenanceBannerResumeActionTests {
     }
 }
 
-// MARK: - MaintenanceModeBanner — Exiting State
+// MARK: - RecoveryModeBanner — Exiting State
 
-@Suite("MaintenanceModeBanner — Exiting (in-flight) state")
-struct MaintenanceBannerExitingStateTests {
+@Suite("RecoveryModeBanner — Exiting (in-flight) state")
+struct RecoveryBannerExitingStateTests {
 
     /// While exiting, `isExiting` is true; after completion it should be false.
     @Test @MainActor
@@ -130,15 +130,15 @@ struct MaintenanceBannerExitingStateTests {
     }
 }
 
-// MARK: - MaintenanceModeBanner — Debug Pod Name Display
+// MARK: - RecoveryModeBanner — Debug Pod Name Display
 
-@Suite("MaintenanceModeBanner — Debug pod name")
-struct MaintenanceBannerDebugPodNameTests {
+@Suite("RecoveryModeBanner — Debug pod name")
+struct RecoveryBannerDebugPodNameTests {
 
     /// When `debug_pod_name` is set, it should be surfaced to the user.
     @Test @MainActor
     func debugPodNamePresent() {
-        let mode = PlatformAssistantMaintenanceMode(
+        let mode = PlatformAssistantRecoveryMode(
             enabled: true,
             entered_at: "2026-03-30T10:00:00Z",
             debug_pod_name: "debug-pod-gamma"
@@ -149,7 +149,7 @@ struct MaintenanceBannerDebugPodNameTests {
     /// When `debug_pod_name` is nil, the banner still renders (fallback copy).
     @Test @MainActor
     func debugPodNameAbsentShowsFallback() {
-        let mode = PlatformAssistantMaintenanceMode(
+        let mode = PlatformAssistantRecoveryMode(
             enabled: true,
             entered_at: "2026-03-30T10:00:00Z",
             debug_pod_name: nil
@@ -162,7 +162,7 @@ struct MaintenanceBannerDebugPodNameTests {
     /// Empty string `debug_pod_name` is treated the same as nil (falls back to generic copy).
     @Test @MainActor
     func emptyDebugPodNameTreatedAsAbsent() {
-        let mode = PlatformAssistantMaintenanceMode(
+        let mode = PlatformAssistantRecoveryMode(
             enabled: true,
             entered_at: nil,
             debug_pod_name: ""
@@ -173,31 +173,31 @@ struct MaintenanceBannerDebugPodNameTests {
     }
 }
 
-// MARK: - ChatView Maintenance Banner Props
+// MARK: - ChatView Recovery Banner Props
 
-@Suite("ChatView — Maintenance banner prop wiring")
-struct ChatViewMaintenancePropTests {
+@Suite("ChatView — Recovery banner prop wiring")
+struct ChatViewRecoveryPropTests {
 
-    /// ChatView renders the banner only for managed assistants in maintenance mode.
+    /// ChatView renders the banner only for managed assistants in recovery mode.
     @Test @MainActor
-    func bannerOnlyRenderedForManagedAssistantInMaintenanceMode() {
-        // Non-managed: nil maintenanceMode → banner absent
-        let nonManagedMode: PlatformAssistantMaintenanceMode? = nil
+    func bannerOnlyRenderedForManagedAssistantInRecoveryMode() {
+        // Non-managed: nil recoveryMode → banner absent
+        let nonManagedMode: PlatformAssistantRecoveryMode? = nil
         let showForNonManaged = nonManagedMode.map { $0.enabled } ?? false
         #expect(showForNonManaged == false)
 
         // Managed, not in maintenance: enabled == false → banner absent
-        let managedNotInMaintenance = PlatformAssistantMaintenanceMode(enabled: false)
-        let showForManagedNotActive = managedNotInMaintenance.enabled
+        let managedNotInRecovery = PlatformAssistantRecoveryMode(enabled: false)
+        let showForManagedNotActive = managedNotInRecovery.enabled
         #expect(showForManagedNotActive == false)
 
         // Managed, in maintenance: enabled == true → banner shown
-        let managedInMaintenance = PlatformAssistantMaintenanceMode(
+        let managedInRecovery = PlatformAssistantRecoveryMode(
             enabled: true,
             entered_at: "2026-03-30T10:00:00Z",
             debug_pod_name: "debug-pod-delta"
         )
-        let showForManagedActive = managedInMaintenance.enabled
+        let showForManagedActive = managedInRecovery.enabled
         #expect(showForManagedActive == true)
     }
 }

--- a/clients/macos/vellum-assistantTests/SettingsDeveloperTabMaintenanceTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsDeveloperTabMaintenanceTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 // MARK: - URLProtocol stub for SSH maintenance UI endpoint calls
 
-private final class DevTabMaintenanceURLProtocol: URLProtocol {
+private final class DevTabRecoveryURLProtocol: URLProtocol {
     static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
 
     override class func canInit(with request: URLRequest) -> Bool { true }
@@ -55,11 +55,11 @@ private func maintenancePayload(
 
 // MARK: - Tests
 
-/// Tests for the store state that drives the SSH Terminal section maintenance-mode
+/// Tests for the store state that drives the SSH Terminal section recovery-mode
 /// controls in `SettingsDeveloperTab`: button visibility logic, disabled states
-/// during mutation, and the active-maintenance status copy values.
+/// during mutation, and the active-recovery status copy values.
 @MainActor
-final class SettingsDeveloperTabMaintenanceTests: XCTestCase {
+final class SettingsDeveloperTabRecoveryTests: XCTestCase {
 
     private let testAssistantId = "devtab-maint-\(UUID().uuidString.prefix(8))"
     private let testOrgId = "org-devtab-\(UUID().uuidString.prefix(8))"
@@ -91,8 +91,8 @@ final class SettingsDeveloperTabMaintenanceTests: XCTestCase {
         UserDefaults.standard.set(testAssistantId, forKey: "connectedAssistantId")
         UserDefaults.standard.set(testOrgId, forKey: "connectedOrganizationId")
 
-        URLProtocol.registerClass(DevTabMaintenanceURLProtocol.self)
-        DevTabMaintenanceURLProtocol.requestHandler = nil
+        URLProtocol.registerClass(DevTabRecoveryURLProtocol.self)
+        DevTabRecoveryURLProtocol.requestHandler = nil
         // Save any existing token so we can restore it in tearDown, preventing
         // the test run from destroying the developer's real session token.
         previousToken = SessionTokenManager.getToken()
@@ -100,8 +100,8 @@ final class SettingsDeveloperTabMaintenanceTests: XCTestCase {
     }
 
     override func tearDown() {
-        URLProtocol.unregisterClass(DevTabMaintenanceURLProtocol.self)
-        DevTabMaintenanceURLProtocol.requestHandler = nil
+        URLProtocol.unregisterClass(DevTabRecoveryURLProtocol.self)
+        DevTabRecoveryURLProtocol.requestHandler = nil
         if let token = previousToken {
             SessionTokenManager.setToken(token)
         } else {
@@ -129,7 +129,7 @@ final class SettingsDeveloperTabMaintenanceTests: XCTestCase {
     }
 
     private func stubSuccess(enabled: Bool, debugPodName: String? = nil, enteredAt: String? = nil) {
-        DevTabMaintenanceURLProtocol.requestHandler = { _ in
+        DevTabRecoveryURLProtocol.requestHandler = { _ in
             let url = URL(string: "https://example.com")!
             let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
             return (response, maintenancePayload(
@@ -142,158 +142,158 @@ final class SettingsDeveloperTabMaintenanceTests: XCTestCase {
     }
 
     private func stubFailure(statusCode: Int = 500) {
-        DevTabMaintenanceURLProtocol.requestHandler = { request in
+        DevTabRecoveryURLProtocol.requestHandler = { request in
             let url = request.url ?? URL(string: "https://example.com")!
             let response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
             return (response, Data("{\"detail\": \"server error\"}".utf8))
         }
     }
 
-    // MARK: - Button visibility: Enter Maintenance Mode shown when not active
+    // MARK: - Button visibility: Enter Recovery Mode shown when not active
 
-    /// When `managedAssistantMaintenanceMode` is nil (initial state), no maintenance
+    /// When `managedAssistantRecoveryMode` is nil (initial state), no maintenance
     /// transition should be in flight and the store should not indicate maintenance is active.
-    func testNoMaintenanceModeActive_whenStateIsNil() {
+    func testNoRecoveryModeActive_whenStateIsNil() {
         let store = makeStore()
-        XCTAssertNil(store.managedAssistantMaintenanceMode,
-                     "Initial maintenance mode state should be nil")
-        XCTAssertFalse(store.maintenanceModeEntering,
-                       "Should not be entering maintenance mode initially")
-        XCTAssertFalse(store.maintenanceModeExiting,
-                       "Should not be exiting maintenance mode initially")
+        XCTAssertNil(store.managedAssistantRecoveryMode,
+                     "Initial recovery mode state should be nil")
+        XCTAssertFalse(store.recoveryModeEntering,
+                       "Should not be entering recovery mode initially")
+        XCTAssertFalse(store.recoveryModeExiting,
+                       "Should not be exiting recovery mode initially")
     }
 
     /// After a successful refresh that returns enabled=false, the SSH section should
-    /// show "Enter Maintenance Mode" (not "Resume Assistant").
-    func testRefreshWithMaintenanceDisabled_stateShowsNotActive() async {
+    /// show "Enter Recovery Mode" (not "Resume Assistant").
+    func testRefreshWithRecoveryDisabled_stateShowsNotActive() async {
         stubSuccess(enabled: false)
         let store = makeStore()
 
-        await store.refreshManagedAssistantMaintenanceMode()
+        await store.refreshManagedAssistantRecoveryMode()
 
-        XCTAssertNotNil(store.managedAssistantMaintenanceMode,
-                        "Maintenance mode state should be populated after refresh")
-        XCTAssertFalse(store.managedAssistantMaintenanceMode!.enabled,
-                       "Maintenance mode should be disabled after refresh with enabled=false")
+        XCTAssertNotNil(store.managedAssistantRecoveryMode,
+                        "Recovery mode state should be populated after refresh")
+        XCTAssertFalse(store.managedAssistantRecoveryMode!.enabled,
+                       "Recovery mode should be disabled after refresh with enabled=false")
     }
 
     // MARK: - Button visibility: Resume Assistant shown when maintenance is active
 
     /// After a successful refresh that returns enabled=true, the SSH section should
-    /// show "Resume Assistant" instead of "Enter Maintenance Mode".
-    func testRefreshWithMaintenanceEnabled_stateShowsActive() async {
+    /// show "Resume Assistant" instead of "Enter Recovery Mode".
+    func testRefreshWithRecoveryEnabled_stateShowsActive() async {
         stubSuccess(enabled: true, debugPodName: "debug-pod-abc123")
         let store = makeStore()
 
-        await store.refreshManagedAssistantMaintenanceMode()
+        await store.refreshManagedAssistantRecoveryMode()
 
-        XCTAssertNotNil(store.managedAssistantMaintenanceMode)
-        XCTAssertTrue(store.managedAssistantMaintenanceMode!.enabled,
-                      "Maintenance mode should be active after refresh with enabled=true")
+        XCTAssertNotNil(store.managedAssistantRecoveryMode)
+        XCTAssertTrue(store.managedAssistantRecoveryMode!.enabled,
+                      "Recovery mode should be active after refresh with enabled=true")
     }
 
-    // MARK: - Active maintenance status copy: debug pod name is surfaced
+    // MARK: - Active recovery status copy: debug pod name is surfaced
 
-    /// When maintenance mode is active and a debug pod name is present, the store
+    /// When recovery mode is active and a debug pod name is present, the store
     /// should expose it so the status row can display "Debug pod: <name>".
-    func testActiveMaintenanceMode_debugPodNameIsPresent() async {
+    func testActiveRecoveryMode_debugPodNameIsPresent() async {
         let expectedPodName = "debug-pod-xyz789"
         stubSuccess(enabled: true, debugPodName: expectedPodName)
         let store = makeStore()
 
-        await store.refreshManagedAssistantMaintenanceMode()
+        await store.refreshManagedAssistantRecoveryMode()
 
-        XCTAssertEqual(store.managedAssistantMaintenanceMode?.debug_pod_name, expectedPodName,
+        XCTAssertEqual(store.managedAssistantRecoveryMode?.debug_pod_name, expectedPodName,
                        "Debug pod name should match what the platform returned")
     }
 
-    /// When maintenance mode is active but no debug pod has been assigned yet,
+    /// When recovery mode is active but no debug pod has been assigned yet,
     /// `debug_pod_name` should be nil (no debug pod copy rendered).
-    func testActiveMaintenanceMode_withoutDebugPod_podNameIsNil() async {
+    func testActiveRecoveryMode_withoutDebugPod_podNameIsNil() async {
         stubSuccess(enabled: true, debugPodName: nil)
         let store = makeStore()
 
-        await store.refreshManagedAssistantMaintenanceMode()
+        await store.refreshManagedAssistantRecoveryMode()
 
-        XCTAssertTrue(store.managedAssistantMaintenanceMode!.enabled)
-        XCTAssertNil(store.managedAssistantMaintenanceMode?.debug_pod_name,
+        XCTAssertTrue(store.managedAssistantRecoveryMode!.enabled)
+        XCTAssertNil(store.managedAssistantRecoveryMode?.debug_pod_name,
                      "Debug pod name should be nil when the platform did not assign one")
     }
 
-    // MARK: - Disabled state during enter-maintenance-mode mutation
+    // MARK: - Disabled state during enter-recovery-mode mutation
 
-    /// `maintenanceModeEntering` flips true while the enter call is in flight and
+    /// `recoveryModeEntering` flips true while the enter call is in flight and
     /// false when it resolves — the SSH section buttons are disabled while this is true.
-    func testEnteringMaintenanceMode_flagIsSetDuringRequest() async throws {
+    func testEnteringRecoveryMode_flagIsSetDuringRequest() async throws {
         stubSuccess(enabled: true)
         let store = makeStore()
 
         // Observe the entering flag via a brief window — fire the action but don't await it;
         // just confirm the flag is false before and after the full async resolution.
-        XCTAssertFalse(store.maintenanceModeEntering, "Should not be entering before action")
-        XCTAssertFalse(store.maintenanceModeExiting, "Should not be exiting before action")
+        XCTAssertFalse(store.recoveryModeEntering, "Should not be entering before action")
+        XCTAssertFalse(store.recoveryModeExiting, "Should not be exiting before action")
 
-        store.enterManagedAssistantMaintenanceMode()
+        store.enterManagedAssistantRecoveryMode()
         // Give the task a chance to settle.
         try await Task.sleep(nanoseconds: 500_000_000)
 
-        XCTAssertFalse(store.maintenanceModeEntering, "Should not be entering after request completes")
-        XCTAssertNil(store.maintenanceModeEnterError, "Enter error should be nil on success")
-        XCTAssertTrue(store.managedAssistantMaintenanceMode?.enabled == true,
-                      "Maintenance mode should be enabled after successful enter")
+        XCTAssertFalse(store.recoveryModeEntering, "Should not be entering after request completes")
+        XCTAssertNil(store.recoveryModeEnterError, "Enter error should be nil on success")
+        XCTAssertTrue(store.managedAssistantRecoveryMode?.enabled == true,
+                      "Recovery mode should be enabled after successful enter")
     }
 
-    // MARK: - Disabled state during exit-maintenance-mode mutation
+    // MARK: - Disabled state during exit-recovery-mode mutation
 
-    /// `maintenanceModeExiting` flips true while the exit call is in flight and
+    /// `recoveryModeExiting` flips true while the exit call is in flight and
     /// false when it resolves — the SSH section buttons are disabled while this is true.
-    func testExitingMaintenanceMode_flagIsSetDuringRequest() async throws {
+    func testExitingRecoveryMode_flagIsSetDuringRequest() async throws {
         stubSuccess(enabled: false)
         let store = makeStore()
         // Pre-seed an active maintenance state.
-        store.managedAssistantMaintenanceMode = PlatformAssistantMaintenanceMode(
+        store.managedAssistantRecoveryMode = PlatformAssistantRecoveryMode(
             enabled: true, debug_pod_name: "debug-pod-pre"
         )
 
-        store.exitManagedAssistantMaintenanceMode()
+        store.exitManagedAssistantRecoveryMode()
         try await Task.sleep(nanoseconds: 500_000_000)
 
-        XCTAssertFalse(store.maintenanceModeExiting, "Should not be exiting after request completes")
-        XCTAssertNil(store.maintenanceModeExitError, "Exit error should be nil on success")
-        XCTAssertFalse(store.managedAssistantMaintenanceMode?.enabled == true,
-                       "Maintenance mode should be disabled after successful exit")
+        XCTAssertFalse(store.recoveryModeExiting, "Should not be exiting after request completes")
+        XCTAssertNil(store.recoveryModeExitError, "Exit error should be nil on success")
+        XCTAssertFalse(store.managedAssistantRecoveryMode?.enabled == true,
+                       "Recovery mode should be disabled after successful exit")
     }
 
     // MARK: - Error state surfaces inline error copy
 
-    /// When entering maintenance mode fails, `maintenanceModeEnterError` is non-nil
+    /// When entering recovery mode fails, `recoveryModeEnterError` is non-nil
     /// so the SSH section can render the inline error text.
-    func testEnterMaintenanceModeFailure_setsEnterError() async throws {
+    func testEnterRecoveryModeFailure_setsEnterError() async throws {
         stubFailure(statusCode: 500)
         let store = makeStore()
 
-        store.enterManagedAssistantMaintenanceMode()
+        store.enterManagedAssistantRecoveryMode()
         try await Task.sleep(nanoseconds: 500_000_000)
 
-        XCTAssertFalse(store.maintenanceModeEntering, "Entering flag should be cleared after failure")
-        XCTAssertNotNil(store.maintenanceModeEnterError,
+        XCTAssertFalse(store.recoveryModeEntering, "Entering flag should be cleared after failure")
+        XCTAssertNotNil(store.recoveryModeEnterError,
                         "Enter error should be set when the request fails")
     }
 
-    /// When exiting maintenance mode fails, `maintenanceModeExitError` is non-nil
+    /// When exiting recovery mode fails, `recoveryModeExitError` is non-nil
     /// so the SSH section can render the inline error text.
-    func testExitMaintenanceModeFailure_setsExitError() async throws {
+    func testExitRecoveryModeFailure_setsExitError() async throws {
         stubFailure(statusCode: 503)
         let store = makeStore()
-        store.managedAssistantMaintenanceMode = PlatformAssistantMaintenanceMode(
+        store.managedAssistantRecoveryMode = PlatformAssistantRecoveryMode(
             enabled: true, debug_pod_name: "debug-pod-pre"
         )
 
-        store.exitManagedAssistantMaintenanceMode()
+        store.exitManagedAssistantRecoveryMode()
         try await Task.sleep(nanoseconds: 500_000_000)
 
-        XCTAssertFalse(store.maintenanceModeExiting, "Exiting flag should be cleared after failure")
-        XCTAssertNotNil(store.maintenanceModeExitError,
+        XCTAssertFalse(store.recoveryModeExiting, "Exiting flag should be cleared after failure")
+        XCTAssertNotNil(store.recoveryModeExitError,
                         "Exit error should be set when the request fails")
     }
 
@@ -305,25 +305,25 @@ final class SettingsDeveloperTabMaintenanceTests: XCTestCase {
         let store = makeStore()
 
         // The `maintenanceTransitionInFlight` helper in the view is:
-        //   store.maintenanceModeEntering || store.maintenanceModeExiting
-        let transitionInFlight = store.maintenanceModeEntering || store.maintenanceModeExiting
+        //   store.recoveryModeEntering || store.recoveryModeExiting
+        let transitionInFlight = store.recoveryModeEntering || store.recoveryModeExiting
         XCTAssertFalse(transitionInFlight, "No transition should be in flight on fresh store")
     }
 
     // MARK: - Refresh error does not leave entering/exiting flags set
 
-    /// A failed refresh should clear `maintenanceModeRefreshing` and set the error,
+    /// A failed refresh should clear `recoveryModeRefreshing` and set the error,
     /// without affecting the enter/exit flags.
     func testRefreshFailure_setsRefreshErrorAndClearsRefreshingFlag() async {
         stubFailure(statusCode: 404)
         let store = makeStore()
 
-        await store.refreshManagedAssistantMaintenanceMode()
+        await store.refreshManagedAssistantRecoveryMode()
 
-        XCTAssertFalse(store.maintenanceModeRefreshing, "Refreshing flag should be cleared after failure")
-        XCTAssertNotNil(store.maintenanceModeRefreshError,
+        XCTAssertFalse(store.recoveryModeRefreshing, "Refreshing flag should be cleared after failure")
+        XCTAssertNotNil(store.recoveryModeRefreshError,
                         "Refresh error should be populated when the request fails")
-        XCTAssertFalse(store.maintenanceModeEntering, "Enter flag should not be set by a failed refresh")
-        XCTAssertFalse(store.maintenanceModeExiting, "Exit flag should not be set by a failed refresh")
+        XCTAssertFalse(store.recoveryModeEntering, "Enter flag should not be set by a failed refresh")
+        XCTAssertFalse(store.recoveryModeExiting, "Exit flag should not be set by a failed refresh")
     }
 }

--- a/clients/macos/vellum-assistantTests/SettingsStoreManagedMaintenanceTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreManagedMaintenanceTests.swift
@@ -2,9 +2,9 @@ import XCTest
 @testable import VellumAssistantLib
 @testable import VellumAssistantShared
 
-// MARK: - URLProtocol stub for maintenance-mode endpoint calls
+// MARK: - URLProtocol stub for recovery-mode endpoint calls
 
-private final class MaintenanceStoreURLProtocol: URLProtocol {
+private final class RecoveryStoreURLProtocol: URLProtocol {
     static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
 
     override class func canInit(with request: URLRequest) -> Bool { true }
@@ -31,21 +31,32 @@ private final class MaintenanceStoreURLProtocol: URLProtocol {
 
 // MARK: - Blocking URLProtocol stub for mid-flight staleness tests
 
-/// A URLProtocol stub that suspends the network response until `resume()` is called.
-/// This lets tests mutate UserDefaults *between* the request being sent and the
-/// response being delivered, exercising staleness-guard code paths.
-private final class BlockingMaintenanceURLProtocol: URLProtocol {
+/// A URLProtocol stub that blocks the *first* POST request until `resume()` is called,
+/// then responds immediately to any follow-up GET requests (e.g. the `refreshAssistant`
+/// call that `enterRecoveryMode`/`exitRecoveryMode` makes after the POST succeeds).
+/// This lets tests mutate UserDefaults *between* the POST being sent and the response
+/// being delivered, exercising staleness-guard code paths.
+private final class BlockingRecoveryURLProtocol: URLProtocol {
     // The pending instance waiting to deliver its response.
-    static var pendingInstance: BlockingMaintenanceURLProtocol?
+    static var pendingInstance: BlockingRecoveryURLProtocol?
     // The (response, data) to deliver when resume() is called.
     static var stagedResponse: (HTTPURLResponse, Data)?
+    // True once the first blocking request has been resumed; subsequent requests respond immediately.
+    static var hasResumed: Bool = false
 
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
     override func startLoading() {
-        // Park ourselves so the test can call resume() after mutating UserDefaults.
-        Self.pendingInstance = self
+        // Only block the first request (the POST). After the first resume(), let follow-up
+        // GET requests (from refreshAssistant) go through immediately so the staleness check
+        // in SettingsStore can run without hanging.
+        if Self.hasResumed {
+            deliverStagedResponse()
+        } else {
+            // Park ourselves so the test can call resume() after mutating UserDefaults.
+            Self.pendingInstance = self
+        }
     }
 
     override func stopLoading() {
@@ -54,6 +65,12 @@ private final class BlockingMaintenanceURLProtocol: URLProtocol {
 
     /// Deliver the staged response to the URLSession machinery.
     func resume() {
+        Self.hasResumed = true
+        deliverStagedResponse()
+        Self.pendingInstance = nil
+    }
+
+    private func deliverStagedResponse() {
         guard let (response, data) = Self.stagedResponse else {
             client?.urlProtocol(self, didFailWithError: URLError(.unknown))
             return
@@ -61,7 +78,6 @@ private final class BlockingMaintenanceURLProtocol: URLProtocol {
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
         client?.urlProtocol(self, didLoad: data)
         client?.urlProtocolDidFinishLoading(self)
-        Self.pendingInstance = nil
     }
 }
 
@@ -102,7 +118,7 @@ private func assistantPayload(
 // MARK: - Tests
 
 @MainActor
-final class SettingsStoreManagedMaintenanceTests: XCTestCase {
+final class SettingsStoreManagedRecoveryTests: XCTestCase {
 
     private let testAssistantId = "maintenance-test-asst-\(UUID().uuidString.prefix(8))"
     private let testOrgId = "org-test-\(UUID().uuidString.prefix(8))"
@@ -139,8 +155,8 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
         try! data.write(to: primaryURL, options: .atomic)
 
         // Register stub network handler and a session token.
-        URLProtocol.registerClass(MaintenanceStoreURLProtocol.self)
-        MaintenanceStoreURLProtocol.requestHandler = nil
+        URLProtocol.registerClass(RecoveryStoreURLProtocol.self)
+        RecoveryStoreURLProtocol.requestHandler = nil
         // Save any existing token so we can restore it in tearDown, preventing
         // the test run from destroying the developer's real session token.
         previousToken = SessionTokenManager.getToken()
@@ -148,8 +164,8 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
     }
 
     override func tearDown() {
-        URLProtocol.unregisterClass(MaintenanceStoreURLProtocol.self)
-        MaintenanceStoreURLProtocol.requestHandler = nil
+        URLProtocol.unregisterClass(RecoveryStoreURLProtocol.self)
+        RecoveryStoreURLProtocol.requestHandler = nil
         if let token = previousToken {
             SessionTokenManager.setToken(token)
         } else {
@@ -192,7 +208,7 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
         enteredAt: String? = nil
     ) {
         let assistantId = id ?? testAssistantId
-        MaintenanceStoreURLProtocol.requestHandler = { _ in
+        RecoveryStoreURLProtocol.requestHandler = { _ in
             let url = URL(string: "https://example.com")!
             let response = HTTPURLResponse(
                 url: url, statusCode: 200, httpVersion: nil, headerFields: nil
@@ -207,7 +223,7 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
     }
 
     private func stubFailure(statusCode: Int) {
-        MaintenanceStoreURLProtocol.requestHandler = { request in
+        RecoveryStoreURLProtocol.requestHandler = { request in
             let url = request.url ?? URL(string: "https://example.com")!
             let response = HTTPURLResponse(
                 url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil
@@ -218,21 +234,21 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
 
     // MARK: - Initial state
 
-    func testInitialMaintenanceModeStateIsNil() {
+    func testInitialRecoveryModeStateIsNil() {
         let store = makeStore()
 
-        XCTAssertNil(store.managedAssistantMaintenanceMode)
-        XCTAssertFalse(store.maintenanceModeRefreshing)
-        XCTAssertFalse(store.maintenanceModeEntering)
-        XCTAssertFalse(store.maintenanceModeExiting)
-        XCTAssertNil(store.maintenanceModeRefreshError)
-        XCTAssertNil(store.maintenanceModeEnterError)
-        XCTAssertNil(store.maintenanceModeExitError)
+        XCTAssertNil(store.managedAssistantRecoveryMode)
+        XCTAssertFalse(store.recoveryModeRefreshing)
+        XCTAssertFalse(store.recoveryModeEntering)
+        XCTAssertFalse(store.recoveryModeExiting)
+        XCTAssertNil(store.recoveryModeRefreshError)
+        XCTAssertNil(store.recoveryModeEnterError)
+        XCTAssertNil(store.recoveryModeExitError)
     }
 
-    // MARK: - refreshManagedAssistantMaintenanceMode
+    // MARK: - refreshManagedAssistantRecoveryMode
 
-    func testRefreshSetsMaintenanceModeEnabledFromSuccessResponse() async {
+    func testRefreshSetsRecoveryModeEnabledFromSuccessResponse() async {
         stubSuccess(
             maintenanceEnabled: true,
             debugPodName: "debug-pod-abc",
@@ -240,37 +256,37 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
         )
 
         let store = makeStore()
-        await store.refreshManagedAssistantMaintenanceMode()
+        await store.refreshManagedAssistantRecoveryMode()
 
-        let mode = try! XCTUnwrap(store.managedAssistantMaintenanceMode)
+        let mode = try! XCTUnwrap(store.managedAssistantRecoveryMode)
         XCTAssertTrue(mode.enabled)
         XCTAssertEqual(mode.debug_pod_name, "debug-pod-abc")
         XCTAssertEqual(mode.entered_at, "2026-03-30T10:00:00Z")
-        XCTAssertNil(store.maintenanceModeRefreshError)
-        XCTAssertFalse(store.maintenanceModeRefreshing)
+        XCTAssertNil(store.recoveryModeRefreshError)
+        XCTAssertFalse(store.recoveryModeRefreshing)
     }
 
-    func testRefreshSetsMaintenanceModeDisabled() async {
+    func testRefreshSetsRecoveryModeDisabled() async {
         stubSuccess(maintenanceEnabled: false)
 
         let store = makeStore()
-        await store.refreshManagedAssistantMaintenanceMode()
+        await store.refreshManagedAssistantRecoveryMode()
 
-        let mode = try! XCTUnwrap(store.managedAssistantMaintenanceMode)
+        let mode = try! XCTUnwrap(store.managedAssistantRecoveryMode)
         XCTAssertFalse(mode.enabled)
         XCTAssertNil(mode.debug_pod_name)
-        XCTAssertNil(store.maintenanceModeRefreshError)
+        XCTAssertNil(store.recoveryModeRefreshError)
     }
 
     func testRefreshSetsErrorOnPlatformFailure() async {
         stubFailure(statusCode: 500)
 
         let store = makeStore()
-        await store.refreshManagedAssistantMaintenanceMode()
+        await store.refreshManagedAssistantRecoveryMode()
 
-        XCTAssertNil(store.managedAssistantMaintenanceMode)
-        XCTAssertNotNil(store.maintenanceModeRefreshError)
-        XCTAssertFalse(store.maintenanceModeRefreshing)
+        XCTAssertNil(store.managedAssistantRecoveryMode)
+        XCTAssertNotNil(store.recoveryModeRefreshError)
+        XCTAssertFalse(store.recoveryModeRefreshing)
     }
 
     func testRefreshClearsRefreshErrorOnSuccess() async {
@@ -279,13 +295,13 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
 
         // First call fails.
         stubFailure(statusCode: 503)
-        await store.refreshManagedAssistantMaintenanceMode()
-        XCTAssertNotNil(store.maintenanceModeRefreshError)
+        await store.refreshManagedAssistantRecoveryMode()
+        XCTAssertNotNil(store.recoveryModeRefreshError)
 
         // Second call succeeds — error should be cleared.
         stubSuccess(maintenanceEnabled: false)
-        await store.refreshManagedAssistantMaintenanceMode()
-        XCTAssertNil(store.maintenanceModeRefreshError)
+        await store.refreshManagedAssistantRecoveryMode()
+        XCTAssertNil(store.recoveryModeRefreshError)
     }
 
     func testRefreshIsNoOpWhenNoConnectedAssistantId() async {
@@ -294,19 +310,19 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
         UserDefaults.standard.removeObject(forKey: "connectedAssistantId")
 
         // If refresh were to hit the network, the nil handler would cause an error.
-        MaintenanceStoreURLProtocol.requestHandler = nil
+        RecoveryStoreURLProtocol.requestHandler = nil
 
         let store = SettingsStore(settingsClient: MockSettingsClient())
-        await store.refreshManagedAssistantMaintenanceMode()
+        await store.refreshManagedAssistantRecoveryMode()
 
-        XCTAssertNil(store.managedAssistantMaintenanceMode)
-        XCTAssertNil(store.maintenanceModeRefreshError)
-        XCTAssertFalse(store.maintenanceModeRefreshing)
+        XCTAssertNil(store.managedAssistantRecoveryMode)
+        XCTAssertNil(store.recoveryModeRefreshError)
+        XCTAssertFalse(store.recoveryModeRefreshing)
     }
 
-    // MARK: - enterManagedAssistantMaintenanceMode
+    // MARK: - enterManagedAssistantRecoveryMode
 
-    func testEnterMaintenanceModeUpdatesStateOnSuccess() async {
+    func testEnterRecoveryModeUpdatesStateOnSuccess() async {
         stubSuccess(
             maintenanceEnabled: true,
             debugPodName: "debug-pod-enter",
@@ -314,12 +330,12 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
         )
 
         let store = makeStore()
-        store.enterManagedAssistantMaintenanceMode()
+        store.enterManagedAssistantRecoveryMode()
 
         let completed = expectation(description: "enter done")
         let task = Task {
             var ticks = 0
-            while store.maintenanceModeEntering && ticks < 200 {
+            while store.recoveryModeEntering && ticks < 200 {
                 await Task.yield()
                 ticks += 1
             }
@@ -328,23 +344,23 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
         await fulfillment(of: [completed], timeout: 5)
         task.cancel()
 
-        let mode = try! XCTUnwrap(store.managedAssistantMaintenanceMode)
+        let mode = try! XCTUnwrap(store.managedAssistantRecoveryMode)
         XCTAssertTrue(mode.enabled)
         XCTAssertEqual(mode.debug_pod_name, "debug-pod-enter")
-        XCTAssertNil(store.maintenanceModeEnterError)
-        XCTAssertFalse(store.maintenanceModeEntering)
+        XCTAssertNil(store.recoveryModeEnterError)
+        XCTAssertFalse(store.recoveryModeEntering)
     }
 
-    func testEnterMaintenanceModeStoresErrorOnFailure() async {
+    func testEnterRecoveryModeStoresErrorOnFailure() async {
         stubFailure(statusCode: 409)
 
         let store = makeStore()
-        store.enterManagedAssistantMaintenanceMode()
+        store.enterManagedAssistantRecoveryMode()
 
         let completed = expectation(description: "enter done with error")
         let task = Task {
             var ticks = 0
-            while store.maintenanceModeEntering && ticks < 200 {
+            while store.recoveryModeEntering && ticks < 200 {
                 await Task.yield()
                 ticks += 1
             }
@@ -353,29 +369,29 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
         await fulfillment(of: [completed], timeout: 5)
         task.cancel()
 
-        XCTAssertNotNil(store.maintenanceModeEnterError)
-        XCTAssertFalse(store.maintenanceModeEntering)
+        XCTAssertNotNil(store.recoveryModeEnterError)
+        XCTAssertFalse(store.recoveryModeEntering)
     }
 
-    // MARK: - exitManagedAssistantMaintenanceMode
+    // MARK: - exitManagedAssistantRecoveryMode
 
-    func testExitMaintenanceModeUpdatesStateOnSuccess() async {
+    func testExitRecoveryModeUpdatesStateOnSuccess() async {
         stubSuccess(maintenanceEnabled: false)
 
         let store = makeStore()
         // Seed an active maintenance state.
-        store.managedAssistantMaintenanceMode = PlatformAssistantMaintenanceMode(
+        store.managedAssistantRecoveryMode = PlatformAssistantRecoveryMode(
             enabled: true,
             entered_at: "2026-03-30T10:00:00Z",
             debug_pod_name: "debug-pod-old"
         )
 
-        store.exitManagedAssistantMaintenanceMode()
+        store.exitManagedAssistantRecoveryMode()
 
         let completed = expectation(description: "exit done")
         let task = Task {
             var ticks = 0
-            while store.maintenanceModeExiting && ticks < 200 {
+            while store.recoveryModeExiting && ticks < 200 {
                 await Task.yield()
                 ticks += 1
             }
@@ -384,22 +400,22 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
         await fulfillment(of: [completed], timeout: 5)
         task.cancel()
 
-        let mode = try! XCTUnwrap(store.managedAssistantMaintenanceMode)
+        let mode = try! XCTUnwrap(store.managedAssistantRecoveryMode)
         XCTAssertFalse(mode.enabled)
-        XCTAssertNil(store.maintenanceModeExitError)
-        XCTAssertFalse(store.maintenanceModeExiting)
+        XCTAssertNil(store.recoveryModeExitError)
+        XCTAssertFalse(store.recoveryModeExiting)
     }
 
-    func testExitMaintenanceModeStoresErrorOnFailure() async {
+    func testExitRecoveryModeStoresErrorOnFailure() async {
         stubFailure(statusCode: 409)
 
         let store = makeStore()
-        store.exitManagedAssistantMaintenanceMode()
+        store.exitManagedAssistantRecoveryMode()
 
         let completed = expectation(description: "exit done with error")
         let task = Task {
             var ticks = 0
-            while store.maintenanceModeExiting && ticks < 200 {
+            while store.recoveryModeExiting && ticks < 200 {
                 await Task.yield()
                 ticks += 1
             }
@@ -408,8 +424,8 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
         await fulfillment(of: [completed], timeout: 5)
         task.cancel()
 
-        XCTAssertNotNil(store.maintenanceModeExitError)
-        XCTAssertFalse(store.maintenanceModeExiting)
+        XCTAssertNotNil(store.recoveryModeExitError)
+        XCTAssertFalse(store.recoveryModeExiting)
     }
 
     // MARK: - Error cleared on next action
@@ -420,11 +436,11 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
 
         // First call fails.
         stubFailure(statusCode: 500)
-        store.enterManagedAssistantMaintenanceMode()
+        store.enterManagedAssistantRecoveryMode()
         let firstDone = expectation(description: "first enter done")
         let task1 = Task {
             var ticks = 0
-            while store.maintenanceModeEntering && ticks < 200 {
+            while store.recoveryModeEntering && ticks < 200 {
                 await Task.yield()
                 ticks += 1
             }
@@ -432,15 +448,15 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
         }
         await fulfillment(of: [firstDone], timeout: 5)
         task1.cancel()
-        XCTAssertNotNil(store.maintenanceModeEnterError)
+        XCTAssertNotNil(store.recoveryModeEnterError)
 
         // Second call succeeds — error should be cleared.
         stubSuccess(maintenanceEnabled: true)
-        store.enterManagedAssistantMaintenanceMode()
+        store.enterManagedAssistantRecoveryMode()
         let secondDone = expectation(description: "second enter done")
         let task2 = Task {
             var ticks = 0
-            while store.maintenanceModeEntering && ticks < 200 {
+            while store.recoveryModeEntering && ticks < 200 {
                 await Task.yield()
                 ticks += 1
             }
@@ -448,7 +464,7 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
         }
         await fulfillment(of: [secondDone], timeout: 5)
         task2.cancel()
-        XCTAssertNil(store.maintenanceModeEnterError)
+        XCTAssertNil(store.recoveryModeEnterError)
     }
 
     func testExitClearsPreviousExitError() async {
@@ -457,11 +473,11 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
 
         // First call fails.
         stubFailure(statusCode: 500)
-        store.exitManagedAssistantMaintenanceMode()
+        store.exitManagedAssistantRecoveryMode()
         let firstDone = expectation(description: "first exit done")
         let task1 = Task {
             var ticks = 0
-            while store.maintenanceModeExiting && ticks < 200 {
+            while store.recoveryModeExiting && ticks < 200 {
                 await Task.yield()
                 ticks += 1
             }
@@ -469,15 +485,15 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
         }
         await fulfillment(of: [firstDone], timeout: 5)
         task1.cancel()
-        XCTAssertNotNil(store.maintenanceModeExitError)
+        XCTAssertNotNil(store.recoveryModeExitError)
 
         // Second call succeeds — error should be cleared.
         stubSuccess(maintenanceEnabled: false)
-        store.exitManagedAssistantMaintenanceMode()
+        store.exitManagedAssistantRecoveryMode()
         let secondDone = expectation(description: "second exit done")
         let task2 = Task {
             var ticks = 0
-            while store.maintenanceModeExiting && ticks < 200 {
+            while store.recoveryModeExiting && ticks < 200 {
                 await Task.yield()
                 ticks += 1
             }
@@ -485,45 +501,46 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
         }
         await fulfillment(of: [secondDone], timeout: 5)
         task2.cancel()
-        XCTAssertNil(store.maintenanceModeExitError)
+        XCTAssertNil(store.recoveryModeExitError)
     }
 
     // MARK: - Staleness-guard regression tests
 
-    /// Verifies that `refreshManagedAssistantMaintenanceMode` discards the response when
+    /// Verifies that `refreshManagedAssistantRecoveryMode` discards the response when
     /// `connectedAssistantId` changes while the request is in flight.
     func testRefreshDiscardsStaleResponseWhenAssistantIdChangesMidFlight() async {
 
         // Stage a success response for the blocking stub.
         let url = URL(string: "https://example.com")!
         let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
-        BlockingMaintenanceURLProtocol.stagedResponse = (
+        BlockingRecoveryURLProtocol.stagedResponse = (
             response,
             assistantPayload(id: testAssistantId, maintenanceEnabled: true, debugPodName: "stale-pod")
         )
-        BlockingMaintenanceURLProtocol.pendingInstance = nil
+        BlockingRecoveryURLProtocol.pendingInstance = nil
 
         // Swap the normal stub for the blocking variant.
-        URLProtocol.unregisterClass(MaintenanceStoreURLProtocol.self)
-        URLProtocol.registerClass(BlockingMaintenanceURLProtocol.self)
+        URLProtocol.unregisterClass(RecoveryStoreURLProtocol.self)
+        URLProtocol.registerClass(BlockingRecoveryURLProtocol.self)
         defer {
-            URLProtocol.unregisterClass(BlockingMaintenanceURLProtocol.self)
-            URLProtocol.registerClass(MaintenanceStoreURLProtocol.self)
-            BlockingMaintenanceURLProtocol.stagedResponse = nil
+            URLProtocol.unregisterClass(BlockingRecoveryURLProtocol.self)
+            URLProtocol.registerClass(RecoveryStoreURLProtocol.self)
+            BlockingRecoveryURLProtocol.stagedResponse = nil
+            BlockingRecoveryURLProtocol.hasResumed = false
         }
 
         let store = makeStore()
 
         // Start the refresh in the background — it will block waiting for the stub to respond.
         let refreshTask = Task { @MainActor in
-            await store.refreshManagedAssistantMaintenanceMode()
+            await store.refreshManagedAssistantRecoveryMode()
         }
 
         // Wait until the blocking stub has received the request (i.e. startLoading() was called).
         let requestReceived = expectation(description: "blocking stub received request")
         let waitTask = Task {
             var ticks = 0
-            while BlockingMaintenanceURLProtocol.pendingInstance == nil && ticks < 500 {
+            while BlockingRecoveryURLProtocol.pendingInstance == nil && ticks < 500 {
                 try? await Task.sleep(nanoseconds: 10_000_000) // 10 ms
                 ticks += 1
             }
@@ -536,47 +553,48 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
         UserDefaults.standard.set("different-assistant-id", forKey: "connectedAssistantId")
 
         // Now unblock the response.
-        BlockingMaintenanceURLProtocol.pendingInstance?.resume()
+        BlockingRecoveryURLProtocol.pendingInstance?.resume()
 
         // Wait for the refresh Task to complete.
         await refreshTask.value
 
         // Staleness guard should have discarded the response — mode must remain nil.
-        XCTAssertNil(store.managedAssistantMaintenanceMode,
-            "managedAssistantMaintenanceMode must not be updated with a stale response when connectedAssistantId changed mid-flight")
-        XCTAssertFalse(store.maintenanceModeRefreshing)
+        XCTAssertNil(store.managedAssistantRecoveryMode,
+            "managedAssistantRecoveryMode must not be updated with a stale response when connectedAssistantId changed mid-flight")
+        XCTAssertFalse(store.recoveryModeRefreshing)
     }
 
-    /// Verifies that `refreshManagedAssistantMaintenanceMode` discards the response when
+    /// Verifies that `refreshManagedAssistantRecoveryMode` discards the response when
     /// `connectedOrganizationId` changes while the request is in flight.
     func testRefreshDiscardsStaleResponseWhenOrgIdChangesMidFlight() async {
 
         let url = URL(string: "https://example.com")!
         let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
-        BlockingMaintenanceURLProtocol.stagedResponse = (
+        BlockingRecoveryURLProtocol.stagedResponse = (
             response,
             assistantPayload(id: testAssistantId, maintenanceEnabled: true, debugPodName: "stale-pod-org")
         )
-        BlockingMaintenanceURLProtocol.pendingInstance = nil
+        BlockingRecoveryURLProtocol.pendingInstance = nil
 
-        URLProtocol.unregisterClass(MaintenanceStoreURLProtocol.self)
-        URLProtocol.registerClass(BlockingMaintenanceURLProtocol.self)
+        URLProtocol.unregisterClass(RecoveryStoreURLProtocol.self)
+        URLProtocol.registerClass(BlockingRecoveryURLProtocol.self)
         defer {
-            URLProtocol.unregisterClass(BlockingMaintenanceURLProtocol.self)
-            URLProtocol.registerClass(MaintenanceStoreURLProtocol.self)
-            BlockingMaintenanceURLProtocol.stagedResponse = nil
+            URLProtocol.unregisterClass(BlockingRecoveryURLProtocol.self)
+            URLProtocol.registerClass(RecoveryStoreURLProtocol.self)
+            BlockingRecoveryURLProtocol.stagedResponse = nil
+            BlockingRecoveryURLProtocol.hasResumed = false
         }
 
         let store = makeStore()
 
         let refreshTask = Task { @MainActor in
-            await store.refreshManagedAssistantMaintenanceMode()
+            await store.refreshManagedAssistantRecoveryMode()
         }
 
         let requestReceived = expectation(description: "blocking stub received request (org)")
         let waitTask = Task {
             var ticks = 0
-            while BlockingMaintenanceURLProtocol.pendingInstance == nil && ticks < 500 {
+            while BlockingRecoveryURLProtocol.pendingInstance == nil && ticks < 500 {
                 try? await Task.sleep(nanoseconds: 10_000_000)
                 ticks += 1
             }
@@ -588,45 +606,46 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
         // Simulate organization switch mid-flight.
         UserDefaults.standard.set("different-org-id", forKey: "connectedOrganizationId")
 
-        BlockingMaintenanceURLProtocol.pendingInstance?.resume()
+        BlockingRecoveryURLProtocol.pendingInstance?.resume()
 
         await refreshTask.value
 
-        XCTAssertNil(store.managedAssistantMaintenanceMode,
-            "managedAssistantMaintenanceMode must not be updated with a stale response when connectedOrganizationId changed mid-flight")
-        XCTAssertFalse(store.maintenanceModeRefreshing)
+        XCTAssertNil(store.managedAssistantRecoveryMode,
+            "managedAssistantRecoveryMode must not be updated with a stale response when connectedOrganizationId changed mid-flight")
+        XCTAssertFalse(store.recoveryModeRefreshing)
     }
 
-    /// Verifies that `enterManagedAssistantMaintenanceMode` does not overwrite
-    /// `managedAssistantMaintenanceMode` when `connectedAssistantId` changes mid-flight.
+    /// Verifies that `enterManagedAssistantRecoveryMode` does not overwrite
+    /// `managedAssistantRecoveryMode` when `connectedAssistantId` changes mid-flight.
     func testEnterDiscardsStaleResponseWhenAssistantIdChangesMidFlight() async {
 
         let url = URL(string: "https://example.com")!
         let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
-        BlockingMaintenanceURLProtocol.stagedResponse = (
+        BlockingRecoveryURLProtocol.stagedResponse = (
             response,
             assistantPayload(id: testAssistantId, maintenanceEnabled: true, debugPodName: "enter-stale-pod")
         )
-        BlockingMaintenanceURLProtocol.pendingInstance = nil
+        BlockingRecoveryURLProtocol.pendingInstance = nil
 
-        URLProtocol.unregisterClass(MaintenanceStoreURLProtocol.self)
-        URLProtocol.registerClass(BlockingMaintenanceURLProtocol.self)
+        URLProtocol.unregisterClass(RecoveryStoreURLProtocol.self)
+        URLProtocol.registerClass(BlockingRecoveryURLProtocol.self)
         defer {
-            URLProtocol.unregisterClass(BlockingMaintenanceURLProtocol.self)
-            URLProtocol.registerClass(MaintenanceStoreURLProtocol.self)
-            BlockingMaintenanceURLProtocol.stagedResponse = nil
+            URLProtocol.unregisterClass(BlockingRecoveryURLProtocol.self)
+            URLProtocol.registerClass(RecoveryStoreURLProtocol.self)
+            BlockingRecoveryURLProtocol.stagedResponse = nil
+            BlockingRecoveryURLProtocol.hasResumed = false
         }
 
         let store = makeStore()
 
         // Kick off enter — it fires a Task internally and returns immediately.
-        store.enterManagedAssistantMaintenanceMode()
+        store.enterManagedAssistantRecoveryMode()
 
         // Wait for the stub to receive the in-flight request.
         let requestReceived = expectation(description: "enter: blocking stub received request")
         let waitTask = Task {
             var ticks = 0
-            while BlockingMaintenanceURLProtocol.pendingInstance == nil && ticks < 500 {
+            while BlockingRecoveryURLProtocol.pendingInstance == nil && ticks < 500 {
                 try? await Task.sleep(nanoseconds: 10_000_000)
                 ticks += 1
             }
@@ -639,13 +658,13 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
         UserDefaults.standard.set("different-assistant-id-enter", forKey: "connectedAssistantId")
 
         // Unblock the response.
-        BlockingMaintenanceURLProtocol.pendingInstance?.resume()
+        BlockingRecoveryURLProtocol.pendingInstance?.resume()
 
         // Wait for the enter task to finish.
         let done = expectation(description: "enter finishes")
         let pollTask = Task {
             var ticks = 0
-            while store.maintenanceModeEntering && ticks < 200 {
+            while store.recoveryModeEntering && ticks < 200 {
                 await Task.yield()
                 ticks += 1
             }
@@ -655,41 +674,42 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
         pollTask.cancel()
 
         // The staleness guard should discard the stale response.
-        XCTAssertNil(store.managedAssistantMaintenanceMode,
-            "managedAssistantMaintenanceMode must not be updated with a stale enter response when connectedAssistantId changed mid-flight")
-        XCTAssertFalse(store.maintenanceModeEntering)
+        XCTAssertNil(store.managedAssistantRecoveryMode,
+            "managedAssistantRecoveryMode must not be updated with a stale enter response when connectedAssistantId changed mid-flight")
+        XCTAssertFalse(store.recoveryModeEntering)
     }
 
-    /// Verifies that `enterManagedAssistantMaintenanceMode` does not overwrite
-    /// `managedAssistantMaintenanceMode` when `connectedOrganizationId` changes mid-flight.
+    /// Verifies that `enterManagedAssistantRecoveryMode` does not overwrite
+    /// `managedAssistantRecoveryMode` when `connectedOrganizationId` changes mid-flight.
     func testEnterDiscardsStaleResponseWhenOrgIdChangesMidFlight() async {
 
         let url = URL(string: "https://example.com")!
         let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
-        BlockingMaintenanceURLProtocol.stagedResponse = (
+        BlockingRecoveryURLProtocol.stagedResponse = (
             response,
             assistantPayload(id: testAssistantId, maintenanceEnabled: true, debugPodName: "enter-stale-pod-org")
         )
-        BlockingMaintenanceURLProtocol.pendingInstance = nil
+        BlockingRecoveryURLProtocol.pendingInstance = nil
 
-        URLProtocol.unregisterClass(MaintenanceStoreURLProtocol.self)
-        URLProtocol.registerClass(BlockingMaintenanceURLProtocol.self)
+        URLProtocol.unregisterClass(RecoveryStoreURLProtocol.self)
+        URLProtocol.registerClass(BlockingRecoveryURLProtocol.self)
         defer {
-            URLProtocol.unregisterClass(BlockingMaintenanceURLProtocol.self)
-            URLProtocol.registerClass(MaintenanceStoreURLProtocol.self)
-            BlockingMaintenanceURLProtocol.stagedResponse = nil
+            URLProtocol.unregisterClass(BlockingRecoveryURLProtocol.self)
+            URLProtocol.registerClass(RecoveryStoreURLProtocol.self)
+            BlockingRecoveryURLProtocol.stagedResponse = nil
+            BlockingRecoveryURLProtocol.hasResumed = false
         }
 
         let store = makeStore()
 
         // Kick off enter — it fires a Task internally and returns immediately.
-        store.enterManagedAssistantMaintenanceMode()
+        store.enterManagedAssistantRecoveryMode()
 
         // Wait for the stub to receive the in-flight request.
         let requestReceived = expectation(description: "enter org: blocking stub received request")
         let waitTask = Task {
             var ticks = 0
-            while BlockingMaintenanceURLProtocol.pendingInstance == nil && ticks < 500 {
+            while BlockingRecoveryURLProtocol.pendingInstance == nil && ticks < 500 {
                 try? await Task.sleep(nanoseconds: 10_000_000)
                 ticks += 1
             }
@@ -702,13 +722,13 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
         UserDefaults.standard.set("different-org-id-enter", forKey: "connectedOrganizationId")
 
         // Unblock the response.
-        BlockingMaintenanceURLProtocol.pendingInstance?.resume()
+        BlockingRecoveryURLProtocol.pendingInstance?.resume()
 
         // Wait for the enter task to finish.
         let done = expectation(description: "enter org finishes")
         let pollTask = Task {
             var ticks = 0
-            while store.maintenanceModeEntering && ticks < 200 {
+            while store.recoveryModeEntering && ticks < 200 {
                 await Task.yield()
                 ticks += 1
             }
@@ -718,47 +738,48 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
         pollTask.cancel()
 
         // The staleness guard should discard the stale response.
-        XCTAssertNil(store.managedAssistantMaintenanceMode,
-            "managedAssistantMaintenanceMode must not be updated with a stale enter response when connectedOrganizationId changed mid-flight")
-        XCTAssertFalse(store.maintenanceModeEntering)
+        XCTAssertNil(store.managedAssistantRecoveryMode,
+            "managedAssistantRecoveryMode must not be updated with a stale enter response when connectedOrganizationId changed mid-flight")
+        XCTAssertFalse(store.recoveryModeEntering)
     }
 
-    /// Verifies that `exitManagedAssistantMaintenanceMode` does not overwrite
-    /// `managedAssistantMaintenanceMode` when `connectedAssistantId` changes mid-flight.
+    /// Verifies that `exitManagedAssistantRecoveryMode` does not overwrite
+    /// `managedAssistantRecoveryMode` when `connectedAssistantId` changes mid-flight.
     func testExitDiscardsStaleResponseWhenAssistantIdChangesMidFlight() async {
 
         let url = URL(string: "https://example.com")!
         let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
-        BlockingMaintenanceURLProtocol.stagedResponse = (
+        BlockingRecoveryURLProtocol.stagedResponse = (
             response,
             assistantPayload(id: testAssistantId, maintenanceEnabled: false)
         )
-        BlockingMaintenanceURLProtocol.pendingInstance = nil
+        BlockingRecoveryURLProtocol.pendingInstance = nil
 
-        URLProtocol.unregisterClass(MaintenanceStoreURLProtocol.self)
-        URLProtocol.registerClass(BlockingMaintenanceURLProtocol.self)
+        URLProtocol.unregisterClass(RecoveryStoreURLProtocol.self)
+        URLProtocol.registerClass(BlockingRecoveryURLProtocol.self)
         defer {
-            URLProtocol.unregisterClass(BlockingMaintenanceURLProtocol.self)
-            URLProtocol.registerClass(MaintenanceStoreURLProtocol.self)
-            BlockingMaintenanceURLProtocol.stagedResponse = nil
+            URLProtocol.unregisterClass(BlockingRecoveryURLProtocol.self)
+            URLProtocol.registerClass(RecoveryStoreURLProtocol.self)
+            BlockingRecoveryURLProtocol.stagedResponse = nil
+            BlockingRecoveryURLProtocol.hasResumed = false
         }
 
         let store = makeStore()
         // Seed an active maintenance state so exit has something to clear.
-        store.managedAssistantMaintenanceMode = PlatformAssistantMaintenanceMode(
+        store.managedAssistantRecoveryMode = PlatformAssistantRecoveryMode(
             enabled: true,
             entered_at: "2026-03-30T10:00:00Z",
             debug_pod_name: "exit-stale-pod"
         )
 
         // Kick off exit — it fires a Task internally and returns immediately.
-        store.exitManagedAssistantMaintenanceMode()
+        store.exitManagedAssistantRecoveryMode()
 
         // Wait for the stub to receive the in-flight request.
         let requestReceived = expectation(description: "exit: blocking stub received request")
         let waitTask = Task {
             var ticks = 0
-            while BlockingMaintenanceURLProtocol.pendingInstance == nil && ticks < 500 {
+            while BlockingRecoveryURLProtocol.pendingInstance == nil && ticks < 500 {
                 try? await Task.sleep(nanoseconds: 10_000_000)
                 ticks += 1
             }
@@ -771,13 +792,13 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
         UserDefaults.standard.set("different-assistant-id-exit", forKey: "connectedAssistantId")
 
         // Unblock the response.
-        BlockingMaintenanceURLProtocol.pendingInstance?.resume()
+        BlockingRecoveryURLProtocol.pendingInstance?.resume()
 
         // Wait for the exit task to finish.
         let done = expectation(description: "exit finishes")
         let pollTask = Task {
             var ticks = 0
-            while store.maintenanceModeExiting && ticks < 200 {
+            while store.recoveryModeExiting && ticks < 200 {
                 await Task.yield()
                 ticks += 1
             }
@@ -787,49 +808,50 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
         pollTask.cancel()
 
         // The staleness guard should discard the stale response — seeded state must be preserved.
-        let mode = try! XCTUnwrap(store.managedAssistantMaintenanceMode,
-            "managedAssistantMaintenanceMode must not be cleared by a stale exit response when connectedAssistantId changed mid-flight")
+        let mode = try! XCTUnwrap(store.managedAssistantRecoveryMode,
+            "managedAssistantRecoveryMode must not be cleared by a stale exit response when connectedAssistantId changed mid-flight")
         XCTAssertTrue(mode.enabled,
             "The seeded enabled=true state should be preserved, not overwritten by the stale response")
-        XCTAssertFalse(store.maintenanceModeExiting)
+        XCTAssertFalse(store.recoveryModeExiting)
     }
 
-    /// Verifies that `exitManagedAssistantMaintenanceMode` does not overwrite
-    /// `managedAssistantMaintenanceMode` when `connectedOrganizationId` changes mid-flight.
+    /// Verifies that `exitManagedAssistantRecoveryMode` does not overwrite
+    /// `managedAssistantRecoveryMode` when `connectedOrganizationId` changes mid-flight.
     func testExitDiscardsStaleResponseWhenOrgIdChangesMidFlight() async {
 
         let url = URL(string: "https://example.com")!
         let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
-        BlockingMaintenanceURLProtocol.stagedResponse = (
+        BlockingRecoveryURLProtocol.stagedResponse = (
             response,
             assistantPayload(id: testAssistantId, maintenanceEnabled: false)
         )
-        BlockingMaintenanceURLProtocol.pendingInstance = nil
+        BlockingRecoveryURLProtocol.pendingInstance = nil
 
-        URLProtocol.unregisterClass(MaintenanceStoreURLProtocol.self)
-        URLProtocol.registerClass(BlockingMaintenanceURLProtocol.self)
+        URLProtocol.unregisterClass(RecoveryStoreURLProtocol.self)
+        URLProtocol.registerClass(BlockingRecoveryURLProtocol.self)
         defer {
-            URLProtocol.unregisterClass(BlockingMaintenanceURLProtocol.self)
-            URLProtocol.registerClass(MaintenanceStoreURLProtocol.self)
-            BlockingMaintenanceURLProtocol.stagedResponse = nil
+            URLProtocol.unregisterClass(BlockingRecoveryURLProtocol.self)
+            URLProtocol.registerClass(RecoveryStoreURLProtocol.self)
+            BlockingRecoveryURLProtocol.stagedResponse = nil
+            BlockingRecoveryURLProtocol.hasResumed = false
         }
 
         let store = makeStore()
         // Seed an active maintenance state so exit has something to clear.
-        store.managedAssistantMaintenanceMode = PlatformAssistantMaintenanceMode(
+        store.managedAssistantRecoveryMode = PlatformAssistantRecoveryMode(
             enabled: true,
             entered_at: "2026-03-30T10:00:00Z",
             debug_pod_name: "exit-stale-pod-org"
         )
 
         // Kick off exit — it fires a Task internally and returns immediately.
-        store.exitManagedAssistantMaintenanceMode()
+        store.exitManagedAssistantRecoveryMode()
 
         // Wait for the stub to receive the in-flight request.
         let requestReceived = expectation(description: "exit org: blocking stub received request")
         let waitTask = Task {
             var ticks = 0
-            while BlockingMaintenanceURLProtocol.pendingInstance == nil && ticks < 500 {
+            while BlockingRecoveryURLProtocol.pendingInstance == nil && ticks < 500 {
                 try? await Task.sleep(nanoseconds: 10_000_000)
                 ticks += 1
             }
@@ -842,13 +864,13 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
         UserDefaults.standard.set("different-org-id-exit", forKey: "connectedOrganizationId")
 
         // Unblock the response.
-        BlockingMaintenanceURLProtocol.pendingInstance?.resume()
+        BlockingRecoveryURLProtocol.pendingInstance?.resume()
 
         // Wait for the exit task to finish.
         let done = expectation(description: "exit org finishes")
         let pollTask = Task {
             var ticks = 0
-            while store.maintenanceModeExiting && ticks < 200 {
+            while store.recoveryModeExiting && ticks < 200 {
                 await Task.yield()
                 ticks += 1
             }
@@ -858,10 +880,10 @@ final class SettingsStoreManagedMaintenanceTests: XCTestCase {
         pollTask.cancel()
 
         // The staleness guard should discard the stale response — seeded state must be preserved.
-        let mode = try! XCTUnwrap(store.managedAssistantMaintenanceMode,
-            "managedAssistantMaintenanceMode must not be cleared by a stale exit response when connectedOrganizationId changed mid-flight")
+        let mode = try! XCTUnwrap(store.managedAssistantRecoveryMode,
+            "managedAssistantRecoveryMode must not be cleared by a stale exit response when connectedOrganizationId changed mid-flight")
         XCTAssertTrue(mode.enabled,
             "The seeded enabled=true state should be preserved, not overwritten by the stale response")
-        XCTAssertFalse(store.maintenanceModeExiting)
+        XCTAssertFalse(store.recoveryModeExiting)
     }
 }

--- a/clients/shared/App/Auth/AuthModels.swift
+++ b/clients/shared/App/Auth/AuthModels.swift
@@ -125,10 +125,10 @@ public struct PaginatedOrganizationsResponse: Codable, Sendable {
 
 // MARK: - Platform Assistant API Models
 
-public struct PlatformAssistantMaintenanceMode: Codable, Sendable {
-    /// Whether maintenance mode is currently active for this assistant.
+public struct PlatformAssistantRecoveryMode: Codable, Sendable {
+    /// Whether recovery mode is currently active for this assistant.
     public let enabled: Bool
-    /// ISO 8601 timestamp of when maintenance mode was entered, or `nil` if not currently active.
+    /// ISO 8601 timestamp of when recovery mode was entered, or `nil` if not currently active.
     public let entered_at: String?
     /// Name of the debug pod that has the assistant's workspace PVC mounted, or `nil` when not active.
     public let debug_pod_name: String?
@@ -146,9 +146,16 @@ public struct PlatformAssistant: Codable, Sendable {
     public let description: String?
     public let created_at: String?
     public let status: String?
-    /// Present when the platform includes maintenance-mode state in the assistant payload.
+    /// Present when the platform includes recovery-mode state in the assistant payload.
     /// `nil` when the field is absent (e.g. older platform versions or endpoints that omit it).
-    public let maintenance_mode: PlatformAssistantMaintenanceMode?
+    public let recovery_mode: PlatformAssistantRecoveryMode?
+
+    /// Maps Swift property names to JSON keys. `recovery_mode` is stored as
+    /// `maintenance_mode` in the platform API response.
+    enum CodingKeys: String, CodingKey {
+        case id, name, description, created_at, status
+        case recovery_mode = "maintenance_mode"
+    }
 
     public init(
         id: String,
@@ -156,14 +163,14 @@ public struct PlatformAssistant: Codable, Sendable {
         description: String? = nil,
         created_at: String? = nil,
         status: String? = nil,
-        maintenance_mode: PlatformAssistantMaintenanceMode? = nil
+        recovery_mode: PlatformAssistantRecoveryMode? = nil
     ) {
         self.id = id
         self.name = name
         self.description = description
         self.created_at = created_at
         self.status = status
-        self.maintenance_mode = maintenance_mode
+        self.recovery_mode = recovery_mode
     }
 }
 

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -346,73 +346,58 @@ public final class AuthService {
         }
     }
 
-    // MARK: - Maintenance Mode
+    // MARK: - Recovery Mode
 
-    /// Enter maintenance mode for a managed assistant.
+    /// Enter recovery mode for a managed assistant.
     ///
     /// On success the platform pauses the normal assistant pod and mounts the workspace PVC
-    /// into a debug pod. Returns the updated `PlatformAssistant` with a populated
-    /// `maintenance_mode` field.
-    public func enterMaintenanceMode(
+    /// into a debug pod. Returns the updated `PlatformAssistant` (fetched via `refreshAssistant`)
+    /// which includes the populated `recovery_mode` field.
+    ///
+    /// The enter endpoint returns `{"detail": "...", "debug_pod_name": "..."}`, not a full
+    /// assistant payload. We POST to trigger the transition and then re-fetch the assistant to
+    /// get the authoritative updated state.
+    public func enterRecoveryMode(
         assistantId: String,
         organizationId: String
     ) async throws -> PlatformAssistant {
-        let urlString = "\(baseURL)/v1/assistants/\(assistantId)/maintenance-mode/enter/"
-        guard let url = URL(string: urlString) else {
-            throw PlatformAPIError.invalidURL
-        }
-
-        var urlRequest = URLRequest(url: url)
-        urlRequest.httpMethod = "POST"
-        urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
-        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        urlRequest.httpBody = Data("{}".utf8)
-        urlRequest.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
-
-        if let token = await SessionTokenManager.getTokenAsync() {
-            urlRequest.setValue(token, forHTTPHeaderField: "X-Session-Token")
-        } else {
-            throw PlatformAPIError.authenticationRequired
-        }
-
-        let data: Data
-        let response: URLResponse
-        do {
-            (data, response) = try await URLSession.shared.data(for: urlRequest)
-        } catch {
-            throw PlatformAPIError.networkError(error.localizedDescription)
-        }
-
-        let httpResponse = response as? HTTPURLResponse
-        let statusCode = httpResponse?.statusCode ?? 0
-
-        log.debug("Platform request POST assistants/\(assistantId)/maintenance-mode/enter/ -> \(statusCode)")
-
-        if statusCode == 401 || statusCode == 403 {
-            throw PlatformAPIError.authenticationRequired
-        }
-
-        guard (200..<300).contains(statusCode) else {
-            let detail = String(data: data, encoding: .utf8)
-            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
-        }
-
-        do {
-            return try JSONDecoder().decode(PlatformAssistant.self, from: data)
-        } catch {
-            throw PlatformAPIError.decodingError(error.localizedDescription)
-        }
+        try await postRecoveryModeTransition(
+            path: "maintenance-mode/enter",
+            assistantId: assistantId,
+            organizationId: organizationId
+        )
+        return try await refreshAssistant(id: assistantId, organizationId: organizationId)
     }
 
-    /// Exit maintenance mode for a managed assistant.
+    /// Exit recovery mode for a managed assistant.
     ///
     /// On success the platform tears down the debug pod and resumes the normal assistant pod.
-    /// Returns the updated `PlatformAssistant` with `maintenance_mode.enabled == false`.
-    public func exitMaintenanceMode(
+    /// Returns the updated `PlatformAssistant` (fetched via `refreshAssistant`) with
+    /// `recovery_mode.enabled == false`.
+    ///
+    /// The exit endpoint returns `{"detail": "..."}`, not a full assistant payload. We POST to
+    /// trigger the transition and then re-fetch the assistant to get the authoritative updated state.
+    public func exitRecoveryMode(
         assistantId: String,
         organizationId: String
     ) async throws -> PlatformAssistant {
-        let urlString = "\(baseURL)/v1/assistants/\(assistantId)/maintenance-mode/exit/"
+        try await postRecoveryModeTransition(
+            path: "maintenance-mode/exit",
+            assistantId: assistantId,
+            organizationId: organizationId
+        )
+        return try await refreshAssistant(id: assistantId, organizationId: organizationId)
+    }
+
+    /// Shared POST helper for enter/exit recovery-mode transitions.
+    /// The platform endpoints return a simple `{"detail": "..."}` body — not a full assistant
+    /// payload — so we only check the status code here.
+    private func postRecoveryModeTransition(
+        path: String,
+        assistantId: String,
+        organizationId: String
+    ) async throws {
+        let urlString = "\(baseURL)/v1/assistants/\(assistantId)/\(path)/"
         guard let url = URL(string: urlString) else {
             throw PlatformAPIError.invalidURL
         }
@@ -441,7 +426,7 @@ public final class AuthService {
         let httpResponse = response as? HTTPURLResponse
         let statusCode = httpResponse?.statusCode ?? 0
 
-        log.debug("Platform request POST assistants/\(assistantId)/maintenance-mode/exit/ -> \(statusCode)")
+        log.debug("Platform request POST assistants/\(assistantId)/\(path)/ -> \(statusCode)")
 
         if statusCode == 401 || statusCode == 403 {
             throw PlatformAPIError.authenticationRequired
@@ -450,18 +435,12 @@ public final class AuthService {
         guard (200..<300).contains(statusCode) else {
             let detail = String(data: data, encoding: .utf8)
             throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
-        }
-
-        do {
-            return try JSONDecoder().decode(PlatformAssistant.self, from: data)
-        } catch {
-            throw PlatformAPIError.decodingError(error.localizedDescription)
         }
     }
 
     /// Re-fetch a managed assistant's current detail from the platform.
     ///
-    /// Convenience used after a maintenance-mode mutation to get the freshest state without
+    /// Convenience used after a recovery-mode mutation to get the freshest state without
     /// callers having to inline the `getAssistant` + result-unwrap pattern.
     /// Throws `PlatformAPIError.serverError(statusCode: 404, ...)` when the assistant is not
     /// found, and `PlatformAPIError.authenticationRequired` on 403/401.

--- a/clients/shared/Tests/PlatformAssistantMaintenanceDecodingTests.swift
+++ b/clients/shared/Tests/PlatformAssistantMaintenanceDecodingTests.swift
@@ -2,9 +2,9 @@ import XCTest
 
 @testable import VellumAssistantShared
 
-// MARK: - URLProtocol stub for maintenance-mode network calls
+// MARK: - URLProtocol stub for recovery-mode network calls
 
-private final class MaintenanceModeURLProtocol: URLProtocol {
+private final class RecoveryModeURLProtocol: URLProtocol {
     static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
 
     override class func canInit(with request: URLRequest) -> Bool {
@@ -36,14 +36,14 @@ private final class MaintenanceModeURLProtocol: URLProtocol {
 // MARK: - Tests
 
 @MainActor
-final class PlatformAssistantMaintenanceDecodingTests: XCTestCase {
+final class PlatformAssistantRecoveryDecodingTests: XCTestCase {
     private let decoder = JSONDecoder()
     private var previousToken: String?
 
     override func setUp() {
         super.setUp()
-        MaintenanceModeURLProtocol.requestHandler = nil
-        URLProtocol.registerClass(MaintenanceModeURLProtocol.self)
+        RecoveryModeURLProtocol.requestHandler = nil
+        URLProtocol.registerClass(RecoveryModeURLProtocol.self)
         // Save any existing token so we can restore it in tearDown, preventing
         // a test-abort from leaving a bogus token in the real credential store.
         previousToken = SessionTokenManager.getToken()
@@ -53,8 +53,8 @@ final class PlatformAssistantMaintenanceDecodingTests: XCTestCase {
     }
 
     override func tearDown() {
-        URLProtocol.unregisterClass(MaintenanceModeURLProtocol.self)
-        MaintenanceModeURLProtocol.requestHandler = nil
+        URLProtocol.unregisterClass(RecoveryModeURLProtocol.self)
+        RecoveryModeURLProtocol.requestHandler = nil
         // Restore the credential store to its pre-test state.
         if let token = previousToken {
             SessionTokenManager.setToken(token)
@@ -65,9 +65,9 @@ final class PlatformAssistantMaintenanceDecodingTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - PlatformAssistant decoding with maintenance_mode present
+    // MARK: - PlatformAssistant decoding with recovery_mode (maintenance_mode JSON key)
 
-    func testDecodesAssistantWithMaintenanceModeEnabled() throws {
+    func testDecodesAssistantWithRecoveryModeEnabled() throws {
         let data = Data(
             """
             {
@@ -84,7 +84,7 @@ final class PlatformAssistantMaintenanceDecodingTests: XCTestCase {
         )
 
         let assistant = try decoder.decode(PlatformAssistant.self, from: data)
-        let maintenance = try XCTUnwrap(assistant.maintenance_mode)
+        let maintenance = try XCTUnwrap(assistant.recovery_mode)
 
         XCTAssertEqual(assistant.id, "asst-123")
         XCTAssertTrue(maintenance.enabled)
@@ -92,7 +92,7 @@ final class PlatformAssistantMaintenanceDecodingTests: XCTestCase {
         XCTAssertEqual(maintenance.debug_pod_name, "debug-asst-123-abc")
     }
 
-    func testDecodesAssistantWithMaintenanceModeDisabled() throws {
+    func testDecodesAssistantWithRecoveryModeDisabled() throws {
         let data = Data(
             """
             {
@@ -109,14 +109,14 @@ final class PlatformAssistantMaintenanceDecodingTests: XCTestCase {
         )
 
         let assistant = try decoder.decode(PlatformAssistant.self, from: data)
-        let maintenance = try XCTUnwrap(assistant.maintenance_mode)
+        let maintenance = try XCTUnwrap(assistant.recovery_mode)
 
         XCTAssertFalse(maintenance.enabled)
         XCTAssertNil(maintenance.entered_at)
         XCTAssertNil(maintenance.debug_pod_name)
     }
 
-    func testDecodesAssistantWithMaintenanceModeAbsent() throws {
+    func testDecodesAssistantWithRecoveryModeAbsent() throws {
         let data = Data(
             """
             {
@@ -130,10 +130,10 @@ final class PlatformAssistantMaintenanceDecodingTests: XCTestCase {
         let assistant = try decoder.decode(PlatformAssistant.self, from: data)
 
         XCTAssertEqual(assistant.id, "asst-789")
-        XCTAssertNil(assistant.maintenance_mode)
+        XCTAssertNil(assistant.recovery_mode)
     }
 
-    func testDecodesAssistantPreservesExistingFieldsWithMaintenanceMode() throws {
+    func testDecodesAssistantPreservesExistingFieldsWithRecoveryMode() throws {
         let data = Data(
             """
             {
@@ -158,14 +158,14 @@ final class PlatformAssistantMaintenanceDecodingTests: XCTestCase {
         XCTAssertEqual(assistant.description, "A complete assistant payload")
         XCTAssertEqual(assistant.created_at, "2025-01-15T09:00:00Z")
         XCTAssertEqual(assistant.status, "provisioned")
-        let maintenance = try XCTUnwrap(assistant.maintenance_mode)
+        let maintenance = try XCTUnwrap(assistant.recovery_mode)
         XCTAssertTrue(maintenance.enabled)
         XCTAssertEqual(maintenance.debug_pod_name, "debug-asst-full-xyz")
     }
 
-    // MARK: - PlatformAssistantMaintenanceMode standalone decoding
+    // MARK: - PlatformAssistantRecoveryMode standalone decoding
 
-    func testDecodeMaintenanceModeWithOnlyRequiredField() throws {
+    func testDecodeRecoveryModeWithOnlyRequiredField() throws {
         let data = Data(
             """
             {
@@ -174,7 +174,7 @@ final class PlatformAssistantMaintenanceDecodingTests: XCTestCase {
             """.utf8
         )
 
-        let mode = try decoder.decode(PlatformAssistantMaintenanceMode.self, from: data)
+        let mode = try decoder.decode(PlatformAssistantRecoveryMode.self, from: data)
         XCTAssertFalse(mode.enabled)
         XCTAssertNil(mode.entered_at)
         XCTAssertNil(mode.debug_pod_name)
@@ -182,19 +182,19 @@ final class PlatformAssistantMaintenanceDecodingTests: XCTestCase {
 
     // MARK: - AuthService error mapping for enter/exit routes
 
-    func testEnterMaintenanceModeNon2xxMapsToServerError() async {
-        MaintenanceModeURLProtocol.requestHandler = { request in
+    func testEnterRecoveryModeNon2xxMapsToServerError() async {
+        RecoveryModeURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
                 statusCode: 409,
                 httpVersion: nil,
                 headerFields: nil
             )!
-            return (response, Data("{\"detail\": \"Already in maintenance mode\"}".utf8))
+            return (response, Data("{\"detail\": \"Already in recovery mode\"}".utf8))
         }
 
         do {
-            _ = try await AuthService.shared.enterMaintenanceMode(
+            _ = try await AuthService.shared.enterRecoveryMode(
                 assistantId: "asst-123",
                 organizationId: "org-1"
             )
@@ -210,19 +210,19 @@ final class PlatformAssistantMaintenanceDecodingTests: XCTestCase {
         }
     }
 
-    func testExitMaintenanceModeNon2xxMapsToServerError() async {
-        MaintenanceModeURLProtocol.requestHandler = { request in
+    func testExitRecoveryModeNon2xxMapsToServerError() async {
+        RecoveryModeURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
                 statusCode: 409,
                 httpVersion: nil,
                 headerFields: nil
             )!
-            return (response, Data("{\"detail\": \"Not in maintenance mode\"}".utf8))
+            return (response, Data("{\"detail\": \"Not in recovery mode\"}".utf8))
         }
 
         do {
-            _ = try await AuthService.shared.exitMaintenanceMode(
+            _ = try await AuthService.shared.exitRecoveryMode(
                 assistantId: "asst-123",
                 organizationId: "org-1"
             )
@@ -238,8 +238,8 @@ final class PlatformAssistantMaintenanceDecodingTests: XCTestCase {
         }
     }
 
-    func testEnterMaintenanceModeUnauthenticatedMapsToAuthRequired() async {
-        MaintenanceModeURLProtocol.requestHandler = { request in
+    func testEnterRecoveryModeUnauthenticatedMapsToAuthRequired() async {
+        RecoveryModeURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
                 statusCode: 401,
@@ -250,7 +250,7 @@ final class PlatformAssistantMaintenanceDecodingTests: XCTestCase {
         }
 
         do {
-            _ = try await AuthService.shared.enterMaintenanceMode(
+            _ = try await AuthService.shared.enterRecoveryMode(
                 assistantId: "asst-123",
                 organizationId: "org-1"
             )
@@ -266,8 +266,8 @@ final class PlatformAssistantMaintenanceDecodingTests: XCTestCase {
         }
     }
 
-    func testExitMaintenanceModeForbiddenMapsToAuthRequired() async {
-        MaintenanceModeURLProtocol.requestHandler = { request in
+    func testExitRecoveryModeForbiddenMapsToAuthRequired() async {
+        RecoveryModeURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
                 statusCode: 403,
@@ -278,7 +278,7 @@ final class PlatformAssistantMaintenanceDecodingTests: XCTestCase {
         }
 
         do {
-            _ = try await AuthService.shared.exitMaintenanceMode(
+            _ = try await AuthService.shared.exitRecoveryMode(
                 assistantId: "asst-789",
                 organizationId: "org-2"
             )


### PR DESCRIPTION
## Summary
- Fix decode error: enter/exit endpoints return `{"detail": "..."}` not a `PlatformAssistant`; POST then re-fetch via `refreshAssistant`
- Rename all UI strings and Swift symbols from Maintenance Mode → Recovery Mode
- `PlatformAssistantMaintenanceMode` → `PlatformAssistantRecoveryMode`
- `MaintenanceModeBanner.swift` → `RecoveryModeBanner.swift`
- `CodingKeys` added to `PlatformAssistant` so JSON key `maintenance_mode` maps to Swift `recovery_mode`
- Blocking test stub updated to only block first POST, pass GET through for `refreshAssistant`

Part of plan: assistant-debug-pods.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22589" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
