### PR TITLE
fix: remove all remaining memory_items table references after table drop

### DIFF
--- a/assistant/src/__tests__/memory-jobs-worker-backoff.test.ts
+++ b/assistant/src/__tests__/memory-jobs-worker-backoff.test.ts
@@ -37,11 +37,6 @@ mock.module("../memory/jobs-store.js", () => ({
   enqueuePruneOldConversationsJob: () => null,
 }));
 
-// Mock db.js (rawRun used in sweepStaleItems)
-mock.module("../memory/db.js", () => ({
-  rawRun: () => 0,
-}));
-
 import {
   POLL_INTERVAL_MAX_MS,
   POLL_INTERVAL_MIN_MS,

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -672,10 +672,8 @@ export async function runDaemon(): Promise<void> {
       try {
         const {
           maybeEnqueueGraphBootstrap,
-          migrateToolCreatedItems,
           cleanupStaleItemVectors,
         } = await import("../memory/graph/bootstrap.js");
-        migrateToolCreatedItems();
         maybeEnqueueGraphBootstrap();
         // Fire-and-forget: clean up orphaned Qdrant vectors from dropped memory_items table
         void cleanupStaleItemVectors().catch((err) =>

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -11,6 +11,7 @@ import { dirname, join } from "node:path";
 
 import { ensureDataDir, getDbPath } from "../util/platform.js";
 import { getDb, getSqlite } from "./db-connection.js";
+import { migrateToolCreatedItems } from "./graph/bootstrap.js";
 import {
   addCoreColumns,
   createActorRefreshTokenRecordsTable,
@@ -553,6 +554,10 @@ export function initializeDb(): void {
 
   // 101. Memory graph tables (nodes, edges, triggers)
   migrateCreateMemoryGraphTables(database);
+
+  // 101b. Migrate tool-created items from legacy memory_items → graph nodes
+  // MUST run before migration 102 drops memory_items so data is preserved.
+  migrateToolCreatedItems();
 
   // 102. Drop legacy memory_items and memory_item_sources tables (migrated to memory_graph_nodes)
   migrateDropMemoryItemsTables(database);

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -2,7 +2,6 @@ import { getConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/types.js";
 import { getLogger } from "../util/logger.js";
 import { getMemoryCheckpoint, setMemoryCheckpoint } from "./checkpoints.js";
-import { rawRun } from "./db.js";
 import { runConsolidation } from "./graph/consolidation.js";
 import { runDecayTick } from "./graph/decay.js";
 import { graphExtractJob } from "./graph/extraction-job.js";
@@ -123,9 +122,6 @@ export async function runMemoryJobsOnce(
   const config = getConfig();
   if (!config.memory.enabled) return 0;
   const enableScheduledCleanup = options.enableScheduledCleanup === true;
-
-  // Periodic stale item sweep (throttled to at most once per hour)
-  sweepStaleItems(config);
 
   // Fail jobs that have been running longer than the configured timeout
   const timedOut = failStalledJobs(config.memory.jobs.stalledJobTimeoutMs);
@@ -534,61 +530,3 @@ function maybeEnqueueGraphMaintenanceJobs(nowMs = Date.now()): void {
   }
 }
 
-// ── Stale item sweep ───────────────────────────────────────────────
-
-const STALE_SWEEP_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
-let lastStaleSweepMs = 0;
-
-/** Reset the sweep throttle so tests can call sweepStaleItems back-to-back. */
-export function resetStaleSweepThrottle(): void {
-  lastStaleSweepMs = 0;
-}
-
-/**
- * Mark deeply stale memory items as invalid. An item is considered deeply
- * stale when it has exceeded 2x its freshness window for its kind and has
- * not been recently accessed.
- *
- * This is non-destructive: items keep their data but get an `invalid_at`
- * timestamp that excludes them from retrieval queries.
- */
-export function sweepStaleItems(config: AssistantConfig): number {
-  const freshness = config.memory.retrieval.freshness;
-  if (!freshness.enabled) return 0;
-
-  const now = Date.now();
-  // Throttle: at most once per hour
-  if (now - lastStaleSweepMs < STALE_SWEEP_INTERVAL_MS) return 0;
-  lastStaleSweepMs = now;
-
-  let totalMarked = 0;
-  for (const [kind, maxAgeDays] of Object.entries(freshness.maxAgeDays)) {
-    if (maxAgeDays <= 0) continue;
-    // Mark invalid if: past 2x window, no access in the shield period, and not already invalid
-    const cutoffMs = now - maxAgeDays * 2 * 86_400_000;
-    const shieldCutoffMs = now - freshness.reinforcementShieldDays * 86_400_000;
-    const changes = rawRun(
-      `
-      UPDATE memory_items
-      SET invalid_at = ?
-      WHERE kind = ?
-        AND status = 'active'
-        AND invalid_at IS NULL
-        AND last_seen_at < ?
-        AND (access_count = 0 OR COALESCE(last_used_at, 0) < ?)
-    `,
-      now,
-      kind,
-      cutoffMs,
-      shieldCutoffMs,
-    );
-    if (changes > 0) {
-      log.info(
-        { kind, marked: changes, cutoffMs },
-        "Marked stale memory items as invalid",
-      );
-      totalMarked += changes;
-    }
-  }
-  return totalMarked;
-}


### PR DESCRIPTION
Address review feedback on PR #22708.

## Summary
- Remove `sweepStaleItems()` and all its artifacts (`resetStaleSweepThrottle`, `STALE_SWEEP_INTERVAL_MS`, `rawRun` import) from `jobs-worker.ts` — this function ran `UPDATE memory_items` on every worker tick, crashing hourly after migration 203 dropped the table
- Remove stale `db.js` mock from `memory-jobs-worker-backoff.test.ts`
- Fix migration ordering: move `migrateToolCreatedItems()` call from `lifecycle.ts` (post-`initializeDb()`) into `db-init.ts` (between migration 101 and 102) so tool-created items are migrated to graph nodes before the table is dropped — prevents irreversible data loss on upgrade
- Remove `migrateToolCreatedItems` import from `lifecycle.ts` (no longer needed there)

## Test plan
- [x] `sweepStaleItems` and `resetStaleSweepThrottle` have zero remaining references
- [x] Migration 101b runs before 102, preserving tool-created items before table drop
- [x] Worker tick no longer crashes hourly on `no such table: memory_items`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22754" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
