### PR TITLE
fix(gateway): always forward client IP for guardian init requests

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -153,16 +153,6 @@ function isBrowserRelaySocketData(
   );
 }
 
-/** Check whether an IP address is a loopback address (127.0.0.0/8 or ::1). */
-function isLoopbackIp(ip: string): boolean {
-  const v4Mapped = ip.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
-  const normalized = v4Mapped ? v4Mapped[1] : ip;
-  if (normalized.includes(".")) {
-    return normalized.startsWith("127.");
-  }
-  return normalized.toLowerCase() === "::1";
-}
-
 function getClientIp(
   req: Request,
   server: ReturnType<typeof Bun.serve>,
@@ -582,17 +572,8 @@ async function main() {
       path: "/v1/guardian/init",
       method: "POST",
       auth: "none",
-      handler: (req, _params, getClientIp) => {
-        const ip = getClientIp();
-        // Only inject x-forwarded-for for non-localhost clients. The runtime
-        // rejects requests with this header to enforce loopback-only access,
-        // so setting it for localhost would break legitimate local bootstrap.
-        const remoteIp = isLoopbackIp(ip) ? undefined : ip;
-        return channelVerificationSessionProxy.handleGuardianInit(
-          req,
-          remoteIp,
-        );
-      },
+      handler: (req, _params, getClientIp) =>
+        channelVerificationSessionProxy.handleGuardianInit(req, getClientIp()),
     },
     {
       path: "/v1/channel-verification-sessions",


### PR DESCRIPTION
## Summary

- Remove the `isLoopbackIp` function and special-casing in the `/v1/guardian/init` handler that suppressed `X-Forwarded-For` injection for loopback peers
- Always forward the client IP to the runtime proxy, ensuring XFF is consistently set for auditability and defense-in-depth
- This workaround was originally needed because the runtime rejected all XFF requests, but PRs #18287 and #19741 updated the runtime to accept private-network XFF IPs, making the special case dead code

Codex finding: https://chatgpt.com/codex/security/findings/9011d13162e081919d8780cb77a7871f?sev=critical%2Chigh

## Original prompt

Security fix: Remove unnecessary isLoopbackIp special-casing in gateway guardian init handler. The gateway's `/v1/guardian/init` route uses `isLoopbackIp()` to suppress X-Forwarded-For injection when the peer IP is loopback. This was originally a workaround for the runtime rejecting ALL XFF requests, but the runtime has since been updated to accept private XFF IPs. The workaround is now dead code that suppresses security-relevant IP information without benefit.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22599" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
