### PR TITLE
fix(macos): complete read-only guard for all mutating callbacks

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -306,12 +306,12 @@ struct ChatView: View {
                 dismissedDocumentSurfaceIds: viewModel.dismissedDocumentSurfaceIds,
                 onConfirmationAllow: isReadonly ? nil : { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "allow") },
                 onConfirmationDeny: isReadonly ? nil : { requestId in viewModel.respondToConfirmation(requestId: requestId, decision: "deny") },
-                onAlwaysAllow: { requestId, selectedPattern, selectedScope, decision in
+                onAlwaysAllow: isReadonly ? nil : { requestId, selectedPattern, selectedScope, decision in
                     viewModel.respondToAlwaysAllow(requestId: requestId, selectedPattern: selectedPattern, selectedScope: selectedScope, decision: decision)
                 },
-                onTemporaryAllow: { requestId, decision in viewModel.respondToConfirmation(requestId: requestId, decision: decision) },
+                onTemporaryAllow: isReadonly ? nil : { requestId, decision in viewModel.respondToConfirmation(requestId: requestId, decision: decision) },
                 onSurfaceAction: isReadonly ? nil : { surfaceId, actionId, data in viewModel.sendSurfaceAction(surfaceId: surfaceId, actionId: actionId, data: data) },
-                onGuardianAction: { requestId, action in viewModel.submitGuardianDecision(requestId: requestId, action: action) },
+                onGuardianAction: isReadonly ? nil : { requestId, action in viewModel.submitGuardianDecision(requestId: requestId, action: action) },
                 onDismissDocumentWidget: { viewModel.dismissDocumentSurface(id: $0) },
                 onForkFromMessage: onForkFromMessage,
                 showInspectButton: showInspectButton,
@@ -325,7 +325,7 @@ struct ChatView: View {
                 onRehydrateMessage: { messageId in viewModel.rehydrateMessage(id: messageId) },
                 onSurfaceRefetch: { surfaceId, conversationId in viewModel.refetchStrippedSurface(surfaceId: surfaceId, conversationId: conversationId) },
                 onRetryFailedMessage: isReadonly ? nil : { messageId in viewModel.retryFailedMessage(id: messageId) },
-                onRetryConversationError: { messageId in viewModel.retryAfterConversationError(messageId: messageId) },
+                onRetryConversationError: isReadonly ? nil : { messageId in viewModel.retryAfterConversationError(messageId: messageId) },
                 subagentDetailStore: viewModel.subagentDetailStore,
                 activePendingRequestId: viewModel.activePendingRequestId,
                 paginatedVisibleMessages: viewModel.paginatedVisibleMessages,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -63,7 +63,7 @@ struct MessageListView: View {
     let dismissedDocumentSurfaceIds: Set<String>
     var onConfirmationAllow: ((String) -> Void)?
     var onConfirmationDeny: ((String) -> Void)?
-    let onAlwaysAllow: (String, String, String, String) -> Void
+    var onAlwaysAllow: ((String, String, String, String) -> Void)?
     /// Called when a temporary approval option is selected: (requestId, decision).
     var onTemporaryAllow: ((String, String) -> Void)?
     var onSurfaceAction: ((String, String, [String: AnyCodable]?) -> Void)?
@@ -1261,7 +1261,7 @@ private struct MessageCellView: View, Equatable {
     let mediaEmbedSettings: MediaEmbedResolverSettings?
     var onConfirmationAllow: ((String) -> Void)?
     var onConfirmationDeny: ((String) -> Void)?
-    let onAlwaysAllow: (String, String, String, String) -> Void
+    var onAlwaysAllow: ((String, String, String, String) -> Void)?
     var onTemporaryAllow: ((String, String) -> Void)?
     var onGuardianAction: ((String, String) -> Void)?
     var onSurfaceAction: ((String, String, [String: AnyCodable]?) -> Void)?
@@ -1367,7 +1367,7 @@ private struct MessageCellView: View, Equatable {
                         isKeyboardActive: confirmation.requestId == activePendingRequestId,
                         onAllow: { onConfirmationAllow?(confirmation.requestId) },
                         onDeny: { onConfirmationDeny?(confirmation.requestId) },
-                        onAlwaysAllow: onAlwaysAllow,
+                        onAlwaysAllow: onAlwaysAllow ?? { _, _, _, _ in },
                         onTemporaryAllow: onTemporaryAllow
                     )
                     .id(message.id)
@@ -1378,7 +1378,7 @@ private struct MessageCellView: View, Equatable {
                         confirmation: confirmation,
                         onAllow: { onConfirmationAllow?(confirmation.requestId) },
                         onDeny: { onConfirmationDeny?(confirmation.requestId) },
-                        onAlwaysAllow: onAlwaysAllow,
+                        onAlwaysAllow: onAlwaysAllow ?? { _, _, _, _ in },
                         onTemporaryAllow: onTemporaryAllow
                     )
                     .id(message.id)


### PR DESCRIPTION
Address review feedback on PR #22515. Nil out onAlwaysAllow, onTemporaryAllow, onGuardianAction, and onRetryConversationError when isReadonly is true.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
