### PR TITLE
fix: sort imports in memory/embed.ts

### DIFF
--- a/assistant/src/memory/embed.ts
+++ b/assistant/src/memory/embed.ts
@@ -9,7 +9,7 @@ import {
   computeRetryDelay,
   isRetryableNetworkError,
 } from "../util/retry.js";
-import { embedWithBackend, type EmbeddingInput } from "./embedding-backend.js";
+import { type EmbeddingInput, embedWithBackend } from "./embedding-backend.js";
 
 const log = getLogger("memory-embed");
 


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error in `assistant/src/memory/embed.ts` by reordering `type EmbeddingInput` before `embedWithBackend` in the named import

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23844789093/job/69509275909
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22817" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
