### PR TITLE
feat: add VSubMenuItem examples to component gallery

### DIFF
--- a/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
+++ b/clients/shared/DesignSystem/Gallery/ComponentGalleryView.swift
@@ -138,6 +138,7 @@ enum ComponentGalleryCategory: String, CaseIterable, Identifiable {
                 GalleryComponent("vLink", "VLink", keywords: ["link", "url", "external link", "hyperlink"], description: "Styled external link that opens a URL in the default browser. Applies pointer cursor, single-line truncation, and caption font by default."),
                 GalleryComponent("vThemeToggle", "VThemeToggle", keywords: ["theme toggle", "dark mode", "light mode"], description: "Three-way theme toggle (System / Light / Dark). Reads and writes themePreference in UserDefaults."),
                 GalleryComponent("vMenu", "VMenu", keywords: ["menu", "popover", "dropdown", "drawer", "overflow"], description: "Reusable popover container with section headers, dividers, action items, and custom rows. Use instead of manual drawer chrome."),
+                GalleryComponent("vSubMenuItem", "VSubMenuItem", keywords: ["submenu", "cascading menu", "nested menu", "flyout"], description: "Cascading submenu item that opens a child VMenuPanel on hover/click. Anchored positioning with screen-edge flip, grace-period close. iOS falls back to native SwiftUI Menu."),
             ]
         case .tokens:
             return [

--- a/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
@@ -391,7 +391,7 @@ struct NavigationGallerySection: View {
                 // MARK: - VSubMenuItem (Cascading Submenu)
                 GallerySectionHeader(
                     title: "VSubMenuItem",
-                    description: "Cascading submenu item that opens a child panel on hover (150ms debounce) or click. Anchored to the item's trailing edge with screen-edge flip. Grace-period close (200ms) prevents accidental dismiss when moving between panels. On iOS, falls back to native SwiftUI Menu."
+                    description: "Cascading submenu item that opens a child panel on hover (150ms debounce) or click. Anchored to the item's trailing edge with screen-edge flip. Grace-period close (200ms) prevents accidental dismiss when moving between panels. On iOS, falls back to native SwiftUI Menu.\n\nNote: The inline examples below show the component's visual appearance. For interactive submenu behavior (flyout panel), right-click the demo card at the bottom — .vContextMenu provides the required VMenuCoordinator."
                 )
 
                 VCard {

--- a/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
@@ -384,6 +384,87 @@ struct NavigationGallerySection: View {
                 }
             }
 
+            if filter == nil || filter == "vSubMenuItem" {
+                if filter == nil {
+                    Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+                }
+                // MARK: - VSubMenuItem (Cascading Submenu)
+                GallerySectionHeader(
+                    title: "VSubMenuItem",
+                    description: "Cascading submenu item that opens a child panel on hover (150ms debounce) or click. Anchored to the item's trailing edge with screen-edge flip. Grace-period close (200ms) prevents accidental dismiss when moving between panels. On iOS, falls back to native SwiftUI Menu."
+                )
+
+                VCard {
+                    VStack(alignment: .leading, spacing: VSpacing.lg) {
+                        Text("Submenu with Actions").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
+
+                        VMenu(width: 200) {
+                            VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename") {}
+                            VMenuItem(icon: VIcon.archive.rawValue, label: "Archive") {}
+                            VSubMenuItem(icon: VIcon.folder.rawValue, label: "Move to") {
+                                VMenuItem(label: "Pinned") {}
+                                VMenuItem(label: "Scheduled") {}
+                                VMenuItem(label: "Work") {}
+                                VMenuDivider()
+                                VMenuItem(label: "Remove from group") {}
+                            }
+                            VMenuDivider()
+                            VMenuItem(icon: VIcon.trash.rawValue, label: "Delete", variant: .destructive) {}
+                        }
+                    }
+                }
+
+                Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+
+                // MARK: - VSubMenuItem (with icon and custom width)
+                GallerySectionHeader(
+                    title: "VSubMenuItem with Custom Width",
+                    description: "Pass a width parameter to override the parent menu's width for the child panel."
+                )
+
+                VCard {
+                    VStack(alignment: .leading, spacing: VSpacing.lg) {
+                        Text("Custom Child Width (250pt)").font(VFont.bodySmallEmphasised).foregroundStyle(VColor.contentSecondary)
+
+                        VMenu(width: 200) {
+                            VMenuItem(icon: VIcon.settings.rawValue, label: "Settings") {}
+                            VSubMenuItem(icon: VIcon.palette.rawValue, label: "Appearance", width: 250) {
+                                VMenuItem(label: "System Default") {}
+                                VMenuItem(label: "Light Mode") {}
+                                VMenuItem(label: "Dark Mode") {}
+                                VMenuItem(label: "High Contrast") {}
+                            }
+                        }
+                    }
+                }
+
+                Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
+
+                // MARK: - VSubMenuItem (in context menu)
+                GallerySectionHeader(
+                    title: "VSubMenuItem in Context Menu",
+                    description: "Right-click the card below to see a VSubMenuItem inside a .vContextMenu."
+                )
+
+                VCard {
+                    Text("Right-click me")
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(VColor.contentSecondary)
+                        .frame(maxWidth: .infinity)
+                        .padding(VSpacing.xl)
+                        .vContextMenu(width: 200) {
+                            VMenuItem(icon: VIcon.copy.rawValue, label: "Copy") {}
+                            VSubMenuItem(icon: VIcon.externalLink.rawValue, label: "Share via") {
+                                VMenuItem(label: "Email") {}
+                                VMenuItem(label: "Slack") {}
+                                VMenuItem(label: "Copy Link") {}
+                            }
+                            VMenuDivider()
+                            VMenuItem(icon: VIcon.trash.rawValue, label: "Delete", variant: .destructive) {}
+                        }
+                }
+            }
+
 
         }
     }
@@ -400,6 +481,7 @@ extension NavigationGallerySection {
         case "vLink": NavigationGallerySection(filter: "vLink")
         case "vThemeToggle": NavigationGallerySection(filter: "vThemeToggle")
         case "vMenu": NavigationGallerySection(filter: "vMenu")
+        case "vSubMenuItem": NavigationGallerySection(filter: "vSubMenuItem")
         default: EmptyView()
         }
     }


### PR DESCRIPTION
## Summary
Add VSubMenuItem to the component gallery with three examples demonstrating the cascading submenu system.

## Examples Added
- **Submenu with Actions** — "Move to" pattern with group targets and "Remove from group" divider
- **Custom Child Width** — Appearance submenu with 250pt override (parent is 200pt)
- **Context Menu Integration** — Right-click card with "Share via" submenu inside `.vContextMenu`

## Test plan
- [ ] Open Component Gallery → Navigation → VSubMenuItem
- [ ] Hover over submenu items to verify flyout panel opens
- [ ] Click submenu items to verify immediate open
- [ ] Right-click the "Right-click me" card to verify context menu submenu

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22630" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
