### PR TITLE
feat(memory): add eventDate column to memory graph nodes schema and types

### DIFF
--- a/assistant/src/config/bundled-skills/playbooks/tools/playbook-create.ts
+++ b/assistant/src/config/bundled-skills/playbooks/tools/playbook-create.ts
@@ -89,6 +89,7 @@ export async function executePlaybookCreate(
       created: now,
       lastAccessed: now,
       lastConsolidated: now,
+      eventDate: null,
       emotionalCharge: {
         valence: 0,
         intensity: 0.1,

--- a/assistant/src/memory/graph/bootstrap.ts
+++ b/assistant/src/memory/graph/bootstrap.ts
@@ -438,6 +438,7 @@ export function migrateToolCreatedItems(): void {
       created: row.first_seen_at || now,
       lastAccessed: now,
       lastConsolidated: now,
+      eventDate: null,
       emotionalCharge: {
         valence: 0,
         intensity: 0.1,

--- a/assistant/src/memory/graph/capability-seed.ts
+++ b/assistant/src/memory/graph/capability-seed.ts
@@ -205,6 +205,7 @@ function upsertCapabilityNode(sourceKey: string, content: string): void {
     created: now,
     lastAccessed: now,
     lastConsolidated: 0,
+    eventDate: null,
     emotionalCharge: {
       valence: 0,
       intensity: 0,

--- a/assistant/src/memory/graph/extraction.ts
+++ b/assistant/src/memory/graph/extraction.ts
@@ -468,6 +468,7 @@ export function parseExtractionResponse(
       created: now,
       lastAccessed: now,
       lastConsolidated: now,
+      eventDate: null,
       emotionalCharge,
       fidelity: "vivid" as Fidelity,
       confidence: clamp(Number(raw.confidence) || 0.5, 0, 1),

--- a/assistant/src/memory/graph/injection.test.ts
+++ b/assistant/src/memory/graph/injection.test.ts
@@ -22,6 +22,7 @@ function makeNode(overrides: Partial<MemoryNode> = {}): MemoryNode {
     created: Date.now() - 5 * DAY_MS,
     lastAccessed: Date.now(),
     lastConsolidated: Date.now(),
+    eventDate: null,
     emotionalCharge: {
       valence: 0,
       intensity: 0,

--- a/assistant/src/memory/graph/pattern-scan.ts
+++ b/assistant/src/memory/graph/pattern-scan.ts
@@ -210,6 +210,7 @@ export async function runPatternScan(
       created: now,
       lastAccessed: now,
       lastConsolidated: now,
+      eventDate: null,
       emotionalCharge: {
         valence: 0,
         intensity: 0.3,

--- a/assistant/src/memory/graph/scoring.test.ts
+++ b/assistant/src/memory/graph/scoring.test.ts
@@ -23,6 +23,7 @@ function makeNode(overrides: Partial<MemoryNode> = {}): MemoryNode {
     created: Date.now(),
     lastAccessed: Date.now(),
     lastConsolidated: Date.now(),
+    eventDate: null,
     emotionalCharge: {
       valence: 0,
       intensity: 0,

--- a/assistant/src/memory/graph/store.test.ts
+++ b/assistant/src/memory/graph/store.test.ts
@@ -34,6 +34,7 @@ function makeNewNode(overrides: Partial<NewNode> = {}): NewNode {
     created: now,
     lastAccessed: now,
     lastConsolidated: now,
+    eventDate: null,
     emotionalCharge: {
       valence: 0,
       intensity: 0.3,

--- a/assistant/src/memory/graph/store.ts
+++ b/assistant/src/memory/graph/store.ts
@@ -38,6 +38,7 @@ function rowToNode(row: typeof memoryGraphNodes.$inferSelect): MemoryNode {
     created: row.created,
     lastAccessed: row.lastAccessed,
     lastConsolidated: row.lastConsolidated,
+    eventDate: row.eventDate ?? null,
     emotionalCharge: JSON.parse(row.emotionalCharge) as EmotionalCharge,
     fidelity: row.fidelity as Fidelity,
     confidence: row.confidence,

--- a/assistant/src/memory/graph/tool-handlers.ts
+++ b/assistant/src/memory/graph/tool-handlers.ts
@@ -282,6 +282,7 @@ function handleSave(
     created: now,
     lastAccessed: now,
     lastConsolidated: now,
+    eventDate: null,
     emotionalCharge,
     fidelity: "vivid" as Fidelity,
     confidence: 0.95, // Explicitly saved = high confidence

--- a/assistant/src/memory/graph/types.ts
+++ b/assistant/src/memory/graph/types.ts
@@ -62,6 +62,8 @@ export interface MemoryNode {
   lastAccessed: number;
   /** Epoch ms of last consolidation pass that touched this node. */
   lastConsolidated: number;
+  /** Epoch ms of the event this memory describes (null for non-event memories). */
+  eventDate: number | null;
 
   // -- Energy --
   emotionalCharge: EmotionalCharge;

--- a/assistant/src/memory/migrations/202-memory-graph-tables.ts
+++ b/assistant/src/memory/migrations/202-memory-graph-tables.ts
@@ -94,4 +94,37 @@ export function migrateCreateMemoryGraphTables(database: DrizzleDb): void {
   raw.exec(
     `CREATE INDEX IF NOT EXISTS idx_graph_triggers_type ON memory_graph_triggers(type)`,
   );
+
+  // -- Add event_date column to nodes (idempotent) --
+  try {
+    raw.exec(
+      `ALTER TABLE memory_graph_nodes ADD COLUMN event_date INTEGER`,
+    );
+  } catch {
+    // Column already exists — safe to ignore.
+  }
+
+  raw.exec(
+    `CREATE INDEX IF NOT EXISTS idx_graph_nodes_event_date ON memory_graph_nodes(event_date)`,
+  );
+
+  // -- Backfill event_date from existing event triggers --
+  raw.exec(`
+    UPDATE memory_graph_nodes
+    SET event_date = (
+      SELECT t.event_date
+      FROM memory_graph_triggers t
+      WHERE t.node_id = memory_graph_nodes.id
+        AND t.type = 'event'
+        AND t.event_date IS NOT NULL
+      LIMIT 1
+    )
+    WHERE event_date IS NULL
+      AND id IN (
+        SELECT t2.node_id
+        FROM memory_graph_triggers t2
+        WHERE t2.type = 'event'
+          AND t2.event_date IS NOT NULL
+      )
+  `);
 }

--- a/assistant/src/memory/schema/memory-graph.ts
+++ b/assistant/src/memory/schema/memory-graph.ts
@@ -28,6 +28,8 @@ export const memoryGraphNodes = sqliteTable(
     lastAccessed: integer("last_accessed").notNull(),
     /** Epoch ms of last consolidation pass. */
     lastConsolidated: integer("last_consolidated").notNull(),
+    /** Epoch ms of the event this memory describes (null for non-event memories). */
+    eventDate: integer("event_date"),
 
     // -- Energy --
     /** JSON-serialized EmotionalCharge object. Read/written atomically. */
@@ -66,6 +68,7 @@ export const memoryGraphNodes = sqliteTable(
     index("idx_graph_nodes_fidelity").on(table.fidelity),
     index("idx_graph_nodes_created").on(table.created),
     index("idx_graph_nodes_significance").on(table.significance),
+    index("idx_graph_nodes_event_date").on(table.eventDate),
   ],
 );
 

--- a/assistant/src/runtime/routes/memory-item-routes.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.ts
@@ -546,6 +546,7 @@ export async function handleCreateMemoryItem(
     created: now,
     lastAccessed: now,
     lastConsolidated: now,
+    eventDate: null,
     emotionalCharge: {
       valence: 0,
       intensity: 0.1,
@@ -732,6 +733,7 @@ function rowToNode(row: typeof memoryGraphNodes.$inferSelect): MemoryNode {
     created: row.created,
     lastAccessed: row.lastAccessed,
     lastConsolidated: row.lastConsolidated,
+    eventDate: row.eventDate ?? null,
     emotionalCharge: JSON.parse(row.emotionalCharge),
     fidelity: row.fidelity as Fidelity,
     confidence: row.confidence,


### PR DESCRIPTION
## Summary
- Add eventDate field (epoch ms, nullable) to MemoryNode interface in types.ts
- Add event_date column and index to Drizzle schema in memory-graph.ts
- Add idempotent DDL migration with backfill from existing event triggers
- Update all MemoryNode/NewNode constructors and rowToNode mappers across the codebase

Part of plan: event-date-memory-nodes.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22784" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
