### PR TITLE
fix: add duplicate-content check when reactivating gone memory items

### DIFF
--- a/assistant/src/runtime/routes/memory-item-routes.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.ts
@@ -647,15 +647,19 @@ export async function handleUpdateMemoryItem(
     changes.significance = body.importance;
   }
 
-  // Check for content collision
-  if (contentChanged) {
+  // Check for content collision when content changed OR when reactivating a
+  // gone item (which could duplicate an existing active item's content).
+  const reactivating =
+    changes.fidelity === "vivid" && existing.fidelity === "gone";
+  if (contentChanged || reactivating) {
+    const contentToCheck = changes.content ?? existing.content;
     const db = getDb();
     const collision = db
       .select({ id: memoryGraphNodes.id })
       .from(memoryGraphNodes)
       .where(
         and(
-          eq(memoryGraphNodes.content, changes.content!),
+          eq(memoryGraphNodes.content, contentToCheck),
           ne(memoryGraphNodes.id, id),
           ne(memoryGraphNodes.fidelity, "gone"),
         ),


### PR DESCRIPTION
## Summary
- Broadens the duplicate-content collision check in `handleUpdateMemoryItem` to also run when reactivating a gone memory item (PATCH with `status: "active"`)
- Previously, the check only ran when `contentChanged` was true, allowing two active items with identical content when a gone item was reactivated without content changes
- Uses `changes.content ?? existing.content` as the content to check against

Addresses review feedback on #22744 from both Codex and Devin.

## Test plan
- [ ] PATCH a gone memory item with `status: "active"` when another active item has the same content → expect 409 CONFLICT
- [ ] PATCH a gone memory item with `status: "active"` when no active duplicate exists → expect success
- [ ] PATCH an active item with new content that collides → still returns 409 (existing behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
