### PR TITLE
fix: add missing mock exports and narrow media retry type check

### DIFF
--- a/assistant/src/__tests__/credential-security-e2e.test.ts
+++ b/assistant/src/__tests__/credential-security-e2e.test.ts
@@ -70,6 +70,8 @@ mock.module("../security/secure-keys.js", () => {
       accounts: [...storedKeys.keys()],
       unreachable: false,
     }),
+    getProviderKeyAsync: async () => undefined,
+    getMaskedProviderKey: async () => null,
   };
 });
 

--- a/assistant/src/__tests__/secret-onetime-send.test.ts
+++ b/assistant/src/__tests__/secret-onetime-send.test.ts
@@ -67,6 +67,8 @@ mock.module("../security/secure-keys.js", () => {
       syncSet(key, value),
     deleteSecureKeyAsync: async (key: string) => syncDelete(key),
     listSecureKeysAsync: async () => ({ accounts: [], unreachable: false }),
+    getProviderKeyAsync: async () => undefined,
+    getMaskedProviderKey: async () => null,
   };
 });
 

--- a/assistant/src/daemon/conversation-media-retry.ts
+++ b/assistant/src/daemon/conversation-media-retry.ts
@@ -176,7 +176,7 @@ export function estimateUnconditionalStubTokens(
         stubTokens += estimateContentBlockTokens(imageBlockToStub(block), options);
       } else if (block.type === "file" && msgIndex !== latestUserIndex) {
         stubTokens += estimateContentBlockTokens(fileBlockToStub(block), options);
-      } else if ((block.type === "tool_result" || block.type === "web_search_tool_result") && block.contentBlocks) {
+      } else if (block.type === "tool_result" && block.contentBlocks) {
         for (const cb of block.contentBlocks) {
           if (cb.type === "image") {
             stubTokens += estimateContentBlockTokens(imageBlockToStub(cb), options);


### PR DESCRIPTION
## Summary
- Add missing `getProviderKeyAsync` and `getMaskedProviderKey` exports to the `secure-keys.js` mock in `secret-onetime-send.test.ts` and `credential-security-e2e.test.ts` — these were added to the real module but never propagated to the mocks
- Narrow `conversation-media-retry.ts` stub token accounting to `tool_result` only — `web_search_tool_result` doesn't have `contentBlocks`, causing a type error

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23832309064/job/69468316653
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
