### PR TITLE
fix: handle managed assistant switch without requiring re-login

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -409,13 +409,57 @@ extension AppDelegate {
     /// 4. Reconfigure transport and reconnect
     /// 5. Resume credential bootstrap
     func performSwitchAssistant(to assistant: LockfileAssistant) {
-        // If switching to a managed assistant while logged out, prompt login first.
+        // If switching to a managed assistant while logged out, check whether
+        // a valid session token exists before forcing re-authentication.
+        // The in-memory auth state may be stale (tied to the previous assistant's
+        // context), so we validate the token against the platform API first.
         if assistant.isManaged && !authManager.isAuthenticated {
-            // Persist the target so we can switch after login completes.
-            UserDefaults.standard.set(assistant.assistantId, forKey: "pendingManagedSwitchAssistantId")
-            showAuthWindow()
+            Task {
+                let hasValidSession = await validateSessionTokenForSwitch()
+                if hasValidSession {
+                    // Session token is still valid — refresh auth state and
+                    // proceed with the switch directly without showing login.
+                    await authManager.checkSession()
+                    log.info("[switchAssistant] Session token valid — proceeding with managed switch to \(assistant.assistantId, privacy: .public) without re-auth")
+                    self.performSwitchAssistantCore(to: assistant)
+                } else {
+                    // Token is expired/invalid — persist the target and show login.
+                    log.info("[switchAssistant] Session token invalid — requiring re-auth for managed switch to \(assistant.assistantId, privacy: .public)")
+                    UserDefaults.standard.set(assistant.assistantId, forKey: "pendingManagedSwitchAssistantId")
+                    self.showAuthWindow()
+                }
+            }
             return
         }
+
+        performSwitchAssistantCore(to: assistant)
+    }
+
+    /// Validates the stored session token against the platform API.
+    /// Returns `true` if a session token exists and the server confirms
+    /// it is still valid; `false` if no token exists or the server
+    /// rejects it (401/403/network error).
+    private func validateSessionTokenForSwitch() async -> Bool {
+        guard SessionTokenManager.getToken() != nil else {
+            return false
+        }
+
+        do {
+            let response = try await AuthService.shared.getSession()
+            if response.status == 200, response.meta?.is_authenticated != false, response.data?.user != nil {
+                return true
+            }
+            return false
+        } catch {
+            log.warning("[switchAssistant] Session validation failed: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
+    /// Core switch logic, extracted so it can be called both from the
+    /// synchronous path (non-managed or already-authenticated) and from
+    /// the async token-validation path.
+    private func performSwitchAssistantCore(to assistant: LockfileAssistant) {
 
         // 1. Clear assistant-scoped runtime state while the assistant is still
         // running so forceStop can deliver a recording_status message.

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -544,12 +544,17 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             // Check for a pending managed assistant switch (set by performSwitchAssistant
             // when the user was logged out). Now that the user has re-authenticated and
             // the app is already set up, complete the switch.
+            // Validate that the pending ID still exists in the lockfile and belongs
+            // to the current platform environment before completing the switch.
             if let pendingId = UserDefaults.standard.string(forKey: "pendingManagedSwitchAssistantId"),
                !pendingId.isEmpty {
                 UserDefaults.standard.removeObject(forKey: "pendingManagedSwitchAssistantId")
-                if let assistant = LockfileAssistant.loadByName(pendingId) {
+                if let assistant = LockfileAssistant.loadByName(pendingId),
+                   assistant.isCurrentEnvironment {
                     performSwitchAssistant(to: assistant)
                     return
+                } else {
+                    log.warning("[proceedToApp] Pending managed switch target '\(pendingId, privacy: .public)' not found in lockfile or not in current environment — ignoring")
                 }
             }
             showMainWindow()
@@ -596,13 +601,18 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         // On cold-start reauth (non-first-launch), check for a pending managed
         // assistant switch BEFORE bootstrapping credentials. This avoids
         // provisioning against the wrong assistant only to immediately switch.
+        // Validate that the pending ID still exists in the lockfile and belongs
+        // to the current platform environment before completing the switch.
         if !isFirstLaunch,
            let pendingId = UserDefaults.standard.string(forKey: "pendingManagedSwitchAssistantId"),
            !pendingId.isEmpty {
             UserDefaults.standard.removeObject(forKey: "pendingManagedSwitchAssistantId")
-            if let assistant = LockfileAssistant.loadByName(pendingId) {
+            if let assistant = LockfileAssistant.loadByName(pendingId),
+               assistant.isCurrentEnvironment {
                 performSwitchAssistant(to: assistant)
                 return
+            } else {
+                log.warning("[proceedToApp] Pending managed switch target '\(pendingId, privacy: .public)' not found in lockfile or not in current environment — ignoring")
             }
         }
 


### PR DESCRIPTION
## Summary
- Check for valid session token before forcing re-authentication on managed assistant switch
- Validate session token against platform API and proceed directly if valid
- Only show auth window when token is truly expired/invalid
- Add lockfile validation for pending switch IDs in proceedToApp()

Part of plan: asst-swap-reliability.md (PR 3 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22672" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
