### PR TITLE
fix: include eventDate in memory item API responses

### DIFF
--- a/assistant/src/runtime/routes/memory-item-routes.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.ts
@@ -127,6 +127,7 @@ function nodeToPayload(
     status: node.fidelity === "gone" ? "superseded" : "active",
     confidence: node.confidence,
     importance: node.significance,
+    eventDate: node.eventDate,
     firstSeenAt: node.created,
     lastSeenAt: node.lastAccessed,
 


### PR DESCRIPTION
## Summary
Add eventDate to nodeToPayload so HTTP API responses include the event date field for memory items.

Fixes integration gap from event-date-memory-nodes plan review.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22796" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
