### PR TITLE
fix: check for existing managed assistant before hatching from developer tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -36,6 +36,8 @@ struct SettingsDeveloperTab: View {
     @State private var devModeTapCount: Int = 0
     @State private var devModeMessage: String?
     @State private var showingHatchConfirmation: Bool = false
+    @State private var showingExistingManagedAssistantDialog: Bool = false
+    @State private var existingManagedAssistant: LockfileAssistant?
     @State private var displayNames: [String: String] = [:]
     @State private var awakeStates: [String: Bool] = [:]
     @State private var transitioningStates: Set<String> = []
@@ -889,7 +891,14 @@ struct SettingsDeveloperTab: View {
     private var hatchNewAssistantSection: some View {
         SettingsCard(title: "Hatch New Assistant", subtitle: "Starts the initial setup flow to create a new assistant.") {
             VButton(label: "Hatch", style: .primary) {
-                showingHatchConfirmation = true
+                // Pre-check: if the user is authenticated, look for an existing managed assistant
+                if authManager.isAuthenticated,
+                   let managed = ManagedAssistantBootstrapService.shared.checkExistingManagedAssistant() {
+                    existingManagedAssistant = managed
+                    showingExistingManagedAssistantDialog = true
+                } else {
+                    showingHatchConfirmation = true
+                }
             }
             .alert("Hatch New Assistant", isPresented: $showingHatchConfirmation) {
                 Button("Cancel", role: .cancel) {}
@@ -899,6 +908,20 @@ struct SettingsDeveloperTab: View {
                 }
             } message: {
                 Text("This will create a brand new assistant. Your existing assistant(s) will continue to exist and you can switch back to using them.")
+            }
+            .alert("Existing Managed Assistant Found", isPresented: $showingExistingManagedAssistantDialog) {
+                Button("Cancel", role: .cancel) {}
+                Button("Switch to Existing") {
+                    if let managed = existingManagedAssistant {
+                        switchToAssistant(managed)
+                    }
+                }
+                Button("Hatch Local Assistant") {
+                    AppDelegate.shared?.hatchNewAssistant()
+                    onClose()
+                }
+            } message: {
+                Text("You already have a managed assistant. Would you like to switch to it instead?")
             }
         }
     }

--- a/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
@@ -195,6 +195,7 @@ public final class ManagedAssistantBootstrapService {
         }
     }
 
+    #if os(macOS)
     /// Fast, local-only check for an existing managed assistant in the current
     /// platform environment. Inspects the lockfile without making any network
     /// calls, so it can gate the more expensive hatch flow cheaply.
@@ -202,6 +203,7 @@ public final class ManagedAssistantBootstrapService {
         let all = LockfileAssistant.loadAll()
         return all.first { $0.isManaged && $0.isCurrentEnvironment }
     }
+    #endif
 
     private func mapPlatformError(_ error: PlatformAPIError) -> ManagedBootstrapError {
         switch error {

--- a/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
@@ -195,6 +195,14 @@ public final class ManagedAssistantBootstrapService {
         }
     }
 
+    /// Fast, local-only check for an existing managed assistant in the current
+    /// platform environment. Inspects the lockfile without making any network
+    /// calls, so it can gate the more expensive hatch flow cheaply.
+    public func checkExistingManagedAssistant() -> LockfileAssistant? {
+        let all = LockfileAssistant.loadAll()
+        return all.first { $0.isManaged && $0.isCurrentEnvironment }
+    }
+
     private func mapPlatformError(_ error: PlatformAPIError) -> ManagedBootstrapError {
         switch error {
         case .authenticationRequired:


### PR DESCRIPTION
## Summary
- Add checkExistingManagedAssistant() helper to check lockfile for existing managed assistants
- Show confirmation dialog in developer tab when managed assistant already exists
- Users can switch to existing managed assistant or hatch a local one instead
- Only affects developer tab hatch flow, not onboarding

Part of plan: asst-swap-reliability.md (PR 4 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22671" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
