### PR TITLE
fix: scope model endpoint paths for managed mode proxy routing

### DIFF
--- a/clients/shared/Network/SettingsClient.swift
+++ b/clients/shared/Network/SettingsClient.swift
@@ -104,7 +104,7 @@ public struct SettingsClient: SettingsClientProtocol {
     public func fetchModelInfo() async -> ModelInfoMessage? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "model", timeout: 10
+                path: "assistants/{assistantId}/model", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchModelInfo failed (HTTP \(response.statusCode))")
@@ -123,7 +123,7 @@ public struct SettingsClient: SettingsClientProtocol {
             var body: [String: Any] = ["modelId": model]
             if let provider { body["provider"] = provider }
             let response = try await GatewayHTTPClient.put(
-                path: "model", json: body, timeout: 10
+                path: "assistants/{assistantId}/model", json: body, timeout: 10
             )
             guard response.isSuccess else {
                 log.error("setModel failed (HTTP \(response.statusCode))")


### PR DESCRIPTION
## Summary
- `fetchModelInfo` and `setModel` in `SettingsClient.swift` were using the flat `"model"` path, causing 404s in managed mode because the platform proxy only forwards `assistants/{assistantId}/...` paths to the daemon
- This was missed in 9228518e3 which correctly scoped `fetchConfig`, `patchConfig`, and `setImageGenModel` but overlooked these two endpoints
- Fixes the `GET /v1/model/` 404 errors seen in platform logs from macOS desktop app v0.6.0

## Test plan
- [ ] Verify model info loads correctly in managed mode (Settings → Model section)
- [ ] Verify switching models works in managed mode
- [ ] Confirm local mode still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
