### PR TITLE
fix: improve retire flow with proper cleanup and last-assistant guard

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -727,6 +727,10 @@ extension AppDelegate {
                 self.removeLockfileEntry(assistantId: assistantName)
             }
 
+            // Explicitly stop the retired assistant's processes to ensure
+            // nothing lingers (the CLI retire may not kill all child processes).
+            await vellumCli.stop(name: assistantName)
+
             // Check if other assistants remain in the lockfile.
             // Prefer remote assistants (always reachable), then try waking local ones.
             let remaining = LockfileAssistant.loadAll().filter { $0.assistantId != assistantName && $0.isCurrentEnvironment }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -170,9 +170,12 @@ struct SettingsDeveloperTab: View {
             }
         } message: {
             if lockfileAssistants.count > 1 {
-                Text("This will stop the current assistant and switch to another. The retired assistant's lockfile entry will be removed.")
+                let otherAssistants = lockfileAssistants.filter { $0.assistantId != selectedAssistantId }
+                let nextAssistant = otherAssistants.first(where: { $0.isRemote }) ?? otherAssistants.first
+                let nextName = nextAssistant.map { displayNames[$0.assistantId] ?? $0.assistantId } ?? "another assistant"
+                Text("This will retire this assistant and switch to \(nextName). The retired assistant's lockfile entry will be removed.")
             } else {
-                Text("This will stop the assistant, remove local data, and return to initial setup. This action cannot be undone.")
+                Text("This will retire your only assistant and return you to setup. This action cannot be undone.")
             }
         }
         .alert("Restart Assistant", isPresented: $showingRestartConfirmation) {
@@ -815,8 +818,8 @@ struct SettingsDeveloperTab: View {
         SettingsCard(
             title: "Retire Assistant",
             subtitle: lockfileAssistants.count > 1
-                ? "Stops the current assistant and switches to another."
-                : "Stops the assistant, removes local data, and returns to initial setup."
+                ? "Retires the current assistant and switches to the next available one."
+                : "Retires your only assistant and returns to initial setup."
         ) {
             VButton(label: "Retire", style: .danger) {
                 showingRetireConfirmation = true


### PR DESCRIPTION
## Summary
- Add explicit vellumCli.stop() for retired assistant processes during cleanup
- Update retire confirmation messages to describe consequences (last vs. multiple)
- Ensures clean state when no assistants remain

Part of plan: asst-swap-reliability.md (PR 8 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22680" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
