### PR TITLE
feat(memory): use multimodal transcript with images in runGraphExtraction

### DIFF
--- a/assistant/src/memory/graph/extraction.ts
+++ b/assistant/src/memory/graph/extraction.ts
@@ -737,17 +737,34 @@ export async function runGraphExtraction(
     triggersCreated: 0,
   };
 
-  // 1. Load transcript
+  // 1. Load transcript — try multimodal first, fall back to text-only
+  const imageResult = loadTranscriptWithImages(
+    conversationId,
+    opts?.afterTimestamp,
+  );
+
   let transcript = opts?.transcript;
   if (!transcript) {
     transcript =
       loadTranscriptFromDisk(conversationId, opts?.afterTimestamp) ?? undefined;
     if (!transcript) {
-      log.warn(
-        { conversationId },
-        "No transcript found on disk, skipping extraction",
-      );
-      return emptyResult;
+      // If we have a multimodal result but no disk transcript, extract text
+      // from the multimodal message content blocks for candidate search.
+      if (imageResult) {
+        transcript = imageResult.message.content
+          .filter(
+            (b): b is { type: "text"; text: string } => b.type === "text",
+          )
+          .map((b) => b.text)
+          .join("");
+      }
+      if (!transcript) {
+        log.warn(
+          { conversationId },
+          "No transcript found on disk, skipping extraction",
+        );
+        return emptyResult;
+      }
     }
   }
 
@@ -791,6 +808,7 @@ export async function runGraphExtraction(
   const conversationTimestamp =
     opts?.conversationTimestamp ??
     resolveConversationTimestamp(conversationId) ??
+    imageResult?.lastTimestamp ??
     Date.now();
 
   const convDate = new Date(conversationTimestamp);
@@ -808,13 +826,30 @@ export async function runGraphExtraction(
       hour12: true,
     });
 
-  // 6. LLM call
+  // 6. LLM call — use multimodal message when images are present
+  const useMultimodal = imageResult?.hasImages === true;
+
+  const extractionMessages: Message[] = useMultimodal
+    ? [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text" as const,
+              text: `## Conversation Date\n\n${conversationDate}\n\n## Conversation Transcript\n\n`,
+            },
+            ...imageResult.message.content,
+          ],
+        },
+      ]
+    : [
+        userMessage(
+          `## Conversation Date\n\n${conversationDate}\n\n## Conversation Transcript\n\n${transcript}`,
+        ),
+      ];
+
   const response = await provider.sendMessage(
-    [
-      userMessage(
-        `## Conversation Date\n\n${conversationDate}\n\n## Conversation Transcript\n\n${transcript}`,
-      ),
-    ],
+    extractionMessages,
     [EXTRACT_TOOL_SCHEMA],
     systemPrompt,
     {


### PR DESCRIPTION
## Summary
- Use loadTranscriptWithImages for image-bearing conversations in extraction
- LLM sees actual images alongside transcript text for better memory creation
- Falls back to existing text-only path for conversations without images
- Prepends conversation date to multimodal message content

Part of plan: image-memory-graph.md (PR 9 of 13)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22813" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
