### PR TITLE
eagerly register local docker assistants with platform

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -201,7 +201,7 @@ extension AppDelegate {
             // Clear platform identity credentials from the running assistant (local assistants only).
             // Skip when the assistant was never set up (e.g. logout during onboarding) —
             // there are no credentials to clear and no assistant to stop.
-            if !isCurrentAssistantManaged && !isCurrentAssistantRemote && hasSetupDaemon {
+            if !isCurrentAssistantManaged && (!isCurrentAssistantRemote || isCurrentAssistantDocker) && hasSetupDaemon {
                 let cleared = await LocalAssistantBootstrapService.clearDaemonCredentials()
                 if !cleared {
                     log.warning("Credential cleanup incomplete — stopping assistant to prevent stale managed credential state")
@@ -324,7 +324,7 @@ extension AppDelegate {
     /// 10s, so that assistant switches (which clear then re-bootstrap actor
     /// credentials) don't race with this method.
     func ensureLocalAssistantApiKey() {
-        guard !isCurrentAssistantManaged, !isCurrentAssistantRemote else {
+        guard !isCurrentAssistantManaged, (!isCurrentAssistantRemote || isCurrentAssistantDocker) else {
             log.debug("Skipping local assistant API key provisioning because current assistant is managed=\(self.isCurrentAssistantManaged, privacy: .public) remote=\(self.isCurrentAssistantRemote, privacy: .public)")
             return
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -700,7 +700,7 @@ extension AppDelegate {
 
         Task {
             let allAssistants = LockfileAssistant.loadAll()
-            let localAssistants = allAssistants.filter { !$0.isRemote }
+            let localAssistants = allAssistants.filter { !$0.isRemote || $0.isDocker }
 
             // Disconnect SSE before retiring so the reconnect loop doesn't
             // hit a half-torn-down gateway and produce 502 errors.

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -212,7 +212,7 @@ extension AppDelegate {
 
             // Clear locally-cached credentials for all local assistants
             let credStorage = FileCredentialStorage()
-            for assistant in LockfileAssistant.loadAll() where !assistant.isRemote && !assistant.isManaged {
+            for assistant in LockfileAssistant.loadAll() where (!assistant.isRemote || assistant.isDocker) && !assistant.isManaged {
                 let credentialAccount = LocalAssistantBootstrapService.credentialAccount(for: assistant.assistantId)
                 _ = credStorage.delete(account: credentialAccount)
             }
@@ -226,7 +226,7 @@ extension AppDelegate {
             // identity credentials. Assistant switches intentionally leave old processes
             // running for fast switching, but on full logout there's no reason to keep
             // them alive with potentially stale state.
-            for assistant in LockfileAssistant.loadAll() where !assistant.isRemote && !assistant.isManaged {
+            for assistant in LockfileAssistant.loadAll() where (!assistant.isRemote || assistant.isDocker) && !assistant.isManaged {
                 if assistant.assistantId != connectedAssistantId {
                     do {
                         try await vellumCli.sleep(name: assistant.assistantId)

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -66,6 +66,7 @@ extension AppDelegate {
     func configureDaemonTransport(for assistant: LockfileAssistant?) {
         isCurrentAssistantRemote = assistant?.isRemote ?? false
         isCurrentAssistantManaged = assistant?.isManaged ?? false
+        isCurrentAssistantDocker = assistant?.isDocker ?? false
 
         // Managed assistant: platform proxy with session token auth.
         if let assistant, assistant.isManaged {

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -160,6 +160,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     /// derived from the platform session, not local actor tokens.
     var isCurrentAssistantManaged = false
 
+    /// Whether the current assistant is running in Docker (cloud == "docker").
+    /// Docker assistants are classified as remote for transport purposes but
+    /// need local credential provisioning like bare-metal local assistants.
+    var isCurrentAssistantDocker = false
+
     /// Set to `true` when `.localBootstrapCompleted` has been posted, so
     /// `awaitLocalBootstrapCompleted` can return immediately if bootstrap
     /// finished before the observer was registered.
@@ -642,7 +647,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                     // If the user is signed in with a local assistant, wait for
                     // credential provisioning to complete before sending the wake-up
                     // greeting, so the managed-proxy key is available for the LLM call.
-                    if authManager.isAuthenticated && !isCurrentAssistantRemote {
+                    if authManager.isAuthenticated && (!isCurrentAssistantRemote || isCurrentAssistantDocker) {
                         await awaitLocalBootstrapCompleted(timeout: 30)
                     }
 


### PR DESCRIPTION
## Context
Previously,
1. Logging into platform
2. Hatching a local Docker assistant via macOS client
3. Sending a message
would fail with a 422 code because the platform API key was never injected into the daemon.

We need some serious cleanup around the `local` / `managed` / `containerized` terminology. I think most of these existing before we introduced local docker as an option.

Local docker assistants are considered remote (I guess for networking purposes?).

We use `isRemote` in at least two different contexts:
1. credential provisioning (whether macOS client should inject api key + clean up credentials)
   - Our infra handles this when hatching platform managed assistants. But local docker setup should still do this.
2. settings (e.g. correcting the gateway URL for clients) https://github.com/vellum-ai/vellum-assistant/blob/89e5af7aeb01e96c7323d8122ebcd7dbcad12c8f/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift#L2776



## Workaround
There was a funny workaround where opening `Settings > Models & Services` would trigger a lazy bootstrap to provision the platform key.

## Fix
bootstrap assistant API key for local docker case

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
