### PR TITLE
feat: compute and pass media token budget during overflow recovery

### DIFF
--- a/assistant/src/__tests__/context-overflow-reducer.test.ts
+++ b/assistant/src/__tests__/context-overflow-reducer.test.ts
@@ -467,6 +467,92 @@ describe("context-overflow-reducer", () => {
     });
   });
 
+  describe("budget-aware media stubbing", () => {
+    test("media stubbing tier retains images within budget", async () => {
+      // Create messages with multiple image-only user messages (5 images in the
+      // latest user message). With budget-aware retention, the reducer should
+      // keep more than the old hardcoded limit of 3 when targetTokens is high.
+      const makeImageBlock = () => ({
+        type: "image" as const,
+        source: {
+          type: "base64" as const,
+          media_type: "image/png" as const,
+          // Small base64 payload so each image doesn't cost many tokens
+          data: "A".repeat(1_000),
+        },
+      });
+
+      const messages: Message[] = [
+        msg("user", "Here are some old images"),
+        {
+          role: "user",
+          content: [makeImageBlock(), makeImageBlock()],
+        },
+        msg("assistant", "I see the old images."),
+        msg("user", "And some more old images"),
+        {
+          role: "user",
+          content: [makeImageBlock()],
+        },
+        msg("assistant", "Got those too."),
+        // Latest user message with 5 images — should retain more than 3
+        {
+          role: "user",
+          content: [
+            makeImageBlock(),
+            makeImageBlock(),
+            makeImageBlock(),
+            makeImageBlock(),
+            makeImageBlock(),
+          ],
+        },
+      ];
+
+      // Set targetTokens very high so all images in the latest message fit
+      const config = makeConfig({
+        targetTokens: 500_000,
+      });
+      const compactFn = makeNoOpCompactFn();
+
+      // Run through forced_compaction and tool_result_truncation first
+      const step1 = await reduceContextOverflow(
+        messages,
+        config,
+        undefined,
+        compactFn,
+      );
+      expect(step1.tier).toBe("forced_compaction");
+
+      const step2 = await reduceContextOverflow(
+        step1.messages,
+        config,
+        step1.state,
+        compactFn,
+      );
+      expect(step2.tier).toBe("tool_result_truncation");
+
+      // Now apply media stubbing
+      const step3 = await reduceContextOverflow(
+        step2.messages,
+        config,
+        step2.state,
+        compactFn,
+      );
+      expect(step3.tier).toBe("media_stubbing");
+
+      // Count remaining image blocks in the latest user message
+      const latestUserMsg = step3.messages[step3.messages.length - 1];
+      expect(latestUserMsg.role).toBe("user");
+      const remainingImages = latestUserMsg.content.filter(
+        (b) => b.type === "image",
+      );
+
+      // With budget-aware retention and a high target, all 5 images should be
+      // retained — more than the old hardcoded limit of 3.
+      expect(remainingImages.length).toBeGreaterThan(3);
+    });
+  });
+
   describe("createInitialReducerState", () => {
     test("returns a clean state with no applied tiers", () => {
       const state = createInitialReducerState();

--- a/assistant/src/daemon/context-overflow-reducer.ts
+++ b/assistant/src/daemon/context-overflow-reducer.ts
@@ -17,7 +17,10 @@
  */
 
 import type { ContextWindowConfig } from "../config/types.js";
-import { estimatePromptTokens } from "../context/token-estimator.js";
+import {
+  estimateContentBlockTokens,
+  estimatePromptTokens,
+} from "../context/token-estimator.js";
 import { truncateToolResultsAcrossHistory } from "../context/tool-result-truncation.js";
 import type {
   ContextWindowCompactOptions,
@@ -240,7 +243,39 @@ function applyMediaStubbing(
   let nextMessages = messages;
 
   if (mediaCount > 0) {
-    const stripped = stripMediaPayloadsForRetry(messages);
+    // Compute the token budget available for media content.
+    const totalTokens = estimatePromptTokens(messages, config.systemPrompt, {
+      providerName: config.providerName,
+      toolTokenBudget: config.toolTokenBudget,
+    });
+
+    // Sum tokens for all image and file blocks (top-level and nested in tool_result).
+    let mediaTokens = 0;
+    for (const msg of messages) {
+      for (const block of msg.content) {
+        if (block.type === "image" || block.type === "file") {
+          mediaTokens += estimateContentBlockTokens(block, {
+            providerName: config.providerName,
+          });
+        } else if (block.type === "tool_result" && block.contentBlocks) {
+          for (const cb of block.contentBlocks) {
+            if (cb.type === "image" || cb.type === "file") {
+              mediaTokens += estimateContentBlockTokens(cb, {
+                providerName: config.providerName,
+              });
+            }
+          }
+        }
+      }
+    }
+
+    const nonMediaTokens = totalTokens - mediaTokens;
+    const mediaTokenBudget = Math.max(0, config.targetTokens - nonMediaTokens);
+
+    const stripped = stripMediaPayloadsForRetry(messages, {
+      mediaTokenBudget,
+      providerName: config.providerName,
+    });
     if (stripped.modified) {
       nextMessages = stripped.messages;
     }


### PR DESCRIPTION
## Summary
- Compute media token budget in `applyMediaStubbing` based on target tokens minus non-media token usage
- Pass budget and provider name to `stripMediaPayloadsForRetry` so it retains as many latest-message images as fit
- Add test verifying budget-aware retention keeps more than the old hardcoded limit of 3

Part of plan: fix-image-token-estimation.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22714" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
