### PR TITLE
fix: correct inactive status filter, reactivation, and pagination in memory items API

### DIFF
--- a/assistant/src/runtime/routes/memory-item-routes.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.ts
@@ -301,7 +301,9 @@ export async function handleListMemoryItems(url: URL): Promise<Response> {
   const fidelityFilter =
     statusParam === "all"
       ? undefined
-      : notInArray(memoryGraphNodes.fidelity, ["gone"]);
+      : statusParam === "inactive"
+        ? eq(memoryGraphNodes.fidelity, "gone")
+        : notInArray(memoryGraphNodes.fidelity, ["gone"]);
 
   // ── Semantic search path ────────────────────────────────────────────
   if (searchParam) {
@@ -329,24 +331,28 @@ export async function handleListMemoryItems(url: URL): Promise<Response> {
         semanticKindCounts[row.kind] = row.count;
       }
 
-      // Apply kind filter while preserving semantic relevance ordering
+      // Apply kind + fidelity filter while preserving semantic relevance ordering
       let filteredIds = semanticResult.ids;
-      if (kindParam) {
-        const kindFilterConditions = [
+      {
+        const filterConditions = [
           inArray(memoryGraphNodes.id, semanticResult.ids),
-          eq(memoryGraphNodes.type, kindParam),
         ];
-        if (fidelityFilter) kindFilterConditions.push(fidelityFilter);
+        if (kindParam) {
+          filterConditions.push(eq(memoryGraphNodes.type, kindParam));
+        }
+        if (fidelityFilter) filterConditions.push(fidelityFilter);
 
-        const kindIdSet = new Set(
-          db
-            .select({ id: memoryGraphNodes.id })
-            .from(memoryGraphNodes)
-            .where(and(...kindFilterConditions))
-            .all()
-            .map((r) => r.id),
-        );
-        filteredIds = semanticResult.ids.filter((id) => kindIdSet.has(id));
+        if (filterConditions.length > 1) {
+          const validIdSet = new Set(
+            db
+              .select({ id: memoryGraphNodes.id })
+              .from(memoryGraphNodes)
+              .where(and(...filterConditions))
+              .all()
+              .map((r) => r.id),
+          );
+          filteredIds = semanticResult.ids.filter((id) => validIdSet.has(id));
+        }
       }
 
       const total = filteredIds.length;
@@ -632,6 +638,8 @@ export async function handleUpdateMemoryItem(
     // Map client status to fidelity
     if (body.status === "superseded" || body.status === "inactive") {
       changes.fidelity = "gone";
+    } else if (body.status === "active") {
+      changes.fidelity = "vivid";
     }
   }
 


### PR DESCRIPTION
Address review feedback on PR #22709.

- **Status filtering**: `status=inactive` now correctly maps to `eq(fidelity, 'gone')` instead of falling through to the active filter.
- **Reactivation**: PATCH with `status=active` now sets `fidelity = 'vivid'`, allowing gone nodes to be reactivated.
- **Pagination**: Semantic search results are now filtered against the DB with the fidelity filter even when no `kindParam` is set, preventing gone nodes from inflating `total` and causing empty pages.

Closes #22709
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
