### PR TITLE
fix: add missing providerOverloaded case in iOS ChatContentView

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -648,6 +648,7 @@ struct ChatContentView: View {
         switch category {
         case .providerNetwork: return .wifiOff
         case .rateLimit: return .clockAlert
+        case .providerOverloaded: return .cloudOff
         case .providerApi: return .cloudOff
         case .providerOrdering: return .cloudOff
         case .providerWebSearch: return .cloudOff


### PR DESCRIPTION
## Summary
- Add missing `.providerOverloaded` case to the `conversationErrorIcon()` switch in `ChatContentView.swift` (iOS), matching the macOS and shared implementations that already use `.cloudOff` for this category.
- Fixes the iOS build failure introduced when `providerOverloaded` was added to `ConversationErrorCategory` in #22745.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23831970929/job/69467280754
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22761" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
