### PR TITLE
fix: address review feedback on memory graph PR #22698

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -712,7 +712,7 @@ export async function runAgentLoopImpl(
       }
     }
 
-    // NOW.md scratchpad removed — replaced by the memory graph `remember` tool.
+    // The `remember` tool handles scratchpad-style memory writes directly to the graph.
 
     const isInteractiveResolved =
       options?.isInteractive ?? (!ctx.hasNoClient && !ctx.headlessLock);

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -150,6 +150,7 @@ export interface DisposeContext extends AbortContext {
   currentTurnSurfaces: Array<unknown>;
   lastSurfaceAction: Map<string, unknown>;
   workspaceTopLevelContext: string | null;
+  trustContext?: { trustClass: TrustClass };
   abort(): void;
 }
 
@@ -282,13 +283,17 @@ export function disposeConversation(ctx: DisposeContext): void {
     // Best-effort — don't block conversation disposal
   }
 
-  // Trigger graph extraction for end-of-conversation sweep
-  try {
-    enqueueMemoryJob("graph_extract", {
-      conversationId: ctx.conversationId,
-    });
-  } catch {
-    // Best-effort — don't block conversation disposal
+  // Trigger graph extraction for end-of-conversation sweep.
+  // Only extract from guardian conversations to preserve the memory trust
+  // boundary — untrusted content must not influence future memory retrieval.
+  if (!isUntrustedTrustClass(ctx.trustContext?.trustClass)) {
+    try {
+      enqueueMemoryJob("graph_extract", {
+        conversationId: ctx.conversationId,
+      });
+    } catch {
+      // Best-effort — don't block conversation disposal
+    }
   }
 
   ctx.abort();

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1051,6 +1051,9 @@ const RUNTIME_INJECTION_PREFIXES = [
   "<memory_context>", // backward-compat: strip legacy blocks from pre-__injected history
   // NOTE: <memory __injected> is intentionally NOT stripped — memory
   // injections persist in history so the assistant can reference them.
+  // Context compaction handles these blocks during history reduction, and
+  // the InContextTracker deduplicates nodes across turns, so accumulation
+  // does not cause unbounded context growth.
   "<voice_call_control>",
   "<workspace_top_level>",
   TEMPORAL_INJECTED_PREFIX,

--- a/assistant/src/memory/graph/extraction-job.ts
+++ b/assistant/src/memory/graph/extraction-job.ts
@@ -45,8 +45,11 @@ export async function graphExtractJob(
       afterTimestamp,
     });
 
-    // Update checkpoint to now — next extraction picks up from here
-    setMemoryCheckpoint(checkpointKey, String(Date.now()));
+    // Update checkpoint to the newest message actually processed — using
+    // Date.now() could skip messages that arrived during extraction.
+    if (result.lastProcessedTimestamp) {
+      setMemoryCheckpoint(checkpointKey, String(result.lastProcessedTimestamp));
+    }
 
     log.info(
       {

--- a/assistant/src/memory/graph/extraction.ts
+++ b/assistant/src/memory/graph/extraction.ts
@@ -586,6 +586,8 @@ export interface ExtractionResult {
   nodesReinforced: number;
   edgesCreated: number;
   triggersCreated: number;
+  /** Epoch ms of the newest message included in extraction. Used for checkpointing. */
+  lastProcessedTimestamp?: number;
 }
 
 /**
@@ -819,6 +821,7 @@ export async function runGraphExtraction(
     nodesReinforced: result.nodesReinforced,
     edgesCreated,
     triggersCreated,
+    lastProcessedTimestamp: conversationTimestamp,
   };
 }
 

--- a/assistant/src/memory/graph/tool-handlers.ts
+++ b/assistant/src/memory/graph/tool-handlers.ts
@@ -144,23 +144,25 @@ async function handleMemoryRecall(
 
 async function handleArchiveRecall(
   input: RecallInput,
-  _scopeId: string,
+  scopeId: string,
 ): Promise<RecallResult> {
   // Archive mode: search raw conversation transcripts via messages FTS
   // This is a simple text search — no embedding needed
   const { rawAll } = await import("../db.js");
 
   try {
-    // Use SQLite FTS on messages table
+    // Use SQLite FTS on messages table, scoped to the active memory scope
     const rows = rawAll(
       `SELECT m.id, m.content, m.role, m.created_at, c.id as conversation_id
        FROM messages_fts fts
        JOIN messages m ON m.rowid = fts.rowid
        JOIN conversations c ON c.id = m.conversation_id
        WHERE messages_fts MATCH ?
+         AND c.memory_scope_id = ?
        ORDER BY rank
        LIMIT 20`,
       input.query,
+      scopeId,
     ) as Array<{
       id: string;
       content: string;

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -128,8 +128,7 @@ export function ensurePromptFiles(): void {
     }
   }
 
-  // NOW.md scratchpad removed — replaced by the `remember` tool which
-  // writes immediately to the memory graph.
+  // The `remember` tool handles scratchpad-style memory writes directly to the graph.
 
   // Seed users/default.md persona template
   try {
@@ -275,8 +274,8 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   const integrationSection = buildIntegrationSection();
   if (integrationSection) dynamicParts.push(integrationSection);
 
-  // Journal context removed — memories are now managed by the memory graph.
-  // Journal files remain writable and are extracted into graph nodes.
+  // Journal entries are extracted into graph nodes by the memory pipeline.
+  // Journal files remain writable on disk.
 
   const dynamic = dynamicParts.join("\n\n");
 


### PR DESCRIPTION
Addresses valid review feedback from Codex and Devin on #22698:

- Gate graph_extract enqueue on trusted provenance in disposeConversation
- Use newest processed message timestamp for extraction checkpoint instead of Date.now()
- Add scopeId filter to archive recall SQL query
- Fix three comments that narrate removed code to describe current state instead
- Clarify memory block accumulation behavior with explanatory comment
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
