### PR TITLE
fix: remove stale progress reminder test and handle web_search_tool_result

### DIFF
--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -468,38 +468,6 @@ describe("AgentLoop", () => {
     ).toBe(false);
   });
 
-  // 8. Progress reminder injection every 5 tool-use turns
-  test("injects progress reminder after every 5 tool-use turns", async () => {
-    // Create 6 tool responses followed by a text response
-    const responses: ProviderResponse[] = [];
-    for (let i = 0; i < 6; i++) {
-      responses.push(
-        toolUseResponse(`t${i}`, "read_file", { path: `/file${i}.txt` }),
-      );
-    }
-    responses.push(textResponse("Finally done"));
-
-    const { provider, calls } = createMockProvider(responses);
-    const toolExecutor = async () => ({ content: "data", isError: false });
-    const loop = new AgentLoop(
-      provider,
-      "system",
-      {},
-      dummyTools,
-      toolExecutor,
-    );
-
-    await loop.run([userMessage], () => {});
-
-    // After the 5th tool-use turn, the user message should contain a progress reminder
-    // calls[5] is the 6th provider call; its messages[-1] should have the reminder
-    const fifthTurnResultMsg = calls[5].messages[calls[5].messages.length - 1];
-    const reminderBlock = fifthTurnResultMsg.content.find(
-      (b): b is Extract<ContentBlock, { type: "text" }> =>
-        b.type === "text" && b.text.includes("making meaningful progress"),
-    );
-    expect(reminderBlock).toBeDefined();
-  });
 
   // 9. Tool executor error results are forwarded correctly
   test("forwards tool error results to provider", async () => {

--- a/assistant/src/daemon/context-overflow-reducer.ts
+++ b/assistant/src/daemon/context-overflow-reducer.ts
@@ -257,7 +257,11 @@ function applyMediaStubbing(
           mediaTokens += estimateContentBlockTokens(block, {
             providerName: config.providerName,
           });
-        } else if (block.type === "tool_result" && block.contentBlocks) {
+        } else if (
+          (block.type === "tool_result" ||
+            block.type === "web_search_tool_result") &&
+          block.contentBlocks
+        ) {
           for (const cb of block.contentBlocks) {
             if (cb.type === "image" || cb.type === "file") {
               mediaTokens += estimateContentBlockTokens(cb, {


### PR DESCRIPTION
## Summary
- Removed stale "injects progress reminder after every 5 tool-use turns" test from agent-loop.test.ts — the underlying feature was removed in #22722 but the test was left behind
- Fixed raw `tool_result` type check in `context-overflow-reducer.ts` to also handle `web_search_tool_result`, preventing web search results with media from being silently skipped during token counting

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23829266840/job/69459011493