### PR TITLE
fix: add providerOverloaded to transient accent color group

### DIFF
--- a/clients/ios/Views/ChatContentView.swift
+++ b/clients/ios/Views/ChatContentView.swift
@@ -665,7 +665,7 @@ struct ChatContentView: View {
     private func conversationErrorAccent(_ category: ConversationErrorCategory) -> Color {
         switch category {
         case .rateLimit: return VColor.systemNegativeHover
-        case .providerNetwork: return .orange
+        case .providerNetwork, .providerOverloaded: return .orange
         case .conversationAborted: return VColor.contentSecondary
         case .contextTooLarge: return VColor.systemNegativeHover
         default: return VColor.systemNegativeStrong

--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -180,7 +180,7 @@ struct ChatConversationErrorToast: View {
             return VColor.systemPositiveStrong
         case .contextTooLarge:
             return VColor.systemMidStrong
-        case .providerOrdering, .providerWebSearch:
+        case .providerOverloaded, .providerOrdering, .providerWebSearch:
             return VColor.systemMidStrong
         default:
             return VColor.systemNegativeStrong


### PR DESCRIPTION
Addresses review feedback on #22756. Adds `providerOverloaded` to the transient/retryable group in `accentColor(for:)` on macOS and `conversationErrorAccent` on iOS so it shows warm/amber instead of hard-failure red.

## Changes
- **macOS** (`ChatErrorToastView.swift`): Added `.providerOverloaded` to the transient group in `accentColor(for:)` → returns `VColor.systemMidStrong` (warm/amber)
- **iOS** (`ChatContentView.swift`): Added `.providerOverloaded` to the transient group in `conversationErrorAccent` → returns `.orange` (matching `providerNetwork`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22767" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
