### PR TITLE
fix: use authHeaders() in inline import/preflight functions

### DIFF
--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -349,7 +349,7 @@ export async function platformImportPreflight(
       method: "POST",
       headers: {
         "Content-Type": "application/octet-stream",
-        "X-Session-Token": token,
+        ...authHeaders(token),
         "Vellum-Organization-Id": orgId,
       },
       body: new Blob([bundleData]),
@@ -375,7 +375,7 @@ export async function platformImportBundle(
     method: "POST",
     headers: {
       "Content-Type": "application/octet-stream",
-      "X-Session-Token": token,
+      ...authHeaders(token),
       "Vellum-Organization-Id": orgId,
     },
     body: new Blob([bundleData]),


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for teleport-signed-url-upload.md.

**Gap:** Auth header inconsistency between GCS path and inline fallback path
**What was expected:** Both paths should use authHeaders() for consistent auth handling
**What was found:** platformImportPreflight and platformImportBundle hardcoded X-Session-Token instead of using authHeaders()
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
