### PR TITLE
fix: enable scrolling in composer for long pasted text

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
@@ -95,6 +95,7 @@ struct ComposerTextEditor: NSViewRepresentable {
         textView.textContainerInset = NSSize(width: 0, height: Self.textInsetY)
         textView.isVerticallyResizable = true
         textView.isHorizontallyResizable = false
+        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
         textView.autoresizingMask = [.width]
         textView.font = font
         textView.insertionPointColor = insertionPointColor


### PR DESCRIPTION
## Summary
- Set `textView.maxSize` to `(greatestFiniteMagnitude, greatestFiniteMagnitude)` in `ComposerTextEditor.makeNSView` so the NSTextView can grow beyond the 300px clip view, enabling NSScrollView to scroll when content overflows.

## Original prompt
fix composer text area not scrolling when long text is pasted
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
