### PR TITLE
fix(security): reject LAN-forwarded requests in guardian bootstrap

### DIFF
--- a/assistant/src/__tests__/actor-token-service.test.ts
+++ b/assistant/src/__tests__/actor-token-service.test.ts
@@ -649,6 +649,25 @@ describe("pairing credential flow", () => {
 // ---------------------------------------------------------------------------
 
 describe("bootstrap private-network guard", () => {
+  test("rejects bootstrap request with private X-Forwarded-For", async () => {
+    const { handleGuardianBootstrap } =
+      await import("../runtime/routes/guardian-bootstrap-routes.js");
+
+    const req = new Request("http://localhost/v1/guardian/init", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Forwarded-For": "192.168.1.10",
+      },
+      body: JSON.stringify({ platform: "macos", deviceId: "test-device" }),
+    });
+
+    const res = await handleGuardianBootstrap(req, loopbackServer);
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toContain("local-only");
+  });
+
   test("rejects bootstrap request with public X-Forwarded-For", async () => {
     const { handleGuardianBootstrap } =
       await import("../runtime/routes/guardian-bootstrap-routes.js");

--- a/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
+++ b/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
@@ -93,24 +93,18 @@ export async function handleGuardianBootstrap(
     return httpError("FORBIDDEN", "Bootstrap endpoint is local-only", 403);
   }
 
-  // Reject requests forwarded from public networks. The gateway sets
-  // x-forwarded-for to the real client IP; if that IP is on a private
-  // network (loopback, Docker bridge, RFC 1918) the request is still
-  // considered local. Only reject when the forwarded IP is public.
+  // In non-containerized mode, any x-forwarded-for header means the request
+  // came through the gateway from a non-loopback client. Legitimate bare-metal
+  // bootstrap clients connect from localhost; the gateway does not inject
+  // x-forwarded-for for loopback peers (see gateway/src/index.ts). Reject
+  // forwarded requests to prevent LAN-adjacent clients from bootstrapping.
   //
-  // Skip this check when running in a container: the peer IP was already
-  // validated above (Docker bridge network = private), so the request
-  // reached us through a co-located gateway. The x-forwarded-for header
-  // reflects the original external client (e.g. platform proxy) and is
-  // not meaningful for local-only enforcement in this topology.
+  // In containerized mode, skip this check: the peer IP was already validated
+  // above (Docker bridge network = private), and the x-forwarded-for header
+  // reflects the original external client which is not meaningful for
+  // local-only enforcement in this topology.
   const forwarded = req.headers.get("x-forwarded-for");
-  const forwardedIp = forwarded ? forwarded.split(",")[0].trim() : null;
-  if (
-    forwardedIp &&
-    !isPrivateAddress(forwardedIp) &&
-    !isHttpAuthDisabled() &&
-    !getIsContainerized()
-  ) {
+  if (forwarded && !isHttpAuthDisabled() && !getIsContainerized()) {
     return httpError("FORBIDDEN", "Bootstrap endpoint is local-only", 403);
   }
 

--- a/gateway/src/http/routes/channel-verification-session-proxy.ts
+++ b/gateway/src/http/routes/channel-verification-session-proxy.ts
@@ -61,8 +61,12 @@ export function createChannelVerificationSessionProxyHandler(
 
     // Inject the real client IP so the runtime can enforce loopback-only
     // checks, overwriting any client-supplied value to prevent spoofing.
+    // When clientIp is undefined (loopback peer), strip any client-supplied
+    // header to prevent forged forwarded-for values from reaching the runtime.
     if (clientIp) {
       reqHeaders.set("x-forwarded-for", clientIp);
+    } else {
+      reqHeaders.delete("x-forwarded-for");
     }
 
     // Mint a short-lived service token for gateway->runtime auth.

--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -87,8 +87,12 @@ export function createRuntimeProxyHandler(config: GatewayConfig) {
 
     // Inject the real client IP so the runtime can rate-limit per-user,
     // overwriting any client-supplied value to prevent spoofing.
+    // When clientIp is undefined (loopback peer), strip any client-supplied
+    // header to prevent forged forwarded-for values from reaching the runtime.
     if (clientIp) {
       reqHeaders.set("x-forwarded-for", clientIp);
+    } else {
+      reqHeaders.delete("x-forwarded-for");
     }
 
     // Replace with the exchange token for the runtime (proves gateway origin)


### PR DESCRIPTION
## Summary
- Tighten the `x-forwarded-for` check in `handleGuardianBootstrap` to reject **any** forwarded request in non-containerized (bare-metal) mode, not just requests with public forwarded IPs. In bare-metal mode, the gateway only injects `x-forwarded-for` for non-loopback clients, so legitimate local bootstrap clients never have this header set.
- This closes a window where LAN-adjacent clients with private IPs (e.g. `192.168.x.x`) could reach the gateway and bootstrap guardian tokens, bypassing the intended local-only boundary.
- Docker/containerized mode is unaffected — the forwarded IP check is already skipped via `getIsContainerized()`. The peer IP check (`isPrivateAddress`) is preserved unchanged to support Docker bridge IPs.

Codex finding: https://chatgpt.com/codex/security/findings/fb641beb7e6c8191b027ec4633f2bedf?sev=critical%2Chigh

## Original prompt
Security fix: Tighten guardian bootstrap to reject LAN-forwarded requests in bare-metal mode
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
