### PR TITLE
fix: disable heartbeat by default

### DIFF
--- a/assistant/src/config/schemas/heartbeat.ts
+++ b/assistant/src/config/schemas/heartbeat.ts
@@ -6,7 +6,7 @@ export const HeartbeatConfigSchema = z
   .object({
     enabled: z
       .boolean({ error: "heartbeat.enabled must be a boolean" })
-      .default(true)
+      .default(false)
       .describe("Whether periodic heartbeat checks are enabled"),
     intervalMs: z
       .number({ error: "heartbeat.intervalMs must be a number" })


### PR DESCRIPTION
## Summary
- Disable heartbeat checks by default (`heartbeat.enabled` defaults to `false` instead of `true`)
- The heartbeat creates periodic background conversations that clutter the macOS sidebar; disabling by default until the UX around generated conversations is improved
- Users can still opt in by setting `heartbeat.enabled: true` in their config
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22828" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
