### PR TITLE
perf: add FontWarmupCoordinator and VFont.prewarmForAppLaunch() for off-main font warmup

### DIFF
--- a/clients/macos/vellum-assistant/App/FontWarmupCoordinator.swift
+++ b/clients/macos/vellum-assistant/App/FontWarmupCoordinator.swift
@@ -1,6 +1,7 @@
 import Foundation
 import os
 import CoreText
+import VellumAssistantShared
 
 /// Coordinates off-main-thread font registration and warmup at app launch.
 ///

--- a/clients/macos/vellum-assistant/App/FontWarmupCoordinator.swift
+++ b/clients/macos/vellum-assistant/App/FontWarmupCoordinator.swift
@@ -14,7 +14,7 @@ final class FontWarmupCoordinator {
 
     @Published private(set) var isReady = false
 
-    private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum", category: "fontWarmup")
+    private let logger = Logger(subsystem: Bundle.appBundleIdentifier, category: "fontWarmup")
 
     /// The detached warmup task — nil until `start()` is called.
     private var warmupTask: Task<Void, Never>?

--- a/clients/macos/vellum-assistant/App/FontWarmupCoordinator.swift
+++ b/clients/macos/vellum-assistant/App/FontWarmupCoordinator.swift
@@ -1,0 +1,84 @@
+import Foundation
+import os
+import CoreText
+
+/// Coordinates off-main-thread font registration and warmup at app launch.
+///
+/// Owned by AppDelegate; callers use `awaitReady()` to gate UI creation
+/// until fonts are resolved and cached by CoreText.
+@MainActor
+final class FontWarmupCoordinator {
+
+    static let shared = FontWarmupCoordinator()
+
+    @Published private(set) var isReady = false
+
+    private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum", category: "fontWarmup")
+
+    /// The detached warmup task — nil until `start()` is called.
+    private var warmupTask: Task<Void, Never>?
+
+    /// Continuations parked by `awaitReady()` callers, resumed when warmup completes.
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    private init() {}
+
+    // MARK: - Public API
+
+    /// Kicks off font registration and prewarm on a detached (non-main) task.
+    ///
+    /// Idempotent — subsequent calls after the first are no-ops.
+    func start(registerFonts: @Sendable @escaping () -> Void) {
+        guard warmupTask == nil else { return }
+
+        logger.info("[fontWarmup] start")
+
+        warmupTask = Task.detached(priority: .userInitiated) { [logger] in
+            registerFonts()
+            logger.info("[fontWarmup] registerFonts done")
+
+            VFont.prewarmForAppLaunch()
+            logger.info("[fontWarmup] prewarm done")
+
+            await MainActor.run {
+                self.markReady()
+            }
+        }
+    }
+
+    /// Suspends the caller until font warmup is complete.
+    ///
+    /// Returns immediately if warmup has already finished.
+    func awaitReady() async {
+        if isReady {
+            logger.info("[fontWarmup] awaitReady: already ready")
+            return
+        }
+
+        logger.info("[fontWarmup] awaitReady: waiting...")
+        let startTime = ContinuousClock.now
+
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            if isReady {
+                continuation.resume()
+            } else {
+                waiters.append(continuation)
+            }
+        }
+
+        let elapsed = ContinuousClock.now - startTime
+        let ms = elapsed.components.seconds * 1000 + elapsed.components.attoseconds / 1_000_000_000_000_000
+        logger.info("[fontWarmup] awaitReady: resumed after \(ms)ms")
+    }
+
+    // MARK: - Private
+
+    private func markReady() {
+        isReady = true
+        logger.info("[fontWarmup] ready")
+        for waiter in waiters {
+            waiter.resume()
+        }
+        waiters.removeAll()
+    }
+}

--- a/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
@@ -177,4 +177,41 @@ public enum VFont {
         NSFontManager.shared.convert(nsMono, toHaveTrait: .italicFontMask)
     }()
     #endif
+
+    // MARK: - Prewarm
+
+    /// Eagerly accesses every static font token, forcing CoreText to resolve and cache them.
+    ///
+    /// Safe to call from any thread — Swift static lets are thread-safe.
+    /// Called by `FontWarmupCoordinator` during off-main warmup.
+    public static func prewarmForAppLaunch() {
+        // SwiftUI Font tokens
+        _ = brandMedium
+        _ = brandSmall
+        _ = displayLarge
+        _ = titleLarge
+        _ = titleMedium
+        _ = titleSmall
+        _ = bodyLargeLighter
+        _ = bodyLargeDefault
+        _ = bodyLargeEmphasised
+        _ = bodyMediumLighter
+        _ = bodyMediumDefault
+        _ = bodyMediumEmphasised
+        _ = bodySmallDefault
+        _ = bodySmallEmphasised
+        _ = labelDefault
+        _ = labelSmall
+        _ = menuCompact
+        _ = chat
+
+        // NSFont tokens (macOS only)
+        #if os(macOS)
+        _ = nsChat
+        _ = nsBodyMediumDefault
+        _ = nsMono
+        _ = nsMonoBold
+        _ = nsMonoItalic
+        #endif
+    }
 }


### PR DESCRIPTION
## Summary
- Add FontWarmupCoordinator: @MainActor singleton that runs font registration + VFont prewarm off-main via Task.detached, with awaitReady() barrier
- Add VFont.prewarmForAppLaunch() to eagerly touch all static font tokens, forcing CoreText resolution

Part of plan: font-warmup-gate.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22833" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
