### PR TITLE
fix: distinguish provider overloaded errors from rate limits

### DIFF
--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -90,7 +90,6 @@ describe("classifyConversationError", () => {
       "rate limit exceeded",
       "Rate-limit hit",
       "too many requests",
-      "overloaded",
     ];
 
     for (const msg of cases) {
@@ -98,10 +97,42 @@ describe("classifyConversationError", () => {
         const result = classifyConversationError(new Error(msg), baseCtx);
         expect(result.code).toBe("PROVIDER_RATE_LIMIT");
         expect(result.retryable).toBe(true);
-        expect(result.userMessage).toContain("busy");
+        expect(result.userMessage).toContain("rate limited");
         expect(result.errorCategory).toBe("rate_limit");
       });
     }
+  });
+
+  describe("provider overloaded errors", () => {
+    it('classifies "overloaded" as PROVIDER_OVERLOADED', () => {
+      const result = classifyConversationError(
+        new Error("overloaded"),
+        baseCtx,
+      );
+      expect(result.code).toBe("PROVIDER_OVERLOADED");
+      expect(result.retryable).toBe(true);
+      expect(result.userMessage).toContain("overloaded");
+      expect(result.errorCategory).toBe("provider_overloaded");
+    });
+
+    it("classifies Anthropic overloaded_error (no statusCode) as PROVIDER_OVERLOADED", () => {
+      const err = new ProviderError(
+        'Anthropic API error (undefined): {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+        "anthropic",
+      );
+      const result = classifyConversationError(err, baseCtx);
+      expect(result.code).toBe("PROVIDER_OVERLOADED");
+      expect(result.retryable).toBe(true);
+      expect(result.errorCategory).toBe("provider_overloaded");
+    });
+
+    it("classifies ProviderError with 529 as PROVIDER_OVERLOADED", () => {
+      const err = new ProviderError("Overloaded", "anthropic", 529);
+      const result = classifyConversationError(err, baseCtx);
+      expect(result.code).toBe("PROVIDER_OVERLOADED");
+      expect(result.retryable).toBe(true);
+      expect(result.errorCategory).toBe("provider_overloaded");
+    });
   });
 
   describe("provider API errors", () => {

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -33,12 +33,10 @@ const NETWORK_PATTERNS = [
 ];
 
 // Rate limit patterns (HTTP 429 or explicit rate limit messages)
-const RATE_LIMIT_PATTERNS = [
-  /429/,
-  /rate.?limit/i,
-  /too many requests/i,
-  /overloaded/i,
-];
+const RATE_LIMIT_PATTERNS = [/429/, /rate.?limit/i, /too many requests/i];
+
+// Overloaded patterns — provider is capacity-constrained (distinct from rate limiting)
+const OVERLOADED_PATTERNS = [/overloaded/i];
 
 // Context-too-large patterns (request exceeds the model's context window)
 const CONTEXT_TOO_LARGE_PATTERNS = [
@@ -249,9 +247,20 @@ function classifyCore(
     if (error.statusCode === 429) {
       return {
         code: "PROVIDER_RATE_LIMIT",
-        userMessage: "The AI provider is busy. Please try again in a moment.",
+        userMessage:
+          "You are being rate limited by the AI provider. Please try again in a moment.",
         retryable: true,
         errorCategory: "rate_limit",
+      };
+    }
+    // Anthropic uses 529 for overloaded_error
+    if (error.statusCode === 529) {
+      return {
+        code: "PROVIDER_OVERLOADED",
+        userMessage:
+          "The AI provider is temporarily overloaded. Please try again in a moment.",
+        retryable: true,
+        errorCategory: "provider_overloaded",
       };
     }
     if (error.statusCode >= 500) {
@@ -363,9 +372,23 @@ function classifyByMessage(
     if (pattern.test(message)) {
       return {
         code: "PROVIDER_RATE_LIMIT",
-        userMessage: "The AI provider is busy. Please try again in a moment.",
+        userMessage:
+          "You are being rate limited by the AI provider. Please try again in a moment.",
         retryable: true,
         errorCategory: "rate_limit",
+      };
+    }
+  }
+
+  // Overloaded — provider is capacity-constrained (not the user's fault)
+  for (const pattern of OVERLOADED_PATTERNS) {
+    if (pattern.test(message)) {
+      return {
+        code: "PROVIDER_OVERLOADED",
+        userMessage:
+          "The AI provider is temporarily overloaded. Please try again in a moment.",
+        retryable: true,
+        errorCategory: "provider_overloaded",
       };
     }
   }

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -370,6 +370,7 @@ export interface ContextCompacted {
 export type ConversationErrorCode =
   | "PROVIDER_NETWORK"
   | "PROVIDER_RATE_LIMIT"
+  | "PROVIDER_OVERLOADED"
   | "PROVIDER_API"
   | "PROVIDER_BILLING"
   | "PROVIDER_ORDERING"

--- a/clients/shared/Features/Chat/ChatConversationError.swift
+++ b/clients/shared/Features/Chat/ChatConversationError.swift
@@ -4,6 +4,7 @@ import Foundation
 public enum ConversationErrorCategory: Equatable, Sendable {
     case providerNetwork
     case rateLimit
+    case providerOverloaded
     case providerApi
     case providerBilling
     case providerOrdering
@@ -23,6 +24,8 @@ public enum ConversationErrorCategory: Equatable, Sendable {
             self = .providerNetwork
         case .providerRateLimit:
             self = .rateLimit
+        case .providerOverloaded:
+            self = .providerOverloaded
         case .providerApi:
             self = .providerApi
         case .providerBilling:
@@ -57,6 +60,8 @@ public enum ConversationErrorCategory: Equatable, Sendable {
             return "Check your internet connection, then click Retry."
         case .rateLimit:
             return "Wait 30–60 seconds, then click Retry."
+        case .providerOverloaded:
+            return "This is usually temporary — click Retry in a moment."
         case .providerApi:
             return "This is usually temporary — click Retry, or check your API key in Settings if it persists."
         case .providerBilling:

--- a/clients/shared/Features/Chat/InlineChatErrorAlert.swift
+++ b/clients/shared/Features/Chat/InlineChatErrorAlert.swift
@@ -26,7 +26,7 @@ public struct InlineChatErrorAlert: View {
 
     private var accentColor: Color {
         switch category {
-        case .rateLimit, .providerNetwork, .contextTooLarge, .providerOrdering, .providerWebSearch:
+        case .rateLimit, .providerOverloaded, .providerNetwork, .contextTooLarge, .providerOrdering, .providerWebSearch:
             return VColor.systemMidStrong
         case .conversationAborted:
             return VColor.systemPositiveStrong
@@ -39,6 +39,7 @@ public struct InlineChatErrorAlert: View {
         switch category {
         case .providerNetwork: return .wifiOff
         case .rateLimit: return .clockAlert
+        case .providerOverloaded: return .cloudOff
         case .providerApi, .providerOrdering, .providerWebSearch: return .cloudOff
         case .providerBilling: return .creditCard
         case .contextTooLarge: return .fileText
@@ -55,6 +56,7 @@ public struct InlineChatErrorAlert: View {
         switch category {
         case .providerNetwork: return "Network Error"
         case .rateLimit: return "Rate Limited"
+        case .providerOverloaded: return "Provider Overloaded"
         case .providerApi: return "API Error"
         case .providerBilling: return "Billing Error"
         case .providerOrdering: return "Processing Error"

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1243,6 +1243,7 @@ public struct TraceEventsHistoryResponse: Decodable, Sendable {
 public enum ConversationErrorCode: String, CaseIterable, Codable, Sendable {
     case providerNetwork = "PROVIDER_NETWORK"
     case providerRateLimit = "PROVIDER_RATE_LIMIT"
+    case providerOverloaded = "PROVIDER_OVERLOADED"
     case providerApi = "PROVIDER_API"
     case providerBilling = "PROVIDER_BILLING"
     case providerOrdering = "PROVIDER_ORDERING"


### PR DESCRIPTION
## Summary
- Add new `PROVIDER_OVERLOADED` error code (daemon + Swift client) for Anthropic `overloaded_error` responses that were previously misclassified as `PROVIDER_RATE_LIMIT`
- Remove `/overloaded/i` from rate limit regex patterns into its own `OVERLOADED_PATTERNS` array
- Handle HTTP 529 (Anthropic's overloaded status code) deterministically in `classifyCore`
- Client now shows "Provider Overloaded" instead of "Rate Limited" for these errors

## Original prompt
let's display a more accurate error message here
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22745" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
