### PR TITLE
fix: allow memory reload on tool-result turns after compaction

### DIFF
--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -160,13 +160,15 @@ export class ConversationGraphMemory {
       mode: "none" as const,
     };
 
-    // Gate: skip for empty/tool-result-only messages
+    // Gate: skip for empty/tool-result-only messages — unless we need to
+    // reload after compaction (needsReload) or haven't initialized yet.
     const lastMessage = messages[messages.length - 1];
     if (!lastMessage || lastMessage.role !== "user") return noopResult;
     const hasUserContent = lastMessage.content.some(
       (block) => block.type === "text" && block.text.trim().length > 0,
     );
-    if (!hasUserContent) return noopResult;
+    if (!hasUserContent && this.initialized && !this.needsReload)
+      return noopResult;
 
     try {
       // Decide which retrieval mode to use


### PR DESCRIPTION
## Summary
- Modify the `hasUserContent` gate in `prepareMemory()` to bypass when `needsReload` is true or uninitialized
- Previously, memory injection was skipped on tool-result-only turns even after compaction set `needsReload = true`
- Now the context-load path fires on tool-result turns when compaction has happened, using conversation summaries as query signal

Part of plan: memory-reinjection-after-compaction.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
