### PR TITLE
fix: add guard annotation for tool_result check in media retry

### DIFF
--- a/assistant/src/daemon/conversation-media-retry.ts
+++ b/assistant/src/daemon/conversation-media-retry.ts
@@ -176,7 +176,7 @@ export function estimateUnconditionalStubTokens(
         stubTokens += estimateContentBlockTokens(imageBlockToStub(block), options);
       } else if (block.type === "file" && msgIndex !== latestUserIndex) {
         stubTokens += estimateContentBlockTokens(fileBlockToStub(block), options);
-      } else if (block.type === "tool_result" && block.contentBlocks) {
+      } else if (block.type === "tool_result" && block.contentBlocks) { // guard:allow-tool-result-only — web_search_tool_result has no contentBlocks
         for (const cb of block.contentBlocks) {
           if (cb.type === "image") {
             stubTokens += estimateContentBlockTokens(imageBlockToStub(cb), options);


### PR DESCRIPTION
## Summary
- Add `guard:allow-tool-result-only` annotation to the `tool_result` type check at line 179 in `conversation-media-retry.ts`
- This check inspects `contentBlocks` for embedded media (images/files) — `web_search_tool_result` has no `contentBlocks`, so only `tool_result` is correct here
- Matches the existing pattern already used on lines 108 and 242 of the same file

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23832702107/job/69469541711