### PR TITLE
fix: eliminate race condition in OAuth2 loopback transport tests

### DIFF
--- a/assistant/src/__tests__/oauth2-gateway-transport.test.ts
+++ b/assistant/src/__tests__/oauth2-gateway-transport.test.ts
@@ -383,17 +383,22 @@ describe("OAuth2 gateway transport", () => {
   describe("loopback transport flow", () => {
     test("success: starts server, receives callback, exchanges for tokens", async () => {
       let capturedAuthUrl = "";
+      let urlReady!: () => void;
+      const urlReadyPromise = new Promise<void>((r) => {
+        urlReady = r;
+      });
       const flowPromise = startOAuth2Flow(
         BASE_OAUTH_CONFIG,
         {
           openUrl: (url) => {
             capturedAuthUrl = url;
+            urlReady();
           },
         },
         { callbackTransport: "loopback" },
       );
 
-      await new Promise((r) => setTimeout(r, 50));
+      await urlReadyPromise;
 
       expect(capturedAuthUrl).toContain("redirect_uri=");
       expect(capturedAuthUrl).toMatch(/localhost|127\.0\.0\.1/);
@@ -418,17 +423,22 @@ describe("OAuth2 gateway transport", () => {
 
     test("error: OAuth provider returns error parameter", async () => {
       let capturedAuthUrl = "";
+      let urlReady!: () => void;
+      const urlReadyPromise = new Promise<void>((r) => {
+        urlReady = r;
+      });
       const flowPromise = startOAuth2Flow(
         BASE_OAUTH_CONFIG,
         {
           openUrl: (url) => {
             capturedAuthUrl = url;
+            urlReady();
           },
         },
         { callbackTransport: "loopback" },
       );
 
-      await new Promise((r) => setTimeout(r, 50));
+      await urlReadyPromise;
 
       const authUrl = new URL(capturedAuthUrl);
       const redirectUri = authUrl.searchParams.get("redirect_uri")!;
@@ -446,17 +456,22 @@ describe("OAuth2 gateway transport", () => {
 
     test("rejects callback with wrong state parameter", async () => {
       let capturedAuthUrl = "";
+      let urlReady!: () => void;
+      const urlReadyPromise = new Promise<void>((r) => {
+        urlReady = r;
+      });
       const flowPromise = startOAuth2Flow(
         BASE_OAUTH_CONFIG,
         {
           openUrl: (url) => {
             capturedAuthUrl = url;
+            urlReady();
           },
         },
         { callbackTransport: "loopback" },
       );
 
-      await new Promise((r) => setTimeout(r, 50));
+      await urlReadyPromise;
 
       const authUrl = new URL(capturedAuthUrl);
       const redirectUri = authUrl.searchParams.get("redirect_uri")!;


### PR DESCRIPTION
## Summary
- Replace fragile `setTimeout(r, 50)` waits with `urlReadyPromise` in three OAuth2 loopback transport tests
- The loopback server bind + dynamic imports can exceed 50ms in CI, causing `capturedAuthUrl` to still be empty when assertions run
- Uses the same `urlReadyPromise` pattern already established by the "token exchange failure" test in the same file

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23842205122/job/69500404249

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22783" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
