### PR TITLE
feat(cli): use signed-URL upload in teleport when importing to platform

### DIFF
--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -291,6 +291,41 @@ beforeEach(() => {
       },
     },
   });
+  platformRequestUploadUrlMock.mockReset();
+  platformRequestUploadUrlMock.mockResolvedValue({
+    uploadUrl: "https://storage.googleapis.com/bucket/signed-upload-url",
+    bundleKey: "bundle-key-123",
+    expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+  });
+  platformUploadToSignedUrlMock.mockReset();
+  platformUploadToSignedUrlMock.mockResolvedValue(undefined);
+  platformImportPreflightFromGcsMock.mockReset();
+  platformImportPreflightFromGcsMock.mockResolvedValue({
+    statusCode: 200,
+    body: {
+      can_import: true,
+      summary: {
+        files_to_create: 2,
+        files_to_overwrite: 1,
+        files_unchanged: 0,
+        total_files: 3,
+      },
+    },
+  });
+  platformImportBundleFromGcsMock.mockReset();
+  platformImportBundleFromGcsMock.mockResolvedValue({
+    statusCode: 200,
+    body: {
+      success: true,
+      summary: {
+        total_files: 3,
+        files_created: 2,
+        files_overwritten: 1,
+        files_skipped: 0,
+        backups_created: 1,
+      },
+    },
+  });
 
   hatchLocalMock.mockReset();
   hatchLocalMock.mockResolvedValue(undefined);
@@ -1031,5 +1066,178 @@ describe("teleport full flow", () => {
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining("--to is deprecated"),
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Signed-URL upload tests
+// ---------------------------------------------------------------------------
+
+describe("signed-URL upload flow", () => {
+  test("happy path: signed URL upload succeeds → GCS-based import used", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await teleport();
+
+      // Signed-URL flow should be used
+      expect(platformRequestUploadUrlMock).toHaveBeenCalled();
+      expect(platformUploadToSignedUrlMock).toHaveBeenCalled();
+      expect(platformImportBundleFromGcsMock).toHaveBeenCalledWith(
+        "bundle-key-123",
+        "platform-token",
+        "org-123",
+        "https://platform.vellum.ai",
+      );
+      // Inline import should NOT be called
+      expect(platformImportBundleMock).not.toHaveBeenCalled();
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Teleport complete"),
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("happy path dry-run: signed URL upload succeeds → GCS-based preflight used", async () => {
+    setArgv(
+      "--from",
+      "my-local",
+      "--platform",
+      "existing-platform",
+      "--dry-run",
+    );
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    const platformEntry = makeEntry("existing-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-local") return localEntry;
+      if (name === "existing-platform") return platformEntry;
+      return null;
+    });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await teleport();
+
+      // Signed-URL flow should be used for preflight
+      expect(platformRequestUploadUrlMock).toHaveBeenCalled();
+      expect(platformUploadToSignedUrlMock).toHaveBeenCalled();
+      expect(platformImportPreflightFromGcsMock).toHaveBeenCalledWith(
+        "bundle-key-123",
+        "platform-token",
+        "org-123",
+        "https://platform.vellum.ai",
+      );
+      // Inline preflight should NOT be called
+      expect(platformImportPreflightMock).not.toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("fallback: platformRequestUploadUrl throws 503 → falls back to inline import", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    // Simulate 503 — "not available" in the error message
+    platformRequestUploadUrlMock.mockRejectedValue(
+      new Error("Signed uploads are not available on this platform instance"),
+    );
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await teleport();
+
+      // Should fall back to inline import
+      expect(platformRequestUploadUrlMock).toHaveBeenCalled();
+      expect(platformUploadToSignedUrlMock).not.toHaveBeenCalled();
+      expect(platformImportBundleFromGcsMock).not.toHaveBeenCalled();
+      expect(platformImportBundleMock).toHaveBeenCalled();
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Teleport complete"),
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("upload error: platformUploadToSignedUrl throws → error propagates", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    // Upload succeeds at getting URL but fails during PUT
+    platformUploadToSignedUrlMock.mockRejectedValue(
+      new Error("Upload to signed URL failed: 500 Internal Server Error"),
+    );
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await expect(teleport()).rejects.toThrow(
+        "Upload to signed URL failed: 500 Internal Server Error",
+      );
+      // Should NOT fall back to inline import
+      expect(platformImportBundleMock).not.toHaveBeenCalled();
+      expect(platformImportBundleFromGcsMock).not.toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("413 from GCS import: error message includes 'too large'", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    // GCS import returns 413
+    platformImportBundleFromGcsMock.mockRejectedValue(
+      new Error("Bundle too large to import"),
+    );
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await expect(teleport()).rejects.toThrow("too large");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -20,6 +20,10 @@ import {
   platformDownloadExport,
   platformImportPreflight,
   platformImportBundle,
+  platformRequestUploadUrl,
+  platformUploadToSignedUrl,
+  platformImportPreflightFromGcs,
+  platformImportBundleFromGcs,
 } from "../lib/platform-client.js";
 import {
   hatchDocker,
@@ -649,6 +653,27 @@ async function importToAssistant(
       throw err;
     }
 
+    // Try signed-URL upload for large bundle support
+    let bundleKey: string | undefined;
+    try {
+      const { uploadUrl, bundleKey: key } = await platformRequestUploadUrl(
+        token,
+        orgId,
+        entry.runtimeUrl,
+      );
+      bundleKey = key;
+      console.log("Uploading bundle...");
+      await platformUploadToSignedUrl(uploadUrl, bundleData);
+    } catch (err) {
+      // If signed uploads unavailable (503), fall back to inline upload
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes("not available")) {
+        bundleKey = undefined;
+      } else {
+        throw err;
+      }
+    }
+
     if (dryRun) {
       console.log("Running preflight analysis...\n");
 
@@ -657,12 +682,19 @@ async function importToAssistant(
         body: Record<string, unknown>;
       };
       try {
-        preflightResult = await platformImportPreflight(
-          bundleData,
-          token,
-          orgId,
-          entry.runtimeUrl,
-        );
+        preflightResult = bundleKey
+          ? await platformImportPreflightFromGcs(
+              bundleKey,
+              token,
+              orgId,
+              entry.runtimeUrl,
+            )
+          : await platformImportPreflight(
+              bundleData,
+              token,
+              orgId,
+              entry.runtimeUrl,
+            );
       } catch (err) {
         if (err instanceof Error && err.name === "TimeoutError") {
           console.error("Error: Preflight request timed out after 2 minutes.");
@@ -712,12 +744,19 @@ async function importToAssistant(
 
     let importResult: { statusCode: number; body: Record<string, unknown> };
     try {
-      importResult = await platformImportBundle(
-        bundleData,
-        token,
-        orgId,
-        entry.runtimeUrl,
-      );
+      importResult = bundleKey
+        ? await platformImportBundleFromGcs(
+            bundleKey,
+            token,
+            orgId,
+            entry.runtimeUrl,
+          )
+        : await platformImportBundle(
+            bundleData,
+            token,
+            orgId,
+            entry.runtimeUrl,
+          );
     } catch (err) {
       if (err instanceof Error && err.name === "TimeoutError") {
         console.error("Error: Import request timed out after 2 minutes.");


### PR DESCRIPTION
## Summary
- Update teleport command to use GCS signed-URL upload when importing to platform
- Falls back to inline upload if platform returns 503 (signed uploads not available)
- Supports both dry-run (preflight) and actual import via GCS-backed endpoints
- Add tests for happy path, fallback, upload errors, and 413 handling

Part of plan: teleport-signed-url-upload.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22590" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
