### PR TITLE
fix: sort upcoming event reservation by proximity, not significance

### DIFF
--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -490,16 +490,24 @@ export async function loadContextMemory(
     hasEventDate: true,
     eventDateAfter: nowMs,
     eventDateBefore: nowMs + 30 * 24 * 60 * 60 * 1000, // next 30 days
-    limit: UPCOMING_RESERVE,
+    limit: 20, // Fetch extra candidates — post-sort by proximity below
   });
 
-  const unresolvedUpcoming = upcomingEvents.filter((node) => {
-    if (prospectiveIds.has(node.id)) return false; // already reserved as prospective
-    const incoming = getEdgesForNode(node.id, "incoming");
-    return !incoming.some(
-      (e) => e.relationship === "supersedes" || e.relationship === "resolved-by",
-    );
-  });
+  // Sort by event date ascending so soonest events get reserved first
+  // (queryNodes sorts by significance, which would drop a tomorrow-event
+  // with low significance in favor of a 3-weeks-away high-significance one)
+  upcomingEvents.sort((a, b) => (a.eventDate ?? 0) - (b.eventDate ?? 0));
+
+  const unresolvedUpcoming = upcomingEvents
+    .filter((node) => {
+      if (prospectiveIds.has(node.id)) return false; // already reserved as prospective
+      const incoming = getEdgesForNode(node.id, "incoming");
+      return !incoming.some(
+        (e) =>
+          e.relationship === "supersedes" || e.relationship === "resolved-by",
+      );
+    })
+    .slice(0, UPCOMING_RESERVE);
 
   const upcomingIds = new Set(unresolvedUpcoming.map((n) => n.id));
   const reservedUpcoming: ScoredNode[] = unresolvedUpcoming.map((node) => {


### PR DESCRIPTION
## Summary
Query more candidates (limit 20) and post-sort by eventDate ascending so the soonest events get reserved, not the most significant. Slice to UPCOMING_RESERVE after filtering.

Fixes gap identified during plan review for event-date-memory-nodes.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
