### PR TITLE
test: add test coverage for memory graph system

### DIFF
--- a/assistant/src/memory/graph/decay.test.ts
+++ b/assistant/src/memory/graph/decay.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test } from "bun:test";
+
+import { computeDecayedIntensity, computeFidelityLevel } from "./decay.js";
+import type { EmotionalCharge } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCharge(overrides: Partial<EmotionalCharge> = {}): EmotionalCharge {
+  return {
+    valence: 0.5,
+    intensity: 0.8,
+    decayCurve: "linear",
+    decayRate: 0.05,
+    originalIntensity: 0.8,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// computeDecayedIntensity
+// ---------------------------------------------------------------------------
+
+describe("computeDecayedIntensity", () => {
+  test("returns current intensity when no time has elapsed", () => {
+    const charge = makeCharge({ intensity: 0.8 });
+    expect(computeDecayedIntensity(charge, 0)).toBe(0.8);
+  });
+
+  test("returns current intensity for negative elapsed time", () => {
+    const charge = makeCharge({ intensity: 0.8 });
+    expect(computeDecayedIntensity(charge, -5)).toBe(0.8);
+  });
+
+  // --- Linear ---
+
+  test("linear: decays at constant rate per day", () => {
+    const charge = makeCharge({
+      decayCurve: "linear",
+      decayRate: 0.1,
+      originalIntensity: 1.0,
+    });
+    // After 5 days: 1.0 - 0.1 × 5 = 0.5
+    expect(computeDecayedIntensity(charge, 5)).toBeCloseTo(0.5, 5);
+  });
+
+  test("linear: floors at 0", () => {
+    const charge = makeCharge({
+      decayCurve: "linear",
+      decayRate: 0.1,
+      originalIntensity: 0.5,
+    });
+    // After 10 days: 0.5 - 0.1 × 10 = -0.5 → clamped to 0
+    expect(computeDecayedIntensity(charge, 10)).toBe(0);
+  });
+
+  test("linear: fully decayed after enough time", () => {
+    const charge = makeCharge({
+      decayCurve: "linear",
+      decayRate: 0.05,
+      originalIntensity: 0.8,
+    });
+    // After 20 days: 0.8 - 0.05 × 20 = -0.2 → 0
+    expect(computeDecayedIntensity(charge, 20)).toBe(0);
+  });
+
+  // --- Logarithmic ---
+
+  test("logarithmic: sharp initial drop, long tail", () => {
+    const charge = makeCharge({
+      decayCurve: "logarithmic",
+      decayRate: 0.5,
+      originalIntensity: 1.0,
+    });
+    const at1 = computeDecayedIntensity(charge, 1);
+    const at10 = computeDecayedIntensity(charge, 10);
+    const at100 = computeDecayedIntensity(charge, 100);
+
+    // Sharp drop initially
+    expect(at1).toBeLessThan(1.0);
+    // But long tail — never reaches 0
+    expect(at10).toBeGreaterThan(0);
+    expect(at100).toBeGreaterThan(0);
+    // Monotonic decay
+    expect(at1).toBeGreaterThan(at10);
+    expect(at10).toBeGreaterThan(at100);
+  });
+
+  test("logarithmic: formula I₀ / (1 + rate × ln(1 + t))", () => {
+    const charge = makeCharge({
+      decayCurve: "logarithmic",
+      decayRate: 0.5,
+      originalIntensity: 0.8,
+    });
+    const days = 10;
+    const expected = 0.8 / (1 + 0.5 * Math.log(1 + days));
+    expect(computeDecayedIntensity(charge, days)).toBeCloseTo(expected, 10);
+  });
+
+  // --- Transformative ---
+
+  test("transformative: decays but floors at 20% of original", () => {
+    const charge = makeCharge({
+      decayCurve: "transformative",
+      decayRate: 0.1,
+      originalIntensity: 1.0,
+    });
+    const atInfinity = computeDecayedIntensity(charge, 10000);
+    // Floor is 20% of original = 0.2
+    expect(atInfinity).toBeCloseTo(0.2, 5);
+  });
+
+  test("transformative: exponential decay above the floor", () => {
+    const charge = makeCharge({
+      decayCurve: "transformative",
+      decayRate: 0.1,
+      originalIntensity: 1.0,
+    });
+    const at5 = computeDecayedIntensity(charge, 5);
+    const at10 = computeDecayedIntensity(charge, 10);
+
+    expect(at5).toBeGreaterThan(at10);
+    // at5: max(0.2, 1.0 × e^(-0.1×5)) = max(0.2, 0.607) = 0.607
+    expect(at5).toBeCloseTo(Math.exp(-0.5), 3);
+    // at10: max(0.2, 1.0 × e^(-0.1×10)) = max(0.2, 0.368) = 0.368
+    expect(at10).toBeCloseTo(Math.exp(-1), 3);
+  });
+
+  // --- Permanent ---
+
+  test("permanent: no decay at all", () => {
+    const charge = makeCharge({
+      decayCurve: "permanent",
+      decayRate: 0.5, // ignored
+      originalIntensity: 0.9,
+      intensity: 0.9,
+    });
+    // At elapsed=0, returns charge.intensity (the early return)
+    expect(computeDecayedIntensity(charge, 0)).toBe(0.9);
+    // For any elapsed > 0, returns originalIntensity (permanent never decays)
+    expect(computeDecayedIntensity(charge, 100)).toBe(0.9);
+    expect(computeDecayedIntensity(charge, 10000)).toBe(0.9);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeFidelityLevel
+// ---------------------------------------------------------------------------
+
+describe("computeFidelityLevel", () => {
+  test("stays vivid within the first 7 days", () => {
+    expect(computeFidelityLevel("vivid", 3, 0.5)).toBe("vivid");
+    expect(computeFidelityLevel("vivid", 6, 0.5)).toBe("vivid");
+  });
+
+  test("downgrades vivid → clear after 7 days", () => {
+    expect(computeFidelityLevel("vivid", 8, 0.5)).toBe("clear");
+  });
+
+  test("downgrades clear → faded after 37 days (7 vivid + 30 clear)", () => {
+    expect(computeFidelityLevel("vivid", 38, 0.5)).toBe("faded");
+  });
+
+  test("downgrades faded → gist after 127 days (7+30+90)", () => {
+    expect(computeFidelityLevel("vivid", 130, 0.5)).toBe("gist");
+  });
+
+  test("never auto-downgrades to gone", () => {
+    // Even after 500 days, should cap at gist (gone is consolidation's job)
+    expect(computeFidelityLevel("vivid", 500, 0.5)).toBe("gist");
+    expect(computeFidelityLevel("gist", 5000, 0.5)).toBe("gist");
+  });
+
+  test("never upgrades fidelity", () => {
+    // If currently at "faded", should stay at "faded" even if time says "vivid"
+    expect(computeFidelityLevel("faded", 1, 0.5)).toBe("faded");
+    expect(computeFidelityLevel("clear", 1, 0.5)).toBe("clear");
+    expect(computeFidelityLevel("gist", 1, 0.5)).toBe("gist");
+    expect(computeFidelityLevel("gone", 1, 0.5)).toBe("gone");
+  });
+
+  test("high significance (0.8+) doubles thresholds", () => {
+    // vivid threshold at sig 0.8: 7 × 2 = 14 days
+    expect(computeFidelityLevel("vivid", 10, 0.8)).toBe("vivid");
+    expect(computeFidelityLevel("vivid", 15, 0.8)).toBe("clear");
+
+    // vivid+clear at sig 0.8: (7+30) × 2 = 74 days
+    expect(computeFidelityLevel("vivid", 70, 0.8)).toBe("clear");
+    expect(computeFidelityLevel("vivid", 75, 0.8)).toBe("faded");
+  });
+
+  test("very high significance (0.9+) triples thresholds", () => {
+    // vivid threshold at sig 0.9: 7 × 3 = 21 days
+    expect(computeFidelityLevel("vivid", 15, 0.9)).toBe("vivid");
+    expect(computeFidelityLevel("vivid", 22, 0.9)).toBe("clear");
+
+    // vivid+clear at sig 0.9: (7+30) × 3 = 111 days
+    expect(computeFidelityLevel("vivid", 100, 0.9)).toBe("clear");
+    expect(computeFidelityLevel("vivid", 112, 0.9)).toBe("faded");
+  });
+
+  test("low significance uses normal thresholds", () => {
+    // No resistance factor for sig < 0.8
+    expect(computeFidelityLevel("vivid", 8, 0.3)).toBe("clear");
+    expect(computeFidelityLevel("vivid", 8, 0.79)).toBe("clear");
+  });
+});

--- a/assistant/src/memory/graph/extraction.test.ts
+++ b/assistant/src/memory/graph/extraction.test.ts
@@ -1,0 +1,716 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseExtractionResponse } from "./extraction.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CONV_ID = "conv-test-1";
+const SCOPE_ID = "default";
+const NOW = Date.now();
+
+function parse(input: Record<string, unknown>, candidateIds: string[] = []) {
+  return parseExtractionResponse(
+    input,
+    CONV_ID,
+    SCOPE_ID,
+    new Set(candidateIds),
+    NOW,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Node creation
+// ---------------------------------------------------------------------------
+
+describe("parseExtractionResponse — node creation", () => {
+  test("parses a valid create_node into a NewNode", () => {
+    const { diff } = parse({
+      create_nodes: [
+        {
+          content: "User loves hiking.",
+          type: "semantic",
+          emotional_charge: {
+            valence: 0.3,
+            intensity: 0.2,
+            decay_curve: "linear",
+            decay_rate: 0.05,
+          },
+          significance: 0.6,
+          confidence: 0.9,
+          source_type: "direct",
+        },
+      ],
+      reinforce_node_ids: [],
+    });
+
+    expect(diff.createNodes).toHaveLength(1);
+    const node = diff.createNodes[0];
+    expect(node.content).toBe("User loves hiking.");
+    expect(node.type).toBe("semantic");
+    expect(node.emotionalCharge.valence).toBe(0.3);
+    expect(node.emotionalCharge.intensity).toBe(0.2);
+    expect(node.emotionalCharge.decayCurve).toBe("linear");
+    expect(node.emotionalCharge.decayRate).toBe(0.05);
+    expect(node.emotionalCharge.originalIntensity).toBe(0.2);
+    expect(node.significance).toBe(0.6);
+    expect(node.confidence).toBe(0.9);
+    expect(node.sourceType).toBe("direct");
+    expect(node.fidelity).toBe("vivid");
+    expect(node.stability).toBe(14);
+    expect(node.reinforcementCount).toBe(0);
+    expect(node.created).toBe(NOW);
+    expect(node.sourceConversations).toEqual([CONV_ID]);
+    expect(node.scopeId).toBe(SCOPE_ID);
+  });
+
+  test("prospective nodes get stability=5", () => {
+    const { diff } = parse({
+      create_nodes: [
+        {
+          content: "Deploy the new version tomorrow.",
+          type: "prospective",
+          emotional_charge: {
+            valence: 0.1,
+            intensity: 0.1,
+            decay_curve: "linear",
+            decay_rate: 0.05,
+          },
+          significance: 0.5,
+          confidence: 0.8,
+          source_type: "direct",
+        },
+      ],
+      reinforce_node_ids: [],
+    });
+
+    expect(diff.createNodes[0].stability).toBe(5);
+  });
+
+  test("non-prospective nodes get default stability=14", () => {
+    const { diff } = parse({
+      create_nodes: [
+        {
+          content: "User graduated from MIT.",
+          type: "semantic",
+          emotional_charge: {
+            valence: 0.5,
+            intensity: 0.3,
+            decay_curve: "transformative",
+            decay_rate: 0.02,
+          },
+          significance: 0.7,
+          confidence: 0.95,
+          source_type: "direct",
+        },
+      ],
+      reinforce_node_ids: [],
+    });
+
+    expect(diff.createNodes[0].stability).toBe(14);
+  });
+
+  test("clamps significance to [0, 1]", () => {
+    const { diff } = parse({
+      create_nodes: [
+        {
+          content: "Test",
+          type: "semantic",
+          emotional_charge: {
+            valence: 0,
+            intensity: 0,
+            decay_curve: "linear",
+            decay_rate: 0.05,
+          },
+          significance: 1.5, // over max
+          confidence: 0.5,
+          source_type: "direct",
+        },
+      ],
+      reinforce_node_ids: [],
+    });
+    expect(diff.createNodes[0].significance).toBe(1.0);
+  });
+
+  test("clamps negative significance to 0", () => {
+    const { diff } = parse({
+      create_nodes: [
+        {
+          content: "Test",
+          type: "semantic",
+          emotional_charge: {
+            valence: 0,
+            intensity: 0,
+            decay_curve: "linear",
+            decay_rate: 0.05,
+          },
+          significance: -0.5,
+          confidence: 0.5,
+          source_type: "direct",
+        },
+      ],
+      reinforce_node_ids: [],
+    });
+    expect(diff.createNodes[0].significance).toBe(0);
+  });
+
+  test("clamps valence to [-1, 1]", () => {
+    const { diff } = parse({
+      create_nodes: [
+        {
+          content: "Test",
+          type: "semantic",
+          emotional_charge: {
+            valence: 2.0,
+            intensity: 0.5,
+            decay_curve: "linear",
+            decay_rate: 0.05,
+          },
+          significance: 0.5,
+          confidence: 0.5,
+          source_type: "direct",
+        },
+      ],
+      reinforce_node_ids: [],
+    });
+    expect(diff.createNodes[0].emotionalCharge.valence).toBe(1);
+  });
+
+  test("defaults invalid decay_curve to linear", () => {
+    const { diff } = parse({
+      create_nodes: [
+        {
+          content: "Test",
+          type: "semantic",
+          emotional_charge: {
+            valence: 0,
+            intensity: 0.5,
+            decay_curve: "bogus",
+            decay_rate: 0.05,
+          },
+          significance: 0.5,
+          confidence: 0.5,
+          source_type: "direct",
+        },
+      ],
+      reinforce_node_ids: [],
+    });
+    expect(diff.createNodes[0].emotionalCharge.decayCurve).toBe("linear");
+  });
+
+  test("defaults invalid source_type to inferred", () => {
+    const { diff } = parse({
+      create_nodes: [
+        {
+          content: "Test",
+          type: "semantic",
+          emotional_charge: {
+            valence: 0,
+            intensity: 0,
+            decay_curve: "linear",
+            decay_rate: 0.05,
+          },
+          significance: 0.5,
+          confidence: 0.5,
+          source_type: "bogus",
+        },
+      ],
+      reinforce_node_ids: [],
+    });
+    expect(diff.createNodes[0].sourceType).toBe("inferred");
+  });
+
+  test("skips nodes with missing content", () => {
+    const { diff } = parse({
+      create_nodes: [{ type: "semantic" }],
+      reinforce_node_ids: [],
+    });
+    expect(diff.createNodes).toHaveLength(0);
+  });
+
+  test("skips nodes with invalid type", () => {
+    const { diff } = parse({
+      create_nodes: [
+        {
+          content: "Test",
+          type: "invalid_type",
+          emotional_charge: {
+            valence: 0,
+            intensity: 0,
+            decay_curve: "linear",
+            decay_rate: 0.05,
+          },
+          significance: 0.5,
+          confidence: 0.5,
+          source_type: "direct",
+        },
+      ],
+      reinforce_node_ids: [],
+    });
+    expect(diff.createNodes).toHaveLength(0);
+  });
+
+  test("defaults missing emotional_charge fields", () => {
+    const { diff } = parse({
+      create_nodes: [
+        {
+          content: "Test",
+          type: "semantic",
+          emotional_charge: {}, // all fields missing
+          significance: 0.5,
+          confidence: 0.5,
+          source_type: "direct",
+        },
+      ],
+      reinforce_node_ids: [],
+    });
+    const charge = diff.createNodes[0].emotionalCharge;
+    expect(charge.valence).toBe(0);
+    expect(charge.intensity).toBe(0);
+    expect(charge.decayCurve).toBe("linear");
+    expect(charge.decayRate).toBe(0.05);
+    expect(charge.originalIntensity).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reinforcement
+// ---------------------------------------------------------------------------
+
+describe("parseExtractionResponse — reinforcement", () => {
+  test("only includes IDs that exist in candidate set", () => {
+    const { diff } = parse(
+      {
+        create_nodes: [],
+        reinforce_node_ids: ["existing-1", "fake-id", "existing-2"],
+      },
+      ["existing-1", "existing-2"],
+    );
+    expect(diff.reinforceNodeIds).toEqual(["existing-1", "existing-2"]);
+  });
+
+  test("returns empty array when no IDs match candidates", () => {
+    const { diff } = parse(
+      {
+        create_nodes: [],
+        reinforce_node_ids: ["fake-1", "fake-2"],
+      },
+      ["real-1"],
+    );
+    expect(diff.reinforceNodeIds).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Node updates
+// ---------------------------------------------------------------------------
+
+describe("parseExtractionResponse — updates", () => {
+  test("parses content update for existing node", () => {
+    const { diff } = parse(
+      {
+        create_nodes: [],
+        reinforce_node_ids: [],
+        update_nodes: [{ id: "node-1", content: "Updated content." }],
+      },
+      ["node-1"],
+    );
+    expect(diff.updateNodes).toHaveLength(1);
+    expect(diff.updateNodes[0].id).toBe("node-1");
+    expect(diff.updateNodes[0].changes.content).toBe("Updated content.");
+  });
+
+  test("parses fidelity downgrade", () => {
+    const { diff } = parse(
+      {
+        create_nodes: [],
+        reinforce_node_ids: [],
+        update_nodes: [{ id: "node-1", fidelity: "gist" }],
+      },
+      ["node-1"],
+    );
+    expect(diff.updateNodes[0].changes.fidelity).toBe("gist");
+  });
+
+  test("ignores invalid fidelity values", () => {
+    const { diff } = parse(
+      {
+        create_nodes: [],
+        reinforce_node_ids: [],
+        update_nodes: [{ id: "node-1", fidelity: "super-vivid" }],
+      },
+      ["node-1"],
+    );
+    // No valid changes → should not produce an update entry
+    expect(diff.updateNodes).toHaveLength(0);
+  });
+
+  test("clamps updated significance to [0, 1]", () => {
+    const { diff } = parse(
+      {
+        create_nodes: [],
+        reinforce_node_ids: [],
+        update_nodes: [{ id: "node-1", significance: 1.5 }],
+      },
+      ["node-1"],
+    );
+    expect(diff.updateNodes[0].changes.significance).toBe(1.0);
+  });
+
+  test("skips updates for nodes not in candidate set", () => {
+    const { diff } = parse(
+      {
+        create_nodes: [],
+        reinforce_node_ids: [],
+        update_nodes: [{ id: "unknown-node", content: "New content." }],
+      },
+      ["node-1"],
+    );
+    expect(diff.updateNodes).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edges between existing nodes
+// ---------------------------------------------------------------------------
+
+describe("parseExtractionResponse — edges", () => {
+  test("creates edges between existing candidate nodes", () => {
+    const { diff } = parse(
+      {
+        create_nodes: [],
+        reinforce_node_ids: [],
+        new_edges: [
+          {
+            source_node_id: "a",
+            target_node_id: "b",
+            relationship: "caused-by",
+            weight: 0.8,
+          },
+        ],
+      },
+      ["a", "b"],
+    );
+    expect(diff.createEdges).toHaveLength(1);
+    expect(diff.createEdges[0].sourceNodeId).toBe("a");
+    expect(diff.createEdges[0].targetNodeId).toBe("b");
+    expect(diff.createEdges[0].relationship).toBe("caused-by");
+    expect(diff.createEdges[0].weight).toBe(0.8);
+  });
+
+  test("skips edges referencing non-candidate nodes", () => {
+    const { diff } = parse(
+      {
+        create_nodes: [],
+        reinforce_node_ids: [],
+        new_edges: [
+          {
+            source_node_id: "a",
+            target_node_id: "unknown",
+            relationship: "caused-by",
+          },
+        ],
+      },
+      ["a"],
+    );
+    expect(diff.createEdges).toHaveLength(0);
+  });
+
+  test("skips edges with invalid relationships", () => {
+    const { diff } = parse(
+      {
+        create_nodes: [],
+        reinforce_node_ids: [],
+        new_edges: [
+          {
+            source_node_id: "a",
+            target_node_id: "b",
+            relationship: "invalid-rel",
+          },
+        ],
+      },
+      ["a", "b"],
+    );
+    expect(diff.createEdges).toHaveLength(0);
+  });
+
+  test("defaults edge weight to 1.0", () => {
+    const { diff } = parse(
+      {
+        create_nodes: [],
+        reinforce_node_ids: [],
+        new_edges: [
+          {
+            source_node_id: "a",
+            target_node_id: "b",
+            relationship: "reminds-of",
+          },
+        ],
+      },
+      ["a", "b"],
+    );
+    expect(diff.createEdges[0].weight).toBe(1.0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Deferred edges (new node → existing node)
+// ---------------------------------------------------------------------------
+
+describe("parseExtractionResponse — deferred edges", () => {
+  test("collects edges from new nodes to existing candidates", () => {
+    const { deferredEdges } = parse(
+      {
+        create_nodes: [
+          {
+            content: "New memory.",
+            type: "episodic",
+            emotional_charge: {
+              valence: 0,
+              intensity: 0,
+              decay_curve: "linear",
+              decay_rate: 0.05,
+            },
+            significance: 0.5,
+            confidence: 0.5,
+            source_type: "direct",
+            edges_to_existing: [
+              {
+                target_node_id: "existing-1",
+                relationship: "caused-by",
+                weight: 0.7,
+              },
+            ],
+          },
+        ],
+        reinforce_node_ids: [],
+      },
+      ["existing-1"],
+    );
+    expect(deferredEdges).toHaveLength(1);
+    expect(deferredEdges[0].newNodeIndex).toBe(0);
+    expect(deferredEdges[0].targetNodeId).toBe("existing-1");
+    expect(deferredEdges[0].relationship).toBe("caused-by");
+    expect(deferredEdges[0].weight).toBe(0.7);
+  });
+
+  test("ignores deferred edges to non-candidate targets", () => {
+    const { deferredEdges } = parse(
+      {
+        create_nodes: [
+          {
+            content: "New memory.",
+            type: "episodic",
+            emotional_charge: {
+              valence: 0,
+              intensity: 0,
+              decay_curve: "linear",
+              decay_rate: 0.05,
+            },
+            significance: 0.5,
+            confidence: 0.5,
+            source_type: "direct",
+            edges_to_existing: [
+              {
+                target_node_id: "non-existing",
+                relationship: "caused-by",
+              },
+            ],
+          },
+        ],
+        reinforce_node_ids: [],
+      },
+      ["other-node"],
+    );
+    expect(deferredEdges).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Deferred triggers
+// ---------------------------------------------------------------------------
+
+describe("parseExtractionResponse — deferred triggers", () => {
+  test("collects temporal triggers for new nodes", () => {
+    const { deferredTriggers } = parse({
+      create_nodes: [
+        {
+          content: "Check in every Monday.",
+          type: "prospective",
+          emotional_charge: {
+            valence: 0,
+            intensity: 0,
+            decay_curve: "linear",
+            decay_rate: 0.05,
+          },
+          significance: 0.4,
+          confidence: 0.8,
+          source_type: "direct",
+          triggers: [
+            {
+              type: "temporal",
+              schedule: "day-of-week:monday",
+              recurring: true,
+            },
+          ],
+        },
+      ],
+      reinforce_node_ids: [],
+    });
+
+    expect(deferredTriggers).toHaveLength(1);
+    expect(deferredTriggers[0].newNodeIndex).toBe(0);
+    expect(deferredTriggers[0].trigger.type).toBe("temporal");
+    expect(deferredTriggers[0].trigger.schedule).toBe("day-of-week:monday");
+    expect(deferredTriggers[0].trigger.recurring).toBe(true);
+    expect(deferredTriggers[0].trigger.cooldownMs).toBe(1000 * 60 * 60 * 12);
+  });
+
+  test("collects semantic triggers with default threshold 0.7", () => {
+    const { deferredTriggers } = parse({
+      create_nodes: [
+        {
+          content: "When cooking comes up, mention the recipe.",
+          type: "semantic",
+          emotional_charge: {
+            valence: 0.3,
+            intensity: 0.2,
+            decay_curve: "linear",
+            decay_rate: 0.05,
+          },
+          significance: 0.4,
+          confidence: 0.7,
+          source_type: "direct",
+          triggers: [
+            {
+              type: "semantic",
+              condition: "topic of cooking comes up",
+            },
+          ],
+        },
+      ],
+      reinforce_node_ids: [],
+    });
+
+    expect(deferredTriggers[0].trigger.type).toBe("semantic");
+    expect(deferredTriggers[0].trigger.threshold).toBe(0.7);
+    expect(deferredTriggers[0].trigger.condition).toBe(
+      "topic of cooking comes up",
+    );
+  });
+
+  test("collects event triggers with date and ramp settings", () => {
+    const eventDate = Date.now() + 7 * 24 * 60 * 60 * 1000;
+    const { deferredTriggers } = parse({
+      create_nodes: [
+        {
+          content: "Trip next week.",
+          type: "prospective",
+          emotional_charge: {
+            valence: 0.5,
+            intensity: 0.4,
+            decay_curve: "linear",
+            decay_rate: 0.05,
+          },
+          significance: 0.6,
+          confidence: 0.9,
+          source_type: "direct",
+          triggers: [
+            {
+              type: "event",
+              event_date: eventDate,
+              ramp_days: 5,
+              follow_up_days: 3,
+            },
+          ],
+        },
+      ],
+      reinforce_node_ids: [],
+    });
+
+    expect(deferredTriggers[0].trigger.type).toBe("event");
+    expect(deferredTriggers[0].trigger.eventDate).toBe(eventDate);
+    expect(deferredTriggers[0].trigger.rampDays).toBe(5);
+    expect(deferredTriggers[0].trigger.followUpDays).toBe(3);
+  });
+
+  test("skips triggers with invalid types", () => {
+    const { deferredTriggers } = parse({
+      create_nodes: [
+        {
+          content: "Test.",
+          type: "semantic",
+          emotional_charge: {
+            valence: 0,
+            intensity: 0,
+            decay_curve: "linear",
+            decay_rate: 0.05,
+          },
+          significance: 0.5,
+          confidence: 0.5,
+          source_type: "direct",
+          triggers: [{ type: "invalid-type" }],
+        },
+      ],
+      reinforce_node_ids: [],
+    });
+    expect(deferredTriggers).toHaveLength(0);
+  });
+
+  test("non-recurring triggers get null cooldownMs", () => {
+    const { deferredTriggers } = parse({
+      create_nodes: [
+        {
+          content: "One-time check.",
+          type: "prospective",
+          emotional_charge: {
+            valence: 0,
+            intensity: 0,
+            decay_curve: "linear",
+            decay_rate: 0.05,
+          },
+          significance: 0.5,
+          confidence: 0.5,
+          source_type: "direct",
+          triggers: [
+            {
+              type: "temporal",
+              schedule: "date:04-08",
+              recurring: false,
+            },
+          ],
+        },
+      ],
+      reinforce_node_ids: [],
+    });
+    expect(deferredTriggers[0].trigger.recurring).toBe(false);
+    expect(deferredTriggers[0].trigger.cooldownMs).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Empty / missing fields
+// ---------------------------------------------------------------------------
+
+describe("parseExtractionResponse — robustness", () => {
+  test("handles completely empty input", () => {
+    const { diff, deferredEdges, deferredTriggers } = parse({});
+    expect(diff.createNodes).toHaveLength(0);
+    expect(diff.updateNodes).toHaveLength(0);
+    expect(diff.reinforceNodeIds).toEqual([]);
+    expect(diff.createEdges).toHaveLength(0);
+    expect(deferredEdges).toHaveLength(0);
+    expect(deferredTriggers).toHaveLength(0);
+  });
+
+  test("handles missing create_nodes gracefully", () => {
+    const { diff } = parse({ reinforce_node_ids: [] });
+    expect(diff.createNodes).toHaveLength(0);
+  });
+
+  test("handles missing reinforce_node_ids gracefully", () => {
+    const { diff } = parse({ create_nodes: [] });
+    expect(diff.reinforceNodeIds).toEqual([]);
+  });
+});

--- a/assistant/src/memory/graph/extraction.ts
+++ b/assistant/src/memory/graph/extraction.ts
@@ -395,7 +395,7 @@ function clamp(v: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, v));
 }
 
-function parseExtractionResponse(
+export function parseExtractionResponse(
   input: Record<string, unknown>,
   conversationId: string,
   scopeId: string,

--- a/assistant/src/memory/graph/injection.test.ts
+++ b/assistant/src/memory/graph/injection.test.ts
@@ -1,0 +1,318 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  assembleContextBlock,
+  assembleInjectionBlock,
+  InContextTracker,
+} from "./injection.js";
+import type { MemoryNode, ScoredNode } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+const HOUR_MS = 1000 * 60 * 60;
+
+function makeNode(overrides: Partial<MemoryNode> = {}): MemoryNode {
+  return {
+    id: "node-1",
+    content: "Test memory content.",
+    type: "episodic",
+    created: Date.now() - 5 * DAY_MS,
+    lastAccessed: Date.now(),
+    lastConsolidated: Date.now(),
+    emotionalCharge: {
+      valence: 0,
+      intensity: 0,
+      decayCurve: "linear",
+      decayRate: 0.05,
+      originalIntensity: 0,
+    },
+    fidelity: "vivid",
+    confidence: 0.8,
+    significance: 0.5,
+    stability: 14,
+    reinforcementCount: 0,
+    lastReinforced: Date.now(),
+    sourceConversations: ["conv-1"],
+    sourceType: "direct",
+    narrativeRole: null,
+    partOfStory: null,
+    scopeId: "default",
+    ...overrides,
+  };
+}
+
+function makeScored(
+  nodeOverrides: Partial<MemoryNode> = {},
+  scoreOverrides: Partial<ScoredNode["scoreBreakdown"]> = {},
+): ScoredNode {
+  return {
+    node: makeNode(nodeOverrides),
+    score: 0.5,
+    scoreBreakdown: {
+      semanticSimilarity: 0.5,
+      effectiveSignificance: 0.5,
+      emotionalIntensity: 0,
+      temporalBoost: 0,
+      recencyBoost: 0.5,
+      triggerBoost: 0,
+      activationBoost: 0,
+      ...scoreOverrides,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// InContextTracker
+// ---------------------------------------------------------------------------
+
+describe("InContextTracker", () => {
+  test("tracks added node IDs", () => {
+    const tracker = new InContextTracker();
+    tracker.add(["a", "b"]);
+    expect(tracker.isInContext("a")).toBe(true);
+    expect(tracker.isInContext("b")).toBe(true);
+    expect(tracker.isInContext("c")).toBe(false);
+  });
+
+  test("filters out nodes already in context", () => {
+    const tracker = new InContextTracker();
+    tracker.add(["a"]);
+
+    const candidates: ScoredNode[] = [
+      makeScored({ id: "a" }),
+      makeScored({ id: "b" }),
+      makeScored({ id: "c" }),
+    ];
+    const filtered = tracker.filterNew(candidates);
+    expect(filtered).toHaveLength(2);
+    expect(filtered.map((c) => c.node.id)).toEqual(["b", "c"]);
+  });
+
+  test("advances turn counter", () => {
+    const tracker = new InContextTracker();
+    expect(tracker.getTurn()).toBe(0);
+    tracker.advanceTurn();
+    expect(tracker.getTurn()).toBe(1);
+    tracker.advanceTurn();
+    expect(tracker.getTurn()).toBe(2);
+  });
+
+  test("records injection log with turn numbers", () => {
+    const tracker = new InContextTracker();
+    tracker.add(["a"]);
+    tracker.advanceTurn();
+    tracker.add(["b"]);
+
+    const log = tracker.getLog();
+    expect(log).toHaveLength(2);
+    expect(log[0]).toEqual({ nodeId: "a", turn: 0 });
+    expect(log[1]).toEqual({ nodeId: "b", turn: 1 });
+  });
+
+  test("returns all active node IDs", () => {
+    const tracker = new InContextTracker();
+    tracker.add(["a", "b"]);
+    tracker.advanceTurn();
+    tracker.add(["c"]);
+
+    const active = tracker.getActiveNodeIds();
+    expect(active.sort()).toEqual(["a", "b", "c"]);
+  });
+
+  test("evicts compacted turns", () => {
+    const tracker = new InContextTracker();
+    tracker.add(["a"]);
+    tracker.advanceTurn();
+    tracker.add(["b"]);
+    tracker.advanceTurn();
+    tracker.add(["c"]);
+
+    // Evict turns 0 and 1
+    tracker.evictCompactedTurns(1);
+
+    expect(tracker.isInContext("a")).toBe(false);
+    expect(tracker.isInContext("b")).toBe(false);
+    expect(tracker.isInContext("c")).toBe(true);
+  });
+
+  test("keeps nodes that appear in both compacted and non-compacted turns", () => {
+    const tracker = new InContextTracker();
+    tracker.add(["a"]);
+    tracker.advanceTurn();
+    tracker.add(["a"]); // same node re-injected in turn 1
+
+    // Evict turn 0 only
+    tracker.evictCompactedTurns(0);
+
+    // "a" should still be in context because it was also injected in turn 1
+    expect(tracker.isInContext("a")).toBe(true);
+  });
+
+  test("eviction cleans up log entries", () => {
+    const tracker = new InContextTracker();
+    tracker.add(["a"]);
+    tracker.advanceTurn();
+    tracker.add(["b"]);
+
+    tracker.evictCompactedTurns(0);
+
+    const log = tracker.getLog();
+    expect(log).toHaveLength(1);
+    expect(log[0].nodeId).toBe("b");
+  });
+
+  test("evicting with upToTurn=0 only evicts turn 0", () => {
+    const tracker = new InContextTracker();
+    tracker.add(["a"]);
+    tracker.advanceTurn();
+    tracker.add(["b"]);
+    tracker.advanceTurn();
+    tracker.add(["c"]);
+
+    tracker.evictCompactedTurns(0);
+
+    expect(tracker.isInContext("a")).toBe(false);
+    expect(tracker.isInContext("b")).toBe(true);
+    expect(tracker.isInContext("c")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assembleContextBlock
+// ---------------------------------------------------------------------------
+
+describe("assembleContextBlock", () => {
+  test("returns empty string for no nodes", () => {
+    expect(assembleContextBlock([])).toBe("");
+  });
+
+  test("includes the main heading", () => {
+    const result = assembleContextBlock([makeScored()]);
+    expect(result).toContain("## What I Remember Right Now");
+  });
+
+  test("puts prospective nodes under Active Threads", () => {
+    const result = assembleContextBlock([
+      makeScored({ type: "prospective", content: "Deploy the service." }),
+    ]);
+    expect(result).toContain("### Active Threads");
+    expect(result).toContain("Deploy the service.");
+  });
+
+  test("puts trigger-boosted nodes under What Today Means", () => {
+    const result = assembleContextBlock([
+      makeScored({ content: "Anniversary today." }, { triggerBoost: 0.5 }),
+    ]);
+    expect(result).toContain("### What Today Means");
+    expect(result).toContain("Anniversary today.");
+  });
+
+  test("puts recent emotional nodes under Right Now", () => {
+    const result = assembleContextBlock([
+      makeScored({
+        type: "emotional",
+        content: "Feeling great about the launch.",
+        created: Date.now() - HOUR_MS, // 1 hour ago, within 2-day recency
+      }),
+    ]);
+    expect(result).toContain("### Right Now");
+    expect(result).toContain("Feeling great about the launch.");
+  });
+
+  test("puts very recent non-emotional nodes under Right Now", () => {
+    const result = assembleContextBlock([
+      makeScored({
+        type: "episodic",
+        content: "Just finished the meeting.",
+        created: Date.now() - HOUR_MS, // 1 hour ago, within 4-hour very-recent window
+      }),
+    ]);
+    expect(result).toContain("### Right Now");
+    expect(result).toContain("Just finished the meeting.");
+  });
+
+  test("puts older general nodes under On My Mind", () => {
+    const result = assembleContextBlock([
+      makeScored({
+        type: "semantic",
+        content: "User works at Acme Corp.",
+        created: Date.now() - 30 * DAY_MS,
+      }),
+    ]);
+    expect(result).toContain("### On My Mind");
+    expect(result).toContain("User works at Acme Corp.");
+  });
+
+  test("includes serendipity section when provided", () => {
+    const result = assembleContextBlock([], {
+      serendipityNodes: [makeScored({ content: "Random old memory." })],
+    });
+    expect(result).toContain("### Serendipity");
+    expect(result).toContain("Random old memory.");
+  });
+
+  test("formats nodes with relative age", () => {
+    const result = assembleContextBlock([
+      makeScored({
+        content: "Something happened.",
+        created: Date.now() - 5 * DAY_MS,
+      }),
+    ]);
+    expect(result).toContain("5d ago");
+  });
+
+  test("limits Active Threads to 5 entries", () => {
+    const nodes = Array.from({ length: 8 }, (_, i) =>
+      makeScored({
+        id: `p-${i}`,
+        type: "prospective",
+        content: `Task ${i}.`,
+      }),
+    );
+    const result = assembleContextBlock(nodes);
+    // Count how many "Task" entries appear in Active Threads
+    const threadSection = result
+      .split("### Active Threads")[1]
+      ?.split("###")[0];
+    const taskMatches = threadSection?.match(/Task \d+\./g) ?? [];
+    expect(taskMatches.length).toBeLessThanOrEqual(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assembleInjectionBlock
+// ---------------------------------------------------------------------------
+
+describe("assembleInjectionBlock", () => {
+  test("returns empty string for no nodes", () => {
+    expect(assembleInjectionBlock([])).toBe("");
+  });
+
+  test("formats each node as a bullet with age", () => {
+    const result = assembleInjectionBlock([
+      makeScored({
+        content: "Memory A.",
+        created: Date.now() - 3 * DAY_MS,
+      }),
+      makeScored({
+        id: "node-2",
+        content: "Memory B.",
+        created: Date.now() - 10 * DAY_MS,
+      }),
+    ]);
+    expect(result).toContain("- (3d ago) Memory A.");
+    expect(result).toContain("- (10d ago) Memory B.");
+  });
+
+  test("joins multiple entries with newlines", () => {
+    const result = assembleInjectionBlock([
+      makeScored({ content: "A." }),
+      makeScored({ id: "node-2", content: "B." }),
+    ]);
+    const lines = result.split("\n");
+    expect(lines).toHaveLength(2);
+  });
+});

--- a/assistant/src/memory/graph/scoring.test.ts
+++ b/assistant/src/memory/graph/scoring.test.ts
@@ -1,0 +1,546 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  computeActivationSpread,
+  computeEffectiveSignificance,
+  computeRecencyBoost,
+  computeTemporalBoost,
+  PER_TURN_WEIGHTS,
+  scoreCandidate,
+  type ScoringWeights,
+} from "./scoring.js";
+import type { MemoryNode } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeNode(overrides: Partial<MemoryNode> = {}): MemoryNode {
+  return {
+    id: "node-1",
+    content: "Test memory",
+    type: "episodic",
+    created: Date.now(),
+    lastAccessed: Date.now(),
+    lastConsolidated: Date.now(),
+    emotionalCharge: {
+      valence: 0,
+      intensity: 0,
+      decayCurve: "linear",
+      decayRate: 0.05,
+      originalIntensity: 0,
+    },
+    fidelity: "vivid",
+    confidence: 0.8,
+    significance: 0.5,
+    stability: 14,
+    reinforcementCount: 0,
+    lastReinforced: Date.now(),
+    sourceConversations: ["conv-1"],
+    sourceType: "direct",
+    narrativeRole: null,
+    partOfStory: null,
+    scopeId: "default",
+    ...overrides,
+  };
+}
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+// ---------------------------------------------------------------------------
+// computeTemporalBoost
+// ---------------------------------------------------------------------------
+
+describe("computeTemporalBoost", () => {
+  test("returns 1.0 when node created at exact same time-of-day/day/month", () => {
+    const now = new Date("2025-06-15T10:00:00Z");
+    const node = makeNode({
+      created: new Date("2024-06-15T10:00:00Z").getTime(),
+    });
+    // Same hour, same day-of-week might differ by year but same month
+    // Hour: 10 vs 10 → sim=1.0, Month: June vs June → sim=1.0
+    // Day: depends on year but same formula applies
+    const boost = computeTemporalBoost(node, now);
+    // Hour match (0.5×1.0) + Month match (0.2×1.0) = 0.7 + dayOfWeek contribution
+    expect(boost).toBeGreaterThan(0.5);
+  });
+
+  test("returns near -1 when node created at opposite time of day", () => {
+    // 0:00 vs 12:00 → opposite hours (12 apart on a 24 cycle)
+    const now = new Date("2025-06-15T00:00:00Z");
+    const node = makeNode({
+      created: new Date("2025-06-15T12:00:00Z").getTime(),
+    });
+    const boost = computeTemporalBoost(node, now);
+    // Hour: 0 vs 12 → sim=-1.0 (opposite), other components vary
+    // 0.5 × (-1) = -0.5, plus day (same day → +0.3) and month (same → +0.2)
+    // Net: -0.5 + 0.3 + 0.2 = 0.0 (ish)
+    expect(boost).toBeLessThan(0.5);
+  });
+
+  test("hour component dominates the boost", () => {
+    // Same hour, different day/month vs different hour, same day/month
+    const now = new Date("2025-06-15T10:00:00Z");
+
+    const sameHourNode = makeNode({
+      created: new Date("2025-01-01T10:00:00Z").getTime(),
+    });
+    const diffHourNode = makeNode({
+      created: new Date("2025-06-15T22:00:00Z").getTime(),
+    });
+
+    const sameHourBoost = computeTemporalBoost(sameHourNode, now);
+    const diffHourBoost = computeTemporalBoost(diffHourNode, now);
+
+    // Same hour should produce higher boost than same day/month but different hour
+    expect(sameHourBoost).toBeGreaterThan(diffHourBoost);
+  });
+
+  test("returns a value in [-1, 1] range", () => {
+    const now = new Date("2025-06-15T10:00:00Z");
+    for (let h = 0; h < 24; h++) {
+      for (let d = 0; d < 7; d++) {
+        // Create dates with varying hours and days
+        const date = new Date(2025, d, h + 1, h, 0, 0);
+        const node = makeNode({ created: date.getTime() });
+        const boost = computeTemporalBoost(node, now);
+        expect(boost).toBeGreaterThanOrEqual(-1);
+        expect(boost).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeEffectiveSignificance
+// ---------------------------------------------------------------------------
+
+describe("computeEffectiveSignificance", () => {
+  test("returns full significance when no time has elapsed", () => {
+    const now = Date.now();
+    const node = makeNode({
+      significance: 0.8,
+      stability: 14,
+      lastReinforced: now,
+    });
+    const eff = computeEffectiveSignificance(node, now);
+    expect(eff).toBe(0.8);
+  });
+
+  test("returns full significance when elapsed is negative", () => {
+    const now = Date.now();
+    const node = makeNode({
+      significance: 0.8,
+      stability: 14,
+      lastReinforced: now + 1000,
+    });
+    const eff = computeEffectiveSignificance(node, now);
+    expect(eff).toBe(0.8);
+  });
+
+  test("decays to ~37% of original after one stability period", () => {
+    const now = Date.now();
+    const stability = 14;
+    const node = makeNode({
+      significance: 1.0,
+      stability,
+      lastReinforced: now - stability * DAY_MS,
+    });
+    const eff = computeEffectiveSignificance(node, now);
+    // e^(-1) ≈ 0.3679
+    expect(eff).toBeCloseTo(Math.exp(-1), 4);
+  });
+
+  test("high stability slows decay dramatically", () => {
+    const now = Date.now();
+    const elapsed = 14 * DAY_MS; // 14 days
+
+    const lowStability = makeNode({
+      significance: 1.0,
+      stability: 14,
+      lastReinforced: now - elapsed,
+    });
+    const highStability = makeNode({
+      significance: 1.0,
+      stability: 806, // ~10 reinforcements (14 × 1.5^10)
+      lastReinforced: now - elapsed,
+    });
+
+    const lowEff = computeEffectiveSignificance(lowStability, now);
+    const highEff = computeEffectiveSignificance(highStability, now);
+
+    // Low stability: e^(-14/14) = e^(-1) ≈ 0.368
+    expect(lowEff).toBeCloseTo(Math.exp(-1), 3);
+    // High stability: e^(-14/806) ≈ 0.983 — essentially permanent
+    expect(highEff).toBeGreaterThan(0.98);
+    expect(highEff).toBeGreaterThan(lowEff);
+  });
+
+  test("zero significance stays zero regardless of time", () => {
+    const now = Date.now();
+    const node = makeNode({
+      significance: 0,
+      stability: 14,
+      lastReinforced: now - 100 * DAY_MS,
+    });
+    const eff = computeEffectiveSignificance(node, now);
+    expect(eff).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeRecencyBoost
+// ---------------------------------------------------------------------------
+
+describe("computeRecencyBoost", () => {
+  test("returns 1.0 for a node created right now", () => {
+    const now = Date.now();
+    const node = makeNode({ created: now });
+    expect(computeRecencyBoost(node, now)).toBe(1.0);
+  });
+
+  test("returns 1.0 for a node created in the future (negative elapsed)", () => {
+    const now = Date.now();
+    const node = makeNode({ created: now + 1000 });
+    expect(computeRecencyBoost(node, now)).toBe(1.0);
+  });
+
+  test("returns 0.5 at the half-life point", () => {
+    const now = Date.now();
+    const halfLifeDays = 7;
+    const node = makeNode({ created: now - halfLifeDays * DAY_MS });
+    const boost = computeRecencyBoost(node, now, halfLifeDays);
+    expect(boost).toBeCloseTo(0.5, 5);
+  });
+
+  test("returns 0.0 at 2x the half-life", () => {
+    const now = Date.now();
+    const halfLifeDays = 7;
+    const node = makeNode({ created: now - 2 * halfLifeDays * DAY_MS });
+    const boost = computeRecencyBoost(node, now, halfLifeDays);
+    expect(boost).toBe(0);
+  });
+
+  test("returns 0.0 for very old nodes (beyond 2x half-life)", () => {
+    const now = Date.now();
+    const halfLifeDays = 7;
+    const node = makeNode({ created: now - 365 * DAY_MS });
+    const boost = computeRecencyBoost(node, now, halfLifeDays);
+    expect(boost).toBe(0);
+  });
+
+  test("linear decay between 0 and 2×halfLife days", () => {
+    const now = Date.now();
+    const halfLifeDays = 7;
+
+    const boostAt3d = computeRecencyBoost(
+      makeNode({ created: now - 3 * DAY_MS }),
+      now,
+      halfLifeDays,
+    );
+    const boostAt7d = computeRecencyBoost(
+      makeNode({ created: now - 7 * DAY_MS }),
+      now,
+      halfLifeDays,
+    );
+    const boostAt10d = computeRecencyBoost(
+      makeNode({ created: now - 10 * DAY_MS }),
+      now,
+      halfLifeDays,
+    );
+
+    expect(boostAt3d).toBeGreaterThan(boostAt7d);
+    expect(boostAt7d).toBeGreaterThan(boostAt10d);
+    expect(boostAt10d).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeActivationSpread
+// ---------------------------------------------------------------------------
+
+describe("computeActivationSpread", () => {
+  test("returns empty map with no edges", () => {
+    const result = computeActivationSpread(["a"], []);
+    expect(result.size).toBe(0);
+  });
+
+  test("returns empty map with no start nodes", () => {
+    const result = computeActivationSpread(
+      [],
+      [
+        {
+          id: "e1",
+          sourceNodeId: "a",
+          targetNodeId: "b",
+          relationship: "reminds-of",
+          weight: 1.0,
+          created: Date.now(),
+        },
+      ],
+    );
+    expect(result.size).toBe(0);
+  });
+
+  test("spreads activation to direct neighbors", () => {
+    const edges = [
+      {
+        id: "e1",
+        sourceNodeId: "a",
+        targetNodeId: "b",
+        relationship: "reminds-of" as const,
+        weight: 1.0,
+        created: Date.now(),
+      },
+    ];
+    const result = computeActivationSpread(["a"], edges, 1, 0.5);
+    expect(result.has("b")).toBe(true);
+    // weight: 1.0 × edgeWeight: 1.0 × decay: 0.5 = 0.5
+    expect(result.get("b")).toBe(0.5);
+  });
+
+  test("does not include start nodes in output", () => {
+    const edges = [
+      {
+        id: "e1",
+        sourceNodeId: "a",
+        targetNodeId: "b",
+        relationship: "reminds-of" as const,
+        weight: 1.0,
+        created: Date.now(),
+      },
+    ];
+    const result = computeActivationSpread(["a"], edges, 2, 0.5);
+    expect(result.has("a")).toBe(false);
+  });
+
+  test("spreads bidirectionally", () => {
+    const edges = [
+      {
+        id: "e1",
+        sourceNodeId: "a",
+        targetNodeId: "b",
+        relationship: "reminds-of" as const,
+        weight: 1.0,
+        created: Date.now(),
+      },
+    ];
+    // Start from b — should still reach a... except a is a start node? No, only b is start.
+    // Wait, start from b, edge goes a→b, but it's bidirectional. So b→a is also traversable.
+    // But we start from "b", so "b" is the start node. "a" is reachable.
+    const result = computeActivationSpread(["b"], edges, 1, 0.5);
+    expect(result.has("a")).toBe(true);
+    expect(result.get("a")).toBe(0.5);
+  });
+
+  test("decays further with each hop", () => {
+    const edges = [
+      {
+        id: "e1",
+        sourceNodeId: "a",
+        targetNodeId: "b",
+        relationship: "reminds-of" as const,
+        weight: 1.0,
+        created: Date.now(),
+      },
+      {
+        id: "e2",
+        sourceNodeId: "b",
+        targetNodeId: "c",
+        relationship: "reminds-of" as const,
+        weight: 1.0,
+        created: Date.now(),
+      },
+    ];
+    const result = computeActivationSpread(["a"], edges, 2, 0.5);
+    // Hop 1: b gets 1.0 × 1.0 × 0.5 = 0.5
+    expect(result.get("b")).toBe(0.5);
+    // Hop 2: c gets 0.5 × 1.0 × 0.5 = 0.25
+    expect(result.get("c")).toBe(0.25);
+  });
+
+  test("takes max activation across multiple paths", () => {
+    const edges = [
+      {
+        id: "e1",
+        sourceNodeId: "a",
+        targetNodeId: "c",
+        relationship: "reminds-of" as const,
+        weight: 0.5,
+        created: Date.now(),
+      },
+      {
+        id: "e2",
+        sourceNodeId: "b",
+        targetNodeId: "c",
+        relationship: "reminds-of" as const,
+        weight: 1.0,
+        created: Date.now(),
+      },
+    ];
+    const result = computeActivationSpread(["a", "b"], edges, 1, 0.5);
+    // From a: c gets 1.0 × 0.5 × 0.5 = 0.25
+    // From b: c gets 1.0 × 1.0 × 0.5 = 0.5
+    // Max wins: 0.5
+    expect(result.get("c")).toBe(0.5);
+  });
+
+  test("edge weight scales activation", () => {
+    const edges = [
+      {
+        id: "e1",
+        sourceNodeId: "a",
+        targetNodeId: "b",
+        relationship: "reminds-of" as const,
+        weight: 0.3,
+        created: Date.now(),
+      },
+    ];
+    const result = computeActivationSpread(["a"], edges, 1, 0.5);
+    // 1.0 × 0.3 × 0.5 = 0.15
+    expect(result.get("b")).toBeCloseTo(0.15, 10);
+  });
+
+  test("respects maxHops limit", () => {
+    const edges = [
+      {
+        id: "e1",
+        sourceNodeId: "a",
+        targetNodeId: "b",
+        relationship: "reminds-of" as const,
+        weight: 1.0,
+        created: Date.now(),
+      },
+      {
+        id: "e2",
+        sourceNodeId: "b",
+        targetNodeId: "c",
+        relationship: "reminds-of" as const,
+        weight: 1.0,
+        created: Date.now(),
+      },
+      {
+        id: "e3",
+        sourceNodeId: "c",
+        targetNodeId: "d",
+        relationship: "reminds-of" as const,
+        weight: 1.0,
+        created: Date.now(),
+      },
+    ];
+    const result = computeActivationSpread(["a"], edges, 1, 0.5);
+    expect(result.has("b")).toBe(true);
+    expect(result.has("c")).toBe(false);
+    expect(result.has("d")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scoreCandidate
+// ---------------------------------------------------------------------------
+
+describe("scoreCandidate", () => {
+  test("returns weighted sum of all components", () => {
+    const node = makeNode();
+    const components = {
+      semanticSimilarity: 1.0,
+      effectiveSignificance: 1.0,
+      emotionalIntensity: 1.0,
+      temporalBoost: 1.0,
+      recencyBoost: 1.0,
+      triggerBoost: 1.0,
+      activationBoost: 1.0,
+    };
+    const result = scoreCandidate(node, components);
+    // With default weights summing to 1.0, score should be 1.0
+    expect(result.score).toBeCloseTo(1.0, 5);
+    expect(result.node).toBe(node);
+    expect(result.scoreBreakdown).toBe(components);
+  });
+
+  test("returns 0 when all components are 0", () => {
+    const node = makeNode();
+    const components = {
+      semanticSimilarity: 0,
+      effectiveSignificance: 0,
+      emotionalIntensity: 0,
+      temporalBoost: 0,
+      recencyBoost: 0,
+      triggerBoost: 0,
+      activationBoost: 0,
+    };
+    const result = scoreCandidate(node, components);
+    expect(result.score).toBe(0);
+  });
+
+  test("clamps negative temporalBoost to 0", () => {
+    const node = makeNode();
+    const components = {
+      semanticSimilarity: 0,
+      effectiveSignificance: 0,
+      emotionalIntensity: 0,
+      temporalBoost: -0.5,
+      recencyBoost: 0,
+      triggerBoost: 0,
+      activationBoost: 0,
+    };
+    const result = scoreCandidate(node, components);
+    // temporalBoost is clamped to 0 via Math.max(0, ...)
+    expect(result.score).toBe(0);
+  });
+
+  test("uses custom weights when provided", () => {
+    const node = makeNode();
+    const components = {
+      semanticSimilarity: 1.0,
+      effectiveSignificance: 0,
+      emotionalIntensity: 0,
+      temporalBoost: 0,
+      recencyBoost: 0,
+      triggerBoost: 0,
+      activationBoost: 0,
+    };
+    const customWeights: ScoringWeights = {
+      semanticSimilarity: 0.5,
+      effectiveSignificance: 0,
+      emotionalIntensity: 0,
+      temporalBoost: 0,
+      recencyBoost: 0,
+      triggerBoost: 0,
+      activationBoost: 0,
+    };
+    const result = scoreCandidate(node, components, customWeights);
+    expect(result.score).toBeCloseTo(0.5, 5);
+  });
+
+  test("PER_TURN_WEIGHTS heavily favor semantic similarity", () => {
+    const node = makeNode();
+    const components = {
+      semanticSimilarity: 1.0,
+      effectiveSignificance: 0,
+      emotionalIntensity: 0,
+      temporalBoost: 0,
+      recencyBoost: 0,
+      triggerBoost: 0,
+      activationBoost: 0,
+    };
+    const result = scoreCandidate(node, components, PER_TURN_WEIGHTS);
+    expect(result.score).toBe(0.6);
+  });
+
+  test("preserves scoreBreakdown for debugging", () => {
+    const node = makeNode();
+    const components = {
+      semanticSimilarity: 0.9,
+      effectiveSignificance: 0.7,
+      emotionalIntensity: 0.3,
+      temporalBoost: 0.1,
+      recencyBoost: 0.5,
+      triggerBoost: 0,
+      activationBoost: 0.2,
+    };
+    const result = scoreCandidate(node, components);
+    expect(result.scoreBreakdown.semanticSimilarity).toBe(0.9);
+    expect(result.scoreBreakdown.effectiveSignificance).toBe(0.7);
+  });
+});

--- a/assistant/src/memory/graph/store.test.ts
+++ b/assistant/src/memory/graph/store.test.ts
@@ -1,0 +1,782 @@
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import { initializeDb, resetTestTables } from "../db.js";
+import {
+  applyDiff,
+  countNodes,
+  createEdge,
+  createNode,
+  createTrigger,
+  deleteEdge,
+  deleteNode,
+  getActiveTriggersByType,
+  getEdgesForNode,
+  getNode,
+  getNodesByIds,
+  getTriggersForNode,
+  queryNodes,
+  reinforceNode,
+  supersedeNode,
+  updateNode,
+  updateTrigger,
+} from "./store.js";
+import type { NewNode } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+function makeNewNode(overrides: Partial<NewNode> = {}): NewNode {
+  const now = Date.now();
+  return {
+    content: "Test memory.",
+    type: "episodic",
+    created: now,
+    lastAccessed: now,
+    lastConsolidated: now,
+    emotionalCharge: {
+      valence: 0,
+      intensity: 0.3,
+      decayCurve: "linear",
+      decayRate: 0.05,
+      originalIntensity: 0.3,
+    },
+    fidelity: "vivid",
+    confidence: 0.8,
+    significance: 0.5,
+    stability: 14,
+    reinforcementCount: 0,
+    lastReinforced: now,
+    sourceConversations: ["conv-1"],
+    sourceType: "direct",
+    narrativeRole: null,
+    partOfStory: null,
+    scopeId: "default",
+    ...overrides,
+  };
+}
+
+beforeAll(() => {
+  initializeDb();
+});
+
+beforeEach(() => {
+  resetTestTables(
+    "memory_graph_triggers",
+    "memory_graph_edges",
+    "memory_graph_nodes",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Node CRUD
+// ---------------------------------------------------------------------------
+
+describe("node CRUD", () => {
+  test("createNode assigns an ID and returns the full node", () => {
+    const node = createNode(makeNewNode({ content: "Hello world." }));
+    expect(node.id).toBeTruthy();
+    expect(typeof node.id).toBe("string");
+    expect(node.content).toBe("Hello world.");
+    expect(node.type).toBe("episodic");
+  });
+
+  test("getNode returns the node by ID", () => {
+    const created = createNode(makeNewNode({ content: "Find me." }));
+    const found = getNode(created.id);
+    expect(found).not.toBeNull();
+    expect(found!.id).toBe(created.id);
+    expect(found!.content).toBe("Find me.");
+  });
+
+  test("getNode returns null for non-existent ID", () => {
+    expect(getNode("non-existent")).toBeNull();
+  });
+
+  test("getNodesByIds returns multiple nodes", () => {
+    const a = createNode(makeNewNode({ content: "Node A." }));
+    const b = createNode(makeNewNode({ content: "Node B." }));
+    createNode(makeNewNode({ content: "Node C." }));
+
+    const found = getNodesByIds([a.id, b.id]);
+    expect(found).toHaveLength(2);
+    const contents = found.map((n) => n.content).sort();
+    expect(contents).toEqual(["Node A.", "Node B."]);
+  });
+
+  test("getNodesByIds returns empty for empty input", () => {
+    expect(getNodesByIds([])).toEqual([]);
+  });
+
+  test("updateNode modifies specified fields", () => {
+    const node = createNode(makeNewNode({ content: "Original." }));
+    updateNode(node.id, {
+      content: "Updated.",
+      significance: 0.9,
+    });
+    const updated = getNode(node.id);
+    expect(updated!.content).toBe("Updated.");
+    expect(updated!.significance).toBe(0.9);
+    // Untouched fields should remain
+    expect(updated!.type).toBe("episodic");
+  });
+
+  test("updateNode with empty changes is a no-op", () => {
+    const node = createNode(makeNewNode({ content: "Unchanged." }));
+    updateNode(node.id, {});
+    const same = getNode(node.id);
+    expect(same!.content).toBe("Unchanged.");
+  });
+
+  test("updateNode serializes emotionalCharge as JSON", () => {
+    const node = createNode(makeNewNode());
+    updateNode(node.id, {
+      emotionalCharge: {
+        valence: 0.8,
+        intensity: 0.9,
+        decayCurve: "permanent",
+        decayRate: 0,
+        originalIntensity: 0.9,
+      },
+    });
+    const updated = getNode(node.id);
+    expect(updated!.emotionalCharge.valence).toBe(0.8);
+    expect(updated!.emotionalCharge.decayCurve).toBe("permanent");
+  });
+
+  test("deleteNode removes the node", () => {
+    const node = createNode(makeNewNode());
+    deleteNode(node.id);
+    expect(getNode(node.id)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Node queries
+// ---------------------------------------------------------------------------
+
+describe("queryNodes", () => {
+  test("filters by scopeId", () => {
+    createNode(makeNewNode({ scopeId: "scope-a", content: "A." }));
+    createNode(makeNewNode({ scopeId: "scope-b", content: "B." }));
+
+    const results = queryNodes({ scopeId: "scope-a" });
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe("A.");
+  });
+
+  test("filters by type", () => {
+    createNode(makeNewNode({ type: "episodic", content: "Ep." }));
+    createNode(makeNewNode({ type: "semantic", content: "Sem." }));
+    createNode(makeNewNode({ type: "emotional", content: "Em." }));
+
+    const results = queryNodes({ types: ["semantic", "emotional"] });
+    expect(results).toHaveLength(2);
+  });
+
+  test("excludes fidelity levels", () => {
+    createNode(makeNewNode({ fidelity: "vivid", content: "Vivid." }));
+    createNode(makeNewNode({ fidelity: "gone", content: "Gone." }));
+
+    const results = queryNodes({ fidelityNot: ["gone"] });
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe("Vivid.");
+  });
+
+  test("filters by minimum significance", () => {
+    createNode(makeNewNode({ significance: 0.3, content: "Low." }));
+    createNode(makeNewNode({ significance: 0.7, content: "High." }));
+
+    const results = queryNodes({ minSignificance: 0.5 });
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe("High.");
+  });
+
+  test("respects limit", () => {
+    for (let i = 0; i < 5; i++) {
+      createNode(makeNewNode({ content: `Node ${i}.` }));
+    }
+    const results = queryNodes({ limit: 3 });
+    expect(results).toHaveLength(3);
+  });
+
+  test("orders by significance descending", () => {
+    createNode(makeNewNode({ significance: 0.3 }));
+    createNode(makeNewNode({ significance: 0.9 }));
+    createNode(makeNewNode({ significance: 0.6 }));
+
+    const results = queryNodes({});
+    expect(results[0].significance).toBe(0.9);
+    expect(results[1].significance).toBe(0.6);
+    expect(results[2].significance).toBe(0.3);
+  });
+});
+
+describe("countNodes", () => {
+  test("counts non-gone nodes in a scope", () => {
+    createNode(makeNewNode({ scopeId: "s1", fidelity: "vivid" }));
+    createNode(makeNewNode({ scopeId: "s1", fidelity: "clear" }));
+    createNode(makeNewNode({ scopeId: "s1", fidelity: "gone" }));
+    createNode(makeNewNode({ scopeId: "s2", fidelity: "vivid" }));
+
+    expect(countNodes("s1")).toBe(2);
+    expect(countNodes("s2")).toBe(1);
+    expect(countNodes("s3")).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge CRUD
+// ---------------------------------------------------------------------------
+
+describe("edge CRUD", () => {
+  test("createEdge assigns an ID and returns the full edge", () => {
+    const a = createNode(makeNewNode());
+    const b = createNode(makeNewNode());
+    const edge = createEdge({
+      sourceNodeId: a.id,
+      targetNodeId: b.id,
+      relationship: "caused-by",
+      weight: 0.8,
+      created: Date.now(),
+    });
+    expect(edge.id).toBeTruthy();
+    expect(edge.sourceNodeId).toBe(a.id);
+    expect(edge.targetNodeId).toBe(b.id);
+    expect(edge.relationship).toBe("caused-by");
+    expect(edge.weight).toBe(0.8);
+  });
+
+  test("getEdgesForNode returns all edges (both directions)", () => {
+    const a = createNode(makeNewNode());
+    const b = createNode(makeNewNode());
+    const c = createNode(makeNewNode());
+    createEdge({
+      sourceNodeId: a.id,
+      targetNodeId: b.id,
+      relationship: "reminds-of",
+      weight: 1.0,
+      created: Date.now(),
+    });
+    createEdge({
+      sourceNodeId: c.id,
+      targetNodeId: a.id,
+      relationship: "part-of",
+      weight: 0.5,
+      created: Date.now(),
+    });
+
+    const edges = getEdgesForNode(a.id);
+    expect(edges).toHaveLength(2);
+  });
+
+  test("getEdgesForNode with outgoing direction", () => {
+    const a = createNode(makeNewNode());
+    const b = createNode(makeNewNode());
+    createEdge({
+      sourceNodeId: a.id,
+      targetNodeId: b.id,
+      relationship: "reminds-of",
+      weight: 1.0,
+      created: Date.now(),
+    });
+    createEdge({
+      sourceNodeId: b.id,
+      targetNodeId: a.id,
+      relationship: "caused-by",
+      weight: 1.0,
+      created: Date.now(),
+    });
+
+    const outgoing = getEdgesForNode(a.id, "outgoing");
+    expect(outgoing).toHaveLength(1);
+    expect(outgoing[0].targetNodeId).toBe(b.id);
+  });
+
+  test("getEdgesForNode with incoming direction", () => {
+    const a = createNode(makeNewNode());
+    const b = createNode(makeNewNode());
+    createEdge({
+      sourceNodeId: b.id,
+      targetNodeId: a.id,
+      relationship: "caused-by",
+      weight: 1.0,
+      created: Date.now(),
+    });
+
+    const incoming = getEdgesForNode(a.id, "incoming");
+    expect(incoming).toHaveLength(1);
+    expect(incoming[0].sourceNodeId).toBe(b.id);
+  });
+
+  test("deleteEdge removes the edge", () => {
+    const a = createNode(makeNewNode());
+    const b = createNode(makeNewNode());
+    const edge = createEdge({
+      sourceNodeId: a.id,
+      targetNodeId: b.id,
+      relationship: "reminds-of",
+      weight: 1.0,
+      created: Date.now(),
+    });
+    deleteEdge(edge.id);
+    expect(getEdgesForNode(a.id)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Trigger CRUD
+// ---------------------------------------------------------------------------
+
+describe("trigger CRUD", () => {
+  test("createTrigger assigns an ID and returns the full trigger", () => {
+    const node = createNode(makeNewNode());
+    const trigger = createTrigger({
+      nodeId: node.id,
+      type: "temporal",
+      schedule: "day-of-week:monday",
+      condition: null,
+      conditionEmbedding: null,
+      threshold: null,
+      eventDate: null,
+      rampDays: null,
+      followUpDays: null,
+      recurring: true,
+      consumed: false,
+      cooldownMs: 1000 * 60 * 60 * 12,
+      lastFired: null,
+    });
+    expect(trigger.id).toBeTruthy();
+    expect(trigger.type).toBe("temporal");
+    expect(trigger.schedule).toBe("day-of-week:monday");
+    expect(trigger.recurring).toBe(true);
+  });
+
+  test("getTriggersForNode returns triggers for a given node", () => {
+    const node = createNode(makeNewNode());
+    createTrigger({
+      nodeId: node.id,
+      type: "temporal",
+      schedule: "time:morning",
+      condition: null,
+      conditionEmbedding: null,
+      threshold: null,
+      eventDate: null,
+      rampDays: null,
+      followUpDays: null,
+      recurring: false,
+      consumed: false,
+      cooldownMs: null,
+      lastFired: null,
+    });
+    createTrigger({
+      nodeId: node.id,
+      type: "semantic",
+      schedule: null,
+      condition: "cooking topic",
+      conditionEmbedding: null,
+      threshold: 0.7,
+      eventDate: null,
+      rampDays: null,
+      followUpDays: null,
+      recurring: false,
+      consumed: false,
+      cooldownMs: null,
+      lastFired: null,
+    });
+
+    const triggers = getTriggersForNode(node.id);
+    expect(triggers).toHaveLength(2);
+  });
+
+  test("updateTrigger modifies consumed and lastFired", () => {
+    const node = createNode(makeNewNode());
+    const trigger = createTrigger({
+      nodeId: node.id,
+      type: "temporal",
+      schedule: "date:04-08",
+      condition: null,
+      conditionEmbedding: null,
+      threshold: null,
+      eventDate: null,
+      rampDays: null,
+      followUpDays: null,
+      recurring: false,
+      consumed: false,
+      cooldownMs: null,
+      lastFired: null,
+    });
+
+    const now = Date.now();
+    updateTrigger(trigger.id, { consumed: true, lastFired: now });
+
+    const updated = getTriggersForNode(node.id);
+    expect(updated[0].consumed).toBe(true);
+    expect(updated[0].lastFired).toBe(now);
+  });
+
+  test("getActiveTriggersByType returns only non-consumed triggers", () => {
+    const node = createNode(makeNewNode());
+    createTrigger({
+      nodeId: node.id,
+      type: "temporal",
+      schedule: "time:morning",
+      condition: null,
+      conditionEmbedding: null,
+      threshold: null,
+      eventDate: null,
+      rampDays: null,
+      followUpDays: null,
+      recurring: false,
+      consumed: false,
+      cooldownMs: null,
+      lastFired: null,
+    });
+    createTrigger({
+      nodeId: node.id,
+      type: "temporal",
+      schedule: "time:evening",
+      condition: null,
+      conditionEmbedding: null,
+      threshold: null,
+      eventDate: null,
+      rampDays: null,
+      followUpDays: null,
+      recurring: false,
+      consumed: true,
+      cooldownMs: null,
+      lastFired: null,
+    });
+
+    const active = getActiveTriggersByType("temporal");
+    expect(active).toHaveLength(1);
+    expect(active[0].schedule).toBe("time:morning");
+  });
+
+  test("getActiveTriggersByType filters by scope when provided", () => {
+    const nodeA = createNode(makeNewNode({ scopeId: "scope-a" }));
+    const nodeB = createNode(makeNewNode({ scopeId: "scope-b" }));
+    createTrigger({
+      nodeId: nodeA.id,
+      type: "temporal",
+      schedule: "time:morning",
+      condition: null,
+      conditionEmbedding: null,
+      threshold: null,
+      eventDate: null,
+      rampDays: null,
+      followUpDays: null,
+      recurring: false,
+      consumed: false,
+      cooldownMs: null,
+      lastFired: null,
+    });
+    createTrigger({
+      nodeId: nodeB.id,
+      type: "temporal",
+      schedule: "time:evening",
+      condition: null,
+      conditionEmbedding: null,
+      threshold: null,
+      eventDate: null,
+      rampDays: null,
+      followUpDays: null,
+      recurring: false,
+      consumed: false,
+      cooldownMs: null,
+      lastFired: null,
+    });
+
+    const scopeA = getActiveTriggersByType("temporal", "scope-a");
+    expect(scopeA).toHaveLength(1);
+    expect(scopeA[0].schedule).toBe("time:morning");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reinforcement
+// ---------------------------------------------------------------------------
+
+describe("reinforceNode", () => {
+  test("increments reinforcementCount", () => {
+    const node = createNode(
+      makeNewNode({ reinforcementCount: 0, stability: 14, significance: 0.5 }),
+    );
+    reinforceNode(node.id);
+    const updated = getNode(node.id)!;
+    expect(updated.reinforcementCount).toBe(1);
+  });
+
+  test("multiplies stability by 1.5", () => {
+    const node = createNode(makeNewNode({ stability: 14 }));
+    reinforceNode(node.id);
+    const updated = getNode(node.id)!;
+    expect(updated.stability).toBeCloseTo(21, 5); // 14 × 1.5
+  });
+
+  test("boosts significance by 10%, capped at 1.0", () => {
+    const node = createNode(makeNewNode({ significance: 0.5 }));
+    reinforceNode(node.id);
+    const updated = getNode(node.id)!;
+    expect(updated.significance).toBeCloseTo(0.55, 5); // 0.5 × 1.1
+  });
+
+  test("significance does not exceed 1.0", () => {
+    const node = createNode(makeNewNode({ significance: 0.95 }));
+    reinforceNode(node.id);
+    const updated = getNode(node.id)!;
+    expect(updated.significance).toBeLessThanOrEqual(1.0);
+  });
+
+  test("updates lastReinforced timestamp", () => {
+    const oldTime = Date.now() - 10000;
+    const node = createNode(makeNewNode({ lastReinforced: oldTime }));
+    reinforceNode(node.id);
+    const updated = getNode(node.id)!;
+    expect(updated.lastReinforced).toBeGreaterThan(oldTime);
+  });
+
+  test("multiple reinforcements compound stability", () => {
+    const node = createNode(makeNewNode({ stability: 14 }));
+    reinforceNode(node.id);
+    reinforceNode(node.id);
+    reinforceNode(node.id);
+    const updated = getNode(node.id)!;
+    expect(updated.reinforcementCount).toBe(3);
+    // 14 × 1.5^3 = 47.25
+    expect(updated.stability).toBeCloseTo(47.25, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Supersession
+// ---------------------------------------------------------------------------
+
+describe("supersedeNode", () => {
+  test("creates new node with inherited durability", () => {
+    const old = createNode(
+      makeNewNode({
+        content: "Old fact.",
+        stability: 50,
+        reinforcementCount: 5,
+        significance: 0.9,
+      }),
+    );
+    const newNodeInput = makeNewNode({
+      content: "Updated fact.",
+      stability: 14,
+      reinforcementCount: 0,
+      significance: 0.5,
+    });
+
+    const { newNode, oldNode } = supersedeNode(old.id, newNodeInput);
+
+    expect(newNode.content).toBe("Updated fact.");
+    // Inherits max of each durability metric
+    expect(newNode.stability).toBe(50); // max(14, 50)
+    expect(newNode.reinforcementCount).toBe(5); // max(0, 5)
+    expect(newNode.significance).toBe(0.9); // max(0.5, 0.9)
+    expect(oldNode).not.toBeNull();
+    expect(oldNode!.id).toBe(old.id);
+  });
+
+  test("creates a supersedes edge between new and old node", () => {
+    const old = createNode(makeNewNode({ content: "Old." }));
+    const { newNode } = supersedeNode(old.id, makeNewNode({ content: "New." }));
+
+    const edges = getEdgesForNode(newNode.id, "outgoing");
+    expect(edges).toHaveLength(1);
+    expect(edges[0].relationship).toBe("supersedes");
+    expect(edges[0].targetNodeId).toBe(old.id);
+    expect(edges[0].weight).toBe(1.0);
+  });
+
+  test("handles non-existent old node by just creating new node", () => {
+    const { newNode, oldNode } = supersedeNode(
+      "non-existent",
+      makeNewNode({ content: "Brand new." }),
+    );
+    expect(newNode.content).toBe("Brand new.");
+    expect(oldNode).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyDiff
+// ---------------------------------------------------------------------------
+
+describe("applyDiff", () => {
+  test("creates nodes and returns counts", () => {
+    const result = applyDiff({
+      createNodes: [
+        makeNewNode({ content: "Node 1." }),
+        makeNewNode({ content: "Node 2." }),
+      ],
+      updateNodes: [],
+      deleteNodeIds: [],
+      createEdges: [],
+      deleteEdgeIds: [],
+      createTriggers: [],
+      deleteTriggerIds: [],
+      reinforceNodeIds: [],
+    });
+
+    expect(result.nodesCreated).toBe(2);
+    expect(result.createdNodeIds).toHaveLength(2);
+  });
+
+  test("deletes nodes", () => {
+    const node = createNode(makeNewNode());
+    const result = applyDiff({
+      createNodes: [],
+      updateNodes: [],
+      deleteNodeIds: [node.id],
+      createEdges: [],
+      deleteEdgeIds: [],
+      createTriggers: [],
+      deleteTriggerIds: [],
+      reinforceNodeIds: [],
+    });
+    expect(result.nodesDeleted).toBe(1);
+    expect(getNode(node.id)).toBeNull();
+  });
+
+  test("updates nodes", () => {
+    const node = createNode(makeNewNode({ content: "Before." }));
+    const result = applyDiff({
+      createNodes: [],
+      updateNodes: [{ id: node.id, changes: { content: "After." } }],
+      deleteNodeIds: [],
+      createEdges: [],
+      deleteEdgeIds: [],
+      createTriggers: [],
+      deleteTriggerIds: [],
+      reinforceNodeIds: [],
+    });
+    expect(result.nodesUpdated).toBe(1);
+    expect(getNode(node.id)!.content).toBe("After.");
+  });
+
+  test("reinforces nodes", () => {
+    const node = createNode(makeNewNode({ reinforcementCount: 0 }));
+    const result = applyDiff({
+      createNodes: [],
+      updateNodes: [],
+      deleteNodeIds: [],
+      createEdges: [],
+      deleteEdgeIds: [],
+      createTriggers: [],
+      deleteTriggerIds: [],
+      reinforceNodeIds: [node.id],
+    });
+    expect(result.nodesReinforced).toBe(1);
+    expect(getNode(node.id)!.reinforcementCount).toBe(1);
+  });
+
+  test("creates and deletes edges", () => {
+    const a = createNode(makeNewNode());
+    const b = createNode(makeNewNode());
+    const existingEdge = createEdge({
+      sourceNodeId: a.id,
+      targetNodeId: b.id,
+      relationship: "reminds-of",
+      weight: 1.0,
+      created: Date.now(),
+    });
+
+    const result = applyDiff({
+      createNodes: [],
+      updateNodes: [],
+      deleteNodeIds: [],
+      createEdges: [
+        {
+          sourceNodeId: b.id,
+          targetNodeId: a.id,
+          relationship: "caused-by",
+          weight: 0.5,
+          created: Date.now(),
+        },
+      ],
+      deleteEdgeIds: [existingEdge.id],
+      createTriggers: [],
+      deleteTriggerIds: [],
+      reinforceNodeIds: [],
+    });
+    expect(result.edgesCreated).toBe(1);
+    expect(result.edgesDeleted).toBe(1);
+  });
+
+  test("creates and deletes triggers", () => {
+    const node = createNode(makeNewNode());
+    const existingTrigger = createTrigger({
+      nodeId: node.id,
+      type: "temporal",
+      schedule: "time:morning",
+      condition: null,
+      conditionEmbedding: null,
+      threshold: null,
+      eventDate: null,
+      rampDays: null,
+      followUpDays: null,
+      recurring: false,
+      consumed: false,
+      cooldownMs: null,
+      lastFired: null,
+    });
+
+    const result = applyDiff({
+      createNodes: [],
+      updateNodes: [],
+      deleteNodeIds: [],
+      createEdges: [],
+      deleteEdgeIds: [],
+      createTriggers: [
+        {
+          nodeId: node.id,
+          type: "semantic",
+          schedule: null,
+          condition: "test",
+          conditionEmbedding: null,
+          threshold: 0.7,
+          eventDate: null,
+          rampDays: null,
+          followUpDays: null,
+          recurring: false,
+          consumed: false,
+          cooldownMs: null,
+          lastFired: null,
+        },
+      ],
+      deleteTriggerIds: [existingTrigger.id],
+      reinforceNodeIds: [],
+    });
+    expect(result.triggersCreated).toBe(1);
+    expect(result.triggersDeleted).toBe(1);
+    const remaining = getTriggersForNode(node.id);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].type).toBe("semantic");
+  });
+
+  test("applies all operations atomically", () => {
+    // Verify all operations are in the same transaction by creating
+    // a complex diff and checking the result counts.
+    const existingNode = createNode(makeNewNode({ content: "Existing." }));
+
+    const result = applyDiff({
+      createNodes: [makeNewNode({ content: "New 1." })],
+      updateNodes: [{ id: existingNode.id, changes: { content: "Updated." } }],
+      deleteNodeIds: [],
+      createEdges: [],
+      deleteEdgeIds: [],
+      createTriggers: [],
+      deleteTriggerIds: [],
+      reinforceNodeIds: [existingNode.id],
+    });
+
+    expect(result.nodesCreated).toBe(1);
+    expect(result.nodesUpdated).toBe(1);
+    expect(result.nodesReinforced).toBe(1);
+    expect(getNode(existingNode.id)!.content).toBe("Updated.");
+    expect(getNode(existingNode.id)!.reinforcementCount).toBe(1);
+  });
+});

--- a/assistant/src/memory/graph/triggers.test.ts
+++ b/assistant/src/memory/graph/triggers.test.ts
@@ -1,0 +1,487 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  evaluateEventTriggers,
+  evaluateSemanticTriggers,
+  evaluateTemporalTriggers,
+} from "./triggers.js";
+import type { MemoryTrigger } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+function makeTrigger(overrides: Partial<MemoryTrigger> = {}): MemoryTrigger {
+  return {
+    id: "trigger-1",
+    nodeId: "node-1",
+    type: "temporal",
+    schedule: null,
+    condition: null,
+    conditionEmbedding: null,
+    threshold: null,
+    eventDate: null,
+    rampDays: null,
+    followUpDays: null,
+    recurring: false,
+    consumed: false,
+    cooldownMs: null,
+    lastFired: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// evaluateTemporalTriggers
+// ---------------------------------------------------------------------------
+
+describe("evaluateTemporalTriggers", () => {
+  test("fires day-of-week trigger on matching day", () => {
+    // 2025-06-16 is a Monday
+    const monday = new Date("2025-06-16T10:00:00Z");
+    const trigger = makeTrigger({
+      type: "temporal",
+      schedule: "day-of-week:monday",
+    });
+    const results = evaluateTemporalTriggers([trigger], monday);
+    expect(results).toHaveLength(1);
+    expect(results[0].boost).toBe(1.0);
+  });
+
+  test("does not fire day-of-week trigger on non-matching day", () => {
+    // 2025-06-17 is a Tuesday
+    const tuesday = new Date("2025-06-17T10:00:00Z");
+    const trigger = makeTrigger({
+      type: "temporal",
+      schedule: "day-of-week:monday",
+    });
+    const results = evaluateTemporalTriggers([trigger], tuesday);
+    expect(results).toHaveLength(0);
+  });
+
+  test("fires date trigger on matching date", () => {
+    const april8 = new Date("2025-04-08T15:00:00Z");
+    const trigger = makeTrigger({
+      type: "temporal",
+      schedule: "date:04-08",
+    });
+    const results = evaluateTemporalTriggers([trigger], april8);
+    expect(results).toHaveLength(1);
+  });
+
+  test("does not fire date trigger on non-matching date", () => {
+    const april9 = new Date("2025-04-09T15:00:00Z");
+    const trigger = makeTrigger({
+      type: "temporal",
+      schedule: "date:04-08",
+    });
+    const results = evaluateTemporalTriggers([trigger], april9);
+    expect(results).toHaveLength(0);
+  });
+
+  test("fires time:morning trigger between 5-11", () => {
+    const morning = new Date("2025-06-15T08:00:00"); // local hour 8
+    const trigger = makeTrigger({
+      type: "temporal",
+      schedule: "time:morning",
+    });
+    const results = evaluateTemporalTriggers([trigger], morning);
+    expect(results).toHaveLength(1);
+  });
+
+  test("fires time:afternoon trigger between 12-16", () => {
+    const afternoon = new Date("2025-06-15T14:00:00"); // local hour 14
+    const trigger = makeTrigger({
+      type: "temporal",
+      schedule: "time:afternoon",
+    });
+    const results = evaluateTemporalTriggers([trigger], afternoon);
+    expect(results).toHaveLength(1);
+  });
+
+  test("fires time:evening trigger between 17-20", () => {
+    const evening = new Date("2025-06-15T18:00:00"); // local hour 18
+    const trigger = makeTrigger({
+      type: "temporal",
+      schedule: "time:evening",
+    });
+    const results = evaluateTemporalTriggers([trigger], evening);
+    expect(results).toHaveLength(1);
+  });
+
+  test("fires time:night trigger at 22:00", () => {
+    const night = new Date("2025-06-15T22:00:00"); // local hour 22
+    const trigger = makeTrigger({
+      type: "temporal",
+      schedule: "time:night",
+    });
+    const results = evaluateTemporalTriggers([trigger], night);
+    expect(results).toHaveLength(1);
+  });
+
+  test("fires time:night trigger at 3 AM (wraps past midnight)", () => {
+    const lateNight = new Date("2025-06-15T03:00:00"); // local hour 3
+    const trigger = makeTrigger({
+      type: "temporal",
+      schedule: "time:night",
+    });
+    const results = evaluateTemporalTriggers([trigger], lateNight);
+    expect(results).toHaveLength(1);
+  });
+
+  test("does not fire time:morning at 14:00", () => {
+    const afternoon = new Date("2025-06-15T14:00:00");
+    const trigger = makeTrigger({
+      type: "temporal",
+      schedule: "time:morning",
+    });
+    const results = evaluateTemporalTriggers([trigger], afternoon);
+    expect(results).toHaveLength(0);
+  });
+
+  test("skips non-temporal triggers", () => {
+    const now = new Date("2025-06-16T10:00:00Z");
+    const trigger = makeTrigger({
+      type: "semantic",
+      schedule: "day-of-week:monday",
+    });
+    const results = evaluateTemporalTriggers([trigger], now);
+    expect(results).toHaveLength(0);
+  });
+
+  test("skips triggers without a schedule", () => {
+    const now = new Date("2025-06-16T10:00:00Z");
+    const trigger = makeTrigger({
+      type: "temporal",
+      schedule: null,
+    });
+    const results = evaluateTemporalTriggers([trigger], now);
+    expect(results).toHaveLength(0);
+  });
+
+  test("respects cooldown for recurring triggers", () => {
+    const now = new Date("2025-06-16T10:00:00Z");
+    const trigger = makeTrigger({
+      type: "temporal",
+      schedule: "day-of-week:monday",
+      recurring: true,
+      cooldownMs: DAY_MS,
+      lastFired: now.getTime() - DAY_MS / 2, // fired 12h ago, cooldown 24h
+    });
+    const results = evaluateTemporalTriggers([trigger], now);
+    expect(results).toHaveLength(0);
+  });
+
+  test("fires recurring trigger after cooldown expires", () => {
+    const now = new Date("2025-06-16T10:00:00Z");
+    const trigger = makeTrigger({
+      type: "temporal",
+      schedule: "day-of-week:monday",
+      recurring: true,
+      cooldownMs: DAY_MS,
+      lastFired: now.getTime() - DAY_MS * 2, // fired 2 days ago, cooldown 24h
+    });
+    const results = evaluateTemporalTriggers([trigger], now);
+    expect(results).toHaveLength(1);
+  });
+
+  test("non-recurring triggers bypass cooldown check", () => {
+    const now = new Date("2025-06-16T10:00:00Z");
+    const trigger = makeTrigger({
+      type: "temporal",
+      schedule: "day-of-week:monday",
+      recurring: false,
+      lastFired: now.getTime() - 1000, // fired 1s ago
+    });
+    const results = evaluateTemporalTriggers([trigger], now);
+    expect(results).toHaveLength(1);
+  });
+
+  test("handles case-insensitive schedule matching", () => {
+    const monday = new Date("2025-06-16T10:00:00Z");
+    const trigger = makeTrigger({
+      type: "temporal",
+      schedule: "Day-Of-Week:Monday",
+    });
+    const results = evaluateTemporalTriggers([trigger], monday);
+    expect(results).toHaveLength(1);
+  });
+
+  test("evaluates multiple triggers independently", () => {
+    const monday = new Date("2025-06-16T10:00:00Z");
+    const triggers = [
+      makeTrigger({
+        id: "t1",
+        type: "temporal",
+        schedule: "day-of-week:monday",
+      }),
+      makeTrigger({
+        id: "t2",
+        type: "temporal",
+        schedule: "day-of-week:tuesday",
+      }),
+      makeTrigger({
+        id: "t3",
+        type: "temporal",
+        schedule: "day-of-week:monday",
+      }),
+    ];
+    const results = evaluateTemporalTriggers(triggers, monday);
+    expect(results).toHaveLength(2);
+    expect(results.map((r) => r.trigger.id)).toEqual(["t1", "t3"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateSemanticTriggers
+// ---------------------------------------------------------------------------
+
+describe("evaluateSemanticTriggers", () => {
+  test("fires when cosine similarity exceeds threshold", () => {
+    // Two identical unit vectors → similarity = 1.0
+    const embedding = new Float32Array([1, 0, 0]);
+    const trigger = makeTrigger({
+      type: "semantic",
+      conditionEmbedding: new Float32Array([1, 0, 0]),
+      threshold: 0.5,
+    });
+    const results = evaluateSemanticTriggers([trigger], embedding);
+    expect(results).toHaveLength(1);
+    expect(results[0].boost).toBeGreaterThanOrEqual(0.5);
+  });
+
+  test("does not fire when similarity is below threshold", () => {
+    // Orthogonal vectors → similarity = 0
+    const embedding = new Float32Array([1, 0, 0]);
+    const trigger = makeTrigger({
+      type: "semantic",
+      conditionEmbedding: new Float32Array([0, 1, 0]),
+      threshold: 0.5,
+    });
+    const results = evaluateSemanticTriggers([trigger], embedding);
+    expect(results).toHaveLength(0);
+  });
+
+  test("boost scales by how far above threshold", () => {
+    // Identical vectors: similarity = 1.0, threshold = 0.5
+    // boost = (1.0 - 0.5) / (1 - 0.5 + 0.001) ≈ 1.0
+    const embedding = new Float32Array([1, 0, 0]);
+    const trigger = makeTrigger({
+      type: "semantic",
+      conditionEmbedding: new Float32Array([1, 0, 0]),
+      threshold: 0.5,
+    });
+    const results = evaluateSemanticTriggers([trigger], embedding);
+    expect(results[0].boost).toBeCloseTo(1.0, 1);
+  });
+
+  test("boost has minimum of 0.5", () => {
+    // Barely above threshold — boost would be near 0, but floored to 0.5
+    const embedding = new Float32Array([1, 0, 0]);
+    const trigger = makeTrigger({
+      type: "semantic",
+      conditionEmbedding: new Float32Array([0.98, 0.2, 0]),
+      threshold: 0.97,
+    });
+    const results = evaluateSemanticTriggers([trigger], embedding);
+    if (results.length > 0) {
+      expect(results[0].boost).toBeGreaterThanOrEqual(0.5);
+    }
+  });
+
+  test("skips consumed triggers", () => {
+    const embedding = new Float32Array([1, 0, 0]);
+    const trigger = makeTrigger({
+      type: "semantic",
+      conditionEmbedding: new Float32Array([1, 0, 0]),
+      threshold: 0.5,
+      consumed: true,
+    });
+    const results = evaluateSemanticTriggers([trigger], embedding);
+    expect(results).toHaveLength(0);
+  });
+
+  test("skips triggers without embeddings", () => {
+    const embedding = new Float32Array([1, 0, 0]);
+    const trigger = makeTrigger({
+      type: "semantic",
+      conditionEmbedding: null,
+      threshold: 0.5,
+    });
+    const results = evaluateSemanticTriggers([trigger], embedding);
+    expect(results).toHaveLength(0);
+  });
+
+  test("skips triggers without threshold", () => {
+    const embedding = new Float32Array([1, 0, 0]);
+    const trigger = makeTrigger({
+      type: "semantic",
+      conditionEmbedding: new Float32Array([1, 0, 0]),
+      threshold: null,
+    });
+    const results = evaluateSemanticTriggers([trigger], embedding);
+    expect(results).toHaveLength(0);
+  });
+
+  test("skips non-semantic triggers", () => {
+    const embedding = new Float32Array([1, 0, 0]);
+    const trigger = makeTrigger({
+      type: "temporal",
+      conditionEmbedding: new Float32Array([1, 0, 0]),
+      threshold: 0.5,
+    });
+    const results = evaluateSemanticTriggers([trigger], embedding);
+    expect(results).toHaveLength(0);
+  });
+
+  test("handles mismatched vector lengths gracefully", () => {
+    const embedding = new Float32Array([1, 0, 0]);
+    const trigger = makeTrigger({
+      type: "semantic",
+      conditionEmbedding: new Float32Array([1, 0]),
+      threshold: 0.5,
+    });
+    // cosineSimilarity returns 0 for mismatched lengths → no fire
+    const results = evaluateSemanticTriggers([trigger], embedding);
+    expect(results).toHaveLength(0);
+  });
+
+  test("accepts number[] as query embedding", () => {
+    const embedding = [1, 0, 0];
+    const trigger = makeTrigger({
+      type: "semantic",
+      conditionEmbedding: new Float32Array([1, 0, 0]),
+      threshold: 0.5,
+    });
+    const results = evaluateSemanticTriggers([trigger], embedding);
+    expect(results).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateEventTriggers
+// ---------------------------------------------------------------------------
+
+describe("evaluateEventTriggers", () => {
+  test("returns background boost (0.05) for events far in the future", () => {
+    const now = new Date("2025-06-15T10:00:00Z");
+    const trigger = makeTrigger({
+      type: "event",
+      eventDate: now.getTime() + 30 * DAY_MS, // 30 days away
+      rampDays: 7,
+      followUpDays: 2,
+    });
+    const results = evaluateEventTriggers([trigger], now);
+    expect(results).toHaveLength(1);
+    expect(results[0].boost).toBeCloseTo(0.05, 5);
+  });
+
+  test("ramps linearly from 0.05 to 1.0 as event approaches", () => {
+    const now = new Date("2025-06-15T10:00:00Z");
+    const eventDate = now.getTime() + 7 * DAY_MS; // exactly at rampDays boundary
+    const trigger = makeTrigger({
+      type: "event",
+      eventDate,
+      rampDays: 7,
+      followUpDays: 2,
+    });
+
+    // At rampDays boundary: daysUntil = 7, rampDays = 7 → boost = 0.05
+    const resultsAtBoundary = evaluateEventTriggers([trigger], now);
+    expect(resultsAtBoundary[0].boost).toBeCloseTo(0.05, 5);
+
+    // Halfway through ramp: 3.5 days before event
+    const halfwayNow = new Date(now.getTime() + 3.5 * DAY_MS);
+    const resultsHalfway = evaluateEventTriggers([trigger], halfwayNow);
+    expect(resultsHalfway[0].boost).toBeCloseTo(0.525, 1);
+
+    // Day before: daysUntil ≈ 0 → boost ≈ 1.0
+    const dayBeforeNow = new Date(eventDate - 0.1 * DAY_MS);
+    const resultsDayBefore = evaluateEventTriggers([trigger], dayBeforeNow);
+    expect(resultsDayBefore[0].boost).toBeGreaterThan(0.9);
+  });
+
+  test("returns full boost (1.0) on the day of the event", () => {
+    const now = new Date("2025-06-15T10:00:00Z");
+    const eventDate = now.getTime(); // right now
+    const trigger = makeTrigger({
+      type: "event",
+      eventDate,
+      rampDays: 7,
+      followUpDays: 2,
+    });
+    // daysUntil = 0, which is > -1 → day-of boost = 1.0
+    const results = evaluateEventTriggers([trigger], now);
+    expect(results).toHaveLength(1);
+    expect(results[0].boost).toBe(1.0);
+  });
+
+  test("decays exponentially after the event", () => {
+    const eventDate = new Date("2025-06-15T10:00:00Z").getTime();
+    const trigger = makeTrigger({
+      type: "event",
+      eventDate,
+      rampDays: 7,
+      followUpDays: 2,
+    });
+
+    // 1.5 days after event
+    const afterNow = new Date(eventDate + 1.5 * DAY_MS);
+    const results = evaluateEventTriggers([trigger], afterNow);
+    expect(results).toHaveLength(1);
+    expect(results[0].boost).toBeGreaterThan(0.01);
+    expect(results[0].boost).toBeLessThan(1.0);
+  });
+
+  test("returns 0 after followUpDays", () => {
+    const eventDate = new Date("2025-06-15T10:00:00Z").getTime();
+    const trigger = makeTrigger({
+      type: "event",
+      eventDate,
+      rampDays: 7,
+      followUpDays: 2,
+    });
+
+    // 3 days after event (beyond followUpDays=2)
+    const longAfter = new Date(eventDate + 3 * DAY_MS);
+    const results = evaluateEventTriggers([trigger], longAfter);
+    expect(results).toHaveLength(0);
+  });
+
+  test("skips non-event triggers", () => {
+    const now = new Date("2025-06-15T10:00:00Z");
+    const trigger = makeTrigger({
+      type: "temporal",
+      eventDate: now.getTime() + DAY_MS,
+    });
+    const results = evaluateEventTriggers([trigger], now);
+    expect(results).toHaveLength(0);
+  });
+
+  test("skips triggers without eventDate", () => {
+    const now = new Date("2025-06-15T10:00:00Z");
+    const trigger = makeTrigger({
+      type: "event",
+      eventDate: null,
+    });
+    const results = evaluateEventTriggers([trigger], now);
+    expect(results).toHaveLength(0);
+  });
+
+  test("uses default rampDays=7 and followUpDays=2 when not specified", () => {
+    const now = new Date("2025-06-15T10:00:00Z");
+    const eventDate = now.getTime() + 5 * DAY_MS; // 5 days away (inside default 7-day ramp)
+    const trigger = makeTrigger({
+      type: "event",
+      eventDate,
+      rampDays: null, // triggers default of 7
+      followUpDays: null, // triggers default of 2
+    });
+    const results = evaluateEventTriggers([trigger], now);
+    expect(results).toHaveLength(1);
+    // Should be in the ramp-up phase with boost > background
+    expect(results[0].boost).toBeGreaterThan(0.05);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds unit tests for graph scoring (significance decay, temporal boost, recency, activation spread, combined scoring)
- Adds unit tests for graph store CRUD operations (nodes, edges, triggers, reinforcement, supersession, diff application)
- Adds unit tests for injection formatting (InContextTracker, context block assembly, injection block formatting)
- Adds unit tests for extraction parsing (node creation, reinforcement, updates, edges, deferred edges/triggers, robustness)
- Adds unit tests for trigger evaluation (temporal, semantic, event triggers with ramp/decay)
- Adds unit tests for decay mechanics (emotional intensity decay curves, fidelity level computation)
- Exports `parseExtractionResponse` from extraction.ts for testability
- Tests are pure/deterministic — no LLM or Qdrant dependencies

180 tests, 672 assertions.

## Test plan
- [x] All new tests pass: `bun test src/memory/graph/*.test.ts` (180 pass)
- [x] `bunx tsc --noEmit` clean
- [x] `bun run lint` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22706" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
