### PR TITLE
feat: add `reinjectCachedMemory` to ConversationGraphMemory

### DIFF
--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -46,6 +46,8 @@ export class ConversationGraphMemory {
   private needsReload = false;
   private scopeId: string;
   private conversationId: string;
+  private lastInjectedBlock: string | null = null;
+  private lastInjectedNodeIds: string[] = [];
 
   constructor(scopeId: string, conversationId: string) {
     this.scopeId = scopeId;
@@ -126,6 +128,26 @@ export class ConversationGraphMemory {
       { compactedMessageCount },
       "Compaction detected — will reload context on next turn",
     );
+  }
+
+  /**
+   * Re-inject the most recent memory block after context compaction.
+   * Synchronous — reuses the cached block from the last successful retrieval.
+   * Does NOT advance turn count or run new retrieval.
+   */
+  reinjectCachedMemory(messages: Message[]): {
+    runMessages: Message[];
+    injectedTokens: number;
+  } {
+    if (!this.lastInjectedBlock) {
+      return { runMessages: messages, injectedTokens: 0 };
+    }
+    // Re-track node IDs since onCompacted evicted them
+    this.tracker.add(this.lastInjectedNodeIds);
+    return {
+      runMessages: injectTextBlock(messages, this.lastInjectedBlock),
+      injectedTokens: estimateTextTokens(this.lastInjectedBlock),
+    };
   }
 
   /**
@@ -258,6 +280,12 @@ export class ConversationGraphMemory {
       degraded: false,
     } as ServerMessage);
 
+    this.lastInjectedBlock = contextBlock;
+    this.lastInjectedNodeIds = [
+      ...result.nodes.map((n) => n.node.id),
+      ...result.serendipityNodes.map((n) => n.node.id),
+    ];
+
     return {
       runMessages: injectTextBlock(messages, contextBlock),
       injectedTokens,
@@ -313,6 +341,9 @@ export class ConversationGraphMemory {
         mode: "refresh" as const,
       };
     }
+
+    this.lastInjectedBlock = injectionBlock;
+    this.lastInjectedNodeIds = result.nodes.map((n) => n.node.id);
 
     return {
       runMessages: injectTextBlock(messages, injectionBlock),
@@ -378,6 +409,9 @@ export class ConversationGraphMemory {
         mode: "per-turn" as const,
       };
     }
+
+    this.lastInjectedBlock = injectionBlock;
+    this.lastInjectedNodeIds = result.nodes.map((n) => n.node.id);
 
     return {
       runMessages: injectTextBlock(messages, injectionBlock),


### PR DESCRIPTION
## Summary
- Add `lastInjectedBlock` and `lastInjectedNodeIds` cache fields to `ConversationGraphMemory`
- Cache the assembled memory text and node IDs in all three retrieval modes (context-load, refresh, per-turn)
- Add synchronous `reinjectCachedMemory()` method that re-prepends the cached block and re-tracks node IDs

Part of plan: memory-reinjection-after-compaction.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
