### PR TITLE
fix: add missing daemonSupportsGroups property to test mock

### DIFF
--- a/clients/macos/vellum-assistantTests/ConversationRestorerTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationRestorerTests.swift
@@ -9,6 +9,7 @@ import VellumAssistantShared
 final class MockConversationRestorerDelegate: ConversationRestorerDelegate {
     var conversations: [ConversationModel] = []
     var groups: [ConversationGroup] = []
+    var daemonSupportsGroups: Bool = false
     var restoreRecentConversations: Bool = true
     var isLoadingMoreConversations: Bool = false
     var hasMoreConversations: Bool = false


### PR DESCRIPTION
## Summary
- Add daemonSupportsGroups: Bool = false to MockConversationRestorerDelegate to conform to the updated ConversationRestorerDelegate protocol (added in conversation groups feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
