### PR TITLE
fix: preserve backwards-compatible imageData field alongside imageDataList

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -441,6 +441,7 @@ export function handleToolResult(
     diff: event.diff,
     status: event.status,
     conversationId: deps.ctx.conversationId,
+    imageData: imageDataList?.[0],
     imageDataList,
     toolUseId: event.toolUseId,
   });

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -60,6 +60,8 @@ export interface HistoryToolCall {
   input: Record<string, unknown>;
   result?: string;
   isError?: boolean;
+  /** Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot). @deprecated Use imageDataList. */
+  imageData?: string;
   /** Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot, image generation). */
   imageDataList?: string[];
   /** Unix ms when the tool started executing. */
@@ -361,14 +363,19 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
       if (matched) {
         matched.result = resultContent;
         matched.isError = isError;
-        if (imageDataList.length > 0) matched.imageDataList = imageDataList;
+        if (imageDataList.length > 0) {
+          matched.imageData = imageDataList[0];
+          matched.imageDataList = imageDataList;
+        }
       } else {
         toolCalls.push({
           name: "unknown",
           input: {},
           result: resultContent,
           isError,
-          ...(imageDataList.length > 0 ? { imageDataList } : {}),
+          ...(imageDataList.length > 0
+            ? { imageData: imageDataList[0], imageDataList }
+            : {}),
         });
       }
       continue;

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -264,6 +264,8 @@ export interface HistoryResponseToolCall {
   input: Record<string, unknown>;
   result?: string;
   isError?: boolean;
+  /** Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot). @deprecated Use imageDataList. */
+  imageData?: string;
   /** Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot, image generation). */
   imageDataList?: string[];
   /** Unix ms when the tool started executing. */

--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -124,6 +124,8 @@ export interface ToolResult {
   };
   status?: string;
   conversationId?: string;
+  /** Base64-encoded image data extracted from contentBlocks (e.g. browser_screenshot). @deprecated Use imageDataList. */
+  imageData?: string;
   /** Base64-encoded image data extracted from contentBlocks (e.g. browser_screenshot, image generation). */
   imageDataList?: string[];
   /** The tool_use block ID for client-side correlation. */

--- a/clients/shared/Features/Chat/HistoryReconstructionService.swift
+++ b/clients/shared/Features/Chat/HistoryReconstructionService.swift
@@ -26,7 +26,7 @@ enum HistoryReconstructionService {
     /// Reconstructs ChatMessage and SubagentInfo arrays from raw history items.
     /// This method is nonisolated and accesses no @MainActor state, so it can
     /// be called from a background context. Images are decoded eagerly via
-    /// `ToolCallData.decodeImage` and stored in `cachedImage` for display.
+    /// `ToolCallData.decodeImage` and stored in `cachedImages` for display.
     nonisolated static func reconstructMessages(
         from historyMessages: [HistoryResponseMessage],
         conversationId: String?

--- a/clients/shared/Features/Chat/ToolCallProgressBar.swift
+++ b/clients/shared/Features/Chat/ToolCallProgressBar.swift
@@ -183,7 +183,7 @@ public struct ToolCallProgressBar: View {
             // Screenshots / generated images
             ForEach(Array(toolCall.cachedImages.enumerated()), id: \.offset) { _, cachedImage in
                 VStack(alignment: .leading, spacing: VSpacing.xxs) {
-                    Text("Screenshot")
+                    Text("Image")
                         .font(VFont.labelDefault)
                         .foregroundStyle(VColor.contentTertiary)
 


### PR DESCRIPTION
Address review feedback on PR #22726. Emit both `imageData` (first image) and `imageDataList` (all images) for wire compatibility. Fix stale comment (`cachedImage` → `cachedImages`) and update "Screenshot" label to "Image".
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
