### PR TITLE
perf: gate window creation on FontWarmupCoordinator to eliminate first-access font hang

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -444,7 +444,7 @@ extension AppDelegate {
             }
             var error: Unmanaged<CFError>?
             if !CTFontManagerRegisterFontsForURL(url as CFURL, .process, &error) {
-                log.warning("Failed to register font \(name): \(error?.takeRetainedValue().localizedDescription ?? \"unknown\")")
+                log.warning("Failed to register font \(name): \(error?.takeRetainedValue().localizedDescription ?? "unknown")")
             }
         }
     }

--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -435,7 +435,8 @@ extension AppDelegate {
         }
     }
 
-    func registerBundledFonts() {
+    nonisolated static func registerBundledFonts() {
+        let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "AppDelegate+Notifications")
         for name in ["DMMono-Regular", "DMMono-Medium", "DMSans-Regular", "DMSans-Medium", "DMSans-SemiBold", "InstrumentSerif-Regular"] {
             guard let url = ResourceBundle.bundle.url(forResource: name, withExtension: "ttf") else {
                 log.warning("Font file \(name).ttf not found in bundle")
@@ -443,7 +444,7 @@ extension AppDelegate {
             }
             var error: Unmanaged<CFError>?
             if !CTFontManagerRegisterFontsForURL(url as CFURL, .process, &error) {
-                log.warning("Failed to register font \(name): \(error?.takeRetainedValue().localizedDescription ?? "unknown")")
+                log.warning("Failed to register font \(name): \(error?.takeRetainedValue().localizedDescription ?? \"unknown\")")
             }
         }
     }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -204,6 +204,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         // may be a custom dock label (e.g. an assistant name), so we patch
         // both the process name and the main menu items.
         ProcessInfo.processInfo.processName = Self.appName
+
+        FontWarmupCoordinator.shared.start(registerFonts: {
+            AppDelegate.registerBundledFonts()
+        })
     }
 
     /// Installs observers that patch the app menu bar title and items to
@@ -462,7 +466,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         applyThemePreference()
-        registerBundledFonts()
         AvatarAppearanceManager.shared.start()
 
         #if DEBUG
@@ -472,9 +475,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         #endif
 
         if let statusFile = ProcessInfo.processInfo.environment["E2E_STATUS_FILE"] {
-            let overlay = E2EStatusOverlayWindow(statusFilePath: statusFile)
-            overlay.show()
-            self.e2eStatusOverlayWindow = overlay
+            Task { @MainActor in
+                await FontWarmupCoordinator.shared.awaitReady()
+                let overlay = E2EStatusOverlayWindow(statusFilePath: statusFile)
+                overlay.show()
+                self.e2eStatusOverlayWindow = overlay
+            }
         }
 
         // Set up menu bar and hotkeys early so they work regardless of auth state.
@@ -497,13 +503,19 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         log.info("[appLaunch] skipOnboarding=\(skipOnboarding) hasAssistants=\(hasAssistants)")
 
         if !skipOnboarding && !hasAssistants {
-            log.info("[appLaunch] → showOnboarding()")
-            showOnboarding()
+            log.info("[appLaunch] → showOnboarding() (awaiting font warmup)")
+            Task { @MainActor in
+                await FontWarmupCoordinator.shared.awaitReady()
+                self.showOnboarding()
+            }
             return
         }
 
-        log.info("[appLaunch] → startAuthenticatedFlow()")
-        startAuthenticatedFlow()
+        log.info("[appLaunch] → startAuthenticatedFlow() (awaiting font warmup)")
+        Task { @MainActor in
+            await FontWarmupCoordinator.shared.awaitReady()
+            self.startAuthenticatedFlow()
+        }
     }
 
     var hasSetupApp = false


### PR DESCRIPTION
## Summary
- Move registerBundledFonts() to nonisolated static func, called via FontWarmupCoordinator off-main
- Gate showOnboarding(), startAuthenticatedFlow(), and E2E overlay on awaitReady() barrier
- Remove direct main-thread registerBundledFonts() call from applicationDidFinishLaunching

Part of plan: font-warmup-gate.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
