### PR TITLE
Fix autosuggestion ghost text overlapping with placeholder

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerTextView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerTextView.swift
@@ -12,7 +12,9 @@ final class ComposerTextView: NSTextView {
 
     // MARK: - Properties
 
-    var placeholderString: String = ""
+    var placeholderString: String = "" {
+        didSet { needsDisplay = true }
+    }
     var cmdEnterToSend: Bool = false
     var onSubmit: (() -> Void)?
     var onTab: (() -> Bool)?


### PR DESCRIPTION
## Summary
Add `didSet { needsDisplay = true }` to `ComposerTextView.placeholderString` so the NSTextView redraws when the placeholder is cleared (because ghost text is active). Without this, the stale placeholder from the previous draw pass remains visible while the SwiftUI ghost text overlay shows through the transparent NSTextView.

## Root cause
`placeholderString` was a plain stored property with no observer. When `updateNSView` set it to `""` (to suppress the placeholder for ghost text), the NSTextView never scheduled a redraw. Compare with the `string` property on the same class which correctly has `didSet { needsDisplay = true }`.

Closes #22692
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22693" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
