### PR TITLE
Fix teleport-to-cloud 415 error: use GCS signed URL upload flow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -155,7 +155,7 @@ struct AssistantTransferSection: View {
             }
 
             // Step 3 — Import bundle to managed assistant
-            currentStep = "Importing data to cloud..."
+            currentStep = "Uploading data to cloud..."
             try await importBundleToManaged(bundleData: bundleData)
 
             // Step 4 — Switch to managed assistant

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -370,28 +370,29 @@ struct AssistantTransferSection: View {
         throw TransferError.notSignedIn
     }
 
-    /// Imports a `.vbundle` archive into the managed assistant via the platform API.
+    /// Imports a `.vbundle` archive into the managed assistant via the signed URL upload flow.
+    ///
+    /// Uses 3 steps: request signed URL → upload to GCS → trigger import from GCS.
+    /// All endpoints are org-scoped, so no `connectedAssistantId` swap is needed.
     private func importBundleToManaged(bundleData: Data, managedAssistantId: String) async throws {
-        let previousId = UserDefaults.standard.string(forKey: "connectedAssistantId")
-        UserDefaults.standard.set(managedAssistantId, forKey: "connectedAssistantId")
-        defer { UserDefaults.standard.set(previousId, forKey: "connectedAssistantId") }
+        // Step 1: Request a signed upload URL from the platform
+        let uploadInfo = try await PlatformMigrationClient.requestUploadUrl()
 
-        let response = try await GatewayHTTPClient.post(
-            path: "assistants/{assistantId}/migrations/import",
-            body: bundleData,
-            contentType: "application/octet-stream",
-            timeout: 120
-        )
+        // Step 2: Upload bundle directly to GCS via signed URL
+        try await PlatformMigrationClient.uploadToSignedUrl(uploadInfo.uploadUrl, bundleData: bundleData)
 
-        guard response.isSuccess else {
-            if let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
+        // Step 3: Trigger import from GCS
+        let (statusCode, data) = try await PlatformMigrationClient.importFromGcs(bundleKey: uploadInfo.bundleKey)
+
+        guard (200..<300).contains(statusCode) else {
+            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                let errorMsg = json["error"] as? String {
                 throw TransferError.importFailed(message: errorMsg)
             }
-            throw TransferError.importFailed(message: "HTTP \(response.statusCode)")
+            throw TransferError.importFailed(message: "HTTP \(statusCode)")
         }
 
-        if let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
+        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
            let success = json["success"] as? Bool, !success {
             let errorMsg = (json["error"] as? String) ?? "Import reported failure"
             throw TransferError.importFailed(message: errorMsg)

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -156,7 +156,7 @@ struct AssistantTransferSection: View {
 
             // Step 3 — Import bundle to managed assistant
             currentStep = "Importing data to cloud..."
-            try await importBundleToManaged(bundleData: bundleData, managedAssistantId: platformAssistant.id)
+            try await importBundleToManaged(bundleData: bundleData)
 
             // Step 4 — Switch to managed assistant
             currentStep = "Switching to cloud assistant..."
@@ -374,7 +374,7 @@ struct AssistantTransferSection: View {
     ///
     /// Uses 3 steps: request signed URL → upload to GCS → trigger import from GCS.
     /// All endpoints are org-scoped, so no `connectedAssistantId` swap is needed.
-    private func importBundleToManaged(bundleData: Data, managedAssistantId: String) async throws {
+    private func importBundleToManaged(bundleData: Data) async throws {
         // Step 1: Request a signed upload URL from the platform
         let uploadInfo = try await PlatformMigrationClient.requestUploadUrl()
 

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -359,7 +359,7 @@ struct TeleportSection: View {
         }
 
         // Step 3 — Import bundle to managed assistant
-        phase = .transferring(step: "Importing data to cloud...")
+        phase = .transferring(step: "Uploading data to cloud...")
         try await importBundleToManaged(bundleData: bundleData, managedAssistantId: platformAssistant.id)
 
         // Step 4 — Resolve managed assistant for later switch
@@ -477,7 +477,7 @@ struct TeleportSection: View {
         }
 
         // Step 3 — Import bundle to managed assistant
-        phase = .transferring(step: "Importing data to cloud...")
+        phase = .transferring(step: "Uploading data to cloud...")
         try await importBundleToManaged(bundleData: bundleData, managedAssistantId: platformAssistant.id)
 
         // Step 4 — Resolve managed assistant for later switch
@@ -505,28 +505,29 @@ struct TeleportSection: View {
         return response.data
     }
 
-    /// Imports a `.vbundle` archive into the managed assistant via the platform API.
+    /// Imports a `.vbundle` archive into the managed assistant via the signed URL upload flow.
+    ///
+    /// Uses 3 steps: request signed URL → upload to GCS → trigger import from GCS.
+    /// All endpoints are org-scoped, so no `connectedAssistantId` swap is needed.
     private func importBundleToManaged(bundleData: Data, managedAssistantId: String) async throws {
-        let previousId = UserDefaults.standard.string(forKey: "connectedAssistantId")
-        UserDefaults.standard.set(managedAssistantId, forKey: "connectedAssistantId")
-        defer { UserDefaults.standard.set(previousId, forKey: "connectedAssistantId") }
+        // Step 1: Request a signed upload URL from the platform
+        let uploadInfo = try await PlatformMigrationClient.requestUploadUrl()
 
-        let response = try await GatewayHTTPClient.post(
-            path: "assistants/{assistantId}/migrations/import",
-            body: bundleData,
-            contentType: "application/octet-stream",
-            timeout: 120
-        )
+        // Step 2: Upload bundle directly to GCS via signed URL
+        try await PlatformMigrationClient.uploadToSignedUrl(uploadInfo.uploadUrl, bundleData: bundleData)
 
-        guard response.isSuccess else {
-            if let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
+        // Step 3: Trigger import from GCS
+        let (statusCode, data) = try await PlatformMigrationClient.importFromGcs(bundleKey: uploadInfo.bundleKey)
+
+        guard (200..<300).contains(statusCode) else {
+            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                let errorMsg = json["error"] as? String {
                 throw TeleportError.importFailed(message: errorMsg)
             }
-            throw TeleportError.importFailed(message: "HTTP \(response.statusCode)")
+            throw TeleportError.importFailed(message: "HTTP \(statusCode)")
         }
 
-        if let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
+        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
            let success = json["success"] as? Bool, !success {
             let errorMsg = (json["error"] as? String) ?? "Import reported failure"
             throw TeleportError.importFailed(message: errorMsg)

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -360,7 +360,7 @@ struct TeleportSection: View {
 
         // Step 3 — Import bundle to managed assistant
         phase = .transferring(step: "Uploading data to cloud...")
-        try await importBundleToManaged(bundleData: bundleData, managedAssistantId: platformAssistant.id)
+        try await importBundleToManaged(bundleData: bundleData)
 
         // Step 4 — Resolve managed assistant for later switch
         guard let managedAssistant = LockfileAssistant.loadAll().first(where: { $0.assistantId == platformAssistant.id && $0.isManaged }) else {
@@ -478,7 +478,7 @@ struct TeleportSection: View {
 
         // Step 3 — Import bundle to managed assistant
         phase = .transferring(step: "Uploading data to cloud...")
-        try await importBundleToManaged(bundleData: bundleData, managedAssistantId: platformAssistant.id)
+        try await importBundleToManaged(bundleData: bundleData)
 
         // Step 4 — Resolve managed assistant for later switch
         guard let managedAssistant = LockfileAssistant.loadAll().first(where: { $0.assistantId == platformAssistant.id && $0.isManaged }) else {
@@ -509,7 +509,7 @@ struct TeleportSection: View {
     ///
     /// Uses 3 steps: request signed URL → upload to GCS → trigger import from GCS.
     /// All endpoints are org-scoped, so no `connectedAssistantId` swap is needed.
-    private func importBundleToManaged(bundleData: Data, managedAssistantId: String) async throws {
+    private func importBundleToManaged(bundleData: Data) async throws {
         // Step 1: Request a signed upload URL from the platform
         let uploadInfo = try await PlatformMigrationClient.requestUploadUrl()
 

--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -159,7 +159,10 @@ public enum PlatformMigrationClient {
             userDefaults: .standard
         )
 
-        let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId")
+        let orgId: String? = {
+            guard let id = UserDefaults.standard.string(forKey: "connectedOrganizationId"), !id.isEmpty else { return nil }
+            return id
+        }()
 
         return (baseURL: baseURL, token: token, orgId: orgId)
     }

--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -1,0 +1,166 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "PlatformMigrationClient")
+
+/// Direct client for platform migration endpoints (signed URL upload flow).
+///
+/// Unlike `GatewayHTTPClient`, which routes through the assistant-scoped proxy,
+/// this client talks directly to the platform's org-scoped migration endpoints.
+/// Used for teleport-to-cloud uploads where binary data must go through GCS
+/// signed URLs rather than the JSON-only proxy.
+public enum PlatformMigrationClient {
+
+    // MARK: - Response Types
+
+    /// Response from the platform's upload URL endpoint.
+    public struct UploadUrlResponse: Decodable {
+        public let uploadUrl: String
+        public let bundleKey: String
+        public let expiresAt: String
+
+        private enum CodingKeys: String, CodingKey {
+            case uploadUrl = "upload_url"
+            case bundleKey = "bundle_key"
+            case expiresAt = "expires_at"
+        }
+    }
+
+    // MARK: - Errors
+
+    /// Errors specific to platform migration requests.
+    public enum PlatformMigrationError: LocalizedError {
+        case notAuthenticated
+        case signedUrlsNotAvailable
+        case requestFailed(statusCode: Int, detail: String)
+        case uploadFailed(statusCode: Int)
+
+        public var errorDescription: String? {
+            switch self {
+            case .notAuthenticated:
+                return "Not authenticated — sign in to your Vellum account to continue."
+            case .signedUrlsNotAvailable:
+                return "Signed URL uploads are not available — the platform may not support this feature yet."
+            case .requestFailed(let statusCode, let detail):
+                return "Migration request failed (HTTP \(statusCode)): \(detail)"
+            case .uploadFailed(let statusCode):
+                return "Bundle upload failed (HTTP \(statusCode))."
+            }
+        }
+    }
+
+    // MARK: - Public API
+
+    /// Requests a signed upload URL from the platform for uploading a migration bundle.
+    ///
+    /// - Returns: An `UploadUrlResponse` containing the signed URL, bundle key, and expiration.
+    /// - Throws: `PlatformMigrationError` on auth or request failures.
+    public static func requestUploadUrl() async throws -> UploadUrlResponse {
+        let (baseURL, token, orgId) = try resolveAuthContext()
+
+        guard let url = URL(string: "\(baseURL)/v1/migrations/upload-url/") else {
+            throw PlatformMigrationError.requestFailed(statusCode: 0, detail: "Invalid URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        if let orgId {
+            request.setValue(orgId, forHTTPHeaderField: "Vellum-Organization-Id")
+        }
+        request.httpBody = try JSONSerialization.data(withJSONObject: ["content_type": "application/octet-stream"])
+
+        log.info("POST \(url.absoluteString, privacy: .public) — requesting upload URL")
+        let (data, response) = try await URLSession.shared.data(for: request)
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+        log.info("POST \(url.absoluteString, privacy: .public) → \(statusCode)")
+
+        if statusCode == 503 || statusCode == 404 {
+            throw PlatformMigrationError.signedUrlsNotAvailable
+        }
+
+        guard statusCode == 201 else {
+            let detail = String(data: data, encoding: .utf8) ?? "No response body"
+            throw PlatformMigrationError.requestFailed(statusCode: statusCode, detail: detail)
+        }
+
+        let decoder = JSONDecoder()
+        return try decoder.decode(UploadUrlResponse.self, from: data)
+    }
+
+    /// Uploads binary bundle data to a GCS signed URL.
+    ///
+    /// - Parameters:
+    ///   - url: The signed upload URL from `requestUploadUrl()`.
+    ///   - bundleData: The raw bundle data to upload.
+    /// - Throws: `PlatformMigrationError.uploadFailed` if the upload returns a non-2xx status.
+    public static func uploadToSignedUrl(_ url: String, bundleData: Data) async throws {
+        guard let uploadURL = URL(string: url) else {
+            throw PlatformMigrationError.uploadFailed(statusCode: 0)
+        }
+
+        var request = URLRequest(url: uploadURL)
+        request.httpMethod = "PUT"
+        request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
+        request.httpBody = bundleData
+        request.timeoutInterval = 600
+
+        log.info("PUT \(uploadURL.host() ?? "signed-url", privacy: .public) — uploading bundle (\(bundleData.count) bytes)")
+        let (_, response) = try await URLSession.shared.data(for: request)
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+        log.info("PUT \(uploadURL.host() ?? "signed-url", privacy: .public) → \(statusCode)")
+
+        guard (200..<300).contains(statusCode) else {
+            throw PlatformMigrationError.uploadFailed(statusCode: statusCode)
+        }
+    }
+
+    /// Triggers a GCS-based import on the platform after the bundle has been uploaded.
+    ///
+    /// - Parameter bundleKey: The bundle key returned by `requestUploadUrl()`.
+    /// - Returns: A tuple of the HTTP status code and raw response data.
+    /// - Throws: `PlatformMigrationError` on auth failures, or network errors from `URLSession`.
+    public static func importFromGcs(bundleKey: String) async throws -> (statusCode: Int, data: Data) {
+        let (baseURL, token, orgId) = try resolveAuthContext()
+
+        guard let url = URL(string: "\(baseURL)/v1/migrations/import-from-gcs/") else {
+            throw PlatformMigrationError.requestFailed(statusCode: 0, detail: "Invalid URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 120
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        if let orgId {
+            request.setValue(orgId, forHTTPHeaderField: "Vellum-Organization-Id")
+        }
+        request.httpBody = try JSONSerialization.data(withJSONObject: ["bundle_key": bundleKey])
+
+        log.info("POST \(url.absoluteString, privacy: .public) — importing from GCS (key: \(bundleKey, privacy: .public))")
+        let (data, response) = try await URLSession.shared.data(for: request)
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+        log.info("POST \(url.absoluteString, privacy: .public) → \(statusCode)")
+
+        return (statusCode: statusCode, data: data)
+    }
+
+    // MARK: - Internals
+
+    /// Resolves the platform base URL, session token, and org ID for authenticated requests.
+    private static func resolveAuthContext() throws -> (baseURL: String, token: String, orgId: String?) {
+        guard let token = SessionTokenManager.getToken(), !token.isEmpty else {
+            throw PlatformMigrationError.notAuthenticated
+        }
+
+        let baseURL = AuthService.resolveBaseURL(
+            environment: ProcessInfo.processInfo.environment,
+            userDefaults: .standard
+        )
+
+        let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId")
+
+        return (baseURL: baseURL, token: token, orgId: orgId)
+    }
+}


### PR DESCRIPTION
## Summary
Fixes 415 (Unsupported Media Type) error when teleporting an assistant to the cloud from the macOS app. The root cause was that `GatewayHTTPClient` sent binary bundle data through Django's `RuntimeProxyWildcardView`, which only supports JSON parsers. The fix switches the macOS client to the same GCS signed URL upload flow that the CLI already uses successfully.

The new flow:
1. Request a signed upload URL from `/v1/migrations/upload-url/`
2. PUT the bundle directly to GCS via the signed URL
3. Trigger import via `/v1/migrations/import-from-gcs/`

No binary data passes through the Django proxy anymore.

## PRs merged into feature branch
- #22669: Add PlatformMigrationClient with signed URL upload support
- #22675: Switch macOS teleport-to-cloud to use GCS signed URL upload flow

Part of plan: teleport-signed-url-upload.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22676" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
