### PR TITLE
fix: add Number() coercion to event_date parsing in extraction and consolidation

### DIFF
--- a/assistant/src/__tests__/graph-extraction-event-date.test.ts
+++ b/assistant/src/__tests__/graph-extraction-event-date.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  parseEpochMs,
+  parseExtractionResponse,
+} from "../memory/graph/extraction.js";
+
+// ---------------------------------------------------------------------------
+// parseEpochMs unit tests
+// ---------------------------------------------------------------------------
+
+describe("parseEpochMs", () => {
+  test("returns number as-is", () => {
+    expect(parseEpochMs(1712534400000)).toBe(1712534400000);
+  });
+
+  test("coerces numeric string to number", () => {
+    expect(parseEpochMs("1712534400000")).toBe(1712534400000);
+  });
+
+  test("returns null for non-numeric string", () => {
+    expect(parseEpochMs("not a number")).toBeNull();
+  });
+
+  test("returns null for null", () => {
+    expect(parseEpochMs(null)).toBeNull();
+  });
+
+  test("returns null for undefined", () => {
+    expect(parseEpochMs(undefined)).toBeNull();
+  });
+
+  test("returns null for Infinity", () => {
+    expect(parseEpochMs(Infinity)).toBeNull();
+  });
+
+  test("returns null for NaN", () => {
+    expect(parseEpochMs(NaN)).toBeNull();
+  });
+
+  test("returns null for empty string", () => {
+    expect(parseEpochMs("")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseExtractionResponse — event_date coercion
+// ---------------------------------------------------------------------------
+
+describe("parseExtractionResponse event_date coercion", () => {
+  const candidateNodeIds = new Set<string>();
+  const conversationId = "test-convo";
+  const scopeId = "default";
+  const now = Date.now();
+
+  function makeInput(overrides: Record<string, unknown> = {}) {
+    return {
+      create_nodes: [
+        {
+          content: "Test memory",
+          type: "episodic",
+          emotional_charge: {
+            valence: 0.5,
+            intensity: 0.5,
+            decay_curve: "linear",
+            decay_rate: 0.05,
+          },
+          significance: 0.5,
+          confidence: 0.8,
+          source_type: "direct",
+          ...overrides,
+        },
+      ],
+      reinforce_node_ids: [],
+    };
+  }
+
+  test("coerces string event_date on create_nodes", () => {
+    const input = makeInput({ event_date: "1712534400000" });
+    const { diff } = parseExtractionResponse(
+      input,
+      conversationId,
+      scopeId,
+      candidateNodeIds,
+      now,
+    );
+    expect(diff.createNodes[0].eventDate).toBe(1712534400000);
+  });
+
+  test("passes through numeric event_date on create_nodes", () => {
+    const input = makeInput({ event_date: 1712534400000 });
+    const { diff } = parseExtractionResponse(
+      input,
+      conversationId,
+      scopeId,
+      candidateNodeIds,
+      now,
+    );
+    expect(diff.createNodes[0].eventDate).toBe(1712534400000);
+  });
+
+  test("nullifies non-numeric string event_date on create_nodes", () => {
+    const input = makeInput({ event_date: "next tuesday" });
+    const { diff } = parseExtractionResponse(
+      input,
+      conversationId,
+      scopeId,
+      candidateNodeIds,
+      now,
+    );
+    expect(diff.createNodes[0].eventDate).toBeNull();
+  });
+
+  test("coerces string event_date on triggers", () => {
+    const input = makeInput({
+      event_date: 1712534400000,
+      triggers: [
+        {
+          type: "event",
+          event_date: "1712534400000",
+          ramp_days: 7,
+          follow_up_days: 2,
+        },
+      ],
+    });
+    const { deferredTriggers } = parseExtractionResponse(
+      input,
+      conversationId,
+      scopeId,
+      candidateNodeIds,
+      now,
+    );
+    // Should have the explicit trigger (coerced) plus possibly the auto-created one
+    const explicitTrigger = deferredTriggers.find(
+      (t) => t.trigger.eventDate === 1712534400000,
+    );
+    expect(explicitTrigger).toBeTruthy();
+    expect(explicitTrigger!.trigger.eventDate).toBe(1712534400000);
+  });
+
+  test("coerces string event_date on update_nodes", () => {
+    const existingNodeId = "existing-node-1";
+    const candidates = new Set([existingNodeId]);
+    const input = {
+      create_nodes: [],
+      reinforce_node_ids: [],
+      update_nodes: [
+        {
+          id: existingNodeId,
+          event_date: "1712534400000",
+        },
+      ],
+    };
+    const { diff } = parseExtractionResponse(
+      input,
+      conversationId,
+      scopeId,
+      candidates,
+      now,
+    );
+    expect(diff.updateNodes[0].changes.eventDate).toBe(1712534400000);
+  });
+
+  test("null-clears event_date on update_nodes when explicitly null", () => {
+    const existingNodeId = "existing-node-1";
+    const candidates = new Set([existingNodeId]);
+    const input = {
+      create_nodes: [],
+      reinforce_node_ids: [],
+      update_nodes: [
+        {
+          id: existingNodeId,
+          event_date: null,
+        },
+      ],
+    };
+    const { diff } = parseExtractionResponse(
+      input,
+      conversationId,
+      scopeId,
+      candidates,
+      now,
+    );
+    expect(diff.updateNodes[0].changes.eventDate).toBeNull();
+  });
+});

--- a/assistant/src/memory/graph/consolidation.ts
+++ b/assistant/src/memory/graph/consolidation.ts
@@ -25,6 +25,7 @@ import {
   queryNodes,
   updateNode,
 } from "./store.js";
+import { parseEpochMs } from "./extraction.js";
 import type { MemoryNode } from "./types.js";
 
 const log = getLogger("graph-consolidation");
@@ -493,7 +494,7 @@ async function consolidateChunk(
       changes.narrativeRole = update.narrativeRole || null;
     if (update.partOfStory !== undefined)
       changes.partOfStory = update.partOfStory || null;
-    if (update.event_date !== undefined) changes.eventDate = update.event_date;
+    if (update.event_date !== undefined) changes.eventDate = parseEpochMs(update.event_date);
     changes.lastConsolidated = Date.now();
 
     if (Object.keys(changes).length > 1) {

--- a/assistant/src/memory/graph/extraction.ts
+++ b/assistant/src/memory/graph/extraction.ts
@@ -449,6 +449,13 @@ function clamp(v: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, v));
 }
 
+/** Coerce an LLM-returned event_date to number | null, guarding against string values. */
+export function parseEpochMs(value: unknown): number | null {
+  if (value == null || value === "") return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
 export function parseExtractionResponse(
   input: Record<string, unknown>,
   conversationId: string,
@@ -522,7 +529,7 @@ export function parseExtractionResponse(
       created: now,
       lastAccessed: now,
       lastConsolidated: now,
-      eventDate: raw.event_date ?? null,
+      eventDate: parseEpochMs(raw.event_date),
       emotionalCharge,
       fidelity: "vivid" as Fidelity,
       confidence: clamp(Number(raw.confidence) || 0.5, 0, 1),
@@ -578,7 +585,7 @@ export function parseExtractionResponse(
             condition: t.condition ?? null,
             conditionEmbedding: null, // Embedded async via job
             threshold: t.type === "semantic" ? 0.7 : null,
-            eventDate: t.event_date ?? null,
+            eventDate: parseEpochMs(t.event_date),
             rampDays: t.ramp_days ?? null,
             followUpDays: t.follow_up_days ?? null,
             recurring: t.recurring ?? false,
@@ -653,7 +660,7 @@ export function parseExtractionResponse(
       ["vivid", "clear", "faded", "gist"].includes(raw.fidelity)
     )
       changes.fidelity = raw.fidelity;
-    if (raw.event_date !== undefined) changes.eventDate = raw.event_date;
+    if (raw.event_date !== undefined) changes.eventDate = parseEpochMs(raw.event_date);
     if (Object.keys(changes).length > 0) {
       diff.updateNodes.push({ id: raw.id, changes });
     }


### PR DESCRIPTION
## Summary
Add parseEpochMs helper that coerces event_date values from LLM output through Number() + isFinite, matching the pattern used for all other numeric fields (significance, confidence, etc.). Applied to all 4 parsing paths: create_nodes, triggers, update_nodes, and consolidation updates.

Fixes coercion gap from event-date-memory-nodes plan review round 6.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
