### PR TITLE
fix: increment switchGeneration in rollbackToPreviousAssistant

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -602,6 +602,9 @@ extension AppDelegate {
     /// the same sequence as `performSwitchAssistant` but without the
     /// post-switch validation to avoid infinite rollback loops.
     private func rollbackToPreviousAssistant(_ assistant: LockfileAssistant) {
+        // Invalidate any in-flight bootstrap tasks from the failed switch
+        switchGeneration += 1
+
         // Disconnect the failed connection
         connectionManager.disconnect()
         AvatarAppearanceManager.shared.resetForDisconnect()


### PR DESCRIPTION
## Summary
- Increment switchGeneration at the start of rollback to invalidate stale bootstrap tasks from the failed switch
- Prevents credential races between old and new bootstrap tasks during rollback

Fixes gap identified during plan review for asst-swap-reliability.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
