### PR TITLE
fix: re-seed skill capability memories on disable

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -503,6 +503,7 @@ export function disableSkill(
       name: skillId,
       state: "disabled",
     });
+    seedCatalogSkillMemories();
     return { success: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Address review feedback on PR #22513. Add seedCatalogSkillMemories() call to disableSkill handler so disabled skill capability memories are pruned immediately.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22739" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
