### PR TITLE
fix(macos): use ConfirmationSendResult enum instead of Bool in AppDelegate

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -121,11 +121,11 @@ extension AppDelegate {
                 && msg.conversationId == cuConversationId
             if cuAutoApprove, confirmationMatchesCuSession,
                (msg.riskLevel == "low" || msg.riskLevel == "medium") {
-                let success = await InteractionClient().sendConfirmationResponse(
+                let result = await InteractionClient().sendConfirmationResponse(
                     requestId: msg.requestId,
                     decision: "allow"
                 )
-                if success {
+                if result == .success {
                     self.mainWindow?.conversationManager.updateConfirmationStateAcrossConversations(
                         requestId: msg.requestId,
                         decision: "allow"
@@ -152,11 +152,11 @@ extension AppDelegate {
             guard decision != ToolConfirmationNotificationService.inlineHandledSentinel else {
                 return
             }
-            let success = await InteractionClient().sendConfirmationResponse(
+            let result = await InteractionClient().sendConfirmationResponse(
                 requestId: msg.requestId,
                 decision: decision
             )
-            if success {
+            if result == .success {
                 self.mainWindow?.conversationManager.updateConfirmationStateAcrossConversations(
                     requestId: msg.requestId,
                     decision: decision


### PR DESCRIPTION
## Summary
- `sendConfirmationResponse` was changed to return `ConfirmationSendResult` instead of `Bool`, but two call sites in `AppDelegate+WindowsAndSurfaces.swift` still treated the return value as a `Bool`
- Updated both the CU auto-approve path (line 124) and the notification path (line 155) to compare against `.success`

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23833074061/job/69470890365
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
