### PR TITLE
fix(macos): remove dead TeleportPhase.completed enum case

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -36,7 +36,6 @@ private enum TeleportPhase {
     case idle
     case transferring(step: String)
     case verifying
-    case completed(oldAssistantId: String)
     case failed(error: String)
 }
 


### PR DESCRIPTION
## Summary
Removes unused .completed(oldAssistantId:) case from TeleportPhase enum.
The confirmation flow uses .verifying → confirmAndSwitch() → onClose(), making the completed case dead code.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22619" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
