### PR TITLE
fix: prevent prospective-upcoming double-counting in retriever

### DIFF
--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -494,6 +494,7 @@ export async function loadContextMemory(
   });
 
   const unresolvedUpcoming = upcomingEvents.filter((node) => {
+    if (prospectiveIds.has(node.id)) return false; // already reserved as prospective
     const incoming = getEdgesForNode(node.id, "incoming");
     return !incoming.some(
       (e) => e.relationship === "supersedes" || e.relationship === "resolved-by",


### PR DESCRIPTION
## Summary
Filter out nodes already reserved as prospective from the upcoming events reservation to prevent double-counting in slot budget and duplicate entries in the deterministic output.

Fixes gap identified during plan review for event-date-memory-nodes.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22790" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
