### PR TITLE
fix: add event_date to update_nodes schema and parsing

### DIFF
--- a/assistant/src/memory/graph/extraction.ts
+++ b/assistant/src/memory/graph/extraction.ts
@@ -288,6 +288,11 @@ const EXTRACT_TOOL_SCHEMA = {
               description:
                 "Downgrade fidelity when a transient event has resolved",
             },
+            event_date: {
+              type: "number",
+              description:
+                "Epoch ms of the event date. Use to update when an event is rescheduled.",
+            },
           },
           required: ["id"],
         },
@@ -356,6 +361,7 @@ interface RawUpdateNode {
   significance?: number;
   confidence?: number;
   fidelity?: string;
+  event_date?: number;
 }
 
 interface RawNewEdge {
@@ -582,6 +588,7 @@ export function parseExtractionResponse(
       ["vivid", "clear", "faded", "gist"].includes(raw.fidelity)
     )
       changes.fidelity = raw.fidelity;
+    if (raw.event_date !== undefined) changes.eventDate = raw.event_date;
     if (Object.keys(changes).length > 0) {
       diff.updateNodes.push({ id: raw.id, changes });
     }


### PR DESCRIPTION
## Summary
Add event_date to the update_nodes tool schema, RawUpdateNode interface, and update parsing logic so the LLM can modify event dates on existing nodes (e.g., rescheduled flights).

Fixes gap identified during plan review for event-date-memory-nodes.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
