### PR TITLE
Skills tab: source-based filter redesign & UX polish

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -89,9 +89,32 @@ function resolveProvenance(summary: SkillSummary): SkillProvenance {
     return { kind: "first-party", provider: "Vellum" };
   }
 
-  // Managed skills are third-party (installed from clawhub). The homepage field
-  // confirms provenance.
+  // Managed skills — check .origin.json first, then fall back to homepage heuristic
   if (summary.source === "managed") {
+    // Check .origin.json written during install
+    try {
+      const originPath = join(summary.directoryPath, ".origin.json");
+      if (existsSync(originPath)) {
+        const origin = JSON.parse(readFileSync(originPath, "utf-8"));
+        if (origin.source === "vellum-catalog") {
+          return { kind: "first-party", provider: "Vellum" };
+        }
+        if (origin.source === "clawhub") {
+          return {
+            kind: "third-party",
+            provider: "skills.sh",
+            originId: summary.id,
+            sourceUrl:
+              summary.homepage ??
+              `${CLAWHUB_BASE_URL}/skills/${encodeURIComponent(summary.id)}`,
+          };
+        }
+      }
+    } catch {
+      // Fall through to heuristics
+    }
+
+    // Legacy heuristic: check homepage for clawhub URLs
     if (
       summary.homepage?.includes("skills.sh") ||
       summary.homepage?.includes("clawhub")
@@ -105,8 +128,7 @@ function resolveProvenance(summary: SkillSummary): SkillProvenance {
           `${CLAWHUB_BASE_URL}/skills/${encodeURIComponent(summary.id)}`,
       };
     }
-    // No positive evidence of clawhub origin -- likely user-authored.
-    // Default to "local" to avoid mislabeling.
+    // No positive evidence of origin -- likely user-authored.
     return { kind: "local" };
   }
 

--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -306,6 +306,16 @@ export async function installSkillLocally(
     );
   }
 
+  // Write origin marker so provenance resolver can identify the install source
+  atomicWriteFile(
+    join(skillDir, ".origin.json"),
+    JSON.stringify(
+      { source: "vellum-catalog", installedAt: new Date().toISOString() },
+      null,
+      2,
+    ) + "\n",
+  );
+
   // Install npm dependencies if the skill has a package.json
   if (existsSync(join(skillDir, "package.json"))) {
     const bunPath = `${homedir()}/.bun/bin`;

--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -265,6 +265,21 @@ export async function clawhubInstall(
       return { success: false, error };
     }
     verifyAndRecordSkillHash(slug);
+    // Write origin marker so provenance resolver can identify clawhub installs
+    const skillName = slug.includes("/") ? slug.split("/").pop()! : slug;
+    const originPath = join(getManagedSkillsDir(), skillName, ".origin.json");
+    try {
+      writeFileSync(
+        originPath,
+        JSON.stringify(
+          { source: "clawhub", installedAt: new Date().toISOString() },
+          null,
+          2,
+        ) + "\n",
+      );
+    } catch {
+      // Non-fatal — provenance will fall back to homepage check
+    }
     return { success: true, skillName: slug };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -283,6 +298,21 @@ export async function clawhubUpdate(
       return { success: false, error };
     }
     verifyAndRecordSkillHash(name);
+    // Re-write origin marker in case the update replaced directory contents
+    const skillName = name.includes("/") ? name.split("/").pop()! : name;
+    const originPath = join(getManagedSkillsDir(), skillName, ".origin.json");
+    try {
+      writeFileSync(
+        originPath,
+        JSON.stringify(
+          { source: "clawhub", installedAt: new Date().toISOString() },
+          null,
+          2,
+        ) + "\n",
+      );
+    } catch {
+      // Non-fatal
+    }
     return { success: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -313,6 +313,7 @@ struct SkillItemRow: View {
                     label: "Remove",
                     leftIcon: VIcon.trash.rawValue,
                     style: .dangerGhost,
+                    size: .compact,
                     action: onDelete
                 )
                 .disabled(!isRemovable)
@@ -371,6 +372,7 @@ struct AvailableSkillItemRow: View {
                         label: "Install",
                         leftIcon: VIcon.arrowDownToLine.rawValue,
                         style: .ghost,
+                        size: .compact,
                         action: onInstall
                     )
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -318,7 +318,7 @@ struct SkillItemRow: View {
                 )
                 .disabled(!isRemovable)
                 .opacity(isRemovable ? 1.0 : 0.3)
-                .vTooltip(isRemovable ? "Remove skill" : "Bundled skills cannot be removed")
+                .if(!isRemovable) { $0.vTooltip("Bundled skills cannot be removed") }
                 .accessibilityLabel(isRemovable ? "Uninstall skill" : "Core skill cannot be removed")
             }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -163,6 +163,50 @@ struct AgentPanelContent: View {
         .accessibilityAddTraits(skillsManager.selectedCategory == category ? .isSelected : [])
     }
 
+    // MARK: - Empty State
+
+    private var emptyStateTitle: String {
+        if let category = skillsManager.selectedCategory {
+            return "No \(category.displayName) Skills"
+        }
+        switch skillsManager.skillFilter {
+        case .all: return "No Skills Available"
+        case .installed: return "No Skills Installed"
+        case .available: return "No Skills Available"
+        case .vellum: return "No Vellum Skills"
+        case .community: return "No Community Skills"
+        case .custom: return "No Custom Skills"
+        }
+    }
+
+    private var emptyStateSubtitle: String {
+        if skillsManager.selectedCategory != nil {
+            return "Try selecting a different category or clearing the filter."
+        }
+        switch skillsManager.skillFilter {
+        case .all: return "Check your connection to the Vellum catalog."
+        case .installed: return "Ask your assistant in chat to search for and install new skills."
+        case .available: return "All available skills have been installed."
+        case .vellum: return "No bundled Vellum skills found."
+        case .community: return "No Community skills found. Try installing some from the catalog."
+        case .custom: return "Create a custom skill by describing what you want in chat."
+        }
+    }
+
+    private var emptyStateIcon: String {
+        if skillsManager.selectedCategory != nil {
+            return VIcon.layoutGrid.rawValue
+        }
+        switch skillsManager.skillFilter {
+        case .all: return VIcon.cloudOff.rawValue
+        case .installed: return VIcon.zap.rawValue
+        case .available: return VIcon.circleCheck.rawValue
+        case .vellum: return VIcon.package.rawValue
+        case .community: return VIcon.globe.rawValue
+        case .custom: return VIcon.user.rawValue
+        }
+    }
+
     // MARK: - Content View
 
     @ViewBuilder
@@ -190,15 +234,9 @@ struct AgentPanelContent: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if skillsManager.filteredSkills.isEmpty {
             VEmptyState(
-                title: skillsManager.skillFilter == .all
-                    ? "No Skills Available"
-                    : (skillsManager.selectedCategory == nil ? "No Skills Installed" : "No \(skillsManager.selectedCategory!.displayName) Skills"),
-                subtitle: skillsManager.skillFilter == .all
-                    ? "Check your connection to the Vellum catalog."
-                    : (skillsManager.selectedCategory == nil
-                        ? "Ask your assistant in chat to search for and install new skills."
-                        : "Try selecting a different category or clearing the filter."),
-                icon: skillsManager.skillFilter == .all ? VIcon.cloudOff.rawValue : VIcon.zap.rawValue
+                title: emptyStateTitle,
+                subtitle: emptyStateSubtitle,
+                icon: emptyStateIcon
             )
         } else {
             ScrollView {
@@ -259,7 +297,7 @@ struct SkillItemRow: View {
                             .lineLimit(1)
                             .truncationMode(.tail)
 
-                        skillTag(for: skill.source)
+                        VSkillTypePill(source: skill.source, provenanceKind: skill.provenance?.kind)
 
                         Spacer()
                     }
@@ -271,19 +309,23 @@ struct SkillItemRow: View {
                         .truncationMode(.tail)
                 }
 
-                if isRemovable {
-                    VButton(
-                        label: "Delete",
-                        iconOnly: VIcon.trash.rawValue,
-                        style: .dangerGhost,
-                        action: onDelete
-                    )
-                    .accessibilityLabel("Uninstall skill")
-                }
+                VButton(
+                    label: "Delete",
+                    iconOnly: VIcon.trash.rawValue,
+                    style: .dangerGhost,
+                    size: .compact,
+                    action: onDelete
+                )
+                .disabled(!isRemovable)
+                .opacity(isRemovable ? 1.0 : 0.3)
+                .vTooltip(isRemovable ? "Remove skill" : "Bundled skills cannot be removed")
+                .accessibilityLabel(isRemovable ? "Uninstall skill" : "Core skill cannot be removed")
             }
         }
-        .contextMenu {
-            Button("Remove", role: .destructive, action: onDelete)
+        .if(isRemovable) { view in
+            view.contextMenu {
+                Button("Remove", role: .destructive, action: onDelete)
+            }
         }
         .accessibilityElement(children: .combine)
     }
@@ -297,47 +339,47 @@ struct AvailableSkillItemRow: View {
     var isInstalling: Bool = false
 
     var body: some View {
-        HStack(alignment: .center, spacing: VSpacing.lg) {
-            if let emoji = skill.emoji, !emoji.isEmpty {
-                Text(emoji)
-                    .font(.system(size: 32))
-                    .opacity(0.5)
-            }
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                HStack(alignment: .center, spacing: VSpacing.sm) {
-                    Text(skill.name)
-                        .font(VFont.titleSmall)
+        VCard {
+            HStack(alignment: .center, spacing: VSpacing.lg) {
+                if let emoji = skill.emoji, !emoji.isEmpty {
+                    Text(emoji)
+                        .font(.system(size: 32))
+                }
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    HStack(alignment: .center, spacing: VSpacing.sm) {
+                        Text(skill.name)
+                            .font(VFont.titleSmall)
+                            .foregroundStyle(VColor.contentEmphasized)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                        if skill.source == "clawhub" {
+                            VSkillTypePill(type: .community)
+                        } else if skill.source == "catalog" {
+                            VSkillTypePill(type: .vellum)
+                        }
+                        VSkillTypePill(type: .available)
+                        Spacer()
+                    }
+                    Text(skill.description)
+                        .font(VFont.bodyMediumDefault)
                         .foregroundStyle(VColor.contentSecondary)
                         .lineLimit(1)
                         .truncationMode(.tail)
-                    skillTag(for: skill.source)
-                    Spacer()
                 }
-                Text(skill.description)
-                    .font(VFont.bodyMediumDefault)
-                    .foregroundStyle(VColor.contentTertiary)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-            }
-            if isInstalling {
-                VLoadingIndicator()
-            } else {
-                VButton(
-                    label: "Install",
-                    style: .outlined,
-                    action: onInstall
-                )
+                if isInstalling {
+                    VLoadingIndicator()
+                } else {
+                    VButton(
+                        label: "Install",
+                        iconOnly: VIcon.arrowDownToLine.rawValue,
+                        style: .ghost,
+                        size: .compact,
+                        action: onInstall
+                    )
+                    .vTooltip("Install skill")
+                }
             }
         }
-        .padding(VSpacing.lg)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.xl)
-                .strokeBorder(
-                    VColor.borderDisabled,
-                    style: StrokeStyle(lineWidth: 2, dash: [6, 4])
-                )
-        )
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -310,10 +310,9 @@ struct SkillItemRow: View {
                 }
 
                 VButton(
-                    label: "Delete",
-                    iconOnly: VIcon.trash.rawValue,
+                    label: "Remove",
+                    leftIcon: VIcon.trash.rawValue,
                     style: .dangerGhost,
-                    size: .compact,
                     action: onDelete
                 )
                 .disabled(!isRemovable)
@@ -370,12 +369,10 @@ struct AvailableSkillItemRow: View {
                 } else {
                     VButton(
                         label: "Install",
-                        iconOnly: VIcon.arrowDownToLine.rawValue,
+                        leftIcon: VIcon.arrowDownToLine.rawValue,
                         style: .ghost,
-                        size: .compact,
                         action: onInstall
                     )
-                    .vTooltip("Install skill")
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -382,22 +382,3 @@ struct AvailableSkillItemRow: View {
         }
     }
 }
-
-// MARK: - Skill Tag Helper
-
-private func skillTag(for source: String) -> VTag {
-    switch source {
-    case "bundled":
-        return VTag("Core", color: VColor.contentDefault, icon: .package)
-    case "managed", "clawhub":
-        return VTag("Installed", color: VColor.systemPositiveStrong, icon: .circleCheck)
-    case "workspace":
-        return VTag("Created", color: VColor.contentSecondary, icon: .sparkles)
-    case "extra":
-        return VTag("Extra", color: VColor.contentTertiary, icon: .puzzle)
-    case "catalog":
-        return VTag("Available", color: VColor.funTeal, icon: .arrowDownToLine)
-    default:
-        return VTag(source.capitalized, color: VColor.contentTertiary, icon: .puzzle)
-    }
-}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -357,7 +357,6 @@ struct AvailableSkillItemRow: View {
                         } else if skill.source == "catalog" {
                             VSkillTypePill(type: .vellum)
                         }
-                        VSkillTypePill(type: .available)
                         Spacer()
                     }
                     Text(skill.description)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
@@ -149,10 +149,11 @@ struct SkillDetailTitleRow: View {
                         .lineLimit(1)
                 }
 
-                VSkillTypePill(source: skill.source)
             }
 
             Spacer()
+
+            VSkillTypePill(source: skill.source, provenanceKind: skill.provenance?.kind)
 
             if skill.source == "managed" || skill.source == "clawhub" {
                 VButton(label: "Remove", style: .dangerOutline) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -2,17 +2,28 @@ import SwiftUI
 import Combine
 import VellumAssistantShared
 
-/// Filter for showing all skills or only installed ones.
+/// Filter for showing skills by status or source.
 enum SkillFilter: String, CaseIterable {
     case all = "All"
     case installed = "Installed"
+    case available = "Available"
+    case vellum = "Vellum"
+    case community = "Community"
+    case custom = "Custom"
 
     var icon: VIcon {
         switch self {
-        case .all: return .circle
+        case .all: return .layoutGrid
         case .installed: return .circleCheck
+        case .available: return .arrowDownToLine
+        case .vellum: return .package
+        case .community: return .globe
+        case .custom: return .user
         }
     }
+
+    static var statusFilters: [SkillFilter] { [.all, .installed, .available] }
+    static var sourceFilters: [SkillFilter] { [.vellum, .community, .custom] }
 }
 
 @MainActor
@@ -127,10 +138,25 @@ final class SkillsManager {
         let hasSearch = !query.isEmpty
 
         let baseSkills: [SkillInfo]
-        if skillFilter == .all {
+        switch skillFilter {
+        case .all:
             baseSkills = skills
-        } else {
+        case .installed:
             baseSkills = skills.filter { $0.isInstalled }
+        case .available:
+            baseSkills = skills.filter { $0.isAvailable }
+        case .vellum:
+            baseSkills = skills.filter {
+                $0.source == "bundled" || ($0.source == "managed" && $0.provenance?.kind == "first-party")
+            }
+        case .community:
+            baseSkills = skills.filter {
+                $0.source == "clawhub" || ($0.source == "managed" && $0.provenance?.kind == "third-party")
+            }
+        case .custom:
+            baseSkills = skills.filter {
+                $0.source == "workspace" || $0.source == "extra" || ($0.source == "managed" && $0.provenance?.kind == "local")
+            }
         }
 
         let searchFiltered: [SkillInfo]
@@ -139,7 +165,7 @@ final class SkillsManager {
                 $0.name.lowercased().contains(query) ||
                 $0.description.lowercased().contains(query) ||
                 $0.id.lowercased().contains(query) ||
-                Self.sourceLabel($0.source).lowercased().contains(query)
+                Self.sourceLabel($0.source, provenanceKind: $0.provenance?.kind).lowercased().contains(query)
             }
         } else {
             searchFiltered = baseSkills
@@ -173,18 +199,22 @@ final class SkillsManager {
     // MARK: - Helpers
 
     /// Human-readable label for a skill source.
-    static func sourceLabel(_ source: String) -> String {
+    static func sourceLabel(_ source: String, provenanceKind: String? = nil) -> String {
         switch source {
         case "bundled":
-            return "Core"
-        case "managed", "clawhub":
-            return "Installed"
-        case "workspace":
-            return "Created"
-        case "extra":
-            return "Extra"
+            return "Vellum"
+        case "clawhub":
+            return "Community"
+        case "managed":
+            switch provenanceKind {
+            case "first-party": return "Vellum"
+            case "third-party": return "Community"
+            default: return "Custom"
+            }
+        case "workspace", "extra":
+            return "Custom"
         case "catalog":
-            return "Available"
+            return "Available Vellum"
         default:
             return source.replacingOccurrences(of: "-", with: " ").capitalized
         }

--- a/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
@@ -1,56 +1,51 @@
 import SwiftUI
 
-/// A pill badge indicating the type/source of a skill (Core, Installed, Created).
+/// A pill badge indicating the source/provenance of a skill.
 public struct VSkillTypePill: View {
     public enum SkillType {
-        case core
-        case installed
-        case created
-        case extra
+        case vellum
+        case community
+        case custom
         case available
-        case custom(label: String, icon: String, foreground: Color, background: Color)
+        case other(label: String, icon: String, foreground: Color, background: Color)
 
         var label: String {
             switch self {
-            case .core: return "Core"
-            case .installed: return "Installed"
-            case .created: return "Created"
-            case .extra: return "Extra"
+            case .vellum: return "Vellum"
+            case .community: return "Community"
+            case .custom: return "Custom"
             case .available: return "Available"
-            case .custom(let label, _, _, _): return label
+            case .other(let label, _, _, _): return label
             }
         }
 
         var vIcon: VIcon {
             switch self {
-            case .core: return .package
-            case .installed: return .circleCheck
-            case .created: return .sparkles
-            case .extra: return .puzzle
+            case .vellum: return .package
+            case .community: return .globe
+            case .custom: return .user
             case .available: return .arrowDownToLine
-            case .custom(_, let icon, _, _): return .resolve(icon)
+            case .other(_, let icon, _, _): return .resolve(icon)
             }
         }
 
         var foregroundColor: Color {
             switch self {
-            case .core: return VColor.contentDefault
-            case .installed: return VColor.systemPositiveStrong
-            case .created: return VColor.contentSecondary
-            case .extra: return VColor.contentTertiary
+            case .vellum: return VColor.primaryBase
+            case .community: return VColor.funTeal
+            case .custom: return VColor.funPurple
             case .available: return VColor.funTeal
-            case .custom(_, _, let fg, _): return fg
+            case .other(_, _, let fg, _): return fg
             }
         }
 
         var backgroundColor: Color {
             switch self {
-            case .core: return VColor.surfaceBase
-            case .installed: return VColor.systemPositiveWeak
-            case .created: return VColor.surfaceBase
-            case .extra: return VColor.surfaceOverlay
+            case .vellum: return VColor.primaryBase.opacity(0.12)
+            case .community: return VColor.funTeal.opacity(0.12)
+            case .custom: return VColor.funPurple.opacity(0.12)
             case .available: return VColor.funTeal.opacity(0.12)
-            case .custom(_, _, _, let bg): return bg
+            case .other(_, _, _, let bg): return bg
             }
         }
     }
@@ -61,21 +56,31 @@ public struct VSkillTypePill: View {
         self.type = type
     }
 
-    /// Convenience initializer from a skill source string.
-    public init(source: String) {
+    /// Convenience initializer from a skill source string and optional provenance kind.
+    /// - Parameters:
+    ///   - source: The skill source (e.g. "bundled", "managed", "clawhub", "workspace", "extra", "catalog")
+    ///   - provenanceKind: Optional provenance kind (e.g. "first-party", "third-party", "local")
+    public init(source: String, provenanceKind: String? = nil) {
         switch source {
         case "bundled":
-            self.type = .core
-        case "managed", "clawhub":
-            self.type = .installed
-        case "workspace":
-            self.type = .created
-        case "extra":
-            self.type = .extra
+            self.type = .vellum
+        case "clawhub":
+            self.type = .community
+        case "managed":
+            switch provenanceKind {
+            case "first-party":
+                self.type = .vellum
+            case "third-party":
+                self.type = .community
+            default:
+                self.type = .custom
+            }
+        case "workspace", "extra":
+            self.type = .custom
         case "catalog":
             self.type = .available
         default:
-            self.type = .custom(
+            self.type = .other(
                 label: source.replacingOccurrences(of: "-", with: " ").capitalized,
                 icon: VIcon.puzzle.rawValue,
                 foreground: VColor.contentTertiary,

--- a/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
@@ -457,10 +457,9 @@ struct FeedbackGallerySection: View {
 
                 VCard {
                     HStack(spacing: VSpacing.lg) {
-                        VSkillTypePill(type: .core)
-                        VSkillTypePill(type: .installed)
-                        VSkillTypePill(type: .created)
-                        VSkillTypePill(type: .extra)
+                        VSkillTypePill(type: .vellum)
+                        VSkillTypePill(type: .community)
+                        VSkillTypePill(type: .custom)
                         VSkillTypePill(type: .available)
                     }
                 }


### PR DESCRIPTION
## Summary
- Replace generic Core/Installed skill tags with provenance-aware source labels (Vellum, Community, Custom) via `VSkillTypePill`
- Extend `SkillFilter` in `SkillsManager` with source-type sub-filters (Available, Vellum, Community, Custom) using the standard `VDropdown` component
- Polish available skill rows (icon-only ghost install button, disabled remove on core skills) and write `.origin.json` on clawhub updates for provenance tracking

## Original prompt
Close PR tkheyfets/skills-source-filter-redesign, create a new branch against main with changes from that branch, create a new PR against main with a fresh branch, remove old branch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
