### PR TITLE
fix: adjust Anthropic image pixel cap to match 1600-token threshold

### DIFF
--- a/assistant/src/__tests__/context-token-estimator.test.ts
+++ b/assistant/src/__tests__/context-token-estimator.test.ts
@@ -287,9 +287,9 @@ describe("token estimator", () => {
 
     // 1920x1080 scaled to fit 1568px bounding box: dimScale = 1568/1920 = 0.8167
     // scaledWidth = round(1920 * 0.8167) = 1568, scaledHeight = round(1080 * 0.8167) = 882
-    // pixels = 1568 * 882 = 1,382,976 > 1,150,000 → mpScale = sqrt(1150000/1382976) = 0.9117
-    // scaledWidth = round(1568 * 0.9117) = 1430, scaledHeight = round(882 * 0.9117) = 804
-    // tokens = ceil(1430 * 804 / 750) = ceil(1533.12) = ~1,533
+    // pixels = 1568 * 882 = 1,382,976 > 1,200,000 → mpScale = sqrt(1200000/1382976) = 0.9315
+    // scaledWidth = round(1568 * 0.9315) = 1461, scaledHeight = round(882 * 0.9315) = 822
+    // tokens = ceil(1461 * 822 / 750) = ceil(1601.26) = ~1,602
     // With IMAGE_BLOCK_OVERHEAD_TOKENS and media_type overhead, still well under 5000
     expect(anthropicTokens).toBeLessThan(5_000);
 
@@ -415,10 +415,10 @@ describe("token estimator", () => {
     );
 
     // 2000x2000 → dimScale = 1568/2000 = 0.784 → 1568x1568 = 2,458,624 pixels
-    // 2,458,624 > 1,150,000 → mpScale = sqrt(1150000/2458624) ≈ 0.6837
-    // scaledWidth = round(1568 * 0.6837) = 1072, scaledHeight = round(1568 * 0.6837) = 1072
-    // tokens = ceil(1072 * 1072 / 750) = ceil(1532.7) ≈ 1533
-    // Previously would have been ceil(1568 * 1568 / 750) ≈ 3277
+    // 2,458,624 > 1,200,000 → mpScale = sqrt(1200000/2458624) ≈ 0.6987
+    // scaledWidth = round(1568 * 0.6987) = 1096, scaledHeight = round(1568 * 0.6987) = 1096
+    // tokens = ceil(1096 * 1096 / 750) = ceil(1601.6) ≈ 1602
+    // Without megapixel cap would have been ceil(1568 * 1568 / 750) ≈ 3277
     expect(tokens).toBeLessThanOrEqual(1_700);
   });
 
@@ -450,23 +450,17 @@ describe("token estimator", () => {
       { providerName: "anthropic" },
     );
 
-    // 1092x1092 = 1,192,464 pixels → slightly above 1,150,000 but close.
-    // The image tokens (excluding block overhead) should be ~1,590.
-    // With IMAGE_BLOCK_OVERHEAD_TOKENS (16) + media_type overhead (~3), total includes overhead.
-    // We check that the result (with overhead) is in a reasonable range.
-    // 1092*1092 = 1,192,464 > 1,150,000 → slight scaling applies
-    // mpScale = sqrt(1150000/1192464) ≈ 0.9824
-    // scaledWidth = round(1092 * 0.9824) = 1073, scaledHeight = round(1092 * 0.9824) = 1073
-    // tokens = ceil(1073 * 1073 / 750) = ceil(1535.2) ≈ 1536
-    // With overhead: 16 + 3 + 1536 = 1555
+    // 1092x1092 = 1,192,464 pixels < 1,200,000 → no megapixel scaling needed.
+    // tokens = ceil(1092 * 1092 / 750) = ceil(1589.95) ≈ 1590
+    // With overhead: 16 + 3 + 1590 = 1609
     expect(squareTokens).toBeGreaterThan(1_400);
     expect(squareTokens).toBeLessThan(1_800);
 
-    // 784*1568 = 1,229,312 > 1,150,000 → slight scaling applies
-    // mpScale = sqrt(1150000/1229312) ≈ 0.9674
-    // scaledWidth = round(784 * 0.9674) = 758, scaledHeight = round(1568 * 0.9674) = 1517
-    // tokens = ceil(758 * 1517 / 750) = ceil(1533.5) ≈ 1534
-    // With overhead: 16 + 3 + 1534 = 1553
+    // 784*1568 = 1,229,312 > 1,200,000 → slight scaling applies
+    // mpScale = sqrt(1200000/1229312) ≈ 0.9881
+    // scaledWidth = round(784 * 0.9881) = 775, scaledHeight = round(1568 * 0.9881) = 1549
+    // tokens = ceil(775 * 1549 / 750) = ceil(1600.6) ≈ 1601
+    // With overhead: 16 + 3 + 1601 = 1620
     expect(tallTokens).toBeGreaterThan(1_400);
     expect(tallTokens).toBeLessThan(1_800);
   });

--- a/assistant/src/context/token-estimator.ts
+++ b/assistant/src/context/token-estimator.ts
@@ -20,12 +20,13 @@ const GEMINI_INLINE_FILE_MIME_TYPES = new Set(["application/pdf"]);
 // Anthropic scales images to fit within 1568x1568 maintaining aspect ratio,
 // then charges ~(width * height) / 750 tokens.
 const ANTHROPIC_IMAGE_MAX_DIMENSION = 1568;
-// Anthropic caps images at ~1.15 megapixels in addition to the 1568px dimension limit.
+// Anthropic caps images at ~1.2 megapixels in addition to the 1568px dimension limit.
 // Images exceeding this are further scaled down. The docs state images above ~1,600 tokens
-// are resized. Reference table (max sizes that won't be resized):
+// are resized. 1,200,000 / 750 = 1,600 tokens, matching the documented threshold.
+// Reference table (max sizes that won't be resized):
 //   1:1 → 1092x1092 (~1,590 tokens)   1:2 → 784x1568 (~1,639 tokens)
 // See: https://platform.claude.com/docs/en/build-with-claude/vision#evaluate-image-size
-const ANTHROPIC_IMAGE_MAX_PIXELS = 1_150_000;
+const ANTHROPIC_IMAGE_MAX_PIXELS = 1_200_000;
 const ANTHROPIC_IMAGE_TOKENS_PER_PIXEL = 1 / 750;
 const ANTHROPIC_IMAGE_MAX_TOKENS = 1_600;
 


### PR DESCRIPTION
Address review feedback on PR #22711. Increase ANTHROPIC_IMAGE_MAX_PIXELS from 1,150,000 to 1,200,000 so that 1,200,000 / 750 = 1,600 tokens, correctly matching the documented ~1,600-token resize threshold. Also fixes test comments to reflect current behavior instead of historical comparisons.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22748" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
