### PR TITLE
fix: sort LLM calls chronologically in context inspector

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
@@ -198,7 +198,7 @@ struct MessageInspectorView: View {
 
                     Spacer(minLength: VSpacing.sm)
 
-                    if index == 0 {
+                    if index == viewState.logs.count - 1 {
                         Text("Latest")
                             .font(VFont.labelSmall)
                             .foregroundStyle(VColor.primaryBase)
@@ -623,7 +623,7 @@ struct MessageInspectorViewState {
                 return
             }
 
-            selectedLogID = orderedLogs.first?.id
+            selectedLogID = orderedLogs.last?.id
         case .empty:
             logs = []
             memoryRecall = nil
@@ -653,10 +653,10 @@ struct MessageInspectorViewState {
     static func ordered(_ logs: [LLMRequestLogEntry]) -> [LLMRequestLogEntry] {
         logs.sorted { lhs, rhs in
             if lhs.createdAt != rhs.createdAt {
-                return lhs.createdAt > rhs.createdAt
+                return lhs.createdAt < rhs.createdAt
             }
 
-            return lhs.id > rhs.id
+            return lhs.id < rhs.id
         }
     }
 }


### PR DESCRIPTION
## Summary

- Reversed the sort order in the LLM context inspector from newest-first to oldest-first, so "LLM Call 1" is the earliest call and "LLM Call N" is the most recent
- Moved the "Latest" badge from index 0 to the last item in the list
- Default selection now points to the latest (last) entry so the most recent call is shown on open

## Original prompt

The LLM calls are in the wrong order in the LLM context inspector. LLM Call 1 should be the earliest and LLM Call 2 should have a later timestamp
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22814" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
