### PR TITLE
fix: update media retry test for new image token estimation

### DIFF
--- a/assistant/src/__tests__/conversation-media-retry.test.ts
+++ b/assistant/src/__tests__/conversation-media-retry.test.ts
@@ -103,9 +103,10 @@ describe("stripMediaPayloadsForRetry", () => {
   // ---------------------------------------------------------------------------
 
   test("budget-aware: keeps images that fit within token budget", () => {
-    // Each small image (data length 100) costs 1024 tokens on non-Anthropic.
-    // Budget of 3500 allows 3 images (3 * 1024 = 3072 <= 3500) but not 4.
-    const images = Array.from({ length: 5 }, () => makeImageBlockWithSize(100));
+    // Non-Anthropic estimation: estimateTextTokens(base64Data) + overhead (~19 tokens).
+    // Data length 4000 → 1000 data tokens + 19 overhead ≈ 1019 tokens/image.
+    // Budget of 3500 allows 3 images (3 * 1019 = 3057 <= 3500) but not 4.
+    const images = Array.from({ length: 5 }, () => makeImageBlockWithSize(4000));
     const messages: Message[] = [
       makeUserMessage({ type: "text", text: "describe these" }, ...images),
     ];


### PR DESCRIPTION
## Summary
- Updated `conversation-media-retry.test.ts` budget-aware test to use 4000-byte images instead of 100-byte images
- The 1024-token minimum floor for image estimation was removed in #22772, so small images now estimate at ~44 tokens instead of 1024 — all 5 fit within the 3500-token budget and nothing gets stripped
- With 4000-byte images, each costs ~1019 tokens, so 3 fit (3057 ≤ 3500) but not 4

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23836476408/job/69481406754
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
