### PR TITLE
Fix composer text and placeholder visibility

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
@@ -90,6 +90,7 @@ struct ComposerTextEditor: NSViewRepresentable {
         textView.typingAttributes = [
             .font: font,
             .paragraphStyle: paragraphStyle,
+            .foregroundColor: NSColor.labelColor,
         ]
 
         textView.postsFrameChangedNotifications = true
@@ -145,18 +146,16 @@ struct ComposerTextEditor: NSViewRepresentable {
         paragraphStyle.lineSpacing = lineSpacing
         textView.font = font
         textView.defaultParagraphStyle = paragraphStyle
-        textView.typingAttributes = [
-            .font: font,
-            .paragraphStyle: paragraphStyle,
-        ]
 
         textView.placeholderString = placeholder
 
-        if let override = textColorOverride {
-            textView.textColor = override
-        } else {
-            textView.textColor = .labelColor
-        }
+        let resolvedColor: NSColor = textColorOverride ?? .labelColor
+        textView.textColor = resolvedColor
+        textView.typingAttributes = [
+            .font: font,
+            .paragraphStyle: paragraphStyle,
+            .foregroundColor: resolvedColor,
+        ]
 
         textView.cmdEnterToSend = cmdEnterToSend
         textView.onSubmit = onSubmit


### PR DESCRIPTION
## Summary
- The NSTextView's `typingAttributes` in `makeNSView` were missing `.foregroundColor`, causing typed text to be invisible against the composer background
- Simplifies the color override logic in `updateNSView` to always set a resolved color consistently

## Test plan
- [ ] Open the app on main — verify composer text field shows placeholder and typed text
- [ ] Type text — verify it's visible with correct color
- [ ] Verify slash command highlighting still makes text transparent when active

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
