### PR TITLE
M2: Fix composer text color to use design token instead of .labelColor

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
@@ -1,6 +1,7 @@
 #if os(macOS)
 import AppKit
 import SwiftUI
+import VellumAssistantShared
 
 /// NSScrollView subclass that reports intrinsic content size based on
 /// its document view's text layout height. This lets SwiftUI size the
@@ -155,7 +156,7 @@ struct ComposerTextEditor: NSViewRepresentable {
         if let override = textColorOverride {
             textView.textColor = override
         } else {
-            textView.textColor = .labelColor
+            textView.textColor = NSColor(VColor.contentDefault)
         }
 
         textView.cmdEnterToSend = cmdEnterToSend


### PR DESCRIPTION
## Summary
Fixes invisible text in the composer by replacing `NSColor.labelColor` with `NSColor(VColor.contentDefault)`.

The old SwiftUI TextField used `VColor.contentDefault` (#2A2A28, dark charcoal) via `.foregroundStyle()`. When the composer was migrated to NSViewRepresentable (#22400), the fallback text color was changed to `NSColor.labelColor` — a system dynamic color that doesn't produce correct contrast against the app's custom warm/beige theme background (`VColor.surfaceOverlay`).

Part of #22605
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22620" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
