### PR TITLE
fix: remove web_search_tool_result from contentBlocks type check

### DIFF
--- a/assistant/src/daemon/context-overflow-reducer.ts
+++ b/assistant/src/daemon/context-overflow-reducer.ts
@@ -257,11 +257,7 @@ function applyMediaStubbing(
           mediaTokens += estimateContentBlockTokens(block, {
             providerName: config.providerName,
           });
-        } else if (
-          (block.type === "tool_result" ||
-            block.type === "web_search_tool_result") &&
-          block.contentBlocks
-        ) {
+        } else if (block.type === "tool_result" && block.contentBlocks) {
           for (const cb of block.contentBlocks) {
             if (cb.type === "image" || cb.type === "file") {
               mediaTokens += estimateContentBlockTokens(cb, {


### PR DESCRIPTION
## Summary
- Remove `web_search_tool_result` from the `contentBlocks` check in `context-overflow-reducer.ts` — `WebSearchToolResultContent` doesn't have a `contentBlocks` property, so including it caused TS2339 type errors.
- Only `ToolResultContent` has `contentBlocks`, so the narrowed check is both correct and sufficient.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23829433981/job/69459503382
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
