### PR TITLE
feat(memory): add Upcoming section with human-readable event dates to injection

### DIFF
--- a/assistant/src/memory/graph/injection.test.ts
+++ b/assistant/src/memory/graph/injection.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   assembleContextBlock,
   assembleInjectionBlock,
+  formatEventDate,
   InContextTracker,
 } from "./injection.js";
 import type { MemoryNode, ScoredNode } from "./types.js";
@@ -315,5 +316,145 @@ describe("assembleInjectionBlock", () => {
     ]);
     const lines = result.split("\n");
     expect(lines).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Upcoming section
+// ---------------------------------------------------------------------------
+
+describe("assembleContextBlock — Upcoming section", () => {
+  test("node with future eventDate appears in Upcoming, not On My Mind", () => {
+    const futureDate = Date.now() + 3 * DAY_MS;
+    const result = assembleContextBlock([
+      makeScored({
+        content: "Doctor appointment.",
+        eventDate: futureDate,
+        created: Date.now() - 2 * DAY_MS,
+      }),
+    ]);
+    expect(result).toContain("### Upcoming");
+    expect(result).toContain("Doctor appointment.");
+    expect(result).not.toContain("### On My Mind");
+  });
+
+  test("upcoming nodes are sorted by eventDate ascending (soonest first)", () => {
+    const result = assembleContextBlock([
+      makeScored({
+        id: "far",
+        content: "Far event.",
+        eventDate: Date.now() + 10 * DAY_MS,
+        created: Date.now() - DAY_MS,
+      }),
+      makeScored({
+        id: "near",
+        content: "Near event.",
+        eventDate: Date.now() + 2 * DAY_MS,
+        created: Date.now() - DAY_MS,
+      }),
+      makeScored({
+        id: "mid",
+        content: "Mid event.",
+        eventDate: Date.now() + 5 * DAY_MS,
+        created: Date.now() - DAY_MS,
+      }),
+    ]);
+    const upcomingSection = result.split("### Upcoming")[1]?.split("###")[0];
+    expect(upcomingSection).toBeDefined();
+    const nearIdx = upcomingSection!.indexOf("Near event.");
+    const midIdx = upcomingSection!.indexOf("Mid event.");
+    const farIdx = upcomingSection!.indexOf("Far event.");
+    expect(nearIdx).toBeLessThan(midIdx);
+    expect(midIdx).toBeLessThan(farIdx);
+  });
+
+  test("node with future eventDate AND triggerBoost > 0 goes to What Today Means, not Upcoming", () => {
+    const futureDate = Date.now() + DAY_MS;
+    const result = assembleContextBlock([
+      makeScored(
+        {
+          content: "Birthday party tomorrow.",
+          eventDate: futureDate,
+          created: Date.now() - 5 * DAY_MS,
+        },
+        { triggerBoost: 0.5 },
+      ),
+    ]);
+    expect(result).toContain("### What Today Means");
+    expect(result).toContain("Birthday party tomorrow.");
+    expect(result).not.toContain("### Upcoming");
+  });
+
+  test("node with past eventDate goes to On My Mind, not Upcoming", () => {
+    const pastDate = Date.now() - 2 * DAY_MS;
+    const result = assembleContextBlock([
+      makeScored({
+        content: "Concert last week.",
+        eventDate: pastDate,
+        created: Date.now() - 10 * DAY_MS,
+      }),
+    ]);
+    expect(result).toContain("### On My Mind");
+    expect(result).toContain("Concert last week.");
+    expect(result).not.toContain("### Upcoming");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatEventDate
+// ---------------------------------------------------------------------------
+
+describe("formatEventDate", () => {
+  test("formats a date happening today with (today) relative", () => {
+    // Use noon today to have a time component
+    const today = new Date();
+    today.setHours(12, 0, 0, 0);
+    const result = formatEventDate(today.getTime());
+    expect(result).toContain("(today)");
+    expect(result).toContain("12:00 PM");
+  });
+
+  test("formats a date happening tomorrow with (tomorrow) relative", () => {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    tomorrow.setHours(9, 0, 0, 0);
+    const result = formatEventDate(tomorrow.getTime());
+    expect(result).toContain("(tomorrow)");
+    expect(result).toContain("9:00 AM");
+  });
+
+  test("formats a date several days out with (in Xd) relative", () => {
+    const future = new Date();
+    future.setDate(future.getDate() + 5);
+    future.setHours(0, 0, 0, 0); // midnight = date-only
+    const result = formatEventDate(future.getTime());
+    expect(result).toContain("(in 5d)");
+    // Midnight should not include a time part
+    expect(result).not.toMatch(/\d+:\d+ [AP]M/);
+  });
+
+  test("formats a date with non-zero minutes correctly", () => {
+    const future = new Date();
+    future.setDate(future.getDate() + 3);
+    future.setHours(14, 30, 0, 0);
+    const result = formatEventDate(future.getTime());
+    expect(result).toContain("2:30 PM");
+    expect(result).toContain("(in 3d)");
+  });
+
+  test("formats weeks-out dates with (in Xw) relative", () => {
+    const future = new Date();
+    future.setDate(future.getDate() + 21);
+    future.setHours(0, 0, 0, 0);
+    const result = formatEventDate(future.getTime());
+    expect(result).toContain("(in 3w)");
+  });
+
+  test("formats months-out dates with (in Xmo) relative", () => {
+    const future = new Date();
+    future.setDate(future.getDate() + 90);
+    future.setHours(0, 0, 0, 0);
+    const result = formatEventDate(future.getTime());
+    expect(result).toContain("(in 3mo)");
   });
 });

--- a/assistant/src/memory/graph/injection.ts
+++ b/assistant/src/memory/graph/injection.ts
@@ -111,6 +111,94 @@ function relativeAge(createdMs: number): string {
   return `${months}mo ago`;
 }
 
+/**
+ * Format an event date as a human-readable string with relative countdown.
+ * Examples:
+ *   "Tue Apr 8, 6:00 PM (in 3d)"
+ *   "Thu Apr 10 (in 5d)"
+ *   "Mon Apr 7, 9:00 AM (tomorrow)"
+ *   "Wed Apr 1 (today)"
+ */
+export function formatEventDate(epochMs: number): string {
+  const date = new Date(epochMs);
+  const now = new Date();
+
+  // Day names and month names
+  const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  const monthNames = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+  ];
+
+  const dayName = dayNames[date.getDay()];
+  const monthName = monthNames[date.getMonth()];
+  const dayOfMonth = date.getDate();
+
+  // Include time only when hours/minutes are non-zero (midnight = date-only event)
+  const hasTime = date.getHours() !== 0 || date.getMinutes() !== 0;
+  let datePart = `${dayName} ${monthName} ${dayOfMonth}`;
+  if (hasTime) {
+    const hours = date.getHours();
+    const minutes = date.getMinutes();
+    const ampm = hours >= 12 ? "PM" : "AM";
+    const displayHour = hours % 12 || 12;
+    const timePart =
+      minutes === 0
+        ? `${displayHour}:00 ${ampm}`
+        : `${displayHour}:${String(minutes).padStart(2, "0")} ${ampm}`;
+    datePart += `, ${timePart}`;
+  }
+
+  // Calculate relative countdown using calendar days
+  const todayStart = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+  );
+  const eventStart = new Date(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate(),
+  );
+  const diffDays = Math.round(
+    (eventStart.getTime() - todayStart.getTime()) / (1000 * 60 * 60 * 24),
+  );
+
+  let relative: string;
+  if (diffDays === 0) {
+    relative = "today";
+  } else if (diffDays === 1) {
+    relative = "tomorrow";
+  } else if (diffDays < 14) {
+    relative = `in ${diffDays}d`;
+  } else if (diffDays < 60) {
+    relative = `in ${Math.floor(diffDays / 7)}w`;
+  } else {
+    relative = `in ${Math.floor(diffDays / 30)}mo`;
+  }
+
+  return `${datePart} (${relative})`;
+}
+
+/** Format an upcoming entry — uses event date when available, falls back to standard format. */
+function formatUpcomingEntry(scored: ScoredNode): string {
+  const node = scored.node;
+  if (node.eventDate != null) {
+    return `- ${formatEventDate(node.eventDate)} — ${node.content}`;
+  }
+  return formatNodeEntry(scored);
+}
+
 /** Format a single node for the context block. */
 function formatNodeEntry(scored: ScoredNode): string {
   const node = scored.node;
@@ -136,6 +224,7 @@ export function assembleContextBlock(
   const rightNow: ScoredNode[] = [];
   const threads: ScoredNode[] = [];
   const triggered: ScoredNode[] = [];
+  const upcoming: ScoredNode[] = [];
   const onMyMind: ScoredNode[] = [];
 
   for (const scored of nodes) {
@@ -143,6 +232,9 @@ export function assembleContextBlock(
 
     if (scored.scoreBreakdown.triggerBoost > 0) {
       triggered.push(scored);
+    } else if (node.eventDate && node.eventDate > Date.now()) {
+      // Future-dated events without an active trigger go to Upcoming
+      upcoming.push(scored);
     } else if (node.type === "prospective") {
       threads.push(scored);
     } else if (node.type === "emotional" && isRecent(node)) {
@@ -155,6 +247,9 @@ export function assembleContextBlock(
       onMyMind.push(scored);
     }
   }
+
+  // Sort upcoming by eventDate ascending (soonest first)
+  upcoming.sort((a, b) => (a.node.eventDate ?? 0) - (b.node.eventDate ?? 0));
 
   const parts: string[] = [];
 
@@ -171,6 +266,14 @@ export function assembleContextBlock(
     const entries = buildSection(threads, 5);
     if (entries.length > 0) {
       parts.push(`### Active Threads\n${entries.join("\n")}`);
+    }
+  }
+
+  // --- Upcoming ---
+  if (upcoming.length > 0) {
+    const entries = upcoming.slice(0, 5).map(formatUpcomingEntry);
+    if (entries.length > 0) {
+      parts.push(`### Upcoming\n${entries.join("\n")}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- Add formatEventDate helper for human-readable event dates with relative countdown
- Add Upcoming section to assembleContextBlock between Active Threads and What Today Means
- Future-dated events sorted by eventDate ascending, capped at 5
- No double-display: triggered nodes go to What Today Means, not Upcoming
- Add comprehensive tests for the new section

Part of plan: event-date-memory-nodes.md (PR 4 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
