### PR TITLE
fix: downscale oversized images at ingestion to prevent 413 errors

### DIFF
--- a/assistant/src/agent/attachments.ts
+++ b/assistant/src/agent/attachments.ts
@@ -1,4 +1,5 @@
 import type { ContentBlock, Message } from "../providers/types.js";
+import { optimizeImageForTransport } from "./image-optimize.js";
 
 export interface MessageAttachmentInput {
   id?: string;
@@ -14,12 +15,16 @@ export function attachmentsToContentBlocks(
 ): ContentBlock[] {
   return attachments.map((attachment) => {
     if (attachment.mimeType.toLowerCase().startsWith("image/")) {
+      const { data, mediaType } = optimizeImageForTransport(
+        attachment.data,
+        attachment.mimeType,
+      );
       return {
         type: "image",
         source: {
           type: "base64",
-          media_type: attachment.mimeType,
-          data: attachment.data,
+          media_type: mediaType,
+          data,
         },
       } as ContentBlock;
     }

--- a/assistant/src/agent/image-optimize.ts
+++ b/assistant/src/agent/image-optimize.ts
@@ -1,0 +1,167 @@
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { parseImageDimensions } from "../context/image-dimensions.js";
+import { getWorkspaceDir } from "../util/platform.js";
+
+// Anthropic's documented max dimension — images larger than this are scaled
+// down server-side anyway, so pre-scaling is zero quality loss.
+const MAX_DIMENSION = 1568;
+
+// Threshold below which we skip optimization — small images don't need it.
+const OPTIMIZE_THRESHOLD_BYTES = 300 * 1024; // 300 KB
+
+const JPEG_QUALITY = 80;
+
+// Content-addressed disk cache to avoid re-running sips on the same image.
+const CACHE_SUBDIR = "cache/optimized-images";
+const CACHE_MAX_ENTRIES = 500;
+
+function getCacheDir(): string {
+  return join(getWorkspaceDir(), CACHE_SUBDIR);
+}
+
+function readFromCache(
+  key: string,
+): { data: string; mediaType: string } | null {
+  try {
+    const cachePath = join(getCacheDir(), `${key}.jpg`);
+    if (!existsSync(cachePath)) return null;
+    const buf = readFileSync(cachePath) as Buffer;
+    return { data: buf.toString("base64"), mediaType: "image/jpeg" };
+  } catch {
+    return null;
+  }
+}
+
+function writeToCache(key: string, optimizedBytes: Buffer): void {
+  try {
+    const dir = getCacheDir();
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `${key}.jpg`), optimizedBytes);
+    evictIfNeeded(dir);
+  } catch {
+    // Cache write failure is non-fatal.
+  }
+}
+
+function evictIfNeeded(dir: string): void {
+  try {
+    const entries = readdirSync(dir)
+      .filter((f) => f.endsWith(".jpg"))
+      .map((f) => {
+        const full = join(dir, f);
+        return { path: full, mtimeMs: statSync(full).mtimeMs };
+      })
+      .sort((a, b) => a.mtimeMs - b.mtimeMs);
+    let excess = entries.length - CACHE_MAX_ENTRIES;
+    for (let i = 0; i < excess; i++) {
+      try {
+        unlinkSync(entries[i]!.path);
+      } catch {
+        /* ignore */
+      }
+    }
+  } catch {
+    /* ignore */
+  }
+}
+
+function runSips(inputBytes: Buffer): Buffer | null {
+  const srcPath = join(tmpdir(), `vellum-img-opt-${Date.now()}-src`);
+  const outPath = join(tmpdir(), `vellum-img-opt-${Date.now()}-out.jpg`);
+  try {
+    writeFileSync(srcPath, inputBytes);
+    execFileSync(
+      "sips",
+      [
+        "--resampleHeightWidthMax",
+        String(MAX_DIMENSION),
+        "-s",
+        "format",
+        "jpeg",
+        "-s",
+        "formatOptions",
+        String(JPEG_QUALITY),
+        srcPath,
+        "--out",
+        outPath,
+      ],
+      { stdio: "pipe", timeout: 15_000 },
+    );
+    return readFileSync(outPath) as Buffer;
+  } catch {
+    return null;
+  } finally {
+    try {
+      unlinkSync(srcPath);
+    } catch {
+      /* ignore */
+    }
+    try {
+      unlinkSync(outPath);
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+/**
+ * Downscale a base64 image to fit within Anthropic's recommended dimensions
+ * (1568px max side). Returns the original data unchanged if the image is
+ * already small enough or if optimization fails.
+ *
+ * Anthropic applies the same scaling server-side, so this is zero quality
+ * loss — we just do it pre-flight to keep request payloads small and avoid
+ * 413 "request too large" errors when many images accumulate in context.
+ *
+ * Results are cached on disk by content hash so repeated sends of the same
+ * image (or daemon restarts) skip the sips call entirely.
+ */
+export function optimizeImageForTransport(
+  base64Data: string,
+  mediaType: string,
+): { data: string; mediaType: string } {
+  const rawBytes = Buffer.from(base64Data, "base64");
+
+  // Small images don't need optimization.
+  if (rawBytes.length <= OPTIMIZE_THRESHOLD_BYTES) {
+    return { data: base64Data, mediaType };
+  }
+
+  // If dimensions are already within limits, skip.
+  const dims = parseImageDimensions(base64Data, mediaType);
+  if (
+    dims &&
+    dims.width <= MAX_DIMENSION &&
+    dims.height <= MAX_DIMENSION
+  ) {
+    return { data: base64Data, mediaType };
+  }
+
+  // Content-addressed cache lookup.
+  const hash = createHash("sha256").update(rawBytes).digest("hex");
+  const cacheKey = hash.slice(0, 16);
+  const cached = readFromCache(cacheKey);
+  if (cached) return cached;
+
+  // Run sips (macOS). On other platforms this gracefully returns null.
+  const optimized = runSips(rawBytes);
+  if (!optimized) {
+    return { data: base64Data, mediaType };
+  }
+
+  writeToCache(cacheKey, optimized);
+  return { data: optimized.toString("base64"), mediaType: "image/jpeg" };
+}

--- a/assistant/src/tools/shared/filesystem/image-read.ts
+++ b/assistant/src/tools/shared/filesystem/image-read.ts
@@ -1,9 +1,7 @@
-import { execFileSync } from "node:child_process";
-import { readFileSync, statSync, unlinkSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { readFileSync, statSync } from "node:fs";
 
 import type { ImageContent } from "../../../providers/types.js";
+import { optimizeImageForTransport } from "../../../agent/image-optimize.js";
 import type { ToolExecutionResult } from "../../types.js";
 
 export const IMAGE_EXTENSIONS = new Set([
@@ -16,12 +14,6 @@ export const IMAGE_EXTENSIONS = new Set([
 
 const MAX_SIZE_BYTES = 20 * 1024 * 1024; // 20 MB — LLM API transport limit (post-optimization)
 const MAX_SOURCE_SIZE_BYTES = 100 * 1024 * 1024; // 100 MB — pre-optimization guard
-
-// Images above this threshold get auto-optimized via sips (macOS) to avoid
-// sending multi-MB base64 payloads to the LLM API.
-const OPTIMIZE_THRESHOLD_BYTES = 1 * 1024 * 1024; // 1 MB
-const OPTIMIZE_MAX_DIMENSION = 1568; // Anthropic's recommended max
-const OPTIMIZE_JPEG_QUALITY = 80;
 
 /**
  * Detect the actual image format from the first bytes of the buffer.
@@ -70,36 +62,6 @@ function detectMediaType(buf: Buffer): string | null {
 }
 
 /**
- * Use macOS `sips` to resize and convert an image to JPEG.
- * Returns the path to the optimized temp file, or null if sips is unavailable.
- */
-function optimizeWithSips(srcPath: string): string | null {
-  const tmpPath = join(tmpdir(), `vellum-view-image-${Date.now()}.jpg`);
-  try {
-    execFileSync(
-      "sips",
-      [
-        "--resampleHeightWidthMax",
-        String(OPTIMIZE_MAX_DIMENSION),
-        "-s",
-        "format",
-        "jpeg",
-        "-s",
-        "formatOptions",
-        String(OPTIMIZE_JPEG_QUALITY),
-        srcPath,
-        "--out",
-        tmpPath,
-      ],
-      { stdio: "pipe", timeout: 15_000 },
-    );
-    return tmpPath;
-  } catch {
-    return null;
-  }
-}
-
-/**
  * Read an image file from disk, optionally optimize it, and return a
  * ToolExecutionResult with base64-encoded image content blocks.
  *
@@ -130,49 +92,17 @@ export function readImageFile(resolvedPath: string): ToolExecutionResult {
   }
 
   let buffer: Buffer;
-  let optimized = false;
-  let tmpPath: string | null = null;
-
   try {
-    if (stat.size > OPTIMIZE_THRESHOLD_BYTES) {
-      tmpPath = optimizeWithSips(resolvedPath);
-      if (tmpPath) {
-        buffer = readFileSync(tmpPath) as Buffer;
-        optimized = true;
-      } else {
-        // sips unavailable — fast-fail if original file exceeds the transport limit
-        if (stat.size > MAX_SIZE_BYTES) {
-          const sizeMB = (stat.size / (1024 * 1024)).toFixed(1);
-          return {
-            content: `Error: image too large (${sizeMB} MB). Maximum is 20 MB. Image optimization (sips) is unavailable on this platform.`,
-            isError: true,
-          };
-        }
-        buffer = readFileSync(resolvedPath) as Buffer;
-      }
-    } else {
-      buffer = readFileSync(resolvedPath) as Buffer;
-    }
+    buffer = readFileSync(resolvedPath) as Buffer;
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return { content: `Error reading file: ${msg}`, isError: true };
-  } finally {
-    if (tmpPath) {
-      try {
-        unlinkSync(tmpPath);
-      } catch {
-        /* ignore cleanup errors */
-      }
-    }
   }
 
   if (buffer.length > MAX_SIZE_BYTES) {
     const sizeMB = (buffer.length / (1024 * 1024)).toFixed(1);
-    const msg = optimized
-      ? `Error: image too large after optimization (${sizeMB} MB). Maximum is 20 MB.`
-      : `Error: image too large (${sizeMB} MB). Maximum is 20 MB.`;
     return {
-      content: msg,
+      content: `Error: image too large (${sizeMB} MB). Maximum is 20 MB.`,
       isError: true,
     };
   }
@@ -187,25 +117,31 @@ export function readImageFile(resolvedPath: string): ToolExecutionResult {
     };
   }
 
-  const base64Data = buffer.toString("base64");
+  const rawBase64 = buffer.toString("base64");
+  const { data: base64Data, mediaType: finalType } =
+    optimizeImageForTransport(rawBase64, detectedType);
+  const optimized = base64Data !== rawBase64;
 
   const imageBlock: ImageContent = {
     type: "image" as const,
     source: {
       type: "base64" as const,
-      media_type: detectedType,
+      media_type: finalType,
       data: base64Data,
     },
   };
 
+  const optimizedBytes = optimized
+    ? Math.ceil((base64Data.length * 3) / 4)
+    : buffer.length;
   const sizeSuffix = optimized
     ? ` (optimized from ${(stat.size / 1024).toFixed(0)} KB to ${(
-        buffer.length / 1024
+        optimizedBytes / 1024
       ).toFixed(0)} KB)`
     : "";
 
   return {
-    content: `Image loaded: ${resolvedPath} (${buffer.length} bytes, ${detectedType})${sizeSuffix}`,
+    content: `Image loaded: ${resolvedPath} (${optimizedBytes} bytes, ${finalType})${sizeSuffix}`,
     isError: false,
     contentBlocks: [imageBlock],
   };


### PR DESCRIPTION
## Summary
- User-sent images accumulate as full-resolution base64 in conversation history, eventually exceeding Anthropic's 32 MB request body limit and triggering 413 errors with ~26s recovery loops
- Adds a shared `image-optimize.ts` helper that downscales images to 1568px max dimension (Anthropic's documented limit — zero quality loss since they do the same server-side) with a content-addressed disk cache
- Applies optimization at ingestion in `attachmentsToContentBlocks` and refactors `readImageFile` to use the same helper, eliminating duplicate sips logic

## Original prompt
it