### PR TITLE
fix: guard nil assistant name in retire and add early return

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -529,41 +529,42 @@ extension AppDelegate {
     func performRetireAsync() async -> Bool {
         let assistantName = UserDefaults.standard.string(forKey: "connectedAssistantId")
 
-        if assistantName == nil {
+        guard let assistantName else {
             log.error("No stored connected assistant ID found — skipping retire")
+            mainWindow?.windowState.showToast(
+                message: "No assistant is selected for retirement.",
+                style: .error
+            )
+            return false
         }
 
-        if let name = assistantName {
-            // Disconnect SSE and health checks *before* the CLI kills the
-            // daemon/gateway. Otherwise the EventStreamClient reconnect loop
-            // hits the gateway while the upstream daemon is already dead,
-            // producing spurious "SSE connection failed with status 502" errors.
-            connectionManager.disconnect()
+        // Disconnect SSE and health checks *before* the CLI kills the
+        // daemon/gateway. Otherwise the EventStreamClient reconnect loop
+        // hits the gateway while the upstream daemon is already dead,
+        // producing spurious "SSE connection failed with status 502" errors.
+        connectionManager.disconnect()
 
-            do {
-                try await vellumCli.retire(name: name)
-            } catch {
-                log.error("CLI retire failed: \(error.localizedDescription)")
-                let alert = NSAlert()
-                alert.messageText = "Failed to Retire Remote Instance"
-                alert.informativeText = "\(error.localizedDescription)\n\nYou can force-remove the local configuration, but the remote cloud instance may still be running and will need to be deleted manually."
-                alert.alertStyle = .warning
-                alert.addButton(withTitle: "Force Remove")
-                alert.addButton(withTitle: "Cancel")
-                if alert.runModal() != .alertFirstButtonReturn {
-                    // Assistant is still running — reconnect so the user can
-                    // continue using the app (we disconnected above to avoid
-                    // 502 errors during the retire attempt).
-                    try? await connectionManager.connect()
-                    return false
-                }
-                // Retire failed but user chose Force Remove — stop the assistant
-                // before cleaning up local state.
-                await vellumCli.stop(name: name)
-                self.removeLockfileEntry(assistantId: name)
+        do {
+            try await vellumCli.retire(name: assistantName)
+        } catch {
+            log.error("CLI retire failed: \(error.localizedDescription)")
+            let alert = NSAlert()
+            alert.messageText = "Failed to Retire Remote Instance"
+            alert.informativeText = "\(error.localizedDescription)\n\nYou can force-remove the local configuration, but the remote cloud instance may still be running and will need to be deleted manually."
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: "Force Remove")
+            alert.addButton(withTitle: "Cancel")
+            if alert.runModal() != .alertFirstButtonReturn {
+                // Assistant is still running — reconnect so the user can
+                // continue using the app (we disconnected above to avoid
+                // 502 errors during the retire attempt).
+                try? await connectionManager.connect()
+                return false
             }
-        } else {
+            // Retire failed but user chose Force Remove — stop the assistant
+            // before cleaning up local state.
             await vellumCli.stop(name: assistantName)
+            self.removeLockfileEntry(assistantId: assistantName)
         }
 
         // Check if other assistants remain in the lockfile.

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -529,75 +529,78 @@ extension AppDelegate {
     func performRetireAsync() async -> Bool {
         let assistantName = UserDefaults.standard.string(forKey: "connectedAssistantId")
 
-        guard let assistantName else {
-            log.error("No stored connected assistant ID found — skipping retire")
+        if let assistantName {
+            // Disconnect SSE and health checks *before* the CLI kills the
+            // daemon/gateway. Otherwise the EventStreamClient reconnect loop
+            // hits the gateway while the upstream daemon is already dead,
+            // producing spurious "SSE connection failed with status 502" errors.
+            connectionManager.disconnect()
+
+            do {
+                try await vellumCli.retire(name: assistantName)
+            } catch {
+                log.error("CLI retire failed: \(error.localizedDescription)")
+                let alert = NSAlert()
+                alert.messageText = "Failed to Retire Remote Instance"
+                alert.informativeText = "\(error.localizedDescription)\n\nYou can force-remove the local configuration, but the remote cloud instance may still be running and will need to be deleted manually."
+                alert.alertStyle = .warning
+                alert.addButton(withTitle: "Force Remove")
+                alert.addButton(withTitle: "Cancel")
+                if alert.runModal() != .alertFirstButtonReturn {
+                    // Assistant is still running — reconnect so the user can
+                    // continue using the app (we disconnected above to avoid
+                    // 502 errors during the retire attempt).
+                    try? await connectionManager.connect()
+                    return false
+                }
+                // Retire failed but user chose Force Remove — stop the assistant
+                // before cleaning up local state.
+                await vellumCli.stop(name: assistantName)
+                self.removeLockfileEntry(assistantId: assistantName)
+            }
+
+            // Check if other assistants remain in the lockfile.
+            // Prefer remote assistants (always reachable), then try waking local ones.
+            let remaining = LockfileAssistant.loadAll().filter { $0.assistantId != assistantName && $0.isCurrentEnvironment }
+            if !remaining.isEmpty {
+                // Try remote assistants first — they're always reachable
+                if let remote = remaining.first(where: { $0.isRemote }) {
+                    performSwitchAssistant(to: remote)
+                    return true
+                }
+
+                // Try local assistants — check if awake, otherwise wake them
+                for candidate in remaining {
+                    if await HealthCheckClient.isReachable(for: candidate) {
+                        performSwitchAssistant(to: candidate)
+                        return true
+                    }
+
+                    // Sleeping — try to wake it
+                    do {
+                        try await vellumCli.wake(name: candidate.assistantId)
+                        performSwitchAssistant(to: candidate)
+                        return true
+                    } catch {
+                        log.warning("Failed to wake \(candidate.assistantId): \(error.localizedDescription)")
+                        continue
+                    }
+                }
+                // All local wake attempts failed — fall through to onboarding
+            }
+        } else {
+            // Corrupted state: no connectedAssistantId in UserDefaults.
+            // Skip CLI retire/stop (no name to pass) but fall through to
+            // full teardown + onboarding so the user can recover.
+            log.warning("No stored connected assistant ID found — skipping CLI retire, falling through to teardown")
             mainWindow?.windowState.showToast(
-                message: "No assistant is selected for retirement.",
-                style: .error
+                message: "No assistant selected — resetting to onboarding.",
+                style: .warning
             )
-            return false
+            connectionManager.disconnect()
         }
 
-        // Disconnect SSE and health checks *before* the CLI kills the
-        // daemon/gateway. Otherwise the EventStreamClient reconnect loop
-        // hits the gateway while the upstream daemon is already dead,
-        // producing spurious "SSE connection failed with status 502" errors.
-        connectionManager.disconnect()
-
-        do {
-            try await vellumCli.retire(name: assistantName)
-        } catch {
-            log.error("CLI retire failed: \(error.localizedDescription)")
-            let alert = NSAlert()
-            alert.messageText = "Failed to Retire Remote Instance"
-            alert.informativeText = "\(error.localizedDescription)\n\nYou can force-remove the local configuration, but the remote cloud instance may still be running and will need to be deleted manually."
-            alert.alertStyle = .warning
-            alert.addButton(withTitle: "Force Remove")
-            alert.addButton(withTitle: "Cancel")
-            if alert.runModal() != .alertFirstButtonReturn {
-                // Assistant is still running — reconnect so the user can
-                // continue using the app (we disconnected above to avoid
-                // 502 errors during the retire attempt).
-                try? await connectionManager.connect()
-                return false
-            }
-            // Retire failed but user chose Force Remove — stop the assistant
-            // before cleaning up local state.
-            await vellumCli.stop(name: assistantName)
-            self.removeLockfileEntry(assistantId: assistantName)
-        }
-
-        // Check if other assistants remain in the lockfile.
-        // Prefer remote assistants (always reachable), then try waking local ones.
-        let remaining = LockfileAssistant.loadAll().filter { $0.assistantId != assistantName && $0.isCurrentEnvironment }
-        if !remaining.isEmpty {
-            // Try remote assistants first — they're always reachable
-            if let remote = remaining.first(where: { $0.isRemote }) {
-                performSwitchAssistant(to: remote)
-                return true
-            }
-
-            // Try local assistants — check if awake, otherwise wake them
-            for candidate in remaining {
-                if await HealthCheckClient.isReachable(for: candidate) {
-                    performSwitchAssistant(to: candidate)
-                    return true
-                }
-
-                // Sleeping — try to wake it
-                do {
-                    try await vellumCli.wake(name: candidate.assistantId)
-                    performSwitchAssistant(to: candidate)
-                    return true
-                } catch {
-                    log.warning("Failed to wake \(candidate.assistantId): \(error.localizedDescription)")
-                    continue
-                }
-            }
-            // All local wake attempts failed — fall through to onboarding
-        }
-
-        // No assistants left — tear down fully and show onboarding
+        // No assistants left (or corrupted state) — tear down fully and show onboarding
         AvatarAppearanceManager.shared.resetForDisconnect()
         OnboardingState.clearPersistedState()
         UserDefaults.standard.removeObject(forKey: "bootstrapState")


### PR DESCRIPTION
## Summary
- Add early return in performRetireAsync() when connectedAssistantId is nil to prevent calling CLI stop with nil name
- Show toast feedback to user when no assistant is selected for retirement
- Prevents potential issue where all assistants could be stopped

Part of plan: asst-swap-reliability.md (PR 1 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22670" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
