### PR TITLE
M5: Fix zero-width text view — add missing autoresizingMask

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
@@ -95,6 +95,7 @@ struct ComposerTextEditor: NSViewRepresentable {
         textView.textContainerInset = NSSize(width: 0, height: Self.textInsetY)
         textView.isVerticallyResizable = true
         textView.isHorizontallyResizable = false
+        textView.autoresizingMask = [.width]
         textView.font = font
         textView.insertionPointColor = insertionPointColor
 


### PR DESCRIPTION
## Summary
The actual root cause of invisible composer text: the NSTextView has zero width.

When the TextKit 1 fix (M3) changed the initializer from `ComposerTextView()` to
`ComposerTextView(frame: .zero, textContainer: textContainer)`, the text view lost
its default autoresizing behavior. Without `autoresizingMask = [.width]`, the
NSScrollView never propagates its width to the document view (the NSTextView).

Result: text container has 0 width → text laid out in zero-width column → glyphs
invisible, cursor still renders (1px intrinsic width), Cmd+A selects nothing.

The fix is one line: `textView.autoresizingMask = [.width]` — matching the pattern
already used by `VSelectableTextView` in this codebase (line 128).

Part of #22605
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22632" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
