### PR TITLE
fix: remove unused managedAssistantId parameter from AssistantTransferSection

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -156,7 +156,7 @@ struct AssistantTransferSection: View {
 
             // Step 3 — Import bundle to managed assistant
             currentStep = "Importing data to cloud..."
-            try await importBundleToManaged(bundleData: bundleData, managedAssistantId: platformAssistant.id)
+            try await importBundleToManaged(bundleData: bundleData)
 
             // Step 4 — Switch to managed assistant
             currentStep = "Switching to cloud assistant..."
@@ -374,7 +374,7 @@ struct AssistantTransferSection: View {
     ///
     /// Uses 3 steps: request signed URL → upload to GCS → trigger import from GCS.
     /// All endpoints are org-scoped, so no `connectedAssistantId` swap is needed.
-    private func importBundleToManaged(bundleData: Data, managedAssistantId: String) async throws {
+    private func importBundleToManaged(bundleData: Data) async throws {
         // Step 1: Request a signed upload URL from the platform
         let uploadInfo = try await PlatformMigrationClient.requestUploadUrl()
 


### PR DESCRIPTION
## Summary
Removes the unused managedAssistantId parameter from AssistantTransferSection.importBundleToManaged, matching the same cleanup done in TeleportSection. The signed URL flow is org-scoped and doesn't need an assistant ID.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22679" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
