### PR TITLE
fix: complete memory tool rename in permission files and test mocks (#22699)

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -459,7 +459,7 @@ function makeCtx(
 
     graphMemory: {
       onCompacted: () => {},
-      prepareMemory: async () => ({ injections: [], tokenEstimate: 0 }),
+      prepareMemory: async () => ({ runMessages: [], injectedTokens: 0, latencyMs: 0, mode: "none" as const }),
     } as unknown as AgentLoopConversationContext["graphMemory"],
 
     ...overrides,

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -447,7 +447,7 @@ function makeCtx(
 
     graphMemory: {
       onCompacted: () => {},
-      prepareMemory: async () => ({ injections: [], tokenEstimate: 0 }),
+      prepareMemory: async () => ({ runMessages: [], injectedTokens: 0, latencyMs: 0, mode: "none" as const }),
     } as unknown as AgentLoopConversationContext["graphMemory"],
 
     ...overrides,

--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -287,11 +287,11 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     }),
   );
 
-  // memory_recall is a read-only tool — always allow without prompting.
+  // recall is a read-only tool — always allow without prompting.
   const memoryRecallRule: DefaultRuleTemplate = {
-    id: "default:allow-memory_recall-global",
-    tool: "memory_recall",
-    pattern: "memory_recall:*",
+    id: "default:allow-recall-global",
+    tool: "recall",
+    pattern: "recall:*",
     scope: "everywhere",
     decision: "allow",
     priority: 100,

--- a/assistant/src/permissions/workspace-policy.ts
+++ b/assistant/src/permissions/workspace-policy.ts
@@ -79,7 +79,7 @@ const HOST_TOOLS = new Set([
 /** Safe local-only tools that are always workspace-scoped. */
 const ALWAYS_SCOPED_TOOLS = new Set([
   "skill_load",
-  "memory_recall",
+  "recall",
   "ui_update",
   "ui_dismiss",
 ]);


### PR DESCRIPTION
Address review feedback on PR #22699.

## Summary
- Update `workspace-policy.ts` ALWAYS_SCOPED_TOOLS: `memory_recall` → `recall`
- Update `defaults.ts` auto-allow rule: `memory_recall` → `recall` (id, tool, pattern)
- Fix `prepareMemory` mock shape in both agent loop test files to match actual return type (`runMessages`, `injectedTokens`, `latencyMs`, `mode` instead of legacy `injections`/`tokenEstimate`)

## Test plan
- [ ] CI passes on permission guard tests
- [ ] Agent loop tests pass with corrected mock shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
