### PR TITLE
feat(memory): add loadImageRefData helper to resolve image bytes from stored messages

### DIFF
--- a/assistant/src/memory/graph/image-ref-utils.ts
+++ b/assistant/src/memory/graph/image-ref-utils.ts
@@ -1,0 +1,29 @@
+import { eq } from "drizzle-orm";
+
+import { getDb } from "../db.js";
+import { extractMediaBlocks } from "../message-content.js";
+import { messages } from "../schema.js";
+import type { ImageRef } from "./types.js";
+
+/**
+ * Load image data from the messages table for an ImageRef.
+ * Returns null if the message or image block no longer exists
+ * (e.g., conversation was deleted).
+ */
+export async function loadImageRefData(
+  ref: ImageRef,
+): Promise<{ data: Buffer; mimeType: string } | null> {
+  const db = getDb();
+  const msg = db
+    .select({ content: messages.content })
+    .from(messages)
+    .where(eq(messages.id, ref.messageId))
+    .get();
+  if (!msg) return null;
+
+  const mediaBlocks = extractMediaBlocks(msg.content);
+  const block = mediaBlocks.find((b) => b.index === ref.blockIndex);
+  if (!block) return null;
+
+  return { data: block.data, mimeType: block.mimeType };
+}


### PR DESCRIPTION
## Summary
- Create image-ref-utils.ts with loadImageRefData function
- Resolves ImageRef to image Buffer from the messages table
- Returns null gracefully when message or image block no longer exists

Part of plan: image-memory-graph.md (PR 5 of 13)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
