### PR TITLE
fix(slack): allow file_share subtype so image uploads reach the assistant

### DIFF
--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -463,6 +463,103 @@ describe("attachment extraction in normalize functions", () => {
     });
   });
 
+  describe("file_share subtype handling", () => {
+    describe("normalizeSlackDirectMessage", () => {
+      it("normalizes DM with file_share subtype and files", () => {
+        const config = makeConfig();
+        const event = makeDmEvent({
+          subtype: "file_share",
+          files: [
+            makeSlackFile({
+              id: "F030",
+              mimetype: "image/png",
+              name: "screenshot.png",
+            }),
+          ],
+        });
+        const result = normalizeSlackDirectMessage(event, "evt-fs-1", config);
+
+        expect(result).not.toBeNull();
+        expect(result!.event.message.attachments).toHaveLength(1);
+        expect(result!.event.message.attachments![0].fileId).toBe("F030");
+        expect(result!.event.message.attachments![0].type).toBe("image");
+        expect(result!.slackFiles).toBeDefined();
+        expect(result!.slackFiles!.get("F030")!.id).toBe("F030");
+      });
+
+      it("normalizes DM with file_share subtype without files", () => {
+        const config = makeConfig();
+        const event = makeDmEvent({ subtype: "file_share" });
+        const result = normalizeSlackDirectMessage(event, "evt-fs-2", config);
+
+        expect(result).not.toBeNull();
+        expect(result!.event.message.content).toBe("hello");
+        expect(result!.event.message.attachments).toBeUndefined();
+      });
+
+      it("drops DM with bot_message subtype", () => {
+        const config = makeConfig();
+        const event = makeDmEvent({ subtype: "bot_message" });
+        const result = normalizeSlackDirectMessage(event, "evt-fs-3", config);
+
+        expect(result).toBeNull();
+      });
+    });
+
+    describe("normalizeSlackChannelMessage", () => {
+      it("normalizes channel message with file_share subtype and files", () => {
+        const config = makeConfig();
+        const event = makeChannelEvent({
+          subtype: "file_share",
+          files: [
+            makeSlackFile({
+              id: "F031",
+              mimetype: "image/jpeg",
+              name: "photo.jpg",
+            }),
+          ],
+        });
+        const result = normalizeSlackChannelMessage(
+          event,
+          "evt-fs-4",
+          config,
+        );
+
+        expect(result).not.toBeNull();
+        expect(result!.event.message.attachments).toHaveLength(1);
+        expect(result!.event.message.attachments![0].fileId).toBe("F031");
+        expect(result!.event.message.attachments![0].type).toBe("image");
+        expect(result!.slackFiles).toBeDefined();
+      });
+
+      it("normalizes channel message with file_share subtype without files", () => {
+        const config = makeConfig();
+        const event = makeChannelEvent({ subtype: "file_share" });
+        const result = normalizeSlackChannelMessage(
+          event,
+          "evt-fs-5",
+          config,
+        );
+
+        expect(result).not.toBeNull();
+        expect(result!.event.message.content).toBe("hello");
+        expect(result!.event.message.attachments).toBeUndefined();
+      });
+
+      it("drops channel message with bot_message subtype", () => {
+        const config = makeConfig();
+        const event = makeChannelEvent({ subtype: "bot_message" });
+        const result = normalizeSlackChannelMessage(
+          event,
+          "evt-fs-6",
+          config,
+        );
+
+        expect(result).toBeNull();
+      });
+    });
+  });
+
   describe("normalizeSlackAppMention", () => {
     it("populates attachments for app mention events with files", () => {
       const config = makeConfig();

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -317,7 +317,8 @@ export function normalizeSlackDirectMessage(
   if (botUserId && event.user === botUserId) return null;
   // Ignore message subtypes (edits, deletions, etc.) — only handle plain user messages.
   // message_changed is handled separately by normalizeSlackMessageEdit.
-  if (event.subtype) return null;
+  // file_share is allowed so image/file uploads are delivered to the assistant.
+  if (event.subtype && event.subtype !== "file_share") return null;
   // user is required for routing
   if (!event.user) return null;
 
@@ -400,7 +401,8 @@ export function normalizeSlackChannelMessage(
   botToken?: string,
 ): NormalizedSlackEvent | null {
   if (botUserId && event.user === botUserId) return null;
-  if (event.subtype) return null;
+  // file_share is allowed so image/file uploads are delivered to the assistant.
+  if (event.subtype && event.subtype !== "file_share") return null;
   if (!event.user) return null;
 
   const routing = resolveAssistant(config, event.channel, event.user);


### PR DESCRIPTION
## Summary
- Slack sends `subtype: "file_share"` on messages with image/file uploads. Both `normalizeSlackDirectMessage` and `normalizeSlackChannelMessage` dropped all messages with a non-null subtype, silently discarding the entire message (text + image).
- Changed the subtype guard to allow `file_share` through while continuing to block other subtypes.
- Added tests for `file_share` acceptance and other-subtype rejection in both DM and channel normalizers.

## Original prompt
--yolo this

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
