### PR TITLE
fix: preserve imageRefs during consolidation merge and annotate in prompt

### DIFF
--- a/assistant/src/memory/graph/consolidation.ts
+++ b/assistant/src/memory/graph/consolidation.ts
@@ -44,6 +44,7 @@ function buildConsolidationPrompt(
     reinforcementCount: number;
     created: number;
     eventDate: number | null;
+    hasImage: boolean;
   }>,
   edges: Array<{ sourceId: string; targetId: string; relationship: string }>,
 ): string {
@@ -54,7 +55,8 @@ function buildConsolidationPrompt(
         n.eventDate != null
           ? ` eventDate=${new Date(n.eventDate).toISOString().split("T")[0]}`
           : "";
-      return `  [${n.id}] type=${n.type} sig=${n.significance.toFixed(2)} fidelity=${n.fidelity} reinforced=${n.reinforcementCount}x age=${age}d${eventStr}\n    ${n.content}`;
+      const imageStr = n.hasImage ? " [has_image]" : "";
+      return `  [${n.id}] type=${n.type} sig=${n.significance.toFixed(2)} fidelity=${n.fidelity} reinforced=${n.reinforcementCount}x age=${age}d${eventStr}${imageStr}\n    ${n.content}`;
     })
     .join("\n\n");
 
@@ -439,6 +441,7 @@ async function consolidateChunk(
       reinforcementCount: n.reinforcementCount,
       created: n.created,
       eventDate: n.eventDate,
+      hasImage: n.imageRefs != null && n.imageRefs.length > 0,
     })),
     dedupedEdges,
   );
@@ -525,6 +528,16 @@ async function consolidateChunk(
         survivor.eventDate == null
       ) {
         updateNode(merge.survivor_id, { eventDate: deleted.eventDate });
+      }
+
+      // Preserve imageRefs from deleted node if survivor doesn't have any
+      if (
+        survivor &&
+        deleted?.imageRefs != null &&
+        deleted.imageRefs.length > 0 &&
+        (survivor.imageRefs == null || survivor.imageRefs.length === 0)
+      ) {
+        updateNode(merge.survivor_id, { imageRefs: deleted.imageRefs });
       }
     } catch (err) {
       log.warn({ err }, "Failed to create merge edge");


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for image-memory-graph.md.

**Gap:** Consolidation merge drops imageRefs from deleted nodes
**What was expected:** imageRefs preserved on survivor when deleted node has them
**What was found:** No imageRefs handling in consolidation merge handler

- Added `[has_image]` annotation in `buildConsolidationPrompt` node listings so the LLM can see which nodes carry images and make informed merge decisions
- Added parallel imageRefs preservation logic in the merge handler (alongside existing eventDate preservation): if the survivor has no imageRefs and the deleted node does, the imageRefs are copied to the survivor

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
