### PR TITLE
fix: auto-fix lint errors from image-optimize PR

### DIFF
--- a/assistant/src/__tests__/rebuild-index-graph-nodes.test.ts
+++ b/assistant/src/__tests__/rebuild-index-graph-nodes.test.ts
@@ -37,6 +37,7 @@ mock.module("../memory/embedding-backend.js", () => ({
 // ── In-memory SQLite ─────────────────────────────────────────────────
 
 import Database from "bun:sqlite";
+
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import * as schema from "../memory/schema.js";

--- a/assistant/src/agent/image-optimize.ts
+++ b/assistant/src/agent/image-optimize.ts
@@ -1,10 +1,10 @@
-import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   existsSync,
   mkdirSync,
-  readFileSync,
   readdirSync,
+  readFileSync,
   statSync,
   unlinkSync,
   writeFileSync,
@@ -65,7 +65,7 @@ function evictIfNeeded(dir: string): void {
         return { path: full, mtimeMs: statSync(full).mtimeMs };
       })
       .sort((a, b) => a.mtimeMs - b.mtimeMs);
-    let excess = entries.length - CACHE_MAX_ENTRIES;
+    const excess = entries.length - CACHE_MAX_ENTRIES;
     for (let i = 0; i < excess; i++) {
       try {
         unlinkSync(entries[i]!.path);

--- a/assistant/src/tools/shared/filesystem/image-read.ts
+++ b/assistant/src/tools/shared/filesystem/image-read.ts
@@ -1,7 +1,7 @@
 import { readFileSync, statSync } from "node:fs";
 
-import type { ImageContent } from "../../../providers/types.js";
 import { optimizeImageForTransport } from "../../../agent/image-optimize.js";
+import type { ImageContent } from "../../../providers/types.js";
 import type { ToolExecutionResult } from "../../types.js";
 
 export const IMAGE_EXTENSIONS = new Set([


### PR DESCRIPTION
## Summary
- Fix 4 eslint errors introduced by #22781: import sorting in 3 files and `let` → `const` in `image-optimize.ts`
- All fixes are auto-fixable (`eslint --fix`)

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23841308175/job/69497339846
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
