### PR TITLE
fix: remove web_search_tool_result from contentBlocks check in context-overflow-reducer

### DIFF
--- a/assistant/src/__tests__/conversation-history-web-search.test.ts
+++ b/assistant/src/__tests__/conversation-history-web-search.test.ts
@@ -782,6 +782,11 @@ describe("web_search_tool_result structural guard", () => {
     // Extracts tool results from persisted message content for work-item
     // display. web_search_tool_result blocks are not relevant here.
     "runtime/routes/work-items-routes.ts",
+
+    // Media token counting iterates tool_result.contentBlocks for nested
+    // image/file blocks. web_search_tool_result has opaque content with no
+    // contentBlocks property, so it cannot contain nested media.
+    "daemon/context-overflow-reducer.ts",
   ]);
 
   /**

--- a/assistant/src/daemon/context-overflow-reducer.ts
+++ b/assistant/src/daemon/context-overflow-reducer.ts
@@ -257,11 +257,7 @@ function applyMediaStubbing(
           mediaTokens += estimateContentBlockTokens(block, {
             providerName: config.providerName,
           });
-        } else if (
-          (block.type === "tool_result" ||
-            block.type === "web_search_tool_result") &&
-          block.contentBlocks
-        ) {
+        } else if (block.type === "tool_result" && block.contentBlocks) {
           for (const cb of block.contentBlocks) {
             if (cb.type === "image" || cb.type === "file") {
               mediaTokens += estimateContentBlockTokens(cb, {


### PR DESCRIPTION
## Summary
- Remove `web_search_tool_result` from the `contentBlocks` media token counting check in `context-overflow-reducer.ts` — `WebSearchToolResultContent` has opaque `content: unknown` with no `contentBlocks` property, causing TS2339
- Allowlist the file in `conversation-history-web-search.test.ts` structural guard since this is a legitimate `tool_result`-only check

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23829748102/job/69460426061
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22732" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
