### PR TITLE
fix: track actual rollback success for accurate toast message

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -581,13 +581,15 @@ extension AppDelegate {
                 // Roll back to the previous assistant if one was connected.
                 // Show the error toast AFTER rollback so it appears on the
                 // newly created main window (rollback closes the current one).
+                var didRollback = false
                 if let previousAssistantId,
                    let previousAssistant = LockfileAssistant.loadByName(previousAssistantId) {
                     log.info("Rolling back to previous assistant \(previousAssistantId, privacy: .public)")
                     self.rollbackToPreviousAssistant(previousAssistant)
+                    didRollback = true
                 }
 
-                let toastMessage = previousAssistantId != nil
+                let toastMessage = didRollback
                     ? "Assistant is not responding. Switching back to previous assistant."
                     : "Assistant is not responding. It may be offline."
                 self.mainWindow?.windowState.showToast(


### PR DESCRIPTION
## Summary
- Track whether rollback actually occurred with didRollback boolean
- Use didRollback instead of previousAssistantId != nil for toast message
- Prevents misleading 'switching back' message when rollback target was already retired

Fixes gap identified during plan review for asst-swap-reliability.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
