### PR TITLE
fix: inherit eventDate in supersedeNode

### DIFF
--- a/assistant/src/memory/graph/store.test.ts
+++ b/assistant/src/memory/graph/store.test.ts
@@ -680,6 +680,32 @@ describe("supersedeNode", () => {
     expect(edges[0].weight).toBe(1.0);
   });
 
+  test("inherits eventDate from old node when new node has null eventDate", () => {
+    const eventDate = 1712534400000; // April 8 2024
+    const old = createNode(makeNewNode({ content: "Dentist April 8.", eventDate }));
+    const newNodeInput = makeNewNode({
+      content: "Dentist appointment rescheduled.",
+      eventDate: null,
+    });
+
+    const { newNode } = supersedeNode(old.id, newNodeInput);
+
+    expect(newNode.eventDate).toBe(eventDate);
+  });
+
+  test("uses new node eventDate when both nodes have eventDate", () => {
+    const old = createNode(makeNewNode({ content: "Flight Tuesday.", eventDate: 1712534400000 }));
+    const newEventDate = 1712620800000;
+    const newNodeInput = makeNewNode({
+      content: "Flight moved to Thursday.",
+      eventDate: newEventDate,
+    });
+
+    const { newNode } = supersedeNode(old.id, newNodeInput);
+
+    expect(newNode.eventDate).toBe(newEventDate);
+  });
+
   test("handles non-existent old node by just creating new node", () => {
     const { newNode, oldNode } = supersedeNode(
       "non-existent",

--- a/assistant/src/memory/graph/store.ts
+++ b/assistant/src/memory/graph/store.ts
@@ -487,6 +487,7 @@ export function supersedeNode(
       oldNode.reinforcementCount,
     ),
     significance: Math.max(newNode.significance, oldNode.significance),
+    eventDate: newNode.eventDate ?? oldNode.eventDate,
   };
 
   const created = createNode(inherited);


### PR DESCRIPTION
## Summary
Add eventDate inheritance to supersedeNode so the new node preserves the old node's event date when the new node doesn't have one.

Fixes supersede gap from event-date-memory-nodes plan review round 6.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22824" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
