### PR TITLE
fix: set correct Content-Type for teleport bundle uploads

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
@@ -363,7 +363,7 @@ extension AssistantBackupsSection {
 
         do {
             let fileData = try Data(contentsOf: fileURL)
-            let response = try await GatewayHTTPClient.post(path: "migrations/import", body: fileData, timeout: 120)
+            let response = try await GatewayHTTPClient.post(path: "migrations/import", body: fileData, contentType: "application/octet-stream", timeout: 120)
 
             if response.isSuccess {
                 if let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -283,6 +283,7 @@ struct AssistantTransferSection: View {
             let importResponse = try await GatewayHTTPClient.post(
                 path: "assistants/{assistantId}/migrations/import",
                 body: bundleData,
+                contentType: "application/octet-stream",
                 timeout: 120
             )
             guard importResponse.isSuccess else {
@@ -378,6 +379,7 @@ struct AssistantTransferSection: View {
         let response = try await GatewayHTTPClient.post(
             path: "assistants/{assistantId}/migrations/import",
             body: bundleData,
+            contentType: "application/octet-stream",
             timeout: 120
         )
 

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -430,6 +430,7 @@ struct TeleportSection: View {
         let importResponse = try await GatewayHTTPClient.post(
             path: "assistants/{assistantId}/migrations/import",
             body: bundleData,
+            contentType: "application/octet-stream",
             timeout: 120
         )
         guard importResponse.isSuccess else {
@@ -513,6 +514,7 @@ struct TeleportSection: View {
         let response = try await GatewayHTTPClient.post(
             path: "assistants/{assistantId}/migrations/import",
             body: bundleData,
+            contentType: "application/octet-stream",
             timeout: 120
         )
 

--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -91,9 +91,12 @@ public enum GatewayHTTPClient {
     ///   - timeout: Request timeout in seconds. Defaults to 30.
     /// - Returns: A `Response` with the raw data and HTTP status code.
     /// - Throws: `ClientError` if the request cannot be constructed, or network errors from `URLSession`.
-    public static func post(path: String, body: Data? = nil, params: [String: String]? = nil, timeout: TimeInterval = 30) async throws -> Response {
+    public static func post(path: String, body: Data? = nil, params: [String: String]? = nil, contentType: String? = nil, timeout: TimeInterval = 30) async throws -> Response {
         return try await executeWithRetry(path: path, params: params, method: "POST", timeout: timeout) { request in
             request.httpBody = body
+            if let contentType {
+                request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
Fix 400 error when using "Move to Cloud (Platform)" teleport button. The macOS client's `GatewayHTTPClient` hardcodes `Content-Type: application/json` for all requests, but `.vbundle` binary uploads require `application/octet-stream`. Added an optional `contentType` parameter to override the default, and set it for all migration import calls.

## PRs merged into feature branch
- #22657: fix: allow overriding Content-Type in GatewayHTTPClient.post for binary uploads

Part of plan: fix-teleport-upload-400.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
