### PR TITLE
fix: remove double vellumCli.stop() on retire force-remove path

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -696,6 +696,9 @@ extension AppDelegate {
 
             do {
                 try await vellumCli.retire(name: assistantName)
+                // Explicitly stop the retired assistant's processes to ensure
+                // nothing lingers (the CLI retire may not kill all child processes).
+                await vellumCli.stop(name: assistantName)
             } catch {
                 log.error("CLI retire failed: \(error.localizedDescription)")
                 let alert = NSAlert()
@@ -716,10 +719,6 @@ extension AppDelegate {
                 await vellumCli.stop(name: assistantName)
                 self.removeLockfileEntry(assistantId: assistantName)
             }
-
-            // Explicitly stop the retired assistant's processes to ensure
-            // nothing lingers (the CLI retire may not kill all child processes).
-            await vellumCli.stop(name: assistantName)
 
             // Check if other assistants remain in the lockfile.
             // Prefer remote assistants (always reachable), then try waking local ones.


### PR DESCRIPTION
## Summary
- Move explicit stop call into the do block so it only runs on successful retire
- Prevents double-stop on the force-remove path where stop was already called

Fixes gap identified during plan review for asst-swap-reliability.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22688" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
