### PR TITLE
fix: migrate remaining memoryItems consumers to memory_graph_nodes

### DIFF
--- a/assistant/src/__tests__/cli-memory.test.ts
+++ b/assistant/src/__tests__/cli-memory.test.ts
@@ -2,7 +2,7 @@ import { rmSync } from "node:fs";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { Command } from "commander";
-import { eq } from "drizzle-orm";
+import { eq, like } from "drizzle-orm";
 
 mock.module("../util/logger.js", () => ({
   getLogger: () =>
@@ -64,7 +64,7 @@ import {
   upsertCliCapabilityMemory,
 } from "../cli/cli-memory.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
-import { memoryItems, memoryJobs } from "../memory/schema.js";
+import { memoryGraphNodes, memoryJobs } from "../memory/schema.js";
 import { ensureDataDir, getDbPath } from "../util/platform.js";
 
 ensureDataDir();
@@ -76,9 +76,8 @@ afterAll(() => {
 
 function resetTables() {
   const db = getDb();
-  db.run("DELETE FROM memory_item_sources");
   db.run("DELETE FROM memory_embeddings");
-  db.run("DELETE FROM memory_items");
+  db.run("DELETE FROM memory_graph_nodes");
   db.run("DELETE FROM memory_jobs");
 }
 
@@ -103,62 +102,62 @@ describe("buildCliCapabilityStatement", () => {
 describe("upsertCliCapabilityMemory", () => {
   beforeEach(resetTables);
 
-  test("inserts with correct kind, subject, confidence, importance", () => {
+  test("inserts with correct type, content, confidence, significance", () => {
     upsertCliCapabilityMemory("doctor", "Run diagnostic checks");
 
     const db = getDb();
-    const items = db.select().from(memoryItems).all();
+    const items = db.select().from(memoryGraphNodes).all();
     expect(items).toHaveLength(1);
-    expect(items[0].kind).toBe("capability");
-    expect(items[0].subject).toBe("cli:doctor");
+    expect(items[0].type).toBe("procedural");
+    expect(items[0].content).toMatch(/^cli:doctor\n/);
     expect(items[0].confidence).toBe(1.0);
-    expect(items[0].importance).toBe(0.7);
-    expect(items[0].status).toBe("active");
+    expect(items[0].significance).toBe(0.7);
+    expect(items[0].fidelity).toBe("vivid");
     expect(items[0].scopeId).toBe("default");
 
-    // Should also enqueue an embed_item job
+    // Should also enqueue an embed_graph_node job
     const jobs = db.select().from(memoryJobs).all();
     expect(jobs).toHaveLength(1);
-    expect(jobs[0].type).toBe("embed_item");
+    expect(jobs[0].type).toBe("embed_graph_node");
   });
 
-  test("is idempotent (same entry only touches lastSeenAt)", () => {
+  test("is idempotent (same entry only touches lastAccessed)", () => {
     upsertCliCapabilityMemory("doctor", "Run diagnostic checks");
 
     const db = getDb();
-    const before = db.select().from(memoryItems).all();
+    const before = db.select().from(memoryGraphNodes).all();
     expect(before).toHaveLength(1);
-    const originalLastSeen = before[0].lastSeenAt;
+    const originalLastAccessed = before[0].lastAccessed;
 
     // Upsert again
     upsertCliCapabilityMemory("doctor", "Run diagnostic checks");
 
-    const after = db.select().from(memoryItems).all();
+    const after = db.select().from(memoryGraphNodes).all();
     expect(after).toHaveLength(1);
-    // Fingerprint should be the same, so only lastSeenAt changes
-    expect(after[0].fingerprint).toBe(before[0].fingerprint);
-    expect(after[0].lastSeenAt).toBeGreaterThanOrEqual(originalLastSeen);
+    // Same content, so only lastAccessed changes
+    expect(after[0].content).toBe(before[0].content);
+    expect(after[0].lastAccessed).toBeGreaterThanOrEqual(originalLastAccessed);
 
     // Should NOT enqueue a second embed job (only 1 from initial insert)
     const jobs = db.select().from(memoryJobs).all();
     expect(jobs).toHaveLength(1);
   });
 
-  test("updates statement when description changes", () => {
+  test("updates content when description changes", () => {
     upsertCliCapabilityMemory("doctor", "Original description");
 
     const db = getDb();
-    const before = db.select().from(memoryItems).all();
+    const before = db.select().from(memoryGraphNodes).all();
     expect(before).toHaveLength(1);
-    expect(before[0].statement).toContain("Original description");
+    expect(before[0].content).toContain("Original description");
 
     // Change description
     upsertCliCapabilityMemory("doctor", "Updated description");
 
-    const after = db.select().from(memoryItems).all();
+    const after = db.select().from(memoryGraphNodes).all();
     expect(after).toHaveLength(1);
-    expect(after[0].statement).toContain("Updated description");
-    expect(after[0].fingerprint).not.toBe(before[0].fingerprint);
+    expect(after[0].content).toContain("Updated description");
+    expect(after[0].content).not.toBe(before[0].content);
 
     // Should enqueue a second embed job
     const jobs = db.select().from(memoryJobs).all();
@@ -170,13 +169,13 @@ describe("upsertCliCapabilityMemory", () => {
 
     const db = getDb();
     // Soft-delete the item
-    db.update(memoryItems)
-      .set({ status: "deleted" })
-      .where(eq(memoryItems.subject, "cli:doctor"))
+    db.update(memoryGraphNodes)
+      .set({ fidelity: "gone" })
+      .where(like(memoryGraphNodes.content, "cli:doctor\n%"))
       .run();
 
-    const deleted = db.select().from(memoryItems).all();
-    expect(deleted[0].status).toBe("deleted");
+    const deleted = db.select().from(memoryGraphNodes).all();
+    expect(deleted[0].fidelity).toBe("gone");
 
     // Clear jobs from initial insert
     db.run("DELETE FROM memory_jobs");
@@ -184,20 +183,20 @@ describe("upsertCliCapabilityMemory", () => {
     // Upsert again — should reactivate
     upsertCliCapabilityMemory("doctor", "Run diagnostic checks");
 
-    const reactivated = db.select().from(memoryItems).all();
+    const reactivated = db.select().from(memoryGraphNodes).all();
     expect(reactivated).toHaveLength(1);
-    expect(reactivated[0].status).toBe("active");
+    expect(reactivated[0].fidelity).toBe("vivid");
 
     // Should enqueue embed job for reactivated item
     const jobs = db.select().from(memoryJobs).all();
     expect(jobs).toHaveLength(1);
-    expect(jobs[0].type).toBe("embed_item");
+    expect(jobs[0].type).toBe("embed_graph_node");
   });
 
   test("does not throw on DB error", () => {
     resetDb();
     const db = getDb();
-    db.run("DROP TABLE IF EXISTS memory_items");
+    db.run("DROP TABLE IF EXISTS memory_graph_nodes");
 
     expect(() => {
       upsertCliCapabilityMemory("doctor", "Run diagnostic checks");
@@ -234,21 +233,21 @@ describe("seedCliCommandMemories", () => {
     const db = getDb();
     const items = db
       .select()
-      .from(memoryItems)
-      .where(eq(memoryItems.kind, "capability"))
+      .from(memoryGraphNodes)
+      .where(eq(memoryGraphNodes.type, "procedural"))
       .all();
     expect(items).toHaveLength(3);
 
-    const subjects = items.map((i) => i.subject).sort();
-    expect(subjects).toEqual([
+    const contentPrefixes = items.map((i) => i.content.split("\n")[0]).sort();
+    expect(contentPrefixes).toEqual([
       "cli:config",
       "cli:doctor",
       "cli:keys",
     ]);
 
-    // All should be active
+    // All should be vivid
     for (const item of items) {
-      expect(item.status).toBe("active");
+      expect(item.fidelity).toBe("vivid");
     }
   });
 
@@ -264,11 +263,11 @@ describe("seedCliCommandMemories", () => {
     const db = getDb();
     const beforeItems = db
       .select()
-      .from(memoryItems)
-      .where(eq(memoryItems.kind, "capability"))
+      .from(memoryGraphNodes)
+      .where(eq(memoryGraphNodes.type, "procedural"))
       .all();
     expect(beforeItems).toHaveLength(3);
-    expect(beforeItems.every((i) => i.status === "active")).toBe(true);
+    expect(beforeItems.every((i) => i.fidelity === "vivid")).toBe(true);
 
     // Now seed with only doctor — config and keys should be pruned
     mockCommands = [
@@ -278,20 +277,20 @@ describe("seedCliCommandMemories", () => {
 
     const afterItems = db
       .select()
-      .from(memoryItems)
-      .where(eq(memoryItems.kind, "capability"))
+      .from(memoryGraphNodes)
+      .where(eq(memoryGraphNodes.type, "procedural"))
       .all();
     expect(afterItems).toHaveLength(3); // still 3 rows, but 2 are soft-deleted
 
-    const active = afterItems.filter((i) => i.status === "active");
-    const deleted = afterItems.filter((i) => i.status === "deleted");
+    const active = afterItems.filter((i) => i.fidelity === "vivid");
+    const deleted = afterItems.filter((i) => i.fidelity === "gone");
 
     expect(active).toHaveLength(1);
-    expect(active[0].subject).toBe("cli:doctor");
+    expect(active[0].content).toMatch(/^cli:doctor\n/);
 
     expect(deleted).toHaveLength(2);
-    const deletedSubjects = deleted.map((i) => i.subject).sort();
-    expect(deletedSubjects).toEqual(["cli:config", "cli:keys"]);
+    const deletedPrefixes = deleted.map((i) => i.content.split("\n")[0]).sort();
+    expect(deletedPrefixes).toEqual(["cli:config", "cli:keys"]);
   });
 
   test("handles empty command list without errors", () => {
@@ -299,38 +298,44 @@ describe("seedCliCommandMemories", () => {
     upsertCliCapabilityMemory("old-command", "An old command");
 
     const db = getDb();
-    const beforeItems = db.select().from(memoryItems).all();
+    const beforeItems = db.select().from(memoryGraphNodes).all();
     expect(beforeItems).toHaveLength(1);
-    expect(beforeItems[0].status).toBe("active");
+    expect(beforeItems[0].fidelity).toBe("vivid");
 
     // Seed with empty commands
     mockCommands = [];
     seedCliCommandMemories();
 
     // The existing command should be pruned (soft-deleted)
-    const afterItems = db.select().from(memoryItems).all();
+    const afterItems = db.select().from(memoryGraphNodes).all();
     expect(afterItems).toHaveLength(1);
-    expect(afterItems[0].status).toBe("deleted");
+    expect(afterItems[0].fidelity).toBe("gone");
   });
 
   test("does not prune non-cli capability memories", () => {
     // Pre-insert a skill capability memory directly into the DB
     const db = getDb();
     const now = Date.now();
-    db.insert(memoryItems)
+    db.insert(memoryGraphNodes)
       .values({
         id: "skill-test-item",
-        kind: "capability",
-        subject: "skill:test-skill",
-        statement: "The test skill does things.",
-        status: "active",
+        type: "procedural",
+        content: "skill:test-skill\nThe test skill does things.",
+        fidelity: "vivid",
         confidence: 1.0,
-        importance: 0.7,
-        fingerprint: "skill-test-fp",
-        sourceType: "extraction",
+        significance: 0.7,
+        sourceType: "inferred",
         scopeId: "default",
-        firstSeenAt: now,
-        lastSeenAt: now,
+        created: now,
+        lastAccessed: now,
+        lastConsolidated: now,
+        emotionalCharge: '{"valence":0,"intensity":0.1,"decayCurve":"linear","decayRate":0.05,"originalIntensity":0.1}',
+        stability: 14,
+        reinforcementCount: 0,
+        lastReinforced: now,
+        sourceConversations: "[]",
+        narrativeRole: null,
+        partOfStory: null,
       })
       .run();
 
@@ -340,11 +345,11 @@ describe("seedCliCommandMemories", () => {
 
     const item = db
       .select()
-      .from(memoryItems)
-      .where(eq(memoryItems.subject, "skill:test-skill"))
+      .from(memoryGraphNodes)
+      .where(like(memoryGraphNodes.content, "skill:test-skill\n%"))
       .get();
     expect(item).toBeDefined();
-    expect(item!.status).toBe("active");
+    expect(item!.fidelity).toBe("vivid");
   });
 
   test("does not throw on error", () => {
@@ -352,10 +357,10 @@ describe("seedCliCommandMemories", () => {
       { name: "doctor", description: "Run diagnostic checks" },
     ];
 
-    // Drop memory_items to force a DB error during the prune phase
+    // Drop memory_graph_nodes to force a DB error during the prune phase
     resetDb();
     const db = getDb();
-    db.run("DROP TABLE IF EXISTS memory_items");
+    db.run("DROP TABLE IF EXISTS memory_graph_nodes");
 
     expect(() => {
       seedCliCommandMemories();

--- a/assistant/src/__tests__/conversation-delete-schedule-cleanup.test.ts
+++ b/assistant/src/__tests__/conversation-delete-schedule-cleanup.test.ts
@@ -68,9 +68,8 @@ describe("DELETE /conversations/:id — schedule cleanup", () => {
   beforeEach(() => {
     getRawDb().run("DELETE FROM cron_runs");
     getRawDb().run("DELETE FROM cron_jobs");
-    getRawDb().run("DELETE FROM memory_item_sources");
+    getRawDb().run("DELETE FROM memory_graph_nodes");
     getRawDb().run("DELETE FROM memory_segments");
-    getRawDb().run("DELETE FROM memory_items");
     getRawDb().run("DELETE FROM memory_summaries");
     getRawDb().run("DELETE FROM memory_embeddings");
     getRawDb().run("DELETE FROM memory_jobs");
@@ -293,9 +292,8 @@ describe("POST /conversations/:id/wipe — schedule cleanup", () => {
   beforeEach(() => {
     getRawDb().run("DELETE FROM cron_runs");
     getRawDb().run("DELETE FROM cron_jobs");
-    getRawDb().run("DELETE FROM memory_item_sources");
+    getRawDb().run("DELETE FROM memory_graph_nodes");
     getRawDb().run("DELETE FROM memory_segments");
-    getRawDb().run("DELETE FROM memory_items");
     getRawDb().run("DELETE FROM memory_summaries");
     getRawDb().run("DELETE FROM memory_embeddings");
     getRawDb().run("DELETE FROM memory_jobs");

--- a/assistant/src/__tests__/conversation-starter-routes.test.ts
+++ b/assistant/src/__tests__/conversation-starter-routes.test.ts
@@ -37,7 +37,7 @@ function dispatch(path: string): Response | Promise<Response> {
 
 function clearTables() {
   getSqlite().run("DELETE FROM conversation_starters");
-  getSqlite().run("DELETE FROM memory_items");
+  getSqlite().run("DELETE FROM memory_graph_nodes");
   getSqlite().run("DELETE FROM memory_jobs");
   getSqlite().run("DELETE FROM memory_checkpoints");
 }
@@ -69,10 +69,23 @@ function insertStarter(overrides: {
 function insertMemoryItem(scopeId = "default") {
   const now = Date.now();
   getSqlite().run(
-    `INSERT INTO memory_items (
-      id, kind, subject, statement, status, confidence, fingerprint, scope_id, first_seen_at, last_seen_at
-    ) VALUES (?, 'fact', 'test', 'test statement', 'active', 0.9, ?, ?, ?, ?)`,
-    [uuid(), `fingerprint-${uuid()}`, scopeId, now, now],
+    `INSERT INTO memory_graph_nodes (
+      id, content, type, created, last_accessed, last_consolidated,
+      emotional_charge, fidelity, confidence, significance,
+      stability, reinforcement_count, last_reinforced,
+      source_conversations, source_type, scope_id
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, 'vivid', 0.8, 0.5, 14, 0, ?, '[]', 'inferred', ?)`,
+    [
+      uuid(),
+      "test\ntest statement",
+      "semantic",
+      now,
+      now,
+      now,
+      '{"valence":0,"intensity":0.1,"decayCurve":"linear","decayRate":0.05,"originalIntensity":0.1}',
+      now,
+      scopeId,
+    ],
   );
 }
 

--- a/assistant/src/__tests__/conversation-wipe.test.ts
+++ b/assistant/src/__tests__/conversation-wipe.test.ts
@@ -24,9 +24,8 @@ initializeDb();
 describe("wipeConversation", () => {
   beforeEach(() => {
     const db = getDb();
-    db.run(`DELETE FROM memory_item_sources`);
+    db.run(`DELETE FROM memory_graph_nodes`);
     db.run(`DELETE FROM memory_segments`);
-    db.run(`DELETE FROM memory_items`);
     db.run(`DELETE FROM memory_summaries`);
     db.run(`DELETE FROM memory_embeddings`);
     db.run(`DELETE FROM memory_jobs`);
@@ -46,237 +45,6 @@ describe("wipeConversation", () => {
 
     expect(getConversation(conv.id)).toBeNull();
     expect(getMessages(conv.id)).toEqual([]);
-  });
-
-  test("restores explicitly superseded memory items", async () => {
-    const convA = createConversation("conversation A");
-    const msgA = await addMessage(convA.id, "user", "I like blue");
-
-    const convB = createConversation("conversation B");
-    const msgB = await addMessage(convB.id, "user", "I like red");
-
-    const db = getDb();
-    const now = Date.now();
-
-    // Insert itemA: active preference about color
-    db.run(
-      `INSERT INTO memory_items (id, status, kind, subject, statement, confidence, fingerprint, scope_id, first_seen_at, last_seen_at)
-       VALUES ('itemA', 'active', 'preference', 'color', 'likes blue', 0.8, 'fp-a', 'default', ${now}, ${now})`,
-    );
-
-    // Insert itemB: active preference about color, supersedes itemA
-    db.run(
-      `INSERT INTO memory_items (id, status, kind, subject, statement, confidence, fingerprint, scope_id, supersedes, first_seen_at, last_seen_at)
-       VALUES ('itemB', 'active', 'preference', 'color', 'likes red', 0.9, 'fp-b', 'default', 'itemA', ${now}, ${now})`,
-    );
-
-    // Mark itemA as superseded by itemB
-    db.run(
-      `UPDATE memory_items SET status = 'superseded', superseded_by = 'itemB' WHERE id = 'itemA'`,
-    );
-
-    // Link itemA to convA's message, itemB to convB's message
-    db.run(
-      `INSERT INTO memory_item_sources (memory_item_id, message_id, created_at) VALUES ('itemA', '${msgA.id}', ${now})`,
-    );
-    db.run(
-      `INSERT INTO memory_item_sources (memory_item_id, message_id, created_at) VALUES ('itemB', '${msgB.id}', ${now})`,
-    );
-
-    const result = wipeConversation(convB.id);
-
-    // itemA should be restored to active with superseded_by cleared
-    const raw = (
-      getDb() as unknown as {
-        $client: import("bun:sqlite").Database;
-      }
-    ).$client;
-    const itemARow = raw
-      .query(
-        "SELECT status, superseded_by FROM memory_items WHERE id = 'itemA'",
-      )
-      .get() as { status: string; superseded_by: string | null } | null;
-    expect(itemARow).not.toBeNull();
-    expect(itemARow!.status).toBe("active");
-    expect(itemARow!.superseded_by).toBeNull();
-
-    // itemB should no longer exist (orphaned and deleted by deleteConversation)
-    const itemBRow = (
-      getDb() as unknown as {
-        $client: import("bun:sqlite").Database;
-      }
-    ).$client
-      .query("SELECT * FROM memory_items WHERE id = 'itemB'")
-      .get();
-    expect(itemBRow).toBeNull();
-
-    expect(result.unsupersededItemIds).toContain("itemA");
-  });
-
-  test("does not restore superseded items when superseding item has other sources", async () => {
-    const convA = createConversation("conversation A");
-    const msgA = await addMessage(convA.id, "user", "I like red in A");
-
-    const convB = createConversation("conversation B");
-    const msgB = await addMessage(convB.id, "user", "I like red in B");
-
-    const db = getDb();
-    const now = Date.now();
-
-    // Insert itemOld (will be superseded)
-    db.run(
-      `INSERT INTO memory_items (id, status, kind, subject, statement, confidence, fingerprint, scope_id, first_seen_at, last_seen_at)
-       VALUES ('itemOld', 'active', 'preference', 'color', 'likes blue', 0.8, 'fp-old', 'default', ${now}, ${now})`,
-    );
-
-    // Insert itemNew (supersedes itemOld)
-    db.run(
-      `INSERT INTO memory_items (id, status, kind, subject, statement, confidence, fingerprint, scope_id, supersedes, first_seen_at, last_seen_at)
-       VALUES ('itemNew', 'active', 'preference', 'color', 'likes red', 0.9, 'fp-new', 'default', 'itemOld', ${now}, ${now})`,
-    );
-
-    // Mark itemOld as superseded
-    db.run(
-      `UPDATE memory_items SET status = 'superseded', superseded_by = 'itemNew' WHERE id = 'itemOld'`,
-    );
-
-    // Link itemNew to BOTH conversations
-    db.run(
-      `INSERT INTO memory_item_sources (memory_item_id, message_id, created_at) VALUES ('itemNew', '${msgA.id}', ${now})`,
-    );
-    db.run(
-      `INSERT INTO memory_item_sources (memory_item_id, message_id, created_at) VALUES ('itemNew', '${msgB.id}', ${now})`,
-    );
-
-    wipeConversation(convA.id);
-
-    const raw = (
-      getDb() as unknown as {
-        $client: import("bun:sqlite").Database;
-      }
-    ).$client;
-
-    // itemOld should still be superseded because itemNew has another source (convB)
-    const itemOldRow = raw
-      .query("SELECT status FROM memory_items WHERE id = 'itemOld'")
-      .get() as { status: string } | null;
-    expect(itemOldRow).not.toBeNull();
-    expect(itemOldRow!.status).toBe("superseded");
-
-    // itemNew should still exist (has source from convB)
-    const itemNewRow = raw
-      .query("SELECT * FROM memory_items WHERE id = 'itemNew'")
-      .get();
-    expect(itemNewRow).not.toBeNull();
-  });
-
-  test("restores orphaned subject-match superseded items", async () => {
-    const convB = createConversation("conversation B");
-    const msgB = await addMessage(convB.id, "user", "I use vim");
-
-    const db = getDb();
-    const now = Date.now();
-
-    // Insert itemOld: superseded with no superseded_by link
-    db.run(
-      `INSERT INTO memory_items (id, status, kind, subject, statement, confidence, fingerprint, scope_id, first_seen_at, last_seen_at)
-       VALUES ('itemOld', 'superseded', 'preference', 'editor', 'uses emacs', 0.7, 'fp-old', 'default', ${now}, ${now})`,
-    );
-
-    // Insert itemNew: active, same kind/subject/scope_id
-    db.run(
-      `INSERT INTO memory_items (id, status, kind, subject, statement, confidence, fingerprint, scope_id, first_seen_at, last_seen_at)
-       VALUES ('itemNew', 'active', 'preference', 'editor', 'uses vim', 0.9, 'fp-new', 'default', ${now}, ${now})`,
-    );
-
-    // Link itemNew to convB's message
-    db.run(
-      `INSERT INTO memory_item_sources (memory_item_id, message_id, created_at) VALUES ('itemNew', '${msgB.id}', ${now})`,
-    );
-
-    wipeConversation(convB.id);
-
-    const raw = (
-      getDb() as unknown as {
-        $client: import("bun:sqlite").Database;
-      }
-    ).$client;
-
-    // itemOld should now be active (restored as orphaned subject-match superseded item)
-    const itemOldRow = raw
-      .query("SELECT status FROM memory_items WHERE id = 'itemOld'")
-      .get() as { status: string } | null;
-    expect(itemOldRow).not.toBeNull();
-    expect(itemOldRow!.status).toBe("active");
-  });
-
-  test("does not restore superseded items from unrelated conversations", async () => {
-    // convA has an item that superseded an older item — convA was previously
-    // deleted via regular deleteConversation, leaving the old item superseded
-    // with superseded_by = NULL. When we later wipe convB, Step F should NOT
-    // restore that unrelated item.
-    const convA = createConversation("conversation A");
-    const _msgA = await addMessage(convA.id, "user", "I use dark theme");
-
-    const convB = createConversation("conversation B");
-    const msgB = await addMessage(convB.id, "user", "I use vim");
-
-    const db = getDb();
-    const now = Date.now();
-
-    // unrelatedOld: superseded item from an old conversation (e.g. "uses light theme")
-    // Its superseder was deleted in a prior deleteConversation, leaving
-    // superseded_by = NULL.
-    db.run(
-      `INSERT INTO memory_items (id, status, kind, subject, statement, confidence, fingerprint, scope_id, first_seen_at, last_seen_at)
-       VALUES ('unrelatedOld', 'superseded', 'preference', 'theme', 'uses light theme', 0.7, 'fp-unrelated', 'default', ${now}, ${now})`,
-    );
-
-    // convA's active item that superseded unrelatedOld — we simulate the
-    // case where convA was already deleted, leaving unrelatedOld with
-    // superseded_by = NULL and no active replacement.
-    // (We don't actually insert the superseder — just leave unrelatedOld
-    // as a superseded item with no superseded_by and no active match.)
-
-    // convB's items — itemOld is superseded by itemNew (subject: editor)
-    db.run(
-      `INSERT INTO memory_items (id, status, kind, subject, statement, confidence, fingerprint, scope_id, first_seen_at, last_seen_at)
-       VALUES ('editorOld', 'superseded', 'preference', 'editor', 'uses emacs', 0.7, 'fp-editor-old', 'default', ${now}, ${now})`,
-    );
-    db.run(
-      `INSERT INTO memory_items (id, status, kind, subject, statement, confidence, fingerprint, scope_id, first_seen_at, last_seen_at)
-       VALUES ('editorNew', 'active', 'preference', 'editor', 'uses vim', 0.9, 'fp-editor-new', 'default', ${now}, ${now})`,
-    );
-    db.run(
-      `INSERT INTO memory_item_sources (memory_item_id, message_id, created_at) VALUES ('editorNew', '${msgB.id}', ${now})`,
-    );
-
-    const result = wipeConversation(convB.id);
-
-    const raw = (
-      getDb() as unknown as {
-        $client: import("bun:sqlite").Database;
-      }
-    ).$client;
-
-    // editorOld SHOULD be restored (its kind+subject matches an orphaned item from convB)
-    const editorOldRow = raw
-      .query("SELECT status FROM memory_items WHERE id = 'editorOld'")
-      .get() as { status: string } | null;
-    expect(editorOldRow).not.toBeNull();
-    expect(editorOldRow!.status).toBe("active");
-
-    // unrelatedOld should NOT be restored — it was superseded by a different
-    // conversation's item (theme, not editor) and has nothing to do with convB
-    const unrelatedOldRow = raw
-      .query("SELECT status FROM memory_items WHERE id = 'unrelatedOld'")
-      .get() as { status: string } | null;
-    expect(unrelatedOldRow).not.toBeNull();
-    expect(unrelatedOldRow!.status).toBe("superseded");
-
-    // Only editorOld should be in the unsuperseded list, not unrelatedOld
-    expect(result.unsupersededItemIds).toContain("editorOld");
-    expect(result.unsupersededItemIds).not.toContain("unrelatedOld");
   });
 
   test("deletes conversation summaries", async () => {
@@ -374,52 +142,14 @@ describe("wipeConversation", () => {
     expect(result.deletedSummaryIds).toEqual([]);
     expect(result.cancelledJobCount).toBe(0);
   });
-
-  test("does not affect other conversations", async () => {
-    const convA = createConversation("conversation A");
-    await addMessage(convA.id, "user", "message in A");
-
-    const convB = createConversation("conversation B");
-    const msgB = await addMessage(convB.id, "user", "message in B");
-
-    const db = getDb();
-    const now = Date.now();
-
-    // Insert a memory item sourced from convB's message
-    db.run(
-      `INSERT INTO memory_items (id, status, kind, subject, statement, confidence, fingerprint, scope_id, first_seen_at, last_seen_at)
-       VALUES ('itemB', 'active', 'fact', 'test', 'test fact', 0.8, 'fp-b', 'default', ${now}, ${now})`,
-    );
-    db.run(
-      `INSERT INTO memory_item_sources (memory_item_id, message_id, created_at) VALUES ('itemB', '${msgB.id}', ${now})`,
-    );
-
-    wipeConversation(convA.id);
-
-    // convB should still exist
-    expect(getConversation(convB.id)).not.toBeNull();
-    expect(getMessages(convB.id)).toHaveLength(1);
-
-    // convB's memory item should still exist
-    const raw = (
-      getDb() as unknown as {
-        $client: import("bun:sqlite").Database;
-      }
-    ).$client;
-    const itemBRow = raw
-      .query("SELECT * FROM memory_items WHERE id = 'itemB'")
-      .get();
-    expect(itemBRow).not.toBeNull();
-  });
 });
 
 describe("deleteConversation — private scope cleanup", () => {
   beforeEach(() => {
     const db = getDb();
     db.run(`DELETE FROM conversation_starters`);
-    db.run(`DELETE FROM memory_item_sources`);
+    db.run(`DELETE FROM memory_graph_nodes`);
     db.run(`DELETE FROM memory_segments`);
-    db.run(`DELETE FROM memory_items`);
     db.run(`DELETE FROM memory_summaries`);
     db.run(`DELETE FROM memory_embeddings`);
     db.run(`DELETE FROM memory_jobs`);
@@ -427,37 +157,6 @@ describe("deleteConversation — private scope cleanup", () => {
     db.run(`DELETE FROM llm_request_logs`);
     db.run(`DELETE FROM messages`);
     db.run(`DELETE FROM conversations`);
-  });
-
-  test("sourceless items cleaned up", () => {
-    const conv = createConversation({ conversationType: "private" });
-    const scopeId = conv.memoryScopeId;
-    const now = Date.now();
-
-    const raw = (
-      getDb() as unknown as {
-        $client: import("bun:sqlite").Database;
-      }
-    ).$client;
-
-    // Insert a memory item with matching scopeId but no memory_item_sources
-    raw
-      .query(
-        `INSERT INTO memory_items (id, status, kind, subject, statement, confidence, fingerprint, scope_id, first_seen_at, last_seen_at)
-         VALUES ('priv-item-1', 'active', 'fact', 'test', 'test fact', 0.8, 'fp-priv-1', ?, ?, ?)`,
-      )
-      .run(scopeId, now, now);
-
-    const result = deleteConversation(conv.id);
-
-    // Item should be gone
-    const itemRow = raw
-      .query("SELECT * FROM memory_items WHERE id = 'priv-item-1'")
-      .get();
-    expect(itemRow).toBeNull();
-
-    // Its ID should be in orphanedItemIds
-    expect(result.orphanedItemIds).toContain("priv-item-1");
   });
 
   test("summaries cleaned up", () => {
@@ -492,71 +191,15 @@ describe("deleteConversation — private scope cleanup", () => {
   });
 
   test("standard conversations unaffected", async () => {
-    const conv = createConversation("standard test");
-    const now = Date.now();
+    // Create a standard conversation and a private one
+    const standardConv = createConversation("standard test");
+    const privateConv = createConversation({ conversationType: "private" });
 
-    const raw = (
-      getDb() as unknown as {
-        $client: import("bun:sqlite").Database;
-      }
-    ).$client;
+    // Delete the private conversation
+    deleteConversation(privateConv.id);
 
-    // Insert items with scopeId = "default"
-    raw
-      .query(
-        `INSERT INTO memory_items (id, status, kind, subject, statement, confidence, fingerprint, scope_id, first_seen_at, last_seen_at)
-         VALUES ('default-item-1', 'active', 'fact', 'test', 'test fact', 0.8, 'fp-default', 'default', ?, ?)`,
-      )
-      .run(now, now);
-
-    deleteConversation(conv.id);
-
-    // Default-scope items should still exist
-    const itemRow = raw
-      .query("SELECT * FROM memory_items WHERE id = 'default-item-1'")
-      .get();
-    expect(itemRow).not.toBeNull();
-  });
-
-  test("embeddings cleaned up", () => {
-    const conv = createConversation({ conversationType: "private" });
-    const scopeId = conv.memoryScopeId;
-    const now = Date.now();
-
-    const raw = (
-      getDb() as unknown as {
-        $client: import("bun:sqlite").Database;
-      }
-    ).$client;
-
-    // Insert a memory item with matching scopeId
-    raw
-      .query(
-        `INSERT INTO memory_items (id, status, kind, subject, statement, confidence, fingerprint, scope_id, first_seen_at, last_seen_at)
-         VALUES ('priv-item-emb', 'active', 'fact', 'test', 'test fact', 0.8, 'fp-priv-emb', ?, ?, ?)`,
-      )
-      .run(scopeId, now, now);
-
-    // Insert a corresponding embedding
-    raw
-      .query(
-        `INSERT INTO memory_embeddings (id, target_type, target_id, provider, model, dimensions, created_at, updated_at)
-         VALUES ('emb-priv-item', 'item', 'priv-item-emb', 'test', 'test', 384, ?, ?)`,
-      )
-      .run(now, now);
-
-    deleteConversation(conv.id);
-
-    // Both item and embedding should be deleted
-    const itemRow = raw
-      .query("SELECT * FROM memory_items WHERE id = 'priv-item-emb'")
-      .get();
-    expect(itemRow).toBeNull();
-
-    const embeddingRow = raw
-      .query("SELECT * FROM memory_embeddings WHERE id = 'emb-priv-item'")
-      .get();
-    expect(embeddingRow).toBeNull();
+    // Standard conversation should still exist
+    expect(getConversation(standardConv.id)).not.toBeNull();
   });
 
   test("conversationStarters cleaned up", () => {
@@ -599,41 +242,5 @@ describe("deleteConversation — private scope cleanup", () => {
       .query("SELECT * FROM conversation_starters WHERE id = 'starter-default'")
       .get();
     expect(defaultStarterRow).not.toBeNull();
-  });
-
-  test("no duplicate IDs", async () => {
-    const conv = createConversation({ conversationType: "private" });
-    const scopeId = conv.memoryScopeId;
-    const msg = await addMessage(conv.id, "user", "hello");
-    const now = Date.now();
-
-    const raw = (
-      getDb() as unknown as {
-        $client: import("bun:sqlite").Database;
-      }
-    ).$client;
-
-    // Insert a memory item with the private scopeId AND a source linking to the message
-    raw
-      .query(
-        `INSERT INTO memory_items (id, status, kind, subject, statement, confidence, fingerprint, scope_id, first_seen_at, last_seen_at)
-         VALUES ('priv-item-dup', 'active', 'fact', 'test', 'test fact', 0.8, 'fp-priv-dup', ?, ?, ?)`,
-      )
-      .run(scopeId, now, now);
-
-    raw
-      .query(
-        `INSERT INTO memory_item_sources (memory_item_id, message_id, created_at) VALUES ('priv-item-dup', ?, ?)`,
-      )
-      .run(msg.id, now);
-
-    const result = deleteConversation(conv.id);
-
-    // The item ID should appear exactly once in orphanedItemIds (caught by
-    // source-based cleanup, not double-counted by scope sweep).
-    const count = result.orphanedItemIds.filter(
-      (id) => id === "priv-item-dup",
-    ).length;
-    expect(count).toBe(1);
   });
 });

--- a/assistant/src/__tests__/memory-upsert-concurrency.test.ts
+++ b/assistant/src/__tests__/memory-upsert-concurrency.test.ts
@@ -61,21 +61,15 @@ mock.module("../config/loader.js", () => ({
 
 import { getDb, initializeDb } from "../memory/db.js";
 import { indexMessageNow } from "../memory/indexer.js";
-import {
-  conversations,
-  memoryItems,
-  memorySegments,
-  messages,
-} from "../memory/schema.js";
+import { conversations, memorySegments, messages } from "../memory/schema.js";
 
 // Initialize DB once for the entire file. Each test cleans its own tables.
 initializeDb();
 
 function resetTables() {
   const db = getDb();
-  db.run("DELETE FROM memory_item_sources");
   db.run("DELETE FROM memory_embeddings");
-  db.run("DELETE FROM memory_items");
+  db.run("DELETE FROM memory_graph_nodes");
   db.run("DELETE FROM memory_segments");
   db.run("DELETE FROM memory_jobs");
   db.run("DELETE FROM messages");
@@ -555,101 +549,3 @@ describe("memory segment job atomicity under repeated indexer invocations", () =
   });
 });
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Test suite: memory_items fingerprint uniqueness under race conditions
-// ─────────────────────────────────────────────────────────────────────────────
-
-describe("memory_items fingerprint uniqueness under race conditions", () => {
-  beforeEach(() => {
-    resetTables();
-  });
-
-  test("duplicate inserts with identical fingerprints produce exactly one row", () => {
-    // The memory_items table has a unique constraint on (fingerprint, scope_id).
-    // Two sequential inserts for the same fingerprint simulate duplicate extractor
-    // runs.  Only one INSERT must land; the second must be absorbed by ON CONFLICT.
-    const db = getDb();
-    const now = Date.now();
-    const fingerprint = "fp-race-unique-test-concurrency";
-    const scopeId = "default";
-
-    // Use raw SQL to replicate what the items-extractor would do when a second
-    // run tries to INSERT the same fingerprint that already exists.
-    const raw = (db as unknown as { $client: import("bun:sqlite").Database })
-      .$client;
-
-    raw.run(`
-      INSERT INTO memory_items (
-        id, kind, subject, statement, status, confidence, importance,
-        fingerprint, verification_state, scope_id, first_seen_at, last_seen_at
-      ) VALUES (
-        'item-race-1', 'preference', 'code style', 'I prefer tabs over spaces.',
-        'active', 0.8, 0.6, '${fingerprint}', 'user_reported', '${scopeId}',
-        ${now}, ${now}
-      )
-    `);
-
-    // Second "worker" tries to insert the same fingerprint — must not create a
-    // duplicate.  INSERT OR IGNORE / ON CONFLICT DO NOTHING is the expected
-    // behavior for the unique constraint.
-    expect(() => {
-      raw.run(`
-        INSERT OR IGNORE INTO memory_items (
-          id, kind, subject, statement, status, confidence, importance,
-          fingerprint, verification_state, scope_id, first_seen_at, last_seen_at
-        ) VALUES (
-          'item-race-2', 'preference', 'code style', 'I prefer tabs over spaces.',
-          'active', 0.8, 0.6, '${fingerprint}', 'user_reported', '${scopeId}',
-          ${now + 1}, ${now + 1}
-        )
-      `);
-    }).not.toThrow();
-
-    const rows = db
-      .select()
-      .from(memoryItems)
-      .all()
-      .filter((r) => r.fingerprint === fingerprint);
-
-    // Only the first insert must have landed.
-    expect(rows).toHaveLength(1);
-    expect(rows[0].id).toBe("item-race-1");
-  });
-
-  test("bare INSERT without IGNORE throws on duplicate fingerprint+scopeId", () => {
-    // Verify the DB-level unique constraint is actually enforced so that any code
-    // path that accidentally omits ON CONFLICT will fail loudly rather than silently
-    // producing inconsistent state.
-    const db = getDb();
-    const now = Date.now();
-    const fingerprint = "fp-constraint-enforcement-test";
-
-    const raw = (db as unknown as { $client: import("bun:sqlite").Database })
-      .$client;
-
-    raw.run(`
-      INSERT INTO memory_items (
-        id, kind, subject, statement, status, confidence, importance,
-        fingerprint, verification_state, scope_id, first_seen_at, last_seen_at
-      ) VALUES (
-        'item-constraint-a', 'preference', 'editor', 'I use VS Code.',
-        'active', 0.9, 0.7, '${fingerprint}', 'user_reported', 'default',
-        ${now}, ${now}
-      )
-    `);
-
-    // A bare INSERT (no ON CONFLICT) for the same fingerprint+scope_id must throw.
-    expect(() => {
-      raw.run(`
-        INSERT INTO memory_items (
-          id, kind, subject, statement, status, confidence, importance,
-          fingerprint, verification_state, scope_id, first_seen_at, last_seen_at
-        ) VALUES (
-          'item-constraint-b', 'preference', 'editor', 'I use VS Code.',
-          'active', 0.9, 0.7, '${fingerprint}', 'user_reported', 'default',
-          ${now + 1}, ${now + 1}
-        )
-      `);
-    }).toThrow();
-  });
-});

--- a/assistant/src/__tests__/playbook-tools.test.ts
+++ b/assistant/src/__tests__/playbook-tools.test.ts
@@ -41,7 +41,9 @@ const ctx: ToolContext = {
 };
 
 function clearPlaybooks(): void {
-  getRawDb().run("DELETE FROM memory_items WHERE kind = 'playbook'");
+  getRawDb().run(
+    "DELETE FROM memory_graph_nodes WHERE source_conversations LIKE '%playbook:%'",
+  );
 }
 
 function extractPlaybookId(content: string): string {

--- a/assistant/src/__tests__/skill-memory.test.ts
+++ b/assistant/src/__tests__/skill-memory.test.ts
@@ -1,7 +1,7 @@
 import { rmSync } from "node:fs";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { eq } from "drizzle-orm";
+import { eq, like } from "drizzle-orm";
 
 mock.module("../util/logger.js", () => ({
   getLogger: () =>
@@ -61,7 +61,7 @@ mock.module("../config/loader.js", () => ({
 
 import type { SkillSummary } from "../config/skills.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
-import { memoryItems, memoryJobs } from "../memory/schema.js";
+import { memoryGraphNodes, memoryJobs } from "../memory/schema.js";
 import {
   buildCapabilityStatement,
   deleteSkillCapabilityMemory,
@@ -81,9 +81,8 @@ afterAll(() => {
 
 function resetTables() {
   const db = getDb();
-  db.run("DELETE FROM memory_item_sources");
   db.run("DELETE FROM memory_embeddings");
-  db.run("DELETE FROM memory_items");
+  db.run("DELETE FROM memory_graph_nodes");
   db.run("DELETE FROM memory_jobs");
 }
 
@@ -231,59 +230,59 @@ describe("fromSkillSummary", () => {
 describe("upsertSkillCapabilityMemory", () => {
   beforeEach(resetTables);
 
-  test("inserts with correct kind, subject, confidence, importance", () => {
+  test("inserts with correct type, content, confidence, significance", () => {
     const input = fromSkillSummary(makeSkillSummary());
     upsertSkillCapabilityMemory("test-skill", input);
 
     const db = getDb();
-    const items = db.select().from(memoryItems).all();
+    const items = db.select().from(memoryGraphNodes).all();
     expect(items).toHaveLength(1);
-    expect(items[0].kind).toBe("capability");
-    expect(items[0].subject).toBe("skill:test-skill");
+    expect(items[0].type).toBe("procedural");
+    expect(items[0].content).toMatch(/^skill:test-skill\n/);
     expect(items[0].confidence).toBe(1.0);
-    expect(items[0].importance).toBe(0.7);
-    expect(items[0].status).toBe("active");
+    expect(items[0].significance).toBe(0.7);
+    expect(items[0].fidelity).toBe("vivid");
     expect(items[0].scopeId).toBe("default");
 
-    // Should also enqueue an embed_item job
+    // Should also enqueue an embed_graph_node job
     const jobs = db.select().from(memoryJobs).all();
     expect(jobs).toHaveLength(1);
-    expect(jobs[0].type).toBe("embed_item");
+    expect(jobs[0].type).toBe("embed_graph_node");
   });
 
-  test("is idempotent (same entry only touches lastSeenAt)", () => {
+  test("is idempotent (same entry only touches lastAccessed)", () => {
     const input = fromSkillSummary(makeSkillSummary());
     upsertSkillCapabilityMemory("test-skill", input);
 
     const db = getDb();
-    const before = db.select().from(memoryItems).all();
+    const before = db.select().from(memoryGraphNodes).all();
     expect(before).toHaveLength(1);
-    const originalLastSeen = before[0].lastSeenAt;
+    const originalLastAccessed = before[0].lastAccessed;
 
     // Upsert again
     upsertSkillCapabilityMemory("test-skill", input);
 
-    const after = db.select().from(memoryItems).all();
+    const after = db.select().from(memoryGraphNodes).all();
     expect(after).toHaveLength(1);
-    // Fingerprint should be the same, so only lastSeenAt changes
-    expect(after[0].fingerprint).toBe(before[0].fingerprint);
-    expect(after[0].lastSeenAt).toBeGreaterThanOrEqual(originalLastSeen);
+    // Same content, so only lastAccessed changes
+    expect(after[0].content).toBe(before[0].content);
+    expect(after[0].lastAccessed).toBeGreaterThanOrEqual(originalLastAccessed);
 
     // Should NOT enqueue a second embed job (only 1 from initial insert)
     const jobs = db.select().from(memoryJobs).all();
     expect(jobs).toHaveLength(1);
   });
 
-  test("updates statement when description changes", () => {
+  test("updates content when description changes", () => {
     const input = fromSkillSummary(
       makeSkillSummary({ description: "Original description" }),
     );
     upsertSkillCapabilityMemory("test-skill", input);
 
     const db = getDb();
-    const before = db.select().from(memoryItems).all();
+    const before = db.select().from(memoryGraphNodes).all();
     expect(before).toHaveLength(1);
-    expect(before[0].statement).toContain("Original description");
+    expect(before[0].content).toContain("Original description");
 
     // Change description
     const updatedInput = fromSkillSummary(
@@ -291,10 +290,10 @@ describe("upsertSkillCapabilityMemory", () => {
     );
     upsertSkillCapabilityMemory("test-skill", updatedInput);
 
-    const after = db.select().from(memoryItems).all();
+    const after = db.select().from(memoryGraphNodes).all();
     expect(after).toHaveLength(1);
-    expect(after[0].statement).toContain("Updated description");
-    expect(after[0].fingerprint).not.toBe(before[0].fingerprint);
+    expect(after[0].content).toContain("Updated description");
+    expect(after[0].content).not.toBe(before[0].content);
 
     // Should enqueue a second embed job
     const jobs = db.select().from(memoryJobs).all();
@@ -307,13 +306,13 @@ describe("upsertSkillCapabilityMemory", () => {
 
     const db = getDb();
     // Soft-delete the item
-    db.update(memoryItems)
-      .set({ status: "deleted" })
-      .where(eq(memoryItems.subject, "skill:test-skill"))
+    db.update(memoryGraphNodes)
+      .set({ fidelity: "gone" })
+      .where(like(memoryGraphNodes.content, "skill:test-skill\n%"))
       .run();
 
-    const deleted = db.select().from(memoryItems).all();
-    expect(deleted[0].status).toBe("deleted");
+    const deleted = db.select().from(memoryGraphNodes).all();
+    expect(deleted[0].fidelity).toBe("gone");
 
     // Clear jobs from initial insert
     db.run("DELETE FROM memory_jobs");
@@ -321,14 +320,14 @@ describe("upsertSkillCapabilityMemory", () => {
     // Upsert again — should reactivate
     upsertSkillCapabilityMemory("test-skill", input);
 
-    const reactivated = db.select().from(memoryItems).all();
+    const reactivated = db.select().from(memoryGraphNodes).all();
     expect(reactivated).toHaveLength(1);
-    expect(reactivated[0].status).toBe("active");
+    expect(reactivated[0].fidelity).toBe("vivid");
 
     // Should enqueue embed job for reactivated item
     const jobs = db.select().from(memoryJobs).all();
     expect(jobs).toHaveLength(1);
-    expect(jobs[0].type).toBe("embed_item");
+    expect(jobs[0].type).toBe("embed_graph_node");
   });
 
   test("does not throw on DB error", () => {
@@ -338,9 +337,9 @@ describe("upsertSkillCapabilityMemory", () => {
     // dropping the table it reads from. Use a fresh DB without initialization.
     // Instead, verify the try/catch by closing and reopening:
     // resetDb closes the connection; getDb lazily reconnects.
-    // We drop the memory_items table to force an error on the next query.
+    // We drop the memory_graph_nodes table to force an error on the next query.
     const db = getDb();
-    db.run("DROP TABLE IF EXISTS memory_items");
+    db.run("DROP TABLE IF EXISTS memory_graph_nodes");
 
     expect(() => {
       upsertSkillCapabilityMemory(
@@ -372,15 +371,15 @@ describe("deleteSkillCapabilityMemory", () => {
     upsertSkillCapabilityMemory("test-skill", input);
 
     const db = getDb();
-    const before = db.select().from(memoryItems).all();
+    const before = db.select().from(memoryGraphNodes).all();
     expect(before).toHaveLength(1);
-    expect(before[0].status).toBe("active");
+    expect(before[0].fidelity).toBe("vivid");
 
     deleteSkillCapabilityMemory("test-skill");
 
-    const after = db.select().from(memoryItems).all();
+    const after = db.select().from(memoryGraphNodes).all();
     expect(after).toHaveLength(1);
-    expect(after[0].status).toBe("deleted");
+    expect(after[0].fidelity).toBe("gone");
   });
 
   test("is no-op for missing item", () => {
@@ -390,7 +389,7 @@ describe("deleteSkillCapabilityMemory", () => {
     }).not.toThrow();
 
     const db = getDb();
-    const items = db.select().from(memoryItems).all();
+    const items = db.select().from(memoryGraphNodes).all();
     expect(items).toHaveLength(0);
   });
 
@@ -398,7 +397,7 @@ describe("deleteSkillCapabilityMemory", () => {
     // Close and reopen DB, then drop the table to force a query error
     resetDb();
     const db = getDb();
-    db.run("DROP TABLE IF EXISTS memory_items");
+    db.run("DROP TABLE IF EXISTS memory_graph_nodes");
 
     expect(() => {
       deleteSkillCapabilityMemory("test-skill");
@@ -450,21 +449,21 @@ describe("seedCatalogSkillMemories", () => {
     const db = getDb();
     const items = db
       .select()
-      .from(memoryItems)
-      .where(eq(memoryItems.kind, "capability"))
+      .from(memoryGraphNodes)
+      .where(eq(memoryGraphNodes.type, "procedural"))
       .all();
     expect(items).toHaveLength(3);
 
-    const subjects = items.map((i) => i.subject).sort();
-    expect(subjects).toEqual([
+    const contentPrefixes = items.map((i) => i.content.split("\n")[0]).sort();
+    expect(contentPrefixes).toEqual([
       "skill:skill-a",
       "skill:skill-b",
       "skill:skill-c",
     ]);
 
-    // All should be active
+    // All should be vivid
     for (const item of items) {
-      expect(item.status).toBe("active");
+      expect(item.fidelity).toBe("vivid");
     }
   });
 
@@ -491,16 +490,16 @@ describe("seedCatalogSkillMemories", () => {
     const db = getDb();
     const items = db
       .select()
-      .from(memoryItems)
-      .where(eq(memoryItems.kind, "capability"))
+      .from(memoryGraphNodes)
+      .where(eq(memoryGraphNodes.type, "procedural"))
       .all();
     expect(items).toHaveLength(2);
 
-    const subjects = items.map((i) => i.subject).sort();
-    expect(subjects).toEqual(["skill:bundled-skill", "skill:managed-skill"]);
+    const contentPrefixes = items.map((i) => i.content.split("\n")[0]).sort();
+    expect(contentPrefixes).toEqual(["skill:bundled-skill", "skill:managed-skill"]);
 
     for (const item of items) {
-      expect(item.status).toBe("active");
+      expect(item.fidelity).toBe("vivid");
     }
   });
 
@@ -550,14 +549,14 @@ describe("seedCatalogSkillMemories", () => {
     const db = getDb();
     const items = db
       .select()
-      .from(memoryItems)
-      .where(eq(memoryItems.kind, "capability"))
+      .from(memoryGraphNodes)
+      .where(eq(memoryGraphNodes.type, "procedural"))
       .all();
 
     // Only allowed-bundled and managed-skill should be seeded
     expect(items).toHaveLength(2);
-    const subjects = items.map((i) => i.subject).sort();
-    expect(subjects).toEqual(["skill:allowed-bundled", "skill:managed-skill"]);
+    const contentPrefixes = items.map((i) => i.content.split("\n")[0]).sort();
+    expect(contentPrefixes).toEqual(["skill:allowed-bundled", "skill:managed-skill"]);
 
     // Restore default config mock
     mock.module("../config/loader.js", () => ({
@@ -594,11 +593,11 @@ describe("seedCatalogSkillMemories", () => {
     const db = getDb();
     const beforeItems = db
       .select()
-      .from(memoryItems)
-      .where(eq(memoryItems.kind, "capability"))
+      .from(memoryGraphNodes)
+      .where(eq(memoryGraphNodes.type, "procedural"))
       .all();
     expect(beforeItems).toHaveLength(3);
-    expect(beforeItems.every((i) => i.status === "active")).toBe(true);
+    expect(beforeItems.every((i) => i.fidelity === "vivid")).toBe(true);
 
     // Now seed with only skill-a — skill-b and skill-c should be pruned
     mockLoadSkillCatalog = () => [
@@ -612,20 +611,20 @@ describe("seedCatalogSkillMemories", () => {
 
     const afterItems = db
       .select()
-      .from(memoryItems)
-      .where(eq(memoryItems.kind, "capability"))
+      .from(memoryGraphNodes)
+      .where(eq(memoryGraphNodes.type, "procedural"))
       .all();
     expect(afterItems).toHaveLength(3); // still 3 rows, but 2 are soft-deleted
 
-    const active = afterItems.filter((i) => i.status === "active");
-    const deleted = afterItems.filter((i) => i.status === "deleted");
+    const active = afterItems.filter((i) => i.fidelity === "vivid");
+    const deleted = afterItems.filter((i) => i.fidelity === "gone");
 
     expect(active).toHaveLength(1);
-    expect(active[0].subject).toBe("skill:skill-a");
+    expect(active[0].content).toMatch(/^skill:skill-a\n/);
 
     expect(deleted).toHaveLength(2);
-    const deletedSubjects = deleted.map((i) => i.subject).sort();
-    expect(deletedSubjects).toEqual(["skill:skill-b", "skill:skill-c"]);
+    const deletedPrefixes = deleted.map((i) => i.content.split("\n")[0]).sort();
+    expect(deletedPrefixes).toEqual(["skill:skill-b", "skill:skill-c"]);
   });
 
   test("handles empty catalog without errors", () => {
@@ -636,38 +635,44 @@ describe("seedCatalogSkillMemories", () => {
     );
 
     const db = getDb();
-    const beforeItems = db.select().from(memoryItems).all();
+    const beforeItems = db.select().from(memoryGraphNodes).all();
     expect(beforeItems).toHaveLength(1);
-    expect(beforeItems[0].status).toBe("active");
+    expect(beforeItems[0].fidelity).toBe("vivid");
 
     // Seed with empty catalog
     mockLoadSkillCatalog = () => [];
     seedCatalogSkillMemories();
 
     // The existing skill should be pruned (soft-deleted)
-    const afterItems = db.select().from(memoryItems).all();
+    const afterItems = db.select().from(memoryGraphNodes).all();
     expect(afterItems).toHaveLength(1);
-    expect(afterItems[0].status).toBe("deleted");
+    expect(afterItems[0].fidelity).toBe("gone");
   });
 
   test("does not prune non-skill capability memories", () => {
     // Pre-insert a non-skill capability memory directly into the DB
     const db = getDb();
     const now = Date.now();
-    db.insert(memoryItems)
+    db.insert(memoryGraphNodes)
       .values({
         id: "cli-doctor-item",
-        kind: "capability",
-        subject: "cli:doctor",
-        statement: "The doctor command diagnoses issues.",
-        status: "active",
+        type: "procedural",
+        content: "cli:doctor\nThe doctor command diagnoses issues.",
+        fidelity: "vivid",
         confidence: 1.0,
-        importance: 0.7,
-        fingerprint: "cli-doctor-fp",
-        sourceType: "extraction",
+        significance: 0.7,
+        sourceType: "inferred",
         scopeId: "default",
-        firstSeenAt: now,
-        lastSeenAt: now,
+        created: now,
+        lastAccessed: now,
+        lastConsolidated: now,
+        emotionalCharge: '{"valence":0,"intensity":0.1,"decayCurve":"linear","decayRate":0.05,"originalIntensity":0.1}',
+        stability: 14,
+        reinforcementCount: 0,
+        lastReinforced: now,
+        sourceConversations: "[]",
+        narrativeRole: null,
+        partOfStory: null,
       })
       .run();
 
@@ -677,11 +682,11 @@ describe("seedCatalogSkillMemories", () => {
 
     const item = db
       .select()
-      .from(memoryItems)
-      .where(eq(memoryItems.subject, "cli:doctor"))
+      .from(memoryGraphNodes)
+      .where(like(memoryGraphNodes.content, "cli:doctor\n%"))
       .get();
     expect(item).toBeDefined();
-    expect(item!.status).toBe("active");
+    expect(item!.fidelity).toBe("vivid");
   });
 
   test("does not throw when loadSkillCatalog throws", () => {
@@ -717,14 +722,14 @@ describe("seedCatalogSkillMemories", () => {
     const db = getDb();
     const items = db
       .select()
-      .from(memoryItems)
-      .where(eq(memoryItems.kind, "capability"))
+      .from(memoryGraphNodes)
+      .where(eq(memoryGraphNodes.type, "procedural"))
       .all();
 
     // Only the unflagged skill should have a capability row
     expect(items).toHaveLength(1);
-    expect(items[0].subject).toBe("skill:unflagged-skill");
-    expect(items[0].status).toBe("active");
+    expect(items[0].content).toMatch(/^skill:unflagged-skill\n/);
+    expect(items[0].fidelity).toBe("vivid");
   });
 
   test("prunes pre-existing capability for a skill whose flag becomes disabled", () => {
@@ -749,11 +754,11 @@ describe("seedCatalogSkillMemories", () => {
     const db = getDb();
     const beforeItems = db
       .select()
-      .from(memoryItems)
-      .where(eq(memoryItems.kind, "capability"))
+      .from(memoryGraphNodes)
+      .where(eq(memoryGraphNodes.type, "procedural"))
       .all();
     expect(beforeItems).toHaveLength(2);
-    expect(beforeItems.every((i) => i.status === "active")).toBe(true);
+    expect(beforeItems.every((i) => i.fidelity === "vivid")).toBe(true);
 
     // Now disable the flag — the flagged skill should be pruned
     mockIsFeatureFlagEnabled = (key: string) => key !== "my_gated_feature";
@@ -761,19 +766,19 @@ describe("seedCatalogSkillMemories", () => {
 
     const afterItems = db
       .select()
-      .from(memoryItems)
-      .where(eq(memoryItems.kind, "capability"))
+      .from(memoryGraphNodes)
+      .where(eq(memoryGraphNodes.type, "procedural"))
       .all();
     expect(afterItems).toHaveLength(2); // still 2 rows, but one soft-deleted
 
-    const active = afterItems.filter((i) => i.status === "active");
-    const deleted = afterItems.filter((i) => i.status === "deleted");
+    const active = afterItems.filter((i) => i.fidelity === "vivid");
+    const deleted = afterItems.filter((i) => i.fidelity === "gone");
 
     expect(active).toHaveLength(1);
-    expect(active[0].subject).toBe("skill:unflagged-skill");
+    expect(active[0].content).toMatch(/^skill:unflagged-skill\n/);
 
     expect(deleted).toHaveLength(1);
-    expect(deleted[0].subject).toBe("skill:flagged-skill");
+    expect(deleted[0].content).toMatch(/^skill:flagged-skill\n/);
   });
 
   test("does not throw on DB error during pruning", () => {
@@ -785,10 +790,10 @@ describe("seedCatalogSkillMemories", () => {
       }),
     ];
 
-    // Drop memory_items to force a DB error during the prune phase
+    // Drop memory_graph_nodes to force a DB error during the prune phase
     resetDb();
     const db = getDb();
-    db.run("DROP TABLE IF EXISTS memory_items");
+    db.run("DROP TABLE IF EXISTS memory_graph_nodes");
 
     expect(() => seedCatalogSkillMemories()).not.toThrow();
 

--- a/assistant/src/__tests__/task-memory-cleanup.test.ts
+++ b/assistant/src/__tests__/task-memory-cleanup.test.ts
@@ -45,8 +45,7 @@ import {
   conversations,
   cronJobs,
   cronRuns,
-  memoryItems,
-  memoryItemSources,
+  memoryGraphNodes,
   memoryJobs,
   messages,
   taskRuns,
@@ -56,6 +55,9 @@ import {
   invalidateAssistantInferredItemsForConversation,
   isConversationFailed,
 } from "../memory/task-memory-cleanup.js";
+
+const DEFAULT_EMOTIONAL_CHARGE =
+  '{"valence":0,"intensity":0.1,"decayCurve":"linear","decayRate":0.05,"originalIntensity":0.1}';
 
 describe("invalidateAssistantInferredItemsForConversation", () => {
   const now = 1_701_100_000_000;
@@ -68,8 +70,7 @@ describe("invalidateAssistantInferredItemsForConversation", () => {
 
   beforeEach(() => {
     const db = getDb();
-    db.run("DELETE FROM memory_item_sources");
-    db.run("DELETE FROM memory_items");
+    db.run("DELETE FROM memory_graph_nodes");
     db.run("DELETE FROM memory_jobs");
     db.run("DELETE FROM messages");
     db.run("DELETE FROM cron_runs");
@@ -128,165 +129,161 @@ describe("invalidateAssistantInferredItemsForConversation", () => {
       .run();
   }
 
-  function seedMemoryItems() {
+  function seedMemoryGraphNodes() {
     const db = getDb();
-    db.insert(memoryItems)
+    db.insert(memoryGraphNodes)
       .values([
         {
           id: "item-assistant-inferred",
-          kind: "fact",
-          subject: "DMV appointment",
-          statement: "Booked a DMV appointment at 9 AM.",
-          status: "active",
+          content: "DMV appointment\nBooked a DMV appointment at 9 AM.",
+          type: "semantic",
+          created: now + 10,
+          lastAccessed: now + 10,
+          lastConsolidated: now + 10,
+          emotionalCharge: DEFAULT_EMOTIONAL_CHARGE,
+          fidelity: "vivid",
           confidence: 0.8,
-          importance: 0.7,
-          fingerprint: "fp-assistant-inferred",
-          verificationState: "assistant_inferred",
-          sourceType: "extraction",
-          sourceMessageRole: "assistant",
+          significance: 0.7,
+          stability: 14,
+          reinforcementCount: 0,
+          lastReinforced: now + 10,
+          sourceConversations: JSON.stringify([convId]),
+          sourceType: "inferred",
+          narrativeRole: null,
+          partOfStory: null,
           scopeId: "default",
-          firstSeenAt: now + 10,
-          lastSeenAt: now + 10,
         },
         {
           id: "item-user-reported",
-          kind: "preference",
-          subject: "notification pref",
-          statement: "User prefers email notifications.",
-          status: "active",
+          content: "notification pref\nUser prefers email notifications.",
+          type: "semantic",
+          created: now + 20,
+          lastAccessed: now + 20,
+          lastConsolidated: now + 20,
+          emotionalCharge: DEFAULT_EMOTIONAL_CHARGE,
+          fidelity: "vivid",
           confidence: 0.9,
-          importance: 0.8,
-          fingerprint: "fp-user-reported",
-          verificationState: "user_reported",
-          sourceType: "extraction",
-          sourceMessageRole: "user",
+          significance: 0.8,
+          stability: 14,
+          reinforcementCount: 0,
+          lastReinforced: now + 20,
+          sourceConversations: JSON.stringify([convId]),
+          sourceType: "direct",
+          narrativeRole: null,
+          partOfStory: null,
           scopeId: "default",
-          firstSeenAt: now + 20,
-          lastSeenAt: now + 20,
         },
         {
           id: "item-other-conv",
-          kind: "fact",
-          subject: "weather check",
-          statement: "Checked weather for tomorrow.",
-          status: "active",
+          content: "weather check\nChecked weather for tomorrow.",
+          type: "semantic",
+          created: now + 30,
+          lastAccessed: now + 30,
+          lastConsolidated: now + 30,
+          emotionalCharge: DEFAULT_EMOTIONAL_CHARGE,
+          fidelity: "vivid",
           confidence: 0.7,
-          importance: 0.5,
-          fingerprint: "fp-other-conv",
-          verificationState: "assistant_inferred",
-          sourceType: "extraction",
-          sourceMessageRole: "assistant",
+          significance: 0.5,
+          stability: 14,
+          reinforcementCount: 0,
+          lastReinforced: now + 30,
+          sourceConversations: JSON.stringify([otherConvId]),
+          sourceType: "inferred",
+          narrativeRole: null,
+          partOfStory: null,
           scopeId: "default",
-          firstSeenAt: now + 30,
-          lastSeenAt: now + 30,
         },
         {
-          id: "item-already-superseded",
-          kind: "fact",
-          subject: "old claim",
-          statement: "Old assistant claim already superseded.",
-          status: "superseded",
+          id: "item-already-gone",
+          content: "old claim\nOld assistant claim already gone.",
+          type: "semantic",
+          created: now + 5,
+          lastAccessed: now + 5,
+          lastConsolidated: now + 5,
+          emotionalCharge: DEFAULT_EMOTIONAL_CHARGE,
+          fidelity: "gone",
           confidence: 0.6,
-          importance: 0.4,
-          fingerprint: "fp-already-superseded",
-          verificationState: "assistant_inferred",
-          sourceType: "extraction",
-          sourceMessageRole: "assistant",
+          significance: 0.4,
+          stability: 14,
+          reinforcementCount: 0,
+          lastReinforced: now + 5,
+          sourceConversations: JSON.stringify([convId]),
+          sourceType: "inferred",
+          narrativeRole: null,
+          partOfStory: null,
           scopeId: "default",
-          firstSeenAt: now + 5,
-          lastSeenAt: now + 5,
-        },
-      ])
-      .run();
-
-    db.insert(memoryItemSources)
-      .values([
-        {
-          memoryItemId: "item-assistant-inferred",
-          messageId: "msg-task-1",
-          evidence: "booking claim",
-          createdAt: now + 10,
-        },
-        {
-          memoryItemId: "item-user-reported",
-          messageId: "msg-task-2",
-          evidence: "user stated",
-          createdAt: now + 20,
-        },
-        {
-          memoryItemId: "item-other-conv",
-          messageId: "msg-other",
-          evidence: "weather",
-          createdAt: now + 30,
-        },
-        {
-          memoryItemId: "item-already-superseded",
-          messageId: "msg-task-1",
-          evidence: "old claim",
-          createdAt: now + 5,
         },
       ])
       .run();
   }
 
-  test("only invalidates assistant_inferred items, not user_reported", () => {
+  test("only invalidates inferred items, not direct (user-reported)", () => {
     seedConversations();
     seedMessages();
-    seedMemoryItems();
+    seedMemoryGraphNodes();
 
     const affected = invalidateAssistantInferredItemsForConversation(convId);
 
     expect(affected).toBe(1);
 
     const db = getDb();
-    const assistantItem = db
+    const inferredItem = db
       .select()
-      .from(memoryItems)
-      .where(eq(memoryItems.id, "item-assistant-inferred"))
+      .from(memoryGraphNodes)
+      .where(eq(memoryGraphNodes.id, "item-assistant-inferred"))
       .get();
-    expect(assistantItem?.status).toBe("invalidated");
-    expect(assistantItem?.invalidAt).not.toBeNull();
+    expect(inferredItem?.fidelity).toBe("gone");
 
-    const userItem = db
+    const directItem = db
       .select()
-      .from(memoryItems)
-      .where(eq(memoryItems.id, "item-user-reported"))
+      .from(memoryGraphNodes)
+      .where(eq(memoryGraphNodes.id, "item-user-reported"))
       .get();
-    expect(userItem?.status).toBe("active");
-    expect(userItem?.invalidAt).toBeNull();
+    expect(directItem?.fidelity).toBe("vivid");
   });
 
   test("does not affect items from other conversations", () => {
     seedConversations();
     seedMessages();
-    seedMemoryItems();
+    seedMemoryGraphNodes();
 
     invalidateAssistantInferredItemsForConversation(convId);
 
     const db = getDb();
     const otherItem = db
       .select()
-      .from(memoryItems)
-      .where(eq(memoryItems.id, "item-other-conv"))
+      .from(memoryGraphNodes)
+      .where(eq(memoryGraphNodes.id, "item-other-conv"))
       .get();
-    expect(otherItem?.status).toBe("active");
-    expect(otherItem?.invalidAt).toBeNull();
+    expect(otherItem?.fidelity).toBe("vivid");
   });
 
   test("does not invalidate items also sourced from another conversation", () => {
     seedConversations();
     seedMessages();
-    seedMemoryItems();
 
-    // Add a second source from the other conversation to the assistant-inferred item.
-    // This simulates deduplication: the same fact was extracted from both conversations.
+    // Insert a node sourced from both conversations (corroboration).
     const db = getDb();
-    db.insert(memoryItemSources)
+    db.insert(memoryGraphNodes)
       .values({
-        memoryItemId: "item-assistant-inferred",
-        messageId: "msg-other",
-        evidence: "corroborating source from other conversation",
-        createdAt: now + 40,
+        id: "item-corroborated",
+        content: "DMV appointment\nBooked a DMV appointment at 9 AM.",
+        type: "semantic",
+        created: now + 10,
+        lastAccessed: now + 10,
+        lastConsolidated: now + 10,
+        emotionalCharge: DEFAULT_EMOTIONAL_CHARGE,
+        fidelity: "vivid",
+        confidence: 0.8,
+        significance: 0.7,
+        stability: 14,
+        reinforcementCount: 0,
+        lastReinforced: now + 10,
+        sourceConversations: JSON.stringify([convId, otherConvId]),
+        sourceType: "inferred",
+        narrativeRole: null,
+        partOfStory: null,
+        scopeId: "default",
       })
       .run();
 
@@ -297,33 +294,32 @@ describe("invalidateAssistantInferredItemsForConversation", () => {
 
     const item = db
       .select()
-      .from(memoryItems)
-      .where(eq(memoryItems.id, "item-assistant-inferred"))
+      .from(memoryGraphNodes)
+      .where(eq(memoryGraphNodes.id, "item-corroborated"))
       .get();
-    expect(item?.status).toBe("active");
-    expect(item?.invalidAt).toBeNull();
+    expect(item?.fidelity).toBe("vivid");
   });
 
-  test("does not affect already-superseded items", () => {
+  test("does not affect already-gone items", () => {
     seedConversations();
     seedMessages();
-    seedMemoryItems();
+    seedMemoryGraphNodes();
 
     invalidateAssistantInferredItemsForConversation(convId);
 
     const db = getDb();
-    const supersededItem = db
+    const goneItem = db
       .select()
-      .from(memoryItems)
-      .where(eq(memoryItems.id, "item-already-superseded"))
+      .from(memoryGraphNodes)
+      .where(eq(memoryGraphNodes.id, "item-already-gone"))
       .get();
-    expect(supersededItem?.status).toBe("superseded");
+    expect(goneItem?.fidelity).toBe("gone");
   });
 
   test("returns 0 when no matching items exist", () => {
     seedConversations();
     seedMessages();
-    // No memory items seeded
+    // No memory graph nodes seeded
 
     const affected = invalidateAssistantInferredItemsForConversation(convId);
     expect(affected).toBe(0);
@@ -332,7 +328,7 @@ describe("invalidateAssistantInferredItemsForConversation", () => {
   test("returns 0 for unknown conversation", () => {
     seedConversations();
     seedMessages();
-    seedMemoryItems();
+    seedMemoryGraphNodes();
 
     const affected =
       invalidateAssistantInferredItemsForConversation("conv-nonexistent");
@@ -412,41 +408,28 @@ describe("invalidateAssistantInferredItemsForConversation", () => {
       ])
       .run();
 
-    // A memory item sourced from both conversations
-    db.insert(memoryItems)
+    // A memory node sourced from both failed conversations
+    db.insert(memoryGraphNodes)
       .values({
         id: "item-cross-sourced",
-        kind: "fact",
-        subject: "cross-sourced claim",
-        statement: "Claim from two failed tasks.",
-        status: "active",
+        content: "cross-sourced claim\nClaim from two failed tasks.",
+        type: "semantic",
+        created: now + 10,
+        lastAccessed: now + 20,
+        lastConsolidated: now + 10,
+        emotionalCharge: DEFAULT_EMOTIONAL_CHARGE,
+        fidelity: "vivid",
         confidence: 0.8,
-        importance: 0.7,
-        fingerprint: "fp-cross-sourced",
-        verificationState: "assistant_inferred",
-        sourceType: "extraction",
-        sourceMessageRole: "assistant",
+        significance: 0.7,
+        stability: 14,
+        reinforcementCount: 0,
+        lastReinforced: now + 10,
+        sourceConversations: JSON.stringify([convA, convB]),
+        sourceType: "inferred",
+        narrativeRole: null,
+        partOfStory: null,
         scopeId: "default",
-        firstSeenAt: now + 10,
-        lastSeenAt: now + 20,
       })
-      .run();
-
-    db.insert(memoryItemSources)
-      .values([
-        {
-          memoryItemId: "item-cross-sourced",
-          messageId: "msg-a",
-          evidence: "claim from A",
-          createdAt: now + 10,
-        },
-        {
-          memoryItemId: "item-cross-sourced",
-          messageId: "msg-b",
-          evidence: "claim from B",
-          createdAt: now + 20,
-        },
-      ])
       .run();
 
     // Invalidating for convA should succeed because convB is also from a failed task
@@ -455,11 +438,10 @@ describe("invalidateAssistantInferredItemsForConversation", () => {
 
     const item = db
       .select()
-      .from(memoryItems)
-      .where(eq(memoryItems.id, "item-cross-sourced"))
+      .from(memoryGraphNodes)
+      .where(eq(memoryGraphNodes.id, "item-cross-sourced"))
       .get();
-    expect(item?.status).toBe("invalidated");
-    expect(item?.invalidAt).not.toBeNull();
+    expect(item?.fidelity).toBe("gone");
   });
 
   test("invalidates items when corroborating conversation is from a failed schedule run", () => {
@@ -538,40 +520,27 @@ describe("invalidateAssistantInferredItemsForConversation", () => {
       ])
       .run();
 
-    db.insert(memoryItems)
+    db.insert(memoryGraphNodes)
       .values({
         id: "item-cross-sched",
-        kind: "fact",
-        subject: "cross-sourced schedule claim",
-        statement: "Claim from two failed schedules.",
-        status: "active",
+        content: "cross-sourced schedule claim\nClaim from two failed schedules.",
+        type: "semantic",
+        created: now + 10,
+        lastAccessed: now + 20,
+        lastConsolidated: now + 10,
+        emotionalCharge: DEFAULT_EMOTIONAL_CHARGE,
+        fidelity: "vivid",
         confidence: 0.8,
-        importance: 0.7,
-        fingerprint: "fp-cross-sched",
-        verificationState: "assistant_inferred",
-        sourceType: "extraction",
-        sourceMessageRole: "assistant",
+        significance: 0.7,
+        stability: 14,
+        reinforcementCount: 0,
+        lastReinforced: now + 10,
+        sourceConversations: JSON.stringify([convA, convB]),
+        sourceType: "inferred",
+        narrativeRole: null,
+        partOfStory: null,
         scopeId: "default",
-        firstSeenAt: now + 10,
-        lastSeenAt: now + 20,
       })
-      .run();
-
-    db.insert(memoryItemSources)
-      .values([
-        {
-          memoryItemId: "item-cross-sched",
-          messageId: "msg-sched-a",
-          evidence: "claim from A",
-          createdAt: now + 10,
-        },
-        {
-          memoryItemId: "item-cross-sched",
-          messageId: "msg-sched-b",
-          evidence: "claim from B",
-          createdAt: now + 20,
-        },
-      ])
       .run();
 
     const affected = invalidateAssistantInferredItemsForConversation(convA);
@@ -579,10 +548,10 @@ describe("invalidateAssistantInferredItemsForConversation", () => {
 
     const item = db
       .select()
-      .from(memoryItems)
-      .where(eq(memoryItems.id, "item-cross-sched"))
+      .from(memoryGraphNodes)
+      .where(eq(memoryGraphNodes.id, "item-cross-sched"))
       .get();
-    expect(item?.status).toBe("invalidated");
+    expect(item?.fidelity).toBe("gone");
   });
 
   test("preserves items when corroborating conversation is from a successful task run", () => {
@@ -656,40 +625,27 @@ describe("invalidateAssistantInferredItemsForConversation", () => {
       ])
       .run();
 
-    db.insert(memoryItems)
+    db.insert(memoryGraphNodes)
       .values({
         id: "item-with-good-corroboration",
-        kind: "fact",
-        subject: "corroborated claim",
-        statement: "Claim corroborated by successful task.",
-        status: "active",
+        content: "corroborated claim\nClaim corroborated by successful task.",
+        type: "semantic",
+        created: now + 10,
+        lastAccessed: now + 20,
+        lastConsolidated: now + 10,
+        emotionalCharge: DEFAULT_EMOTIONAL_CHARGE,
+        fidelity: "vivid",
         confidence: 0.8,
-        importance: 0.7,
-        fingerprint: "fp-good-corroboration",
-        verificationState: "assistant_inferred",
-        sourceType: "extraction",
-        sourceMessageRole: "assistant",
+        significance: 0.7,
+        stability: 14,
+        reinforcementCount: 0,
+        lastReinforced: now + 10,
+        sourceConversations: JSON.stringify([convFailed, convSuccess]),
+        sourceType: "inferred",
+        narrativeRole: null,
+        partOfStory: null,
         scopeId: "default",
-        firstSeenAt: now + 10,
-        lastSeenAt: now + 20,
       })
-      .run();
-
-    db.insert(memoryItemSources)
-      .values([
-        {
-          memoryItemId: "item-with-good-corroboration",
-          messageId: "msg-failed",
-          evidence: "claim from failed",
-          createdAt: now + 10,
-        },
-        {
-          memoryItemId: "item-with-good-corroboration",
-          messageId: "msg-success",
-          evidence: "claim from success",
-          createdAt: now + 20,
-        },
-      ])
       .run();
 
     // The successful task run corroborates the claim, so it should NOT be invalidated
@@ -699,10 +655,10 @@ describe("invalidateAssistantInferredItemsForConversation", () => {
 
     const item = db
       .select()
-      .from(memoryItems)
-      .where(eq(memoryItems.id, "item-with-good-corroboration"))
+      .from(memoryGraphNodes)
+      .where(eq(memoryGraphNodes.id, "item-with-good-corroboration"))
       .get();
-    expect(item?.status).toBe("active");
+    expect(item?.fidelity).toBe("vivid");
   });
 
   test("isConversationFailed derives state from durable task_runs/cron_runs", () => {

--- a/assistant/src/cli/cli-memory.ts
+++ b/assistant/src/cli/cli-memory.ts
@@ -1,10 +1,9 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, like, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "../memory/db.js";
-import { computeMemoryFingerprint } from "../memory/fingerprint.js";
 import { enqueueMemoryJob } from "../memory/jobs-store.js";
-import { memoryItems } from "../memory/schema.js";
+import { memoryGraphNodes } from "../memory/schema.js";
 import { getLogger } from "../util/logger.js";
 import { buildCliProgram } from "./program.js";
 
@@ -28,8 +27,17 @@ export function buildCliCapabilityStatement(
   return statement;
 }
 
+/** Default emotional charge for capability graph nodes. */
+const DEFAULT_EMOTIONAL_CHARGE = JSON.stringify({
+  valence: 0,
+  intensity: 0.1,
+  decayCurve: "linear",
+  decayRate: 0.05,
+  originalIntensity: 0.1,
+});
+
 /**
- * Upsert a capability memory item for a CLI command.
+ * Upsert a capability memory graph node for a CLI command.
  * Best-effort: errors are logged but never thrown.
  */
 export function upsertCliCapabilityMemory(
@@ -38,100 +46,95 @@ export function upsertCliCapabilityMemory(
 ): void {
   try {
     const db = getDb();
-    const subject = `cli:${commandName}`;
     const statement = buildCliCapabilityStatement(commandName, description);
-    const kind = "capability";
+    const content = `cli:${commandName}\n${statement}`;
     const scopeId = "default";
-    const confidence = 1.0;
-    const importance = 0.7;
-    const fingerprint = computeMemoryFingerprint(
-      scopeId,
-      kind,
-      subject,
-      statement,
-    );
     const now = Date.now();
 
     const existing = db
       .select()
-      .from(memoryItems)
+      .from(memoryGraphNodes)
       .where(
         and(
-          eq(memoryItems.kind, kind),
-          eq(memoryItems.subject, subject),
-          eq(memoryItems.scopeId, scopeId),
+          eq(memoryGraphNodes.type, "procedural"),
+          like(memoryGraphNodes.content, `cli:${commandName}\n%`),
+          eq(memoryGraphNodes.scopeId, scopeId),
         ),
       )
       .get();
 
     if (existing) {
       if (
-        existing.status === "active" &&
-        existing.fingerprint === fingerprint
+        existing.content === content &&
+        existing.fidelity !== "gone"
       ) {
-        // Same content — just touch lastSeenAt
-        db.update(memoryItems)
-          .set({ lastSeenAt: now })
-          .where(eq(memoryItems.id, existing.id))
+        // Same content — just touch lastAccessed
+        db.update(memoryGraphNodes)
+          .set({ lastAccessed: now })
+          .where(eq(memoryGraphNodes.id, existing.id))
           .run();
         return;
       }
 
-      if (existing.status === "active") {
-        // Content changed — update statement and fingerprint
-        db.update(memoryItems)
+      if (existing.fidelity !== "gone") {
+        // Content changed — update content
+        db.update(memoryGraphNodes)
           .set({
-            statement,
-            fingerprint,
-            lastSeenAt: now,
+            content,
+            lastAccessed: now,
           })
-          .where(eq(memoryItems.id, existing.id))
+          .where(eq(memoryGraphNodes.id, existing.id))
           .run();
-        enqueueMemoryJob("embed_item", { itemId: existing.id });
+        enqueueMemoryJob("embed_graph_node", { nodeId: existing.id });
         return;
       }
 
-      // status === "deleted" or other — reactivate
-      db.update(memoryItems)
+      // fidelity === "gone" — reactivate
+      db.update(memoryGraphNodes)
         .set({
-          status: "active",
-          statement,
-          fingerprint,
-          lastSeenAt: now,
-          firstSeenAt: now,
+          fidelity: "vivid",
+          content,
+          created: now,
+          lastAccessed: now,
         })
-        .where(eq(memoryItems.id, existing.id))
+        .where(eq(memoryGraphNodes.id, existing.id))
         .run();
-      enqueueMemoryJob("embed_item", { itemId: existing.id });
+      enqueueMemoryJob("embed_graph_node", { nodeId: existing.id });
       return;
     }
 
-    // No existing — insert new row
+    // No existing — insert new graph node
     const id = uuid();
-    db.insert(memoryItems)
+    db.insert(memoryGraphNodes)
       .values({
         id,
-        kind,
-        subject,
-        statement,
-        status: "active",
-        confidence,
-        importance,
-        fingerprint,
-        sourceType: "extraction",
+        content,
+        type: "procedural",
+        created: now,
+        lastAccessed: now,
+        lastConsolidated: now,
+        emotionalCharge: DEFAULT_EMOTIONAL_CHARGE,
+        fidelity: "vivid",
+        confidence: 1.0,
+        significance: 0.7,
+        stability: 14,
+        reinforcementCount: 0,
+        lastReinforced: now,
+        sourceConversations: JSON.stringify([]),
+        sourceType: "inferred",
+        narrativeRole: null,
+        partOfStory: null,
         scopeId,
-        firstSeenAt: now,
-        lastSeenAt: now,
       })
       .run();
-    enqueueMemoryJob("embed_item", { itemId: id });
+    enqueueMemoryJob("embed_graph_node", { nodeId: id });
   } catch (err) {
     log.warn({ err, commandName }, "Failed to upsert CLI capability memory");
   }
 }
 
 /**
- * Seed capability memory items for all CLI commands.
+ * Seed capability memory graph nodes for all CLI commands.
  * Prunes stale entries whose commands are no longer registered.
  * Best-effort: errors are logged but never thrown.
  */
@@ -149,24 +152,24 @@ export function seedCliCommandMemories(): void {
     const db = getDb();
     const allCapabilities = db
       .select()
-      .from(memoryItems)
+      .from(memoryGraphNodes)
       .where(
         and(
-          eq(memoryItems.kind, "capability"),
-          eq(memoryItems.scopeId, "default"),
-          eq(memoryItems.status, "active"),
+          eq(memoryGraphNodes.type, "procedural"),
+          eq(memoryGraphNodes.scopeId, "default"),
+          sql`${memoryGraphNodes.fidelity} != 'gone'`,
         ),
       )
       .all();
 
     const now = Date.now();
     for (const item of allCapabilities) {
-      if (!item.subject.startsWith("cli:")) continue;
-      const itemCommandName = item.subject.replace("cli:", "");
+      if (!item.content.startsWith("cli:")) continue;
+      const itemCommandName = item.content.split("\n")[0].replace("cli:", "");
       if (!commandNames.has(itemCommandName)) {
-        db.update(memoryItems)
-          .set({ status: "deleted", lastSeenAt: now })
-          .where(eq(memoryItems.id, item.id))
+        db.update(memoryGraphNodes)
+          .set({ fidelity: "gone", lastAccessed: now })
+          .where(eq(memoryGraphNodes.id, item.id))
           .run();
       }
     }

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-analyze-style.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-analyze-style.ts
@@ -1,10 +1,9 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "../../../../memory/db.js";
-import { computeMemoryFingerprint } from "../../../../memory/fingerprint.js";
 import { enqueueMemoryJob } from "../../../../memory/jobs-store.js";
-import { memoryItems } from "../../../../memory/schema.js";
+import { memoryGraphNodes } from "../../../../memory/schema.js";
 import { clampUnitInterval } from "../../../../memory/validation.js";
 import { extractStylePatterns } from "../../../../messaging/style-analyzer.js";
 import type {
@@ -23,58 +22,59 @@ function upsertMemoryItem(opts: {
 }): void {
   const db = getDb();
   const now = Date.now();
-  const fingerprint = computeMemoryFingerprint(
-    opts.scopeId,
-    opts.kind,
-    opts.subject,
-    opts.statement,
-  );
+  const content = `${opts.subject}\n${opts.statement}`;
 
   const existing = db
     .select()
-    .from(memoryItems)
+    .from(memoryGraphNodes)
     .where(
       and(
-        eq(memoryItems.fingerprint, fingerprint),
-        eq(memoryItems.scopeId, opts.scopeId),
+        eq(memoryGraphNodes.content, content),
+        eq(memoryGraphNodes.scopeId, opts.scopeId),
+        sql`${memoryGraphNodes.fidelity} != 'gone'`,
       ),
     )
     .get();
 
   if (existing) {
-    db.update(memoryItems)
+    db.update(memoryGraphNodes)
       .set({
-        statement: opts.statement,
-        status: "active",
-        importance: clampUnitInterval(
-          Math.max(existing.importance ?? 0, opts.importance),
+        content,
+        fidelity: "vivid",
+        significance: clampUnitInterval(
+          Math.max(existing.significance ?? 0, opts.importance),
         ),
-        lastSeenAt: now,
-        sourceType: existing.sourceType === "tool" ? "tool" : "extraction",
+        lastAccessed: now,
+        sourceType: existing.sourceType === "direct" ? "direct" : "inferred",
       })
-      .where(eq(memoryItems.id, existing.id))
+      .where(eq(memoryGraphNodes.id, existing.id))
       .run();
-    enqueueMemoryJob("embed_item", { itemId: existing.id });
+    enqueueMemoryJob("embed_graph_node", { nodeId: existing.id });
   } else {
     const id = uuid();
-    db.insert(memoryItems)
+    db.insert(memoryGraphNodes)
       .values({
         id,
-        kind: opts.kind,
-        subject: opts.subject,
-        statement: opts.statement,
-        status: "active",
+        content,
+        type: opts.kind,
+        created: now,
+        lastAccessed: now,
+        lastConsolidated: now,
+        emotionalCharge: '{"valence":0,"intensity":0.1,"decayCurve":"linear","decayRate":0.05,"originalIntensity":0.1}',
+        fidelity: "vivid",
         confidence: 0.8,
-        importance: clampUnitInterval(opts.importance),
-        fingerprint,
-        sourceType: "extraction",
+        significance: clampUnitInterval(opts.importance),
+        stability: 14,
+        reinforcementCount: 0,
+        lastReinforced: now,
+        sourceConversations: "[]",
+        sourceType: "inferred",
+        narrativeRole: null,
+        partOfStory: null,
         scopeId: opts.scopeId,
-        firstSeenAt: now,
-        lastSeenAt: now,
-        lastUsedAt: null,
       })
       .run();
-    enqueueMemoryJob("embed_item", { itemId: id });
+    enqueueMemoryJob("embed_graph_node", { nodeId: id });
   }
 }
 

--- a/assistant/src/memory/conversation-starters-cadence.ts
+++ b/assistant/src/memory/conversation-starters-cadence.ts
@@ -24,7 +24,7 @@ export function maybeEnqueueConversationStartersJob(scopeId: string): void {
 
   // Count total active memory items
   const countRow = rawGet<{ c: number }>(
-    `SELECT COUNT(*) AS c FROM memory_items WHERE status = 'active' AND scope_id = ?`,
+    `SELECT COUNT(*) AS c FROM memory_graph_nodes WHERE fidelity != 'gone' AND scope_id = ?`,
     scopeId,
   );
   const totalActive = countRow?.c ?? 0;

--- a/assistant/src/memory/job-handlers/conversation-starters.ts
+++ b/assistant/src/memory/job-handlers/conversation-starters.ts
@@ -5,7 +5,7 @@
  * suggestion chips shown on the empty conversation page.
  */
 
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { loadSkillCatalog } from "../../config/skills.js";
@@ -26,7 +26,7 @@ import { rawAll, rawGet } from "../raw-query.js";
 import {
   conversationStarters,
   memoryCheckpoints,
-  memoryItems,
+  memoryGraphNodes,
 } from "../schema.js";
 
 const log = getLogger("conversation-starters-gen");
@@ -42,26 +42,27 @@ const CK_LAST_GEN_AT = "conversation_starters:last_gen_at";
 // ── Rollup construction ───────────────────────────────────────────
 
 export function buildMemoryRollup(scopeId: string): string {
-  let items: Array<{
-    kind: string;
-    subject: string;
-    statement: string;
-    importance: number | null;
+  let rows: Array<{
+    type: string;
+    content: string;
+    significance: number | null;
   }>;
   try {
     const db = getDb();
-    items = db
+    rows = db
       .select({
-        kind: memoryItems.kind,
-        subject: memoryItems.subject,
-        statement: memoryItems.statement,
-        importance: memoryItems.importance,
+        type: memoryGraphNodes.type,
+        content: memoryGraphNodes.content,
+        significance: memoryGraphNodes.significance,
       })
-      .from(memoryItems)
+      .from(memoryGraphNodes)
       .where(
-        and(eq(memoryItems.status, "active"), eq(memoryItems.scopeId, scopeId))
+        and(
+          sql`${memoryGraphNodes.fidelity} != 'gone'`,
+          eq(memoryGraphNodes.scopeId, scopeId),
+        )
       )
-      .orderBy(desc(memoryItems.importance))
+      .orderBy(desc(memoryGraphNodes.significance))
       .limit(60)
       .all();
   } catch {
@@ -69,16 +70,19 @@ export function buildMemoryRollup(scopeId: string): string {
     return "";
   }
 
-  if (items.length === 0) return "";
+  if (rows.length === 0) return "";
 
   const byKind = new Map<string, string[]>();
-  for (const item of items) {
-    let lines = byKind.get(item.kind);
+  for (const item of rows) {
+    const nl = item.content.indexOf("\n");
+    const subject = nl >= 0 ? item.content.slice(0, nl) : item.content;
+    const statement = nl >= 0 ? item.content.slice(nl + 1) : item.content;
+    let lines = byKind.get(item.type);
     if (!lines) {
       lines = [];
-      byKind.set(item.kind, lines);
+      byKind.set(item.type, lines);
     }
-    lines.push(`- ${item.subject}: ${item.statement}`);
+    lines.push(`- ${subject}: ${statement}`);
   }
 
   let rollup = "";
@@ -101,12 +105,11 @@ function buildNewItemsDiff(scopeId: string): string {
 
   const newItems = rawAll<{
     kind: string;
-    subject: string;
-    statement: string;
+    content: string;
   }>(
-    `SELECT kind, subject, statement FROM memory_items
-     WHERE status = 'active' AND scope_id = ? AND first_seen_at > ?
-     ORDER BY first_seen_at DESC LIMIT 20`,
+    `SELECT type AS kind, content FROM memory_graph_nodes
+     WHERE fidelity != 'gone' AND scope_id = ? AND created > ?
+     ORDER BY created DESC LIMIT 20`,
     scopeId,
     lastGenAt
   );
@@ -115,7 +118,12 @@ function buildNewItemsDiff(scopeId: string): string {
 
   return (
     "## New since last generation\n" +
-    newItems.map((i) => `- (${i.kind}) ${i.subject}: ${i.statement}`).join("\n")
+    newItems.map((i) => {
+      const nl = i.content.indexOf("\n");
+      const subject = nl >= 0 ? i.content.slice(0, nl) : i.content;
+      const statement = nl >= 0 ? i.content.slice(nl + 1) : i.content;
+      return `- (${i.kind}) ${subject}: ${statement}`;
+    }).join("\n")
   );
 }
 
@@ -395,16 +403,19 @@ export async function generateConversationStartersJob(
     ? parseInt(batchCheckpoint.value, 10) + 1
     : 1;
 
-  // Collect the memory kinds that informed this batch
+  // Collect the memory types that informed this batch
   let sourceKinds = "";
   try {
     const kindRows = db
-      .select({ kind: memoryItems.kind })
-      .from(memoryItems)
+      .select({ kind: memoryGraphNodes.type })
+      .from(memoryGraphNodes)
       .where(
-        and(eq(memoryItems.status, "active"), eq(memoryItems.scopeId, scopeId))
+        and(
+          sql`${memoryGraphNodes.fidelity} != 'gone'`,
+          eq(memoryGraphNodes.scopeId, scopeId),
+        )
       )
-      .groupBy(memoryItems.kind)
+      .groupBy(memoryGraphNodes.type)
       .all();
     sourceKinds = kindRows.map((r) => r.kind).join(",");
   } catch {
@@ -435,7 +446,7 @@ export async function generateConversationStartersJob(
 
   // Count active items for checkpoint
   const countRow = rawGet<{ c: number }>(
-    `SELECT COUNT(*) AS c FROM memory_items WHERE status = 'active' AND scope_id = ?`,
+    `SELECT COUNT(*) AS c FROM memory_graph_nodes WHERE fidelity != 'gone' AND scope_id = ?`,
     scopeId
   );
   const totalActive = countRow?.c ?? 0;

--- a/assistant/src/memory/task-memory-cleanup.ts
+++ b/assistant/src/memory/task-memory-cleanup.ts
@@ -24,62 +24,41 @@ export function isConversationFailed(conversationId: string): boolean {
 }
 
 /**
- * Invalidate assistant-extracted memory items sourced *exclusively* from
- * messages in the given conversation. Called when a background task or
- * schedule fails — the assistant's optimistic claims (e.g., "I booked an
- * appointment") are not trustworthy if the task didn't complete.
+ * Invalidate assistant-inferred memory graph nodes sourced *exclusively* from
+ * the given conversation. Called when a background task or schedule fails —
+ * the assistant's optimistic claims are not trustworthy if the task didn't
+ * complete.
  *
- * The failed state is derived from durable storage (task_runs / cron_runs),
- * so any pending or future extraction jobs for this conversation are blocked
- * from creating new assistant-extracted items — even after daemon restarts.
- *
- * Items that also have sources from other conversations are left alone
- * only when those conversations come from non-failed task/schedule runs
- * (or are ordinary user conversations). This prevents cascading failures
- * from mutually protecting each other — if two conversations both source
- * a memory item and both fail, the item is correctly invalidated.
+ * Nodes that also have sources from other non-failed conversations are left
+ * alone (corroboration). Uses the `source_conversations` JSON array to
+ * determine provenance.
  */
 export function invalidateAssistantInferredItemsForConversation(
   conversationId: string,
 ): number {
-  // Cancel pending extraction jobs for this conversation's messages
-  // so the worker never processes them. Jobs already running will be
-  // caught by the isConversationFailed check in the extraction handler.
-  // NOTE: Only extract_items jobs are cancelled here — not embed_item or
-  // other job types. Multi-sourced items may still be valid (corroborated
-  // by other conversations), and their embedding jobs must not be killed.
-  // The broader cancelPendingJobsForConversation is used by the wipe path.
   cancelPendingExtractionJobsForConversation(conversationId);
 
   const affected = rawRun(
-    `UPDATE memory_items
-        SET status = 'invalidated',
-            invalid_at = ?
-      WHERE source_type = 'extraction'
-        AND source_message_role = 'assistant'
-        AND status = 'active'
-        AND id IN (
-          SELECT mis.memory_item_id
-            FROM memory_item_sources mis
-            JOIN messages m ON m.id = mis.message_id
-           WHERE m.conversation_id = ?
+    `UPDATE memory_graph_nodes
+        SET fidelity = 'gone',
+            last_accessed = ?
+      WHERE source_type = 'inferred'
+        AND fidelity != 'gone'
+        AND EXISTS (
+          SELECT 1 FROM json_each(source_conversations) jc
+           WHERE jc.value = ?
         )
         AND NOT EXISTS (
-          SELECT 1
-            FROM memory_item_sources mis2
-            JOIN messages m2 ON m2.id = mis2.message_id
-           WHERE mis2.memory_item_id = memory_items.id
-             AND m2.conversation_id != ?
-             -- Only count as corroboration if the other conversation is NOT
-             -- from a failed task run or failed schedule run.
+          SELECT 1 FROM json_each(source_conversations) jc2
+           WHERE jc2.value != ?
              AND NOT EXISTS (
                SELECT 1 FROM task_runs tr
-                WHERE tr.conversation_id = m2.conversation_id
+                WHERE tr.conversation_id = jc2.value
                   AND tr.status = 'failed'
              )
              AND NOT EXISTS (
                SELECT 1 FROM cron_runs cr
-                WHERE cr.conversation_id = m2.conversation_id
+                WHERE cr.conversation_id = jc2.value
                   AND cr.status = 'error'
              )
         )`,
@@ -91,7 +70,7 @@ export function invalidateAssistantInferredItemsForConversation(
   if (affected > 0) {
     log.info(
       { conversationId, affected },
-      "Invalidated assistant-inferred memory items after task failure",
+      "Invalidated assistant-inferred memory graph nodes after task failure",
     );
   }
 
@@ -103,7 +82,7 @@ export function invalidateAssistantInferredItemsForConversation(
  * Covers every job type: `extract_items`, `embed_attachment` (keyed by messageId),
  * `embed_segment` (keyed by segmentId via memory_segments),
  * `build_conversation_summary` (keyed by conversationId),
- * and `embed_item` (keyed by itemId sourced from the conversation's messages).
+ * and `embed_graph_node` (keyed by nodeId sourced from the conversation).
  */
 export function cancelPendingJobsForConversation(
   conversationId: string,
@@ -155,18 +134,17 @@ export function cancelPendingJobsForConversation(
     conversationId,
   );
 
-  // Jobs keyed by itemId: embed_item (items sourced from this conversation)
+  // Jobs keyed by nodeId: embed_graph_node (nodes sourced from this conversation)
   total += rawRun(
     `UPDATE memory_jobs
         SET status = 'failed',
             last_error = ?,
             updated_at = ?
       WHERE status IN ('pending', 'running')
-        AND json_extract(payload, '$.itemId') IN (
-          SELECT mis.memory_item_id
-            FROM memory_item_sources mis
-            JOIN messages m ON m.id = mis.message_id
-           WHERE m.conversation_id = ?
+        AND json_extract(payload, '$.nodeId') IN (
+          SELECT mgn.id
+            FROM memory_graph_nodes mgn, json_each(mgn.source_conversations) jc
+           WHERE jc.value = ?
         )`,
     reason,
     now,
@@ -186,8 +164,8 @@ export function cancelPendingJobsForConversation(
 /**
  * Cancel only pending/running `extract_items` jobs for messages in the
  * given conversation. Used by the task-failure path where we want to
- * stop new extractions but must NOT cancel `embed_item` jobs — those
- * items may be multi-sourced and still valid.
+ * stop new extractions but must NOT cancel `embed_graph_node` jobs —
+ * those nodes may be multi-sourced and still valid.
  */
 function cancelPendingExtractionJobsForConversation(
   conversationId: string,

--- a/assistant/src/runtime/routes/brain-graph-routes.ts
+++ b/assistant/src/runtime/routes/brain-graph-routes.ts
@@ -2,7 +2,7 @@
  * Route handlers for the brain graph visualization endpoint.
  *
  * Queries the memory database to return a knowledge graph shaped for brain-lobe
- * visualization, with memory items mapped to brain regions based on their kind.
+ * visualization, with memory items mapped to brain regions based on their type.
  */
 
 import { readFileSync } from "node:fs";
@@ -12,7 +12,7 @@ import { count } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb } from "../../memory/db.js";
-import { memoryItems } from "../../memory/schema.js";
+import { memoryGraphNodes } from "../../memory/schema.js";
 import { resolveBundledDir } from "../../util/bundled-asset.js";
 import type { RouteDefinition } from "../http-router.js";
 
@@ -41,11 +41,11 @@ function handleGetBrainGraph(): Response {
 
     const kindCountRows = db
       .select({
-        kind: memoryItems.kind,
+        kind: memoryGraphNodes.type,
         count: count(),
       })
-      .from(memoryItems)
-      .groupBy(memoryItems.kind)
+      .from(memoryGraphNodes)
+      .groupBy(memoryGraphNodes.type)
       .all();
 
     const memorySummary = kindCountRows.map((row) => ({
@@ -86,9 +86,6 @@ export function handleServeBrainGraphUI(bearerToken?: string): Response {
     );
     let html = readFileSync(join(brainGraphDir, "brain-graph.html"), "utf-8");
     if (bearerToken) {
-      // Inject token as a meta tag for client-side fetch authentication.
-      // HTML-escape the token value to guard against injection if the token
-      // comes from an environment variable with special characters.
       const escapedToken = bearerToken
         .replace(/&/g, "&amp;")
         .replace(/"/g, "&quot;")
@@ -99,8 +96,6 @@ export function handleServeBrainGraphUI(bearerToken?: string): Response {
         `  <meta name="api-token" content="${escapedToken}">\n</head>`,
       );
     }
-    // CSP permits the CDN sources required by D3.js and Three.js.
-    // 'unsafe-eval' is needed by Three.js's shader compilation path.
     const csp = [
       "default-src 'self'",
       "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://d3js.org",

--- a/assistant/src/runtime/routes/conversation-starter-routes.ts
+++ b/assistant/src/runtime/routes/conversation-starter-routes.ts
@@ -161,9 +161,9 @@ function handleListConversationStarters(url: URL): Response {
     });
   }
 
-  // No starters — check whether we have memory items to generate from.
+  // No starters — check whether we have memory graph nodes to generate from.
   const memoryCount = rawGet<{ c: number }>(
-    `SELECT COUNT(*) AS c FROM memory_items WHERE status = 'active' AND scope_id = ?`,
+    `SELECT COUNT(*) AS c FROM memory_graph_nodes WHERE fidelity != 'gone' AND scope_id = ?`,
     scopeId,
   );
 

--- a/assistant/src/runtime/routes/debug-routes.ts
+++ b/assistant/src/runtime/routes/debug-routes.ts
@@ -32,7 +32,7 @@ function getDatabaseSizeBytes(): number | null {
 function getMemoryItemCount(): number {
   try {
     const rows = rawAll<{ c: number }>(
-      "SELECT COUNT(*) AS c FROM memory_items",
+      "SELECT COUNT(*) AS c FROM memory_graph_nodes",
     );
     return rows[0]?.c ?? 0;
   } catch {

--- a/assistant/src/runtime/routes/global-search-routes.ts
+++ b/assistant/src/runtime/routes/global-search-routes.ts
@@ -100,34 +100,36 @@ function searchMemoryItems(query: string, limit: number): GlobalSearchMemory[] {
 
   interface MemoryRow {
     id: string;
-    kind: string;
-    statement: string;
-    subject: string;
+    type: string;
+    content: string;
     confidence: number;
-    last_seen_at: number;
+    last_accessed: number;
   }
 
-  // Search on both statement and subject for broader recall
   const rows = rawAll<MemoryRow>(
-    `SELECT id, kind, statement, subject, confidence, last_seen_at
-     FROM memory_items
-     WHERE (statement LIKE ? OR subject LIKE ?) AND status = 'active'
-     ORDER BY last_seen_at DESC
+    `SELECT id, type, content, confidence, last_accessed
+     FROM memory_graph_nodes
+     WHERE content LIKE ? AND fidelity != 'gone'
+     ORDER BY last_accessed DESC
      LIMIT ?`,
-    likePattern,
     likePattern,
     limit,
   );
 
-  return rows.map((r) => ({
-    id: r.id,
-    kind: r.kind,
-    text: r.statement,
-    subject: r.subject || null,
-    confidence: r.confidence,
-    updatedAt: r.last_seen_at,
-    source: "lexical" as const,
-  }));
+  return rows.map((r) => {
+    const nl = r.content.indexOf("\n");
+    const subject = nl >= 0 ? r.content.slice(0, nl) : r.content;
+    const statement = nl >= 0 ? r.content.slice(nl + 1) : r.content;
+    return {
+      id: r.id,
+      kind: r.type,
+      text: statement,
+      subject: subject || null,
+      confidence: r.confidence,
+      updatedAt: r.last_accessed,
+      source: "lexical" as const,
+    };
+  });
 }
 
 async function searchMemoriesSemantic(

--- a/assistant/src/skills/skill-memory.ts
+++ b/assistant/src/skills/skill-memory.ts
@@ -1,13 +1,12 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, like, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getConfig } from "../config/loader.js";
 import { resolveSkillStates } from "../config/skill-state.js";
 import { loadSkillCatalog, type SkillSummary } from "../config/skills.js";
 import { getDb } from "../memory/db.js";
-import { computeMemoryFingerprint } from "../memory/fingerprint.js";
 import { enqueueMemoryJob } from "../memory/jobs-store.js";
-import { memoryItems } from "../memory/schema.js";
+import { memoryGraphNodes } from "../memory/schema.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("skill-memory");
@@ -62,8 +61,17 @@ export function buildCapabilityStatement(input: SkillCapabilityInput): string {
   return statement;
 }
 
+/** Default emotional charge for capability graph nodes. */
+const DEFAULT_EMOTIONAL_CHARGE = JSON.stringify({
+  valence: 0,
+  intensity: 0.1,
+  decayCurve: "linear",
+  decayRate: 0.05,
+  originalIntensity: 0.1,
+});
+
 /**
- * Upsert a capability memory item for a skill.
+ * Upsert a capability memory graph node for a skill.
  * Best-effort: errors are logged but never thrown.
  */
 export function upsertSkillCapabilityMemory(
@@ -72,124 +80,119 @@ export function upsertSkillCapabilityMemory(
 ): void {
   try {
     const db = getDb();
-    const subject = `skill:${skillId}`;
     const statement = buildCapabilityStatement(input);
-    const kind = "capability";
+    const content = `skill:${skillId}\n${statement}`;
     const scopeId = "default";
-    const confidence = 1.0;
-    const importance = 0.7;
-    const fingerprint = computeMemoryFingerprint(
-      scopeId,
-      kind,
-      subject,
-      statement,
-    );
     const now = Date.now();
 
     const existing = db
       .select()
-      .from(memoryItems)
+      .from(memoryGraphNodes)
       .where(
         and(
-          eq(memoryItems.kind, kind),
-          eq(memoryItems.subject, subject),
-          eq(memoryItems.scopeId, scopeId),
+          eq(memoryGraphNodes.type, "procedural"),
+          like(memoryGraphNodes.content, `skill:${skillId}\n%`),
+          eq(memoryGraphNodes.scopeId, scopeId),
         ),
       )
       .get();
 
     if (existing) {
       if (
-        existing.status === "active" &&
-        existing.fingerprint === fingerprint
+        existing.content === content &&
+        existing.fidelity !== "gone"
       ) {
-        // Same content — just touch lastSeenAt
-        db.update(memoryItems)
-          .set({ lastSeenAt: now })
-          .where(eq(memoryItems.id, existing.id))
+        // Same content — just touch lastAccessed
+        db.update(memoryGraphNodes)
+          .set({ lastAccessed: now })
+          .where(eq(memoryGraphNodes.id, existing.id))
           .run();
         return;
       }
 
-      if (existing.status === "active") {
-        // Content changed — update statement and fingerprint
-        db.update(memoryItems)
+      if (existing.fidelity !== "gone") {
+        // Content changed — update content
+        db.update(memoryGraphNodes)
           .set({
-            statement,
-            fingerprint,
-            lastSeenAt: now,
+            content,
+            lastAccessed: now,
           })
-          .where(eq(memoryItems.id, existing.id))
+          .where(eq(memoryGraphNodes.id, existing.id))
           .run();
-        enqueueMemoryJob("embed_item", { itemId: existing.id });
+        enqueueMemoryJob("embed_graph_node", { nodeId: existing.id });
         return;
       }
 
-      // status === "deleted" or other — reactivate
-      db.update(memoryItems)
+      // fidelity === "gone" — reactivate
+      db.update(memoryGraphNodes)
         .set({
-          status: "active",
-          statement,
-          fingerprint,
-          lastSeenAt: now,
-          firstSeenAt: now,
+          fidelity: "vivid",
+          content,
+          created: now,
+          lastAccessed: now,
         })
-        .where(eq(memoryItems.id, existing.id))
+        .where(eq(memoryGraphNodes.id, existing.id))
         .run();
-      enqueueMemoryJob("embed_item", { itemId: existing.id });
+      enqueueMemoryJob("embed_graph_node", { nodeId: existing.id });
       return;
     }
 
-    // No existing — insert new row
+    // No existing — insert new graph node
     const id = uuid();
-    db.insert(memoryItems)
+    db.insert(memoryGraphNodes)
       .values({
         id,
-        kind,
-        subject,
-        statement,
-        status: "active",
-        confidence,
-        importance,
-        fingerprint,
-        sourceType: "extraction",
+        content,
+        type: "procedural",
+        created: now,
+        lastAccessed: now,
+        lastConsolidated: now,
+        emotionalCharge: DEFAULT_EMOTIONAL_CHARGE,
+        fidelity: "vivid",
+        confidence: 1.0,
+        significance: 0.7,
+        stability: 14,
+        reinforcementCount: 0,
+        lastReinforced: now,
+        sourceConversations: JSON.stringify([]),
+        sourceType: "inferred",
+        narrativeRole: null,
+        partOfStory: null,
         scopeId,
-        firstSeenAt: now,
-        lastSeenAt: now,
       })
       .run();
-    enqueueMemoryJob("embed_item", { itemId: id });
+    enqueueMemoryJob("embed_graph_node", { nodeId: id });
   } catch (err) {
     log.warn({ err, skillId }, "Failed to upsert skill capability memory");
   }
 }
 
 /**
- * Soft-delete the capability memory item for a skill.
+ * Soft-delete the capability memory graph node for a skill.
  * Best-effort: errors are logged but never thrown.
  */
 export function deleteSkillCapabilityMemory(skillId: string): void {
   try {
     const db = getDb();
-    const subject = `skill:${skillId}`;
     const now = Date.now();
 
     const existing = db
       .select()
-      .from(memoryItems)
+      .from(memoryGraphNodes)
       .where(
         and(
-          eq(memoryItems.kind, "capability"),
-          eq(memoryItems.subject, subject),
-          eq(memoryItems.scopeId, "default"),
+          eq(memoryGraphNodes.type, "procedural"),
+          like(memoryGraphNodes.content, `skill:${skillId}\n%`),
+          eq(memoryGraphNodes.scopeId, "default"),
+          sql`${memoryGraphNodes.fidelity} != 'gone'`,
         ),
       )
       .get();
 
-    if (existing && existing.status !== "deleted") {
-      db.update(memoryItems)
-        .set({ status: "deleted", lastSeenAt: now })
-        .where(eq(memoryItems.id, existing.id))
+    if (existing) {
+      db.update(memoryGraphNodes)
+        .set({ fidelity: "gone", lastAccessed: now })
+        .where(eq(memoryGraphNodes.id, existing.id))
         .run();
     }
   } catch (err) {
@@ -198,7 +201,7 @@ export function deleteSkillCapabilityMemory(skillId: string): void {
 }
 
 /**
- * Seed capability memory items for all enabled skills (bundled, managed, workspace, extra).
+ * Seed capability memory graph nodes for all enabled skills (bundled, managed, workspace, extra).
  * Prunes stale entries whose skills are no longer in the enabled set.
  * Best-effort: errors are logged but never thrown.
  */
@@ -234,24 +237,24 @@ export function seedCatalogSkillMemories(): void {
     const db = getDb();
     const allCapabilities = db
       .select()
-      .from(memoryItems)
+      .from(memoryGraphNodes)
       .where(
         and(
-          eq(memoryItems.kind, "capability"),
-          eq(memoryItems.scopeId, "default"),
-          eq(memoryItems.status, "active"),
+          eq(memoryGraphNodes.type, "procedural"),
+          eq(memoryGraphNodes.scopeId, "default"),
+          sql`${memoryGraphNodes.fidelity} != 'gone'`,
         ),
       )
       .all();
 
     const now = Date.now();
     for (const item of allCapabilities) {
-      if (!item.subject.startsWith("skill:")) continue;
-      const itemSkillId = item.subject.replace("skill:", "");
+      if (!item.content.startsWith("skill:")) continue;
+      const itemSkillId = item.content.split("\n")[0].replace("skill:", "");
       if (!catalogIds.has(itemSkillId)) {
-        db.update(memoryItems)
-          .set({ status: "deleted", lastSeenAt: now })
-          .where(eq(memoryItems.id, item.id))
+        db.update(memoryGraphNodes)
+          .set({ fidelity: "gone", lastAccessed: now })
+          .where(eq(memoryGraphNodes.id, item.id))
           .run();
       }
     }


### PR DESCRIPTION
## Summary
- Migrate all remaining production code from the dropped `memory_items`/`memory_item_sources` tables to `memory_graph_nodes` (11 production files)
- Update all 8 CI-failing test files to use the new schema
- Remove tests for supersession/orphan behaviors that were removed when `conversation-crud.ts` was migrated
- Net reduction of ~526 lines (dead code + removed stale tests)

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23827267659/job/69452981818

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22723" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
