### PR TITLE
Redesign TeleportSection to match SettingsCard pattern

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -129,11 +129,7 @@ struct TeleportSection: View {
 
     @ViewBuilder
     private var teleportContent: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text("Teleport")
-                .font(VFont.titleSmall)
-                .foregroundStyle(VColor.contentDefault)
-
+        SettingsCard(title: "Teleport", subtitle: "Move your assistant to a different hosting environment") {
             if case .verifying = phase {
                 verifyingBanner
             } else if case .transferring(let step) = phase {
@@ -150,9 +146,6 @@ struct TeleportSection: View {
                 destinationPicker
             }
         }
-        .padding(VSpacing.lg)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .vCard(background: VColor.surfaceOverlay)
     }
 
     // MARK: - Destination Picker
@@ -180,7 +173,7 @@ struct TeleportSection: View {
 
             VButton(
                 label: destination.displayLabel,
-                style: .primary,
+                style: .outlined,
                 isDisabled: isDestinationDisabled(destination)
             ) {
                 pendingDestination = destination
@@ -188,9 +181,7 @@ struct TeleportSection: View {
             }
 
             if destination == .platform && SessionTokenManager.getToken() == nil {
-                Text("Sign in to move to cloud.")
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(VColor.contentTertiary)
+                VInlineMessage("Sign in to move to cloud.", tone: .info)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Refactor `TeleportSection` to use `SettingsCard` component with title and subtitle
- Switch destination buttons from `.primary` to `.outlined` style matching AssistantUpgradeSection
- Replace plain text sign-in hint with `VInlineMessage` with `.info` tone

Part of plan: remove-hatch-teleport-flags.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22652" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
