### PR TITLE
feat(memory): add image_refs column to memory_graph_nodes table

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -94,6 +94,7 @@ import {
   migrateInviteContactId,
   migrateLlmRequestLogMessageId,
   migrateLlmRequestLogProvider,
+  migrateMemoryGraphImageRefs,
   migrateMemoryItemSupersession,
   migrateMessagesConversationCreatedAtIndex,
   migrateMessagesFtsBackfill,
@@ -571,6 +572,9 @@ export function initializeDb(): void {
 
   // 103. Rename legacy memory graph node type values: style → behavioral, relationship → semantic
   migrateRenameMemoryGraphTypeValues(database);
+
+  // 104. Add nullable image_refs TEXT column to memory_graph_nodes
+  migrateMemoryGraphImageRefs(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/205-memory-graph-image-refs.ts
+++ b/assistant/src/memory/migrations/205-memory-graph-image-refs.ts
@@ -1,0 +1,11 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+export function migrateMemoryGraphImageRefs(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  try {
+    raw.exec(`ALTER TABLE memory_graph_nodes ADD COLUMN image_refs TEXT`);
+  } catch {
+    // Column already exists — idempotent
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -145,6 +145,7 @@ export { migrateDropCallbackTransportColumn } from "./202-drop-callback-transpor
 export { migrateCreateMemoryGraphTables } from "./202-memory-graph-tables.js";
 export { migrateDropMemoryItemsTables } from "./203-drop-memory-items-tables.js";
 export { migrateRenameMemoryGraphTypeValues } from "./204-rename-memory-graph-type-values.js";
+export { migrateMemoryGraphImageRefs } from "./205-memory-graph-image-refs.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/memory-graph.ts
+++ b/assistant/src/memory/schema/memory-graph.ts
@@ -61,6 +61,9 @@ export const memoryGraphNodes = sqliteTable(
 
     /** Memory scope for multi-scope isolation. */
     scopeId: text("scope_id").notNull().default("default"),
+
+    /** JSON array of ImageRef objects — images attached to this memory. */
+    imageRefs: text("image_refs"),
   },
   (table) => [
     index("idx_graph_nodes_scope_id").on(table.scopeId),


### PR DESCRIPTION
## Summary
- Add image_refs TEXT column to memory_graph_nodes Drizzle schema
- Add idempotent ALTER TABLE migration (205-memory-graph-image-refs)
- Register migration in index.ts and wire into db-init startup

Part of plan: image-memory-graph.md (PR 2 of 13)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22795" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
