### PR TITLE
Fix: retry after conversation error uses regenerate to avoid duplicate messages

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1621,37 +1621,13 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         }
         dismissConversationError()
 
-        // When the last message is from the user (i.e. the assistant never
-        // responded — e.g. because the send was rate-limited with 429), resend
-        // the original message instead of regenerating. A /regenerate request
-        // would fail with 404 because the daemon never received the message.
-        if let lastMsg = messages.last, lastMsg.role == .user {
-            lastFailedMessageText = lastMsg.text
-            lastFailedMessageDisplayText = nil
-            lastFailedMessageAutomated = lastMsg.isHidden
-            lastFailedMessageBypassSecretCheck = false
-            // Preserve attachments so they are resent with the retry.
-            // ChatAttachment.data may already be cleared for older messages,
-            // but for a just-sent 429'd message it is still populated.
-            // Also keep file-path-based attachments even when data is empty,
-            // since the daemon can read the file from disk.
-            lastFailedMessageAttachments = lastMsg.attachments.compactMap { att in
-                guard !att.data.isEmpty || att.filePath != nil else { return nil }
-                return UserMessageAttachment(
-                    id: att.id,
-                    filename: att.filename,
-                    mimeType: att.mimeType,
-                    data: att.data,
-                    extractedText: nil,
-                    sizeBytes: att.sizeBytes,
-                    thumbnailData: att.thumbnailData?.base64EncodedString(),
-                    filePath: att.filePath
-                )
-            }
-            retryLastMessage()
-        } else {
-            regenerateLastMessage()
-        }
+        // Use regenerate instead of resending: the daemon already persisted
+        // the user message and the error assistant message. Regenerate deletes
+        // the error message and re-runs the agent loop with the existing user
+        // message, avoiding duplicate user messages in history.
+        // Client-side send failures (HTTP 429 from runtime rate limiter, etc.)
+        // use the per-message send failure path and never reach this method.
+        regenerateLastMessage()
     }
 
     /// Whether the current error has a failed user message that can be retried.


### PR DESCRIPTION
## Summary

- Replace the `retryLastMessage()` / `regenerateLastMessage()` branch in `retryAfterConversationError()` with unconditional `regenerateLastMessage()`
- The existing `/regenerate` endpoint already handles deleting the error assistant message from the DB and re-running the agent loop with the original user message — no backend changes needed
- Client-side HTTP send failures (429 from runtime rate limiter, etc.) use the per-message send failure path and never reach `retryAfterConversationError`, so they're unaffected

## Original prompt

Retry after conversation error should use regenerate to clean error messages from history instead of resending (which duplicates user messages)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22703" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
