### PR TITLE
fix(macos): hide Show more button in background section during unread auto-expansion

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -327,7 +327,7 @@ struct SidebarSectionView: View {
 
     @ViewBuilder
     private var showMoreLessButton: some View {
-        if conversations.count > maxCollapsed {
+        if conversations.count > maxCollapsed, showAll || !effectiveShowAll {
             HStack {
                 VButton(
                     label: showAll ? "Show less" : "Show more",


### PR DESCRIPTION
Address review feedback on PR #22507. Apply the same hasHiddenUnread guard to the background section's Show more button for consistency with channel sections.

When `effectiveShowAll` is true due to hidden unread messages but the user hasn't explicitly toggled `showAll`, the Show more/less button is now hidden — matching the behavior PR #22507 introduced for channel sections.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22742" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
