### PR TITLE
fix: cancel stale bootstrap tasks when switching assistants

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -477,8 +477,6 @@ extension AppDelegate {
         UserDefaults.standard.removeObject(forKey: "connectedOrganizationId")
         SentryDeviceInfo.updateOrganizationTag(nil)
         // Clear stale actor token for the previous assistant
-        actorTokenBootstrapTask?.cancel()
-        actorTokenBootstrapTask = nil
         ActorTokenManager.deleteToken()
 
         // 4. Reconfigure transport and reconnect

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -340,6 +340,7 @@ extension AppDelegate {
 
         log.info("Starting local assistant API key provisioning for \(assistantId, privacy: .public)")
 
+        let generation = self.switchGeneration
         Task {
             // Wait for the actor token — GatewayHTTPClient requires it for
             // auth and will throw immediately if it's not available yet.
@@ -348,12 +349,21 @@ extension AppDelegate {
                 for attempt in 1...6 {
                     token = await ActorTokenManager.waitForToken(timeout: 10)
                     if token != nil { break }
+                    guard self.switchGeneration == generation else {
+                        log.info("Local API key provisioning aborted — assistant switch generation changed (attempt \(attempt))")
+                        return
+                    }
                     log.info("Actor token not yet available (attempt \(attempt)/6), retrying...")
                 }
                 guard token != nil else {
                     log.warning("No actor token available for local API key provisioning after 60s")
                     return
                 }
+            }
+
+            guard self.switchGeneration == generation else {
+                log.info("Local API key provisioning aborted — assistant switch generation changed (after token wait)")
+                return
             }
 
             // Wait for the assistant (and gateway) to be reachable. The bootstrap
@@ -365,10 +375,19 @@ extension AppDelegate {
                 for attempt in 1...20 {
                     if self.connectionManager.isConnected { break }
                     try? await Task.sleep(nanoseconds: 500_000_000)
+                    guard self.switchGeneration == generation else {
+                        log.info("Local API key provisioning aborted — assistant switch generation changed (connection wait attempt \(attempt))")
+                        return
+                    }
                     if attempt == 20 {
                         log.warning("Assistant not connected after 10s — proceeding with credential bootstrap anyway")
                     }
                 }
+            }
+
+            guard self.switchGeneration == generation else {
+                log.info("Local API key provisioning aborted — assistant switch generation changed (before bootstrap)")
+                return
             }
 
             do {
@@ -381,11 +400,22 @@ extension AppDelegate {
                 )
                 log.info("Local assistant registered: \(platformId, privacy: .public)")
 
+                guard self.switchGeneration == generation else {
+                    log.info("Local API key provisioning completed but assistant switched — discarding result")
+                    return
+                }
+
                 self.localBootstrapDidComplete = true
                 SentryDeviceInfo.updateOrganizationTag(UserDefaults.standard.string(forKey: "connectedOrganizationId"))
                 NotificationCenter.default.post(name: .localBootstrapCompleted, object: nil)
             } catch {
                 log.error("Failed to provision local assistant API key: \(error.localizedDescription)")
+
+                guard self.switchGeneration == generation else {
+                    log.info("Local API key provisioning failed but assistant switched — suppressing error toast")
+                    return
+                }
+
                 self.localBootstrapDidComplete = true
                 SentryDeviceInfo.updateOrganizationTag(UserDefaults.standard.string(forKey: "connectedOrganizationId"))
                 NotificationCenter.default.post(name: .localBootstrapCompleted, object: nil)
@@ -416,6 +446,13 @@ extension AppDelegate {
             showAuthWindow()
             return
         }
+
+        // Cancel any in-flight bootstrap tasks from a previous assistant switch.
+        // Incrementing switchGeneration causes running bootstrap tasks to detect
+        // staleness and abort, preventing credential confusion during rapid switches.
+        switchGeneration += 1
+        actorTokenBootstrapTask?.cancel()
+        actorTokenBootstrapTask = nil
 
         // 1. Clear assistant-scoped runtime state while the assistant is still
         // running so forceStop can deliver a recording_status message.

--- a/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
@@ -180,6 +180,7 @@ extension AppDelegate {
             }
         }
 
+        let generation = self.switchGeneration
         actorTokenBootstrapTask = Task { [weak self] in
             guard let self else { return }
 
@@ -196,10 +197,20 @@ extension AppDelegate {
                 await self.performInitialBootstrap()
             }
 
+            guard self.switchGeneration == generation else {
+                log.info("Actor credential bootstrap aborted — assistant switch generation changed (after initial bootstrap)")
+                return
+            }
+
             // Run proactive refresh loop
             while !Task.isCancelled {
                 try? await Task.sleep(nanoseconds: 5 * 60 * 1_000_000_000) // Check every 5 minutes
                 guard !Task.isCancelled else { return }
+
+                guard self.switchGeneration == generation else {
+                    log.info("Actor credential refresh loop exiting — assistant switch generation changed")
+                    return
+                }
 
                 if ActorTokenManager.needsProactiveRefresh {
                     guard self.connectionManager.isConnected else { continue }
@@ -240,13 +251,23 @@ extension AppDelegate {
             return
         }
 
+        let generation = self.switchGeneration
         let deviceId = PairingQRCodeSheet.computeHostId()
         let retryDelay: UInt64 = 500_000_000
 
         while !Task.isCancelled {
+            guard self.switchGeneration == generation else {
+                log.info("Initial actor bootstrap aborted — assistant switch generation changed")
+                return
+            }
+
             if !connectionManager.isConnected {
                 await awaitConnectionEstablished()
                 guard !Task.isCancelled else { return }
+                guard self.switchGeneration == generation else {
+                    log.info("Initial actor bootstrap aborted — assistant switch generation changed (after connection wait)")
+                    return
+                }
             }
 
             let success = await GuardianClient().bootstrapActorToken(

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -135,12 +135,18 @@ extension AppDelegate {
         // Subscribe to SSE event stream for UI event routing.
         startEventSubscription()
 
+        let generation = self.switchGeneration
         Task {
             // Import guardian token from CLI file before connecting, so the
             // health check has valid credentials in the credential store.
             if let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
                !ActorTokenManager.hasToken {
                 _ = GuardianTokenFileReader.importIfAvailable(assistantId: assistantId)
+            }
+
+            guard self.switchGeneration == generation else {
+                log.info("setupGatewayConnectionManager: aborting connect — assistant switch generation changed")
+                return
             }
 
             if !connectionManager.isConnected && !connectionManager.isConnecting {
@@ -154,6 +160,12 @@ extension AppDelegate {
             } else {
                 log.info("setupGatewayConnectionManager: skipping connect() — isConnected=\(self.connectionManager.isConnected), isConnecting=\(self.connectionManager.isConnecting)")
             }
+
+            guard self.switchGeneration == generation else {
+                log.info("setupGatewayConnectionManager: skipping post-connect setup — assistant switch generation changed")
+                return
+            }
+
             if connectionManager.isConnected {
                 setupAmbientAgent()
                 refreshAppsCache()

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -170,6 +170,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     /// finished before the observer was registered.
     var localBootstrapDidComplete = false
 
+    /// Monotonically increasing counter incremented on each assistant switch.
+    /// Bootstrap tasks capture this value at start and abort early if the
+    /// current generation has advanced, preventing stale credential operations
+    /// from racing with a newer switch.
+    var switchGeneration: Int = 0
+
     /// Onboarding state retained during first-launch so post-hatch logic
     /// can access the randomly-generated avatar traits.
     var onboardingState: OnboardingState?


### PR DESCRIPTION
## Summary
- Add switchGeneration counter to AppDelegate that increments on each assistant switch
- Pass generation token to bootstrap tasks (ensureActorCredentials, ensureLocalAssistantApiKey)
- Bootstrap tasks abort early when they detect a newer switch has occurred
- Prevents race conditions between credential operations during rapid switches

Part of plan: asst-swap-reliability.md (PR 6 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22673" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
