### PR TITLE
refactor: rename clawhub* functions and types to skillssh* across backend

### DIFF
--- a/assistant/src/__tests__/remote-skill-policy.test.ts
+++ b/assistant/src/__tests__/remote-skill-policy.test.ts
@@ -6,7 +6,7 @@ import {
   type RemoteSkillPolicy,
 } from "../skills/remote-skill-policy.js";
 
-describe("remote skill policy — clawhub", () => {
+describe("remote skill policy — skillssh moderation", () => {
   const policy: RemoteSkillPolicy = {
     blockSuspicious: true,
     blockMalware: true,
@@ -59,7 +59,7 @@ describe("remote skill policy — clawhub", () => {
     expect(decision).toEqual({ ok: false, reason: "clawhub_malware_blocked" });
   });
 
-  test("clawhub skill with undefined moderation is blocked (fail-closed)", () => {
+  test("skill with undefined moderation is blocked (fail-closed)", () => {
     const decision = evaluateRemoteSkillInstall(
       {
         provider: "clawhub",
@@ -75,7 +75,7 @@ describe("remote skill policy — clawhub", () => {
     });
   });
 
-  test("clawhub skill with null moderation is blocked (fail-closed)", () => {
+  test("skill with null moderation is blocked (fail-closed)", () => {
     const decision = evaluateRemoteSkillInstall(
       {
         provider: "clawhub",
@@ -91,7 +91,7 @@ describe("remote skill policy — clawhub", () => {
     });
   });
 
-  test("clawhub skill without moderation property is blocked (fail-closed)", () => {
+  test("skill without moderation property is blocked (fail-closed)", () => {
     const decision = evaluateRemoteSkillInstall(
       {
         provider: "clawhub",
@@ -106,7 +106,7 @@ describe("remote skill policy — clawhub", () => {
     });
   });
 
-  test("clawhub skills with missing moderation are excluded from installable list", () => {
+  test("skills with missing moderation are excluded from installable list", () => {
     const candidates = [
       {
         provider: "clawhub" as const,

--- a/assistant/src/__tests__/skillssh.test.ts
+++ b/assistant/src/__tests__/skillssh.test.ts
@@ -13,9 +13,9 @@ mock.module("../util/logger.js", () => ({
 }));
 
 import {
-  clawhubInspect,
-  clawhubInstall,
   loadIntegrityManifest,
+  skillsshInspect,
+  skillsshInstall,
   verifyAndRecordSkillHash,
 } from "../skills/skillssh.js";
 
@@ -23,70 +23,70 @@ import {
 // Slug validation (exercised through public API)
 // ---------------------------------------------------------------------------
 
-describe("clawhubInstall slug validation", () => {
+describe("skillsshInstall slug validation", () => {
   test("rejects empty slug", async () => {
-    const result = await clawhubInstall("");
+    const result = await skillsshInstall("");
     expect(result.success).toBe(false);
     expect(result.error).toContain("Invalid skill slug");
   });
 
   test("rejects slug starting with a dot", async () => {
-    const result = await clawhubInstall(".hidden");
+    const result = await skillsshInstall(".hidden");
     expect(result.success).toBe(false);
     expect(result.error).toContain("Invalid skill slug");
   });
 
   test("rejects slug starting with a hyphen", async () => {
-    const result = await clawhubInstall("-dashed");
+    const result = await skillsshInstall("-dashed");
     expect(result.success).toBe(false);
     expect(result.error).toContain("Invalid skill slug");
   });
 
   test("rejects slug with path traversal", async () => {
-    const result = await clawhubInstall("../escape");
+    const result = await skillsshInstall("../escape");
     expect(result.success).toBe(false);
     expect(result.error).toContain("Invalid skill slug");
   });
 
   test("rejects slug with spaces", async () => {
-    const result = await clawhubInstall("my skill");
+    const result = await skillsshInstall("my skill");
     expect(result.success).toBe(false);
     expect(result.error).toContain("Invalid skill slug");
   });
 
   test("rejects slug with double slash", async () => {
-    const result = await clawhubInstall("ns//skill");
+    const result = await skillsshInstall("ns//skill");
     expect(result.success).toBe(false);
     expect(result.error).toContain("Invalid skill slug");
   });
 
   test("rejects slug ending with slash", async () => {
-    const result = await clawhubInstall("skill/");
+    const result = await skillsshInstall("skill/");
     expect(result.success).toBe(false);
     expect(result.error).toContain("Invalid skill slug");
   });
 
   test("rejects slug with special characters", async () => {
-    const result = await clawhubInstall("skill@latest");
+    const result = await skillsshInstall("skill@latest");
     expect(result.success).toBe(false);
     expect(result.error).toContain("Invalid skill slug");
   });
 });
 
-describe("clawhubInspect slug validation", () => {
+describe("skillsshInspect slug validation", () => {
   test("rejects empty slug", async () => {
-    const result = await clawhubInspect("");
+    const result = await skillsshInspect("");
     expect(result.error).toContain("Invalid skill slug");
     expect(result.data).toBeUndefined();
   });
 
   test("rejects slug with path traversal", async () => {
-    const result = await clawhubInspect("../../etc/passwd");
+    const result = await skillsshInspect("../../etc/passwd");
     expect(result.error).toContain("Invalid skill slug");
   });
 
   test("rejects slug with spaces", async () => {
-    const result = await clawhubInspect("bad slug");
+    const result = await skillsshInspect("bad slug");
     expect(result.error).toContain("Invalid skill slug");
   });
 });

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -39,12 +39,12 @@ import {
   seedCatalogSkillMemories,
 } from "../../skills/skill-memory.js";
 import {
-  clawhubCheckUpdates,
-  clawhubInspect,
-  type ClawhubInspectResult,
-  clawhubInstall,
-  clawhubSearch,
-  clawhubUpdate,
+  skillsshCheckUpdates,
+  skillsshInspect,
+  type SkillsshInspectResult,
+  skillsshInstall,
+  skillsshSearch,
+  skillsshUpdate,
 } from "../../skills/skillssh.js";
 import { getWorkspaceSkillsDir } from "../../util/platform.js";
 import {
@@ -81,7 +81,7 @@ interface SkillProvenance {
   sourceUrl?: string;
 }
 
-const CLAWHUB_BASE_URL = "https://skills.sh";
+const SKILLSSH_BASE_URL = "https://skills.sh";
 
 function resolveProvenance(summary: SkillSummary): SkillProvenance {
   // Bundled skills are always first-party (shipped with Vellum)
@@ -89,7 +89,7 @@ function resolveProvenance(summary: SkillSummary): SkillProvenance {
     return { kind: "first-party", provider: "Vellum" };
   }
 
-  // Managed skills are third-party (installed from clawhub). The homepage field
+  // Managed skills are third-party (installed from skills.sh). The homepage field
   // confirms provenance.
   if (summary.source === "managed") {
     if (
@@ -102,10 +102,10 @@ function resolveProvenance(summary: SkillSummary): SkillProvenance {
         originId: summary.id,
         sourceUrl:
           summary.homepage ??
-          `${CLAWHUB_BASE_URL}/skills/${encodeURIComponent(summary.id)}`,
+          `${SKILLSSH_BASE_URL}/skills/${encodeURIComponent(summary.id)}`,
       };
     }
-    // No positive evidence of clawhub origin -- likely user-authored.
+    // No positive evidence of skills.sh origin -- likely user-authored.
     // Default to "local" to avoid mislabeling.
     return { kind: "local" };
   }
@@ -238,7 +238,13 @@ export interface SkillListItem {
   description: string;
   emoji?: string;
   homepage?: string;
-  source: "bundled" | "managed" | "workspace" | "clawhub" | "extra" | "catalog";
+  source:
+    | "bundled"
+    | "managed"
+    | "workspace"
+    | "skillssh"
+    | "extra"
+    | "catalog";
   state: "enabled" | "disabled";
   installStatus: "bundled" | "installed" | "available";
   updateAvailable: boolean;
@@ -612,15 +618,15 @@ export async function installSkill(
         return { success: true };
       }
     } catch (err) {
-      // If catalog lookup/install fails, fall through to clawhub
+      // If catalog lookup/install fails, fall through to skillssh
       log.warn(
         { err, skillId: spec.slug },
         "Vellum catalog install failed, falling back to community registry",
       );
     }
 
-    // Install from clawhub (community)
-    const result = await clawhubInstall(spec.slug, { version: spec.version });
+    // Install from skillssh (community)
+    const result = await skillsshInstall(spec.slug, { version: spec.version });
     if (!result.success) {
       return { success: false, error: result.error ?? "Unknown error" };
     }
@@ -732,7 +738,7 @@ export async function updateSkill(
   _ctx: SkillOperationContext,
 ): Promise<{ success: true } | { success: false; error: string }> {
   try {
-    const result = await clawhubUpdate(skillId);
+    const result = await skillsshUpdate(skillId);
     if (!result.success) {
       return { success: false, error: result.error ?? "Unknown error" };
     }
@@ -752,7 +758,7 @@ export async function checkSkillUpdates(
   { success: true; data: unknown } | { success: false; error: string }
 > {
   try {
-    const updates = await clawhubCheckUpdates();
+    const updates = await skillsshCheckUpdates();
     return { success: true, data: updates };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -776,8 +782,8 @@ export async function searchSkills(
       (s) => s.description,
     ]);
 
-    // Shape that matches ClawhubSearchResultItem so the client
-    // (Swift ClawhubSkillItem) can decode results uniformly.
+    // Shape that matches SkillsshSearchResultItem so the client
+    // can decode results uniformly.
     interface SearchItem {
       name: string;
       slug: string;
@@ -787,7 +793,7 @@ export async function searchSkills(
       installs: number;
       version: string;
       createdAt: number;
-      source: "vellum" | "clawhub";
+      source: "vellum" | "skillssh";
     }
 
     const catalogItems: SearchItem[] = catalogMatches.map((s) => ({
@@ -805,12 +811,12 @@ export async function searchSkills(
     // Search the community registry (non-fatal on failure)
     let communitySkills: SearchItem[] = [];
     try {
-      const communityResult = await clawhubSearch(query);
+      const communityResult = await skillsshSearch(query);
       communitySkills = communityResult.skills;
     } catch (err) {
       log.warn(
         { err },
-        "clawhub search failed, returning catalog-only results",
+        "skillssh search failed, returning catalog-only results",
       );
     }
 
@@ -832,9 +838,9 @@ export async function searchSkills(
 export async function inspectSkill(
   skillId: string,
   _ctx: SkillOperationContext,
-): Promise<{ slug: string; data?: ClawhubInspectResult; error?: string }> {
+): Promise<{ slug: string; data?: SkillsshInspectResult; error?: string }> {
   try {
-    const result = await clawhubInspect(skillId);
+    const result = await skillsshInspect(skillId);
     return {
       slug: skillId,
       ...(result.data ? { data: result.data } : {}),

--- a/assistant/src/daemon/message-types/skills.ts
+++ b/assistant/src/daemon/message-types/skills.ts
@@ -84,12 +84,12 @@ export interface SkillsListResponse {
     description: string;
     emoji?: string;
     homepage?: string;
-    source: "bundled" | "managed" | "workspace" | "clawhub" | "extra";
+    source: "bundled" | "managed" | "workspace" | "skillssh" | "extra";
     state: "enabled" | "disabled";
     installedVersion?: string;
     latestVersion?: string;
     updateAvailable: boolean;
-    clawhub?: {
+    skillssh?: {
       author: string;
       stars: number;
       installs: number;

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -72,7 +72,7 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
                 "bundled",
                 "managed",
                 "workspace",
-                "clawhub",
+                "skillssh",
                 "extra",
                 "catalog",
               ]),

--- a/assistant/src/skills/remote-skill-policy.ts
+++ b/assistant/src/skills/remote-skill-policy.ts
@@ -26,7 +26,7 @@ export interface RemoteSkillPolicy {
   maxSkillsShRisk: SkillsShRiskThreshold;
 }
 
-export interface ClawhubModerationState {
+export interface SkillsshModerationState {
   isSuspicious?: boolean;
   isMalwareBlocked?: boolean;
 }
@@ -40,9 +40,9 @@ interface RemoteSkillCandidateBase {
   slug: string;
 }
 
-export interface ClawhubRemoteSkillCandidate extends RemoteSkillCandidateBase {
+export interface SkillsshModerationCandidate extends RemoteSkillCandidateBase {
   provider: "clawhub";
-  moderation?: ClawhubModerationState | null;
+  moderation?: SkillsshModerationState | null;
 }
 
 export interface SkillsShRemoteSkillCandidate extends RemoteSkillCandidateBase {
@@ -51,7 +51,7 @@ export interface SkillsShRemoteSkillCandidate extends RemoteSkillCandidateBase {
 }
 
 export type RemoteSkillCandidate =
-  | ClawhubRemoteSkillCandidate
+  | SkillsshModerationCandidate
   | SkillsShRemoteSkillCandidate;
 
 export type RemoteSkillDenyReason =
@@ -104,7 +104,7 @@ export function evaluateRemoteSkillInstall(
   policy: RemoteSkillPolicy = DEFAULT_REMOTE_SKILL_POLICY,
 ): RemoteSkillInstallDecision {
   if (candidate.provider === "clawhub") {
-    // Fail closed: block Clawhub skills when moderation data is missing.
+    // Fail closed: block skills when moderation data is missing.
     if (candidate.moderation == null) {
       return { ok: false, reason: "clawhub_moderation_missing" };
     }

--- a/assistant/src/skills/skillssh.ts
+++ b/assistant/src/skills/skillssh.ts
@@ -17,9 +17,9 @@ function getManagedSkillsDir(): string {
   return getWorkspaceSkillsDir();
 }
 
-// ClaWHub project root — clawhub creates a `skills/` subdir inside its cwd,
+// Skills.sh project root — skillssh creates a `skills/` subdir inside its cwd,
 // so we use the parent of the managed skills dir as the project root.
-function getClawhubProjectRoot(): string {
+function getSkillsshProjectRoot(): string {
   return dirname(getWorkspaceSkillsDir());
 }
 
@@ -160,14 +160,14 @@ export function verifyAndRecordSkillHash(slug: string): void {
   saveIntegrityManifest(manifest);
 }
 
-interface ClawhubInstallResult {
+interface SkillsshInstallResult {
   success: boolean;
   skillName?: string;
   version?: string;
   error?: string;
 }
 
-interface ClawhubSearchResultItem {
+interface SkillsshSearchResultItem {
   name: string;
   slug: string;
   description: string;
@@ -176,43 +176,43 @@ interface ClawhubSearchResultItem {
   installs: number;
   version: string;
   createdAt: number;
-  /** Where this skill comes from: "vellum" (first-party) or "clawhub" (community). */
-  source: "vellum" | "clawhub";
+  /** Where this skill comes from: "vellum" (first-party) or "skillssh" (community). */
+  source: "vellum" | "skillssh";
 }
 
-interface ClawhubSearchResult {
-  skills: ClawhubSearchResultItem[];
+interface SkillsshSearchResult {
+  skills: SkillsshSearchResultItem[];
 }
 
-interface ClawhubUpdateResult {
+interface SkillsshUpdateResult {
   success: boolean;
   updatedVersion?: string;
   error?: string;
 }
 
-interface ClawhubUpdateCheckItem {
+interface SkillsshUpdateCheckItem {
   name: string;
   installedVersion: string;
   latestVersion: string;
 }
 
-// Helper to run clawhub commands
-async function runClawhub(
+// Helper to run skillssh commands
+async function runSkillssh(
   args: string[],
   opts?: { cwd?: string; timeout?: number },
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-  const cwd = opts?.cwd ?? getClawhubProjectRoot();
+  const cwd = opts?.cwd ?? getSkillsshProjectRoot();
   const timeout = opts?.timeout ?? 60000;
 
   // Ensure managed skills dir exists
   const { mkdirSync } = await import("node:fs");
   mkdirSync(cwd, { recursive: true });
 
-  log.info({ args, cwd }, "Running clawhub command");
+  log.info({ args, cwd }, "Running skillssh command");
 
-  const proc = Bun.spawn(["npx", "clawhub", ...args], {
+  const proc = Bun.spawn(["npx", "skillssh", ...args], {
     cwd,
-    env: { ...process.env, CLAWHUB_DISABLE_TELEMETRY: "1" },
+    env: { ...process.env, SKILLSSH_DISABLE_TELEMETRY: "1" },
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -221,7 +221,7 @@ async function runClawhub(
   const timeoutPromise = new Promise<[string, string]>((_, reject) => {
     timer = setTimeout(() => {
       proc.kill();
-      reject(new Error(`clawhub command timed out after ${timeout}ms`));
+      reject(new Error(`skillssh command timed out after ${timeout}ms`));
     }, timeout);
   });
 
@@ -240,16 +240,16 @@ async function runClawhub(
 
   log.info(
     { exitCode, stdoutLen: stdout.length, stderrLen: stderr.length },
-    "clawhub command completed",
+    "skillssh command completed",
   );
 
   return { stdout, stderr, exitCode };
 }
 
-export async function clawhubInstall(
+export async function skillsshInstall(
   slug: string,
   opts?: { version?: string },
-): Promise<ClawhubInstallResult> {
+): Promise<SkillsshInstallResult> {
   if (!validateSlug(slug)) {
     return { success: false, error: `Invalid skill slug: ${slug}` };
   }
@@ -258,7 +258,7 @@ export async function clawhubInstall(
   const args = ["install", installSlug, "--force"]; // non-interactive
 
   try {
-    const result = await runClawhub(args);
+    const result = await runSkillssh(args);
     if (result.exitCode !== 0) {
       const error =
         result.stderr.trim() || result.stdout.trim() || "Unknown error";
@@ -272,11 +272,11 @@ export async function clawhubInstall(
   }
 }
 
-export async function clawhubUpdate(
+export async function skillsshUpdate(
   name: string,
-): Promise<ClawhubUpdateResult> {
+): Promise<SkillsshUpdateResult> {
   try {
-    const result = await runClawhub(["update", name, "--force"]);
+    const result = await runSkillssh(["update", name, "--force"]);
     if (result.exitCode !== 0) {
       const error =
         result.stderr.trim() || result.stdout.trim() || "Unknown error";
@@ -290,16 +290,16 @@ export async function clawhubUpdate(
   }
 }
 
-export async function clawhubSearch(
+export async function skillsshSearch(
   query: string,
-): Promise<ClawhubSearchResult> {
+): Promise<SkillsshSearchResult> {
   // Empty query: use explore (browse trending) instead of search
   if (!query.trim()) {
-    return clawhubExplore();
+    return skillsshExplore();
   }
 
   try {
-    const result = await runClawhub(["search", query, "--limit", "25"]);
+    const result = await runSkillssh(["search", query, "--limit", "25"]);
     if (result.exitCode !== 0) {
       return { skills: [] };
     }
@@ -308,17 +308,17 @@ export async function clawhubSearch(
       const parsed = JSON.parse(result.stdout);
       if (Array.isArray(parsed)) {
         return {
-          skills: parsed.map((s: ClawhubSearchResultItem) => ({
+          skills: parsed.map((s: SkillsshSearchResultItem) => ({
             ...s,
-            source: s.source ?? ("clawhub" as const),
+            source: s.source ?? ("skillssh" as const),
           })),
         };
       }
       if (parsed.skills && Array.isArray(parsed.skills)) {
         return {
-          skills: parsed.skills.map((s: ClawhubSearchResultItem) => ({
+          skills: parsed.skills.map((s: SkillsshSearchResultItem) => ({
             ...s,
-            source: s.source ?? ("clawhub" as const),
+            source: s.source ?? ("skillssh" as const),
           })),
         };
       }
@@ -327,7 +327,7 @@ export async function clawhubSearch(
     }
 
     // Parse text output lines: "slug vVersion  Display Name  (score)"
-    const skills: ClawhubSearchResultItem[] = [];
+    const skills: SkillsshSearchResultItem[] = [];
     for (const line of result.stdout.split("\n")) {
       const match = line.match(/^(\S+)\s+v(\S+)\s+(.+?)\s+\([\d.]+\)\s*$/);
       if (match) {
@@ -340,26 +340,26 @@ export async function clawhubSearch(
           stars: 0,
           installs: 0,
           createdAt: 0,
-          source: "clawhub",
+          source: "skillssh",
         });
       }
     }
     return { skills };
   } catch (err) {
-    log.warn({ err }, "clawhub search failed");
+    log.warn({ err }, "skillssh search failed");
     return { skills: [] };
   }
 }
 
-export async function clawhubExplore(opts?: {
+export async function skillsshExplore(opts?: {
   limit?: number;
   sort?: string;
-}): Promise<ClawhubSearchResult> {
+}): Promise<SkillsshSearchResult> {
   const limit = String(opts?.limit ?? 25);
   const sort = opts?.sort ?? "installsAllTime";
 
   try {
-    const result = await runClawhub([
+    const result = await runSkillssh([
       "explore",
       "--json",
       "--limit",
@@ -375,8 +375,8 @@ export async function clawhubExplore(opts?: {
       const items = parsed.items ?? parsed;
       if (!Array.isArray(items)) return { skills: [] };
 
-      // Normalize explore response to ClawhubSearchResultItem shape
-      const skills: ClawhubSearchResultItem[] = items.map(
+      // Normalize explore response to SkillsshSearchResultItem shape
+      const skills: SkillsshSearchResultItem[] = items.map(
         (item: Record<string, unknown>) => ({
           name: (item.displayName as string) ?? (item.slug as string) ?? "",
           slug: (item.slug as string) ?? "",
@@ -387,7 +387,7 @@ export async function clawhubExplore(opts?: {
             (item.stats as Record<string, number>)?.installsAllTime ?? 0,
           version: (item.tags as Record<string, string>)?.latest ?? "",
           createdAt: (item.createdAt as number) ?? 0,
-          source: "clawhub",
+          source: "skillssh",
         }),
       );
       return { skills };
@@ -396,12 +396,12 @@ export async function clawhubExplore(opts?: {
     }
     return { skills: [] };
   } catch (err) {
-    log.warn({ err }, "clawhub explore failed");
+    log.warn({ err }, "skillssh explore failed");
     return { skills: [] };
   }
 }
 
-export interface ClawhubInspectResult {
+export interface SkillsshInspectResult {
   skill: { slug: string; displayName: string; summary: string };
   owner: { handle: string; displayName: string; image?: string } | null;
   stats: {
@@ -417,15 +417,15 @@ export interface ClawhubInspectResult {
   skillMdContent: string | null;
 }
 
-export async function clawhubInspect(
+export async function skillsshInspect(
   slug: string,
-): Promise<{ data?: ClawhubInspectResult; error?: string }> {
+): Promise<{ data?: SkillsshInspectResult; error?: string }> {
   if (!validateSlug(slug)) {
     return { error: `Invalid skill slug: ${slug}` };
   }
 
   try {
-    const result = await runClawhub([
+    const result = await runSkillssh([
       "inspect",
       slug,
       "--json",
@@ -441,7 +441,7 @@ export async function clawhubInspect(
     try {
       const parsed = JSON.parse(result.stdout);
       // Normalize the raw inspect response to our interface
-      const data: ClawhubInspectResult = {
+      const data: SkillsshInspectResult = {
         skill: {
           slug: parsed.slug ?? slug,
           displayName: parsed.displayName ?? parsed.name ?? slug,
@@ -495,8 +495,10 @@ export async function clawhubInspect(
   }
 }
 
-export async function clawhubCheckUpdates(): Promise<ClawhubUpdateCheckItem[]> {
-  // This is a placeholder -- clawhub doesn't have a dedicated check-updates command
+export async function skillsshCheckUpdates(): Promise<
+  SkillsshUpdateCheckItem[]
+> {
+  // This is a placeholder -- skillssh doesn't have a dedicated check-updates command
   // For now return empty; will be implemented when the CLI supports it
   return [];
 }


### PR DESCRIPTION
## Summary
- Rename all exported symbols from clawhub* to skillssh* in skillssh.ts
- Update source field type from "clawhub" to "skillssh" on search results
- Rename CLAWHUB_BASE_URL to SKILLSSH_BASE_URL
- Update all consumers: handlers, policies, and test files

Part of plan: skills-rename-clawhub.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
