### PR TITLE
fix: guard queued attachment hydration against file read failures

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -625,9 +625,18 @@ export class DaemonServer {
       if (conversation.isProcessing()) {
         // Hydrate file data now — the queue path won't re-read from
         // the attachment store, so base64 content must be inline.
-        for (const att of resolvedAttachments) {
+        for (let i = resolvedAttachments.length - 1; i >= 0; i--) {
+          const att = resolvedAttachments[i];
           if (att.filePath && !att.data) {
-            att.data = readFileSync(att.filePath).toString("base64");
+            try {
+              att.data = readFileSync(att.filePath).toString("base64");
+            } catch (err) {
+              log.warn(
+                { err, path: att.filePath },
+                "Failed to read queued signal attachment, skipping",
+              );
+              resolvedAttachments.splice(i, 1);
+            }
           }
         }
         const requestId = crypto.randomUUID();


### PR DESCRIPTION
Address review feedback on PR #22350. Wrap readFileSync in try/catch so one unreadable attachment doesn't crash the entire signal message. Failed attachments are logged and removed from the resolved list before enqueuing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22737" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
