### PR TITLE
Switch macOS teleport-to-cloud to use GCS signed URL upload flow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -359,7 +359,7 @@ struct TeleportSection: View {
         }
 
         // Step 3 — Import bundle to managed assistant
-        phase = .transferring(step: "Importing data to cloud...")
+        phase = .transferring(step: "Uploading data to cloud...")
         try await importBundleToManaged(bundleData: bundleData, managedAssistantId: platformAssistant.id)
 
         // Step 4 — Resolve managed assistant for later switch
@@ -477,7 +477,7 @@ struct TeleportSection: View {
         }
 
         // Step 3 — Import bundle to managed assistant
-        phase = .transferring(step: "Importing data to cloud...")
+        phase = .transferring(step: "Uploading data to cloud...")
         try await importBundleToManaged(bundleData: bundleData, managedAssistantId: platformAssistant.id)
 
         // Step 4 — Resolve managed assistant for later switch
@@ -505,28 +505,29 @@ struct TeleportSection: View {
         return response.data
     }
 
-    /// Imports a `.vbundle` archive into the managed assistant via the platform API.
+    /// Imports a `.vbundle` archive into the managed assistant via the signed URL upload flow.
+    ///
+    /// Uses 3 steps: request signed URL → upload to GCS → trigger import from GCS.
+    /// All endpoints are org-scoped, so no `connectedAssistantId` swap is needed.
     private func importBundleToManaged(bundleData: Data, managedAssistantId: String) async throws {
-        let previousId = UserDefaults.standard.string(forKey: "connectedAssistantId")
-        UserDefaults.standard.set(managedAssistantId, forKey: "connectedAssistantId")
-        defer { UserDefaults.standard.set(previousId, forKey: "connectedAssistantId") }
+        // Step 1: Request a signed upload URL from the platform
+        let uploadInfo = try await PlatformMigrationClient.requestUploadUrl()
 
-        let response = try await GatewayHTTPClient.post(
-            path: "assistants/{assistantId}/migrations/import",
-            body: bundleData,
-            contentType: "application/octet-stream",
-            timeout: 120
-        )
+        // Step 2: Upload bundle directly to GCS via signed URL
+        try await PlatformMigrationClient.uploadToSignedUrl(uploadInfo.uploadUrl, bundleData: bundleData)
 
-        guard response.isSuccess else {
-            if let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
+        // Step 3: Trigger import from GCS
+        let (statusCode, data) = try await PlatformMigrationClient.importFromGcs(bundleKey: uploadInfo.bundleKey)
+
+        guard (200..<300).contains(statusCode) else {
+            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                let errorMsg = json["error"] as? String {
                 throw TeleportError.importFailed(message: errorMsg)
             }
-            throw TeleportError.importFailed(message: "HTTP \(response.statusCode)")
+            throw TeleportError.importFailed(message: "HTTP \(statusCode)")
         }
 
-        if let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
+        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
            let success = json["success"] as? Bool, !success {
             let errorMsg = (json["error"] as? String) ?? "Import reported failure"
             throw TeleportError.importFailed(message: errorMsg)


### PR DESCRIPTION
## Summary
- Replaces direct binary upload through Django proxy with 3-step GCS signed URL flow
- Removes connectedAssistantId swap (signed URL endpoints are org-scoped)
- Fixes 415 Unsupported Media Type error when teleporting to cloud

Part of plan: teleport-signed-url-upload.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22675" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
