### PR TITLE
fix: skip hatch precheck dialog when managed assistant is already connected

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -956,8 +956,11 @@ struct SettingsDeveloperTab: View {
         SettingsCard(title: "Hatch New Assistant", subtitle: "Starts the initial setup flow to create a new assistant.") {
             VButton(label: "Hatch", style: .primary, isDisabled: isSwitching) {
                 // Pre-check: if the user is authenticated, look for an existing managed assistant
+                // that is different from the one already connected (skip the dialog for same-assistant).
+                let currentConnectedId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
                 if authManager.isAuthenticated,
-                   let managed = ManagedAssistantBootstrapService.shared.checkExistingManagedAssistant() {
+                   let managed = ManagedAssistantBootstrapService.shared.checkExistingManagedAssistant(),
+                   managed.assistantId != currentConnectedId {
                     existingManagedAssistant = managed
                     showingExistingManagedAssistantDialog = true
                 } else {


### PR DESCRIPTION
## Summary
- Skip the 'existing managed assistant' dialog when the found assistant is the currently connected one
- Prevents disruptive no-op switch cycle when user is already on their managed assistant

Fixes gap identified during plan review for asst-swap-reliability.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22690" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
