### PR TITLE
fix: account for truncation marker tokens in transcript budget

### DIFF
--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -628,14 +628,18 @@ export class ContextWindowManager {
       const excess = totalTokens - maxTranscriptTokens;
       if (blockTokens > excess && result[i].type === "text") {
         // Truncate this block to shed exactly the excess tokens.
-        const keepTokens = blockTokens - excess;
+        // Subtract the cost of the "[...truncated] " prefix so the final
+        // block (prefix + kept text) stays within budget.
+        const truncationPrefix = "[...truncated] ";
+        const prefixTokens = estimateTextTokens(truncationPrefix);
+        const keepTokens = Math.max(1, blockTokens - excess - prefixTokens);
         const text = (result[i] as { type: "text"; text: string }).text;
         // Approximate: 1 token ≈ 4 characters for truncation purposes.
         const keepChars = Math.max(1, Math.floor(keepTokens * 4));
         const truncatedText = text.slice(-keepChars);
         const truncatedBlock: ContentBlock = {
           type: "text",
-          text: `[...truncated] ${truncatedText}`,
+          text: `${truncationPrefix}${truncatedText}`,
         };
         const newBlockTokens = estimateBlockTokens(truncatedBlock);
         droppedTokens += blockTokens - newBlockTokens;


### PR DESCRIPTION
Address review feedback on PR #22335. Subtract the estimated cost of the truncation marker prefix from keepTokens before trimming to ensure the output stays within maxTranscriptTokens.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
