### PR TITLE
fix: strip formatting delimiters wrapping guardian request codes

### DIFF
--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -730,6 +730,62 @@ describe("routing invariant: channel formatting delimiters stripped from code pa
     const resolved = getCanonicalGuardianRequest(req.id);
     expect(resolved!.status).toBe("approved");
   });
+
+  test("*CODE* action — formatting wraps only the code portion", async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: "tool_approval",
+      sourceType: "channel",
+      conversationId: "conv-1",
+      guardianExternalUserId: "guardian-1",
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      requestCode: "A1B2C3",
+      toolName: "shell",
+      inputDigest: "sha256:abc",
+      expiresAt: Date.now() + 60_000,
+    });
+    registerPendingToolApprovalInteraction(req.id, "conv-1", "shell");
+
+    const result = await routeGuardianReply(
+      replyCtx({
+        messageText: "*A1B2C3* approve",
+        conversationId: "conv-1",
+      }),
+    );
+
+    expect(result.consumed).toBe(true);
+    expect(result.type).toBe("canonical_decision_applied");
+    expect(result.decisionApplied).toBe(true);
+
+    const resolved = getCanonicalGuardianRequest(req.id);
+    expect(resolved!.status).toBe("approved");
+  });
+
+  test("**CODE** action — double-asterisk formatting wraps only the code portion", async () => {
+    const req = createCanonicalGuardianRequest({
+      kind: "tool_approval",
+      sourceType: "channel",
+      conversationId: "conv-1",
+      guardianExternalUserId: "guardian-1",
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      requestCode: "D4E5F6",
+      expiresAt: Date.now() + 60_000,
+    });
+    registerPendingToolApprovalInteraction(req.id, "conv-1", "shell");
+
+    const result = await routeGuardianReply(
+      replyCtx({
+        messageText: "**D4E5F6** reject",
+        conversationId: "conv-1",
+      }),
+    );
+
+    expect(result.consumed).toBe(true);
+    expect(result.type).toBe("canonical_decision_applied");
+    expect(result.decisionApplied).toBe(true);
+
+    const resolved = getCanonicalGuardianRequest(req.id);
+    expect(resolved!.status).toBe("denied");
+  });
 });
 
 // ===========================================================================

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -157,7 +157,11 @@ function parseRequestCode(
 ): CodeParseResult | null {
   // Strip common channel formatting delimiters (backticks, bold, italic,
   // strikethrough) that messaging platforms wrap around inline code.
-  const cleaned = text.replace(/^[`*_~]+/, "").replace(/[`*_~]+$/, "").trim();
+  const cleaned = text
+    .replace(/^[`*_~]+/, "")
+    .replace(/[`*_~]+$/, "")
+    .replace(/^([A-Fa-f0-9]{6})[`*_~]+/, "$1")
+    .trim();
   // Request codes are 6 hex chars (A-F, 0-9), uppercase
   const upper = cleaned.toUpperCase();
   const match = upper.match(/^([A-F0-9]{6})(?:\s|$)/);


### PR DESCRIPTION
Address review feedback on PR #22510. Add regex step to strip formatting chars after 6-char hex code so patterns like `*CODE* action` and `**CODE** action` parse correctly.

## Summary
- Add `.replace(/^([A-Fa-f0-9]{6})[`*_~]+/, "$1")` to the formatting cleanup chain in `parseRequestCode()`
- Add test cases for `*CODE* approve` and `**CODE** reject` patterns

## Test plan
- [x] New tests cover `*CODE* action` and `**CODE** action` patterns
- [x] Existing formatting tests still pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
