### PR TITLE
fix: parse imageRefs in routes rowToNode instead of hardcoding null

### DIFF
--- a/assistant/src/runtime/routes/memory-item-routes.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.ts
@@ -39,6 +39,7 @@ import {
 } from "../../memory/graph/store.js";
 import type {
   Fidelity,
+  ImageRef,
   MemoryNode,
   MemoryType,
   NewNode,
@@ -751,7 +752,7 @@ function rowToNode(row: typeof memoryGraphNodes.$inferSelect): MemoryNode {
       | "told-by-other",
     narrativeRole: row.narrativeRole,
     partOfStory: row.partOfStory,
-    imageRefs: null, // Column added in a later migration; default to null until then.
+    imageRefs: row.imageRefs ? (JSON.parse(row.imageRefs) as ImageRef[]) : null,
     scopeId: row.scopeId,
   };
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for image-memory-graph.md.

**Gap:** Duplicate rowToNode in memory-item-routes hardcodes imageRefs: null
**What was expected:** imageRefs parsed from DB row
**What was found:** Hardcoded null with stale comment
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22822" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
