### PR TITLE
fix: validate gateway connection succeeds after switching assistants

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -417,6 +417,10 @@ extension AppDelegate {
             return
         }
 
+        // Capture the previous assistant ID before any state changes so we can
+        // rollback if the new assistant's gateway connection fails.
+        let previousAssistantId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+
         // 1. Clear assistant-scoped runtime state while the assistant is still
         // running so forceStop can deliver a recording_status message.
         recordingManager.forceStop()
@@ -472,6 +476,80 @@ extension AppDelegate {
 
         // Reload avatar for the new assistant (customAvatarURL now resolves
         // to the new assistant's path after connectedAssistantId was updated).
+        AvatarAppearanceManager.shared.reloadAvatar()
+
+        showMainWindow()
+
+        // 7. Validate the gateway connection with a timeout. If the connection
+        //    doesn't establish within 15 seconds, roll back to the previous
+        //    assistant so the app doesn't end up in a broken state.
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+
+            let connected = await self.waitForGatewayConnection(timeout: 15)
+            if !connected {
+                log.error("Gateway connection failed after switching to \(assistant.assistantId, privacy: .public) — rolling back")
+                self.mainWindow?.windowState.showToast(
+                    message: "Could not connect to assistant — it may be offline",
+                    style: .error
+                )
+
+                // Roll back to the previous assistant if one was connected
+                if let previousAssistantId,
+                   let previousAssistant = LockfileAssistant.loadByName(previousAssistantId) {
+                    log.info("Rolling back to previous assistant \(previousAssistantId, privacy: .public)")
+                    self.rollbackToPreviousAssistant(previousAssistant)
+                }
+            }
+        }
+    }
+
+    /// Waits for `connectionManager.isConnected` to become `true`, polling
+    /// every 500ms up to the given timeout in seconds.
+    ///
+    /// Returns `true` if the connection was established within the timeout,
+    /// `false` otherwise.
+    private func waitForGatewayConnection(timeout: Int) async -> Bool {
+        let iterations = timeout * 2  // 500ms per iteration
+        for _ in 0..<iterations {
+            if connectionManager.isConnected { return true }
+            try? await Task.sleep(nanoseconds: 500_000_000)
+        }
+        return connectionManager.isConnected
+    }
+
+    /// Rolls back to a previous assistant after a failed switch. Performs
+    /// the same sequence as `performSwitchAssistant` but without the
+    /// post-switch validation to avoid infinite rollback loops.
+    private func rollbackToPreviousAssistant(_ assistant: LockfileAssistant) {
+        // Disconnect the failed connection
+        connectionManager.disconnect()
+        AvatarAppearanceManager.shared.resetForDisconnect()
+        threadWindowManager?.closeAll()
+        mainWindow?.close()
+        mainWindow = nil
+
+        // Restore the previous assistant selection
+        UserDefaults.standard.set(assistant.assistantId, forKey: "connectedAssistantId")
+        SentryDeviceInfo.updateAssistantTag(assistant.assistantId)
+        UserDefaults.standard.removeObject(forKey: "connectedOrganizationId")
+        SentryDeviceInfo.updateOrganizationTag(nil)
+        actorTokenBootstrapTask?.cancel()
+        actorTokenBootstrapTask = nil
+        ActorTokenManager.deleteToken()
+
+        // Reconfigure transport and reconnect
+        hasSetupDaemon = false
+        setupGatewayConnectionManager()
+
+        if !isCurrentAssistantManaged {
+            ensureActorCredentials()
+        }
+        localBootstrapDidComplete = false
+        ensureLocalAssistantApiKey()
+        syncApiKeysToAssistant(assistant)
+
+        featureFlagStore.reloadFromDisk()
         AvatarAppearanceManager.shared.reloadAvatar()
 
         showMainWindow()

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -417,6 +417,11 @@ extension AppDelegate {
             return
         }
 
+        // Cancel any in-flight validation task from a previous switch so a
+        // stale timeout doesn't rollback to the wrong assistant (A→B→C race).
+        switchValidationTask?.cancel()
+        switchValidationTask = nil
+
         // Capture the previous assistant ID before any state changes so we can
         // rollback if the new assistant's gateway connection fails.
         let previousAssistantId = UserDefaults.standard.string(forKey: "connectedAssistantId")
@@ -483,23 +488,31 @@ extension AppDelegate {
         // 7. Validate the gateway connection with a timeout. If the connection
         //    doesn't establish within 15 seconds, roll back to the previous
         //    assistant so the app doesn't end up in a broken state.
-        Task { @MainActor [weak self] in
+        self.switchValidationTask = Task { @MainActor [weak self] in
             guard let self else { return }
 
             let connected = await self.waitForGatewayConnection(timeout: 15)
+
+            // If a newer switch cancelled this task, bail out — the rollback
+            // target (previousAssistantId) is stale.
+            guard !Task.isCancelled else { return }
+
             if !connected {
                 log.error("Gateway connection failed after switching to \(assistant.assistantId, privacy: .public) — rolling back")
-                self.mainWindow?.windowState.showToast(
-                    message: "Could not connect to assistant — it may be offline",
-                    style: .error
-                )
 
-                // Roll back to the previous assistant if one was connected
+                // Roll back to the previous assistant if one was connected.
+                // Show the error toast AFTER rollback so it appears on the
+                // newly created main window (rollback closes the current one).
                 if let previousAssistantId,
                    let previousAssistant = LockfileAssistant.loadByName(previousAssistantId) {
                     log.info("Rolling back to previous assistant \(previousAssistantId, privacy: .public)")
                     self.rollbackToPreviousAssistant(previousAssistant)
                 }
+
+                self.mainWindow?.windowState.showToast(
+                    message: "Could not connect to assistant — it may be offline",
+                    style: .error
+                )
             }
         }
     }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -138,6 +138,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     /// cancelled before creating a new subscription (e.g. on reconnection or
     /// assistant switch), preventing duplicate event processing.
     var eventSubscriptionTask: Task<Void, Never>?
+    /// In-flight gateway validation task spawned by `performSwitchAssistant`.
+    /// Stored so it can be cancelled on rapid re-switch to prevent a stale
+    /// timeout from rolling back to the wrong assistant.
+    var switchValidationTask: Task<Void, Never>?
     /// Pending fallback notification tokens, keyed by conversationId.
     /// Used to avoid duplicate native alerts when notification_intent arrives.
     var pendingFallbackNotifications: [String: UUID] = [:]


### PR DESCRIPTION
## Summary
- Capture previous assistant ID before switch to enable rollback on failure
- Add timeout guard (15s) for gateway connection setup
- Show error toast and rollback to previous assistant if gateway setup fails
- Successful switches continue to work as before

Part of plan: asst-swap-reliability.md (PR 2 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22674" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
