### PR TITLE
fix: migrate playbook tools and compiler to memory_graph_nodes

### DIFF
--- a/assistant/src/config/bundled-skills/playbooks/tools/playbook-create.ts
+++ b/assistant/src/config/bundled-skills/playbooks/tools/playbook-create.ts
@@ -1,10 +1,10 @@
-import { and, eq } from "drizzle-orm";
-import { v4 as uuid } from "uuid";
+import { sql } from "drizzle-orm";
 
 import { getDb } from "../../../../memory/db.js";
-import { computeMemoryFingerprint } from "../../../../memory/fingerprint.js";
+import { createNode, updateNode } from "../../../../memory/graph/store.js";
+import type { NewNode } from "../../../../memory/graph/types.js";
 import { enqueueMemoryJob } from "../../../../memory/jobs-store.js";
-import { memoryItems } from "../../../../memory/schema.js";
+import { memoryGraphNodes } from "../../../../memory/schema.js";
 import type {
   Playbook,
   PlaybookAutonomyLevel,
@@ -13,7 +13,6 @@ import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
-import { truncate } from "../../../../util/truncate.js";
 
 const VALID_AUTONOMY_LEVELS = new Set<string>(["auto", "draft", "notify"]);
 
@@ -56,27 +55,22 @@ export async function executePlaybookCreate(
     priority,
   };
   const statement = JSON.stringify(playbook);
-  const subject = truncate(`Playbook: ${trigger}`, 80, "");
+  const subject = `Playbook: ${trigger}`.slice(0, 80);
+  const content = `${subject}\n${statement}`;
   const scopeId = context.memoryScopeId ?? "default";
-
-  const fingerprint = computeMemoryFingerprint(
-    scopeId,
-    "playbook",
-    subject,
-    statement,
-  );
 
   try {
     const db = getDb();
 
+    // Check for duplicate by matching content in playbook-prefixed graph nodes
     const existing = db
-      .select()
-      .from(memoryItems)
+      .select({ id: memoryGraphNodes.id })
+      .from(memoryGraphNodes)
       .where(
-        and(
-          eq(memoryItems.fingerprint, fingerprint),
-          eq(memoryItems.scopeId, scopeId),
-        ),
+        sql`${memoryGraphNodes.sourceConversations} LIKE '%playbook:%'
+            AND ${memoryGraphNodes.content} = ${content}
+            AND ${memoryGraphNodes.scopeId} = ${scopeId}
+            AND ${memoryGraphNodes.fidelity} != 'gone'`,
       )
       .get();
 
@@ -87,29 +81,39 @@ export async function executePlaybookCreate(
       };
     }
 
-    const id = uuid();
     const now = Date.now();
+    const newNode: NewNode = {
+      content,
+      type: "semantic",
+      created: now,
+      lastAccessed: now,
+      lastConsolidated: now,
+      emotionalCharge: {
+        valence: 0,
+        intensity: 0.1,
+        decayCurve: "linear",
+        decayRate: 0.05,
+        originalIntensity: 0.1,
+      },
+      fidelity: "vivid",
+      confidence: 0.95,
+      significance: 0.8,
+      stability: 14,
+      reinforcementCount: 0,
+      lastReinforced: now,
+      sourceConversations: [],
+      sourceType: "direct",
+      narrativeRole: null,
+      partOfStory: null,
+      scopeId,
+    };
 
-    db.insert(memoryItems)
-      .values({
-        id,
-        kind: "playbook",
-        subject,
-        statement,
-        status: "active",
-        confidence: 0.95,
-        importance: 0.8,
-        fingerprint,
-        sourceType: "tool",
-        verificationState: "user_confirmed",
-        scopeId,
-        firstSeenAt: now,
-        lastSeenAt: now,
-        lastUsedAt: null,
-      })
-      .run();
+    const node = createNode(newNode);
+    updateNode(node.id, {
+      sourceConversations: [`playbook:${node.id}`],
+    });
 
-    enqueueMemoryJob("embed_item", { itemId: id });
+    enqueueMemoryJob("embed_graph_node", { nodeId: node.id });
 
     const autonomyLabel =
       autonomyLevel === "auto"
@@ -121,7 +125,7 @@ export async function executePlaybookCreate(
     return {
       content: [
         "Playbook created successfully.",
-        `  ID: ${id}`,
+        `  ID: ${node.id}`,
         `  Trigger: ${trigger}`,
         `  Channel: ${channel}`,
         `  Category: ${category}`,

--- a/assistant/src/config/bundled-skills/playbooks/tools/playbook-delete.ts
+++ b/assistant/src/config/bundled-skills/playbooks/tools/playbook-delete.ts
@@ -1,7 +1,4 @@
-import { and, eq } from "drizzle-orm";
-
-import { getDb } from "../../../../memory/db.js";
-import { memoryItems } from "../../../../memory/schema.js";
+import { getNode, updateNode } from "../../../../memory/graph/store.js";
 import { parsePlaybookStatement } from "../../../../playbooks/types.js";
 import type {
   ToolContext,
@@ -23,38 +20,28 @@ export async function executePlaybookDelete(
   const scopeId = context.memoryScopeId ?? "default";
 
   try {
-    const db = getDb();
-
-    const existing = db
-      .select()
-      .from(memoryItems)
-      .where(
-        and(
-          eq(memoryItems.id, playbookId),
-          eq(memoryItems.kind, "playbook"),
-          eq(memoryItems.scopeId, scopeId),
-        ),
-      )
-      .get();
-
-    if (!existing) {
+    const existing = getNode(playbookId);
+    if (
+      !existing ||
+      existing.scopeId !== scopeId ||
+      !existing.sourceConversations.some((s) => s.startsWith("playbook:")) ||
+      existing.fidelity === "gone"
+    ) {
       return {
         content: `Error: Playbook with ID "${playbookId}" not found`,
         isError: true,
       };
     }
 
-    const playbook = parsePlaybookStatement(existing.statement);
-    const triggerLabel = playbook?.trigger ?? existing.subject;
+    // Extract trigger label from content
+    const newlineIdx = existing.content.indexOf("\n");
+    const statement =
+      newlineIdx !== -1 ? existing.content.slice(newlineIdx + 1) : "";
+    const playbook = parsePlaybookStatement(statement);
+    const triggerLabel = playbook?.trigger ?? existing.content.split("\n")[0];
 
-    // Soft-delete by marking as superseded rather than hard-deleting,
-    // consistent with how other memory items are retired.
-    // Setting invalidAt so the cleanup job can eventually hard-delete it.
-    const now = Date.now();
-    db.update(memoryItems)
-      .set({ status: "superseded", invalidAt: now })
-      .where(eq(memoryItems.id, existing.id))
-      .run();
+    // Soft-delete by setting fidelity to "gone"
+    updateNode(existing.id, { fidelity: "gone" });
 
     return {
       content: `Playbook deleted (ID: ${existing.id}, trigger: "${triggerLabel}").`,

--- a/assistant/src/config/bundled-skills/playbooks/tools/playbook-list.ts
+++ b/assistant/src/config/bundled-skills/playbooks/tools/playbook-list.ts
@@ -1,7 +1,7 @@
-import { and, desc, eq, isNull } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 
 import { getDb } from "../../../../memory/db.js";
-import { memoryItems } from "../../../../memory/schema.js";
+import { memoryGraphNodes } from "../../../../memory/schema.js";
 import { parsePlaybookStatement } from "../../../../playbooks/types.js";
 import type {
   ToolContext,
@@ -23,22 +23,20 @@ export async function executePlaybookList(
 
     const rows = db
       .select({
-        id: memoryItems.id,
-        subject: memoryItems.subject,
-        statement: memoryItems.statement,
-        importance: memoryItems.importance,
-        lastSeenAt: memoryItems.lastSeenAt,
+        id: memoryGraphNodes.id,
+        content: memoryGraphNodes.content,
+        significance: memoryGraphNodes.significance,
+        lastAccessed: memoryGraphNodes.lastAccessed,
       })
-      .from(memoryItems)
+      .from(memoryGraphNodes)
       .where(
         and(
-          eq(memoryItems.kind, "playbook"),
-          eq(memoryItems.status, "active"),
-          eq(memoryItems.scopeId, scopeId),
-          isNull(memoryItems.invalidAt),
+          eq(memoryGraphNodes.scopeId, scopeId),
+          sql`${memoryGraphNodes.sourceConversations} LIKE '%playbook:%'`,
+          sql`${memoryGraphNodes.fidelity} != 'gone'`,
         ),
       )
-      .orderBy(desc(memoryItems.importance))
+      .orderBy(sql`${memoryGraphNodes.significance} DESC`)
       .all();
 
     if (rows.length === 0) {
@@ -47,12 +45,14 @@ export async function executePlaybookList(
 
     const entries: Array<{
       id: string;
-      subject: string;
-      statement: string;
       playbook: NonNullable<ReturnType<typeof parsePlaybookStatement>>;
     }> = [];
     for (const row of rows) {
-      const playbook = parsePlaybookStatement(row.statement);
+      // Content format: "Playbook: <trigger>\n<json statement>"
+      const newlineIdx = row.content.indexOf("\n");
+      if (newlineIdx === -1) continue;
+      const statement = row.content.slice(newlineIdx + 1);
+      const playbook = parsePlaybookStatement(statement);
       if (!playbook) continue;
 
       // Apply filters
@@ -66,8 +66,6 @@ export async function executePlaybookList(
 
       entries.push({
         id: row.id,
-        subject: row.subject,
-        statement: row.statement,
         playbook,
       });
     }

--- a/assistant/src/config/bundled-skills/playbooks/tools/playbook-update.ts
+++ b/assistant/src/config/bundled-skills/playbooks/tools/playbook-update.ts
@@ -1,9 +1,9 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 
 import { getDb } from "../../../../memory/db.js";
-import { computeMemoryFingerprint } from "../../../../memory/fingerprint.js";
+import { getNode, updateNode } from "../../../../memory/graph/store.js";
 import { enqueueMemoryJob } from "../../../../memory/jobs-store.js";
-import { memoryItems } from "../../../../memory/schema.js";
+import { memoryGraphNodes } from "../../../../memory/schema.js";
 import type {
   Playbook,
   PlaybookAutonomyLevel,
@@ -13,7 +13,6 @@ import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
-import { truncate } from "../../../../util/truncate.js";
 
 const VALID_AUTONOMY_LEVELS = new Set<string>(["auto", "draft", "notify"]);
 
@@ -32,28 +31,29 @@ export async function executePlaybookUpdate(
   const scopeId = context.memoryScopeId ?? "default";
 
   try {
-    const db = getDb();
-
-    const existing = db
-      .select()
-      .from(memoryItems)
-      .where(
-        and(
-          eq(memoryItems.id, playbookId),
-          eq(memoryItems.kind, "playbook"),
-          eq(memoryItems.scopeId, scopeId),
-        ),
-      )
-      .get();
-
-    if (!existing) {
+    const existing = getNode(playbookId);
+    if (
+      !existing ||
+      existing.scopeId !== scopeId ||
+      !existing.sourceConversations.some((s) => s.startsWith("playbook:")) ||
+      existing.fidelity === "gone"
+    ) {
       return {
         content: `Error: Playbook with ID "${playbookId}" not found`,
         isError: true,
       };
     }
 
-    const currentPlaybook = parsePlaybookStatement(existing.statement);
+    // Extract the JSON statement from the content (after the first newline)
+    const newlineIdx = existing.content.indexOf("\n");
+    if (newlineIdx === -1) {
+      return {
+        content: `Error: Playbook data is corrupted for ID "${playbookId}"`,
+        isError: true,
+      };
+    }
+    const currentStatement = existing.content.slice(newlineIdx + 1);
+    const currentPlaybook = parsePlaybookStatement(currentStatement);
     if (!currentPlaybook) {
       return {
         content: `Error: Playbook data is corrupted for ID "${playbookId}"`,
@@ -91,47 +91,38 @@ export async function executePlaybookUpdate(
     };
 
     const statement = JSON.stringify(updated);
-    const subject = truncate(`Playbook: ${updated.trigger}`, 80, "");
-    const now = Date.now();
+    const subject = `Playbook: ${updated.trigger}`.slice(0, 80);
+    const content = `${subject}\n${statement}`;
 
-    const fingerprint = computeMemoryFingerprint(
-      scopeId,
-      "playbook",
-      subject,
-      statement,
-    );
-
-    // Check if another playbook already has this fingerprint
+    // Check for duplicate content among other playbook nodes
+    const db = getDb();
     const collision = db
-      .select({ id: memoryItems.id })
-      .from(memoryItems)
+      .select({ id: memoryGraphNodes.id })
+      .from(memoryGraphNodes)
       .where(
         and(
-          eq(memoryItems.fingerprint, fingerprint),
-          eq(memoryItems.scopeId, scopeId),
+          eq(memoryGraphNodes.scopeId, scopeId),
+          sql`${memoryGraphNodes.sourceConversations} LIKE '%playbook:%'`,
+          eq(memoryGraphNodes.content, content),
+          sql`${memoryGraphNodes.fidelity} != 'gone'`,
+          sql`${memoryGraphNodes.id} != ${existing.id}`,
         ),
       )
       .get();
-    if (collision && collision.id !== existing.id) {
+
+    if (collision) {
       return {
         content: `Error: Another playbook with this exact configuration already exists (ID: ${collision.id}).`,
         isError: true,
       };
     }
 
-    db.update(memoryItems)
-      .set({
-        subject,
-        statement,
-        fingerprint,
-        lastSeenAt: now,
-        sourceType: "tool",
-        verificationState: "user_confirmed",
-      })
-      .where(eq(memoryItems.id, existing.id))
-      .run();
+    updateNode(existing.id, {
+      content,
+      lastAccessed: Date.now(),
+    });
 
-    enqueueMemoryJob("embed_item", { itemId: existing.id });
+    enqueueMemoryJob("embed_graph_node", { nodeId: existing.id });
 
     const autonomyLabel =
       updated.autonomyLevel === "auto"

--- a/assistant/src/memory/fingerprint.ts
+++ b/assistant/src/memory/fingerprint.ts
@@ -5,8 +5,8 @@ import { createHash } from "node:crypto";
  *
  * Format: sha256(`${scopeId}|${kind}|${subject}|${statement}`)
  *
- * All writers (memory_manage save/update ops, items-extractor, playbook-create,
- * playbook-update, gmail-analyze-style) MUST use this function so the
+ * All writers (memory_manage save/update ops, items-extractor,
+ * gmail-analyze-style) MUST use this function so the
  * fingerprint scheme stays consistent and deduplication works correctly.
  */
 export function computeMemoryFingerprint(

--- a/assistant/src/playbooks/playbook-compiler.ts
+++ b/assistant/src/playbooks/playbook-compiler.ts
@@ -1,20 +1,20 @@
 /**
- * Compile all active playbook memory items into a triage context block
+ * Compile all active playbook graph nodes into a triage context block
  * that can be injected into the system prompt alongside the contact
  * graph.
  */
 
-import { and, desc, eq, isNull } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 
 import { getDb } from "../memory/db.js";
-import { memoryItems } from "../memory/schema.js";
+import { memoryGraphNodes } from "../memory/schema.js";
 import type { Playbook } from "./types.js";
 import { parsePlaybookStatement } from "./types.js";
 
 export interface CompiledPlaybooks {
   /** Formatted text block ready for system prompt injection. */
   text: string;
-  /** Total number of active playbook items found. */
+  /** Total number of active playbook nodes found. */
   totalCount: number;
   /** Number of playbooks successfully parsed and included. */
   includedCount: number;
@@ -26,8 +26,7 @@ export interface CompilePlaybooksOptions {
 
 interface PlaybookRow {
   id: string;
-  subject: string;
-  statement: string;
+  content: string;
 }
 
 export function compilePlaybooks(
@@ -38,31 +37,33 @@ export function compilePlaybooks(
 
   const rows: PlaybookRow[] = db
     .select({
-      id: memoryItems.id,
-      subject: memoryItems.subject,
-      statement: memoryItems.statement,
+      id: memoryGraphNodes.id,
+      content: memoryGraphNodes.content,
     })
-    .from(memoryItems)
+    .from(memoryGraphNodes)
     .where(
       and(
-        eq(memoryItems.kind, "playbook"),
-        eq(memoryItems.status, "active"),
-        eq(memoryItems.scopeId, scopeId),
-        isNull(memoryItems.invalidAt),
+        eq(memoryGraphNodes.scopeId, scopeId),
+        sql`${memoryGraphNodes.sourceConversations} LIKE '%playbook:%'`,
+        sql`${memoryGraphNodes.fidelity} != 'gone'`,
       ),
     )
-    .orderBy(desc(memoryItems.importance))
+    .orderBy(sql`${memoryGraphNodes.significance} DESC`)
     .all();
 
   if (rows.length === 0) {
     return { text: "", totalCount: 0, includedCount: 0 };
   }
 
-  const parsed: Array<{ id: string; subject: string; playbook: Playbook }> = [];
+  const parsed: Array<{ id: string; playbook: Playbook }> = [];
   for (const row of rows) {
-    const playbook = parsePlaybookStatement(row.statement);
+    // Content format: "Playbook: <trigger>\n<json statement>"
+    const newlineIdx = row.content.indexOf("\n");
+    if (newlineIdx === -1) continue;
+    const statement = row.content.slice(newlineIdx + 1);
+    const playbook = parsePlaybookStatement(statement);
     if (playbook) {
-      parsed.push({ id: row.id, subject: row.subject, playbook });
+      parsed.push({ id: row.id, playbook });
     }
   }
 

--- a/assistant/src/playbooks/types.ts
+++ b/assistant/src/playbooks/types.ts
@@ -2,9 +2,10 @@
  * Action Playbook — a structured trigger→action rule that tells the
  * triage engine how to handle incoming messages matching a pattern.
  *
- * Playbooks are stored as memory items with kind='playbook'. The
- * structured fields below are serialized into the statement column as
- * JSON, while the subject column holds a human-readable label.
+ * Playbooks are stored as memory_graph_nodes with
+ * sourceConversations containing a "playbook:{nodeId}" entry. The
+ * content column holds "Playbook: <trigger>\n<json>" where the JSON
+ * encodes the structured fields below.
  */
 
 export interface Playbook {


### PR DESCRIPTION
## Summary
- Migrates playbook-create/list/update/delete tools from `memoryItems` to `memory_graph_nodes`
- Migrates playbook-compiler to read from graph nodes instead of memoryItems
- Uses `sourceConversations` with `"playbook:"` prefix for identification (consistent with the bootstrap migration in `graph/bootstrap.ts`)
- Soft-delete uses `fidelity: "gone"` instead of `status: "superseded"` + `invalidAt`
- Deduplication uses content matching instead of fingerprint hashing
- Enqueues `embed_graph_node` jobs instead of `embed_item`
- Updates doc comments in `types.ts` and `fingerprint.ts` to reflect the migration

## Test plan
- [x] `bunx tsc --noEmit` passes (only pre-existing `AssemblyOptions` error in `injection.ts`)
- [x] `bun run lint` clean
- [x] `rg memoryItems` in playbook files shows zero remaining references
- Manual: create/list/update/delete playbook via tools still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22705" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
