### PR TITLE
feat(flags): add `teleport` macOS feature flag

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -368,6 +368,14 @@
       "label": "Fast Mode",
       "description": "Enable Anthropic fast mode for Opus 4.6, delivering up to 2.5x higher output tokens per second at premium pricing",
       "defaultEnabled": false
+    },
+    {
+      "id": "teleport",
+      "scope": "macos",
+      "key": "teleport",
+      "label": "Teleport",
+      "description": "Enable teleport UI in General settings for moving assistants between hosting environments",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `teleport` feature flag to the macOS feature flag registry with `defaultEnabled: false`
- Sync bundled copies to clients/ directories

Part of plan: teleport-settings-ui.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22609" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
