### PR TITLE
feat: make greeting generation model intent configurable

### DIFF
--- a/assistant/src/config/schemas/platform.ts
+++ b/assistant/src/config/schemas/platform.ts
@@ -56,6 +56,14 @@ export const UiConfigSchema = z
       .describe(
         "IANA timezone identifier for displaying dates and times (e.g. 'America/New_York')",
       ),
+    greetingModelIntent: z
+      .enum(["latency-optimized", "quality-optimized"], {
+        error: "ui.greetingModelIntent must be 'latency-optimized' or 'quality-optimized'",
+      })
+      .default("latency-optimized")
+      .describe(
+        "Model intent for empty-state greeting generation (latency-optimized = fast/small model, quality-optimized = primary model)",
+      ),
   })
   .describe("User interface display settings");
 

--- a/assistant/src/runtime/routes/btw-routes.ts
+++ b/assistant/src/runtime/routes/btw-routes.ts
@@ -16,6 +16,7 @@ import { existsSync, readFileSync } from "node:fs";
 
 import { z } from "zod";
 
+import { getConfig } from "../../config/loader.js";
 import { getConversationByKey } from "../../memory/conversation-key-store.js";
 import {
   resolveChannelPersona,
@@ -34,6 +35,9 @@ const log = getLogger("btw-routes");
 
 /** Conversation key used by the client for identity intro generation. */
 const IDENTITY_INTRO_KEY = "identity-intro";
+
+/** Conversation key used by the client for empty-state greeting generation. */
+const GREETING_KEY = "greeting";
 
 /**
  * Parse the `## Identity Intro` section from SOUL.md.
@@ -150,6 +154,7 @@ async function handleBtw(
       (async () => {
         try {
           const isIntroRequest = conversationKey === IDENTITY_INTRO_KEY;
+          const isGreeting = conversationKey === GREETING_KEY;
           const userPersona = resolveGuardianPersona();
           const channelPersona = resolveChannelPersona(undefined);
           const result = await runBtwSidechain({
@@ -158,6 +163,9 @@ async function handleBtw(
             signal: req.signal,
             userPersona,
             channelPersona,
+            ...(isGreeting
+              ? { modelIntent: getConfig().ui.greetingModelIntent }
+              : {}),
             onEvent: (event) => {
               if (event.type === "text_delta") {
                 controller.enqueue(


### PR DESCRIPTION
## Summary

- Add `ui.greetingModelIntent` config option to `UiConfigSchema` (enum: `latency-optimized` | `quality-optimized`, default: `latency-optimized`)
- Pass the configured model intent to the BTW sidechain when generating empty-state greetings (`conversationKey === "greeting"`)
- Allows switching from Haiku to Opus for greeting generation when the smaller model doesn't reliably follow persona constraints (e.g. pet name rules)

## Original prompt

Implement changes 1 and 2 from the plan at /Users/sidd/.claude/plans/clever-brewing-cocke.md:

1. Add `greetingModelIntent` config option to `UiConfigSchema` in `assistant/src/config/schemas/platform.ts` — enum of "latency-optimized" | "quality-optimized", default "latency-optimized"

2. In `assistant/src/runtime/routes/btw-routes.ts`, when `conversationKey === "greeting"`, read `getConfig().ui.greetingModelIntent` and pass it as `modelIntent` to `runBtwSidechain`

Do NOT modify btw-sidechain.ts — skip step 3 (explicit thinking disable).