### PR TITLE
fix: handle web_search_tool_result in media retry stub token accounting

### DIFF
--- a/assistant/src/daemon/conversation-media-retry.ts
+++ b/assistant/src/daemon/conversation-media-retry.ts
@@ -176,7 +176,7 @@ export function estimateUnconditionalStubTokens(
         stubTokens += estimateContentBlockTokens(imageBlockToStub(block), options);
       } else if (block.type === "file" && msgIndex !== latestUserIndex) {
         stubTokens += estimateContentBlockTokens(fileBlockToStub(block), options);
-      } else if (block.type === "tool_result" && block.contentBlocks) {
+      } else if ((block.type === "tool_result" || block.type === "web_search_tool_result") && block.contentBlocks) {
         for (const cb of block.contentBlocks) {
           if (cb.type === "image") {
             stubTokens += estimateContentBlockTokens(imageBlockToStub(cb), options);


### PR DESCRIPTION
## Summary
- Add `web_search_tool_result` type check alongside `tool_result` in `estimateStubReplacementTokens` to satisfy the structural guard in `conversation-history-web-search.test.ts`
- The guard ensures all raw `tool_result` checks also handle `web_search_tool_result` to prevent web search results from being silently dropped

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23832211100/job/69468006403
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22757" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
