### PR TITLE
fix(gateway): enforce scope checks on migration proxy routes

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -798,13 +798,15 @@ async function main() {
     {
       path: "/v1/migrations/export",
       method: "POST",
-      auth: "edge",
+      auth: "edge-scoped",
+      scope: "settings.write",
       handler: (req) => migrationExportProxy(req),
     },
     {
       path: "/v1/migrations/import",
       method: "POST",
-      auth: "edge",
+      auth: "edge-scoped",
+      scope: "settings.write",
       handler: (req) => migrationImportProxy(req),
     },
 


### PR DESCRIPTION
## Summary

- Switch migration export/import gateway routes from `auth: "edge"` to `auth: "edge-scoped"` with `scope: "settings.write"` to prevent privilege escalation
- Low-scope edge tokens (e.g., `ui_page_v1` with only `settings.read`) can no longer reach migration endpoints that require `settings.write`
- Legitimate callers using `actor_client_v1` tokens (desktop/CLI) are unaffected since that profile already includes `settings.write`

Codex finding: https://chatgpt.com/codex/security/findings/0beb1a89649481919daec06f232de250?sev=critical%2Chigh

## Original prompt

Fix privilege escalation on gateway migration proxy routes. The migration export/import routes are registered with `auth: "edge"` instead of scoped auth, allowing low-privilege edge tokens to reach privileged migration endpoints via the gateway's service-token minting.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
