### PR TITLE
Fix user message bubbles overflowing past chat container width

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -3,6 +3,22 @@ import os.signpost
 import SwiftUI
 import VellumAssistantShared
 
+// MARK: - Bubble Max Width Environment
+
+/// The effective maximum width for chat bubble content, accounting for
+/// the actual container width. Defaults to the static cap when the
+/// container is wide enough.
+private struct BubbleMaxWidthKey: EnvironmentKey {
+    static let defaultValue: CGFloat = VSpacing.chatBubbleMaxWidth
+}
+
+extension EnvironmentValues {
+    var bubbleMaxWidth: CGFloat {
+        get { self[BubbleMaxWidthKey.self] }
+        set { self[BubbleMaxWidthKey.self] = newValue }
+    }
+}
+
 // MARK: - Chat Bubble
 
 struct ChatBubble: View, Equatable {
@@ -65,6 +81,7 @@ struct ChatBubble: View, Equatable {
     /// Owned but never read in this body — only ChatBubbleOverflowMenu reads it,
     /// so hover changes invalidate only the overflow menu, not this view.
     @State private var hoverState = ChatBubbleHoverState()
+    @Environment(\.bubbleMaxWidth) private var bubbleMaxWidth
     /// Stores async-parsed segments for large messages (>500 chars) that missed the
     /// synchronous cache. Keyed by text content so multiple segments can be in flight.
     @State var asyncSegments: [String: [MarkdownSegment]] = [:]
@@ -239,7 +256,7 @@ struct ChatBubble: View, Equatable {
                 bubbleBorderOverlay
             }
             // Outer frame: cap the maximum width and position the bubble.
-            .frame(maxWidth: message.isError ? .infinity : VSpacing.chatBubbleMaxWidth, alignment: isUser ? .trailing : .leading)
+            .frame(maxWidth: message.isError ? .infinity : bubbleMaxWidth, alignment: isUser ? .trailing : .leading)
     }
 
     /// Surfaces not currently shown in the floating overlay, computed once per body evaluation.
@@ -463,7 +480,7 @@ struct ChatBubble: View, Equatable {
                     MarkdownSegmentView(
                         segments: segments,
                         isStreaming: message.isStreaming,
-                        maxContentWidth: isUser ? nil : VSpacing.chatBubbleMaxWidth,
+                        maxContentWidth: isUser ? max(bubbleMaxWidth - 2 * VSpacing.lg, 0) : bubbleMaxWidth,
                         textColor: isUser ? VColor.contentDefault : VColor.contentDefault,
                         secondaryTextColor: isUser ? VColor.contentSecondary : VColor.contentSecondary,
                         mutedTextColor: isUser ? VColor.contentSecondary : VColor.contentTertiary,

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -81,7 +81,7 @@ struct ChatBubble: View, Equatable {
     /// Owned but never read in this body — only ChatBubbleOverflowMenu reads it,
     /// so hover changes invalidate only the overflow menu, not this view.
     @State private var hoverState = ChatBubbleHoverState()
-    @Environment(\.bubbleMaxWidth) private var bubbleMaxWidth
+    @Environment(\.bubbleMaxWidth) var bubbleMaxWidth
     /// Stores async-parsed segments for large messages (>500 chars) that missed the
     /// synchronous cache. Keyed by text content so multiple segments can be in flight.
     @State var asyncSegments: [String: [MarkdownSegment]] = [:]

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -18,7 +18,7 @@ extension ChatBubble {
             // Switching between Text and MarkdownSegmentView caused
             // LazyVStack to use stale height measurements, resulting in
             // content truncation and footer overlap.
-            MarkdownSegmentView(segments: segments, isStreaming: streaming)
+            MarkdownSegmentView(segments: segments, isStreaming: streaming, maxContentWidth: bubbleMaxWidth)
                 .equatable()
         }
         .task(id: "\(segmentText)|\(streaming)") {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -112,12 +112,11 @@ struct ChatView: View {
                     chatBackground
                 }
                 .background(VColor.surfaceBase)
-                .background(
-                    GeometryReader { geo in
-                        Color.clear.preference(key: ChatContainerWidthKey.self, value: geo.size.width)
-                    }
-                )
-                .onPreferenceChange(ChatContainerWidthKey.self) { containerWidth = $0 }
+                .onGeometryChange(for: CGFloat.self) { proxy in
+                    proxy.size.width
+                } action: { newWidth in
+                    containerWidth = newWidth
+                }
                 .overlay(alignment: .bottom) {
                     btwOverlay
                 }
@@ -735,12 +734,4 @@ struct ScrollWheelPassthrough: NSViewRepresentable {
     }
 }
 
-/// Propagates the chat container's measured width up to ChatView so it can
-/// forward it to MessageListView for resize-aware scroll stabilization.
-private struct ChatContainerWidthKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = max(value, nextValue())
-    }
-}
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -767,6 +767,9 @@ struct MessageListView: View {
         .padding(.bottom, VSpacing.md)
         .frame(maxWidth: VSpacing.chatColumnMaxWidth)
         .frame(maxWidth: .infinity)
+        .environment(\.bubbleMaxWidth, containerWidth > 0
+            ? min(VSpacing.chatBubbleMaxWidth, max(containerWidth - 2 * VSpacing.xl, 0))
+            : VSpacing.chatBubbleMaxWidth)
     }
 
     // MARK: - Scroll-to-latest overlay


### PR DESCRIPTION
## Summary
- Fix user message bubbles extending past the chat container's right edge by making bubble max width responsive to the actual container width
- Define a `BubbleMaxWidthKey` EnvironmentKey to propagate effective bubble max width from container to child views
- Modernize ChatView's geometry measurement from `GeometryReader` + `PreferenceKey` to `onGeometryChange` per AGENTS.md guidance

## Changes
- **ChatBubble.swift**: Added `BubbleMaxWidthKey` EnvironmentKey (defaults to 760pt), `@Environment(\.bubbleMaxWidth)` read, updated `bubbleChrome` outer frame and `maxContentWidth` for user messages to use dynamic width with non-negative clamp
- **MessageListView.swift**: Compute and inject `bubbleMaxWidth` environment value from `containerWidth`, accounting for horizontal padding (48pt) with fallback to static default before first geometry measurement
- **ChatView.swift**: Replaced `GeometryReader` + `ChatContainerWidthKey` PreferenceKey with `onGeometryChange(for:body:action:)`, removed unused `ChatContainerWidthKey` type

## Root cause
`ChatBubble.swift:466` passed `maxContentWidth: nil` for user messages, causing `MarkdownSegmentView` to measure text at the full 760pt width. After bubble padding (2×16pt = 32pt), the total bubble exceeded the 760pt outer `maxWidth` cap. The fixed `.frame(width:height:)` on `VSelectableTextView` ignored SwiftUI layout proposals, causing visual overflow.

## Milestone PRs (merged into feature branch)
- #22634: M1: Pass container-responsive maxContentWidth for user message bubbles

## Project issue
Closes #22628

## Test plan
- [ ] Build and run the macOS app
- [ ] Send a long user message (200+ characters) — confirm bubble stays within chat container
- [ ] Send a short user message — confirm shrink-wrap behavior preserved
- [ ] Resize window to various widths — confirm bubbles adapt to container width
- [ ] Open an existing conversation — confirm no layout glitches on initial render
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22639" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
