### PR TITLE
fix(gateway): don't set x-forwarded-for for loopback client IPs

### DIFF
--- a/gateway/src/http/routes/browser-relay-websocket.ts
+++ b/gateway/src/http/routes/browser-relay-websocket.ts
@@ -4,6 +4,7 @@ import {
 } from "../../auth/token-exchange.js";
 import type { GatewayConfig } from "../../config.js";
 import { getLogger } from "../../logger.js";
+import { isLoopbackAddress } from "../../util/is-loopback-address.js";
 
 const log = getLogger("browser-relay-ws");
 
@@ -46,28 +47,6 @@ function isPrivateNetworkPeer(
   const ip = server.requestIP(req);
   if (!ip) return false;
   return isPrivateAddress(ip.address);
-}
-
-/**
- * Stricter loopback-only check: accepts only 127.0.0.0/8 and ::1.
- * Use this instead of isPrivateNetworkPeer for endpoints that must be
- * restricted to the local machine (e.g. token minting).
- */
-function isLoopbackAddress(addr: string): boolean {
-  const v4Mapped = addr.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
-  const normalized = v4Mapped ? v4Mapped[1] : addr;
-
-  if (normalized.includes(".")) {
-    const parts = normalized.split(".").map(Number);
-    if (
-      parts.length !== 4 ||
-      parts.some((p) => Number.isNaN(p) || p < 0 || p > 255)
-    )
-      return false;
-    return parts[0] === 127;
-  }
-
-  return normalized.toLowerCase() === "::1";
 }
 
 export function isLoopbackPeer(

--- a/gateway/src/http/routes/channel-verification-session-proxy.ts
+++ b/gateway/src/http/routes/channel-verification-session-proxy.ts
@@ -13,6 +13,7 @@ import type { GatewayConfig } from "../../config.js";
 import { getRootDir } from "../../credential-reader.js";
 import { fetchImpl } from "../../fetch.js";
 import { getLogger } from "../../logger.js";
+import { isLoopbackAddress } from "../../util/is-loopback-address.js";
 import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
 
 const log = getLogger("channel-verification-session-proxy");
@@ -61,9 +62,10 @@ export function createChannelVerificationSessionProxyHandler(
 
     // Inject the real client IP so the runtime can enforce loopback-only
     // checks, overwriting any client-supplied value to prevent spoofing.
-    // When clientIp is undefined (loopback peer), strip any client-supplied
-    // header to prevent forged forwarded-for values from reaching the runtime.
-    if (clientIp) {
+    // Strip the header for loopback peers: the runtime rejects any request
+    // with x-forwarded-for in bare-metal mode, and forwarding 127.0.0.1
+    // conveys no useful information.
+    if (clientIp && !isLoopbackAddress(clientIp)) {
       reqHeaders.set("x-forwarded-for", clientIp);
     } else {
       reqHeaders.delete("x-forwarded-for");

--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -6,6 +6,7 @@ import {
 import type { GatewayConfig } from "../../config.js";
 import { fetchImpl } from "../../fetch.js";
 import { getLogger } from "../../logger.js";
+import { isLoopbackAddress } from "../../util/is-loopback-address.js";
 import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
 
 const log = getLogger("runtime-proxy");
@@ -87,9 +88,10 @@ export function createRuntimeProxyHandler(config: GatewayConfig) {
 
     // Inject the real client IP so the runtime can rate-limit per-user,
     // overwriting any client-supplied value to prevent spoofing.
-    // When clientIp is undefined (loopback peer), strip any client-supplied
-    // header to prevent forged forwarded-for values from reaching the runtime.
-    if (clientIp) {
+    // Strip the header for loopback peers: the runtime rejects any request
+    // with x-forwarded-for in bare-metal mode, and forwarding 127.0.0.1
+    // conveys no useful information.
+    if (clientIp && !isLoopbackAddress(clientIp)) {
       reqHeaders.set("x-forwarded-for", clientIp);
     } else {
       reqHeaders.delete("x-forwarded-for");

--- a/gateway/src/util/is-loopback-address.ts
+++ b/gateway/src/util/is-loopback-address.ts
@@ -1,0 +1,21 @@
+/**
+ * Stricter loopback-only check: accepts only 127.0.0.0/8 and ::1.
+ * Use this instead of isPrivateNetworkPeer for endpoints that must be
+ * restricted to the local machine (e.g. token minting).
+ */
+export function isLoopbackAddress(addr: string): boolean {
+  const v4Mapped = addr.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
+  const normalized = v4Mapped ? v4Mapped[1] : addr;
+
+  if (normalized.includes(".")) {
+    const parts = normalized.split(".").map(Number);
+    if (
+      parts.length !== 4 ||
+      parts.some((p) => Number.isNaN(p) || p < 0 || p > 255)
+    )
+      return false;
+    return parts[0] === 127;
+  }
+
+  return normalized.toLowerCase() === "::1";
+}


### PR DESCRIPTION
## Summary
- `getClientIp()` returns `"127.0.0.1"` for loopback peers, never `undefined`. The `else { delete }` branch added in #22591 was dead code — the gateway always set `x-forwarded-for: 127.0.0.1` for local connections.
- The runtime's stricter check (reject any `x-forwarded-for` in bare-metal mode) then 403'd legitimate local bootstrap requests during startup.
- Fix: check `isLoopbackAddress(clientIp)` before setting the header. Extract `isLoopbackAddress` into a shared gateway utility (`gateway/src/util/is-loopback-address.ts`) used by both proxy handlers and the browser-relay websocket module.

## Original prompt
Fix the regression from PR #22591 where guardian bootstrap fails with 403 in bare-metal mode because the gateway forwards `x-forwarded-for: 127.0.0.1` for loopback peers.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22646" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
