### PR TITLE
fix: remove unused managedAssistantId parameter from importBundleToManaged

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -360,7 +360,7 @@ struct TeleportSection: View {
 
         // Step 3 — Import bundle to managed assistant
         phase = .transferring(step: "Uploading data to cloud...")
-        try await importBundleToManaged(bundleData: bundleData, managedAssistantId: platformAssistant.id)
+        try await importBundleToManaged(bundleData: bundleData)
 
         // Step 4 — Resolve managed assistant for later switch
         guard let managedAssistant = LockfileAssistant.loadAll().first(where: { $0.assistantId == platformAssistant.id && $0.isManaged }) else {
@@ -478,7 +478,7 @@ struct TeleportSection: View {
 
         // Step 3 — Import bundle to managed assistant
         phase = .transferring(step: "Uploading data to cloud...")
-        try await importBundleToManaged(bundleData: bundleData, managedAssistantId: platformAssistant.id)
+        try await importBundleToManaged(bundleData: bundleData)
 
         // Step 4 — Resolve managed assistant for later switch
         guard let managedAssistant = LockfileAssistant.loadAll().first(where: { $0.assistantId == platformAssistant.id && $0.isManaged }) else {
@@ -509,7 +509,7 @@ struct TeleportSection: View {
     ///
     /// Uses 3 steps: request signed URL → upload to GCS → trigger import from GCS.
     /// All endpoints are org-scoped, so no `connectedAssistantId` swap is needed.
-    private func importBundleToManaged(bundleData: Data, managedAssistantId: String) async throws {
+    private func importBundleToManaged(bundleData: Data) async throws {
         // Step 1: Request a signed upload URL from the platform
         let uploadInfo = try await PlatformMigrationClient.requestUploadUrl()
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for teleport-signed-url-upload.md.

**Gap:** managedAssistantId parameter is accepted but unused
**What was expected:** Clean API with no dead parameters
**What was found:** TeleportSection.importBundleToManaged accepted managedAssistantId but never used it after switching to signed URL flow
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22678" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
