### PR TITLE
fix: include bootstrap migration in test template DB hash

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -142,8 +142,8 @@ import {
 // ---------------------------------------------------------------------------
 
 function getTemplateDbPath(): string {
-  // Hash this file + all migration files so the template auto-invalidates
-  // when any migration changes.
+  // Hash this file + all migration files + bootstrap migration so the template
+  // auto-invalidates when any migration changes.
   const thisFile = new URL(import.meta.url).pathname;
   const hash = createHash("md5");
   hash.update(readFileSync(thisFile, "utf-8"));
@@ -152,6 +152,12 @@ function getTemplateDbPath(): string {
     if (name.endsWith(".ts")) {
       hash.update(readFileSync(join(migrationsDir, name), "utf-8"));
     }
+  }
+  // Include the bootstrap migration (migrateToolCreatedItems) which also runs
+  // during initializeDb but lives outside the migrations/ directory.
+  const bootstrapFile = join(dirname(thisFile), "graph", "bootstrap.ts");
+  if (existsSync(bootstrapFile)) {
+    hash.update(readFileSync(bootstrapFile, "utf-8"));
   }
   return join(
     tmpdir(),


### PR DESCRIPTION
## Summary
- Include `graph/bootstrap.ts` in the test template DB hash computation so changes to `migrateToolCreatedItems` invalidate stale test templates.

Addresses review feedback on #22754.

## Test plan
- [ ] Verify that modifying `graph/bootstrap.ts` produces a different template DB filename
- [ ] Confirm existing tests still pass with the updated hash

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22766" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
