### PR TITLE
fix: remove progress check injection from agent loop

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -101,10 +101,7 @@ const DEFAULT_CONFIG: AgentLoopConfig = {
   minTurnIntervalMs: 150,
 };
 
-const PROGRESS_CHECK_INTERVAL = 5;
 const MAX_CONSECUTIVE_ERROR_NUDGES = 3;
-const PROGRESS_CHECK_REMINDER =
-  "You have been using tools for several turns. Check whether you are making meaningful progress toward the user's goal. If you are stuck in a loop or not making progress, summarize what you have tried and ask the user for guidance instead of continuing.";
 
 export interface ResolvedSystemPrompt {
   systemPrompt: string;
@@ -573,21 +570,11 @@ export class AgentLoop {
           break;
         }
 
-        // Track tool-use turns and inject progress reminder every N turns
         toolUseTurns++;
-        const isProgressCheckTurn =
-          toolUseTurns % PROGRESS_CHECK_INTERVAL === 0;
-        if (isProgressCheckTurn) {
-          resultBlocks.push({
-            type: "text",
-            text: `<system_notice>${PROGRESS_CHECK_REMINDER}</system_notice>`,
-          });
-        }
 
         // When any tool returned an error, nudge the LLM to retry with
         // corrected parameters instead of ending its turn. Skip the nudge
-        // when the progress check fires (to avoid contradictory instructions)
-        // and after MAX_CONSECUTIVE_ERROR_NUDGES consecutive error turns
+        // after MAX_CONSECUTIVE_ERROR_NUDGES consecutive error turns
         // (the error is likely unrecoverable at that point).
         const hasToolError = toolResults.some(({ result }) => result.isError);
         if (hasToolError) {
@@ -597,7 +584,6 @@ export class AgentLoop {
         }
         if (
           hasToolError &&
-          !isProgressCheckTurn &&
           consecutiveErrorTurns <= MAX_CONSECUTIVE_ERROR_NUDGES
         ) {
           resultBlocks.push({


### PR DESCRIPTION
## Summary
- Removed the `PROGRESS_CHECK_INTERVAL` / `PROGRESS_CHECK_REMINDER` constants and the injection block that appended a `<system_notice>` every 5 tool-use turns
- Removed the `isProgressCheckTurn` guard that suppressed the error-retry nudge on progress-check turns (no longer needed)
- `toolUseTurns` counter is preserved — still used by the checkpoint callback and error logging

## Original prompt
Remove this injection "<system_notice>You have been using tools for several turns. Check whether you are making meaningful progress toward the user's goal. If you are stuck in a loop or not making progress, summarize what you have tried and ask the user for guidance instead of continuing.</system_notice>"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22722" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
