### PR TITLE
fix: fix SQLite LIKE escaping and add migration for memory type rename

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-analyze-style.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-analyze-style.ts
@@ -46,6 +46,7 @@ function upsertMemoryItem(opts: {
     db.update(memoryGraphNodes)
       .set({
         content,
+        type: KIND_TO_MEMORY_TYPE[opts.kind] ?? opts.kind,
         fidelity: "vivid",
         significance: clampUnitInterval(
           Math.max(existing.significance ?? 0, opts.importance),

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -122,6 +122,7 @@ import {
   migrateRenameThreadStartersTable,
   migrateRenameVerificationSessionIdColumn,
   migrateRenameVerificationTable,
+  migrateRenameMemoryGraphTypeValues,
   migrateRenameVoiceToPhone,
   migrateScheduleOneShotRouting,
   migrateScheduleQuietFlag,
@@ -561,6 +562,9 @@ export function initializeDb(): void {
 
   // 102. Drop legacy memory_items and memory_item_sources tables (migrated to memory_graph_nodes)
   migrateDropMemoryItemsTables(database);
+
+  // 103. Rename legacy memory graph node type values: style → behavioral, relationship → semantic
+  migrateRenameMemoryGraphTypeValues(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/204-rename-memory-graph-type-values.ts
+++ b/assistant/src/memory/migrations/204-rename-memory-graph-type-values.ts
@@ -1,0 +1,49 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+/**
+ * One-shot migration: rename legacy memory graph node type values.
+ *
+ * The PR that introduced the memory graph used "style" and "relationship"
+ * as type values.  These were renamed to "behavioral" and "semantic" in
+ * code, but existing rows in the database still carry the old values.
+ */
+export function migrateRenameMemoryGraphTypeValues(database: DrizzleDb): void {
+  withCrashRecovery(
+    database,
+    "migration_rename_memory_graph_type_values_v1",
+    () => {
+      const raw = getSqliteFrom(database);
+      raw
+        .prepare(
+          /*sql*/ `UPDATE memory_graph_nodes SET type = 'behavioral' WHERE type = 'style'`,
+        )
+        .run();
+      raw
+        .prepare(
+          /*sql*/ `UPDATE memory_graph_nodes SET type = 'semantic' WHERE type = 'relationship'`,
+        )
+        .run();
+    },
+  );
+}
+
+/**
+ * Reverse: restore the original type values.
+ */
+export function migrateRenameMemoryGraphTypeValuesDown(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+  raw
+    .prepare(
+      /*sql*/ `UPDATE memory_graph_nodes SET type = 'style' WHERE type = 'behavioral'`,
+    )
+    .run();
+  raw
+    .prepare(
+      /*sql*/ `UPDATE memory_graph_nodes SET type = 'relationship' WHERE type = 'semantic'`,
+    )
+    .run();
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -144,6 +144,7 @@ export { migrateOAuthProvidersFeatureFlag } from "./201-oauth-providers-feature-
 export { migrateDropCallbackTransportColumn } from "./202-drop-callback-transport-column.js";
 export { migrateCreateMemoryGraphTables } from "./202-memory-graph-tables.js";
 export { migrateDropMemoryItemsTables } from "./203-drop-memory-items-tables.js";
+export { migrateRenameMemoryGraphTypeValues } from "./204-rename-memory-graph-type-values.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -39,6 +39,7 @@ import { migrateRenameThreadStartersCheckpointsDown } from "./181-rename-thread-
 import { migrateBackfillAudioAttachmentMimeTypesDown } from "./191-backfill-audio-attachment-mime-types.js";
 import { migrateAddSourceTypeColumnsDown } from "./193-add-source-type-columns.js";
 import { migrateStripIntegrationPrefixFromProviderKeysDown } from "./196-strip-integration-prefix-from-provider-keys.js";
+import { migrateRenameMemoryGraphTypeValuesDown } from "./204-rename-memory-graph-type-values.js";
 
 export interface MigrationRegistryEntry {
   /** The checkpoint key written to memory_checkpoints on completion. */
@@ -340,6 +341,13 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Strip integration: prefix from provider_key across oauth_providers, oauth_apps, and oauth_connections",
     down: migrateStripIntegrationPrefixFromProviderKeysDown,
+  },
+  {
+    key: "migration_rename_memory_graph_type_values_v1",
+    version: 39,
+    description:
+      "Rename legacy memory graph node type values: style → behavioral, relationship → semantic",
+    down: migrateRenameMemoryGraphTypeValuesDown,
   },
 ];
 

--- a/assistant/src/skills/skill-memory.ts
+++ b/assistant/src/skills/skill-memory.ts
@@ -11,9 +11,10 @@ import { getLogger } from "../util/logger.js";
 
 const log = getLogger("skill-memory");
 
-/** Escape SQL LIKE wildcards (`%` and `_`) so they match literally. */
+/** Strip SQL LIKE wildcards so they match literally.
+ * SQLite has no default escape character for LIKE, so we strip rather than escape. */
 function escapeLike(s: string): string {
-  return s.replace(/%/g, "\\%").replace(/_/g, "\\_");
+  return s.replace(/%/g, "").replace(/_/g, "");
 }
 
 /**


### PR DESCRIPTION
## Summary
Addresses review feedback on #22747:

- **Fix `escapeLike` in `skill-memory.ts`**: Strip LIKE wildcards (`%`, `_`) instead of backslash-escaping them. SQLite has no default escape character, so `\%` and `\_` don't work without an explicit `ESCAPE` clause. Follows the same pattern as `contact-store.ts`.
- **Add DB migration (204)**: Renames existing `style` → `behavioral` and `relationship` → `semantic` type values in `memory_graph_nodes` for records created before the type rename.
- **Self-healing upsert**: Include `type` in the `.set()` call of `upsertMemoryItem` so re-encountered records get their type corrected automatically.

## Test plan
- [x] Migration is idempotent (UPDATE WHERE matching old values is a no-op if already renamed)
- [x] `escapeLike` now strips wildcards consistently with `contact-store.ts`
- [x] Existing upsert paths will correct stale type values on next encounter

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
