### PR TITLE
fix: retry overloaded_error with undefined statusCode from mid-stream SSE

### DIFF
--- a/assistant/src/__tests__/provider-error-scenarios.test.ts
+++ b/assistant/src/__tests__/provider-error-scenarios.test.ts
@@ -603,6 +603,27 @@ describe("RetryProvider — streaming response handling", () => {
     expect(receivedSignal).toBe(controller.signal);
   });
 
+  test("retries overloaded_error with undefined statusCode (mid-stream SSE)", async () => {
+    let callCount = 0;
+    const inner: Provider = {
+      name: "retry-overloaded-undefined",
+      async sendMessage() {
+        callCount++;
+        if (callCount <= 1) {
+          throw new ProviderError(
+            'Anthropic API error (undefined): {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+            "anthropic",
+            undefined,
+          );
+        }
+        return successResponse();
+      },
+    };
+    const provider = new RetryProvider(inner);
+    await provider.sendMessage(MESSAGES);
+    expect(callCount).toBe(2);
+  });
+
   test("events accumulate across retries (each attempt delivers events independently)", async () => {
     let callCount = 0;
     const inner: Provider = {

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -34,16 +34,30 @@ const RETRYABLE_STREAM_PATTERNS = [
   "stream has ended, this shouldn't happen",
 ];
 
+/**
+ * Patterns that indicate a transient provider error even when no HTTP status
+ * code is available (e.g. overloaded errors delivered as SSE events mid-stream
+ * where the initial HTTP response was 200).
+ */
+const RETRYABLE_PROVIDER_MESSAGE_PATTERNS = [/overloaded/i];
+
 function isRetryableStreamError(error: unknown): boolean {
   if (!(error instanceof ProviderError)) return false;
   if (error.statusCode !== undefined) return false; // has a real HTTP status — not a stream error
   return RETRYABLE_STREAM_PATTERNS.some((p) => error.message.includes(p));
 }
 
+function isRetryableProviderMessage(error: unknown): boolean {
+  if (!(error instanceof ProviderError)) return false;
+  if (error.statusCode !== undefined) return false; // has a real HTTP status — handled by status check
+  return RETRYABLE_PROVIDER_MESSAGE_PATTERNS.some((p) => p.test(error.message));
+}
+
 function isRetryableError(error: unknown): boolean {
   if (error instanceof ProviderError && error.statusCode !== undefined) {
     if (error.statusCode === 429 || error.statusCode >= 500) return true;
   }
+  if (isRetryableProviderMessage(error)) return true;
   if (isRetryableStreamError(error)) return true;
   return isRetryableNetworkError(error);
 }
@@ -161,9 +175,11 @@ export class RetryProvider implements Provider {
                   error.statusCode !== undefined &&
                   error.statusCode >= 500
                 ? `server_error_${error.statusCode}`
-                : isRetryableStreamError(error)
-                  ? "stream_corruption"
-                  : "network_error";
+                : isRetryableProviderMessage(error)
+                  ? "provider_overloaded"
+                  : isRetryableStreamError(error)
+                    ? "stream_corruption"
+                    : "network_error";
           log.warn(
             {
               attempt: attempt + 1,


### PR DESCRIPTION
## Summary
- When Anthropic returns `overloaded_error` mid-stream (SSE event, no HTTP status code), the `RetryProvider` now retries instead of immediately surfacing the error to the user
- Adds `isRetryableProviderMessage()` with `/overloaded/i` pattern, mirroring the existing `isRetryableStreamError()` approach for statusCode-less errors
- Adds test verifying retry works for the exact error shape seen in production logs

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
