### PR TITLE
security: strip external identity fields from contact_upsert tool

### DIFF
--- a/assistant/src/__tests__/contacts-tools.test.ts
+++ b/assistant/src/__tests__/contacts-tools.test.ts
@@ -157,15 +157,15 @@ describe("contact_upsert tool", () => {
 
     const row = getRawDb()
       .query(
-        "SELECT externalUserId, externalChatId FROM contact_channels WHERE type = 'slack' AND address = '@eve'",
+        "SELECT external_user_id, external_chat_id FROM contact_channels WHERE type = 'slack' AND address = '@eve'",
       )
       .get() as {
-      externalUserId: string | null;
-      externalChatId: string | null;
+      external_user_id: string | null;
+      external_chat_id: string | null;
     };
 
-    expect(row.externalUserId).toBeNull();
-    expect(row.externalChatId).toBeNull();
+    expect(row.external_user_id).toBeNull();
+    expect(row.external_chat_id).toBeNull();
   });
 
   test("updates an existing contact by ID", async () => {

--- a/assistant/src/__tests__/contacts-tools.test.ts
+++ b/assistant/src/__tests__/contacts-tools.test.ts
@@ -137,6 +137,37 @@ describe("contact_upsert tool", () => {
     expect(result.content).toContain("slack: @bob");
   });
 
+  test("ignores external identity bindings supplied through tool input", async () => {
+    const result = await executeContactUpsert(
+      {
+        display_name: "Eve",
+        channels: [
+          {
+            type: "slack",
+            address: "@eve",
+            external_user_id: "UATTACKER",
+            external_chat_id: "DATTACKER",
+          },
+        ],
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+
+    const row = getRawDb()
+      .query(
+        "SELECT externalUserId, externalChatId FROM contact_channels WHERE type = 'slack' AND address = '@eve'",
+      )
+      .get() as {
+      externalUserId: string | null;
+      externalChatId: string | null;
+    };
+
+    expect(row.externalUserId).toBeNull();
+    expect(row.externalChatId).toBeNull();
+  });
+
   test("updates an existing contact by ID", async () => {
     const createResult = await executeContactUpsert(
       { display_name: "Charlie" },

--- a/assistant/src/config/bundled-skills/contacts/TOOLS.json
+++ b/assistant/src/config/bundled-skills/contacts/TOOLS.json
@@ -47,14 +47,6 @@
                 "is_primary": {
                   "type": "boolean",
                   "description": "Whether this is the primary channel for this type"
-                },
-                "external_user_id": {
-                  "type": "string",
-                  "description": "Platform-native user ID (e.g. Slack user ID like U12345). Used to cache user lookups."
-                },
-                "external_chat_id": {
-                  "type": "string",
-                  "description": "Platform-native chat/DM channel ID (e.g. Slack DM channel like D12345). Used to cache DM channel lookups."
                 }
               },
               "required": ["type", "address"]

--- a/assistant/src/config/bundled-skills/contacts/tools/contact-upsert.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/contact-upsert.ts
@@ -63,16 +63,12 @@ export async function executeContactUpsert(
         type: string;
         address: string;
         is_primary?: boolean;
-        external_user_id?: string;
-        external_chat_id?: string;
       }>
     | undefined;
   const channels = rawChannels?.map((ch) => ({
     type: ch.type,
     address: ch.address,
     isPrimary: ch.is_primary,
-    externalUserId: ch.external_user_id,
-    externalChatId: ch.external_chat_id,
   }));
 
   try {

--- a/assistant/src/config/bundled-skills/slack/SKILL.md
+++ b/assistant/src/config/bundled-skills/slack/SKILL.md
@@ -68,13 +68,7 @@ When you need to send a DM or look up a Slack user by name, check contacts first
 
 1. **Before calling `users.list`**: Use `contact_search` with `query: "<name>"` and `channel_type: "slack"`. If a matching contact has `externalUserId` (Slack user ID) and `externalChatId` (DM channel ID), skip the API lookups and use those IDs directly with `chat.postMessage`.
 
-2. **After resolving via API**: When you had to call `users.list` or `conversations.open` to resolve a user, save the mapping with `contact_upsert` so future lookups are instant:
-   ```
-   contact_upsert {
-     display_name: "<display name>"
-     channels: [{ type: "slack", address: "<slack handle>", external_user_id: "<U...>", external_chat_id: "<D...>" }]
-   }
-   ```
+2. **Automatic caching**: When the Slack adapter resolves a user via API, it automatically caches the external IDs in the contacts store. No manual `contact_upsert` call is needed for ID caching.
 
 ## Privacy Rules
 

--- a/assistant/src/config/bundled-skills/slack/SKILL.md
+++ b/assistant/src/config/bundled-skills/slack/SKILL.md
@@ -68,7 +68,7 @@ When you need to send a DM or look up a Slack user by name, check contacts first
 
 1. **Before calling `users.list`**: Use `contact_search` with `query: "<name>"` and `channel_type: "slack"`. If a matching contact has `externalUserId` (Slack user ID) and `externalChatId` (DM channel ID), skip the API lookups and use those IDs directly with `chat.postMessage`.
 
-2. **Automatic caching**: When the Slack adapter resolves a user via API, it automatically caches the external IDs in the contacts store. No manual `contact_upsert` call is needed for ID caching.
+2. **After resolving via API**: When you had to call `users.list` or `conversations.open` to resolve a user, save the contact with `contact_upsert` so you can find them by name next time. External Slack IDs (user ID, DM channel ID) are cached automatically by the messaging layer and should not be passed through `contact_upsert`.
 
 ## Privacy Rules
 


### PR DESCRIPTION
## Summary
- Remove `external_user_id` and `external_chat_id` from the `contact_upsert` tool schema and executor to prevent untrusted tool calls from overwriting identity bindings used by the inbound ACL for sender resolution
- Update Slack SKILL.md to reflect that external ID caching is handled automatically by the Slack adapter (no manual `contact_upsert` needed)
- Add regression test verifying that external identity bindings supplied through tool input are ignored

Codex finding: https://chatgpt.com/codex/security/findings/cc550804891c8191a0e026e724c0684d?sev=critical%2Chigh

## Original prompt
Security fix: Strip external_user_id/external_chat_id from contact_upsert tool to prevent identity rebinding auth bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
