### PR TITLE
fix: remove 1024-token minimum floor from image token estimation

### DIFF
--- a/assistant/src/__tests__/context-token-estimator.test.ts
+++ b/assistant/src/__tests__/context-token-estimator.test.ts
@@ -69,7 +69,7 @@ describe("token estimator", () => {
           data: "a".repeat(100),
         },
       }),
-    ).toBeGreaterThan(500);
+    ).toBeGreaterThan(0);
   });
 
   test("estimates message and prompt totals", () => {
@@ -323,10 +323,7 @@ describe("token estimator", () => {
     );
 
     // Should fall back to ANTHROPIC_IMAGE_MAX_TOKENS (1,600)
-    // The total will include IMAGE_BLOCK_OVERHEAD_TOKENS + media_type overhead,
-    // but the max is applied at the outer Math.max(IMAGE_BLOCK_TOKENS, ...) level
-    // ANTHROPIC_IMAGE_MAX_TOKENS = 1600
-    // Total = max(1024, 16 + ceil(9/4) + 1600) = max(1024, 1619) = 1619
+    // Total = 16 (block overhead) + ceil(9/4) (media_type) + 1600 = 1619
     expect(tokens).toBeGreaterThanOrEqual(1_600);
     expect(tokens).toBeLessThan(2_000);
   });
@@ -420,6 +417,66 @@ describe("token estimator", () => {
     // tokens = ceil(1096 * 1096 / 750) = ceil(1601.6) ≈ 1602
     // Without megapixel cap would have been ceil(1568 * 1568 / 750) ≈ 3277
     expect(tokens).toBeLessThanOrEqual(1_700);
+  });
+
+  test("small Anthropic images are not inflated to 1024 tokens", () => {
+    // 200x200 image: ceil(200*200/750) = ceil(53.33) = 54 tokens
+    const tokens = estimateContentBlockTokens(
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/png",
+          data: makePngBase64(200, 200),
+        },
+      },
+      { providerName: "anthropic" },
+    );
+
+    // 54 (dimension-based) + 16 (block overhead) + 3 (media type) = 73
+    expect(tokens).toBeLessThan(100);
+    expect(tokens).toBeGreaterThan(50);
+  });
+
+  test("thumbnail Anthropic images estimate accurately", () => {
+    // 150x150 image: ceil(150*150/750) = ceil(30) = 30 tokens
+    const tokens = estimateContentBlockTokens(
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/png",
+          data: makePngBase64(150, 150),
+        },
+      },
+      { providerName: "anthropic" },
+    );
+
+    // 30 + 16 + 3 = 49
+    expect(tokens).toBeLessThan(70);
+    expect(tokens).toBeGreaterThan(30);
+  });
+
+  test("many small Anthropic images do not trigger phantom token inflation", () => {
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: Array.from({ length: 100 }, () => ({
+          type: "image" as const,
+          source: {
+            type: "base64" as const,
+            media_type: "image/png",
+            data: makePngBase64(200, 200),
+          },
+        })),
+      },
+    ];
+
+    const total = estimateMessagesTokens(messages, { providerName: "anthropic" });
+
+    // Each image: ~73 tokens. 100 images + message overhead ≈ 7,304
+    // Old behavior: 100 * ~1,043 = ~104,300 (14x overestimate)
+    expect(total).toBeLessThan(10_000);
   });
 
   test("matches Anthropic's published table for common aspect ratios", () => {

--- a/assistant/src/context/token-estimator.ts
+++ b/assistant/src/context/token-estimator.ts
@@ -9,7 +9,6 @@ const CHARS_PER_TOKEN = 4;
 const MESSAGE_OVERHEAD_TOKENS = 4;
 const TEXT_BLOCK_OVERHEAD_TOKENS = 2;
 const TOOL_BLOCK_OVERHEAD_TOKENS = 16;
-const IMAGE_BLOCK_TOKENS = 1024;
 const IMAGE_BLOCK_OVERHEAD_TOKENS = 16;
 const FILE_BLOCK_OVERHEAD_TOKENS = 48;
 const WEB_SEARCH_RESULT_TOKENS = 800;
@@ -104,10 +103,7 @@ function estimateAnthropicImageTokens(width: number, height: number): number {
     scaledHeight = Math.round(scaledHeight * mpScale);
   }
 
-  return Math.max(
-    IMAGE_BLOCK_TOKENS, // minimum 1024
-    Math.ceil(scaledWidth * scaledHeight * ANTHROPIC_IMAGE_TOKENS_PER_PIXEL),
-  );
+  return Math.ceil(scaledWidth * scaledHeight * ANTHROPIC_IMAGE_TOKENS_PER_PIXEL);
 }
 
 function estimateImageTokens(
@@ -155,11 +151,10 @@ export function estimateContentBlockTokens(
       return tokens;
     }
     case "image":
-      return Math.max(
-        IMAGE_BLOCK_TOKENS,
+      return (
         IMAGE_BLOCK_OVERHEAD_TOKENS +
-          estimateTextTokens(block.source.media_type) +
-          estimateImageTokens(block, options),
+        estimateTextTokens(block.source.media_type) +
+        estimateImageTokens(block, options)
       );
     case "file":
       return (


### PR DESCRIPTION
## Summary
- Removed `IMAGE_BLOCK_TOKENS = 1024` minimum floor that inflated small Anthropic image token estimates by up to 35x (150x150 thumbnail: 1,043 estimated vs ~30 actual)
- This caused premature context compaction in image-heavy conversations — the estimator crossed the 160k threshold while actual usage was far lower
- Added regression tests for small images and the many-images compaction scenario

## Original prompt
Fix premature context compaction caused by image token overestimation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
