### PR TITLE
M3: Fix invisible text via explicit TextKit 1 init and foregroundColor in typingAttributes

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
@@ -69,28 +69,43 @@ struct ComposerTextEditor: NSViewRepresentable {
         scrollView.autohidesScrollers = true
         scrollView.scrollerStyle = .overlay
 
-        let textView = ComposerTextView()
+        // Build an explicit TextKit 1 stack to avoid the implicit TextKit 2→1
+        // downgrade that occurs when accessing `layoutManager` on a default
+        // NSTextView (macOS 12+). The downgrade causes visual glitches where
+        // typed text is invisible even though the insertion point renders.
+        // Reference: https://developer.apple.com/documentation/appkit/nstextview/1449309-layoutmanager
+        let textStorage = NSTextStorage()
+        let layoutManager = NSLayoutManager()
+        textStorage.addLayoutManager(layoutManager)
+        let textContainer = NSTextContainer(size: NSSize(
+            width: 0,
+            height: CGFloat.greatestFiniteMagnitude
+        ))
+        textContainer.widthTracksTextView = true
+        textContainer.lineFragmentPadding = Self.textInsetX
+        layoutManager.addTextContainer(textContainer)
+
+        let textView = ComposerTextView(frame: .zero, textContainer: textContainer)
         textView.isRichText = false
         textView.importsGraphics = false
         textView.drawsBackground = false
         textView.backgroundColor = .clear
         textView.isAutomaticQuoteSubstitutionEnabled = false
         textView.isAutomaticDashSubstitutionEnabled = false
-        textView.textContainer?.widthTracksTextView = true
-        textView.textContainer?.containerSize = NSSize(width: 0, height: CGFloat.greatestFiniteMagnitude)
-        textView.textContainer?.lineFragmentPadding = Self.textInsetX
         textView.textContainerInset = NSSize(width: 0, height: Self.textInsetY)
         textView.isVerticallyResizable = true
         textView.isHorizontallyResizable = false
         textView.font = font
         textView.insertionPointColor = insertionPointColor
 
+        let defaultColor = NSColor(VColor.contentDefault)
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineSpacing = lineSpacing
         textView.defaultParagraphStyle = paragraphStyle
         textView.typingAttributes = [
             .font: font,
             .paragraphStyle: paragraphStyle,
+            .foregroundColor: defaultColor,
         ]
 
         textView.postsFrameChangedNotifications = true
@@ -142,6 +157,7 @@ struct ComposerTextEditor: NSViewRepresentable {
 
         textView.isEditable = isEditable
 
+        let textColor = textColorOverride ?? NSColor(VColor.contentDefault)
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineSpacing = lineSpacing
         textView.font = font
@@ -149,15 +165,11 @@ struct ComposerTextEditor: NSViewRepresentable {
         textView.typingAttributes = [
             .font: font,
             .paragraphStyle: paragraphStyle,
+            .foregroundColor: textColor,
         ]
 
         textView.placeholderString = placeholder
-
-        if let override = textColorOverride {
-            textView.textColor = override
-        } else {
-            textView.textColor = NSColor(VColor.contentDefault)
-        }
+        textView.textColor = textColor
 
         textView.cmdEnterToSend = cmdEnterToSend
         textView.onSubmit = onSubmit


### PR DESCRIPTION
## Summary
Fixes invisible text in the composer caused by two issues in ComposerTextEditor:

### 1. TextKit 2→1 compatibility glitch
`ComposerTextView()` creates a TextKit 2 view on macOS 12+. The `measureHeight` function then accesses `.layoutManager`, triggering an implicit TextKit 2→1 downgrade that Apple warns causes "visual glitches." This manifests as typed text being invisible while the insertion point still renders correctly.

**Fix:** Build an explicit TextKit 1 stack (NSTextStorage → NSLayoutManager → NSTextContainer) and pass the text container to `ComposerTextView(frame:textContainer:)`, matching the pattern already used by `VSelectableTextView` in this codebase.

### 2. Missing `.foregroundColor` in typingAttributes
`typingAttributes` only included `.font` and `.paragraphStyle` — no `.foregroundColor`. While `textView.textColor` was set separately, the TextKit compatibility mode could interfere with attribute application. Including `.foregroundColor` explicitly in `typingAttributes` ensures every typed character receives the correct color attribute directly.

Part of #22605
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22626" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
