### PR TITLE
fix: handle eventDate in applyDiff inline update logic

### DIFF
--- a/assistant/src/memory/graph/store.ts
+++ b/assistant/src/memory/graph/store.ts
@@ -551,6 +551,7 @@ export function applyDiff(diff: MemoryDiff): ApplyDiffResult {
       if (c.partOfStory !== undefined) updates.partOfStory = c.partOfStory;
       if (c.sourceConversations !== undefined)
         updates.sourceConversations = JSON.stringify(c.sourceConversations);
+      if (c.eventDate !== undefined) updates.eventDate = c.eventDate;
 
       if (Object.keys(updates).length > 0) {
         tx.update(memoryGraphNodes)


### PR DESCRIPTION
## Summary
Fixes gap where applyDiff's inline update block didn't handle eventDate changes, causing extraction diff updates to silently drop eventDate modifications.

Fixes gap identified during plan review for event-date-memory-nodes.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
