### PR TITLE
fix(macos): wrap actor token restoration in defer for docker teleport

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -413,6 +413,14 @@ struct TeleportSection: View {
         let originalActorToken = ActorTokenManager.getToken()
         let actorToken = try await bootstrapActorToken(targetAssistantId: resolvedDocker.assistantId)
         ActorTokenManager.setToken(actorToken)
+        defer {
+            // Restore original actor token so the local assistant works during verification
+            if let originalActorToken {
+                ActorTokenManager.setToken(originalActorToken)
+            } else {
+                ActorTokenManager.deleteToken()
+            }
+        }
 
         // Step 5 — Import bundle to docker assistant
         phase = .transferring(step: "Importing data to Docker...")
@@ -431,13 +439,6 @@ struct TeleportSection: View {
            let success = importJson["success"] as? Bool, !success {
             let errorMsg = (importJson["error"] as? String) ?? "Import reported failure"
             throw TeleportError.importFailed(message: errorMsg)
-        }
-
-        // Step 5.5 — Restore original actor token so the local assistant works during verification
-        if let originalActorToken {
-            ActorTokenManager.setToken(originalActorToken)
-        } else {
-            ActorTokenManager.deleteToken()
         }
 
         // Step 6 — Store target for user confirmation (do NOT switch yet)


### PR DESCRIPTION
## Summary
- Move actor token restoration into a `defer` block in `teleportLocalToDocker()` so the original token is always restored, even if the import throws
- Matches the `defer` pattern already used for `connectedAssistantId` on the next line
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
