### PR TITLE
fix: skip synthetic continuation when next message is already user

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -1278,6 +1278,58 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     expect(sent[5].content[0].text).toBe("Next response");
   });
 
+  test("carryover with tool_result-only user turn skips synthetic when next message is user", async () => {
+    // When the user turn after the consumed pair is already a user message,
+    // the synthetic continuation is unnecessary — the next user message
+    // naturally maintains alternation after the carryover assistant message.
+    const messages: Message[] = [
+      userMsg("Read file"),
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "tu_1", name: "file_read", input: {} },
+          { type: "text", text: "Checking the file now." }, // carryover content
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          // ONLY tool_result, no other content
+          {
+            type: "tool_result",
+            tool_use_id: "tu_1",
+            content: "file contents",
+            is_error: false,
+          },
+        ],
+      },
+      userMsg("Follow-up question"), // next message is user — no synthetic needed
+    ];
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{ type: string; text?: string; tool_use_id?: string }>;
+    }>;
+
+    // Expected structure:
+    // 1. user(Read file)
+    // 2. assistant(tool_use)
+    // 3. user(tool_result)
+    // 4. assistant(Checking the file now.)
+    // 5. user(Follow-up question)  <-- real user message, NO synthetic continuation
+    expect(sent).toHaveLength(5);
+    expect(sent[0].role).toBe("user");
+    expect(sent[1].role).toBe("assistant");
+    expect(sent[1].content[0].type).toBe("tool_use");
+    expect(sent[2].role).toBe("user");
+    expect(sent[2].content[0].type).toBe("tool_result");
+    expect(sent[3].role).toBe("assistant");
+    expect(sent[3].content[0].text).toBe("Checking the file now.");
+    expect(sent[4].role).toBe("user");
+    expect(sent[4].content[0].text).toBe("Follow-up question");
+  });
+
   test("multi-turn with workspace injection: cache on second-to-last user turn only", async () => {
     const messages: Message[] = [
       // Turn 1: workspace + user text (no cache - 3rd-to-last)

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -318,14 +318,24 @@ function expandCollapsedAssistantTurns(
     if (nextIsUser) {
       const remainingResults = Array.from(toolResultMap.values());
       const rebuiltUserContent = [...remainingResults, ...nonToolResultContent];
-      // Replace the original user message with the rebuilt one
-      result.push({
-        role: "user" as const,
-        content:
-          rebuiltUserContent.length > 0
-            ? rebuiltUserContent
-            : [{ type: "text" as const, text: SYNTHETIC_CONTINUATION_TEXT }],
-      });
+      // Replace the original user message with the rebuilt one. When all
+      // tool_results were distributed to intermediate segments (empty rebuilt
+      // content), skip the synthetic placeholder if the next message is already
+      // a user turn — ensureToolPairing will pair the last assistant segment
+      // with that next user message naturally.
+      if (rebuiltUserContent.length > 0) {
+        result.push({ role: "user" as const, content: rebuiltUserContent });
+      } else {
+        const nextAfterUser = messages[mi + 2];
+        if (!nextAfterUser || nextAfterUser.role !== "user") {
+          result.push({
+            role: "user" as const,
+            content: [
+              { type: "text" as const, text: SYNTHETIC_CONTINUATION_TEXT },
+            ],
+          });
+        }
+      }
       mi++; // skip the original user message
     }
   }
@@ -582,16 +592,26 @@ function ensureToolPairing(
           role: "assistant" as const,
           content: carryoverContent,
         });
-        // Always emit a trailing user message to maintain alternation, even if the
-        // original user turn had only tool_result blocks. Use a synthetic placeholder
-        // when remainingContent is empty.
-        result.push({
-          role: "user" as const,
-          content:
-            normalized.remainingContent.length > 0
-              ? normalized.remainingContent
-              : [{ type: "text" as const, text: SYNTHETIC_CONTINUATION_TEXT }],
-        });
+        // Emit a trailing user message when there is remaining content, or when
+        // alternation requires it (next message is assistant or end of array).
+        // Skip the synthetic placeholder if the next message is already a user
+        // turn — it will naturally maintain alternation.
+        if (normalized.remainingContent.length > 0) {
+          result.push({
+            role: "user" as const,
+            content: normalized.remainingContent,
+          });
+        } else {
+          const nextAfterPair = messages[i + 2];
+          if (!nextAfterPair || nextAfterPair.role !== "user") {
+            result.push({
+              role: "user" as const,
+              content: [
+                { type: "text" as const, text: SYNTHETIC_CONTINUATION_TEXT },
+              ],
+            });
+          }
+        }
       } else {
         // No carryover assistant text to restore, so preserve existing behavior
         // and keep additional user blocks in the same message.


### PR DESCRIPTION
## Summary
- `ensureToolPairing()` and `expandCollapsedAssistantTurns()` injected synthetic user messages (`<synthetic_continuation __injected />`) even when the next message was already a user turn, creating unnecessary messages that polluted the LLM context
- Added look-ahead logic: before injecting, check if the message after the consumed pair is a user message — if so, skip the injection since natural alternation is maintained
- Added test verifying the synthetic message is omitted when followed by a real user message

## Original prompt
Add look-ahead to skip unnecessary synthetic injection when next message is user

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22819" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
