### PR TITLE
test: update test fixtures that reference oauth-app-setup skill names

### DIFF
--- a/assistant/src/__tests__/skills-uninstall.test.ts
+++ b/assistant/src/__tests__/skills-uninstall.test.ts
@@ -60,7 +60,7 @@ describe("assistant skills uninstall", () => {
 
     // GIVEN a skill is installed locally
     installFakeSkill("weather");
-    writeSkillsIndex("- weather\n- google-oauth-app-setup\n");
+    writeSkillsIndex("- weather\n- vellum-self-knowledge\n");
 
     // WHEN we uninstall the skill
     uninstallSkillLocally("weather");
@@ -73,7 +73,7 @@ describe("assistant skills uninstall", () => {
     expect(index).not.toContain("weather");
 
     // AND other skills should remain in the index
-    expect(index).toContain("google-oauth-app-setup");
+    expect(index).toContain("vellum-self-knowledge");
   });
 
   test("errors when skill is not installed", () => {


### PR DESCRIPTION
## Summary
- Replaced google-oauth-app-setup with vellum-self-knowledge in test fixtures
- No functional change — test was only using the skill name as arbitrary fixture data

Part of plan: consolidate-oauth-setup-skills.md (PR 8 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22836" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
