### PR TITLE
fix/docker shared network namespace

### DIFF
--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -843,6 +843,15 @@ function startFileWatcher(opts: {
     const services = pendingServices;
     pendingServices = new Set();
 
+    // Gateway and CES share the assistant's network namespace. If the
+    // assistant container is removed and recreated, the shared namespace
+    // is destroyed and the other two lose connectivity. Cascade the
+    // restart to all three services in that case.
+    if (services.has("assistant")) {
+      services.add("gateway");
+      services.add("credential-executor");
+    }
+
     const serviceNames = [...services].join(", ");
     console.log(`\n🔄 Changes detected — rebuilding: ${serviceNames}`);
 
@@ -855,7 +864,10 @@ function startFileWatcher(opts: {
         }),
       );
 
-      for (const service of services) {
+      // Restart in dependency order (assistant first) so the network
+      // namespace owner is up before dependents try to attach.
+      for (const service of SERVICE_START_ORDER) {
+        if (!services.has(service)) continue;
         const container = containerForService[service];
         console.log(`🔄 Restarting ${container}...`);
         await removeContainer(container);

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -479,8 +479,9 @@ async function buildAllImages(
 
 /**
  * Returns a function that builds the `docker run` arguments for a given
- * service. Each container joins a shared Docker bridge network so they
- * can be restarted independently.
+ * service. All three containers share a network namespace via
+ * `--network=container:` so inter-service traffic is over localhost,
+ * matching the platform's Kubernetes pod topology.
  */
 export function serviceDockerRunArgs(opts: {
   signingKey?: string;
@@ -511,6 +512,8 @@ export function serviceDockerRunArgs(opts: {
         "--name",
         res.assistantContainer,
         `--network=${res.network}`,
+        "-p",
+        `${gatewayPort}:${GATEWAY_INTERNAL_PORT}`,
         "-v",
         `${res.workspaceVolume}:/workspace`,
         "-v",
@@ -526,9 +529,9 @@ export function serviceDockerRunArgs(opts: {
         "-e",
         "VELLUM_WORKSPACE_DIR=/workspace",
         "-e",
-        `CES_CREDENTIAL_URL=http://${res.cesContainer}:8090`,
+        "CES_CREDENTIAL_URL=http://localhost:8090",
         "-e",
-        `GATEWAY_INTERNAL_URL=http://${res.gatewayContainer}:${GATEWAY_INTERNAL_PORT}`,
+        `GATEWAY_INTERNAL_URL=http://localhost:${GATEWAY_INTERNAL_PORT}`,
       ];
       if (defaultWorkspaceConfigPath) {
         const containerPath = `/tmp/vellum-default-workspace-config-${Date.now()}.json`;
@@ -567,9 +570,7 @@ export function serviceDockerRunArgs(opts: {
       "-d",
       "--name",
       res.gatewayContainer,
-      `--network=${res.network}`,
-      "-p",
-      `${gatewayPort}:${GATEWAY_INTERNAL_PORT}`,
+      `--network=container:${res.assistantContainer}`,
       "-v",
       `${res.workspaceVolume}:/workspace`,
       "-v",
@@ -581,13 +582,13 @@ export function serviceDockerRunArgs(opts: {
       "-e",
       `GATEWAY_PORT=${GATEWAY_INTERNAL_PORT}`,
       "-e",
-      `ASSISTANT_HOST=${res.assistantContainer}`,
+      "ASSISTANT_HOST=localhost",
       "-e",
       `RUNTIME_HTTP_PORT=${ASSISTANT_INTERNAL_PORT}`,
       "-e",
       "RUNTIME_PROXY_ENABLED=true",
       "-e",
-      `CES_CREDENTIAL_URL=http://${res.cesContainer}:8090`,
+      "CES_CREDENTIAL_URL=http://localhost:8090",
       ...(cesServiceToken
         ? ["-e", `CES_SERVICE_TOKEN=${cesServiceToken}`]
         : []),
@@ -605,7 +606,7 @@ export function serviceDockerRunArgs(opts: {
       "-d",
       "--name",
       res.cesContainer,
-      `--network=${res.network}`,
+      `--network=container:${res.assistantContainer}`,
       "-v",
       `${res.socketVolume}:/run/ces-bootstrap`,
       "-v",

--- a/gateway/src/http/routes/channel-verification-session-proxy.ts
+++ b/gateway/src/http/routes/channel-verification-session-proxy.ts
@@ -257,11 +257,21 @@ export function createChannelVerificationSessionProxyHandler(
         secretsInFlight.add(providedIndex);
       }
       try {
+        // Strip x-forwarded-for by omitting clientIp when a bootstrap secret
+        // was provided. In Docker / shared-network topologies the gateway and
+        // runtime share localhost, so the runtime's peer-IP check passes.
+        // Forwarding the external client IP would cause the runtime's secondary
+        // "reject if x-forwarded-for present" check to 403 even though the
+        // request is already authenticated by the bootstrap secret above.
+        // In bare-metal mode (no secret), preserve the header so the runtime
+        // can reject non-loopback origins as defense-in-depth.
+        const forwardClientIp =
+          expectedSecrets.length > 0 ? undefined : clientIp;
         const response = await proxyToRuntime(
           req,
           "/v1/guardian/init",
           "",
-          clientIp,
+          forwardClientIp,
         );
 
         if (response.status >= 200 && response.status < 300) {


### PR DESCRIPTION
Two changes:
1. Move assistant runtime, gateway, and CES onto the [same network stack](https://docs.docker.com/engine/network/#container-networks). This is more closely aligned with platform anyway, and allows the services to communicate with each other over `http://localhost:XXXX`
2. Strip `x-forwarded-for` header for authenticated guardian bootstrap.
    Previously, this caused 403s with local docker setup -- the `hatch` command runs on host machine, so calls to the gateway would've set `x-forwarded-for` to docker host gateway IP before forwarding to runtime (see https://github.com/vellum-ai/vellum-assistant/pull/22616). We can drop this header for authenticated bootstrap requests.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
