### PR TITLE
fix: drain enrichment before heartbeat in workspace lifecycle test

### DIFF
--- a/assistant/src/__tests__/workspace-lifecycle.test.ts
+++ b/assistant/src/__tests__/workspace-lifecycle.test.ts
@@ -184,6 +184,13 @@ describe("Workspace git lifecycle (integration)", () => {
     await commitTurnChanges(testDir, conversationId, 3);
     expect(commitCount(testDir)).toBe(3); // Still 3
 
+    // Drain fire-and-forget enrichment from turn commits before heartbeat
+    // testing. Enrichment's writeNote() can leave a stale index.lock on
+    // some git versions (see heartbeat-service.ts:240-242), causing the
+    // heartbeat commit to fail with "index.lock: File exists".
+    await getEnrichmentService().shutdown();
+    _resetEnrichmentService();
+
     // ----------------------------------------------------------------
     // Step 5: Heartbeat safety net — simulate uncommitted changes
     //         that linger past the age threshold


### PR DESCRIPTION
## Summary
- Drain the fire-and-forget enrichment queue between turn commits and heartbeat testing in the workspace lifecycle integration test
- Fixes flaky CI failure where enrichment's `writeNote()` left a stale `index.lock` on some git versions, causing the heartbeat commit to fail with "index.lock: File exists"

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23844789093/job/69509275946
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22820" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
