### PR TITLE
fix: account for stub replacement costs in media token budget

### DIFF
--- a/assistant/src/daemon/context-overflow-reducer.ts
+++ b/assistant/src/daemon/context-overflow-reducer.ts
@@ -29,6 +29,7 @@ import type {
 import type { Message } from "../providers/types.js";
 import {
   countMediaBlocks,
+  estimateUnconditionalStubTokens,
   stripMediaPayloadsForRetry,
 } from "./conversation-media-retry.js";
 import type { InjectionMode } from "./conversation-runtime-assembly.js";
@@ -270,7 +271,15 @@ function applyMediaStubbing(
     }
 
     const nonMediaTokens = totalTokens - mediaTokens;
-    const mediaTokenBudget = Math.max(0, config.targetTokens - nonMediaTokens);
+
+    // Account for the token cost of text stubs that replace unconditionally
+    // stubbed media (non-latest-user images/files, tool_result-nested media).
+    // Without this adjustment the budget is systematically over-allocated.
+    const estimatedStubTokens = estimateUnconditionalStubTokens(messages, {
+      providerName: config.providerName,
+    });
+    const adjustedNonMediaTokens = nonMediaTokens + estimatedStubTokens;
+    const mediaTokenBudget = Math.max(0, config.targetTokens - adjustedNonMediaTokens);
 
     const stripped = stripMediaPayloadsForRetry(messages, {
       mediaTokenBudget,

--- a/assistant/src/daemon/conversation-media-retry.ts
+++ b/assistant/src/daemon/conversation-media-retry.ts
@@ -148,6 +148,48 @@ export function stripMediaPayloadsForRetry(
   };
 }
 
+/**
+ * Estimate the total token cost of stubs that will replace unconditionally
+ * stubbed media blocks (non-latest-user-message images/files and all
+ * tool_result-nested media). This lets callers account for stub overhead
+ * when computing the available media token budget.
+ */
+export function estimateUnconditionalStubTokens(
+  messages: Message[],
+  options?: { providerName?: string },
+): number {
+  let latestUserIndex: number | null = null;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.role !== "user") continue;
+    if (isToolResultOnlyMessage(msg)) continue;
+    if (getSummaryFromContextMessage(msg) != null) continue;
+    latestUserIndex = i;
+    break;
+  }
+
+  let stubTokens = 0;
+  for (let msgIndex = 0; msgIndex < messages.length; msgIndex++) {
+    const msg = messages[msgIndex];
+    for (const block of msg.content) {
+      if (block.type === "image" && msgIndex !== latestUserIndex) {
+        stubTokens += estimateContentBlockTokens(imageBlockToStub(block), options);
+      } else if (block.type === "file" && msgIndex !== latestUserIndex) {
+        stubTokens += estimateContentBlockTokens(fileBlockToStub(block), options);
+      } else if (block.type === "tool_result" && block.contentBlocks) {
+        for (const cb of block.contentBlocks) {
+          if (cb.type === "image") {
+            stubTokens += estimateContentBlockTokens(imageBlockToStub(cb), options);
+          } else if (cb.type === "file") {
+            stubTokens += estimateContentBlockTokens(fileBlockToStub(cb), options);
+          }
+        }
+      }
+    }
+  }
+  return stubTokens;
+}
+
 function imageBlockToStub(
   block: Extract<ContentBlock, { type: "image" }>,
 ): Extract<ContentBlock, { type: "text" }> {


### PR DESCRIPTION
Address review feedback on PR #22714. Estimate token cost of text stubs for unconditionally-stubbed media and subtract from available budget.

The `applyMediaStubbing` function computed `mediaTokenBudget` as `targetTokens - nonMediaTokens` without accounting for the token cost of text stubs that replace non-latest-user-message media. This systematically over-allocated the budget.

Fix: After computing `mediaTokens`, estimate the cost of stubs for all media blocks that will be unconditionally stubbed (non-latest-user-message images/files and tool_result-nested media). Add that estimated stub cost to `nonMediaTokens` before computing the budget.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22751" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
