### PR TITLE
security: validate active Slack verification session before delivering DM from bash hook

### DIFF
--- a/assistant/src/__tests__/tool-side-effects-slack-dm.test.ts
+++ b/assistant/src/__tests__/tool-side-effects-slack-dm.test.ts
@@ -43,9 +43,9 @@ mock.module("../daemon/doordash-steps.js", () => ({
   updateDoordashProgress: mock(() => {}),
 }));
 
-const mockLogWarn = mock(() => {});
-const mockLogInfo = mock(() => {});
-const mockLogError = mock(() => {});
+const mockLogWarn = mock((_obj: unknown, _msg: string) => {});
+const mockLogInfo = mock((_obj: unknown, _msg: string) => {});
+const mockLogError = mock((_obj: unknown, _msg: string) => {});
 mock.module("../util/logger.js", () => ({
   getLogger: () => ({
     warn: mockLogWarn,
@@ -143,9 +143,10 @@ describe("bash hook — Slack DM dispatch with session validation", () => {
     );
 
     expect(mockDeliverVerificationSlack).not.toHaveBeenCalled();
-    expect(mockLogWarn).toHaveBeenCalled();
-    const warnArgs = mockLogWarn.mock.calls[0];
-    expect(warnArgs[1]).toContain("no active Slack verification session");
+    expect(mockLogWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "U123" }),
+      expect.stringContaining("no active Slack verification session"),
+    );
   });
 
   test("userId mismatch — DM not dispatched", () => {
@@ -168,9 +169,10 @@ describe("bash hook — Slack DM dispatch with session validation", () => {
     );
 
     expect(mockDeliverVerificationSlack).not.toHaveBeenCalled();
-    expect(mockLogWarn).toHaveBeenCalled();
-    const warnArgs = mockLogWarn.mock.calls[0];
-    expect(warnArgs[1]).toContain("does not match active session destination");
+    expect(mockLogWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "U_ATTACKER", expected: "U999" }),
+      expect.stringContaining("does not match active session destination"),
+    );
   });
 
   test("command without verification substring — hook is no-op", () => {

--- a/assistant/src/__tests__/tool-side-effects-slack-dm.test.ts
+++ b/assistant/src/__tests__/tool-side-effects-slack-dm.test.ts
@@ -57,13 +57,15 @@ mock.module("../util/logger.js", () => ({
 }));
 
 // ---------------------------------------------------------------------------
-// Import after mocks
+// Import after mocks — dynamic import ensures mock.module() calls above
+// are registered before tool-side-effects.ts evaluates its top-level
+// `const log = getLogger(...)`.
 // ---------------------------------------------------------------------------
 
-import {
-  runPostExecutionSideEffects,
-  type SideEffectContext,
-} from "../daemon/tool-side-effects.js";
+import type { SideEffectContext } from "../daemon/tool-side-effects.js";
+
+const { runPostExecutionSideEffects } =
+  await import("../daemon/tool-side-effects.js");
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/assistant/src/__tests__/tool-side-effects-slack-dm.test.ts
+++ b/assistant/src/__tests__/tool-side-effects-slack-dm.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Tests for the bash post-execution hook that dispatches Slack DMs
+ * for channel verification sessions. Validates that the hook only
+ * delivers when an active session exists with a matching destination.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be set up before importing the module under test
+// ---------------------------------------------------------------------------
+
+const mockFindActiveSession = mock(() => null as unknown);
+mock.module("../memory/channel-verification-sessions.js", () => ({
+  findActiveSession: mockFindActiveSession,
+}));
+
+const mockDeliverVerificationSlack = mock(() => {});
+mock.module("../runtime/verification-outbound-actions.js", () => ({
+  deliverVerificationSlack: mockDeliverVerificationSlack,
+}));
+
+// Stub out transitive dependencies to prevent import errors
+mock.module("../bundler/app-compiler.js", () => ({
+  compileApp: mock(() => Promise.resolve({ ok: true })),
+}));
+mock.module("../media/app-icon-generator.js", () => ({
+  generateAppIcon: mock(() => Promise.resolve()),
+}));
+mock.module("../memory/app-store.js", () => ({
+  getApp: mock(() => null),
+  getAppDirPath: mock(() => ""),
+  isMultifileApp: mock(() => false),
+}));
+mock.module("../services/published-app-updater.js", () => ({
+  updatePublishedAppDeployment: mock(() => Promise.resolve()),
+}));
+mock.module("../daemon/conversation-surfaces.js", () => ({
+  refreshSurfacesForApp: mock(() => {}),
+}));
+mock.module("../daemon/doordash-steps.js", () => ({
+  isDoordashCommand: mock(() => false),
+  updateDoordashProgress: mock(() => {}),
+}));
+
+const mockLogWarn = mock(() => {});
+const mockLogInfo = mock(() => {});
+const mockLogError = mock(() => {});
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    warn: mockLogWarn,
+    info: mockLogInfo,
+    error: mockLogError,
+    debug: () => {},
+    trace: () => {},
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import {
+  runPostExecutionSideEffects,
+  type SideEffectContext,
+} from "../daemon/tool-side-effects.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const dummySideEffectCtx = {
+  ctx: {} as SideEffectContext["ctx"],
+} satisfies SideEffectContext;
+
+function callWithBashHook(
+  command: string,
+  content: string,
+  isError = false,
+): void {
+  runPostExecutionSideEffects(
+    "bash",
+    { command },
+    { content, isError },
+    dummySideEffectCtx,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("bash hook — Slack DM dispatch with session validation", () => {
+  beforeEach(() => {
+    mockFindActiveSession.mockReset();
+    mockDeliverVerificationSlack.mockReset();
+    mockLogWarn.mockReset();
+    mockLogInfo.mockReset();
+    mockLogError.mockReset();
+  });
+
+  test("legitimate verification dispatches DM", () => {
+    mockFindActiveSession.mockReturnValue({
+      destinationAddress: "U123",
+      status: "awaiting_response",
+    });
+
+    const output = JSON.stringify({
+      _pendingSlackDm: {
+        userId: "U123",
+        text: "code",
+        assistantId: "aid",
+      },
+    });
+
+    callWithBashHook(
+      "assistant channel-verification-sessions create ...",
+      output,
+    );
+
+    expect(mockDeliverVerificationSlack).toHaveBeenCalledTimes(1);
+    expect(mockDeliverVerificationSlack).toHaveBeenCalledWith(
+      "U123",
+      "code",
+      "aid",
+    );
+  });
+
+  test("no active session — DM not dispatched", () => {
+    mockFindActiveSession.mockReturnValue(null);
+
+    const output = JSON.stringify({
+      _pendingSlackDm: {
+        userId: "U123",
+        text: "code",
+        assistantId: "aid",
+      },
+    });
+
+    callWithBashHook(
+      "assistant channel-verification-sessions create ...",
+      output,
+    );
+
+    expect(mockDeliverVerificationSlack).not.toHaveBeenCalled();
+    expect(mockLogWarn).toHaveBeenCalled();
+    const warnArgs = mockLogWarn.mock.calls[0];
+    expect(warnArgs[1]).toContain("no active Slack verification session");
+  });
+
+  test("userId mismatch — DM not dispatched", () => {
+    mockFindActiveSession.mockReturnValue({
+      destinationAddress: "U999",
+      status: "awaiting_response",
+    });
+
+    const output = JSON.stringify({
+      _pendingSlackDm: {
+        userId: "U_ATTACKER",
+        text: "code",
+        assistantId: "aid",
+      },
+    });
+
+    callWithBashHook(
+      "assistant channel-verification-sessions create ...",
+      output,
+    );
+
+    expect(mockDeliverVerificationSlack).not.toHaveBeenCalled();
+    expect(mockLogWarn).toHaveBeenCalled();
+    const warnArgs = mockLogWarn.mock.calls[0];
+    expect(warnArgs[1]).toContain("does not match active session destination");
+  });
+
+  test("command without verification substring — hook is no-op", () => {
+    mockFindActiveSession.mockReturnValue({
+      destinationAddress: "U123",
+      status: "awaiting_response",
+    });
+
+    const output = JSON.stringify({
+      _pendingSlackDm: {
+        userId: "U123",
+        text: "code",
+        assistantId: "aid",
+      },
+    });
+
+    callWithBashHook("echo hello", output);
+
+    expect(mockDeliverVerificationSlack).not.toHaveBeenCalled();
+  });
+
+  test("output without _pendingSlackDm — hook is no-op", () => {
+    mockFindActiveSession.mockReturnValue({
+      destinationAddress: "U123",
+      status: "awaiting_response",
+    });
+
+    callWithBashHook(
+      "assistant channel-verification-sessions create ...",
+      JSON.stringify({ success: true, sessionId: "s1" }),
+    );
+
+    expect(mockDeliverVerificationSlack).not.toHaveBeenCalled();
+  });
+
+  test("multi-line JSON output — dispatches from correct line", () => {
+    mockFindActiveSession.mockReturnValue({
+      destinationAddress: "U123",
+      status: "awaiting_response",
+    });
+
+    const cancelResult = JSON.stringify({ success: true, cancelled: true });
+    const createResult = JSON.stringify({
+      _pendingSlackDm: {
+        userId: "U123",
+        text: "verify-code",
+        assistantId: "aid2",
+      },
+    });
+    const multiLineOutput = `${cancelResult}\n${createResult}`;
+
+    callWithBashHook(
+      "assistant channel-verification-sessions create ...",
+      multiLineOutput,
+    );
+
+    expect(mockDeliverVerificationSlack).toHaveBeenCalledTimes(1);
+    expect(mockDeliverVerificationSlack).toHaveBeenCalledWith(
+      "U123",
+      "verify-code",
+      "aid2",
+    );
+  });
+});

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -10,6 +10,7 @@
 import { compileApp } from "../bundler/app-compiler.js";
 import { generateAppIcon } from "../media/app-icon-generator.js";
 import { getApp, getAppDirPath, isMultifileApp } from "../memory/app-store.js";
+import { findActiveSession } from "../memory/channel-verification-sessions.js";
 import { deliverVerificationSlack } from "../runtime/verification-outbound-actions.js";
 import { updatePublishedAppDeployment } from "../services/published-app-updater.js";
 import type { ToolExecutionResult } from "../tools/types.js";
@@ -225,6 +226,25 @@ registerHook("bash", (_name, input, result) => {
   const dispatch = (parsed: Parsed) => {
     if (parsed._pendingSlackDm) {
       const { userId, text, assistantId } = parsed._pendingSlackDm;
+
+      // Validate that an active Slack verification session exists and
+      // that the destination matches the userId in the parsed payload.
+      const session = findActiveSession("slack");
+      if (!session) {
+        log.warn(
+          { userId, assistantId },
+          "Bash hook: no active Slack verification session — ignoring _pendingSlackDm",
+        );
+        return false;
+      }
+      if (session.destinationAddress !== userId) {
+        log.warn(
+          { userId, expected: session.destinationAddress, assistantId },
+          "Bash hook: Slack DM userId does not match active session destination — ignoring",
+        );
+        return false;
+      }
+
       deliverVerificationSlack(userId, text, assistantId);
       return true;
     }

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -235,14 +235,14 @@ registerHook("bash", (_name, input, result) => {
           { userId, assistantId },
           "Bash hook: no active Slack verification session — ignoring _pendingSlackDm",
         );
-        return false;
+        return true;
       }
       if (session.destinationAddress !== userId) {
         log.warn(
           { userId, expected: session.destinationAddress, assistantId },
           "Bash hook: Slack DM userId does not match active session destination — ignoring",
         );
-        return false;
+        return true;
       }
 
       deliverVerificationSlack(userId, text, assistantId);


### PR DESCRIPTION
## Summary
- Add session-store validation to the bash post-execution hook for Slack DM delivery
- Hook now verifies an active Slack verification session exists with matching destination before dispatching
- Closes privilege-escalation vector where crafted bash output could trigger unauthorized Slack DMs

Codex finding: https://chatgpt.com/codex/security/findings/57831fd61e98819186aa4c051a10780a?sev=critical%2Chigh

Part of plan: harden-slack-dm-hook.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22602" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
