### PR TITLE
feat: add post-switch assistant health check with retry

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -562,20 +562,21 @@ extension AppDelegate {
 
         showMainWindow()
 
-        // 7. Validate the gateway connection with a timeout. If the connection
-        //    doesn't establish within 15 seconds, roll back to the previous
-        //    assistant so the app doesn't end up in a broken state.
+        // 7. Verify the assistant is actually responding after the switch.
+        //    Uses verifyAssistantReady() which checks both SSE connection state
+        //    and the gateway health endpoint. If the assistant doesn't respond
+        //    within the timeout, roll back to the previous assistant.
         self.switchValidationTask = Task { @MainActor [weak self] in
             guard let self else { return }
 
-            let connected = await self.waitForGatewayConnection(timeout: 15)
+            do {
+                try await self.verifyAssistantReady(timeout: 15)
+            } catch {
+                // If a newer switch cancelled this task, bail out — the rollback
+                // target (previousAssistantId) is stale.
+                guard !Task.isCancelled else { return }
 
-            // If a newer switch cancelled this task, bail out — the rollback
-            // target (previousAssistantId) is stale.
-            guard !Task.isCancelled else { return }
-
-            if !connected {
-                log.error("Gateway connection failed after switching to \(assistant.assistantId, privacy: .public) — rolling back")
+                log.error("Assistant readiness check failed after switching to \(assistant.assistantId, privacy: .public): \(error.localizedDescription) — rolling back")
 
                 // Roll back to the previous assistant if one was connected.
                 // Show the error toast AFTER rollback so it appears on the
@@ -587,25 +588,11 @@ extension AppDelegate {
                 }
 
                 self.mainWindow?.windowState.showToast(
-                    message: "Could not connect to assistant — it may be offline",
+                    message: "Assistant is not responding. Switching back to previous assistant.",
                     style: .error
                 )
             }
         }
-    }
-
-    /// Waits for `connectionManager.isConnected` to become `true`, polling
-    /// every 500ms up to the given timeout in seconds.
-    ///
-    /// Returns `true` if the connection was established within the timeout,
-    /// `false` otherwise.
-    private func waitForGatewayConnection(timeout: Int) async -> Bool {
-        let iterations = timeout * 2  // 500ms per iteration
-        for _ in 0..<iterations {
-            if connectionManager.isConnected { return true }
-            try? await Task.sleep(nanoseconds: 500_000_000)
-        }
-        return connectionManager.isConnected
     }
 
     /// Rolls back to a previous assistant after a failed switch. Performs

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -587,8 +587,11 @@ extension AppDelegate {
                     self.rollbackToPreviousAssistant(previousAssistant)
                 }
 
+                let toastMessage = previousAssistantId != nil
+                    ? "Assistant is not responding. Switching back to previous assistant."
+                    : "Assistant is not responding. It may be offline."
                 self.mainWindow?.windowState.showToast(
-                    message: "Assistant is not responding. Switching back to previous assistant.",
+                    message: toastMessage,
                     style: .error
                 )
             }

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -4,6 +4,15 @@ import os
 
 private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "AppDelegate+ConnectionSetup")
 
+/// Thrown when the assistant does not become ready within the expected timeout.
+enum AssistantNotReadyError: LocalizedError {
+    case timeout
+
+    var errorDescription: String? {
+        "Assistant did not become ready within the expected timeout."
+    }
+}
+
 extension AppDelegate {
 
     // MARK: - Theme
@@ -682,5 +691,47 @@ extension AppDelegate {
         }
 
         log.warning("Could not install CLI symlink for \(commandName) in any candidate directory")
+    }
+
+    // MARK: - Assistant Readiness Check
+
+    /// Verifies the assistant is actually responding after a switch by checking
+    /// both the SSE connection state and the gateway health endpoint.
+    ///
+    /// First waits for `connectionManager.isConnected` to become `true`,
+    /// then performs a health endpoint check to confirm the assistant is
+    /// serving requests (not just accepting TCP connections).
+    ///
+    /// - Parameter timeout: Maximum time to wait in seconds (default 10).
+    /// - Throws: `AssistantNotReadyError.timeout` if the assistant does not
+    ///   become ready within the timeout.
+    func verifyAssistantReady(timeout: TimeInterval = 10) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+
+        // Phase 1: Wait for the SSE connection to establish.
+        while !connectionManager.isConnected {
+            if Date() >= deadline {
+                log.error("verifyAssistantReady: SSE connection not established within \(timeout)s")
+                throw AssistantNotReadyError.timeout
+            }
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+        }
+
+        // Phase 2: Hit the health endpoint to verify the assistant is
+        // actually serving requests. For local assistants this reaches the
+        // gateway's /readyz endpoint; for managed/remote assistants it
+        // routes through GatewayHTTPClient with auth.
+        while Date() < deadline {
+            let healthy = await HealthCheckClient.isReachable(timeout: 2)
+            if healthy {
+                log.info("verifyAssistantReady: assistant is healthy")
+                return
+            }
+            log.info("verifyAssistantReady: health check failed, retrying...")
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+        }
+
+        log.error("verifyAssistantReady: health endpoint not responding within \(timeout)s")
+        throw AssistantNotReadyError.timeout
     }
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -714,7 +714,7 @@ extension AppDelegate {
                 log.error("verifyAssistantReady: SSE connection not established within \(timeout)s")
                 throw AssistantNotReadyError.timeout
             }
-            try? await Task.sleep(nanoseconds: 1_000_000_000)
+            try await Task.sleep(nanoseconds: 1_000_000_000)
         }
 
         // Phase 2: Hit the health endpoint to verify the assistant is
@@ -728,7 +728,7 @@ extension AppDelegate {
                 return
             }
             log.info("verifyAssistantReady: health check failed, retrying...")
-            try? await Task.sleep(nanoseconds: 1_000_000_000)
+            try await Task.sleep(nanoseconds: 1_000_000_000)
         }
 
         log.error("verifyAssistantReady: health endpoint not responding within \(timeout)s")


### PR DESCRIPTION
## Summary
- Add `verifyAssistantReady()` health check in `AppDelegate+ConnectionSetup.swift` that validates both SSE connection state and gateway health endpoint after switching assistants
- Enhance existing `switchValidationTask` in `performSwitchAssistantCore` to use the new readiness check instead of the simpler `waitForGatewayConnection` connection-only check
- Roll back to previous assistant with clear user feedback ("Assistant is not responding. Switching back to previous assistant.") if health check fails
- Remove now-unused `waitForGatewayConnection` method (dead code cleanup)

Part of plan: asst-swap-reliability.md (PR 5 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22681" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
