### PR TITLE
M1: Pass container-responsive maxContentWidth for user message bubbles

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -480,7 +480,7 @@ struct ChatBubble: View, Equatable {
                     MarkdownSegmentView(
                         segments: segments,
                         isStreaming: message.isStreaming,
-                        maxContentWidth: isUser ? (bubbleMaxWidth - 2 * VSpacing.lg) : bubbleMaxWidth,
+                        maxContentWidth: isUser ? max(bubbleMaxWidth - 2 * VSpacing.lg, 0) : bubbleMaxWidth,
                         textColor: isUser ? VColor.contentDefault : VColor.contentDefault,
                         secondaryTextColor: isUser ? VColor.contentSecondary : VColor.contentSecondary,
                         mutedTextColor: isUser ? VColor.contentSecondary : VColor.contentTertiary,

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -3,6 +3,22 @@ import os.signpost
 import SwiftUI
 import VellumAssistantShared
 
+// MARK: - Bubble Max Width Environment
+
+/// The effective maximum width for chat bubble content, accounting for
+/// the actual container width. Defaults to the static cap when the
+/// container is wide enough.
+private struct BubbleMaxWidthKey: EnvironmentKey {
+    static let defaultValue: CGFloat = VSpacing.chatBubbleMaxWidth
+}
+
+extension EnvironmentValues {
+    var bubbleMaxWidth: CGFloat {
+        get { self[BubbleMaxWidthKey.self] }
+        set { self[BubbleMaxWidthKey.self] = newValue }
+    }
+}
+
 // MARK: - Chat Bubble
 
 struct ChatBubble: View, Equatable {
@@ -65,6 +81,7 @@ struct ChatBubble: View, Equatable {
     /// Owned but never read in this body — only ChatBubbleOverflowMenu reads it,
     /// so hover changes invalidate only the overflow menu, not this view.
     @State private var hoverState = ChatBubbleHoverState()
+    @Environment(\.bubbleMaxWidth) private var bubbleMaxWidth
     /// Stores async-parsed segments for large messages (>500 chars) that missed the
     /// synchronous cache. Keyed by text content so multiple segments can be in flight.
     @State var asyncSegments: [String: [MarkdownSegment]] = [:]
@@ -239,7 +256,7 @@ struct ChatBubble: View, Equatable {
                 bubbleBorderOverlay
             }
             // Outer frame: cap the maximum width and position the bubble.
-            .frame(maxWidth: message.isError ? .infinity : VSpacing.chatBubbleMaxWidth, alignment: isUser ? .trailing : .leading)
+            .frame(maxWidth: message.isError ? .infinity : bubbleMaxWidth, alignment: isUser ? .trailing : .leading)
     }
 
     /// Surfaces not currently shown in the floating overlay, computed once per body evaluation.
@@ -463,7 +480,7 @@ struct ChatBubble: View, Equatable {
                     MarkdownSegmentView(
                         segments: segments,
                         isStreaming: message.isStreaming,
-                        maxContentWidth: isUser ? nil : VSpacing.chatBubbleMaxWidth,
+                        maxContentWidth: isUser ? (bubbleMaxWidth - 2 * VSpacing.lg) : bubbleMaxWidth,
                         textColor: isUser ? VColor.contentDefault : VColor.contentDefault,
                         secondaryTextColor: isUser ? VColor.contentSecondary : VColor.contentSecondary,
                         mutedTextColor: isUser ? VColor.contentSecondary : VColor.contentTertiary,

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -112,12 +112,11 @@ struct ChatView: View {
                     chatBackground
                 }
                 .background(VColor.surfaceBase)
-                .background(
-                    GeometryReader { geo in
-                        Color.clear.preference(key: ChatContainerWidthKey.self, value: geo.size.width)
-                    }
-                )
-                .onPreferenceChange(ChatContainerWidthKey.self) { containerWidth = $0 }
+                .onGeometryChange(for: CGFloat.self) { proxy in
+                    proxy.size.width
+                } action: { newWidth in
+                    containerWidth = newWidth
+                }
                 .overlay(alignment: .bottom) {
                     btwOverlay
                 }
@@ -735,12 +734,4 @@ struct ScrollWheelPassthrough: NSViewRepresentable {
     }
 }
 
-/// Propagates the chat container's measured width up to ChatView so it can
-/// forward it to MessageListView for resize-aware scroll stabilization.
-private struct ChatContainerWidthKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = max(value, nextValue())
-    }
-}
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -768,7 +768,7 @@ struct MessageListView: View {
         .frame(maxWidth: VSpacing.chatColumnMaxWidth)
         .frame(maxWidth: .infinity)
         .environment(\.bubbleMaxWidth, containerWidth > 0
-            ? min(VSpacing.chatBubbleMaxWidth, containerWidth - 2 * VSpacing.xl)
+            ? min(VSpacing.chatBubbleMaxWidth, max(containerWidth - 2 * VSpacing.xl, 0))
             : VSpacing.chatBubbleMaxWidth)
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -767,6 +767,7 @@ struct MessageListView: View {
         .padding(.bottom, VSpacing.md)
         .frame(maxWidth: VSpacing.chatColumnMaxWidth)
         .frame(maxWidth: .infinity)
+        .environment(\.bubbleMaxWidth, min(VSpacing.chatBubbleMaxWidth, max(containerWidth - 2 * VSpacing.xl, 0)))
     }
 
     // MARK: - Scroll-to-latest overlay

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -767,7 +767,9 @@ struct MessageListView: View {
         .padding(.bottom, VSpacing.md)
         .frame(maxWidth: VSpacing.chatColumnMaxWidth)
         .frame(maxWidth: .infinity)
-        .environment(\.bubbleMaxWidth, min(VSpacing.chatBubbleMaxWidth, max(containerWidth - 2 * VSpacing.xl, 0)))
+        .environment(\.bubbleMaxWidth, containerWidth > 0
+            ? min(VSpacing.chatBubbleMaxWidth, containerWidth - 2 * VSpacing.xl)
+            : VSpacing.chatBubbleMaxWidth)
     }
 
     // MARK: - Scroll-to-latest overlay


### PR DESCRIPTION
## Summary
- Define `BubbleMaxWidthKey` environment key in ChatBubble.swift to propagate the effective max width
- Compute `min(chatBubbleMaxWidth, containerWidth - 2*xl)` in MessageListView and inject via `.environment()`
- Read `bubbleMaxWidth` in ChatBubble to cap both the outer frame and the text measurement width (user messages subtract horizontal padding to prevent overflow)
- Modernize ChatView geometry measurement from GeometryReader+PreferenceKey to `.onGeometryChange` per AGENTS.md

## Test plan
- [ ] Resize the app window narrower than 760pt and verify user message bubbles shrink to fit
- [ ] Verify assistant message bubbles still cap at 760pt on wide windows
- [ ] Verify user message bubbles no longer overflow past the container boundary
- [ ] Verify error messages still expand to full width

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
