### PR TITLE
Increase provider stream timeout to 30 minutes

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -105,7 +105,7 @@ describe("AssistantConfigSchema", () => {
       shellMaxTimeoutSec: 600,
       permissionTimeoutSec: 300,
       toolExecutionTimeoutSec: 120,
-      providerStreamTimeoutSec: 300,
+      providerStreamTimeoutSec: 1800,
     });
     expect(result.sandbox).toEqual({
       enabled: false,

--- a/assistant/src/config/schemas/timeouts.ts
+++ b/assistant/src/config/schemas/timeouts.ts
@@ -36,7 +36,7 @@ export const TimeoutConfigSchema = z
       .number({ error: "timeouts.providerStreamTimeoutSec must be a number" })
       .finite("timeouts.providerStreamTimeoutSec must be finite")
       .positive("timeouts.providerStreamTimeoutSec must be a positive number")
-      .default(300)
+      .default(1800)
       .describe(
         "Timeout for waiting on the LLM provider's streaming response (seconds)",
       ),

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -678,7 +678,7 @@ export class AnthropicProvider implements Provider {
     this.client = new Anthropic({ apiKey, baseURL: options.baseURL });
     this.model = model;
     this.useNativeWebSearch = options.useNativeWebSearch ?? false;
-    this.streamTimeoutMs = options.streamTimeoutMs ?? 300_000;
+    this.streamTimeoutMs = options.streamTimeoutMs ?? 1_800_000;
   }
 
   async sendMessage(

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -89,7 +89,7 @@ export class GeminiProvider implements Provider {
         })
       : new GoogleGenAI({ apiKey });
     this.model = model;
-    this.streamTimeoutMs = options.streamTimeoutMs ?? 300_000;
+    this.streamTimeoutMs = options.streamTimeoutMs ?? 1_800_000;
   }
 
   async sendMessage(

--- a/assistant/src/providers/openai/client.ts
+++ b/assistant/src/providers/openai/client.ts
@@ -112,7 +112,7 @@ export class OpenAIProvider implements Provider {
       baseURL: options.baseURL,
     });
     this.model = model;
-    this.streamTimeoutMs = options.streamTimeoutMs ?? 300_000;
+    this.streamTimeoutMs = options.streamTimeoutMs ?? 1_800_000;
     this.extraCreateParams = options.extraCreateParams ?? {};
   }
 

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -140,7 +140,7 @@ export async function initializeProviders(
   routingSources.clear();
 
   const streamTimeoutMs =
-    (config.timeouts?.providerStreamTimeoutSec ?? 300) * 1000;
+    (config.timeouts?.providerStreamTimeoutSec ?? 1800) * 1000;
   const inferenceMode = config.services.inference.mode;
   const useNativeWebSearch =
     config.services["web-search"].provider === "inference-provider-native";


### PR DESCRIPTION
## Summary
- Increase the default provider stream timeout from 300s (5 min) to 1800s (30 min) across all providers (Anthropic, OpenAI, Gemini, Ollama, Fireworks, OpenRouter)
- Long-running conversations with extended responses were hitting the 5-minute timeout and aborting mid-stream with "The request was interrupted"

## Original prompt
--yolo increase the stream timeout to 30 minutes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22702" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
