### PR TITLE
Force hosting selector when hatching new assistant from developer tab

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -340,6 +340,7 @@ extension AppDelegate {
         OnboardingState.clearPersistedState()
 
         let onboarding = OnboardingWindow(connectionManager: connectionManager, authManager: authManager)
+        onboarding.state.isRehatch = true
         onboarding.onComplete = { [weak self] state in
             OnboardingState.clearPersistedState()
             UserDefaults.standard.set(state.chosenKey.rawValue, forKey: "activationKey")

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -290,16 +290,17 @@ struct OnboardingFlowView: View {
         isResolvingAssociatedManagedAssistant = true
         defer { isResolvingAssociatedManagedAssistant = false }
 
-        // Only auto-proceed if there's already a managed assistant in the lockfile.
+        // Only auto-proceed if there's already a managed assistant in the lockfile
+        // AND this is a fresh onboarding (not a re-hatch from the developer tab).
         // Do NOT create a new managed assistant here — that should only happen if
         // the user explicitly selects Vellum Cloud on the hosting selector.
-        if let existing = LockfileAssistant.loadLatest(), existing.isManaged {
+        if let existing = LockfileAssistant.loadLatest(), existing.isManaged, !state.isRehatch {
             log.info("Authenticated with existing managed assistant \(existing.assistantId, privacy: .public); proceeding to app")
             onComplete()
             return
         }
 
-        log.info("Authenticated account has no existing managed assistant — advancing to hosting selector")
+        log.info("Authenticated account has \(state.isRehatch ? "rehatch requested" : "no existing managed assistant", privacy: .public) — advancing to hosting selector")
         state.advance()
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -88,6 +88,12 @@ final class OnboardingState {
     var customQRCodeImageData: Data = Data()
     var selectedModel: String = "claude-opus-4-6"
     var selectedProvider: String = "anthropic"
+    /// When true, the onboarding flow was launched from the developer tab's
+    /// "Hatch New Assistant" button. This prevents auto-completing when the user
+    /// already has a managed assistant, forcing the hosting selector to appear so
+    /// they can choose where the new assistant runs.
+    var isRehatch: Bool = false
+
     var isHatching: Bool = false
     var isManagedHatch: Bool = false
     var hasExistingManagedAssistant: Bool = false


### PR DESCRIPTION
## Summary
- Add `isRehatch` flag to `OnboardingState` to distinguish developer-tab hatching from first-time onboarding
- Set the flag in `hatchNewAssistant()` before showing the onboarding window
- Update `continueManagedOnboardingAfterAuthentication()` to skip auto-completion when `isRehatch` is true, ensuring the hosting selector (step 1) always appears so users can choose local, cloud, or other hosting modes

## Original prompt
When a user hatches a new assistant via the developer tab force them to go through onboarding flow to select the place where the assistant runs. In some cases it will only try to launch a platform assistant but if they click hatch it should allow them to select local if they want.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
