### PR TITLE
M1: Replace @FocusState with @State for composer focus tracking

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -70,7 +70,7 @@ struct ComposerView: View {
     #if os(macOS)
     @Environment(\.dropActions) private var dropActions
     #endif
-    @FocusState private var composerFocus: Bool
+    @State private var composerFocus: Bool = false
     @State private var isComposerFocused = false
     @State private var measuredTextHeight: CGFloat = 32
     @State private var textViewIsFocused: Bool = false


### PR DESCRIPTION
## Summary
Fixes composer keyboard input by replacing `@FocusState` with `@State` for the `composerFocus` property in ComposerView.

After migrating from SwiftUI TextField to NSViewRepresentable (ComposerTextEditor), the `.focused($composerFocus)` modifier was removed but `@FocusState` was kept. Without a `.focused()` binding, SwiftUI's focus reconciliation resets the value, creating a cycle where AppKit focus is established then immediately removed — breaking all keyboard input.

`@State` maintains its value reliably and the existing onChange bridge (`composerFocus` ↔ `textViewIsFocused` → `makeFirstResponder`) works correctly.

Closes #22606
Part of #22605
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22607" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
