### PR TITLE
Remove platform-hosted-enabled from feature flag registry

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -18,14 +18,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "platform-hosted-enabled",
-      "scope": "macos",
-      "key": "platform-hosted-enabled",
-      "label": "Platform Hosted Assistants",
-      "description": "Enable the Vellum Cloud hosting option on the Hosting screen",
-      "defaultEnabled": false
-    },
-    {
       "id": "local-docker-enabled",
       "scope": "macos",
       "key": "local-docker-enabled",


### PR DESCRIPTION
## Summary
- Remove the `platform-hosted-enabled` flag entry from `feature-flag-registry.json`
- The `teleport` flag is intentionally kept — it still gates Docker teleporting

Part of plan: remove-hatch-teleport-flags.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
