### PR TITLE
feat(memory): add hasImageBlocks lightweight image detection helper

### DIFF
--- a/assistant/src/memory/message-content.ts
+++ b/assistant/src/memory/message-content.ts
@@ -121,6 +121,22 @@ export function extractMediaBlockMeta(
   }
 }
 
+/**
+ * Lightweight check for whether stored message content contains image blocks.
+ * Does NOT decode base64 data — only checks for `"type":"image"` in the JSON.
+ */
+export function hasImageBlocks(raw: string): boolean {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return false;
+    return parsed.some(
+      (block: { type?: string }) => block.type === "image",
+    );
+  } catch {
+    return false;
+  }
+}
+
 function stableJson(value: unknown): string {
   try {
     return JSON.stringify(value);


### PR DESCRIPTION
## Summary
- Add hasImageBlocks() function to message-content.ts
- Lightweight JSON check for image blocks without base64 decoding

Part of plan: image-memory-graph.md (PR 4 of 13)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
