### PR TITLE
fix: allow overriding Content-Type in GatewayHTTPClient.post for binary uploads

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -430,6 +430,7 @@ struct TeleportSection: View {
         let importResponse = try await GatewayHTTPClient.post(
             path: "assistants/{assistantId}/migrations/import",
             body: bundleData,
+            contentType: "application/octet-stream",
             timeout: 120
         )
         guard importResponse.isSuccess else {
@@ -513,6 +514,7 @@ struct TeleportSection: View {
         let response = try await GatewayHTTPClient.post(
             path: "assistants/{assistantId}/migrations/import",
             body: bundleData,
+            contentType: "application/octet-stream",
             timeout: 120
         )
 

--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -91,9 +91,12 @@ public enum GatewayHTTPClient {
     ///   - timeout: Request timeout in seconds. Defaults to 30.
     /// - Returns: A `Response` with the raw data and HTTP status code.
     /// - Throws: `ClientError` if the request cannot be constructed, or network errors from `URLSession`.
-    public static func post(path: String, body: Data? = nil, params: [String: String]? = nil, timeout: TimeInterval = 30) async throws -> Response {
+    public static func post(path: String, body: Data? = nil, params: [String: String]? = nil, contentType: String? = nil, timeout: TimeInterval = 30) async throws -> Response {
         return try await executeWithRetry(path: path, params: params, method: "POST", timeout: timeout) { request in
             request.httpBody = body
+            if let contentType {
+                request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Add optional contentType parameter to GatewayHTTPClient.post(path:body:...) to allow overriding the default application/json Content-Type
- Set Content-Type to application/octet-stream in importBundleToManaged() so .vbundle uploads are accepted by the platform's extract_bundle_upload() validation
- Also fix the local-to-Docker teleport import call to use application/octet-stream
- Fixes 400 error when using 'Move to Cloud (Platform)' teleport button

Part of plan: fix-teleport-upload-400.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
