### PR TITLE
fix: remove web_search_tool_result from contentBlocks check in context-overflow-reducer

### DIFF
--- a/assistant/src/daemon/context-overflow-reducer.ts
+++ b/assistant/src/daemon/context-overflow-reducer.ts
@@ -257,7 +257,7 @@ function applyMediaStubbing(
           mediaTokens += estimateContentBlockTokens(block, {
             providerName: config.providerName,
           });
-        } else if ((block.type === "tool_result" || block.type === "web_search_tool_result") && block.contentBlocks) {
+        } else if (block.type === "tool_result" && block.contentBlocks) {
           for (const cb of block.contentBlocks) {
             if (cb.type === "image" || cb.type === "file") {
               mediaTokens += estimateContentBlockTokens(cb, {


### PR DESCRIPTION
## Summary
- Remove `web_search_tool_result` from the `contentBlocks` check in the media token counting loop of `context-overflow-reducer.ts`
- `WebSearchToolResultContent` doesn't have a `contentBlocks` property, so TypeScript correctly rejects accessing it on the union type
- Only `ToolResultContent` (type `tool_result`) has the `contentBlocks` property

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23829589944/job/69459955829