### PR TITLE
GA the outlook-oauth-integration feature flag

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -19,13 +19,13 @@ You are a unified messaging assistant with access to multiple platforms (Gmail, 
 
 When composing messages on behalf of your user to external recipients, refer to yourself as an "assistant" (not "AI assistant"). Use your user's name and pronouns from USER.md. Don't volunteer that you are an AI unless directly asked.
 
-For Gmail management (archive, label, triage, declutter), load the **gmail** skill. For email sequences, load the **sequences** skill.
+For Email management (archive, label, triage, declutter), load the **gmail** or **outlook** skill. For email sequences, load the **sequences** skill.
 
 ## Email Routing Priority
 
-When the user mentions "email" - sending, reading, checking, decluttering, drafting, or anything else - **always default to the user's own email (Gmail)** unless they explicitly ask about the assistant's own email address (e.g., "set up your email", "send from your address", "check your inbox"). The vast majority of email requests are about the user's Gmail, not the assistant's AgentMail address.
+When the user mentions "email" - sending, reading, checking, decluttering, drafting, or anything else - **always default to the user's own email** unless they explicitly ask about the assistant's own email address (e.g., "set up your email", "send from your address", "check your inbox"). The vast majority of email requests are about the user's Gmail or Outlook, not the assistant's AgentMail address.
 
-Do not offer AgentMail as an option or mention it unless the user specifically asks. If Gmail is not connected, guide them through Gmail setup - do not suggest AgentMail as an alternative.
+Do not offer AgentMail as an option or mention it unless the user specifically asks. If Gmail and Outlookk are not connected, guide them through setup - do not suggest AgentMail as an alternative.
 
 ## Communication Style
 
@@ -44,15 +44,15 @@ Before using any messaging tool, verify that the platform is connected by callin
 
 ### Public Ingress (required for Telegram)
 
-Telegram setup requires webhook routing, but it does **not** always require ngrok. Before suggesting public ingress for Telegram, check managed callback availability with `assistant platform status --json`. If that reports `containerized: true` with a non-empty `assistantId` and `available: true`, use the platform callback route flow and do not prompt for ngrok. Only use the **public-ingress** skill for local assistants that genuinely need a public gateway URL. Slack uses Socket Mode and does not require public ingress. Gmail on the desktop app uses a loopback callback and does not require public ingress; the channel path (Path B in the google-oauth-app-setup skill) handles public ingress internally when needed.
+Telegram setup requires webhook routing, but it does **not** always require ngrok. Before suggesting public ingress for Telegram, check managed callback availability with `assistant platform status --json`. If that reports `containerized: true` with a non-empty `assistantId` and `available: true`, use the platform callback route flow and do not prompt for ngrok. Only use the **public-ingress** skill for local assistants that genuinely need a public gateway URL. Slack uses Socket Mode and does not require public ingress. Gmail/Outlook on the desktop app uses a loopback callback and does not require public ingress; the channel path (Path B in the google-oauth-app-setup skill) handles public ingress internally when needed.
 
 ### Email Connection Flow
 
 When the user asks to "connect my email", "set up email", "manage my email", or similar - and has not named a specific provider:
 
-1. **Discover what's connected.** Call `messaging_auth_test` for `gmail` (and any other email-capable platforms). If one succeeds, tell the user it's already connected and proceed with their request.
+1. **Discover what's connected.** Call `messaging_auth_test` for `gmail`or `outlook` (and any other email-capable platforms). If one succeeds, tell the user it's already connected and proceed with their request.
 2. **If nothing is connected**, ask which provider they use - but keep it brief and conversational (e.g., "Which email do you use - Gmail, Outlook, etc.?"), not a numbered list of options with descriptions.
-3. **Once the provider is known, act immediately.** Don't present setup options or explain OAuth. If it's Gmail, follow the Gmail section below. For any other provider, let the user know that only Gmail is fully supported right now, and offer to set up Gmail instead.
+3. **Once the provider is known, act immediately.** Don't present setup options or explain OAuth. If it's Gmail or Outlook, follow the sections below. For any other provider, let the user know that only Gmail and Outlook are fully supported right now, and offer to set up Gmail/Outlook instead.
 
 ### Gmail
 
@@ -70,7 +70,8 @@ When the user asks to "connect my email", "set up email", "manage my email", or 
 ### Outlook
 
 1. **Try connecting directly first.** Run `assistant oauth status outlook`. This will show whether the user has previously connected their Outlook account.
-2. **If no connections are found:** Guide the user to connect their Microsoft account through the OAuth flow.
+2. **If no connections are found:** The user needs to either use Vellum's managed outlook integration or set up their own azure oauth app.
+   - Call `skill_load` with `skill: "vellum-oauth-integrations"` with `provider-key: outlook` throughout.
 
 ### Slack
 
@@ -114,7 +115,7 @@ When a messaging tool fails with a token or authorization error:
 
 ## Capabilities
 
-### Universal (Gmail)
+### Gmail
 
 - **Auth Test**: Verify connection and show account info
 - **List Conversations**: Show inboxes, DMs with unread counts

--- a/assistant/src/daemon/providers-setup.ts
+++ b/assistant/src/daemon/providers-setup.ts
@@ -1,11 +1,9 @@
-import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import {
   setPlatformAssistantId,
   setPlatformBaseUrl,
   setPlatformOrganizationId,
   setPlatformUserId,
 } from "../config/env.js";
-import { getConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/types.js";
 import { setSentryOrganizationId, setSentryUserId } from "../instrument.js";
 import { getMcpServerManager } from "../mcp/manager.js";
@@ -139,12 +137,8 @@ export function registerWatcherProviders(): void {
   registerWatcherProvider(googleCalendarProvider);
   registerWatcherProvider(githubProvider);
   registerWatcherProvider(linearProvider);
-
-  const config = getConfig();
-  if (isAssistantFeatureFlagEnabled("outlook-oauth-integration", config)) {
-    registerWatcherProvider(outlookProvider);
-    registerWatcherProvider(outlookCalendarProvider);
-  }
+  registerWatcherProvider(outlookProvider);
+  registerWatcherProvider(outlookCalendarProvider);
 
   initWatcherEngine();
 }

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -642,7 +642,6 @@ const PROVIDER_SEED_DATA: Record<
     appType: "App registration",
     identityUrl: "https://graph.microsoft.com/v1.0/me",
     identityResponsePaths: ["mail", "userPrincipalName"],
-    featureFlag: "outlook-oauth-integration",
   },
 
   // Manual-token providers: these don't use OAuth2 flows but need provider

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -368,14 +368,6 @@
       "label": "Fast Mode",
       "description": "Enable Anthropic fast mode for Opus 4.6, delivering up to 2.5x higher output tokens per second at premium pricing",
       "defaultEnabled": false
-    },
-    {
-      "id": "outlook-oauth-integration",
-      "scope": "assistant",
-      "key": "outlook-oauth-integration",
-      "label": "Outlook / Microsoft Integration",
-      "description": "Enable the Outlook / Microsoft OAuth provider for connecting to Microsoft Graph APIs (email, calendar)",
-      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Remove the `outlook-oauth-integration` feature flag from the registry, making Outlook/Microsoft integration available to all users
- Remove feature flag gating from the Outlook OAuth provider seed and watcher provider registration
- Update messaging SKILL.md to treat Outlook as a first-class email provider alongside Gmail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
