### PR TITLE
Security: elevate file_read risk for actor-token signing key paths

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -170,16 +170,38 @@ describe("Permission Checker", () => {
   // ── classifyRisk ────────────────────────────────────────────────
 
   describe("classifyRisk", () => {
-    // file_read is always low
+    // file_read is low risk except for signing-key material
     describe("file_read", () => {
-      test("file_read is always low risk", async () => {
+      test("file_read is low risk for regular files", async () => {
         const risk = await classifyRisk("file_read", { path: "/etc/passwd" });
         expect(risk).toBe(RiskLevel.Low);
       });
 
-      test("file_read with any path is low risk", async () => {
+      test("file_read with arbitrary non-key path is low risk", async () => {
         const risk = await classifyRisk("file_read", { path: "/tmp/safe.txt" });
         expect(risk).toBe(RiskLevel.Low);
+      });
+
+      test("file_read of workspace signing key path is high risk", async () => {
+        const workspaceDir = join(checkerTestDir, "workspace");
+        const risk = await classifyRisk(
+          "file_read",
+          { path: "deprecated/actor-token-signing-key" },
+          workspaceDir,
+        );
+        expect(risk).toBe(RiskLevel.High);
+      });
+
+      test("file_read of legacy protected signing key path is high risk", async () => {
+        const risk = await classifyRisk("file_read", {
+          path: join(
+            homedir(),
+            ".vellum",
+            "protected",
+            "actor-token-signing-key",
+          ),
+        });
+        expect(risk).toBe(RiskLevel.High);
       });
     });
 

--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -203,6 +203,42 @@ describe("Permission Checker", () => {
         });
         expect(risk).toBe(RiskLevel.High);
       });
+
+      test("file_read via symlink alias to signing key is high risk", async () => {
+        const workspaceDir = join(checkerTestDir, "workspace");
+        const deprecatedDir = join(workspaceDir, "deprecated");
+        const keyPath = join(deprecatedDir, "actor-token-signing-key");
+        const aliasPath = join(workspaceDir, "innocent-file");
+
+        // Create the signing key file and a symlink alias
+        mkdirSync(deprecatedDir, { recursive: true });
+        writeFileSync(keyPath, "fake-key-content");
+        try {
+          symlinkSync(keyPath, aliasPath);
+        } catch {
+          // Symlink may already exist from a previous run
+        }
+
+        try {
+          const risk = await classifyRisk(
+            "file_read",
+            { path: "innocent-file" },
+            workspaceDir,
+          );
+          expect(risk).toBe(RiskLevel.High);
+        } finally {
+          try {
+            rmSync(aliasPath);
+          } catch {
+            /* cleanup */
+          }
+          try {
+            rmSync(keyPath);
+          } catch {
+            /* cleanup */
+          }
+        }
+      });
     });
 
     // file_write is always low (sandboxed)

--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -203,42 +203,6 @@ describe("Permission Checker", () => {
         });
         expect(risk).toBe(RiskLevel.High);
       });
-
-      test("file_read via symlink alias to signing key is high risk", async () => {
-        const workspaceDir = join(checkerTestDir, "workspace");
-        const deprecatedDir = join(workspaceDir, "deprecated");
-        const keyPath = join(deprecatedDir, "actor-token-signing-key");
-        const aliasPath = join(workspaceDir, "innocent-file");
-
-        // Create the signing key file and a symlink alias
-        mkdirSync(deprecatedDir, { recursive: true });
-        writeFileSync(keyPath, "fake-key-content");
-        try {
-          symlinkSync(keyPath, aliasPath);
-        } catch {
-          // Symlink may already exist from a previous run
-        }
-
-        try {
-          const risk = await classifyRisk(
-            "file_read",
-            { path: "innocent-file" },
-            workspaceDir,
-          );
-          expect(risk).toBe(RiskLevel.High);
-        } finally {
-          try {
-            rmSync(aliasPath);
-          } catch {
-            /* cleanup */
-          }
-          try {
-            rmSync(keyPath);
-          } catch {
-            /* cleanup */
-          }
-        }
-      });
     });
 
     // file_write is always low (sandboxed)

--- a/assistant/src/__tests__/volume-security-guard.test.ts
+++ b/assistant/src/__tests__/volume-security-guard.test.ts
@@ -38,6 +38,8 @@ const ALLOWED_FILES = new Set([
   "assistant/src/cli/commands/trust.ts",
   // Auth middleware documentation comment (not a file access)
   "assistant/src/runtime/auth/middleware.ts",
+  // Permission checker: classifies file_read of signing key as High risk
+  "assistant/src/permissions/checker.ts",
 ]);
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -20,7 +20,7 @@ import {
   looksLikePathOnlyInput,
 } from "../tools/network/url-safety.js";
 import { getTool } from "../tools/registry.js";
-import { getWorkspaceHooksDir } from "../util/platform.js";
+import { getDeprecatedDir, getWorkspaceHooksDir } from "../util/platform.js";
 import {
   buildShellAllowlistOptions,
   buildShellCommandCandidates,
@@ -953,7 +953,7 @@ function isActorTokenSigningKeyPath(
   const resolvedPath = resolve(cwd, filePath);
   const signingKeyPaths = [
     join(homedir(), ".vellum", "protected", "actor-token-signing-key"),
-    resolve(cwd, "deprecated", "actor-token-signing-key"),
+    join(getDeprecatedDir(), "actor-token-signing-key"),
   ];
 
   // Lexical match (handles normal paths and cases where files don't exist)

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -663,11 +663,13 @@ export async function classifyRisk(
   signal?.throwIfAborted();
   ensureRiskCacheInvalidationHook();
 
-  // Check cache first (skip when preParsed is provided since caller already
-  // parsed and we'd just be duplicating the key computation cost).
-  const cacheKey = preParsed
-    ? null
-    : riskCacheKey(toolName, input, workingDir, manifestOverride);
+  // Check cache first. Skip when preParsed is provided (caller already
+  // parsed) and for file_read (risk depends on mutable filesystem state
+  // like symlinks, so cached results could become stale).
+  const cacheKey =
+    preParsed || toolName === "file_read"
+      ? null
+      : riskCacheKey(toolName, input, workingDir, manifestOverride);
   if (cacheKey) {
     const cached = riskCache.get(cacheKey);
     if (cached !== undefined) {

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
@@ -948,21 +949,30 @@ function isActorTokenSigningKeyPath(
   workingDir?: string,
 ): boolean {
   if (!filePath) return false;
-  const resolvedPath = resolve(workingDir ?? process.cwd(), filePath);
-  const legacyPath = join(
-    homedir(),
-    ".vellum",
-    "protected",
-    "actor-token-signing-key",
-  );
-  const workspaceDeprecatedPath = resolve(
-    workingDir ?? process.cwd(),
-    "deprecated",
-    "actor-token-signing-key",
-  );
-  return (
-    resolvedPath === legacyPath || resolvedPath === workspaceDeprecatedPath
-  );
+  const cwd = workingDir ?? process.cwd();
+  const resolvedPath = resolve(cwd, filePath);
+  const signingKeyPaths = [
+    join(homedir(), ".vellum", "protected", "actor-token-signing-key"),
+    resolve(cwd, "deprecated", "actor-token-signing-key"),
+  ];
+
+  // Lexical match (handles normal paths and cases where files don't exist)
+  if (signingKeyPaths.includes(resolvedPath)) return true;
+
+  // Canonicalize via realpath to catch symlink/hardlink aliases
+  let realInput: string;
+  try {
+    realInput = realpathSync(resolvedPath);
+  } catch {
+    return false;
+  }
+  return signingKeyPaths.some((p) => {
+    try {
+      return realInput === realpathSync(p);
+    } catch {
+      return realInput === p;
+    }
+  });
 }
 
 export async function check(

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -1,5 +1,4 @@
 import { createHash } from "node:crypto";
-import { realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
@@ -663,13 +662,11 @@ export async function classifyRisk(
   signal?.throwIfAborted();
   ensureRiskCacheInvalidationHook();
 
-  // Check cache first. Skip when preParsed is provided (caller already
-  // parsed) and for file_read (risk depends on mutable filesystem state
-  // like symlinks, so cached results could become stale).
-  const cacheKey =
-    preParsed || toolName === "file_read"
-      ? null
-      : riskCacheKey(toolName, input, workingDir, manifestOverride);
+  // Check cache first (skip when preParsed is provided since caller already
+  // parsed and we'd just be duplicating the key computation cost).
+  const cacheKey = preParsed
+    ? null
+    : riskCacheKey(toolName, input, workingDir, manifestOverride);
   if (cacheKey) {
     const cached = riskCache.get(cacheKey);
     if (cached !== undefined) {
@@ -956,27 +953,9 @@ function isActorTokenSigningKeyPath(
   const signingKeyPaths = [
     join(homedir(), ".vellum", "protected", "actor-token-signing-key"),
     join(getDeprecatedDir(), "actor-token-signing-key"),
-    // Also check against workingDir-relative path for defense-in-depth
     resolve(cwd, "deprecated", "actor-token-signing-key"),
   ];
-
-  // Lexical match (handles normal paths and cases where files don't exist)
-  if (signingKeyPaths.includes(resolvedPath)) return true;
-
-  // Canonicalize via realpath to catch symlink/hardlink aliases
-  let realInput: string;
-  try {
-    realInput = realpathSync(resolvedPath);
-  } catch {
-    return false;
-  }
-  return signingKeyPaths.some((p) => {
-    try {
-      return realInput === realpathSync(p);
-    } catch {
-      return realInput === p;
-    }
-  });
+  return signingKeyPaths.includes(resolvedPath);
 }
 
 export async function check(

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { homedir } from "node:os";
-import { dirname, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
@@ -703,7 +703,13 @@ async function classifyRiskUncached(
   preParsed?: ParsedCommand,
   manifestOverride?: ManifestOverride,
 ): Promise<RiskLevel> {
-  if (toolName === "file_read") return RiskLevel.Low;
+  if (toolName === "file_read") {
+    const filePath = getStringField(input, "path", "file_path");
+    if (isActorTokenSigningKeyPath(filePath, workingDir)) {
+      return RiskLevel.High;
+    }
+    return RiskLevel.Low;
+  }
   if (toolName === "file_write" || toolName === "file_edit") {
     const filePath = getStringField(input, "path", "file_path");
     if (
@@ -935,6 +941,28 @@ async function classifyRiskUncached(
 
   // Unknown tool → Medium
   return RiskLevel.Medium;
+}
+
+function isActorTokenSigningKeyPath(
+  filePath: string | undefined,
+  workingDir?: string,
+): boolean {
+  if (!filePath) return false;
+  const resolvedPath = resolve(workingDir ?? process.cwd(), filePath);
+  const legacyPath = join(
+    homedir(),
+    ".vellum",
+    "protected",
+    "actor-token-signing-key",
+  );
+  const workspaceDeprecatedPath = resolve(
+    workingDir ?? process.cwd(),
+    "deprecated",
+    "actor-token-signing-key",
+  );
+  return (
+    resolvedPath === legacyPath || resolvedPath === workspaceDeprecatedPath
+  );
 }
 
 export async function check(

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -954,6 +954,8 @@ function isActorTokenSigningKeyPath(
   const signingKeyPaths = [
     join(homedir(), ".vellum", "protected", "actor-token-signing-key"),
     join(getDeprecatedDir(), "actor-token-signing-key"),
+    // Also check against workingDir-relative path for defense-in-depth
+    resolve(cwd, "deprecated", "actor-token-signing-key"),
   ];
 
   // Lexical match (handles normal paths and cases where files don't exist)


### PR DESCRIPTION
## Summary

- Elevate `file_read` risk classification from Low to High when the target path resolves to the actor-token signing key (`workspace/deprecated/actor-token-signing-key` or `protected/actor-token-signing-key`)
- Prevents workspace-mode auto-allow from silently permitting prompt-injection-induced reads of the JWT signing key
- Adds test coverage for both workspace and legacy signing key paths

Codex finding: https://chatgpt.com/codex/security/findings/e743d2028d808191a8f924ecadd45eb4?sev=high%2Ccritical

## Original prompt

Security fix: Elevate file_read risk classification for actor-token signing key paths. The actor-token signing key is stored at `workspace/deprecated/actor-token-signing-key` (inside the workspace root). In default workspace mode, `file_read` is classified as Low risk and auto-allowed for workspace-scoped paths. This means a prompt-injection attack could silently read the signing key without user approval, enabling JWT forgery.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22638" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
