### PR TITLE
feat(memory): add ImageRef type and imageRefs field to MemoryNode interface

### DIFF
--- a/assistant/src/config/bundled-skills/playbooks/tools/playbook-create.ts
+++ b/assistant/src/config/bundled-skills/playbooks/tools/playbook-create.ts
@@ -107,6 +107,7 @@ export async function executePlaybookCreate(
       sourceType: "direct",
       narrativeRole: null,
       partOfStory: null,
+      imageRefs: null,
       scopeId,
     };
 

--- a/assistant/src/memory/graph/bootstrap.ts
+++ b/assistant/src/memory/graph/bootstrap.ts
@@ -456,6 +456,7 @@ export function migrateToolCreatedItems(): void {
       sourceType: "direct",
       narrativeRole: null,
       partOfStory: null,
+      imageRefs: null,
       scopeId: row.scope_id || "default",
     };
 

--- a/assistant/src/memory/graph/capability-seed.ts
+++ b/assistant/src/memory/graph/capability-seed.ts
@@ -223,6 +223,7 @@ function upsertCapabilityNode(sourceKey: string, content: string): void {
     sourceType: "direct" as const,
     narrativeRole: null,
     partOfStory: null,
+    imageRefs: null,
     scopeId: "default",
   });
 

--- a/assistant/src/memory/graph/extraction.ts
+++ b/assistant/src/memory/graph/extraction.ts
@@ -495,6 +495,7 @@ export function parseExtractionResponse(
         : "inferred") as SourceType,
       narrativeRole: null,
       partOfStory: null,
+      imageRefs: null,
       scopeId,
     };
 

--- a/assistant/src/memory/graph/injection.test.ts
+++ b/assistant/src/memory/graph/injection.test.ts
@@ -41,6 +41,7 @@ function makeNode(overrides: Partial<MemoryNode> = {}): MemoryNode {
     sourceType: "direct",
     narrativeRole: null,
     partOfStory: null,
+    imageRefs: null,
     scopeId: "default",
     ...overrides,
   };

--- a/assistant/src/memory/graph/pattern-scan.ts
+++ b/assistant/src/memory/graph/pattern-scan.ts
@@ -228,6 +228,7 @@ export async function runPatternScan(
       sourceType: "observed",
       narrativeRole: null,
       partOfStory: pattern.partOfStory ?? null,
+      imageRefs: null,
       scopeId,
     });
 

--- a/assistant/src/memory/graph/scoring.test.ts
+++ b/assistant/src/memory/graph/scoring.test.ts
@@ -41,6 +41,7 @@ function makeNode(overrides: Partial<MemoryNode> = {}): MemoryNode {
     sourceType: "direct",
     narrativeRole: null,
     partOfStory: null,
+    imageRefs: null,
     scopeId: "default",
     ...overrides,
   };

--- a/assistant/src/memory/graph/store.test.ts
+++ b/assistant/src/memory/graph/store.test.ts
@@ -52,6 +52,7 @@ function makeNewNode(overrides: Partial<NewNode> = {}): NewNode {
     sourceType: "direct",
     narrativeRole: null,
     partOfStory: null,
+    imageRefs: null,
     scopeId: "default",
     ...overrides,
   };

--- a/assistant/src/memory/graph/store.ts
+++ b/assistant/src/memory/graph/store.ts
@@ -50,6 +50,7 @@ function rowToNode(row: typeof memoryGraphNodes.$inferSelect): MemoryNode {
     sourceType: row.sourceType as SourceType,
     narrativeRole: row.narrativeRole,
     partOfStory: row.partOfStory,
+    imageRefs: null, // Column added in a later migration; default to null until then.
     scopeId: row.scopeId,
   };
 }

--- a/assistant/src/memory/graph/tool-handlers.ts
+++ b/assistant/src/memory/graph/tool-handlers.ts
@@ -294,6 +294,7 @@ function handleSave(
     sourceType: "direct" as SourceType,
     narrativeRole: null,
     partOfStory: null,
+    imageRefs: null,
     scopeId,
   };
 

--- a/assistant/src/memory/graph/types.ts
+++ b/assistant/src/memory/graph/types.ts
@@ -30,6 +30,18 @@ export type SourceType =
   | "observed" // assistant noticed a pattern
   | "told-by-other"; // third party provided it
 
+/** Reference to an image stored in a conversation message. */
+export interface ImageRef {
+  /** Message ID containing the image. */
+  messageId: string;
+  /** Index of the image ContentBlock within the message's content array. */
+  blockIndex: number;
+  /** LLM-generated description of what the image shows. */
+  description: string;
+  /** MIME type (image/png, image/jpeg, etc). */
+  mimeType: string;
+}
+
 /** Emotional charge attached to a memory — decays independently from the memory itself. */
 export interface EmotionalCharge {
   /** Positive vs negative sentiment (-1 to 1). */
@@ -91,6 +103,9 @@ export interface MemoryNode {
   narrativeRole: string | null;
   /** Which story arc this belongs to. */
   partOfStory: string | null;
+
+  /** Image references attached to this memory (null if text-only). */
+  imageRefs: ImageRef[] | null;
 
   /** Memory scope for multi-scope isolation. */
   scopeId: string;

--- a/assistant/src/runtime/routes/memory-item-routes.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.ts
@@ -564,6 +564,7 @@ export async function handleCreateMemoryItem(
     sourceType: "direct",
     narrativeRole: null,
     partOfStory: null,
+    imageRefs: null,
     scopeId: "default",
   };
 
@@ -749,6 +750,7 @@ function rowToNode(row: typeof memoryGraphNodes.$inferSelect): MemoryNode {
       | "told-by-other",
     narrativeRole: row.narrativeRole,
     partOfStory: row.partOfStory,
+    imageRefs: null, // Column added in a later migration; default to null until then.
     scopeId: row.scopeId,
   };
 }


### PR DESCRIPTION
## Summary
- Add ImageRef interface for referencing images stored in conversation messages
- Add imageRefs field to MemoryNode interface (nullable)

Part of plan: image-memory-graph.md (PR 1 of 13)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
