### PR TITLE
fix: import findActiveSession from service layer instead of store layer

### DIFF
--- a/assistant/src/__tests__/tool-side-effects-slack-dm.test.ts
+++ b/assistant/src/__tests__/tool-side-effects-slack-dm.test.ts
@@ -11,7 +11,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 // ---------------------------------------------------------------------------
 
 const mockFindActiveSession = mock(() => null as unknown);
-mock.module("../memory/channel-verification-sessions.js", () => ({
+mock.module("../runtime/channel-verification-service.js", () => ({
   findActiveSession: mockFindActiveSession,
 }));
 

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -10,7 +10,7 @@
 import { compileApp } from "../bundler/app-compiler.js";
 import { generateAppIcon } from "../media/app-icon-generator.js";
 import { getApp, getAppDirPath, isMultifileApp } from "../memory/app-store.js";
-import { findActiveSession } from "../memory/channel-verification-sessions.js";
+import { findActiveSession } from "../runtime/channel-verification-service.js";
 import { deliverVerificationSlack } from "../runtime/verification-outbound-actions.js";
 import { updatePublishedAppDeployment } from "../services/published-app-updater.js";
 import type { ToolExecutionResult } from "../tools/types.js";


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for harden-slack-dm-hook.md.

**Gap:** Import bypasses service layer for findActiveSession
**What was expected:** All production callers import from channel-verification-service.js (service layer)
**What was found:** The new code imported from channel-verification-sessions.js (store layer)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
