### PR TITLE
Fix stale text selection highlights and make headings selectable

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -312,6 +312,7 @@ struct ChatView: View {
                 onRetryConversationError: { messageId in viewModel.retryAfterConversationError(messageId: messageId) },
                 subagentDetailStore: viewModel.subagentDetailStore,
                 activePendingRequestId: viewModel.activePendingRequestId,
+                paginatedVisibleMessages: viewModel.paginatedVisibleMessages,
                 displayedMessageCount: viewModel.displayedMessageCount,
                 hasMoreMessages: viewModel.hasMoreMessages,
                 isLoadingMoreMessages: viewModel.isLoadingMoreMessages,

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -76,21 +76,6 @@ struct MarkdownSegmentView: View, Equatable {
                         .fixedSize(horizontal: false, vertical: true)
                     #endif
 
-                case .heading(let level, let headingText):
-                    let headingFont: Font = switch level {
-                    case 1: .system(size: 20, weight: .bold)
-                    case 2: .system(size: 16, weight: .semibold)
-                    case 3: .system(size: 14, weight: .semibold)
-                    default: .system(size: 14, weight: .semibold)
-                    }
-                    Text(headingText)
-                        .font(headingFont)
-                        .foregroundStyle(textColor)
-                        .optionalMaxWidth(maxContentWidth)
-                        .lineLimit(nil)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .padding(.top, level == 1 ? 4 : 2)
-
                 case .codeBlock(let language, let code):
                     CodeBlockView(
                         language: language,
@@ -126,10 +111,8 @@ struct MarkdownSegmentView: View, Equatable {
 
     /// Groups of segments for rendering.
     private enum SegmentGroup {
-        /// Consecutive text paragraphs combined for cross-paragraph selection.
+        /// Consecutive text paragraphs and headings combined for cross-paragraph selection.
         case selectableRun([MarkdownSegment])
-        /// A heading rendered as its own block for spacing control.
-        case heading(level: Int, text: String)
         case codeBlock(language: String?, code: String)
         case table(headers: [String], rows: [[String]])
         case image(alt: String, url: String)
@@ -183,9 +166,8 @@ struct MarkdownSegmentView: View, Equatable {
             switch segment {
             case .text:
                 currentRun.append(segment)
-            case .heading(let level, let text):
-                flushRun()
-                groups.append(.heading(level: level, text: text))
+            case .heading:
+                currentRun.append(segment)
             case .list:
                 currentRun.append(segment)
             case .codeBlock(let language, let code):
@@ -308,6 +290,29 @@ struct MarkdownSegmentView: View, Equatable {
                 let attributed = (try? AttributedString(markdown: text, options: mdOptions))
                     ?? AttributedString(text)
                 result += attributed
+
+            case .heading(let level, let text):
+                var headingAttr = AttributedString(text)
+                let headingSize: CGFloat = switch level {
+                case 1: 20
+                case 2: 16
+                default: 14
+                }
+                let wght = 0x77676874 // 'wght' variation axis tag
+                let weightValue: Int = level == 1 ? 700 : 600
+                let baseCT = CTFontCreateWithName("DMSans-Regular" as CFString, headingSize, nil)
+                let vars: [CFNumber: CFNumber] = [wght as CFNumber: weightValue as CFNumber]
+                let headingCT = CTFontCreateCopyWithAttributes(
+                    baseCT, headingSize, nil,
+                    CTFontDescriptorCreateWithAttributes([kCTFontVariationAttribute: vars] as CFDictionary)
+                )
+                headingAttr.font = Font(headingCT as NSFont)
+                if index > 0 {
+                    let paraStyle = NSMutableParagraphStyle()
+                    paraStyle.paragraphSpacingBefore = level == 1 ? 8 : 4
+                    headingAttr.applyParagraphStyle(paraStyle)
+                }
+                result += headingAttr
 
             case .list(let items):
                 for (itemIndex, item) in items.enumerated() {

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -292,7 +292,8 @@ struct MarkdownSegmentView: View, Equatable {
                 result += attributed
 
             case .heading(let level, let text):
-                var headingAttr = AttributedString(text)
+                var headingAttr = (try? AttributedString(markdown: text, options: mdOptions))
+                    ?? AttributedString(text)
                 let headingSize: CGFloat = switch level {
                 case 1: 20
                 case 2: 16

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -384,6 +384,9 @@ struct MarkdownSegmentView: View, Equatable {
         var boldEmphRanges: [Range<AttributedString.Index>] = []
         for run in result.runs {
             guard let intent = run.inlinePresentationIntent, !intent.contains(.code) else { continue }
+            // Skip runs that already have an explicit font (e.g., headings) —
+            // their font was set with the correct size and weight upstream.
+            guard result[run.range].font == nil else { continue }
             let isEmph = intent.contains(.emphasized)
             let isBold = intent.contains(.stronglyEmphasized)
             if isEmph && isBold {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -92,6 +92,10 @@ struct MessageListView: View {
 
     // MARK: - Pagination
 
+    /// Pre-computed paginated visible messages from the model layer.
+    /// Cached as a stored property on `ChatPaginationState` and updated
+    /// reactively via Combine, so reading this in `body` is O(1).
+    let paginatedVisibleMessages: [ChatMessage]
     /// Number of messages the view currently displays (suffix window size).
     var displayedMessageCount: Int = .max
     /// Whether older messages exist beyond the current display window.
@@ -133,13 +137,12 @@ struct MessageListView: View {
     @State private var scrollPosition = ScrollPosition()
 
     /// The subset of messages actually shown, honoring the pagination window.
-    /// Uses the shared `ChatVisibleMessageFilter` so hidden automated messages
-    /// are excluded from rendered rows, pagination anchors, and all derived state.
+    /// Reads the pre-computed cache from the model layer in O(1) instead of
+    /// running the O(n) visibility filter on every body evaluation.
+    ///
+    /// - SeeAlso: [WWDC23 — Demystify SwiftUI performance](https://developer.apple.com/videos/play/wwdc2023/10160/)
     private var visibleMessages: [ChatMessage] {
-        ChatVisibleMessageFilter.paginatedMessages(
-            from: messages,
-            displayedMessageCount: displayedMessageCount
-        )
+        paginatedVisibleMessages
     }
 
     /// Checks whether observable message-level inputs have changed since the

--- a/clients/macos/vellum-assistantTests/MessageListForkActionTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListForkActionTests.swift
@@ -67,6 +67,7 @@ final class MessageListForkActionTests: XCTestCase {
             onRetryFailedMessage: nil,
             onRetryConversationError: nil,
             subagentDetailStore: SubagentDetailStore(),
+            paginatedVisibleMessages: messages,
             displayedMessageCount: .max,
             hasMoreMessages: false,
             isLoadingMoreMessages: false,

--- a/clients/shared/DesignSystem/Components/Display/SelectableTextView.swift
+++ b/clients/shared/DesignSystem/Components/Display/SelectableTextView.swift
@@ -2,6 +2,19 @@
 import AppKit
 import SwiftUI
 
+/// NSTextView subclass that clears text selection when it resigns first
+/// responder. Prevents stale inactive-selection highlights (gray background)
+/// from lingering when the user interacts with a different text view.
+private final class SelectableNSTextView: NSTextView {
+    override func resignFirstResponder() -> Bool {
+        let result = super.resignFirstResponder()
+        if result {
+            setSelectedRange(NSRange(location: 0, length: 0))
+        }
+        return result
+    }
+}
+
 /// A read-only, selectable text view that wraps `NSTextView` via `NSViewRepresentable`.
 ///
 /// Provides native macOS text selection (click-drag, Cmd+A, Shift+arrows) and
@@ -116,7 +129,7 @@ public struct VSelectableTextView: NSViewRepresentable {
         textContainer.lineFragmentPadding = 0
         layoutManager.addTextContainer(textContainer)
 
-        let textView = NSTextView(frame: .zero, textContainer: textContainer)
+        let textView = SelectableNSTextView(frame: .zero, textContainer: textContainer)
         textView.isEditable = false
         textView.isSelectable = true
         textView.isRichText = true

--- a/clients/shared/Features/Chat/ChatPaginationState.swift
+++ b/clients/shared/Features/Chat/ChatPaginationState.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import os
 
@@ -25,13 +26,20 @@ public final class ChatPaginationState {
     /// True while a previous-page load is in progress (brief async delay for UX).
     public var isLoadingMoreMessages: Bool = false
 
-    /// The subset of messages visible to the user (excludes subagent notifications,
-    /// hidden messages, and messages without renderable content).
-    /// Computed from `messageManager.messages` so the Observation framework
-    /// tracks the single underlying stored property.
-    public var displayedMessages: [ChatMessage] {
-        ChatVisibleMessageFilter.visibleMessages(from: messageManager.messages)
-    }
+    /// All visible messages (excludes subagent notifications, hidden messages,
+    /// and messages without renderable content). Cached as a stored property
+    /// and updated reactively via Combine when `messageManager.messages`
+    /// changes, so views read an O(1) cached value instead of recomputing
+    /// the O(n) filter on every body evaluation.
+    ///
+    /// - SeeAlso: [WWDC23 — Demystify SwiftUI performance](https://developer.apple.com/videos/play/wwdc2023/10160/)
+    public private(set) var displayedMessages: [ChatMessage] = []
+
+    /// Paginated suffix of visible messages for the current display window.
+    /// Cached as a stored property so `MessageListView.body` reads it in O(1)
+    /// instead of running the O(n) visibility filter on every body evaluation.
+    /// Updated when either the message list or `displayedMessageCount` changes.
+    public private(set) var paginatedVisibleMessages: [ChatMessage] = []
 
     // MARK: - Daemon History Pagination
 
@@ -53,6 +61,10 @@ public final class ChatPaginationState {
         (displayedMessageCount < displayedMessages.count) || hasMoreHistory
     }
 
+    // MARK: - Visible Messages Cache
+
+    @ObservationIgnored private var visibleMessagesCacheSub: AnyCancellable?
+
     // MARK: - Timeout
 
     /// Timeout task that logs a warning at 30s if the daemon is slow, then
@@ -67,6 +79,7 @@ public final class ChatPaginationState {
 
     deinit {
         loadMoreTimeoutTask?.cancel()
+        visibleMessagesCacheSub?.cancel()
     }
 
     // MARK: - Dependencies
@@ -90,6 +103,40 @@ public final class ChatPaginationState {
         messageManager: ChatMessageManager
     ) {
         self.messageManager = messageManager
+
+        // Seed the cache synchronously so the first view read sees correct data.
+        recomputeVisibleMessages(from: messageManager.messages)
+
+        // Reactively update the cache when messages change. Uses the existing
+        // Combine bridge (`messagesPublisher`) which fires on every mutation
+        // to `messageManager.messages`. This is the same pattern used by
+        // `ChatMessageManager.activePendingRequestId`.
+        visibleMessagesCacheSub = messageManager.messagesPublisher
+            .sink { [weak self] messages in
+                self?.recomputeVisibleMessages(from: messages)
+            }
+    }
+
+    // MARK: - Cache Recomputation
+
+    /// Recomputes `displayedMessages` and `paginatedVisibleMessages` from a
+    /// snapshot of the raw message array. Called by the Combine subscription
+    /// when messages change and by mutation sites that alter the display window.
+    private func recomputeVisibleMessages(from messages: [ChatMessage]) {
+        displayedMessages = ChatVisibleMessageFilter.visibleMessages(from: messages)
+        recomputePaginatedSuffix()
+    }
+
+    /// Recomputes only the paginated suffix from the already-cached
+    /// `displayedMessages`. Called after `displayedMessageCount` changes
+    /// (pagination expand, reset) without re-running the visibility filter.
+    func recomputePaginatedSuffix() {
+        let visible = displayedMessages
+        if displayedMessageCount < visible.count {
+            paginatedVisibleMessages = Array(visible.suffix(displayedMessageCount))
+        } else {
+            paginatedVisibleMessages = visible
+        }
     }
 
     // MARK: - Public API
@@ -114,6 +161,7 @@ public final class ChatPaginationState {
             // (Int.max) so future incoming messages don't shrink the visible history back
             // to a suffix window — the regression described in the parent PR.
             displayedMessageCount = next >= total ? Int.max : next
+            recomputePaginatedSuffix()
             isLoadingMoreMessages = false
             return true
         }
@@ -158,6 +206,7 @@ public final class ChatPaginationState {
         loadMoreTimeoutTask?.cancel()
         loadMoreTimeoutTask = nil
         isLoadingMoreMessages = false
+        recomputePaginatedSuffix()
     }
 
 }

--- a/clients/shared/Features/Chat/ChatPaginationState.swift
+++ b/clients/shared/Features/Chat/ChatPaginationState.swift
@@ -121,8 +121,10 @@ public final class ChatPaginationState {
 
     /// Recomputes `displayedMessages` and `paginatedVisibleMessages` from a
     /// snapshot of the raw message array. Called by the Combine subscription
-    /// when messages change and by mutation sites that alter the display window.
-    private func recomputeVisibleMessages(from messages: [ChatMessage]) {
+    /// when messages change, and by mutation sites that alter both `messages`
+    /// and `displayedMessageCount` in the same synchronous block (where the
+    /// async Combine bridge hasn't delivered the new messages yet).
+    func recomputeVisibleMessages(from messages: [ChatMessage]) {
         displayedMessages = ChatVisibleMessageFilter.visibleMessages(from: messages)
         recomputePaginatedSuffix()
     }
@@ -206,7 +208,7 @@ public final class ChatPaginationState {
         loadMoreTimeoutTask?.cancel()
         loadMoreTimeoutTask = nil
         isLoadingMoreMessages = false
-        recomputePaginatedSuffix()
+        recomputeVisibleMessages(from: messageManager.messages)
     }
 
 }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -737,7 +737,14 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         get { paginationState.displayedMessageCount }
         set {
             paginationState.displayedMessageCount = newValue
-            paginationState.recomputePaginatedSuffix()
+            // Full recompute from the live messages array — not just the
+            // paginated suffix — because callers often mutate `messages` and
+            // `displayedMessageCount` in the same synchronous block (e.g.
+            // trimOldMessagesIfNeeded, populateFromHistory). The async
+            // Combine bridge hasn't delivered the new messages yet, so the
+            // cached `displayedMessages` would be stale if we only called
+            // recomputePaginatedSuffix().
+            paginationState.recomputeVisibleMessages(from: messageManager.messages)
         }
     }
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -735,7 +735,10 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
 
     public var displayedMessageCount: Int {
         get { paginationState.displayedMessageCount }
-        set { paginationState.displayedMessageCount = newValue }
+        set {
+            paginationState.displayedMessageCount = newValue
+            paginationState.recomputePaginatedSuffix()
+        }
     }
 
     public var isLoadingMoreMessages: Bool {
@@ -745,6 +748,13 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
 
     public var displayedMessages: [ChatMessage] {
         paginationState.displayedMessages
+    }
+
+    /// Pre-computed paginated visible messages for the current display window.
+    /// Cached at the model layer so view bodies read O(1) instead of running
+    /// the O(n) visibility filter on every body evaluation.
+    public var paginatedVisibleMessages: [ChatMessage] {
+        paginationState.paginatedVisibleMessages
     }
 
     public var historyCursor: Double? {


### PR DESCRIPTION
## Summary
- **Stale selection fix:** Added `SelectableNSTextView` subclass that clears text selection on `resignFirstResponder`, preventing gray inactive-selection highlights from lingering when interacting with a different text block
- **Heading selectability:** Headings now render inside `VSelectableTextView` (NSTextView) instead of plain SwiftUI `Text`, making them click-drag selectable and enabling cross-selection between headings and body text
- **Font consistency:** Headings now use DM Sans (with proper weight variations via OpenType `wght` axis) instead of system font, matching the rest of the chat text

## Test plan
- [ ] Select text in one paragraph, then click in another — first selection should clear (no gray highlight)
- [ ] Try selecting heading text (h1, h2, h3) via click-drag — should now work
- [ ] Verify cross-selection works (drag from heading into paragraph text)
- [ ] Verify Cmd+C still copies selected text
- [ ] Verify heading font sizes/weights look correct (h1=20pt bold, h2=16pt semibold, h3=14pt semibold)
- [ ] Verify heading spacing looks appropriate relative to surrounding text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
