### PR TITLE
Remove platform-hosted-enabled feature flag from onboarding

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -56,10 +56,6 @@ struct APIKeyStepView: View {
         MacOSClientFeatureFlagManager.shared.isEnabled("user-hosted-enabled")
     }
 
-    private var platformHostedEnabled: Bool {
-        MacOSClientFeatureFlagManager.shared.isEnabled("platform-hosted-enabled")
-    }
-
     private var localDockerEnabled: Bool {
         MacOSClientFeatureFlagManager.shared.isEnabled("local-docker-enabled")
     }
@@ -125,7 +121,7 @@ struct APIKeyStepView: View {
         switch mode {
         case .vellumCloud:
             if !isAuthenticated || state.skippedAuth { return "Requires Account" }
-            return platformHostedEnabled ? nil : "Coming Soon"
+            return nil
         default:
             return nil
         }
@@ -244,7 +240,7 @@ struct APIKeyStepView: View {
 
     private var canContinue: Bool {
         if state.selectedHostingMode == .vellumCloud {
-            return platformHostedEnabled && isAuthenticated && !state.skippedAuth
+            return isAuthenticated && !state.skippedAuth
         }
         return true
     }


### PR DESCRIPTION
## Summary
- Remove the `platformHostedEnabled` computed property that read the `platform-hosted-enabled` feature flag
- Update chip label to never show "Coming Soon" — only "Requires Account" when not authenticated
- Update `canContinue` to no longer require the feature flag for Vellum Cloud selection

Part of plan: remove-hatch-teleport-flags.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
