### PR TITLE
fix: handle web_search_tool_result in context-overflow-reducer media token counting

### DIFF
--- a/assistant/src/daemon/context-overflow-reducer.ts
+++ b/assistant/src/daemon/context-overflow-reducer.ts
@@ -257,7 +257,11 @@ function applyMediaStubbing(
           mediaTokens += estimateContentBlockTokens(block, {
             providerName: config.providerName,
           });
-        } else if (block.type === "tool_result" && block.contentBlocks) {
+        } else if (
+          (block.type === "tool_result" ||
+            block.type === "web_search_tool_result") &&
+          block.contentBlocks
+        ) {
           for (const cb of block.contentBlocks) {
             if (cb.type === "image" || cb.type === "file") {
               mediaTokens += estimateContentBlockTokens(cb, {


### PR DESCRIPTION
## Summary

- Add `web_search_tool_result` to the `tool_result` type check in `context-overflow-reducer.ts` that counts media tokens inside nested content blocks
- Fixes the structural guard test that caught this raw type check without `web_search_tool_result` handling

## Original prompt

--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23829647486/job/69460123027
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22731" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
