### PR TITLE
fix: correct opt-out watermark assertion in telemetry reporter test

### DIFF
--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -504,17 +504,15 @@ describe("UsageTelemetryReporter", () => {
     // No HTTP call should have been made
     expect(mockFetch).not.toHaveBeenCalled();
 
-    // All 6 watermarks should have been advanced (3 timestamps + 3 IDs)
-    expect(mockSetMemoryCheckpoint).toHaveBeenCalledTimes(6);
+    // All 3 timestamp watermarks should have been advanced (IDs left untouched
+    // so the compound-cursor branch stays active)
+    expect(mockSetMemoryCheckpoint).toHaveBeenCalledTimes(3);
 
     const calls = mockSetMemoryCheckpoint.mock.calls;
     const keys = calls.map((c) => c[0]);
     expect(keys).toContain("telemetry:usage:last_reported_at");
-    expect(keys).toContain("telemetry:usage:last_reported_id");
     expect(keys).toContain("telemetry:turns:last_reported_at");
-    expect(keys).toContain("telemetry:turns:last_reported_id");
     expect(keys).toContain("telemetry:lifecycle:last_reported_at");
-    expect(keys).toContain("telemetry:lifecycle:last_reported_id");
   });
 
   test("events sent normally after re-enabling collectUsageData", async () => {


### PR DESCRIPTION
## Summary
- Fix failing test: the opt-out code path sets 3 timestamp watermarks, not 6 (IDs are intentionally left untouched so the compound-cursor branch stays active)
- All 15 telemetry reporter tests pass

Related: vellum-ai/vellum-assistant-platform#3569 (backend now accepts lifecycle events)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
