### PR TITLE
perf: cache NSImage instances in VIcon to fix re-layout hang

### DIFF
--- a/clients/shared/DesignSystem/Tokens/IconTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/IconTokens.swift
@@ -258,11 +258,9 @@ public enum VIcon: String, CaseIterable, Sendable {
     /// On iOS, pass the display size so the PDF is rasterized at the correct resolution.
     public func image(size: CGFloat = 24) -> Image {
         #if canImport(AppKit) && !targetEnvironment(macCatalyst)
-        guard let url = pdfURL, let ns = NSImage(contentsOf: url) else {
+        guard let ns = cachedNSImage(size: size) else {
             return Image(systemName: "questionmark.square")
         }
-        ns.isTemplate = true
-        ns.size = NSSize(width: size, height: size)
         return Image(nsImage: ns)
         #elseif canImport(UIKit)
         guard let url = pdfURL, let ui = Self.rasterizePDF(at: url, size: size, cacheKey: "\(rawValue)-\(size)") else {
@@ -278,18 +276,57 @@ public enum VIcon: String, CaseIterable, Sendable {
     public var image: Image { image() }
 
     #if canImport(AppKit) && !targetEnvironment(macCatalyst)
-    /// AppKit `NSImage` resolved from the vendored PDF.
-    public var nsImage: NSImage? {
+    /// Non-evicting store for loaded NSImage instances, keyed on "rawValue-base" or "rawValue-{size}".
+    /// Unlike NSCache, a plain dictionary is never evicted under memory pressure, preserving
+    /// the identity stability that SwiftUI relies on for diffing.
+    private static var nsImageStore: [String: NSImage] = [:]
+    private static let nsImageLock = NSLock()
+
+    /// Loads (or returns cached) NSImage from the vendored PDF.
+    /// Pass `nil` for the unsized base image, or a size for a sized variant.
+    private func cachedNSImage(size: CGFloat? = nil) -> NSImage? {
+        let cacheKey: String
+        let roundedSize: CGFloat?
+        if let size {
+            roundedSize = CGFloat(Int(size.rounded()))
+            cacheKey = "\(rawValue)-\(Int(size.rounded()))"
+        } else {
+            roundedSize = nil
+            cacheKey = "\(rawValue)-base"
+        }
+
+        Self.nsImageLock.lock()
+        if let cached = Self.nsImageStore[cacheKey] {
+            Self.nsImageLock.unlock()
+            return cached
+        }
+        Self.nsImageLock.unlock()
+
         guard let url = pdfURL, let img = NSImage(contentsOf: url) else { return nil }
         img.isTemplate = true
+        if let roundedSize {
+            img.size = NSSize(width: roundedSize, height: roundedSize)
+        }
+
+        Self.nsImageLock.lock()
+        // Double-check in case another thread populated it while we were loading.
+        if let existing = Self.nsImageStore[cacheKey] {
+            Self.nsImageLock.unlock()
+            return existing
+        }
+        Self.nsImageStore[cacheKey] = img
+        Self.nsImageLock.unlock()
         return img
+    }
+
+    /// AppKit `NSImage` resolved from the vendored PDF.
+    public var nsImage: NSImage? {
+        cachedNSImage()
     }
 
     /// Convenience returning a sized `NSImage`.
     public func nsImage(size: CGFloat) -> NSImage? {
-        guard let img = nsImage else { return nil }
-        img.size = NSSize(width: size, height: size)
-        return img
+        cachedNSImage(size: size)
     }
     #endif
 

--- a/clients/shared/DesignSystem/Tokens/IconTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/IconTokens.swift
@@ -288,8 +288,10 @@ public enum VIcon: String, CaseIterable, Sendable {
         let cacheKey: String
         let roundedSize: CGFloat?
         if let size {
-            roundedSize = CGFloat(Int(size.rounded()))
-            cacheKey = "\(rawValue)-\(Int(size.rounded()))"
+            // Clamped to [1, 512] to bound keyspace; VIcon.allCases.count × 512 ≈ trivial memory
+            let roundedInt = max(1, min(Int(size.rounded()), 512))
+            roundedSize = CGFloat(roundedInt)
+            cacheKey = "\(rawValue)-\(roundedInt)"
         } else {
             roundedSize = nil
             cacheKey = "\(rawValue)-base"

--- a/clients/shared/Tests/IconCachingTests.swift
+++ b/clients/shared/Tests/IconCachingTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import VellumAssistantShared
+
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
+import AppKit
+
+final class IconCachingTests: XCTestCase {
+
+    // MARK: - Identity stability (same icon + same size)
+
+    /// Requesting the same icon at the same size must return the identical NSImage instance.
+    func testSameIconSameSizeReturnsSameInstance() {
+        let icon = VIcon.search
+        let a = icon.nsImage(size: 24)
+        let b = icon.nsImage(size: 24)
+        XCTAssertNotNil(a)
+        XCTAssertTrue(a === b, "Same icon + same size should return identical NSImage instance")
+    }
+
+    // MARK: - Size cross-contamination guard
+
+    /// Different sizes for the same icon must produce distinct instances so one size
+    /// does not overwrite another.
+    func testSameIconDifferentSizeReturnsDifferentInstances() {
+        let icon = VIcon.search
+        let small = icon.nsImage(size: 16)
+        let large = icon.nsImage(size: 32)
+        XCTAssertNotNil(small)
+        XCTAssertNotNil(large)
+        XCTAssertFalse(small === large, "Different sizes should return different NSImage instances")
+    }
+
+    // MARK: - Unsized stability
+
+    /// The unsized `nsImage` property must return a stable identity across repeated access.
+    func testUnsizedNSImageReturnsStableIdentity() {
+        let icon = VIcon.check
+        let a = icon.nsImage
+        let b = icon.nsImage
+        XCTAssertNotNil(a)
+        XCTAssertTrue(a === b, "Unsized nsImage should return identical instance across repeated access")
+    }
+
+    // MARK: - isTemplate preservation
+
+    /// Cached images must preserve `isTemplate == true` so AppKit renders them
+    /// correctly with the current accent/foreground color.
+    func testCachedImagesPreserveIsTemplate() {
+        let icon = VIcon.star
+        let unsized = icon.nsImage
+        let sized = icon.nsImage(size: 20)
+        XCTAssertNotNil(unsized)
+        XCTAssertNotNil(sized)
+        XCTAssertTrue(unsized?.isTemplate == true, "Unsized cached image must have isTemplate == true")
+        XCTAssertTrue(sized?.isTemplate == true, "Sized cached image must have isTemplate == true")
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
Implement a macOS NSImage cache in `VIcon` so repeated renders return the same `NSImage` instance for the same icon+size, eliminating repeated PDF disk reads in SwiftUI body paths and reducing `AG::LayoutDescriptor::compare_partial` churn.

## PRs merged into feature branch
- #22829: perf: cache NSImage instances in VIcon to fix re-layout hang

Part of plan: vicon-nsimage-caching.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22832" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
