### PR TITLE
fix: call `onCompacted` and re-inject memory at all compaction sites

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -460,6 +460,10 @@ function makeCtx(
     graphMemory: {
       onCompacted: () => {},
       prepareMemory: async () => ({ runMessages: [], injectedTokens: 0, latencyMs: 0, mode: "none" as const }),
+      reinjectCachedMemory: (messages: Message[]) => ({
+        runMessages: messages,
+        injectedTokens: 0,
+      }),
     } as unknown as AgentLoopConversationContext["graphMemory"],
 
     ...overrides,

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -448,6 +448,10 @@ function makeCtx(
     graphMemory: {
       onCompacted: () => {},
       prepareMemory: async () => ({ runMessages: [], injectedTokens: 0, latencyMs: 0, mode: "none" as const }),
+      reinjectCachedMemory: (messages: Message[]) => ({
+        runMessages: messages,
+        injectedTokens: 0,
+      }),
     } as unknown as AgentLoopConversationContext["graphMemory"],
 
     ...overrides,

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -840,6 +840,9 @@ export async function runAgentLoopImpl(
             step.compactionResult.summaryCacheReadInputTokens ?? 0,
             collapseRawResponses(step.compactionResult.summaryRawResponses),
           );
+          ctx.graphMemory.onCompacted(
+            step.compactionResult.compactedPersistedMessages,
+          );
         }
 
         // Re-inject with potentially downgraded injection mode
@@ -847,6 +850,10 @@ export async function runAgentLoopImpl(
           ...injectionOpts,
           mode: currentInjectionMode,
         });
+        if (isTrustedActor && currentInjectionMode !== "minimal") {
+          const memResult = ctx.graphMemory.reinjectCachedMemory(runMessages);
+          runMessages = memResult.runMessages;
+        }
 
         // Re-estimate with injections included — step.estimatedTokens was
         // computed on bare history (ctx.messages) and doesn't account for
@@ -1024,6 +1031,9 @@ export async function runAgentLoopImpl(
           midLoopCompact.summaryCacheReadInputTokens ?? 0,
           collapseRawResponses(midLoopCompact.summaryRawResponses),
         );
+        ctx.graphMemory.onCompacted(
+          midLoopCompact.compactedPersistedMessages,
+        );
       }
 
       // Re-inject runtime context and re-enter the agent loop
@@ -1031,6 +1041,10 @@ export async function runAgentLoopImpl(
         ...injectionOpts,
         mode: currentInjectionMode,
       });
+      if (isTrustedActor && currentInjectionMode !== "minimal") {
+        const memResult = ctx.graphMemory.reinjectCachedMemory(runMessages);
+        runMessages = memResult.runMessages;
+      }
       preRepairMessages = runMessages;
       preRunHistoryLength = runMessages.length;
 
@@ -1220,12 +1234,19 @@ export async function runAgentLoopImpl(
             step.compactionResult.summaryCacheReadInputTokens ?? 0,
             collapseRawResponses(step.compactionResult.summaryRawResponses),
           );
+          ctx.graphMemory.onCompacted(
+            step.compactionResult.compactedPersistedMessages,
+          );
         }
 
         runMessages = applyRuntimeInjections(ctx.messages, {
           ...injectionOpts,
           mode: currentInjectionMode,
         });
+        if (isTrustedActor && currentInjectionMode !== "minimal") {
+          const memResult = ctx.graphMemory.reinjectCachedMemory(runMessages);
+          runMessages = memResult.runMessages;
+        }
         preRepairMessages = runMessages;
         preRunHistoryLength = runMessages.length;
         state.contextTooLargeDetected = false;
@@ -1327,12 +1348,19 @@ export async function runAgentLoopImpl(
                 emergencyCompact.summaryCacheReadInputTokens ?? 0,
                 collapseRawResponses(emergencyCompact.summaryRawResponses),
               );
+              ctx.graphMemory.onCompacted(
+                emergencyCompact.compactedPersistedMessages,
+              );
             }
 
             runMessages = applyRuntimeInjections(ctx.messages, {
               ...injectionOpts,
               mode: currentInjectionMode,
             });
+            if (isTrustedActor && currentInjectionMode !== "minimal") {
+              const memResult = ctx.graphMemory.reinjectCachedMemory(runMessages);
+              runMessages = memResult.runMessages;
+            }
             preRepairMessages = runMessages;
             preRunHistoryLength = runMessages.length;
             state.contextTooLargeDetected = false;
@@ -1431,12 +1459,19 @@ export async function runAgentLoopImpl(
               emergencyCompact.summaryCacheReadInputTokens ?? 0,
               collapseRawResponses(emergencyCompact.summaryRawResponses),
             );
+            ctx.graphMemory.onCompacted(
+              emergencyCompact.compactedPersistedMessages,
+            );
           }
 
           runMessages = applyRuntimeInjections(ctx.messages, {
             ...injectionOpts,
             mode: currentInjectionMode,
           });
+          if (isTrustedActor && currentInjectionMode !== "minimal") {
+            const memResult = ctx.graphMemory.reinjectCachedMemory(runMessages);
+            runMessages = memResult.runMessages;
+          }
           preRepairMessages = runMessages;
           preRunHistoryLength = runMessages.length;
           state.contextTooLargeDetected = false;


### PR DESCRIPTION
## Summary
- Add `ctx.graphMemory.onCompacted()` calls at all 5 compaction sites that were missing them
- After each compaction + runtime re-injection, re-inject cached memory via `reinjectCachedMemory()`
- Gate memory re-injection on `isTrustedActor && currentInjectionMode !== "minimal"`
- Update test mocks in both agent-loop test files to include the new method

Part of plan: memory-reinjection-after-compaction.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
