### PR TITLE
M4: Fix invisible text — guard updateNSView + shield NSView from animations

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
@@ -157,19 +157,40 @@ struct ComposerTextEditor: NSViewRepresentable {
 
         textView.isEditable = isEditable
 
+        // Guard attribute updates behind change checks to avoid triggering
+        // redundant TextKit re-layouts during the SwiftUI render cycle.
+        // Each keystroke fires textDidChange → binding update → updateNSView;
+        // unconditionally re-stamping font/color/typingAttributes here would
+        // cause a layout pass on every character, which can leave glyphs
+        // un-drawn until the *next* display cycle (appearing invisible).
+        // Ref: WWDC 2022 "Use SwiftUI with AppKit" — only update changed props.
+        let coordinator = context.coordinator
         let textColor = textColorOverride ?? NSColor(VColor.contentDefault)
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineSpacing = lineSpacing
-        textView.font = font
-        textView.defaultParagraphStyle = paragraphStyle
-        textView.typingAttributes = [
-            .font: font,
-            .paragraphStyle: paragraphStyle,
-            .foregroundColor: textColor,
-        ]
+
+        let fontChanged = coordinator.lastAppliedFont != font
+            || coordinator.lastAppliedLineSpacing != lineSpacing
+        let colorChanged = coordinator.lastAppliedTextColor !== textColor
+
+        if fontChanged {
+            coordinator.lastAppliedFont = font
+            coordinator.lastAppliedLineSpacing = lineSpacing
+            let paragraphStyle = NSMutableParagraphStyle()
+            paragraphStyle.lineSpacing = lineSpacing
+            textView.font = font
+            textView.defaultParagraphStyle = paragraphStyle
+        }
+
+        if fontChanged || colorChanged {
+            coordinator.lastAppliedTextColor = textColor
+            textView.textColor = textColor
+            textView.typingAttributes = [
+                .font: font,
+                .paragraphStyle: textView.defaultParagraphStyle ?? NSParagraphStyle.default,
+                .foregroundColor: textColor,
+            ]
+        }
 
         textView.placeholderString = placeholder
-        textView.textColor = textColor
 
         textView.cmdEnterToSend = cmdEnterToSend
         textView.onSubmit = onSubmit
@@ -215,6 +236,12 @@ struct ComposerTextEditor: NSViewRepresentable {
         var parent: ComposerTextEditor
         var frameObserver: NSObjectProtocol?
         var boundsObserver: NSObjectProtocol?
+
+        // Track last-applied values so updateNSView only touches the text
+        // storage when something actually changed.
+        var lastAppliedFont: NSFont?
+        var lastAppliedLineSpacing: CGFloat?
+        var lastAppliedTextColor: NSColor?
 
         init(parent: ComposerTextEditor) {
             self.parent = parent

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -252,6 +252,11 @@ struct ComposerView: View {
                 onPasteImage: onPaste
             )
             .fixedSize(horizontal: false, vertical: true)
+            // Prevent inherited .animation() modifiers from creating animation
+            // transactions that snapshot the NSView's CALayer. Without this,
+            // parent animations (e.g. .animation(value: isComposerFocused)) can
+            // freeze the text view's rendering, making typed text invisible.
+            .transaction { $0.animation = nil }
         }
         .padding(.vertical, VSpacing.xs)
         .fixedSize(horizontal: false, vertical: true)


### PR DESCRIPTION
## Summary
Fixes invisible text in the composer caused by two issues:

### 1. updateNSView re-stamping text attributes on every keystroke
Each keystroke triggers textDidChange → binding update → updateNSView, which
unconditionally called `textView.font = font`, `textView.textColor = color`,
and reset `typingAttributes`. Each of these mutates the text storage and
triggers a TextKit re-layout during the SwiftUI render cycle. The glyphs get
laid out but are not drawn until the NEXT display cycle — which never arrives
because another keystroke triggers the same cycle.

**Fix:** Track last-applied font, lineSpacing, and textColor in the
Coordinator. Only mutate text storage attributes when values actually change.
Per WWDC 2022 "Use SwiftUI with AppKit": updateNSView should only update
properties that have changed.

### 2. Parent `.animation()` modifiers snapshotting the NSView's CALayer
`.animation(VAnimation.fast, value: isComposerFocused)` on the ComposerView
body wraps the entire view tree including the NSViewRepresentable. When
isComposerFocused changes (on initial focus), SwiftUI can snapshot the
NSView's CALayer for the animation transition, freezing its visual state.

**Fix:** Add `.transaction { $0.animation = nil }` on the ComposerTextEditor
to prevent inherited animation transactions from affecting the NSView.

Part of #22605
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
