### PR TITLE
fix: stabilize VCard identity by removing conditional modifier

### DIFF
--- a/clients/shared/DesignSystem/Components/Display/VCard.swift
+++ b/clients/shared/DesignSystem/Components/Display/VCard.swift
@@ -36,12 +36,8 @@ public struct VCard<Content: View>: View {
                     .strokeBorder(VColor.borderDisabled, lineWidth: 2)
             )
             .contentShape(RoundedRectangle(cornerRadius: VRadius.xl))
-            .onHover { isHovered = $0 }
+            .onTapGesture { action?() }
+            .pointerCursor(enabled: action != nil, onHover: { isHovered = $0 })
             .animation(VAnimation.fast, value: isHovered)
-            .if(action != nil) { view in
-                view
-                    .onTapGesture { action?() }
-                    .pointerCursor()
-            }
     }
 }

--- a/clients/shared/DesignSystem/Modifiers/PointerCursorModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/PointerCursorModifier.swift
@@ -11,12 +11,13 @@ import SwiftUI
 /// into a single `.onHover` handler, avoiding competing hover registrations.
 struct PointerCursorModifier: ViewModifier {
     @Environment(\.isEnabled) private var isEnabled
+    var enabled: Bool = true
     var onHover: ((Bool) -> Void)?
 
     func body(content: Content) -> some View {
         #if os(macOS)
         content
-            .pointerStyle(isEnabled ? .link : nil)
+            .pointerStyle(enabled && isEnabled ? .link : nil)
             .onHover { hovering in
                 onHover?(hovering)
             }
@@ -38,6 +39,11 @@ public extension View {
     /// Applies a pointing-hand cursor and calls `onHover` in a single hover handler.
     func pointerCursor(onHover: @escaping (Bool) -> Void) -> some View {
         modifier(PointerCursorModifier(onHover: onHover))
+    }
+
+    /// Applies a pointing-hand cursor with an enabled flag and optional hover callback.
+    func pointerCursor(enabled: Bool, onHover: @escaping (Bool) -> Void) -> some View {
+        modifier(PointerCursorModifier(enabled: enabled, onHover: onHover))
     }
 }
 


### PR DESCRIPTION
## Summary
- Remove `.if(action != nil)` from `VCard.body` so the view tree has one stable shape regardless of whether `action` is nil or non-nil, preventing `_ConditionalContent + ExclusiveGesture` main-thread hangs
- Add `pointerCursor(enabled:onHover:)` overload to `PointerCursorModifier` so callers can conditionally activate the link cursor without changing the view hierarchy
- `backgroundColor` hover-highlight logic is unchanged — hover highlight still only appears when `action != nil`

## Original prompt
### Stabilize `VCard` Identity and Remove Conditional Modifier

#### Summary
1. Remove `.if(action != nil)` from VCard.swift.
2. Make interaction modifiers always present so `VCard` keeps one structural shape whether `action` is `nil` or non-`nil`.

#### Implementation
1. Update PointerCursorModifier.swift to support an `enabled` flag while preserving existing call sites.
2. Keep `PointerCursorModifier` behavior platform-safe (`pointerStyle` on macOS only) and continue honoring `\.isEnabled`.
3. Replace `VCard`'s current `onHover + .if { onTapGesture + pointerCursor }` chain with a single always-applied chain: `onTapGesture { action?() }` + `pointerCursor(enabled: action != nil, onHover: { isHovered = $0 })`.
4. Keep `backgroundColor` logic unchanged so hover highlight still appears only when interactive (`action != nil`).
5. Leave ConditionalModifier.swift in place for other consumers; only remove `VCard` usage.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22830" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
