### PR TITLE
fix: escape LIKE patterns, fix memory types, and update brain graph colors

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-analyze-style.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-analyze-style.ts
@@ -13,6 +13,12 @@ import type {
 import { truncate } from "../../../../util/truncate.js";
 import { err, getProviderConnection, ok, resolveProvider } from "./shared.js";
 
+/** Map legacy caller kinds to valid MemoryType values. */
+const KIND_TO_MEMORY_TYPE: Record<string, string> = {
+  style: "behavioral",
+  relationship: "semantic",
+};
+
 function upsertMemoryItem(opts: {
   kind: string;
   subject: string;
@@ -56,7 +62,7 @@ function upsertMemoryItem(opts: {
       .values({
         id,
         content,
-        type: opts.kind,
+        type: KIND_TO_MEMORY_TYPE[opts.kind] ?? opts.kind,
         created: now,
         lastAccessed: now,
         lastConsolidated: now,

--- a/assistant/src/runtime/routes/brain-graph-routes.ts
+++ b/assistant/src/runtime/routes/brain-graph-routes.ts
@@ -18,18 +18,22 @@ import type { RouteDefinition } from "../http-router.js";
 
 function getMemoryKindColor(kind: string): string {
   switch (kind) {
-    case "identity":
-      return "#8b5cf6";
-    case "preference":
-      return "#3b82f6";
-    case "project":
-      return "#10b981";
-    case "decision":
-      return "#f59e0b";
-    case "constraint":
-      return "#ef4444";
-    case "event":
-      return "#ec4899";
+    case "episodic":
+      return "#ec4899"; // pink — specific moments/events
+    case "semantic":
+      return "#3b82f6"; // blue — facts/knowledge
+    case "procedural":
+      return "#10b981"; // green — skills/how-to
+    case "emotional":
+      return "#ef4444"; // red — feelings
+    case "prospective":
+      return "#f59e0b"; // amber — future-oriented
+    case "behavioral":
+      return "#8b5cf6"; // violet — behavioral patterns
+    case "narrative":
+      return "#6366f1"; // indigo — stories
+    case "shared":
+      return "#14b8a6"; // teal — relationship memories
     default:
       return "#94a3b8";
   }

--- a/assistant/src/skills/skill-memory.ts
+++ b/assistant/src/skills/skill-memory.ts
@@ -11,6 +11,11 @@ import { getLogger } from "../util/logger.js";
 
 const log = getLogger("skill-memory");
 
+/** Escape SQL LIKE wildcards (`%` and `_`) so they match literally. */
+function escapeLike(s: string): string {
+  return s.replace(/%/g, "\\%").replace(/_/g, "\\_");
+}
+
 /**
  * Generic input for building capability statements.
  * Decoupled from CatalogSkill so other skill sources (e.g. bundled skills) can
@@ -91,7 +96,7 @@ export function upsertSkillCapabilityMemory(
       .where(
         and(
           eq(memoryGraphNodes.type, "procedural"),
-          like(memoryGraphNodes.content, `skill:${skillId}\n%`),
+          like(memoryGraphNodes.content, `skill:${escapeLike(skillId)}\n%`),
           eq(memoryGraphNodes.scopeId, scopeId),
         ),
       )
@@ -182,7 +187,7 @@ export function deleteSkillCapabilityMemory(skillId: string): void {
       .where(
         and(
           eq(memoryGraphNodes.type, "procedural"),
-          like(memoryGraphNodes.content, `skill:${skillId}\n%`),
+          like(memoryGraphNodes.content, `skill:${escapeLike(skillId)}\n%`),
           eq(memoryGraphNodes.scopeId, "default"),
           sql`${memoryGraphNodes.fidelity} != 'gone'`,
         ),


### PR DESCRIPTION
## Summary
- Escape `_` and `%` in skill IDs before using in SQL LIKE patterns (skill IDs can contain underscores)
- Map legacy `"style"` → `"behavioral"` and `"relationship"` → `"semantic"` in messaging-analyze-style tool
- Update brain graph color mapping from old `memory_items.kind` values to new `MemoryType` values (episodic, semantic, procedural, emotional, prospective, behavioral, narrative, shared)

Addresses review feedback on #22723.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22747" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
