### PR TITLE
feat(memory): extract event_date on nodes and auto-generate event triggers

### DIFF
--- a/assistant/src/memory/graph/extraction.test.ts
+++ b/assistant/src/memory/graph/extraction.test.ts
@@ -690,6 +690,226 @@ describe("parseExtractionResponse — deferred triggers", () => {
 });
 
 // ---------------------------------------------------------------------------
+// event_date parsing
+// ---------------------------------------------------------------------------
+
+describe("parseExtractionResponse — event_date parsing", () => {
+  test("parses event_date onto node.eventDate", () => {
+    const eventDate = NOW + 7 * 24 * 60 * 60 * 1000;
+    const { diff } = parse({
+      create_nodes: [
+        {
+          content: "Flight to NYC on April 8.",
+          type: "prospective",
+          emotional_charge: {
+            valence: 0.4,
+            intensity: 0.3,
+            decay_curve: "linear",
+            decay_rate: 0.05,
+          },
+          significance: 0.6,
+          confidence: 0.9,
+          source_type: "direct",
+          event_date: eventDate,
+        },
+      ],
+      reinforce_node_ids: [],
+    });
+
+    expect(diff.createNodes).toHaveLength(1);
+    expect(diff.createNodes[0].eventDate).toBe(eventDate);
+  });
+
+  test("event_date: null results in eventDate: null", () => {
+    const { diff } = parse({
+      create_nodes: [
+        {
+          content: "User likes hiking.",
+          type: "semantic",
+          emotional_charge: {
+            valence: 0.3,
+            intensity: 0.2,
+            decay_curve: "linear",
+            decay_rate: 0.05,
+          },
+          significance: 0.5,
+          confidence: 0.8,
+          source_type: "direct",
+          event_date: null,
+        },
+      ],
+      reinforce_node_ids: [],
+    });
+
+    expect(diff.createNodes[0].eventDate).toBeNull();
+  });
+
+  test("missing event_date results in eventDate: null", () => {
+    const { diff } = parse({
+      create_nodes: [
+        {
+          content: "User likes dark mode.",
+          type: "semantic",
+          emotional_charge: {
+            valence: 0,
+            intensity: 0.1,
+            decay_curve: "linear",
+            decay_rate: 0.05,
+          },
+          significance: 0.3,
+          confidence: 0.9,
+          source_type: "direct",
+        },
+      ],
+      reinforce_node_ids: [],
+    });
+
+    expect(diff.createNodes[0].eventDate).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auto-trigger for event_date
+// ---------------------------------------------------------------------------
+
+describe("parseExtractionResponse — event_date auto-trigger", () => {
+  test("auto-creates event trigger when event_date is set but no event trigger provided", () => {
+    const eventDate = NOW + 7 * 24 * 60 * 60 * 1000;
+    const { diff, deferredTriggers } = parse({
+      create_nodes: [
+        {
+          content: "Dentist appointment next week.",
+          type: "prospective",
+          emotional_charge: {
+            valence: -0.1,
+            intensity: 0.2,
+            decay_curve: "linear",
+            decay_rate: 0.05,
+          },
+          significance: 0.5,
+          confidence: 0.9,
+          source_type: "direct",
+          event_date: eventDate,
+        },
+      ],
+      reinforce_node_ids: [],
+    });
+
+    expect(diff.createNodes).toHaveLength(1);
+    expect(diff.createNodes[0].eventDate).toBe(eventDate);
+    expect(deferredTriggers).toHaveLength(1);
+    expect(deferredTriggers[0].newNodeIndex).toBe(0);
+    expect(deferredTriggers[0].trigger.type).toBe("event");
+    expect(deferredTriggers[0].trigger.eventDate).toBe(eventDate);
+    expect(deferredTriggers[0].trigger.rampDays).toBe(7);
+    expect(deferredTriggers[0].trigger.followUpDays).toBe(2);
+    expect(deferredTriggers[0].trigger.recurring).toBe(false);
+    expect(deferredTriggers[0].trigger.consumed).toBe(false);
+    expect(deferredTriggers[0].trigger.cooldownMs).toBeNull();
+  });
+
+  test("no duplicate trigger when LLM already provided an event trigger", () => {
+    const eventDate = NOW + 7 * 24 * 60 * 60 * 1000;
+    const { deferredTriggers } = parse({
+      create_nodes: [
+        {
+          content: "Trip to Paris next week.",
+          type: "prospective",
+          emotional_charge: {
+            valence: 0.6,
+            intensity: 0.5,
+            decay_curve: "linear",
+            decay_rate: 0.05,
+          },
+          significance: 0.7,
+          confidence: 0.9,
+          source_type: "direct",
+          event_date: eventDate,
+          triggers: [
+            {
+              type: "event",
+              event_date: eventDate,
+              ramp_days: 5,
+              follow_up_days: 3,
+            },
+          ],
+        },
+      ],
+      reinforce_node_ids: [],
+    });
+
+    // Should only have the LLM-provided trigger, no auto-created duplicate
+    expect(deferredTriggers).toHaveLength(1);
+    expect(deferredTriggers[0].trigger.type).toBe("event");
+    expect(deferredTriggers[0].trigger.rampDays).toBe(5); // LLM's value, not auto-trigger's 7
+  });
+
+  test("auto-creates event trigger alongside non-event triggers", () => {
+    const eventDate = NOW + 14 * 24 * 60 * 60 * 1000;
+    const { deferredTriggers } = parse({
+      create_nodes: [
+        {
+          content: "Project deadline in two weeks.",
+          type: "prospective",
+          emotional_charge: {
+            valence: -0.2,
+            intensity: 0.4,
+            decay_curve: "linear",
+            decay_rate: 0.05,
+          },
+          significance: 0.6,
+          confidence: 0.8,
+          source_type: "direct",
+          event_date: eventDate,
+          triggers: [
+            {
+              type: "semantic",
+              condition: "project deadline discussion",
+            },
+          ],
+        },
+      ],
+      reinforce_node_ids: [],
+    });
+
+    // Should have the LLM-provided semantic trigger plus an auto-created event trigger
+    expect(deferredTriggers).toHaveLength(2);
+    const types = deferredTriggers.map((t) => t.trigger.type);
+    expect(types).toContain("semantic");
+    expect(types).toContain("event");
+
+    const autoTrigger = deferredTriggers.find(
+      (t) => t.trigger.type === "event",
+    )!;
+    expect(autoTrigger.trigger.eventDate).toBe(eventDate);
+    expect(autoTrigger.trigger.rampDays).toBe(7);
+  });
+
+  test("no auto-trigger when event_date is not set", () => {
+    const { deferredTriggers } = parse({
+      create_nodes: [
+        {
+          content: "User likes functional programming.",
+          type: "semantic",
+          emotional_charge: {
+            valence: 0.2,
+            intensity: 0.1,
+            decay_curve: "linear",
+            decay_rate: 0.05,
+          },
+          significance: 0.3,
+          confidence: 0.9,
+          source_type: "direct",
+        },
+      ],
+      reinforce_node_ids: [],
+    });
+
+    expect(deferredTriggers).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Empty / missing fields
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/memory/graph/extraction.ts
+++ b/assistant/src/memory/graph/extraction.ts
@@ -95,6 +95,7 @@ Call the \`extract_graph_diff\` tool with the diff. Each node needs:
   - 0.9: Transformative moments, identity-defining events ("User said 'I love you' for the first time")
   - 1.0: RARE — reserve for the single most important memories. A graph of 1000 nodes should have fewer than 20 at 1.0.
 - **confidence**: 0-1. How sure are you this is accurate? Direct statements: 0.9+. Inferences: 0.4-0.7.
+- **event_date**: If this memory is anchored to a specific future date/time (flight, appointment, birthday, deadline, trip), provide the epoch ms. Use the conversation date above to resolve relative references ("next Tuesday", "tomorrow"). ALSO create a matching event trigger with the same date. Leave null for open-ended plans or recurring patterns.
 - **sourceType**: "direct" (user stated it), "inferred" (you derived it), "observed" (you noticed a pattern), "told-by-other".
 
 Also notice patterns in the ASSISTANT's own behavior — meta-memory. "I tend to skip verification when I'm confident." "I write more when I'm processing something big."
@@ -210,6 +211,11 @@ const EXTRACT_TOOL_SCHEMA = {
             source_type: {
               type: "string",
               enum: ["direct", "inferred", "observed", "told-by-other"],
+            },
+            event_date: {
+              type: "number",
+              description:
+                "Epoch ms of the event date for calendar-anchored events (flights, appointments, birthdays, deadlines). Null for non-event memories.",
             },
             triggers: {
               type: "array",
@@ -327,6 +333,7 @@ interface RawCreateNode {
   significance?: number;
   confidence?: number;
   source_type?: string;
+  event_date?: number;
   triggers?: Array<{
     type?: string;
     schedule?: string;
@@ -468,7 +475,7 @@ export function parseExtractionResponse(
       created: now,
       lastAccessed: now,
       lastConsolidated: now,
-      eventDate: null,
+      eventDate: raw.event_date ?? null,
       emotionalCharge,
       fidelity: "vivid" as Fidelity,
       confidence: clamp(Number(raw.confidence) || 0.5, 0, 1),
@@ -533,6 +540,31 @@ export function parseExtractionResponse(
           },
         });
       }
+    }
+
+    // Auto-create event trigger when event_date is set but LLM didn't include one
+    if (
+      node.eventDate &&
+      (!Array.isArray(raw.triggers) ||
+        !raw.triggers.some((t) => t.type === "event"))
+    ) {
+      deferredTriggers.push({
+        newNodeIndex: nodeIndex,
+        trigger: {
+          type: "event" as TriggerType,
+          schedule: null,
+          condition: null,
+          conditionEmbedding: null,
+          threshold: null,
+          eventDate: node.eventDate,
+          rampDays: 7,
+          followUpDays: 2,
+          recurring: false,
+          consumed: false,
+          cooldownMs: null,
+          lastFired: null,
+        },
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
- Add event_date field to extraction tool schema and prompt guidance
- Parse event_date from LLM output onto node's eventDate field
- Auto-generate event trigger when event_date is set but LLM omitted the trigger
- Add tests for parsing and auto-trigger logic

Part of plan: event-date-memory-nodes.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22786" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
