### PR TITLE
feat(memory): wire eventDate through store query filters and updateNode

### DIFF
--- a/assistant/src/memory/graph/store.test.ts
+++ b/assistant/src/memory/graph/store.test.ts
@@ -145,6 +145,37 @@ describe("node CRUD", () => {
     expect(updated!.emotionalCharge.decayCurve).toBe("permanent");
   });
 
+  test("createNode with eventDate round-trips through getNode", () => {
+    const eventDate = Date.now() - 86400000; // yesterday
+    const node = createNode(makeNewNode({ eventDate }));
+    const found = getNode(node.id);
+    expect(found).not.toBeNull();
+    expect(found!.eventDate).toBe(eventDate);
+  });
+
+  test("createNode with null eventDate round-trips as null", () => {
+    const node = createNode(makeNewNode({ eventDate: null }));
+    const found = getNode(node.id);
+    expect(found).not.toBeNull();
+    expect(found!.eventDate).toBeNull();
+  });
+
+  test("updateNode updates eventDate", () => {
+    const node = createNode(makeNewNode({ eventDate: null }));
+    const newEventDate = Date.now() - 86400000;
+    updateNode(node.id, { eventDate: newEventDate });
+    const updated = getNode(node.id);
+    expect(updated!.eventDate).toBe(newEventDate);
+  });
+
+  test("updateNode can set eventDate to null", () => {
+    const eventDate = Date.now() - 86400000;
+    const node = createNode(makeNewNode({ eventDate }));
+    updateNode(node.id, { eventDate: null });
+    const updated = getNode(node.id);
+    expect(updated!.eventDate).toBeNull();
+  });
+
   test("deleteNode removes the node", () => {
     const node = createNode(makeNewNode());
     deleteNode(node.id);
@@ -210,6 +241,62 @@ describe("queryNodes", () => {
     expect(results[0].significance).toBe(0.9);
     expect(results[1].significance).toBe(0.6);
     expect(results[2].significance).toBe(0.3);
+  });
+
+  test("filters by hasEventDate", () => {
+    createNode(makeNewNode({ content: "Dated.", eventDate: 1700000000000 }));
+    createNode(makeNewNode({ content: "Undated.", eventDate: null }));
+
+    const results = queryNodes({ hasEventDate: true });
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe("Dated.");
+  });
+
+  test("filters by eventDateAfter", () => {
+    createNode(
+      makeNewNode({ content: "Old.", eventDate: 1700000000000 }),
+    );
+    createNode(
+      makeNewNode({ content: "Recent.", eventDate: 1710000000000 }),
+    );
+    createNode(makeNewNode({ content: "None.", eventDate: null }));
+
+    const results = queryNodes({ eventDateAfter: 1705000000000 });
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe("Recent.");
+  });
+
+  test("filters by eventDateBefore", () => {
+    createNode(
+      makeNewNode({ content: "Old.", eventDate: 1700000000000 }),
+    );
+    createNode(
+      makeNewNode({ content: "Recent.", eventDate: 1710000000000 }),
+    );
+    createNode(makeNewNode({ content: "None.", eventDate: null }));
+
+    const results = queryNodes({ eventDateBefore: 1705000000000 });
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe("Old.");
+  });
+
+  test("combines eventDateAfter and eventDateBefore for range query", () => {
+    createNode(
+      makeNewNode({ content: "Before.", eventDate: 1690000000000 }),
+    );
+    createNode(
+      makeNewNode({ content: "In range.", eventDate: 1700000000000 }),
+    );
+    createNode(
+      makeNewNode({ content: "After.", eventDate: 1720000000000 }),
+    );
+
+    const results = queryNodes({
+      eventDateAfter: 1695000000000,
+      eventDateBefore: 1710000000000,
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe("In range.");
   });
 });
 

--- a/assistant/src/memory/graph/store.ts
+++ b/assistant/src/memory/graph/store.ts
@@ -62,6 +62,7 @@ function nodeToInsertValues(node: NewNode, id: string) {
     created: node.created,
     lastAccessed: node.lastAccessed,
     lastConsolidated: node.lastConsolidated,
+    eventDate: node.eventDate ?? null,
     emotionalCharge: JSON.stringify(node.emotionalCharge),
     fidelity: node.fidelity,
     confidence: node.confidence,
@@ -176,6 +177,7 @@ export function updateNode(
   if (changes.partOfStory !== undefined)
     updates.partOfStory = changes.partOfStory;
   if (changes.scopeId !== undefined) updates.scopeId = changes.scopeId;
+  if (changes.eventDate !== undefined) updates.eventDate = changes.eventDate;
 
   if (Object.keys(updates).length === 0) return;
 
@@ -201,6 +203,9 @@ export interface NodeQueryFilters {
   minSignificance?: number;
   createdAfter?: number;
   createdBefore?: number;
+  hasEventDate?: boolean;
+  eventDateAfter?: number;
+  eventDateBefore?: number;
   limit?: number;
 }
 
@@ -235,6 +240,19 @@ export function queryNodes(filters: NodeQueryFilters): MemoryNode[] {
   if (filters.createdBefore !== undefined) {
     conditions.push(
       sql`${memoryGraphNodes.created} <= ${filters.createdBefore}`,
+    );
+  }
+  if (filters.hasEventDate) {
+    conditions.push(sql`${memoryGraphNodes.eventDate} IS NOT NULL`);
+  }
+  if (filters.eventDateAfter !== undefined) {
+    conditions.push(
+      sql`${memoryGraphNodes.eventDate} >= ${filters.eventDateAfter}`,
+    );
+  }
+  if (filters.eventDateBefore !== undefined) {
+    conditions.push(
+      sql`${memoryGraphNodes.eventDate} <= ${filters.eventDateBefore}`,
     );
   }
 


### PR DESCRIPTION
## Summary
- Add `eventDate` to `nodeToInsertValues()` so it is persisted on create
- Add `eventDate` to `updateNode()` handler
- Add `hasEventDate`, `eventDateAfter`, `eventDateBefore` query filters to `NodeQueryFilters` and `queryNodes()`
- Add tests for eventDate round-trip (create/get), update (set and clear), and all three query filters including range combination

Part of plan: event-date-memory-nodes.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
