### PR TITLE
refactor: rename clawhub.ts to skillssh.ts and update all internal imports

### DIFF
--- a/assistant/src/__tests__/skill-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags-integration.test.ts
@@ -65,7 +65,6 @@ function makeConfig(overrides: Partial<AssistantConfig> = {}): AssistantConfig {
       allowBundled: null,
       remoteProviders: {
         skillssh: { enabled: true },
-        clawhub: { enabled: true },
       },
       remotePolicy: {
         blockSuspicious: true,

--- a/assistant/src/__tests__/skill-feature-flags.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags.test.ts
@@ -34,7 +34,6 @@ function makeConfig(overrides: Partial<AssistantConfig> = {}): AssistantConfig {
       allowBundled: null,
       remoteProviders: {
         skillssh: { enabled: true },
-        clawhub: { enabled: true },
       },
       remotePolicy: {
         blockSuspicious: true,
@@ -241,7 +240,6 @@ describe("resolveSkillStates with feature flags", () => {
         allowBundled: null,
         remoteProviders: {
           skillssh: { enabled: true },
-          clawhub: { enabled: true },
         },
         remotePolicy: {
           blockSuspicious: true,

--- a/assistant/src/__tests__/skillssh.test.ts
+++ b/assistant/src/__tests__/skillssh.test.ts
@@ -17,7 +17,7 @@ import {
   clawhubInstall,
   loadIntegrityManifest,
   verifyAndRecordSkillHash,
-} from "../skills/clawhub.js";
+} from "../skills/skillssh.js";
 
 // ---------------------------------------------------------------------------
 // Slug validation (exercised through public API)

--- a/assistant/src/__tests__/tool-preview-lifecycle.test.ts
+++ b/assistant/src/__tests__/tool-preview-lifecycle.test.ts
@@ -27,7 +27,6 @@ mock.module("../config/loader.js", () => ({
       allowBundled: null,
       remoteProviders: {
         skillssh: { enabled: true },
-        clawhub: { enabled: true },
       },
       remotePolicy: {
         blockSuspicious: true,

--- a/assistant/src/config/schemas/skills.ts
+++ b/assistant/src/config/schemas/skills.ts
@@ -77,9 +77,6 @@ export const RemoteProvidersConfigSchema = z
     skillssh: RemoteProviderConfigSchema.default(
       RemoteProviderConfigSchema.parse({}),
     ).describe("skills.sh remote skill provider"),
-    clawhub: RemoteProviderConfigSchema.default(
-      RemoteProviderConfigSchema.parse({}),
-    ).describe("ClawHub remote skill provider"),
   })
   .describe("Remote skill provider configurations");
 

--- a/assistant/src/config/schemas/skills.ts
+++ b/assistant/src/config/schemas/skills.ts
@@ -77,6 +77,22 @@ export const RemoteProvidersConfigSchema = z
     skillssh: RemoteProviderConfigSchema.default(
       RemoteProviderConfigSchema.parse({}),
     ).describe("skills.sh remote skill provider"),
+    clawhub: RemoteProviderConfigSchema.optional().describe(
+      "Deprecated alias for skillssh — settings here are merged into skillssh",
+    ),
+  })
+  .transform((val) => {
+    // Merge legacy clawhub settings into skillssh so that existing
+    // config files with `clawhub.enabled: false` continue to work.
+    if (val.clawhub != null) {
+      if (val.clawhub.enabled === false) {
+        val.skillssh.enabled = false;
+      }
+    }
+    // Strip the legacy key from the resolved config so downstream
+    // code only sees `skillssh`.
+    const { clawhub: _, ...rest } = val;
+    return rest;
   })
   .describe("Remote skill provider configurations");
 

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -29,14 +29,6 @@ import { getCatalog } from "../../skills/catalog-cache.js";
 import { installSkillLocally } from "../../skills/catalog-install.js";
 import { filterByQuery } from "../../skills/catalog-search.js";
 import {
-  clawhubCheckUpdates,
-  clawhubInspect,
-  type ClawhubInspectResult,
-  clawhubInstall,
-  clawhubSearch,
-  clawhubUpdate,
-} from "../../skills/clawhub.js";
-import {
   createManagedSkill,
   deleteManagedSkill,
   removeSkillsIndexEntry,
@@ -46,6 +38,14 @@ import {
   deleteSkillCapabilityMemory,
   seedCatalogSkillMemories,
 } from "../../skills/skill-memory.js";
+import {
+  clawhubCheckUpdates,
+  clawhubInspect,
+  type ClawhubInspectResult,
+  clawhubInstall,
+  clawhubSearch,
+  clawhubUpdate,
+} from "../../skills/skillssh.js";
 import { getWorkspaceSkillsDir } from "../../util/platform.js";
 import {
   CONFIG_RELOAD_DEBOUNCE_MS,

--- a/assistant/src/skills/skillssh.ts
+++ b/assistant/src/skills/skillssh.ts
@@ -10,7 +10,7 @@ import { dirname, join } from "node:path";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceSkillsDir } from "../util/platform.js";
 
-const log = getLogger("clawhub");
+const log = getLogger("skillssh");
 
 // Managed skills directory — where installed skill folders live
 function getManagedSkillsDir(): string {


### PR DESCRIPTION
## Summary
- Rename clawhub.ts module to skillssh.ts and clawhub.test.ts to skillssh.test.ts
- Update all import paths from clawhub.js to skillssh.js across handlers, policies, and tests
- Rename config key from clawhub to skillssh in skills schema

Part of plan: skills-rename-clawhub.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22831" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
