### PR TITLE
Show teleport-to-platform always, keep teleport-to-Docker behind feature flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -78,8 +78,7 @@ struct SettingsGeneralTab: View {
                     updateManager: updateManager
                 )
             }
-            if MacOSClientFeatureFlagManager.shared.isEnabled("teleport"),
-               let assistant = currentAssistant,
+            if let assistant = currentAssistant,
                !assistant.isManaged && (!assistant.isRemote || assistant.isDocker) {
                 TeleportSection(assistant: assistant, onClose: onClose)
             }

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -160,8 +160,10 @@ struct TeleportSection: View {
     @ViewBuilder
     private var destinationPicker: some View {
         if assistant.cloud.lowercased() == "local" {
-            // Bare metal local: show both Docker and Platform options
-            destinationButton(for: .docker)
+            // Bare metal local: always show Platform, conditionally show Docker
+            if MacOSClientFeatureFlagManager.shared.isEnabled("teleport") {
+                destinationButton(for: .docker)
+            }
             destinationButton(for: .platform)
         } else if assistant.isDocker {
             // Docker: show only Platform option


### PR DESCRIPTION
## Summary
- Remove `teleport` feature flag check from `SettingsGeneralTab.swift` so TeleportSection always shows
- Move the feature flag into `TeleportSection.swift` to gate only the Docker destination
- Platform (cloud) teleport destination is now always visible for local and Docker assistants

Part of plan: remove-hatch-teleport-flags.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
