### PR TITLE
fix: clear memory cache on zero-result retrieval after compaction

### DIFF
--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -249,6 +249,8 @@ export class ConversationGraphMemory {
     this.needsReload = false;
 
     if (result.nodes.length === 0) {
+      this.lastInjectedBlock = null;
+      this.lastInjectedNodeIds = [];
       return {
         runMessages: messages,
         injectedTokens: 0,
@@ -323,6 +325,8 @@ export class ConversationGraphMemory {
     });
 
     if (result.nodes.length === 0) {
+      this.lastInjectedBlock = null;
+      this.lastInjectedNodeIds = [];
       return {
         runMessages: messages,
         injectedTokens: 0,
@@ -391,6 +395,8 @@ export class ConversationGraphMemory {
     });
 
     if (result.nodes.length === 0) {
+      this.lastInjectedBlock = null;
+      this.lastInjectedNodeIds = [];
       return {
         runMessages: messages,
         injectedTokens: 0,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for memory-reinjection-after-compaction.md.

**Gap:** Stale memory cache on zero-result retrieval after compaction
**What was expected:** Cache cleared when retrieval returns 0 nodes
**What was found:** Zero-result early returns in runContextLoad, runRefresh, and runPerTurn did not clear lastInjectedBlock/lastInjectedNodeIds
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
