### PR TITLE
feat(cli): use signed URLs for large bundle uploads in teleport

### DIFF
--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -291,6 +291,41 @@ beforeEach(() => {
       },
     },
   });
+  platformRequestUploadUrlMock.mockReset();
+  platformRequestUploadUrlMock.mockResolvedValue({
+    uploadUrl: "https://storage.googleapis.com/bucket/signed-upload-url",
+    bundleKey: "bundle-key-123",
+    expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+  });
+  platformUploadToSignedUrlMock.mockReset();
+  platformUploadToSignedUrlMock.mockResolvedValue(undefined);
+  platformImportPreflightFromGcsMock.mockReset();
+  platformImportPreflightFromGcsMock.mockResolvedValue({
+    statusCode: 200,
+    body: {
+      can_import: true,
+      summary: {
+        files_to_create: 2,
+        files_to_overwrite: 1,
+        files_unchanged: 0,
+        total_files: 3,
+      },
+    },
+  });
+  platformImportBundleFromGcsMock.mockReset();
+  platformImportBundleFromGcsMock.mockResolvedValue({
+    statusCode: 200,
+    body: {
+      success: true,
+      summary: {
+        total_files: 3,
+        files_created: 2,
+        files_overwritten: 1,
+        files_skipped: 0,
+        backups_created: 1,
+      },
+    },
+  });
 
   hatchLocalMock.mockReset();
   hatchLocalMock.mockResolvedValue(undefined);
@@ -1031,5 +1066,178 @@ describe("teleport full flow", () => {
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining("--to is deprecated"),
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Signed-URL upload tests
+// ---------------------------------------------------------------------------
+
+describe("signed-URL upload flow", () => {
+  test("happy path: signed URL upload succeeds → GCS-based import used", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await teleport();
+
+      // Signed-URL flow should be used
+      expect(platformRequestUploadUrlMock).toHaveBeenCalled();
+      expect(platformUploadToSignedUrlMock).toHaveBeenCalled();
+      expect(platformImportBundleFromGcsMock).toHaveBeenCalledWith(
+        "bundle-key-123",
+        "platform-token",
+        "org-123",
+        "https://platform.vellum.ai",
+      );
+      // Inline import should NOT be called
+      expect(platformImportBundleMock).not.toHaveBeenCalled();
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Teleport complete"),
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("happy path dry-run: signed URL upload succeeds → GCS-based preflight used", async () => {
+    setArgv(
+      "--from",
+      "my-local",
+      "--platform",
+      "existing-platform",
+      "--dry-run",
+    );
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    const platformEntry = makeEntry("existing-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-local") return localEntry;
+      if (name === "existing-platform") return platformEntry;
+      return null;
+    });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await teleport();
+
+      // Signed-URL flow should be used for preflight
+      expect(platformRequestUploadUrlMock).toHaveBeenCalled();
+      expect(platformUploadToSignedUrlMock).toHaveBeenCalled();
+      expect(platformImportPreflightFromGcsMock).toHaveBeenCalledWith(
+        "bundle-key-123",
+        "platform-token",
+        "org-123",
+        "https://platform.vellum.ai",
+      );
+      // Inline preflight should NOT be called
+      expect(platformImportPreflightMock).not.toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("fallback: platformRequestUploadUrl throws 503 → falls back to inline import", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    // Simulate 503 — "not available" in the error message
+    platformRequestUploadUrlMock.mockRejectedValue(
+      new Error("Signed uploads are not available on this platform instance"),
+    );
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await teleport();
+
+      // Should fall back to inline import
+      expect(platformRequestUploadUrlMock).toHaveBeenCalled();
+      expect(platformUploadToSignedUrlMock).not.toHaveBeenCalled();
+      expect(platformImportBundleFromGcsMock).not.toHaveBeenCalled();
+      expect(platformImportBundleMock).toHaveBeenCalled();
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Teleport complete"),
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("upload error: platformUploadToSignedUrl throws → error propagates", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    // Upload succeeds at getting URL but fails during PUT
+    platformUploadToSignedUrlMock.mockRejectedValue(
+      new Error("Upload to signed URL failed: 500 Internal Server Error"),
+    );
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await expect(teleport()).rejects.toThrow(
+        "Upload to signed URL failed: 500 Internal Server Error",
+      );
+      // Should NOT fall back to inline import
+      expect(platformImportBundleMock).not.toHaveBeenCalled();
+      expect(platformImportBundleFromGcsMock).not.toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("413 from GCS import: error message includes 'too large'", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    // GCS import returns 413
+    platformImportBundleFromGcsMock.mockRejectedValue(
+      new Error("Bundle too large to import"),
+    );
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await expect(teleport()).rejects.toThrow("too large");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -108,6 +108,37 @@ const platformImportBundleMock = mock(async () => ({
     },
   } as Record<string, unknown>,
 }));
+const platformRequestUploadUrlMock = mock(async () => ({
+  uploadUrl: "https://storage.googleapis.com/bucket/signed-upload-url",
+  bundleKey: "bundle-key-123",
+  expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+}));
+const platformUploadToSignedUrlMock = mock(async () => {});
+const platformImportPreflightFromGcsMock = mock(async () => ({
+  statusCode: 200,
+  body: {
+    can_import: true,
+    summary: {
+      files_to_create: 2,
+      files_to_overwrite: 1,
+      files_unchanged: 0,
+      total_files: 3,
+    },
+  } as Record<string, unknown>,
+}));
+const platformImportBundleFromGcsMock = mock(async () => ({
+  statusCode: 200,
+  body: {
+    success: true,
+    summary: {
+      total_files: 3,
+      files_created: 2,
+      files_overwritten: 1,
+      files_skipped: 0,
+      backups_created: 1,
+    },
+  } as Record<string, unknown>,
+}));
 
 mock.module("../lib/platform-client.js", () => ({
   readPlatformToken: readPlatformTokenMock,
@@ -119,6 +150,10 @@ mock.module("../lib/platform-client.js", () => ({
   platformDownloadExport: platformDownloadExportMock,
   platformImportPreflight: platformImportPreflightMock,
   platformImportBundle: platformImportBundleMock,
+  platformRequestUploadUrl: platformRequestUploadUrlMock,
+  platformUploadToSignedUrl: platformUploadToSignedUrlMock,
+  platformImportPreflightFromGcs: platformImportPreflightFromGcsMock,
+  platformImportBundleFromGcs: platformImportBundleFromGcsMock,
 }));
 
 const hatchLocalMock = mock(async () => {});

--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -1186,6 +1186,40 @@ describe("signed-URL upload flow", () => {
     }
   });
 
+  test("fallback: platformRequestUploadUrl throws 404 → falls back to inline import", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    // Simulate 404 — endpoint doesn't exist on older platform versions
+    platformRequestUploadUrlMock.mockRejectedValue(
+      new Error("Signed uploads are not available on this platform instance"),
+    );
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await teleport();
+
+      // Should fall back to inline import
+      expect(platformRequestUploadUrlMock).toHaveBeenCalled();
+      expect(platformUploadToSignedUrlMock).not.toHaveBeenCalled();
+      expect(platformImportBundleFromGcsMock).not.toHaveBeenCalled();
+      expect(platformImportBundleMock).toHaveBeenCalled();
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Teleport complete"),
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test("upload error: platformUploadToSignedUrl throws → error propagates", async () => {
     setArgv("--from", "my-local", "--platform");
 

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -20,6 +20,10 @@ import {
   platformDownloadExport,
   platformImportPreflight,
   platformImportBundle,
+  platformRequestUploadUrl,
+  platformUploadToSignedUrl,
+  platformImportPreflightFromGcs,
+  platformImportBundleFromGcs,
 } from "../lib/platform-client.js";
 import {
   hatchDocker,
@@ -649,6 +653,27 @@ async function importToAssistant(
       throw err;
     }
 
+    // Try signed-URL upload for large bundle support
+    let bundleKey: string | undefined;
+    try {
+      const { uploadUrl, bundleKey: key } = await platformRequestUploadUrl(
+        token,
+        orgId,
+        entry.runtimeUrl,
+      );
+      bundleKey = key;
+      console.log("Uploading bundle...");
+      await platformUploadToSignedUrl(uploadUrl, bundleData);
+    } catch (err) {
+      // If signed uploads unavailable (503), fall back to inline upload
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes("not available")) {
+        bundleKey = undefined;
+      } else {
+        throw err;
+      }
+    }
+
     if (dryRun) {
       console.log("Running preflight analysis...\n");
 
@@ -657,12 +682,19 @@ async function importToAssistant(
         body: Record<string, unknown>;
       };
       try {
-        preflightResult = await platformImportPreflight(
-          bundleData,
-          token,
-          orgId,
-          entry.runtimeUrl,
-        );
+        preflightResult = bundleKey
+          ? await platformImportPreflightFromGcs(
+              bundleKey,
+              token,
+              orgId,
+              entry.runtimeUrl,
+            )
+          : await platformImportPreflight(
+              bundleData,
+              token,
+              orgId,
+              entry.runtimeUrl,
+            );
       } catch (err) {
         if (err instanceof Error && err.name === "TimeoutError") {
           console.error("Error: Preflight request timed out after 2 minutes.");
@@ -712,12 +744,19 @@ async function importToAssistant(
 
     let importResult: { statusCode: number; body: Record<string, unknown> };
     try {
-      importResult = await platformImportBundle(
-        bundleData,
-        token,
-        orgId,
-        entry.runtimeUrl,
-      );
+      importResult = bundleKey
+        ? await platformImportBundleFromGcs(
+            bundleKey,
+            token,
+            orgId,
+            entry.runtimeUrl,
+          )
+        : await platformImportBundle(
+            bundleData,
+            token,
+            orgId,
+            entry.runtimeUrl,
+          );
     } catch (err) {
       if (err instanceof Error && err.name === "TimeoutError") {
         console.error("Error: Import request timed out after 2 minutes.");

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -388,3 +388,129 @@ export async function platformImportBundle(
   >;
   return { statusCode: response.status, body };
 }
+
+// ---------------------------------------------------------------------------
+// Signed-URL upload flow
+// ---------------------------------------------------------------------------
+
+export async function platformRequestUploadUrl(
+  token: string,
+  orgId: string,
+  platformUrl?: string,
+): Promise<{ uploadUrl: string; bundleKey: string; expiresAt: string }> {
+  const resolvedUrl = platformUrl || getPlatformUrl();
+  const response = await fetch(`${resolvedUrl}/v1/migrations/upload-url/`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...authHeaders(token),
+      "Vellum-Organization-Id": orgId,
+    },
+    body: JSON.stringify({ content_type: "application/octet-stream" }),
+  });
+
+  if (response.status === 201) {
+    const body = (await response.json()) as {
+      upload_url: string;
+      bundle_key: string;
+      expires_at: string;
+    };
+    return {
+      uploadUrl: body.upload_url,
+      bundleKey: body.bundle_key,
+      expiresAt: body.expires_at,
+    };
+  }
+
+  if (response.status === 503) {
+    throw new Error(
+      "Signed uploads are not available on this platform instance",
+    );
+  }
+
+  const errorBody = (await response.json().catch(() => ({}))) as {
+    detail?: string;
+  };
+  throw new Error(
+    errorBody.detail ??
+      `Failed to request upload URL: ${response.status} ${response.statusText}`,
+  );
+}
+
+export async function platformUploadToSignedUrl(
+  uploadUrl: string,
+  bundleData: Uint8Array<ArrayBuffer>,
+): Promise<void> {
+  const response = await fetch(uploadUrl, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/octet-stream",
+    },
+    body: new Blob([bundleData]),
+    signal: AbortSignal.timeout(600_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Upload to signed URL failed: ${response.status} ${response.statusText}`,
+    );
+  }
+}
+
+export async function platformImportPreflightFromGcs(
+  bundleKey: string,
+  token: string,
+  orgId: string,
+  platformUrl?: string,
+): Promise<{ statusCode: number; body: Record<string, unknown> }> {
+  const resolvedUrl = platformUrl || getPlatformUrl();
+  const response = await fetch(
+    `${resolvedUrl}/v1/migrations/import-preflight-from-gcs/`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeaders(token),
+        "Vellum-Organization-Id": orgId,
+      },
+      body: JSON.stringify({ bundle_key: bundleKey }),
+    },
+  );
+
+  const body = (await response.json().catch(() => ({}))) as Record<
+    string,
+    unknown
+  >;
+  return { statusCode: response.status, body };
+}
+
+export async function platformImportBundleFromGcs(
+  bundleKey: string,
+  token: string,
+  orgId: string,
+  platformUrl?: string,
+): Promise<{ statusCode: number; body: Record<string, unknown> }> {
+  const resolvedUrl = platformUrl || getPlatformUrl();
+  const response = await fetch(
+    `${resolvedUrl}/v1/migrations/import-from-gcs/`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeaders(token),
+        "Vellum-Organization-Id": orgId,
+      },
+      body: JSON.stringify({ bundle_key: bundleKey }),
+    },
+  );
+
+  if (response.status === 413) {
+    throw new Error("Bundle too large to import");
+  }
+
+  const body = (await response.json().catch(() => ({}))) as Record<
+    string,
+    unknown
+  >;
+  return { statusCode: response.status, body };
+}

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -474,6 +474,7 @@ export async function platformImportPreflightFromGcs(
         "Vellum-Organization-Id": orgId,
       },
       body: JSON.stringify({ bundle_key: bundleKey }),
+      signal: AbortSignal.timeout(120_000),
     },
   );
 
@@ -501,6 +502,7 @@ export async function platformImportBundleFromGcs(
         "Vellum-Organization-Id": orgId,
       },
       body: JSON.stringify({ bundle_key: bundleKey }),
+      signal: AbortSignal.timeout(120_000),
     },
   );
 

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -178,7 +178,7 @@ export async function fetchCurrentUser(
   const resolvedUrl = platformUrl || getPlatformUrl();
   const url = `${resolvedUrl}/_allauth/app/v1/auth/session`;
   const response = await fetch(url, {
-    headers: { ...authHeaders(token) },
+    headers: { "X-Session-Token": token },
   });
 
   if (!response.ok) {

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -143,7 +143,7 @@ export async function fetchOrganizationId(
   const resolvedUrl = platformUrl || getPlatformUrl();
   const url = `${resolvedUrl}/v1/organizations/`;
   const response = await fetch(url, {
-    headers: { "X-Session-Token": token },
+    headers: { ...authHeaders(token) },
   });
 
   if (!response.ok) {
@@ -178,7 +178,7 @@ export async function fetchCurrentUser(
   const resolvedUrl = platformUrl || getPlatformUrl();
   const url = `${resolvedUrl}/_allauth/app/v1/auth/session`;
   const response = await fetch(url, {
-    headers: { "X-Session-Token": token },
+    headers: { ...authHeaders(token) },
   });
 
   if (!response.ok) {
@@ -213,7 +213,7 @@ export async function rollbackPlatformAssistant(
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "X-Session-Token": token,
+      ...authHeaders(token),
       "Vellum-Organization-Id": orgId,
     },
     body: JSON.stringify(version ? { version } : {}),
@@ -258,7 +258,7 @@ export async function platformInitiateExport(
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "X-Session-Token": token,
+      ...authHeaders(token),
       "Vellum-Organization-Id": orgId,
     },
     body: JSON.stringify({ description: description ?? "CLI backup" }),
@@ -292,7 +292,7 @@ export async function platformPollExportStatus(
     `${resolvedUrl}/v1/migrations/export/${jobId}/status/`,
     {
       headers: {
-        "X-Session-Token": token,
+        ...authHeaders(token),
         "Vellum-Organization-Id": orgId,
       },
     },

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -349,7 +349,7 @@ export async function platformImportPreflight(
       method: "POST",
       headers: {
         "Content-Type": "application/octet-stream",
-        "X-Session-Token": token,
+        ...authHeaders(token),
         "Vellum-Organization-Id": orgId,
       },
       body: new Blob([bundleData]),
@@ -375,7 +375,7 @@ export async function platformImportBundle(
     method: "POST",
     headers: {
       "Content-Type": "application/octet-stream",
-      "X-Session-Token": token,
+      ...authHeaders(token),
       "Vellum-Organization-Id": orgId,
     },
     body: new Blob([bundleData]),

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -422,7 +422,7 @@ export async function platformRequestUploadUrl(
     };
   }
 
-  if (response.status === 503) {
+  if (response.status === 404 || response.status === 503) {
     throw new Error(
       "Signed uploads are not available on this platform instance",
     );


### PR DESCRIPTION
## Summary
Update the CLI teleport command to upload bundles via GCS signed URLs when pushing to a platform assistant, eliminating size limits on teleport-to-platform transfers. Falls back to inline upload if the platform doesn't support signed URLs (503).

## PRs merged into feature branch
- #22587: feat(cli): add platform client functions for signed-URL upload flow
- #22590: feat(cli): use signed-URL upload in teleport when importing to platform

Part of plan: teleport-signed-url-upload.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
