### PR TITLE
Remove feature flags & redesign teleport UI

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -775,10 +775,6 @@ if [ -n "${VELLUM_PLATFORM_URL:-}" ]; then
         <string>$PLATFORM_URL_OVERRIDE</string>"
 fi
 if [ "$CONFIG" = "debug" ]; then
-    echo "Embedding VELLUM_FLAG_PLATFORM_HOSTED_ENABLED for debug build"
-    _LSE_ENTRIES+="
-        <key>VELLUM_FLAG_PLATFORM_HOSTED_ENABLED</key>
-        <string>1</string>"
     echo "Embedding VELLUM_FLAG_LOCAL_DOCKER_ENABLED for debug build"
     _LSE_ENTRIES+="
         <key>VELLUM_FLAG_LOCAL_DOCKER_ENABLED</key>

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -56,10 +56,6 @@ struct APIKeyStepView: View {
         MacOSClientFeatureFlagManager.shared.isEnabled("user-hosted-enabled")
     }
 
-    private var platformHostedEnabled: Bool {
-        MacOSClientFeatureFlagManager.shared.isEnabled("platform-hosted-enabled")
-    }
-
     private var localDockerEnabled: Bool {
         MacOSClientFeatureFlagManager.shared.isEnabled("local-docker-enabled")
     }
@@ -125,7 +121,7 @@ struct APIKeyStepView: View {
         switch mode {
         case .vellumCloud:
             if !isAuthenticated || state.skippedAuth { return "Requires Account" }
-            return platformHostedEnabled ? nil : "Coming Soon"
+            return nil
         default:
             return nil
         }
@@ -244,7 +240,7 @@ struct APIKeyStepView: View {
 
     private var canContinue: Bool {
         if state.selectedHostingMode == .vellumCloud {
-            return platformHostedEnabled && isAuthenticated && !state.skippedAuth
+            return isAuthenticated && !state.skippedAuth
         }
         return true
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -78,8 +78,7 @@ struct SettingsGeneralTab: View {
                     updateManager: updateManager
                 )
             }
-            if MacOSClientFeatureFlagManager.shared.isEnabled("teleport"),
-               let assistant = currentAssistant,
+            if let assistant = currentAssistant,
                !assistant.isManaged && (!assistant.isRemote || assistant.isDocker) {
                 TeleportSection(assistant: assistant, onClose: onClose)
             }

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -129,11 +129,7 @@ struct TeleportSection: View {
 
     @ViewBuilder
     private var teleportContent: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text("Teleport")
-                .font(VFont.titleSmall)
-                .foregroundStyle(VColor.contentDefault)
-
+        SettingsCard(title: "Teleport", subtitle: "Move your assistant to a different hosting environment") {
             if case .verifying = phase {
                 verifyingBanner
             } else if case .transferring(let step) = phase {
@@ -150,9 +146,6 @@ struct TeleportSection: View {
                 destinationPicker
             }
         }
-        .padding(VSpacing.lg)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .vCard(background: VColor.surfaceOverlay)
     }
 
     // MARK: - Destination Picker
@@ -180,7 +173,7 @@ struct TeleportSection: View {
 
             VButton(
                 label: destination.displayLabel,
-                style: .primary,
+                style: .outlined,
                 isDisabled: isDestinationDisabled(destination)
             ) {
                 pendingDestination = destination
@@ -188,9 +181,7 @@ struct TeleportSection: View {
             }
 
             if destination == .platform && SessionTokenManager.getToken() == nil {
-                Text("Sign in to move to cloud.")
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(VColor.contentTertiary)
+                VInlineMessage("Sign in to move to cloud.", tone: .info)
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -160,8 +160,10 @@ struct TeleportSection: View {
     @ViewBuilder
     private var destinationPicker: some View {
         if assistant.cloud.lowercased() == "local" {
-            // Bare metal local: show both Docker and Platform options
-            destinationButton(for: .docker)
+            // Bare metal local: always show Platform, conditionally show Docker
+            if MacOSClientFeatureFlagManager.shared.isEnabled("teleport") {
+                destinationButton(for: .docker)
+            }
             destinationButton(for: .platform)
         } else if assistant.isDocker {
             // Docker: show only Platform option

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -18,14 +18,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "platform-hosted-enabled",
-      "scope": "macos",
-      "key": "platform-hosted-enabled",
-      "label": "Platform Hosted Assistants",
-      "description": "Enable the Vellum Cloud hosting option on the Hosting screen",
-      "defaultEnabled": false
-    },
-    {
       "id": "local-docker-enabled",
       "scope": "macos",
       "key": "local-docker-enabled",


### PR DESCRIPTION
## Summary
Remove the `platform-hosted-enabled` feature flag so platform-hosted assistant hatching is always available. Ungate the teleport-to-platform option in settings while keeping teleport-to-Docker behind the `teleport` feature flag. Redesign the `TeleportSection` to use `SettingsCard` for visual consistency with `AssistantUpgradeSection`.

## PRs merged into feature branch
- #22647: Remove platform-hosted-enabled feature flag from onboarding
- #22648: Show teleport-to-platform always, keep teleport-to-Docker behind feature flag
- #22652: Redesign TeleportSection to match SettingsCard pattern
- #22651: Remove platform-hosted-enabled from feature flag registry

Part of plan: remove-hatch-teleport-flags.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
