### PR TITLE
fix: update test expectations for memory_recall → recall rename

### DIFF
--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -771,7 +771,7 @@ describe("Trust Store", () => {
         "host_file_edit",
         "host_file_read",
         "host_file_write",
-        "memory_recall",
+        "recall",
         "scaffold_managed_skill",
         "skill_execute",
         "skill_load",

--- a/assistant/src/__tests__/workspace-policy.test.ts
+++ b/assistant/src/__tests__/workspace-policy.test.ts
@@ -257,7 +257,7 @@ describe("isWorkspaceScopedInvocation", () => {
   describe("always-scoped tools", () => {
     const safeTools = [
       "skill_load",
-      "memory_recall",
+      "recall",
       "ui_update",
       "ui_dismiss",
     ];


### PR DESCRIPTION
## Summary
- Update `trust-store.test.ts` and `workspace-policy.test.ts` to expect `recall` instead of `memory_recall`, completing the rename started in #22741

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23831970283/job/69467278554
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
