### PR TITLE
Show teleport section without feature flag, keep Docker button gated

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -78,8 +78,7 @@ struct SettingsGeneralTab: View {
                     updateManager: updateManager
                 )
             }
-            if MacOSClientFeatureFlagManager.shared.isEnabled("teleport"),
-               let assistant = currentAssistant,
+            if let assistant = currentAssistant,
                !assistant.isManaged && (!assistant.isRemote || assistant.isDocker) {
                 TeleportSection(assistant: assistant, onClose: onClose)
             }

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -160,8 +160,10 @@ struct TeleportSection: View {
     @ViewBuilder
     private var destinationPicker: some View {
         if assistant.cloud.lowercased() == "local" {
-            // Bare metal local: show both Docker and Platform options
-            destinationButton(for: .docker)
+            // Docker option: still behind feature flag
+            if MacOSClientFeatureFlagManager.shared.isEnabled("teleport") {
+                destinationButton(for: .docker)
+            }
             destinationButton(for: .platform)
         } else if assistant.isDocker {
             // Docker: show only Platform option


### PR DESCRIPTION
## Summary
- Remove the teleport feature flag gate from SettingsGeneralTab so TeleportSection always renders for eligible assistants
- Move the feature flag check into TeleportSection.destinationPicker to gate only the Docker destination button
- The Move to Cloud (Platform) button is now always visible; Move to Docker remains behind the teleport flag

Part of plan: teleport-flag-redesign.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22660" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
