### PR TITLE
fix: add timeouts to GCS import/preflight functions

### DIFF
--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -474,6 +474,7 @@ export async function platformImportPreflightFromGcs(
         "Vellum-Organization-Id": orgId,
       },
       body: JSON.stringify({ bundle_key: bundleKey }),
+      signal: AbortSignal.timeout(120_000),
     },
   );
 
@@ -501,6 +502,7 @@ export async function platformImportBundleFromGcs(
         "Vellum-Organization-Id": orgId,
       },
       body: JSON.stringify({ bundle_key: bundleKey }),
+      signal: AbortSignal.timeout(120_000),
     },
   );
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for teleport-signed-url-upload.md.

**Gap:** Missing timeouts on GCS import/preflight functions
**What was expected:** GCS functions should have AbortSignal.timeout like their inline counterparts
**What was found:** platformImportPreflightFromGcs and platformImportBundleFromGcs had no timeout
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
