### PR TITLE
fix: remove orphaned VELLUM_FLAG_PLATFORM_HOSTED_ENABLED from build.sh

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -775,10 +775,6 @@ if [ -n "${VELLUM_PLATFORM_URL:-}" ]; then
         <string>$PLATFORM_URL_OVERRIDE</string>"
 fi
 if [ "$CONFIG" = "debug" ]; then
-    echo "Embedding VELLUM_FLAG_PLATFORM_HOSTED_ENABLED for debug build"
-    _LSE_ENTRIES+="
-        <key>VELLUM_FLAG_PLATFORM_HOSTED_ENABLED</key>
-        <string>1</string>"
     echo "Embedding VELLUM_FLAG_LOCAL_DOCKER_ENABLED for debug build"
     _LSE_ENTRIES+="
         <key>VELLUM_FLAG_LOCAL_DOCKER_ENABLED</key>


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for remove-hatch-teleport-flags.md.

**Gap:** Orphaned VELLUM_FLAG_PLATFORM_HOSTED_ENABLED in build.sh
**What was expected:** No references to the removed platform-hosted-enabled flag
**What was found:** build.sh still embeds the flag into Info.plist for debug builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
