### PR TITLE
feat(macos): show TeleportSection in General settings when teleport flag is enabled

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -46,6 +46,10 @@ struct SettingsGeneralTab: View {
         return Just(nil).eraseToAnyPublisher()
     }
 
+    private var currentAssistant: LockfileAssistant? {
+        lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId })
+    }
+
     /// Derive the topology for the currently selected assistant.
     private var topology: AssistantTopology {
         guard let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }) else {
@@ -73,6 +77,11 @@ struct SettingsGeneralTab: View {
                     healthzLoaded: healthzLoaded,
                     updateManager: updateManager
                 )
+            }
+            if MacOSClientFeatureFlagManager.shared.isEnabled("teleport"),
+               let assistant = currentAssistant,
+               !assistant.isManaged && !assistant.isRemote {
+                TeleportSection(assistant: assistant, onClose: onClose)
             }
             if MacOSClientFeatureFlagManager.shared.isEnabled("mobile-pairing") {
                 mobilePairingCard


### PR DESCRIPTION
## Summary
- Add TeleportSection to General settings tab, gated behind the `teleport` feature flag
- Only shown for local (bare metal) and Docker assistants, not platform/remote
- Positioned between the upgrade section and mobile pairing card

Part of plan: teleport-settings-ui.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22612" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
