### PR TITLE
Remove platform-hosted-enabled feature flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -56,10 +56,6 @@ struct APIKeyStepView: View {
         MacOSClientFeatureFlagManager.shared.isEnabled("user-hosted-enabled")
     }
 
-    private var platformHostedEnabled: Bool {
-        MacOSClientFeatureFlagManager.shared.isEnabled("platform-hosted-enabled")
-    }
-
     private var localDockerEnabled: Bool {
         MacOSClientFeatureFlagManager.shared.isEnabled("local-docker-enabled")
     }
@@ -125,7 +121,7 @@ struct APIKeyStepView: View {
         switch mode {
         case .vellumCloud:
             if !isAuthenticated || state.skippedAuth { return "Requires Account" }
-            return platformHostedEnabled ? nil : "Coming Soon"
+            return nil
         default:
             return nil
         }
@@ -244,7 +240,7 @@ struct APIKeyStepView: View {
 
     private var canContinue: Bool {
         if state.selectedHostingMode == .vellumCloud {
-            return platformHostedEnabled && isAuthenticated && !state.skippedAuth
+            return isAuthenticated && !state.skippedAuth
         }
         return true
     }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -18,14 +18,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "platform-hosted-enabled",
-      "scope": "macos",
-      "key": "platform-hosted-enabled",
-      "label": "Platform Hosted Assistants",
-      "description": "Enable the Vellum Cloud hosting option on the Hosting screen",
-      "defaultEnabled": false
-    },
-    {
       "id": "local-docker-enabled",
       "scope": "macos",
       "key": "local-docker-enabled",


### PR DESCRIPTION
## Summary
- Removed the `platform-hosted-enabled` feature flag from the registry and all code references
- Vellum Cloud hosting option on the onboarding Hosting screen is now always available (no longer shows "Coming Soon")
- Authenticated users can select Vellum Cloud without the flag being enabled

## Original prompt
move the ability to hatch cloud/platform hosted assistants from behind the feature flag
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
