### PR TITLE
fix: handle past dates in formatEventDate

### DIFF
--- a/assistant/src/memory/graph/injection.test.ts
+++ b/assistant/src/memory/graph/injection.test.ts
@@ -458,4 +458,56 @@ describe("formatEventDate", () => {
     const result = formatEventDate(future.getTime());
     expect(result).toContain("(in 3mo)");
   });
+
+  // --- Past date handling ---
+
+  test("yesterday (diffDays === -1) shows (today)", () => {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    yesterday.setHours(0, 0, 0, 0);
+    const result = formatEventDate(yesterday.getTime());
+    expect(result).toContain("(today)");
+  });
+
+  test("2 days ago shows (2d ago)", () => {
+    const past = new Date();
+    past.setDate(past.getDate() - 2);
+    past.setHours(0, 0, 0, 0);
+    const result = formatEventDate(past.getTime());
+    expect(result).toContain("(2d ago)");
+  });
+
+  test("10 days ago shows (10d ago)", () => {
+    const past = new Date();
+    past.setDate(past.getDate() - 10);
+    past.setHours(0, 0, 0, 0);
+    const result = formatEventDate(past.getTime());
+    expect(result).toContain("(10d ago)");
+  });
+
+  test("3 weeks ago shows (3w ago)", () => {
+    const past = new Date();
+    past.setDate(past.getDate() - 21);
+    past.setHours(0, 0, 0, 0);
+    const result = formatEventDate(past.getTime());
+    expect(result).toContain("(3w ago)");
+  });
+
+  test("3 months ago shows (3mo ago)", () => {
+    const past = new Date();
+    past.setDate(past.getDate() - 90);
+    past.setHours(0, 0, 0, 0);
+    const result = formatEventDate(past.getTime());
+    expect(result).toContain("(3mo ago)");
+  });
+
+  test("never produces 'in -' for any past date", () => {
+    for (let d = -1; d >= -365; d -= 7) {
+      const past = new Date();
+      past.setDate(past.getDate() + d);
+      past.setHours(0, 0, 0, 0);
+      const result = formatEventDate(past.getTime());
+      expect(result).not.toContain("in -");
+    }
+  });
 });

--- a/assistant/src/memory/graph/injection.ts
+++ b/assistant/src/memory/graph/injection.ts
@@ -175,8 +175,19 @@ export function formatEventDate(epochMs: number): string {
   );
 
   let relative: string;
-  if (diffDays === 0) {
+  if (diffDays === 0 || diffDays === -1) {
+    // Same calendar day, or just crossed midnight — treat as "today"
     relative = "today";
+  } else if (diffDays < -1) {
+    // Past dates
+    const absDays = -diffDays;
+    if (absDays < 14) {
+      relative = `${absDays}d ago`;
+    } else if (absDays < 60) {
+      relative = `${Math.floor(absDays / 7)}w ago`;
+    } else {
+      relative = `${Math.floor(absDays / 30)}mo ago`;
+    }
   } else if (diffDays === 1) {
     relative = "tomorrow";
   } else if (diffDays < 14) {


### PR DESCRIPTION
## Summary
Add defensive handling for past event dates in formatEventDate to avoid producing 'in -2d' output.

Fixes formatting gap from event-date-memory-nodes plan review.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
