### PR TITLE
fix: display all images from multi-image tool results

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -427,9 +427,12 @@ export function handleToolResult(
   deps: EventHandlerDeps,
   event: Extract<AgentEvent, { type: "tool_result" }>,
 ): void {
-  const imageBlock = event.contentBlocks?.find(
+  const imageBlocks = event.contentBlocks?.filter(
     (b): b is ImageContent => b.type === "image",
   );
+  const imageDataList = imageBlocks?.length
+    ? imageBlocks.map((b) => b.source.data)
+    : undefined;
   deps.onEvent({
     type: "tool_result",
     toolName: "",
@@ -438,7 +441,7 @@ export function handleToolResult(
     diff: event.diff,
     status: event.status,
     conversationId: deps.ctx.conversationId,
-    imageData: imageBlock?.source.data,
+    imageDataList,
     toolUseId: event.toolUseId,
   });
   state.pendingToolResults.set(event.toolUseId, {

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -60,8 +60,8 @@ export interface HistoryToolCall {
   input: Record<string, unknown>;
   result?: string;
   isError?: boolean;
-  /** Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot). */
-  imageData?: string;
+  /** Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot, image generation). */
+  imageDataList?: string[];
   /** Unix ms when the tool started executing. */
   startedAt?: number;
   /** Unix ms when the tool completed. */
@@ -341,16 +341,19 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
       const resultContent =
         typeof block.content === "string" ? block.content : "";
       const isError = block.is_error === true;
-      // Extract base64 image data from persisted contentBlocks (e.g. browser_screenshot)
-      let imageData: string | undefined;
+      // Extract base64 image data from persisted contentBlocks (e.g. browser_screenshot, image generation)
+      const imageDataList: string[] = [];
       if (Array.isArray(block.contentBlocks)) {
-        const imgBlock = block.contentBlocks.find(
-          (b: Record<string, unknown>) => isRecord(b) && b.type === "image",
-        );
-        if (imgBlock && isRecord(imgBlock) && isRecord(imgBlock.source)) {
-          const src = imgBlock.source as Record<string, unknown>;
-          if (typeof src.data === "string") {
-            imageData = src.data;
+        for (const cb of block.contentBlocks) {
+          if (
+            isRecord(cb) &&
+            cb.type === "image" &&
+            isRecord(cb.source) &&
+            typeof (cb.source as Record<string, unknown>).data === "string"
+          ) {
+            imageDataList.push(
+              (cb.source as Record<string, unknown>).data as string,
+            );
           }
         }
       }
@@ -358,14 +361,14 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
       if (matched) {
         matched.result = resultContent;
         matched.isError = isError;
-        if (imageData) matched.imageData = imageData;
+        if (imageDataList.length > 0) matched.imageDataList = imageDataList;
       } else {
         toolCalls.push({
           name: "unknown",
           input: {},
           result: resultContent,
           isError,
-          ...(imageData ? { imageData } : {}),
+          ...(imageDataList.length > 0 ? { imageDataList } : {}),
         });
       }
       continue;

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -264,8 +264,8 @@ export interface HistoryResponseToolCall {
   input: Record<string, unknown>;
   result?: string;
   isError?: boolean;
-  /** Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot). */
-  imageData?: string;
+  /** Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot, image generation). */
+  imageDataList?: string[];
   /** Unix ms when the tool started executing. */
   startedAt?: number;
   /** Unix ms when the tool completed. */

--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -124,8 +124,8 @@ export interface ToolResult {
   };
   status?: string;
   conversationId?: string;
-  /** Base64-encoded image data extracted from contentBlocks (e.g. browser_screenshot). */
-  imageData?: string;
+  /** Base64-encoded image data extracted from contentBlocks (e.g. browser_screenshot, image generation). */
+  imageDataList?: string[];
   /** The tool_use block ID for client-side correlation. */
   toolUseId?: string;
 }

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -480,7 +480,7 @@ struct AssistantProgressView: View {
                 && tc.inputFull.isEmpty
                 && tc.result == nil
                 && tc.inputRawDict == nil
-                && tc.cachedImage == nil
+                && tc.cachedImages.isEmpty
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleAttachmentContent.swift
@@ -429,7 +429,7 @@ extension ChatBubble {
     /// Used to suppress the corresponding tool-block image attachments from the
     /// attachment grid only when inline tool previews are actually rendered.
     var inlineToolCallImageCount: Int {
-        message.toolCalls.filter { $0.cachedImage != nil }.count
+        message.toolCalls.reduce(0) { $0 + $1.cachedImages.count }
     }
 
     /// Returns the image attachments that should still render in the attachment grid.
@@ -478,9 +478,10 @@ extension ChatBubble {
     /// at full width in the message flow instead of as tiny attachment thumbnails.
     @ViewBuilder
     func inlineToolCallImages(from toolCalls: [ToolCallData]) -> some View {
-        let imagesWithIds: [(id: UUID, image: NSImage)] = toolCalls.compactMap { tc in
-            guard let img = tc.cachedImage else { return nil }
-            return (tc.id, img)
+        let imagesWithIds: [(id: String, image: NSImage)] = toolCalls.flatMap { tc in
+            tc.cachedImages.enumerated().map { (idx, img) in
+                ("\(tc.id.uuidString)-\(idx)", img)
+            }
         }
         if !imagesWithIds.isEmpty {
             ForEach(imagesWithIds, id: \.id) { item in

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -751,8 +751,8 @@ public struct ToolCallData: Identifiable, Equatable {
     public var confirmationDecision: ToolConfirmationState?
     /// Friendly label for the confirmation (e.g. "Edit File", "Run Command").
     public var confirmationLabel: String?
-    /// Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot).
-    public var imageData: String?
+    /// Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot, image generation).
+    public var imageDataList: [String]?
     /// Human-readable building status from app tool input (e.g. "Adding dark mode styles").
     public var buildingStatus: String?
     /// Non-technical reason for the tool call, extracted from the `reason` field of tool input.
@@ -767,11 +767,11 @@ public struct ToolCallData: Identifiable, Equatable {
     /// Live pending confirmation attached to this tool call for inline rendering.
     /// Set when a `confirmation_request` arrives, cleared when approved/denied.
     public var pendingConfirmation: ToolConfirmationData?
-    /// Pre-decoded NSImage cached to avoid repeated base64 decoding in SwiftUI body.
+    /// Pre-decoded images cached to avoid repeated base64 decoding in SwiftUI body.
     #if os(macOS)
-    public var cachedImage: NSImage?
+    public var cachedImages: [NSImage] = []
     #elseif os(iOS)
-    public var cachedImage: UIImage?
+    public var cachedImages: [UIImage] = []
     #else
     #error("Unsupported platform")
     #endif
@@ -784,7 +784,7 @@ public struct ToolCallData: Identifiable, Equatable {
             && lhs.isError == rhs.isError
             && lhs.isComplete == rhs.isComplete
             && lhs.arrivedBeforeText == rhs.arrivedBeforeText
-            // inputFull, inputRawValue, and imageData are intentionally excluded
+            // inputFull, inputRawValue, and imageDataList are intentionally excluded
             // from direct comparison — they can be multi-MB / 10k+ chars.
             // Instead, lightweight length sentinels detect rehydration changes
             // (empty -> populated) without expensive full-string comparison.
@@ -800,7 +800,7 @@ public struct ToolCallData: Identifiable, Equatable {
             && lhs.pendingConfirmation == rhs.pendingConfirmation
     }
 
-    public init(id: UUID = UUID(), toolName: String, inputSummary: String, inputFull: String? = nil, inputRawValue: String? = nil, result: String? = nil, isError: Bool = false, isComplete: Bool = false, arrivedBeforeText: Bool = true, imageData: String? = nil, startedAt: Date? = nil, completedAt: Date? = nil) {
+    public init(id: UUID = UUID(), toolName: String, inputSummary: String, inputFull: String? = nil, inputRawValue: String? = nil, result: String? = nil, isError: Bool = false, isComplete: Bool = false, arrivedBeforeText: Bool = true, imageDataList: [String]? = nil, startedAt: Date? = nil, completedAt: Date? = nil) {
         self.id = id
         self.toolName = toolName
         self.inputSummary = inputSummary
@@ -815,10 +815,10 @@ public struct ToolCallData: Identifiable, Equatable {
         self.isError = isError
         self.isComplete = isComplete
         self.arrivedBeforeText = arrivedBeforeText
-        let decoded = Self.decodeImage(from: imageData)
-        // Keep cachedImage for display, nil out raw base64 to save ~2.7MB per screenshot
-        self.cachedImage = decoded
-        self.imageData = decoded == nil ? imageData : nil
+        let decoded = (imageDataList ?? []).compactMap { Self.decodeImage(from: $0) }
+        // Keep cachedImages for display, nil out raw base64 to save memory
+        self.cachedImages = decoded
+        self.imageDataList = decoded.isEmpty ? imageDataList : nil
         self.startedAt = startedAt
         self.completedAt = completedAt
     }
@@ -1712,8 +1712,8 @@ public struct ChatMessage: Identifiable, Equatable {
         // Tool calls: clear images, results, full input, and raw dict.
         // Keep toolName, inputSummary, and inputRawValue (short one-liner) intact for display.
         for i in toolCalls.indices {
-            toolCalls[i].cachedImage = nil
-            toolCalls[i].imageData = nil
+            toolCalls[i].cachedImages = []
+            toolCalls[i].imageDataList = nil
             toolCalls[i].result = nil
             toolCalls[i].resultLength = 0
             toolCalls[i].inputFull = ""

--- a/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
@@ -434,10 +434,10 @@ extension ChatViewModel {
             messages[msgIndex].toolCalls[tcIndex].isError = msg.isError ?? false
             messages[msgIndex].toolCalls[tcIndex].isComplete = true
             messages[msgIndex].toolCalls[tcIndex].completedAt = Date()
-            let decoded = ToolCallData.decodeImage(from: msg.imageData)
-            // Keep cachedImage for display, nil out raw base64 to save ~2.7MB per screenshot
-            messages[msgIndex].toolCalls[tcIndex].cachedImage = decoded
-            messages[msgIndex].toolCalls[tcIndex].imageData = decoded == nil ? msg.imageData : nil
+            let decoded = (msg.imageDataList ?? []).compactMap { ToolCallData.decodeImage(from: $0) }
+            // Keep cachedImages for display, nil out raw base64 to save memory
+            messages[msgIndex].toolCalls[tcIndex].cachedImages = decoded
+            messages[msgIndex].toolCalls[tcIndex].imageDataList = decoded.isEmpty ? msg.imageDataList : nil
             if let status = msg.status, !status.isEmpty {
                 messages[msgIndex].toolCalls[tcIndex].buildingStatus = status
             }

--- a/clients/shared/Features/Chat/HistoryReconstructionService.swift
+++ b/clients/shared/Features/Chat/HistoryReconstructionService.swift
@@ -41,8 +41,8 @@ enum HistoryReconstructionService {
             let toolsBeforeText = item.toolCallsBeforeText ?? true
             if let historyToolCalls = item.toolCalls {
                 toolCalls = historyToolCalls.map { tc in
-                    // Decode image eagerly — pass imageData:nil to init to skip
-                    // its internal decode, then set cachedImage directly below.
+                    // Decode images eagerly — pass imageDataList:nil to init to skip
+                    // its internal decode, then set cachedImages directly below.
                     var toolCall = ToolCallData(
                         toolName: tc.name,
                         inputSummary: summarizeToolInputStatic(tc.input),
@@ -52,11 +52,11 @@ enum HistoryReconstructionService {
                         isError: tc.isError ?? false,
                         isComplete: true,
                         arrivedBeforeText: toolsBeforeText,
-                        imageData: nil
+                        imageDataList: nil
                     )
-                    // Decode image eagerly — NSImage/UIImage init from Data is
-                    // thread-safe and the views expect cachedImage to be populated.
-                    toolCall.cachedImage = ToolCallData.decodeImage(from: tc.imageData)
+                    // Decode images eagerly — NSImage/UIImage init from Data is
+                    // thread-safe and the views expect cachedImages to be populated.
+                    toolCall.cachedImages = (tc.imageDataList ?? []).compactMap { ToolCallData.decodeImage(from: $0) }
                     toolCall.reasonDescription = (tc.input["activity"]?.value as? String)
                         ?? (tc.input["reason"]?.value as? String)
                         ?? (tc.input["reasoning"]?.value as? String)

--- a/clients/shared/Features/Chat/SubagentDetailStore.swift
+++ b/clients/shared/Features/Chat/SubagentDetailStore.swift
@@ -355,7 +355,7 @@ public final class SubagentDetailStore {
             case "tool_result":
                 handleEvent(
                     subagentId: subagentId,
-                    event: .toolResult(ToolResult(type: "tool_result", toolName: event.toolName ?? "unknown", result: event.content, isError: event.isError, diff: nil, status: nil, conversationId: nil, imageData: nil))
+                    event: .toolResult(ToolResult(type: "tool_result", toolName: event.toolName ?? "unknown", result: event.content, isError: event.isError, diff: nil, status: nil, conversationId: nil, imageDataList: nil))
                 )
             default:
                 break

--- a/clients/shared/Features/Chat/ToolCallChip.swift
+++ b/clients/shared/Features/Chat/ToolCallChip.swift
@@ -72,7 +72,7 @@ public struct ToolCallChip: View {
     }
 
     private var hasExpandableContent: Bool {
-        toolCall.result != nil || toolCall.cachedImage != nil
+        toolCall.result != nil || !toolCall.cachedImages.isEmpty
     }
 
     /// Lazily resolved full input text, using the cached value when available.
@@ -150,8 +150,8 @@ public struct ToolCallChip: View {
                     }
                     .padding(.horizontal, VSpacing.sm)
 
-                    // Image preview (for browser_screenshot etc.)
-                    if let cachedImage = toolCall.cachedImage {
+                    // Image preview (for browser_screenshot, image generation etc.)
+                    ForEach(Array(toolCall.cachedImages.enumerated()), id: \.offset) { _, cachedImage in
                         #if os(macOS)
                         let canOpenImage = !toolCall.inputRawValue.isEmpty
                             && FileManager.default.fileExists(atPath: toolCall.inputRawValue)

--- a/clients/shared/Features/Chat/ToolCallProgressBar.swift
+++ b/clients/shared/Features/Chat/ToolCallProgressBar.swift
@@ -180,8 +180,8 @@ public struct ToolCallProgressBar: View {
                 }
             }
 
-            // Screenshot
-            if let cachedImage = toolCall.cachedImage {
+            // Screenshots / generated images
+            ForEach(Array(toolCall.cachedImages.enumerated()), id: \.offset) { _, cachedImage in
                 VStack(alignment: .leading, spacing: VSpacing.xxs) {
                     Text("Screenshot")
                         .font(VFont.labelDefault)

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -2100,8 +2100,8 @@ public struct HistoryResponseToolCall: Codable, Sendable {
     public let input: [String: AnyCodable]
     public let result: String?
     public let isError: Bool?
-    /// Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot).
-    public let imageData: String?
+    /// Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot, image generation).
+    public let imageDataList: [String]?
     /// Unix ms when the tool started executing.
     public let startedAt: Int?
     /// Unix ms when the tool completed.
@@ -2111,12 +2111,12 @@ public struct HistoryResponseToolCall: Codable, Sendable {
     /// Friendly label for the confirmation (e.g. "Edit File", "Run Command").
     public let confirmationLabel: String?
 
-    public init(name: String, input: [String: AnyCodable], result: String? = nil, isError: Bool? = nil, imageData: String? = nil, startedAt: Int? = nil, completedAt: Int? = nil, confirmationDecision: String? = nil, confirmationLabel: String? = nil) {
+    public init(name: String, input: [String: AnyCodable], result: String? = nil, isError: Bool? = nil, imageDataList: [String]? = nil, startedAt: Int? = nil, completedAt: Int? = nil, confirmationDecision: String? = nil, confirmationLabel: String? = nil) {
         self.name = name
         self.input = input
         self.result = result
         self.isError = isError
-        self.imageData = imageData
+        self.imageDataList = imageDataList
         self.startedAt = startedAt
         self.completedAt = completedAt
         self.confirmationDecision = confirmationDecision
@@ -4589,12 +4589,12 @@ public struct ToolResult: Codable, Sendable {
     public let diff: ToolResultDiff?
     public let status: String?
     public let conversationId: String?
-    /// Base64-encoded image data extracted from contentBlocks (e.g. browser_screenshot).
-    public let imageData: String?
+    /// Base64-encoded image data extracted from contentBlocks (e.g. browser_screenshot, image generation).
+    public let imageDataList: [String]?
     /// The tool_use block ID for client-side correlation.
     public let toolUseId: String?
 
-    public init(type: String, toolName: String, result: String, isError: Bool? = nil, diff: ToolResultDiff? = nil, status: String? = nil, conversationId: String? = nil, imageData: String? = nil, toolUseId: String? = nil) {
+    public init(type: String, toolName: String, result: String, isError: Bool? = nil, diff: ToolResultDiff? = nil, status: String? = nil, conversationId: String? = nil, imageDataList: [String]? = nil, toolUseId: String? = nil) {
         self.type = type
         self.toolName = toolName
         self.result = result
@@ -4602,7 +4602,7 @@ public struct ToolResult: Codable, Sendable {
         self.diff = diff
         self.status = status
         self.conversationId = conversationId
-        self.imageData = imageData
+        self.imageDataList = imageDataList
         self.toolUseId = toolUseId
     }
 }

--- a/clients/shared/Tests/RenderChurnTests.swift
+++ b/clients/shared/Tests/RenderChurnTests.swift
@@ -169,11 +169,11 @@ final class RenderChurnTests: XCTestCase {
                        "Local attachment with data should report isLazyLoad = false")
     }
 
-    // MARK: - ToolCallData Equatable (imageData excluded)
+    // MARK: - ToolCallData Equatable (imageDataList excluded)
 
-    /// Two ToolCallData instances that differ only in imageData should be equal
-    /// because imageData is intentionally excluded from the == implementation.
-    func testToolCallDataEqualityExcludesImageData() {
+    /// Two ToolCallData instances that differ only in imageDataList should be equal
+    /// because imageDataList is intentionally excluded from the == implementation.
+    func testToolCallDataEqualityExcludesImageDataList() {
         let id = UUID()
         let a = ToolCallData(
             id: id,
@@ -183,7 +183,7 @@ final class RenderChurnTests: XCTestCase {
             isError: false,
             isComplete: true,
             arrivedBeforeText: true,
-            imageData: "AAAA"
+            imageDataList: ["AAAA"]
         )
         let b = ToolCallData(
             id: id,
@@ -193,11 +193,11 @@ final class RenderChurnTests: XCTestCase {
             isError: false,
             isComplete: true,
             arrivedBeforeText: true,
-            imageData: "BBBB"
+            imageDataList: ["BBBB"]
         )
 
         XCTAssertEqual(a, b,
-                       "ToolCallData instances differing only in imageData should be equal")
+                       "ToolCallData instances differing only in imageDataList should be equal")
     }
 
     /// Two ToolCallData instances that differ in toolName should NOT be equal.


### PR DESCRIPTION
## Summary
- Changed `imageData: string?` to `imageDataList: string[]?` across the backend event types, SSE serialization, and history reconstruction to send all images from tool contentBlocks instead of just the first
- Updated the macOS/iOS client to store and render multiple cached images per tool call (`cachedImage` → `cachedImages` array)
- All image rendering views (inline images, tool call chips, progress bars) now iterate over the full image list

## Original prompt
This tool call generated 4 images but only one of them gets rendered. We should display all the images.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22726" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
