### PR TITLE
Harden file_read risk for actor token signing key

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -192,16 +192,33 @@ describe("Permission Checker", () => {
   // ── classifyRisk ────────────────────────────────────────────────
 
   describe("classifyRisk", () => {
-    // file_read is always low
+    // file_read is low risk except for signing-key material
     describe("file_read", () => {
-      test("file_read is always low risk", async () => {
+      test("file_read is low risk for regular files", async () => {
         const risk = await classifyRisk("file_read", { path: "/etc/passwd" });
         expect(risk).toBe(RiskLevel.Low);
       });
 
-      test("file_read with any path is low risk", async () => {
+      test("file_read with arbitrary non-key path is low risk", async () => {
         const risk = await classifyRisk("file_read", { path: "/tmp/safe.txt" });
         expect(risk).toBe(RiskLevel.Low);
+      });
+
+      test("file_read of workspace signing key path is high risk", async () => {
+        const workspaceDir = join(checkerTestDir, "workspace");
+        const risk = await classifyRisk(
+          "file_read",
+          { path: "deprecated/actor-token-signing-key" },
+          workspaceDir,
+        );
+        expect(risk).toBe(RiskLevel.High);
+      });
+
+      test("file_read of legacy protected signing key path is high risk", async () => {
+        const risk = await classifyRisk("file_read", {
+          path: join(homedir(), ".vellum", "protected", "actor-token-signing-key"),
+        });
+        expect(risk).toBe(RiskLevel.High);
       });
     });
 

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { homedir } from "node:os";
-import { dirname, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
@@ -695,7 +695,13 @@ async function classifyRiskUncached(
   preParsed?: ParsedCommand,
   manifestOverride?: ManifestOverride,
 ): Promise<RiskLevel> {
-  if (toolName === "file_read") return RiskLevel.Low;
+  if (toolName === "file_read") {
+    const filePath = getStringField(input, "path", "file_path");
+    if (isActorTokenSigningKeyPath(filePath, workingDir)) {
+      return RiskLevel.High;
+    }
+    return RiskLevel.Low;
+  }
   if (toolName === "file_write" || toolName === "file_edit") {
     const filePath = getStringField(input, "path", "file_path");
     if (
@@ -903,6 +909,28 @@ async function classifyRiskUncached(
 
   // Unknown tool → Medium
   return RiskLevel.Medium;
+}
+
+function isActorTokenSigningKeyPath(
+  filePath: string | undefined,
+  workingDir?: string,
+): boolean {
+  if (!filePath) return false;
+  const resolvedPath = resolve(workingDir ?? process.cwd(), filePath);
+  const legacyPath = join(
+    homedir(),
+    ".vellum",
+    "protected",
+    "actor-token-signing-key",
+  );
+  const workspaceDeprecatedPath = resolve(
+    workingDir ?? process.cwd(),
+    "deprecated",
+    "actor-token-signing-key",
+  );
+  return (
+    resolvedPath === legacyPath || resolvedPath === workspaceDeprecatedPath
+  );
 }
 
 export async function check(


### PR DESCRIPTION
### Motivation

- The actor-token signing key was persisted under the workspace (`workspace/deprecated/actor-token-signing-key`), which made `file_read` invocations against it auto-allowed in default `workspace` mode and enabled silent exfiltration; this change prevents that.
- The goal is to treat reads of signing-key material as high-risk so they require explicit approval rather than being auto-allowed.

### Description

- Update `classifyRiskUncached` so `file_read` inspects the requested path and returns `RiskLevel.High` when the target is the actor-token signing key, and `RiskLevel.Low` otherwise (added a focused `isActorTokenSigningKeyPath` helper). 
- `isActorTokenSigningKeyPath` checks both legacy `~/.vellum/protected/actor-token-signing-key` and workspace-relative `deprecated/actor-token-signing-key` locations.
- Added `join` import from `node:path` used by the new helper and preserved existing resolution behavior for other path checks.
- Add regression tests in `assistant/src/__tests__/checker.test.ts` asserting that ordinary `file_read` remains Low risk while reads of the workspace and legacy signing-key paths are classified as High risk.

### Testing

- Added unit tests in `assistant/src/__tests__/checker.test.ts` that cover normal `file_read` behavior and the two signing-key paths; the tests assert the new High-risk classification for signing-key reads and keep other `file_read` cases Low.
- Attempted to run the scoped test command: `export PATH="$HOME/.bun/bin:$PATH" && cd assistant && bun test src/__tests__/checker.test.ts`, but the environment lacks `bun`, so automated tests were not executed here (test run failed: `bun: command not found`).
- Lint/type-check steps were skipped in this environment for the same reason; the change is intentionally scoped and includes test coverage to be executed in CI or a developer environment with Bun available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c912ac53bc83238b93781946a54bce)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22621" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
