### PR TITLE
fix: add missing providerOverloaded case to iconForCategory switch

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -143,6 +143,8 @@ struct ChatConversationErrorToast: View {
             return .wifiOff
         case .rateLimit:
             return .clockAlert
+        case .providerOverloaded:
+            return .cloudOff
         case .providerApi:
             return .cloudOff
         case .providerBilling:


### PR DESCRIPTION
## Summary
- Add missing `.providerOverloaded` case to `iconForCategory` in `ChatErrorToastView.swift`, mapping it to `.cloudOff` (consistent with other provider error icons)
- Fixes macOS build failure: `switch must be exhaustive` on `ConversationErrorCategory`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23832211086/job/69468020552
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
