### PR TITLE
Fix autosuggestion ghost text overlapping with placeholder in composer

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerTextView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerTextView.swift
@@ -12,7 +12,9 @@ final class ComposerTextView: NSTextView {
 
     // MARK: - Properties
 
-    var placeholderString: String = ""
+    var placeholderString: String = "" {
+        didSet { needsDisplay = true }
+    }
     var cmdEnterToSend: Bool = false
     var onSubmit: (() -> Void)?
     var onTab: (() -> Bool)?


### PR DESCRIPTION
## Summary
Fixes the visual overlap between autosuggestion ghost text and placeholder text in the composer input. When a suggestion arrives while the input is empty, both the SwiftUI ghost text overlay and the NSTextView-drawn placeholder were visible simultaneously.

## Changes
- Added `didSet { needsDisplay = true }` to `ComposerTextView.placeholderString` so the NSTextView redraws when the placeholder is cleared by `updateNSView` (because ghost text is active). This matches the existing pattern on the `string` property.

## Root cause
`placeholderString` was a plain stored property with no observer. When `updateNSView` set it to `""` (to suppress the placeholder for ghost text), the NSTextView never scheduled a redraw. The stale placeholder from the previous `draw()` pass remained visible while the SwiftUI ghost text overlay showed through the transparent NSTextView.

## Milestone PRs (merged into feature branch)
- #22693: Fix autosuggestion ghost text overlapping with placeholder

## Project issue
Closes #22691

## Test plan
- [ ] Open a conversation and wait for the assistant to respond — verify the autosuggestion ghost text appears cleanly without the placeholder showing through
- [ ] Verify that when no suggestion is active, the placeholder text displays normally
- [ ] Verify that typing text hides both placeholder and ghost text appropriately
- [ ] Verify that accepting a suggestion (Tab) clears the ghost text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22695" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
