### PR TITLE
fix: use event date formatting in per-turn injection for event-dated nodes

### DIFF
--- a/assistant/src/__tests__/injection-block.test.ts
+++ b/assistant/src/__tests__/injection-block.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+
+import { assembleInjectionBlock } from "../memory/graph/injection.js";
+import type { MemoryNode, ScoredNode } from "../memory/graph/types.js";
+
+function makeScoredNode(
+  overrides: Partial<MemoryNode> & { content: string },
+): ScoredNode {
+  return {
+    node: {
+      id: "test-id",
+      content: overrides.content,
+      type: overrides.type ?? "episodic",
+      created: overrides.created ?? Date.now() - 3 * 24 * 60 * 60 * 1000,
+      lastAccessed: overrides.lastAccessed ?? Date.now(),
+      lastConsolidated: overrides.lastConsolidated ?? Date.now(),
+      eventDate: overrides.eventDate ?? null,
+      emotionalCharge: overrides.emotionalCharge ?? {
+        valence: 0,
+        intensity: 0,
+        decayCurve: "linear",
+        decayRate: 0,
+        originalIntensity: 0,
+      },
+      fidelity: overrides.fidelity ?? "clear",
+      confidence: overrides.confidence ?? 1,
+      significance: overrides.significance ?? 0.5,
+      stability: overrides.stability ?? 1,
+      reinforcementCount: overrides.reinforcementCount ?? 0,
+      lastReinforced: overrides.lastReinforced ?? Date.now(),
+      sourceConversations: overrides.sourceConversations ?? [],
+      sourceType: overrides.sourceType ?? "direct",
+      narrativeRole: overrides.narrativeRole ?? null,
+      partOfStory: overrides.partOfStory ?? null,
+      imageRefs: overrides.imageRefs ?? null,
+      scopeId: overrides.scopeId ?? "default",
+    },
+    score: 0.8,
+    scoreBreakdown: {
+      semanticSimilarity: 0.5,
+      effectiveSignificance: 0.5,
+      emotionalIntensity: 0,
+      temporalBoost: 0,
+      recencyBoost: 0,
+      triggerBoost: 0,
+      activationBoost: 0,
+    },
+  };
+}
+
+describe("assembleInjectionBlock", () => {
+  test("returns empty string for empty array", () => {
+    expect(assembleInjectionBlock([])).toBe("");
+  });
+
+  test("uses creation age format for nodes without eventDate", () => {
+    const node = makeScoredNode({ content: "Regular memory node" });
+    const result = assembleInjectionBlock([node]);
+    // Should show relative age like "(3d ago)"
+    expect(result).toMatch(/^\- \(\d+[dhm]o? ago\) Regular memory node$/);
+  });
+
+  test("uses event date format for nodes with eventDate", () => {
+    // Set eventDate to 5 days from now
+    const futureDate = Date.now() + 5 * 24 * 60 * 60 * 1000;
+    const node = makeScoredNode({
+      content: "Flight to NYC",
+      eventDate: futureDate,
+    });
+    const result = assembleInjectionBlock([node]);
+    // Should show event date like "Tue Apr 8, 6:00 PM (in 5d) — Flight to NYC"
+    expect(result).toContain("Flight to NYC");
+    expect(result).toMatch(/\(in \d+d\)/);
+    // Should NOT contain the age-based format
+    expect(result).not.toMatch(/\(\d+[dhm]o? ago\)/);
+  });
+
+  test("mixes both formats when nodes have mixed eventDate presence", () => {
+    const regularNode = makeScoredNode({
+      id: "regular",
+      content: "Had coffee with friend",
+    } as Partial<MemoryNode> & { content: string });
+    const eventNode = makeScoredNode({
+      id: "event",
+      content: "Dentist appointment",
+      eventDate: Date.now() + 2 * 24 * 60 * 60 * 1000,
+    } as Partial<MemoryNode> & { content: string });
+
+    const result = assembleInjectionBlock([regularNode, eventNode]);
+    const lines = result.split("\n");
+
+    expect(lines).toHaveLength(2);
+    // First line: regular node with age format
+    expect(lines[0]).toMatch(/\(\d+[dhm]o? ago\) Had coffee with friend/);
+    // Second line: event node with event date format
+    expect(lines[1]).toContain("Dentist appointment");
+    expect(lines[1]).toMatch(/\(in \d+d\)/);
+  });
+
+  test("uses event date format for past event-dated nodes", () => {
+    // Set eventDate to 3 days ago (past event)
+    const pastDate = Date.now() - 3 * 24 * 60 * 60 * 1000;
+    const node = makeScoredNode({
+      content: "Team standup",
+      eventDate: pastDate,
+    });
+    const result = assembleInjectionBlock([node]);
+    // Should show event date format with past indicator, not creation age
+    expect(result).toContain("Team standup");
+    expect(result).toMatch(/\(\d+d ago\)/);
+    // The line should use the event date format (date — content) not age format ((age) content)
+    expect(result).toContain(" — Team standup");
+  });
+});

--- a/assistant/src/memory/graph/injection.ts
+++ b/assistant/src/memory/graph/injection.ts
@@ -348,7 +348,14 @@ function buildSection(nodes: ScoredNode[], maxItems: number): string[] {
  */
 export function assembleInjectionBlock(nodes: ScoredNode[]): string {
   if (nodes.length === 0) return "";
-  return nodes.map(formatNodeEntry).join("\n");
+  return nodes
+    .map((scored) => {
+      if (scored.node.eventDate != null) {
+        return formatUpcomingEntry(scored);
+      }
+      return formatNodeEntry(scored);
+    })
+    .join("\n");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Update assembleInjectionBlock to use formatUpcomingEntry for nodes with eventDate, so per-turn and refresh injection paths show the actual event date instead of just creation age.

Fixes gap from event-date-memory-nodes plan review round 4.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
