### PR TITLE
feat(memory): reserve retrieval slots for upcoming events in context load

### DIFF
--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -480,9 +480,47 @@ export async function loadContextMemory(
     });
   });
 
-  // Remove prospective nodes from the main pool (they have reserved slots)
-  const mainPool = scored.filter((s) => !prospectiveIds.has(s.node.id));
-  const mainSlots = maxNodes - serendipitySlots - reservedNodes.length;
+  // Reserve slots for upcoming events (nodes with event dates in the future).
+  // Like prospective reservation, these MUST surface — if the user said
+  // "I have a flight Tuesday," the assistant must remember it regardless of score.
+  const UPCOMING_RESERVE = 5;
+  const upcomingEvents = queryNodes({
+    scopeId: opts.scopeId,
+    fidelityNot: ["gone"],
+    hasEventDate: true,
+    eventDateAfter: nowMs,
+    eventDateBefore: nowMs + 30 * 24 * 60 * 60 * 1000, // next 30 days
+    limit: UPCOMING_RESERVE,
+  });
+
+  const unresolvedUpcoming = upcomingEvents.filter((node) => {
+    const incoming = getEdgesForNode(node.id, "incoming");
+    return !incoming.some(
+      (e) => e.relationship === "supersedes" || e.relationship === "resolved-by",
+    );
+  });
+
+  const upcomingIds = new Set(unresolvedUpcoming.map((n) => n.id));
+  const reservedUpcoming: ScoredNode[] = unresolvedUpcoming.map((node) => {
+    const existing = scored.find((s) => s.node.id === node.id);
+    if (existing) return existing;
+    return scoreCandidate(node, {
+      semanticSimilarity: 0,
+      effectiveSignificance: computeEffectiveSignificance(node, nowMs),
+      emotionalIntensity: node.emotionalCharge.intensity,
+      temporalBoost: (computeTemporalBoost(node, now) + 1) / 2,
+      recencyBoost: computeRecencyBoost(node, nowMs),
+      triggerBoost: 0,
+      activationBoost: 0,
+    });
+  });
+
+  // Remove prospective and upcoming nodes from the main pool (they have reserved slots)
+  const mainPool = scored.filter(
+    (s) => !prospectiveIds.has(s.node.id) && !upcomingIds.has(s.node.id),
+  );
+  const mainSlots =
+    maxNodes - serendipitySlots - reservedNodes.length - reservedUpcoming.length;
 
   // 7. LLM re-ranking on the main pool: dedup + select
   const reranked = await rerankAndDedup(
@@ -491,8 +529,8 @@ export async function loadContextMemory(
     opts.config,
   );
 
-  // 8. Combine: reserved prospective + reranked main pool
-  const deterministic = [...reservedNodes, ...reranked].slice(
+  // 8. Combine: reserved prospective + reserved upcoming + reranked main pool
+  const deterministic = [...reservedNodes, ...reservedUpcoming, ...reranked].slice(
     0,
     maxNodes - serendipitySlots,
   );


### PR DESCRIPTION
## Summary
- Reserve up to 5 slots for upcoming events (eventDate within next 30 days) in context load
- Filter out resolved/superseded upcoming events
- Exclude reserved upcoming events from main scoring pool
- Follows same pattern as existing prospective node reservation

Part of plan: event-date-memory-nodes.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
