### PR TITLE
fix(macos): enable text selection in step detail technical details

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -343,7 +343,6 @@ struct AssistantProgressView: View {
         }
         .background(VColor.surfaceOverlay)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-        .textSelection(.disabled)
         .onChange(of: toolCalls) { _, newToolCalls in
             handleToolCallsChange(newToolCalls)
         }
@@ -976,6 +975,7 @@ private struct StepDetailRow: View {
             }
         }
         .padding(.bottom, VSpacing.sm)
+        .textSelection(.enabled)
     }
 
     // MARK: - Output Block


### PR DESCRIPTION
## Summary
- Removed blanket `.textSelection(.disabled)` from `AssistantProgressView` that was preventing text selection in expanded step details
- Added `.textSelection(.enabled)` to `StepDetailRow.stepDetailContent` so users can click-and-drag to select input parameters, tool names, and output text

## Original prompt
I should be able to click and drag to select the text inside technical details