### PR TITLE
fix: guard .vContextMenu usage in NavigationGallerySection for macOS only

### DIFF
--- a/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/NavigationGallerySection.swift
@@ -438,6 +438,7 @@ struct NavigationGallerySection: View {
                     }
                 }
 
+                #if os(macOS)
                 Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
 
                 // MARK: - VSubMenuItem (in context menu)
@@ -463,6 +464,7 @@ struct NavigationGallerySection: View {
                             VMenuItem(icon: VIcon.trash.rawValue, label: "Delete", variant: .destructive) {}
                         }
                 }
+                #endif
             }
 
 


### PR DESCRIPTION
## Summary
- Wrapped the `.vContextMenu` demo in `NavigationGallerySection.swift` with `#if os(macOS)` to match the modifier's platform availability
- The `.vContextMenu` modifier is defined inside `#if os(macOS)` in `VMenuPanel.swift`, so calling it from non-macOS code causes a build error: `Value of type 'some View' has no member 'vContextMenu'`

## Original prompt
fix this test: Testing failed: Value of type 'some View' has no member 'vContextMenu'

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
