### PR TITLE
fix(macos): graceful handling of stale tool confirmation responses

### DIFF
--- a/clients/ios/Tests/ChatViewModelIOSTests.swift
+++ b/clients/ios/Tests/ChatViewModelIOSTests.swift
@@ -372,7 +372,7 @@ final class ChatViewModelIOSTests: XCTestCase {
 
     func testRespondToAlwaysAllowSendsHighRiskDecision() async {
         let mockInteraction = MockInteractionClient()
-        mockInteraction.results = [true]
+        mockInteraction.results = [.success]
 
         let vm = ChatViewModel(connectionManager: mockClient, eventStreamClient: mockClient.eventStreamClient, interactionClient: mockInteraction)
         vm.conversationId = "sess-hr"
@@ -394,7 +394,7 @@ final class ChatViewModelIOSTests: XCTestCase {
 
     func testRespondToAlwaysAllowSendsDefaultDecision() async {
         let mockInteraction = MockInteractionClient()
-        mockInteraction.results = [true]
+        mockInteraction.results = [.success]
 
         let vm = ChatViewModel(connectionManager: mockClient, eventStreamClient: mockClient.eventStreamClient, interactionClient: mockInteraction)
         vm.conversationId = "sess-default"
@@ -414,7 +414,7 @@ final class ChatViewModelIOSTests: XCTestCase {
     func testRespondToAlwaysAllowFallsBackWhenSendFails() async {
         let mockInteraction = MockInteractionClient()
         // First call (always_allow_high_risk) fails, fallback (allow) also fails
-        mockInteraction.results = [false, false]
+        mockInteraction.results = [.failed, .failed]
 
         let vm = ChatViewModel(connectionManager: mockClient, eventStreamClient: mockClient.eventStreamClient, interactionClient: mockInteraction)
         vm.conversationId = "sess-fallback"
@@ -453,7 +453,7 @@ final class ChatViewModelIOSTests: XCTestCase {
     func testRespondToAlwaysAllowConnectedSendFailureFallsBackToAllow() async {
         let mockInteraction = MockInteractionClient()
         // First call (always_allow_high_risk) fails, fallback (allow) succeeds
-        mockInteraction.results = [false, true]
+        mockInteraction.results = [.failed, .success]
 
         let vm = ChatViewModel(connectionManager: mockClient, eventStreamClient: mockClient.eventStreamClient, interactionClient: mockInteraction)
         vm.conversationId = "sess-fail-once"
@@ -534,10 +534,10 @@ private final class MockInteractionClient: InteractionClientProtocol {
 
     private(set) var calls: [Call] = []
     /// Return values for successive calls. Last value repeats for any extra calls.
-    var results: [Bool] = [true]
+    var results: [ConfirmationSendResult] = [.success]
 
-    func sendConfirmationResponse(requestId: String, decision: String, selectedPattern: String?, selectedScope: String?) async -> Bool {
-        let result = calls.count < results.count ? results[calls.count] : results.last ?? true
+    func sendConfirmationResponse(requestId: String, decision: String, selectedPattern: String?, selectedScope: String?) async -> ConfirmationSendResult {
+        let result = calls.count < results.count ? results[calls.count] : results.last ?? .success
         calls.append(Call(requestId: requestId, decision: decision, selectedPattern: selectedPattern, selectedScope: selectedScope))
         return result
     }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1748,10 +1748,19 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         markConfirmationInFlight(requestId: requestId, decision: decision)
         inlineResponseHandledRequestIds.insert(requestId)
         Task {
-            let success = await performConfirmationResponse(
+            let result = await performConfirmationResponse(
                 requestId: requestId, decision: decision, selectedPattern: nil, selectedScope: nil
             )
-            if !success {
+            switch result {
+            case .success:
+                break
+            case .alreadyResolved:
+                // The backend already auto-denied this confirmation (e.g. a new
+                // message arrived). Collapse the prompt silently — the SSE
+                // confirmation_state_changed event will confirm the final state.
+                log.info("[confirm-flow] respondToConfirmation: already resolved, collapsing silently: requestId=\(requestId, privacy: .public)")
+                self.collapseStaleConfirmation(requestId: requestId)
+            case .failed:
                 log.error("[confirm-flow] respondToConfirmation POST failed (will show error banner): requestId=\(requestId, privacy: .public) decision=\(decision, privacy: .public)")
                 self.revertConfirmationInFlight(requestId: requestId)
                 self.inlineResponseHandledRequestIds.remove(requestId)
@@ -1768,29 +1777,36 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         markConfirmationInFlight(requestId: requestId, decision: decision)
         inlineResponseHandledRequestIds.insert(requestId)
         Task {
-            let success = await interactionClient.sendConfirmationResponse(
+            let result = await interactionClient.sendConfirmationResponse(
                 requestId: requestId, decision: decision, selectedPattern: selectedPattern, selectedScope: selectedScope
             )
-            guard success else {
+            switch result {
+            case .success:
+                if let index = self.messages.firstIndex(where: { $0.confirmation?.requestId == requestId }) {
+                    self.messages[index].confirmation?.approvedDecision = decision
+                }
+                self.clearPendingConfirmation(requestId: requestId)
+                self.onInlineConfirmationResponse?(requestId, "allow")
+                self.inlineResponseHandledRequestIds.insert(requestId)
+            case .alreadyResolved:
+                log.info("[confirm-flow] respondToAlwaysAllow: already resolved, collapsing silently: requestId=\(requestId, privacy: .public)")
+                self.collapseStaleConfirmation(requestId: requestId)
+            case .failed:
                 log.warning("Always-allow send failed, trying one-time allow fallback")
-                let fallbackSuccess = await self.performConfirmationResponse(
+                let fallbackResult = await self.performConfirmationResponse(
                     requestId: requestId, decision: "allow", selectedPattern: nil, selectedScope: nil
                 )
-                if !fallbackSuccess {
+                switch fallbackResult {
+                case .success:
+                    self.errorText = "Preference could not be saved. This action was allowed once."
+                case .alreadyResolved:
+                    log.info("[confirm-flow] respondToAlwaysAllow fallback: already resolved, collapsing silently: requestId=\(requestId, privacy: .public)")
+                    self.collapseStaleConfirmation(requestId: requestId)
+                case .failed:
                     self.revertConfirmationInFlight(requestId: requestId)
                     self.inlineResponseHandledRequestIds.remove(requestId)
                 }
-                if fallbackSuccess {
-                    self.errorText = "Preference could not be saved. This action was allowed once."
-                }
-                return
             }
-            if let index = self.messages.firstIndex(where: { $0.confirmation?.requestId == requestId }) {
-                self.messages[index].confirmation?.approvedDecision = decision
-            }
-            self.clearPendingConfirmation(requestId: requestId)
-            self.onInlineConfirmationResponse?(requestId, "allow")
-            self.inlineResponseHandledRequestIds.insert(requestId)
         }
     }
 
@@ -1813,18 +1829,29 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         messages[index].confirmation?.approvedDecision = nil
     }
 
+    /// Collapse a stale confirmation that was already resolved by the backend
+    /// (e.g. auto-denied when a new message arrived). Marks it as denied and
+    /// cleans up tracking state without showing an error banner.
+    private func collapseStaleConfirmation(requestId: String) {
+        if let index = messages.firstIndex(where: { $0.confirmation?.requestId == requestId }) {
+            messages[index].confirmation?.state = .denied
+        }
+        clearPendingConfirmation(requestId: requestId)
+        onInlineConfirmationResponse?(requestId, "deny")
+        inlineResponseHandledRequestIds.insert(requestId)
+    }
+
     /// Shared async helper that sends a confirmation response and updates UI state on success.
-    /// Returns `true` if the send succeeded, `false` otherwise.
     private func performConfirmationResponse(
         requestId: String,
         decision: String,
         selectedPattern: String?,
         selectedScope: String?
-    ) async -> Bool {
-        let success = await interactionClient.sendConfirmationResponse(
+    ) async -> ConfirmationSendResult {
+        let result = await interactionClient.sendConfirmationResponse(
             requestId: requestId, decision: decision, selectedPattern: selectedPattern, selectedScope: selectedScope
         )
-        guard success else { return false }
+        guard result == .success else { return result }
         if let index = messages.firstIndex(where: { $0.confirmation?.requestId == requestId }) {
             let isApproval = decision == "allow" || decision == "allow_10m" || decision == "allow_conversation"
             messages[index].confirmation?.state = isApproval ? .approved : .denied
@@ -1835,7 +1862,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         clearPendingConfirmation(requestId: requestId)
         onInlineConfirmationResponse?(requestId, decision)
         inlineResponseHandledRequestIds.insert(requestId)
-        return true
+        return .success
     }
 
     /// Update the inline confirmation message state without sending a response to the daemon.

--- a/clients/shared/Network/InteractionClient.swift
+++ b/clients/shared/Network/InteractionClient.swift
@@ -3,10 +3,22 @@ import os
 
 private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "InteractionClient")
 
+/// Result of sending a confirmation response to the backend.
+public enum ConfirmationSendResult {
+    /// Backend accepted the confirmation (2xx).
+    case success
+    /// The requestId was already resolved or never existed (404).
+    /// This happens when the backend auto-denied a stale confirmation
+    /// before the user clicked the button — not a real error.
+    case alreadyResolved
+    /// Any other failure (network, auth, server error).
+    case failed
+}
+
 /// Focused client for user interaction responses (confirmations, secrets)
 /// routed through the gateway.
 public protocol InteractionClientProtocol {
-    func sendConfirmationResponse(requestId: String, decision: String, selectedPattern: String?, selectedScope: String?) async -> Bool
+    func sendConfirmationResponse(requestId: String, decision: String, selectedPattern: String?, selectedScope: String?) async -> ConfirmationSendResult
     func sendSecretResponse(requestId: String, value: String?, delivery: String?) async -> Bool
 }
 
@@ -20,7 +32,7 @@ public struct InteractionClient: InteractionClientProtocol {
         decision: String,
         selectedPattern: String? = nil,
         selectedScope: String? = nil
-    ) async -> Bool {
+    ) async -> ConfirmationSendResult {
         do {
             var body: [String: Any] = [
                 "requestId": requestId,
@@ -32,14 +44,18 @@ public struct InteractionClient: InteractionClientProtocol {
             let path = try Self.approvalPath(endpoint: "confirm")
             log.info("[confirm-flow] Sending POST /confirm: requestId=\(requestId, privacy: .public) decision=\(decision, privacy: .public)")
             let response = try await GatewayHTTPClient.post(path: path, json: body, timeout: 10)
-            if !response.isSuccess {
-                log.error("[confirm-flow] POST /confirm failed: requestId=\(requestId, privacy: .public) decision=\(decision, privacy: .public) HTTP \(response.statusCode)")
-                return false
+            if response.isSuccess {
+                return .success
             }
-            return true
+            if response.statusCode == 404 {
+                log.info("[confirm-flow] POST /confirm returned 404 (already resolved): requestId=\(requestId, privacy: .public)")
+                return .alreadyResolved
+            }
+            log.error("[confirm-flow] POST /confirm failed: requestId=\(requestId, privacy: .public) decision=\(decision, privacy: .public) HTTP \(response.statusCode)")
+            return .failed
         } catch {
             log.error("sendConfirmationResponse error: \(error.localizedDescription)")
-            return false
+            return .failed
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `ConfirmationSendResult` enum (`success`/`alreadyResolved`/`failed`) to distinguish 404 from other failures in `InteractionClient.sendConfirmationResponse()`
- When a confirmation POST returns 404 (already auto-denied by backend), silently collapse the prompt instead of showing a red error banner
- Update `respondToConfirmation()`, `respondToAlwaysAllow()`, and `performConfirmationResponse()` to handle all three result cases

## Original prompt
this incrementally, multiple PRs if it makes sense to split up
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
