### PR TITLE
Seamless assistant swapping, hatching, and retiring

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -701,6 +701,9 @@ extension AppDelegate {
 
             do {
                 try await vellumCli.retire(name: assistantName)
+                // Explicitly stop the retired assistant's processes to ensure
+                // nothing lingers (the CLI retire may not kill all child processes).
+                await vellumCli.stop(name: assistantName)
             } catch {
                 log.error("CLI retire failed: \(error.localizedDescription)")
                 let alert = NSAlert()
@@ -721,10 +724,6 @@ extension AppDelegate {
                 await vellumCli.stop(name: assistantName)
                 self.removeLockfileEntry(assistantId: assistantName)
             }
-
-            // Explicitly stop the retired assistant's processes to ensure
-            // nothing lingers (the CLI retire may not kill all child processes).
-            await vellumCli.stop(name: assistantName)
 
             // Check if other assistants remain in the lockfile.
             // Prefer remote assistants (always reachable), then try waking local ones.

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -409,14 +409,57 @@ extension AppDelegate {
     /// 4. Reconfigure transport and reconnect
     /// 5. Resume credential bootstrap
     func performSwitchAssistant(to assistant: LockfileAssistant) {
-        // If switching to a managed assistant while logged out, prompt login first.
+        // If switching to a managed assistant while logged out, check whether
+        // a valid session token exists before forcing re-authentication.
+        // The in-memory auth state may be stale (tied to the previous assistant's
+        // context), so we validate the token against the platform API first.
         if assistant.isManaged && !authManager.isAuthenticated {
-            // Persist the target so we can switch after login completes.
-            UserDefaults.standard.set(assistant.assistantId, forKey: "pendingManagedSwitchAssistantId")
-            showAuthWindow()
+            Task {
+                let hasValidSession = await validateSessionTokenForSwitch()
+                if hasValidSession {
+                    // Session token is still valid — refresh auth state and
+                    // proceed with the switch directly without showing login.
+                    await authManager.checkSession()
+                    log.info("[switchAssistant] Session token valid — proceeding with managed switch to \(assistant.assistantId, privacy: .public) without re-auth")
+                    self.performSwitchAssistantCore(to: assistant)
+                } else {
+                    // Token is expired/invalid — persist the target and show login.
+                    log.info("[switchAssistant] Session token invalid — requiring re-auth for managed switch to \(assistant.assistantId, privacy: .public)")
+                    UserDefaults.standard.set(assistant.assistantId, forKey: "pendingManagedSwitchAssistantId")
+                    self.showAuthWindow()
+                }
+            }
             return
         }
 
+        performSwitchAssistantCore(to: assistant)
+    }
+
+    /// Validates the stored session token against the platform API.
+    /// Returns `true` if a session token exists and the server confirms
+    /// it is still valid; `false` if no token exists or the server
+    /// rejects it (401/403/network error).
+    private func validateSessionTokenForSwitch() async -> Bool {
+        guard SessionTokenManager.getToken() != nil else {
+            return false
+        }
+
+        do {
+            let response = try await AuthService.shared.getSession()
+            if response.status == 200, response.meta?.is_authenticated != false, response.data?.user != nil {
+                return true
+            }
+            return false
+        } catch {
+            log.warning("[switchAssistant] Session validation failed: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
+    /// Core switch logic, extracted so it can be called both from the
+    /// synchronous path (non-managed or already-authenticated) and from
+    /// the async token-validation path.
+    private func performSwitchAssistantCore(to assistant: LockfileAssistant) {
         // Cancel any in-flight validation task from a previous switch so a
         // stale timeout doesn't rollback to the wrong assistant (A→B→C race).
         switchValidationTask?.cancel()

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -562,20 +562,21 @@ extension AppDelegate {
 
         showMainWindow()
 
-        // 7. Validate the gateway connection with a timeout. If the connection
-        //    doesn't establish within 15 seconds, roll back to the previous
-        //    assistant so the app doesn't end up in a broken state.
+        // 7. Verify the assistant is actually responding after the switch.
+        //    Uses verifyAssistantReady() which checks both SSE connection state
+        //    and the gateway health endpoint. If the assistant doesn't respond
+        //    within the timeout, roll back to the previous assistant.
         self.switchValidationTask = Task { @MainActor [weak self] in
             guard let self else { return }
 
-            let connected = await self.waitForGatewayConnection(timeout: 15)
+            do {
+                try await self.verifyAssistantReady(timeout: 15)
+            } catch {
+                // If a newer switch cancelled this task, bail out — the rollback
+                // target (previousAssistantId) is stale.
+                guard !Task.isCancelled else { return }
 
-            // If a newer switch cancelled this task, bail out — the rollback
-            // target (previousAssistantId) is stale.
-            guard !Task.isCancelled else { return }
-
-            if !connected {
-                log.error("Gateway connection failed after switching to \(assistant.assistantId, privacy: .public) — rolling back")
+                log.error("Assistant readiness check failed after switching to \(assistant.assistantId, privacy: .public): \(error.localizedDescription) — rolling back")
 
                 // Roll back to the previous assistant if one was connected.
                 // Show the error toast AFTER rollback so it appears on the
@@ -586,26 +587,15 @@ extension AppDelegate {
                     self.rollbackToPreviousAssistant(previousAssistant)
                 }
 
+                let toastMessage = previousAssistantId != nil
+                    ? "Assistant is not responding. Switching back to previous assistant."
+                    : "Assistant is not responding. It may be offline."
                 self.mainWindow?.windowState.showToast(
-                    message: "Could not connect to assistant — it may be offline",
+                    message: toastMessage,
                     style: .error
                 )
             }
         }
-    }
-
-    /// Waits for `connectionManager.isConnected` to become `true`, polling
-    /// every 500ms up to the given timeout in seconds.
-    ///
-    /// Returns `true` if the connection was established within the timeout,
-    /// `false` otherwise.
-    private func waitForGatewayConnection(timeout: Int) async -> Bool {
-        let iterations = timeout * 2  // 500ms per iteration
-        for _ in 0..<iterations {
-            if connectionManager.isConnected { return true }
-            try? await Task.sleep(nanoseconds: 500_000_000)
-        }
-        return connectionManager.isConnected
     }
 
     /// Rolls back to a previous assistant after a failed switch. Performs

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -529,11 +529,7 @@ extension AppDelegate {
     func performRetireAsync() async -> Bool {
         let assistantName = UserDefaults.standard.string(forKey: "connectedAssistantId")
 
-        if assistantName == nil {
-            log.error("No stored connected assistant ID found — skipping retire")
-        }
-
-        if let name = assistantName {
+        if let assistantName {
             // Disconnect SSE and health checks *before* the CLI kills the
             // daemon/gateway. Otherwise the EventStreamClient reconnect loop
             // hits the gateway while the upstream daemon is already dead,
@@ -541,7 +537,7 @@ extension AppDelegate {
             connectionManager.disconnect()
 
             do {
-                try await vellumCli.retire(name: name)
+                try await vellumCli.retire(name: assistantName)
             } catch {
                 log.error("CLI retire failed: \(error.localizedDescription)")
                 let alert = NSAlert()
@@ -559,44 +555,52 @@ extension AppDelegate {
                 }
                 // Retire failed but user chose Force Remove — stop the assistant
                 // before cleaning up local state.
-                await vellumCli.stop(name: name)
-                self.removeLockfileEntry(assistantId: name)
+                await vellumCli.stop(name: assistantName)
+                self.removeLockfileEntry(assistantId: assistantName)
+            }
+
+            // Check if other assistants remain in the lockfile.
+            // Prefer remote assistants (always reachable), then try waking local ones.
+            let remaining = LockfileAssistant.loadAll().filter { $0.assistantId != assistantName && $0.isCurrentEnvironment }
+            if !remaining.isEmpty {
+                // Try remote assistants first — they're always reachable
+                if let remote = remaining.first(where: { $0.isRemote }) {
+                    performSwitchAssistant(to: remote)
+                    return true
+                }
+
+                // Try local assistants — check if awake, otherwise wake them
+                for candidate in remaining {
+                    if await HealthCheckClient.isReachable(for: candidate) {
+                        performSwitchAssistant(to: candidate)
+                        return true
+                    }
+
+                    // Sleeping — try to wake it
+                    do {
+                        try await vellumCli.wake(name: candidate.assistantId)
+                        performSwitchAssistant(to: candidate)
+                        return true
+                    } catch {
+                        log.warning("Failed to wake \(candidate.assistantId): \(error.localizedDescription)")
+                        continue
+                    }
+                }
+                // All local wake attempts failed — fall through to onboarding
             }
         } else {
-            await vellumCli.stop(name: assistantName)
+            // Corrupted state: no connectedAssistantId in UserDefaults.
+            // Skip CLI retire/stop (no name to pass) but fall through to
+            // full teardown + onboarding so the user can recover.
+            log.warning("No stored connected assistant ID found — skipping CLI retire, falling through to teardown")
+            mainWindow?.windowState.showToast(
+                message: "No assistant selected — resetting to onboarding.",
+                style: .warning
+            )
+            connectionManager.disconnect()
         }
 
-        // Check if other assistants remain in the lockfile.
-        // Prefer remote assistants (always reachable), then try waking local ones.
-        let remaining = LockfileAssistant.loadAll().filter { $0.assistantId != assistantName && $0.isCurrentEnvironment }
-        if !remaining.isEmpty {
-            // Try remote assistants first — they're always reachable
-            if let remote = remaining.first(where: { $0.isRemote }) {
-                performSwitchAssistant(to: remote)
-                return true
-            }
-
-            // Try local assistants — check if awake, otherwise wake them
-            for candidate in remaining {
-                if await HealthCheckClient.isReachable(for: candidate) {
-                    performSwitchAssistant(to: candidate)
-                    return true
-                }
-
-                // Sleeping — try to wake it
-                do {
-                    try await vellumCli.wake(name: candidate.assistantId)
-                    performSwitchAssistant(to: candidate)
-                    return true
-                } catch {
-                    log.warning("Failed to wake \(candidate.assistantId): \(error.localizedDescription)")
-                    continue
-                }
-            }
-            // All local wake attempts failed — fall through to onboarding
-        }
-
-        // No assistants left — tear down fully and show onboarding
+        // No assistants left (or corrupted state) — tear down fully and show onboarding
         AvatarAppearanceManager.shared.resetForDisconnect()
         OnboardingState.clearPersistedState()
         UserDefaults.standard.removeObject(forKey: "bootstrapState")

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -602,6 +602,9 @@ extension AppDelegate {
     /// the same sequence as `performSwitchAssistant` but without the
     /// post-switch validation to avoid infinite rollback loops.
     private func rollbackToPreviousAssistant(_ assistant: LockfileAssistant) {
+        // Invalidate any in-flight bootstrap tasks from the failed switch
+        switchGeneration += 1
+
         // Disconnect the failed connection
         connectionManager.disconnect()
         AvatarAppearanceManager.shared.resetForDisconnect()

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -340,6 +340,7 @@ extension AppDelegate {
 
         log.info("Starting local assistant API key provisioning for \(assistantId, privacy: .public)")
 
+        let generation = self.switchGeneration
         Task {
             // Wait for the actor token — GatewayHTTPClient requires it for
             // auth and will throw immediately if it's not available yet.
@@ -348,12 +349,21 @@ extension AppDelegate {
                 for attempt in 1...6 {
                     token = await ActorTokenManager.waitForToken(timeout: 10)
                     if token != nil { break }
+                    guard self.switchGeneration == generation else {
+                        log.info("Local API key provisioning aborted — assistant switch generation changed (attempt \(attempt))")
+                        return
+                    }
                     log.info("Actor token not yet available (attempt \(attempt)/6), retrying...")
                 }
                 guard token != nil else {
                     log.warning("No actor token available for local API key provisioning after 60s")
                     return
                 }
+            }
+
+            guard self.switchGeneration == generation else {
+                log.info("Local API key provisioning aborted — assistant switch generation changed (after token wait)")
+                return
             }
 
             // Wait for the assistant (and gateway) to be reachable. The bootstrap
@@ -365,10 +375,19 @@ extension AppDelegate {
                 for attempt in 1...20 {
                     if self.connectionManager.isConnected { break }
                     try? await Task.sleep(nanoseconds: 500_000_000)
+                    guard self.switchGeneration == generation else {
+                        log.info("Local API key provisioning aborted — assistant switch generation changed (connection wait attempt \(attempt))")
+                        return
+                    }
                     if attempt == 20 {
                         log.warning("Assistant not connected after 10s — proceeding with credential bootstrap anyway")
                     }
                 }
+            }
+
+            guard self.switchGeneration == generation else {
+                log.info("Local API key provisioning aborted — assistant switch generation changed (before bootstrap)")
+                return
             }
 
             do {
@@ -381,11 +400,22 @@ extension AppDelegate {
                 )
                 log.info("Local assistant registered: \(platformId, privacy: .public)")
 
+                guard self.switchGeneration == generation else {
+                    log.info("Local API key provisioning completed but assistant switched — discarding result")
+                    return
+                }
+
                 self.localBootstrapDidComplete = true
                 SentryDeviceInfo.updateOrganizationTag(UserDefaults.standard.string(forKey: "connectedOrganizationId"))
                 NotificationCenter.default.post(name: .localBootstrapCompleted, object: nil)
             } catch {
                 log.error("Failed to provision local assistant API key: \(error.localizedDescription)")
+
+                guard self.switchGeneration == generation else {
+                    log.info("Local API key provisioning failed but assistant switched — suppressing error toast")
+                    return
+                }
+
                 self.localBootstrapDidComplete = true
                 SentryDeviceInfo.updateOrganizationTag(UserDefaults.standard.string(forKey: "connectedOrganizationId"))
                 NotificationCenter.default.post(name: .localBootstrapCompleted, object: nil)
@@ -460,6 +490,12 @@ extension AppDelegate {
     /// synchronous path (non-managed or already-authenticated) and from
     /// the async token-validation path.
     private func performSwitchAssistantCore(to assistant: LockfileAssistant) {
+        // Cancel any in-flight bootstrap tasks from a previous assistant switch.
+        // Incrementing switchGeneration causes running bootstrap tasks to detect
+        // staleness and abort, preventing credential confusion during rapid switches.
+        switchGeneration += 1
+        actorTokenBootstrapTask?.cancel()
+        actorTokenBootstrapTask = nil
         // Cancel any in-flight validation task from a previous switch so a
         // stale timeout doesn't rollback to the wrong assistant (A→B→C race).
         switchValidationTask?.cancel()
@@ -492,8 +528,6 @@ extension AppDelegate {
         UserDefaults.standard.removeObject(forKey: "connectedOrganizationId")
         SentryDeviceInfo.updateOrganizationTag(nil)
         // Clear stale actor token for the previous assistant
-        actorTokenBootstrapTask?.cancel()
-        actorTokenBootstrapTask = nil
         ActorTokenManager.deleteToken()
 
         // 4. Reconfigure transport and reconnect

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -438,7 +438,7 @@ extension AppDelegate {
     /// 3. Persist the new assistant selection
     /// 4. Reconfigure transport and reconnect
     /// 5. Resume credential bootstrap
-    func performSwitchAssistant(to assistant: LockfileAssistant) {
+    func performSwitchAssistant(to assistant: LockfileAssistant, skipValidation: Bool = false) {
         // If switching to a managed assistant while logged out, check whether
         // a valid session token exists before forcing re-authentication.
         // The in-memory auth state may be stale (tied to the previous assistant's
@@ -451,7 +451,7 @@ extension AppDelegate {
                     // proceed with the switch directly without showing login.
                     await authManager.checkSession()
                     log.info("[switchAssistant] Session token valid — proceeding with managed switch to \(assistant.assistantId, privacy: .public) without re-auth")
-                    self.performSwitchAssistantCore(to: assistant)
+                    self.performSwitchAssistantCore(to: assistant, skipValidation: skipValidation)
                 } else {
                     // Token is expired/invalid — persist the target and show login.
                     log.info("[switchAssistant] Session token invalid — requiring re-auth for managed switch to \(assistant.assistantId, privacy: .public)")
@@ -462,7 +462,7 @@ extension AppDelegate {
             return
         }
 
-        performSwitchAssistantCore(to: assistant)
+        performSwitchAssistantCore(to: assistant, skipValidation: skipValidation)
     }
 
     /// Validates the stored session token against the platform API.
@@ -489,7 +489,7 @@ extension AppDelegate {
     /// Core switch logic, extracted so it can be called both from the
     /// synchronous path (non-managed or already-authenticated) and from
     /// the async token-validation path.
-    private func performSwitchAssistantCore(to assistant: LockfileAssistant) {
+    private func performSwitchAssistantCore(to assistant: LockfileAssistant, skipValidation: Bool = false) {
         // Cancel any in-flight bootstrap tasks from a previous assistant switch.
         // Incrementing switchGeneration causes running bootstrap tasks to detect
         // staleness and abort, preventing credential confusion during rapid switches.
@@ -566,36 +566,41 @@ extension AppDelegate {
         //    Uses verifyAssistantReady() which checks both SSE connection state
         //    and the gateway health endpoint. If the assistant doesn't respond
         //    within the timeout, roll back to the previous assistant.
-        self.switchValidationTask = Task { @MainActor [weak self] in
-            guard let self else { return }
+        //    Skip validation when the caller plans to retire/stop the previous
+        //    assistant — rolling back to a dead assistant would be worse than
+        //    staying on the new one.
+        if !skipValidation {
+            self.switchValidationTask = Task { @MainActor [weak self] in
+                guard let self else { return }
 
-            do {
-                try await self.verifyAssistantReady(timeout: 15)
-            } catch {
-                // If a newer switch cancelled this task, bail out — the rollback
-                // target (previousAssistantId) is stale.
-                guard !Task.isCancelled else { return }
+                do {
+                    try await self.verifyAssistantReady(timeout: 15)
+                } catch {
+                    // If a newer switch cancelled this task, bail out — the rollback
+                    // target (previousAssistantId) is stale.
+                    guard !Task.isCancelled else { return }
 
-                log.error("Assistant readiness check failed after switching to \(assistant.assistantId, privacy: .public): \(error.localizedDescription) — rolling back")
+                    log.error("Assistant readiness check failed after switching to \(assistant.assistantId, privacy: .public): \(error.localizedDescription) — rolling back")
 
-                // Roll back to the previous assistant if one was connected.
-                // Show the error toast AFTER rollback so it appears on the
-                // newly created main window (rollback closes the current one).
-                var didRollback = false
-                if let previousAssistantId,
-                   let previousAssistant = LockfileAssistant.loadByName(previousAssistantId) {
-                    log.info("Rolling back to previous assistant \(previousAssistantId, privacy: .public)")
-                    self.rollbackToPreviousAssistant(previousAssistant)
-                    didRollback = true
+                    // Roll back to the previous assistant if one was connected.
+                    // Show the error toast AFTER rollback so it appears on the
+                    // newly created main window (rollback closes the current one).
+                    var didRollback = false
+                    if let previousAssistantId,
+                       let previousAssistant = LockfileAssistant.loadByName(previousAssistantId) {
+                        log.info("Rolling back to previous assistant \(previousAssistantId, privacy: .public)")
+                        self.rollbackToPreviousAssistant(previousAssistant)
+                        didRollback = true
+                    }
+
+                    let toastMessage = didRollback
+                        ? "Assistant is not responding. Switching back to previous assistant."
+                        : "Assistant is not responding. It may be offline."
+                    self.mainWindow?.windowState.showToast(
+                        message: toastMessage,
+                        style: .error
+                    )
                 }
-
-                let toastMessage = didRollback
-                    ? "Assistant is not responding. Switching back to previous assistant."
-                    : "Assistant is not responding. It may be offline."
-                self.mainWindow?.windowState.showToast(
-                    message: toastMessage,
-                    style: .error
-                )
             }
         }
     }
@@ -731,21 +736,21 @@ extension AppDelegate {
             if !remaining.isEmpty {
                 // Try remote assistants first — they're always reachable
                 if let remote = remaining.first(where: { $0.isRemote }) {
-                    performSwitchAssistant(to: remote)
+                    performSwitchAssistant(to: remote, skipValidation: true)
                     return true
                 }
 
                 // Try local assistants — check if awake, otherwise wake them
                 for candidate in remaining {
                     if await HealthCheckClient.isReachable(for: candidate) {
-                        performSwitchAssistant(to: candidate)
+                        performSwitchAssistant(to: candidate, skipValidation: true)
                         return true
                     }
 
                     // Sleeping — try to wake it
                     do {
                         try await vellumCli.wake(name: candidate.assistantId)
-                        performSwitchAssistant(to: candidate)
+                        performSwitchAssistant(to: candidate, skipValidation: true)
                         return true
                     } catch {
                         log.warning("Failed to wake \(candidate.assistantId): \(error.localizedDescription)")

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -417,6 +417,15 @@ extension AppDelegate {
             return
         }
 
+        // Cancel any in-flight validation task from a previous switch so a
+        // stale timeout doesn't rollback to the wrong assistant (A→B→C race).
+        switchValidationTask?.cancel()
+        switchValidationTask = nil
+
+        // Capture the previous assistant ID before any state changes so we can
+        // rollback if the new assistant's gateway connection fails.
+        let previousAssistantId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+
         // 1. Clear assistant-scoped runtime state while the assistant is still
         // running so forceStop can deliver a recording_status message.
         recordingManager.forceStop()
@@ -472,6 +481,88 @@ extension AppDelegate {
 
         // Reload avatar for the new assistant (customAvatarURL now resolves
         // to the new assistant's path after connectedAssistantId was updated).
+        AvatarAppearanceManager.shared.reloadAvatar()
+
+        showMainWindow()
+
+        // 7. Validate the gateway connection with a timeout. If the connection
+        //    doesn't establish within 15 seconds, roll back to the previous
+        //    assistant so the app doesn't end up in a broken state.
+        self.switchValidationTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+
+            let connected = await self.waitForGatewayConnection(timeout: 15)
+
+            // If a newer switch cancelled this task, bail out — the rollback
+            // target (previousAssistantId) is stale.
+            guard !Task.isCancelled else { return }
+
+            if !connected {
+                log.error("Gateway connection failed after switching to \(assistant.assistantId, privacy: .public) — rolling back")
+
+                // Roll back to the previous assistant if one was connected.
+                // Show the error toast AFTER rollback so it appears on the
+                // newly created main window (rollback closes the current one).
+                if let previousAssistantId,
+                   let previousAssistant = LockfileAssistant.loadByName(previousAssistantId) {
+                    log.info("Rolling back to previous assistant \(previousAssistantId, privacy: .public)")
+                    self.rollbackToPreviousAssistant(previousAssistant)
+                }
+
+                self.mainWindow?.windowState.showToast(
+                    message: "Could not connect to assistant — it may be offline",
+                    style: .error
+                )
+            }
+        }
+    }
+
+    /// Waits for `connectionManager.isConnected` to become `true`, polling
+    /// every 500ms up to the given timeout in seconds.
+    ///
+    /// Returns `true` if the connection was established within the timeout,
+    /// `false` otherwise.
+    private func waitForGatewayConnection(timeout: Int) async -> Bool {
+        let iterations = timeout * 2  // 500ms per iteration
+        for _ in 0..<iterations {
+            if connectionManager.isConnected { return true }
+            try? await Task.sleep(nanoseconds: 500_000_000)
+        }
+        return connectionManager.isConnected
+    }
+
+    /// Rolls back to a previous assistant after a failed switch. Performs
+    /// the same sequence as `performSwitchAssistant` but without the
+    /// post-switch validation to avoid infinite rollback loops.
+    private func rollbackToPreviousAssistant(_ assistant: LockfileAssistant) {
+        // Disconnect the failed connection
+        connectionManager.disconnect()
+        AvatarAppearanceManager.shared.resetForDisconnect()
+        threadWindowManager?.closeAll()
+        mainWindow?.close()
+        mainWindow = nil
+
+        // Restore the previous assistant selection
+        UserDefaults.standard.set(assistant.assistantId, forKey: "connectedAssistantId")
+        SentryDeviceInfo.updateAssistantTag(assistant.assistantId)
+        UserDefaults.standard.removeObject(forKey: "connectedOrganizationId")
+        SentryDeviceInfo.updateOrganizationTag(nil)
+        actorTokenBootstrapTask?.cancel()
+        actorTokenBootstrapTask = nil
+        ActorTokenManager.deleteToken()
+
+        // Reconfigure transport and reconnect
+        hasSetupDaemon = false
+        setupGatewayConnectionManager()
+
+        if !isCurrentAssistantManaged {
+            ensureActorCredentials()
+        }
+        localBootstrapDidComplete = false
+        ensureLocalAssistantApiKey()
+        syncApiKeysToAssistant(assistant)
+
+        featureFlagStore.reloadFromDisk()
         AvatarAppearanceManager.shared.reloadAvatar()
 
         showMainWindow()

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -581,13 +581,15 @@ extension AppDelegate {
                 // Roll back to the previous assistant if one was connected.
                 // Show the error toast AFTER rollback so it appears on the
                 // newly created main window (rollback closes the current one).
+                var didRollback = false
                 if let previousAssistantId,
                    let previousAssistant = LockfileAssistant.loadByName(previousAssistantId) {
                     log.info("Rolling back to previous assistant \(previousAssistantId, privacy: .public)")
                     self.rollbackToPreviousAssistant(previousAssistant)
+                    didRollback = true
                 }
 
-                let toastMessage = previousAssistantId != nil
+                let toastMessage = didRollback
                     ? "Assistant is not responding. Switching back to previous assistant."
                     : "Assistant is not responding. It may be offline."
                 self.mainWindow?.windowState.showToast(

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -717,6 +717,10 @@ extension AppDelegate {
                 self.removeLockfileEntry(assistantId: assistantName)
             }
 
+            // Explicitly stop the retired assistant's processes to ensure
+            // nothing lingers (the CLI retire may not kill all child processes).
+            await vellumCli.stop(name: assistantName)
+
             // Check if other assistants remain in the lockfile.
             // Prefer remote assistants (always reachable), then try waking local ones.
             let remaining = LockfileAssistant.loadAll().filter { $0.assistantId != assistantName && $0.isCurrentEnvironment }

--- a/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
@@ -180,6 +180,7 @@ extension AppDelegate {
             }
         }
 
+        let generation = self.switchGeneration
         actorTokenBootstrapTask = Task { [weak self] in
             guard let self else { return }
 
@@ -196,10 +197,20 @@ extension AppDelegate {
                 await self.performInitialBootstrap()
             }
 
+            guard self.switchGeneration == generation else {
+                log.info("Actor credential bootstrap aborted — assistant switch generation changed (after initial bootstrap)")
+                return
+            }
+
             // Run proactive refresh loop
             while !Task.isCancelled {
                 try? await Task.sleep(nanoseconds: 5 * 60 * 1_000_000_000) // Check every 5 minutes
                 guard !Task.isCancelled else { return }
+
+                guard self.switchGeneration == generation else {
+                    log.info("Actor credential refresh loop exiting — assistant switch generation changed")
+                    return
+                }
 
                 if ActorTokenManager.needsProactiveRefresh {
                     guard self.connectionManager.isConnected else { continue }
@@ -240,13 +251,23 @@ extension AppDelegate {
             return
         }
 
+        let generation = self.switchGeneration
         let deviceId = PairingQRCodeSheet.computeHostId()
         let retryDelay: UInt64 = 500_000_000
 
         while !Task.isCancelled {
+            guard self.switchGeneration == generation else {
+                log.info("Initial actor bootstrap aborted — assistant switch generation changed")
+                return
+            }
+
             if !connectionManager.isConnected {
                 await awaitConnectionEstablished()
                 guard !Task.isCancelled else { return }
+                guard self.switchGeneration == generation else {
+                    log.info("Initial actor bootstrap aborted — assistant switch generation changed (after connection wait)")
+                    return
+                }
             }
 
             let success = await GuardianClient().bootstrapActorToken(

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -4,6 +4,15 @@ import os
 
 private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "AppDelegate+ConnectionSetup")
 
+/// Thrown when the assistant does not become ready within the expected timeout.
+enum AssistantNotReadyError: LocalizedError {
+    case timeout
+
+    var errorDescription: String? {
+        "Assistant did not become ready within the expected timeout."
+    }
+}
+
 extension AppDelegate {
 
     // MARK: - Theme
@@ -682,5 +691,47 @@ extension AppDelegate {
         }
 
         log.warning("Could not install CLI symlink for \(commandName) in any candidate directory")
+    }
+
+    // MARK: - Assistant Readiness Check
+
+    /// Verifies the assistant is actually responding after a switch by checking
+    /// both the SSE connection state and the gateway health endpoint.
+    ///
+    /// First waits for `connectionManager.isConnected` to become `true`,
+    /// then performs a health endpoint check to confirm the assistant is
+    /// serving requests (not just accepting TCP connections).
+    ///
+    /// - Parameter timeout: Maximum time to wait in seconds (default 10).
+    /// - Throws: `AssistantNotReadyError.timeout` if the assistant does not
+    ///   become ready within the timeout.
+    func verifyAssistantReady(timeout: TimeInterval = 10) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+
+        // Phase 1: Wait for the SSE connection to establish.
+        while !connectionManager.isConnected {
+            if Date() >= deadline {
+                log.error("verifyAssistantReady: SSE connection not established within \(timeout)s")
+                throw AssistantNotReadyError.timeout
+            }
+            try await Task.sleep(nanoseconds: 1_000_000_000)
+        }
+
+        // Phase 2: Hit the health endpoint to verify the assistant is
+        // actually serving requests. For local assistants this reaches the
+        // gateway's /readyz endpoint; for managed/remote assistants it
+        // routes through GatewayHTTPClient with auth.
+        while Date() < deadline {
+            let healthy = await HealthCheckClient.isReachable(timeout: 2)
+            if healthy {
+                log.info("verifyAssistantReady: assistant is healthy")
+                return
+            }
+            log.info("verifyAssistantReady: health check failed, retrying...")
+            try await Task.sleep(nanoseconds: 1_000_000_000)
+        }
+
+        log.error("verifyAssistantReady: health endpoint not responding within \(timeout)s")
+        throw AssistantNotReadyError.timeout
     }
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -135,12 +135,18 @@ extension AppDelegate {
         // Subscribe to SSE event stream for UI event routing.
         startEventSubscription()
 
+        let generation = self.switchGeneration
         Task {
             // Import guardian token from CLI file before connecting, so the
             // health check has valid credentials in the credential store.
             if let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
                !ActorTokenManager.hasToken {
                 _ = GuardianTokenFileReader.importIfAvailable(assistantId: assistantId)
+            }
+
+            guard self.switchGeneration == generation else {
+                log.info("setupGatewayConnectionManager: aborting connect — assistant switch generation changed")
+                return
             }
 
             if !connectionManager.isConnected && !connectionManager.isConnecting {
@@ -154,6 +160,12 @@ extension AppDelegate {
             } else {
                 log.info("setupGatewayConnectionManager: skipping connect() — isConnected=\(self.connectionManager.isConnected), isConnecting=\(self.connectionManager.isConnecting)")
             }
+
+            guard self.switchGeneration == generation else {
+                log.info("setupGatewayConnectionManager: skipping post-connect setup — assistant switch generation changed")
+                return
+            }
+
             if connectionManager.isConnected {
                 setupAmbientAgent()
                 refreshAppsCache()

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -174,6 +174,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     /// finished before the observer was registered.
     var localBootstrapDidComplete = false
 
+    /// Monotonically increasing counter incremented on each assistant switch.
+    /// Bootstrap tasks capture this value at start and abort early if the
+    /// current generation has advanced, preventing stale credential operations
+    /// from racing with a newer switch.
+    var switchGeneration: Int = 0
+
     /// Onboarding state retained during first-launch so post-hatch logic
     /// can access the randomly-generated avatar traits.
     var onboardingState: OnboardingState?

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -138,6 +138,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     /// cancelled before creating a new subscription (e.g. on reconnection or
     /// assistant switch), preventing duplicate event processing.
     var eventSubscriptionTask: Task<Void, Never>?
+    /// In-flight gateway validation task spawned by `performSwitchAssistant`.
+    /// Stored so it can be cancelled on rapid re-switch to prevent a stale
+    /// timeout from rolling back to the wrong assistant.
+    var switchValidationTask: Task<Void, Never>?
     /// Pending fallback notification tokens, keyed by conversationId.
     /// Used to avoid duplicate native alerts when notification_intent arrives.
     var pendingFallbackNotifications: [String: UUID] = [:]

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -548,12 +548,17 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             // Check for a pending managed assistant switch (set by performSwitchAssistant
             // when the user was logged out). Now that the user has re-authenticated and
             // the app is already set up, complete the switch.
+            // Validate that the pending ID still exists in the lockfile and belongs
+            // to the current platform environment before completing the switch.
             if let pendingId = UserDefaults.standard.string(forKey: "pendingManagedSwitchAssistantId"),
                !pendingId.isEmpty {
                 UserDefaults.standard.removeObject(forKey: "pendingManagedSwitchAssistantId")
-                if let assistant = LockfileAssistant.loadByName(pendingId) {
+                if let assistant = LockfileAssistant.loadByName(pendingId),
+                   assistant.isCurrentEnvironment {
                     performSwitchAssistant(to: assistant)
                     return
+                } else {
+                    log.warning("[proceedToApp] Pending managed switch target '\(pendingId, privacy: .public)' not found in lockfile or not in current environment — ignoring")
                 }
             }
             showMainWindow()
@@ -600,13 +605,18 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         // On cold-start reauth (non-first-launch), check for a pending managed
         // assistant switch BEFORE bootstrapping credentials. This avoids
         // provisioning against the wrong assistant only to immediately switch.
+        // Validate that the pending ID still exists in the lockfile and belongs
+        // to the current platform environment before completing the switch.
         if !isFirstLaunch,
            let pendingId = UserDefaults.standard.string(forKey: "pendingManagedSwitchAssistantId"),
            !pendingId.isEmpty {
             UserDefaults.standard.removeObject(forKey: "pendingManagedSwitchAssistantId")
-            if let assistant = LockfileAssistant.loadByName(pendingId) {
+            if let assistant = LockfileAssistant.loadByName(pendingId),
+               assistant.isCurrentEnvironment {
                 performSwitchAssistant(to: assistant)
                 return
+            } else {
+                log.warning("[proceedToApp] Pending managed switch target '\(pendingId, privacy: .public)' not found in lockfile or not in current environment — ignoring")
             }
         }
 

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -163,7 +163,7 @@ struct AssistantTransferSection: View {
             guard let managedAssistant = LockfileAssistant.loadAll().first(where: { $0.assistantId == platformAssistant.id && $0.isManaged }) else {
                 throw TransferError.managedEntryNotFound
             }
-            AppDelegate.shared?.performSwitchAssistant(to: managedAssistant)
+            AppDelegate.shared?.performSwitchAssistant(to: managedAssistant, skipValidation: true)
             transferTask = nil
             onClose()
 
@@ -296,7 +296,7 @@ struct AssistantTransferSection: View {
             }
 
             // Step 7 — Switch to local assistant now that import succeeded
-            AppDelegate.shared?.performSwitchAssistant(to: resolvedLocal)
+            AppDelegate.shared?.performSwitchAssistant(to: resolvedLocal, skipValidation: true)
             transferTask = nil
             onClose()
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -170,9 +170,12 @@ struct SettingsDeveloperTab: View {
             }
         } message: {
             if lockfileAssistants.count > 1 {
-                Text("This will stop the current assistant and switch to another. The retired assistant's lockfile entry will be removed.")
+                let otherAssistants = lockfileAssistants.filter { $0.assistantId != selectedAssistantId }
+                let nextAssistant = otherAssistants.first(where: { $0.isRemote }) ?? otherAssistants.first
+                let nextName = nextAssistant.map { displayNames[$0.assistantId] ?? $0.assistantId } ?? "another assistant"
+                Text("This will retire this assistant and switch to \(nextName). The retired assistant's lockfile entry will be removed.")
             } else {
-                Text("This will stop the assistant, remove local data, and return to initial setup. This action cannot be undone.")
+                Text("This will retire your only assistant and return you to setup. This action cannot be undone.")
             }
         }
         .alert("Restart Assistant", isPresented: $showingRestartConfirmation) {
@@ -815,8 +818,8 @@ struct SettingsDeveloperTab: View {
         SettingsCard(
             title: "Retire Assistant",
             subtitle: lockfileAssistants.count > 1
-                ? "Stops the current assistant and switches to another."
-                : "Stops the assistant, removes local data, and returns to initial setup."
+                ? "Retires the current assistant and switches to the next available one."
+                : "Retires your only assistant and returns to initial setup."
         ) {
             VButton(label: "Retire", style: .danger) {
                 showingRetireConfirmation = true

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -36,6 +36,8 @@ struct SettingsDeveloperTab: View {
     @State private var devModeTapCount: Int = 0
     @State private var devModeMessage: String?
     @State private var showingHatchConfirmation: Bool = false
+    @State private var showingExistingManagedAssistantDialog: Bool = false
+    @State private var existingManagedAssistant: LockfileAssistant?
     @State private var displayNames: [String: String] = [:]
     @State private var awakeStates: [String: Bool] = [:]
     @State private var transitioningStates: Set<String> = []
@@ -889,7 +891,14 @@ struct SettingsDeveloperTab: View {
     private var hatchNewAssistantSection: some View {
         SettingsCard(title: "Hatch New Assistant", subtitle: "Starts the initial setup flow to create a new assistant.") {
             VButton(label: "Hatch", style: .primary) {
-                showingHatchConfirmation = true
+                // Pre-check: if the user is authenticated, look for an existing managed assistant
+                if authManager.isAuthenticated,
+                   let managed = ManagedAssistantBootstrapService.shared.checkExistingManagedAssistant() {
+                    existingManagedAssistant = managed
+                    showingExistingManagedAssistantDialog = true
+                } else {
+                    showingHatchConfirmation = true
+                }
             }
             .alert("Hatch New Assistant", isPresented: $showingHatchConfirmation) {
                 Button("Cancel", role: .cancel) {}
@@ -899,6 +908,20 @@ struct SettingsDeveloperTab: View {
                 }
             } message: {
                 Text("This will create a brand new assistant. Your existing assistant(s) will continue to exist and you can switch back to using them.")
+            }
+            .alert("Existing Managed Assistant Found", isPresented: $showingExistingManagedAssistantDialog) {
+                Button("Cancel", role: .cancel) {}
+                Button("Switch to Existing") {
+                    if let managed = existingManagedAssistant {
+                        switchToAssistant(managed)
+                    }
+                }
+                Button("Hatch Local Assistant") {
+                    AppDelegate.shared?.hatchNewAssistant()
+                    onClose()
+                }
+            } message: {
+                Text("You already have a managed assistant. Would you like to switch to it instead?")
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -956,8 +956,11 @@ struct SettingsDeveloperTab: View {
         SettingsCard(title: "Hatch New Assistant", subtitle: "Starts the initial setup flow to create a new assistant.") {
             VButton(label: "Hatch", style: .primary, isDisabled: isSwitching) {
                 // Pre-check: if the user is authenticated, look for an existing managed assistant
+                // that is different from the one already connected (skip the dialog for same-assistant).
+                let currentConnectedId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
                 if authManager.isAuthenticated,
-                   let managed = ManagedAssistantBootstrapService.shared.checkExistingManagedAssistant() {
+                   let managed = ManagedAssistantBootstrapService.shared.checkExistingManagedAssistant(),
+                   managed.assistantId != currentConnectedId {
                     existingManagedAssistant = managed
                     showingExistingManagedAssistantDialog = true
                 } else {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -43,6 +43,12 @@ struct SettingsDeveloperTab: View {
     @State private var transitioningStates: Set<String> = []
     @State private var platformUuid: String?
 
+    // -- Switch assistant UX state --
+    @State private var isSwitching: Bool = false
+    @State private var switchStatus: String?
+    @State private var switchStatusIsError: Bool = false
+    @State private var switchStatusDismissTask: Task<Void, Never>?
+
     // -- Advanced dev state --
     @State private var macOSFlagStates: [MacOSFeatureFlagState] = []
     @State private var assistantFlags: [AssistantFeatureFlag] = []
@@ -549,18 +555,43 @@ struct SettingsDeveloperTab: View {
                         .font(VFont.bodySmallDefault)
                         .foregroundStyle(VColor.contentSecondary)
                     Spacer()
+                    if isSwitching {
+                        HStack(spacing: VSpacing.xs) {
+                            ProgressView()
+                                .controlSize(.small)
+                            Text("Switching\u{2026}")
+                                .font(VFont.bodySmallDefault)
+                                .foregroundStyle(VColor.contentTertiary)
+                        }
+                    }
                     VDropdown(
                         placeholder: "",
                         selection: $selectedAssistantId,
                         options: awakeAssistants.map { (label: displayLabel(for: $0), value: $0.assistantId) },
                         maxWidth: 200
                     )
+                    .disabled(isSwitching)
+                }
+
+                if let status = switchStatus {
+                    HStack(spacing: VSpacing.xs) {
+                        Image(systemName: switchStatusIsError ? "xmark.circle.fill" : "checkmark.circle.fill")
+                            .foregroundStyle(switchStatusIsError ? VColor.systemNegativeStrong : VColor.systemPositiveStrong)
+                        Text(status)
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(switchStatusIsError ? VColor.systemNegativeStrong : VColor.systemPositiveStrong)
+                    }
+                    .transition(.opacity)
                 }
             }
             .onChange(of: selectedAssistantId) { oldValue, newValue in
                 resolvePlatformUuid()
                 let currentId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
                 guard newValue != currentId, newValue != oldValue else { return }
+                guard !isSwitching else {
+                    selectedAssistantId = oldValue
+                    return
+                }
                 guard let assistant = lockfileAssistants.first(where: { $0.assistantId == newValue }) else { return }
                 guard awakeStates[assistant.assistantId] == true else {
                     selectedAssistantId = currentId
@@ -577,6 +608,7 @@ struct SettingsDeveloperTab: View {
 
     private func toggleDisabled(for assistant: LockfileAssistant) -> Bool {
         if assistant.isRemote { return true }
+        if isSwitching { return true }
         if transitioningStates.contains(assistant.assistantId) { return true }
         return false
     }
@@ -644,8 +676,37 @@ struct SettingsDeveloperTab: View {
     }
 
     private func switchToAssistant(_ assistant: LockfileAssistant) {
+        guard !isSwitching else { return }
+        isSwitching = true
+        let targetName = displayLabel(for: assistant)
         AppDelegate.shared?.performSwitchAssistant(to: assistant)
-        onClose()
+        // performSwitchAssistant kicks off validation in a background Task.
+        // Wait briefly, then verify the switch actually stuck by checking
+        // the persisted connectedAssistantId — managed switches can trigger
+        // auth flows and post-switch readiness checks may roll back.
+        Task {
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            isSwitching = false
+            let currentId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
+            if currentId == assistant.assistantId {
+                showSwitchStatus("Switched to \(targetName)", isError: false)
+            } else {
+                showSwitchStatus("Switch to \(targetName) did not complete", isError: true)
+            }
+        }
+    }
+
+    private func showSwitchStatus(_ message: String, isError: Bool) {
+        switchStatusDismissTask?.cancel()
+        switchStatusIsError = isError
+        withAnimation { switchStatus = message }
+        switchStatusDismissTask = Task {
+            try? await Task.sleep(nanoseconds: 4_000_000_000)
+            guard !Task.isCancelled else { return }
+            withAnimation {
+                if switchStatus == message { switchStatus = nil }
+            }
+        }
     }
 
     // MARK: - Restart Assistant
@@ -821,7 +882,7 @@ struct SettingsDeveloperTab: View {
                 ? "Retires the current assistant and switches to the next available one."
                 : "Retires your only assistant and returns to initial setup."
         ) {
-            VButton(label: "Retire", style: .danger) {
+            VButton(label: "Retire", style: .danger, isDisabled: isSwitching) {
                 showingRetireConfirmation = true
             }
         }
@@ -893,7 +954,7 @@ struct SettingsDeveloperTab: View {
 
     private var hatchNewAssistantSection: some View {
         SettingsCard(title: "Hatch New Assistant", subtitle: "Starts the initial setup flow to create a new assistant.") {
-            VButton(label: "Hatch", style: .primary) {
+            VButton(label: "Hatch", style: .primary, isDisabled: isSwitching) {
                 // Pre-check: if the user is authenticated, look for an existing managed assistant
                 if authManager.isAuthenticated,
                    let managed = ManagedAssistantBootstrapService.shared.checkExistingManagedAssistant() {

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -256,8 +256,11 @@ struct TeleportSection: View {
         guard let target = targetAssistant else { return }
         let original = originalAssistant
 
-        // Switch to the new assistant (this destroys the window)
-        AppDelegate.shared?.performSwitchAssistant(to: target)
+        // Switch to the new assistant (this destroys the window).
+        // Skip post-switch validation because we retire the previous
+        // assistant immediately — rolling back to a dead assistant
+        // would be worse than staying on the new one.
+        AppDelegate.shared?.performSwitchAssistant(to: target, skipValidation: true)
 
         // Fire-and-forget retirement of the old assistant
         if let original {

--- a/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
@@ -195,6 +195,16 @@ public final class ManagedAssistantBootstrapService {
         }
     }
 
+    #if os(macOS)
+    /// Fast, local-only check for an existing managed assistant in the current
+    /// platform environment. Inspects the lockfile without making any network
+    /// calls, so it can gate the more expensive hatch flow cheaply.
+    public func checkExistingManagedAssistant() -> LockfileAssistant? {
+        let all = LockfileAssistant.loadAll()
+        return all.first { $0.isManaged && $0.isCurrentEnvironment }
+    }
+    #endif
+
     private func mapPlatformError(_ error: PlatformAPIError) -> ManagedBootstrapError {
         switch error {
         case .authenticationRequired:


### PR DESCRIPTION
## Summary
Comprehensive reliability and UX improvements to assistant management from the developer tab. Fixes the painful logout/login cycle when switching to managed assistants, prevents confusing failures when hatching duplicate managed assistants, and adds proper validation, rollback, and feedback throughout the switch/hatch/retire flows.

## PRs merged into feature branch
- #22670: fix: guard nil assistant name in retire and add early return
- #22674: fix: validate gateway connection succeeds after switching assistants
- #22672: fix: handle managed assistant switch without requiring re-login
- #22671: fix: check for existing managed assistant before hatching from developer tab
- #22673: fix: cancel stale bootstrap tasks when switching assistants
- #22681: feat: add post-switch assistant health check with retry
- #22680: fix: improve retire flow with proper cleanup and last-assistant guard
- #22683: feat: add loading state and status feedback to assistant switch in developer tab

Part of plan: asst-swap-reliability.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22684" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
