### PR TITLE
fix: add missing columns to rebuild-index-graph-nodes test

### DIFF
--- a/assistant/src/__tests__/rebuild-index-graph-nodes.test.ts
+++ b/assistant/src/__tests__/rebuild-index-graph-nodes.test.ts
@@ -100,7 +100,9 @@ function createTestDb() {
       source_type TEXT NOT NULL DEFAULT 'inferred',
       narrative_role TEXT,
       part_of_story TEXT,
-      scope_id TEXT NOT NULL DEFAULT 'default'
+      scope_id TEXT NOT NULL DEFAULT 'default',
+      event_date INTEGER,
+      image_refs TEXT
     );
 
     CREATE TABLE memory_graph_triggers (


### PR DESCRIPTION
## Summary
- The `rebuild-index-graph-nodes.test.ts` test creates an in-memory SQLite table manually, but it was missing the `event_date` and `image_refs` columns added to the Drizzle schema in recent PRs
- Drizzle's generated INSERT statements included these columns, causing `SQLiteError: table memory_graph_nodes has no column named event_date`

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23844103610/job/69506933591
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22798" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
