### PR TITLE
fix: add contentType override for binary uploads in AssistantTransferSection

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
@@ -363,7 +363,7 @@ extension AssistantBackupsSection {
 
         do {
             let fileData = try Data(contentsOf: fileURL)
-            let response = try await GatewayHTTPClient.post(path: "migrations/import", body: fileData, timeout: 120)
+            let response = try await GatewayHTTPClient.post(path: "migrations/import", body: fileData, contentType: "application/octet-stream", timeout: 120)
 
             if response.isSuccess {
                 if let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -283,6 +283,7 @@ struct AssistantTransferSection: View {
             let importResponse = try await GatewayHTTPClient.post(
                 path: "assistants/{assistantId}/migrations/import",
                 body: bundleData,
+                contentType: "application/octet-stream",
                 timeout: 120
             )
             guard importResponse.isSuccess else {
@@ -378,6 +379,7 @@ struct AssistantTransferSection: View {
         let response = try await GatewayHTTPClient.post(
             path: "assistants/{assistantId}/migrations/import",
             body: bundleData,
+            contentType: "application/octet-stream",
             timeout: 120
         )
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-teleport-upload-400.md.

**Gap:** AssistantTransferSection.importBundleToManaged missing contentType fix
**What was expected:** All binary .vbundle upload calls should use contentType: application/octet-stream
**What was found:** AssistantTransferSection.swift posts binary data without the contentType override

- Added `contentType: "application/octet-stream"` to `importBundleToManaged` in AssistantTransferSection.swift
- Added `contentType: "application/octet-stream"` to the managed-to-local import call in AssistantTransferSection.swift
- Added `contentType: "application/octet-stream"` to `performLocalRestore` in AssistantBackupsSection.swift
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
