### PR TITLE
fix: replace synthetic "(continue)" with __injected XML tag

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -931,7 +931,7 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
 
     // Assistant message should have tool_use in paired portion, server_tool_use in carryover
     // ensureToolPairing splits: paired = [tool_use(tu_a)], carryover = [server_tool_use(srvtoolu_b)]
-    // Result: assistant(tool_use) → user(tool_result) → assistant(server_tool_use) → user(continue)
+    // Result: assistant(tool_use) → user(tool_result) → assistant(server_tool_use) → user(synthetic_continuation)
     const assistantMsg = sent[1];
     expect(assistantMsg.role).toBe("assistant");
     expect(assistantMsg.content[0].type).toBe("tool_use");
@@ -1258,7 +1258,7 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     // 2. assistant(tool_use)
     // 3. user(tool_result)
     // 4. assistant(Checking the file now.)
-    // 5. user((continue))  <-- synthetic user message to maintain alternation
+    // 5. user(<synthetic_continuation __injected />)  <-- synthetic user message to maintain alternation
     // 6. assistant(Next response)
     expect(sent).toHaveLength(6);
     expect(sent[0].role).toBe("user");
@@ -1271,7 +1271,9 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     expect(sent[3].content[0].text).toBe("Checking the file now.");
     expect(sent[4].role).toBe("user");
     expect(sent[4].content[0].type).toBe("text");
-    expect(sent[4].content[0].text).toBe("(continue)");
+    expect(sent[4].content[0].text).toBe(
+      "<synthetic_continuation __injected />",
+    );
     expect(sent[5].role).toBe("assistant");
     expect(sent[5].content[0].text).toBe("Next response");
   });

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -101,6 +101,14 @@ export const PLACEHOLDER_EMPTY_TURN =
 export const PLACEHOLDER_BLOCKS_OMITTED =
   "\x00__PLACEHOLDER__[internal blocks omitted]";
 
+/**
+ * Synthetic placeholder injected as user-message content when Anthropic API
+ * alternation requires a user turn but no real user content exists. Uses the
+ * `__injected` XML tag convention so the LLM treats it as system metadata
+ * rather than user speech.
+ */
+const SYNTHETIC_CONTINUATION_TEXT = "<synthetic_continuation __injected />";
+
 /** Type-guard for tool_use blocks in Anthropic-formatted content. */
 function isToolUseBlock(block: unknown): block is Anthropic.ToolUseBlockParam {
   return (
@@ -316,7 +324,7 @@ function expandCollapsedAssistantTurns(
         content:
           rebuiltUserContent.length > 0
             ? rebuiltUserContent
-            : [{ type: "text" as const, text: "(continue)" }],
+            : [{ type: "text" as const, text: SYNTHETIC_CONTINUATION_TEXT }],
       });
       mi++; // skip the original user message
     }
@@ -582,7 +590,7 @@ function ensureToolPairing(
           content:
             normalized.remainingContent.length > 0
               ? normalized.remainingContent
-              : [{ type: "text" as const, text: "(continue)" }],
+              : [{ type: "text" as const, text: SYNTHETIC_CONTINUATION_TEXT }],
         });
       } else {
         // No carryover assistant text to restore, so preserve existing behavior


### PR DESCRIPTION
## Summary
- The Anthropic provider injects synthetic user messages with text `(continue)` to maintain API alternation when no real user content exists
- The LLM interprets this as literal user speech, causing persona confusion (e.g. "Sidd said '(continue)'")
- Replaced with `<synthetic_continuation __injected />` which uses the existing `__injected` XML tag convention that the LLM treats as system metadata

## Original prompt
Change "(continue)" text to `<synthetic_continuation __injected />`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22816" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
