### PR TITLE
fix: use correct createNodes index for deferred edges and triggers

### DIFF
--- a/assistant/src/memory/graph/extraction.ts
+++ b/assistant/src/memory/graph/extraction.ts
@@ -492,6 +492,7 @@ export function parseExtractionResponse(
     }
 
     diff.createNodes.push(node);
+    const nodeIndex = diff.createNodes.length - 1;
 
     // Collect edges to existing nodes (need new node ID after creation)
     if (Array.isArray(raw.edges_to_existing)) {
@@ -501,7 +502,7 @@ export function parseExtractionResponse(
         if (!edge.relationship || !VALID_RELATIONSHIPS.has(edge.relationship))
           continue;
         deferredEdges.push({
-          newNodeIndex: i,
+          newNodeIndex: nodeIndex,
           targetNodeId: edge.target_node_id,
           relationship: edge.relationship,
           weight: clamp(Number(edge.weight) || 1.0, 0, 1),
@@ -514,7 +515,7 @@ export function parseExtractionResponse(
       for (const t of raw.triggers) {
         if (!t.type || !VALID_TRIGGER_TYPES.has(t.type)) continue;
         deferredTriggers.push({
-          newNodeIndex: i,
+          newNodeIndex: nodeIndex,
           trigger: {
             type: t.type as TriggerType,
             schedule: t.schedule ?? null,


### PR DESCRIPTION
Address review feedback on PR #22706. Replace raw loop index `i` with `diff.createNodes.length - 1` for `newNodeIndex` in deferred edges and triggers, since `continue` statements for invalid entries cause the raw index to diverge from the actual position in `diff.createNodes`.

## Summary
- Compute `nodeIndex` from `diff.createNodes.length - 1` after pushing the node
- Use `nodeIndex` instead of `i` for both `deferredEdges` and `deferredTriggers`

## Test plan
- [x] Existing extraction tests cover deferred edge/trigger indexing
- [x] Logic change is minimal and mechanical

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22743" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
