### PR TITLE
fix: update teleport flag description to reflect narrowed scope

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -373,8 +373,8 @@
       "id": "teleport",
       "scope": "macos",
       "key": "teleport",
-      "label": "Teleport",
-      "description": "Enable teleport UI in General settings for moving assistants between hosting environments",
+      "label": "Teleport to Docker",
+      "description": "Show the teleport-to-Docker destination for bare-metal local assistants",
       "defaultEnabled": false
     }
   ]


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for remove-hatch-teleport-flags.md.

**Gap:** Stale teleport flag description
**What was expected:** Description should reflect that flag only gates Docker destination
**What was found:** Description still says it enables the entire teleport UI
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
