### PR TITLE
feat: budget-aware media retention during overflow recovery

### DIFF
--- a/assistant/src/__tests__/conversation-media-retry.test.ts
+++ b/assistant/src/__tests__/conversation-media-retry.test.ts
@@ -18,6 +18,15 @@ function makeImageBlock(
   };
 }
 
+function makeImageBlockWithSize(
+  dataLength: number,
+): Extract<ContentBlock, { type: "image" }> {
+  return {
+    type: "image",
+    source: { type: "base64", media_type: "image/png", data: "A".repeat(dataLength) },
+  };
+}
+
 function makeUserMessage(...blocks: ContentBlock[]): Message {
   return { role: "user", content: blocks };
 }
@@ -87,5 +96,86 @@ describe("stripMediaPayloadsForRetry", () => {
     // Latest kept turn image → kept
     const latestBlocks = result.messages[3].content;
     expect(latestBlocks.filter((b) => b.type === "image").length).toBe(1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Budget-aware media retention
+  // ---------------------------------------------------------------------------
+
+  test("budget-aware: keeps images that fit within token budget", () => {
+    // Each small image (data length 100) costs 1024 tokens on non-Anthropic.
+    // Budget of 3500 allows 3 images (3 * 1024 = 3072 <= 3500) but not 4.
+    const images = Array.from({ length: 5 }, () => makeImageBlockWithSize(100));
+    const messages: Message[] = [
+      makeUserMessage({ type: "text", text: "describe these" }, ...images),
+    ];
+
+    const result = stripMediaPayloadsForRetry(messages, {
+      mediaTokenBudget: 3500,
+      providerName: "mock",
+    });
+    expect(result.modified).toBe(true);
+
+    const content = result.messages[0].content;
+    const keptImages = content.filter((b) => b.type === "image");
+    const stubs = content.filter(
+      (b) => b.type === "text" && (b as { text: string }).text.includes("Image omitted"),
+    );
+    expect(keptImages.length).toBe(3);
+    expect(stubs.length).toBe(2);
+  });
+
+  test("budget-aware: keeps all images when budget is generous", () => {
+    const images = Array.from({ length: 3 }, () => makeImageBlockWithSize(100));
+    const messages: Message[] = [
+      makeUserMessage({ type: "text", text: "describe these" }, ...images),
+    ];
+
+    const result = stripMediaPayloadsForRetry(messages, {
+      mediaTokenBudget: 100_000,
+      providerName: "mock",
+    });
+    expect(result.modified).toBe(false);
+    expect(result.replacedBlocks).toBe(0);
+
+    const content = result.messages[0].content;
+    const keptImages = content.filter((b) => b.type === "image");
+    expect(keptImages.length).toBe(3);
+  });
+
+  test("budget-aware: stubs all when budget is zero", () => {
+    const images = Array.from({ length: 3 }, () => makeImageBlockWithSize(100));
+    const messages: Message[] = [
+      makeUserMessage({ type: "text", text: "describe these" }, ...images),
+    ];
+
+    const result = stripMediaPayloadsForRetry(messages, {
+      mediaTokenBudget: 0,
+      providerName: "mock",
+    });
+    expect(result.modified).toBe(true);
+    expect(result.replacedBlocks).toBe(3);
+
+    const content = result.messages[0].content;
+    const keptImages = content.filter((b) => b.type === "image");
+    expect(keptImages.length).toBe(0);
+  });
+
+  test("no options falls back to hardcoded limit", () => {
+    const images = Array.from({ length: 5 }, () => makeImageBlockWithSize(100));
+    const messages: Message[] = [
+      makeUserMessage({ type: "text", text: "describe these" }, ...images),
+    ];
+
+    const result = stripMediaPayloadsForRetry(messages);
+    expect(result.modified).toBe(true);
+
+    const content = result.messages[0].content;
+    const keptImages = content.filter((b) => b.type === "image");
+    const stubs = content.filter(
+      (b) => b.type === "text" && (b as { text: string }).text.includes("Image omitted"),
+    );
+    expect(keptImages.length).toBe(3);
+    expect(stubs.length).toBe(2);
   });
 });

--- a/assistant/src/daemon/conversation-media-retry.ts
+++ b/assistant/src/daemon/conversation-media-retry.ts
@@ -6,13 +6,25 @@
  * text stubs to shrink the payload before retrying.
  */
 
+import { estimateContentBlockTokens } from "../context/token-estimator.js";
 import { getSummaryFromContextMessage } from "../context/window-manager.js";
 import type { ContentBlock, Message } from "../providers/types.js";
+
+export interface StripMediaOptions {
+  /** Token budget available for media in the latest user message. Keeps as
+   *  many images as fit within this budget instead of the hardcoded limit. */
+  mediaTokenBudget?: number;
+  /** Provider name for per-image token estimation. */
+  providerName?: string;
+}
 
 const RETRY_KEEP_LATEST_MEDIA_BLOCKS = 3;
 const MAX_MEDIA_STUB_TEXT = 2_000;
 
-export function stripMediaPayloadsForRetry(messages: Message[]): {
+export function stripMediaPayloadsForRetry(
+  messages: Message[],
+  options?: StripMediaOptions,
+): {
   messages: Message[];
   modified: boolean;
   replacedBlocks: number;
@@ -31,6 +43,8 @@ export function stripMediaPayloadsForRetry(messages: Message[]): {
   let modified = false;
   let replacedBlocks = 0;
   let keptLatestMediaBlocks = 0;
+  let cumulativeMediaTokens = 0;
+  const useBudget = options?.mediaTokenBudget != null;
 
   const nextMessages = messages.map((msg, msgIndex) => {
     const nextContent: ContentBlock[] = [];
@@ -39,9 +53,20 @@ export function stripMediaPayloadsForRetry(messages: Message[]): {
       // few (in the most recent user message) and strip older ones so the
       // retry can actually reduce context size when images are the cause.
       if (block.type === "image") {
-        const keep =
-          latestUserIndex === msgIndex &&
-          keptLatestMediaBlocks < RETRY_KEEP_LATEST_MEDIA_BLOCKS;
+        let keep = false;
+        if (latestUserIndex === msgIndex) {
+          if (useBudget) {
+            const cost = estimateContentBlockTokens(block, {
+              providerName: options!.providerName,
+            });
+            if (cumulativeMediaTokens + cost <= options!.mediaTokenBudget!) {
+              cumulativeMediaTokens += cost;
+              keep = true;
+            }
+          } else {
+            keep = keptLatestMediaBlocks < RETRY_KEEP_LATEST_MEDIA_BLOCKS;
+          }
+        }
         if (keep) {
           keptLatestMediaBlocks += 1;
           nextContent.push(block);
@@ -54,9 +79,20 @@ export function stripMediaPayloadsForRetry(messages: Message[]): {
       }
 
       if (block.type === "file") {
-        const keep =
-          latestUserIndex === msgIndex &&
-          keptLatestMediaBlocks < RETRY_KEEP_LATEST_MEDIA_BLOCKS;
+        let keep = false;
+        if (latestUserIndex === msgIndex) {
+          if (useBudget) {
+            const cost = estimateContentBlockTokens(block, {
+              providerName: options!.providerName,
+            });
+            if (cumulativeMediaTokens + cost <= options!.mediaTokenBudget!) {
+              cumulativeMediaTokens += cost;
+              keep = true;
+            }
+          } else {
+            keep = keptLatestMediaBlocks < RETRY_KEEP_LATEST_MEDIA_BLOCKS;
+          }
+        }
         if (keep) {
           keptLatestMediaBlocks += 1;
           nextContent.push(block);


### PR DESCRIPTION
## Summary
- Add `StripMediaOptions` interface with optional `mediaTokenBudget` and `providerName` fields
- When budget is provided, keep images in the latest user message until cumulative token cost exceeds the budget
- Falls back to existing hardcoded limit of 3 when no budget is provided (backwards compatible)

Part of plan: fix-image-token-estimation.md (PR 2 of 3)