### PR TITLE
Fix undefined AssemblyOptions type in memory graph injection

### DIFF
--- a/assistant/src/memory/graph/injection.ts
+++ b/assistant/src/memory/graph/injection.ts
@@ -130,7 +130,7 @@ function formatNodeEntry(scored: ScoredNode): string {
  */
 export function assembleContextBlock(
   nodes: ScoredNode[],
-  options?: AssemblyOptions & { serendipityNodes?: ScoredNode[] },
+  options?: { serendipityNodes?: ScoredNode[] },
 ): string {
   // Partition nodes into sections
   const rightNow: ScoredNode[] = [];


### PR DESCRIPTION
## Summary
- Remove reference to non-existent `AssemblyOptions` type in `assembleContextBlock()` that was causing `TS2304: Cannot find name 'AssemblyOptions'` CI failures
- The function only accesses `options?.serendipityNodes`, so the intersection type with the phantom `AssemblyOptions` was unnecessary

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23826739490/job/69451337629
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22704" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
