### PR TITLE
fix: use null check instead of truthiness for eventDate

### DIFF
--- a/assistant/src/memory/graph/extraction.ts
+++ b/assistant/src/memory/graph/extraction.ts
@@ -592,7 +592,7 @@ export function parseExtractionResponse(
 
     // Auto-create event trigger when event_date is set but LLM didn't include one
     if (
-      node.eventDate &&
+      node.eventDate != null &&
       (!Array.isArray(raw.triggers) ||
         !raw.triggers.some((t) => t.type === "event"))
     ) {

--- a/assistant/src/memory/graph/injection.ts
+++ b/assistant/src/memory/graph/injection.ts
@@ -264,7 +264,7 @@ export function assembleContextBlock(
 
     if (scored.scoreBreakdown.triggerBoost > 0) {
       triggered.push(scored);
-    } else if (node.eventDate && node.eventDate > Date.now()) {
+    } else if (node.eventDate != null && node.eventDate > Date.now()) {
       // Future-dated events without an active trigger go to Upcoming
       upcoming.push(scored);
     } else if (node.type === "prospective") {


### PR DESCRIPTION
## Summary
Fix two locations where `node.eventDate && ...` incorrectly treats eventDate=0 as falsy. Use `node.eventDate != null` instead.

- injection.ts: assembleContextBlock partition logic
- extraction.ts: auto-trigger safety net
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22815" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
