### PR TITLE
fix: update AssistantTransferSection to use signed URL upload flow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -370,28 +370,29 @@ struct AssistantTransferSection: View {
         throw TransferError.notSignedIn
     }
 
-    /// Imports a `.vbundle` archive into the managed assistant via the platform API.
+    /// Imports a `.vbundle` archive into the managed assistant via the signed URL upload flow.
+    ///
+    /// Uses 3 steps: request signed URL → upload to GCS → trigger import from GCS.
+    /// All endpoints are org-scoped, so no `connectedAssistantId` swap is needed.
     private func importBundleToManaged(bundleData: Data, managedAssistantId: String) async throws {
-        let previousId = UserDefaults.standard.string(forKey: "connectedAssistantId")
-        UserDefaults.standard.set(managedAssistantId, forKey: "connectedAssistantId")
-        defer { UserDefaults.standard.set(previousId, forKey: "connectedAssistantId") }
+        // Step 1: Request a signed upload URL from the platform
+        let uploadInfo = try await PlatformMigrationClient.requestUploadUrl()
 
-        let response = try await GatewayHTTPClient.post(
-            path: "assistants/{assistantId}/migrations/import",
-            body: bundleData,
-            contentType: "application/octet-stream",
-            timeout: 120
-        )
+        // Step 2: Upload bundle directly to GCS via signed URL
+        try await PlatformMigrationClient.uploadToSignedUrl(uploadInfo.uploadUrl, bundleData: bundleData)
 
-        guard response.isSuccess else {
-            if let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
+        // Step 3: Trigger import from GCS
+        let (statusCode, data) = try await PlatformMigrationClient.importFromGcs(bundleKey: uploadInfo.bundleKey)
+
+        guard (200..<300).contains(statusCode) else {
+            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                let errorMsg = json["error"] as? String {
                 throw TransferError.importFailed(message: errorMsg)
             }
-            throw TransferError.importFailed(message: "HTTP \(response.statusCode)")
+            throw TransferError.importFailed(message: "HTTP \(statusCode)")
         }
 
-        if let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
+        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
            let success = json["success"] as? Bool, !success {
             let errorMsg = (json["error"] as? String) ?? "Import reported failure"
             throw TransferError.importFailed(message: errorMsg)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for teleport-signed-url-upload.md.

**Gap:** AssistantTransferSection has the same 415 bug
**What was expected:** All binary upload paths to managed assistants should use the signed URL flow
**What was found:** AssistantTransferSection.importBundleToManaged still used GatewayHTTPClient binary upload through Django proxy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22677" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
