### PR TITLE
fix: sanitize playbook trigger strings to prevent newline corruption

### DIFF
--- a/assistant/src/config/bundled-skills/playbooks/tools/playbook-create.ts
+++ b/assistant/src/config/bundled-skills/playbooks/tools/playbook-create.ts
@@ -55,7 +55,8 @@ export async function executePlaybookCreate(
     priority,
   };
   const statement = JSON.stringify(playbook);
-  const subject = `Playbook: ${trigger}`.slice(0, 80);
+  const sanitizedTrigger = trigger.replace(/[\r\n]+/g, " ");
+  const subject = `Playbook: ${sanitizedTrigger}`.slice(0, 80);
   const content = `${subject}\n${statement}`;
   const scopeId = context.memoryScopeId ?? "default";
 

--- a/assistant/src/config/bundled-skills/playbooks/tools/playbook-update.ts
+++ b/assistant/src/config/bundled-skills/playbooks/tools/playbook-update.ts
@@ -91,7 +91,8 @@ export async function executePlaybookUpdate(
     };
 
     const statement = JSON.stringify(updated);
-    const subject = `Playbook: ${updated.trigger}`.slice(0, 80);
+    const sanitizedTrigger = updated.trigger.replace(/[\r\n]+/g, " ");
+    const subject = `Playbook: ${sanitizedTrigger}`.slice(0, 80);
     const content = `${subject}\n${statement}`;
 
     // Check for duplicate content among other playbook nodes


### PR DESCRIPTION
Address review feedback on PR #22705. Replace newlines in trigger strings before packing into the newline-delimited content field to prevent corrupted JSON parsing.

## Changes
- `playbook-create.ts`: Sanitize trigger by replacing `\r\n` with spaces before constructing the subject/content
- `playbook-update.ts`: Same sanitization when rebuilding content on update

## Why
The content field uses format `Playbook: <trigger>\n<JSON>`, and readers recover JSON by splitting on the first newline. A trigger containing newlines would produce a row that creates successfully but later parses as corrupted JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22755" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
