### PR TITLE
chore: remove dead _start variable in conversation-graph-memory

### DIFF
--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -168,8 +168,6 @@ export class ConversationGraphMemory {
     );
     if (!hasUserContent) return noopResult;
 
-    const _start = Date.now();
-
     try {
       // Decide which retrieval mode to use
       if (!this.initialized || this.needsReload) {


### PR DESCRIPTION
## Summary
- Delete unused `const _start = Date.now()` in `prepareMemory` — each retrieval mode (`runContextLoad`, `runRefresh`, `runPerTurn`) measures its own latency internally
- Addresses review feedback on PR #22700 per dead code removal rule

## Test plan
- [x] Single-line deletion, no behavioral change — type-check and tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
