### PR TITLE
feat: support nested subdirectories in skill reference file listing

### DIFF
--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -962,8 +962,9 @@ function isEscapingSymlink(filePath: string, rootDir: string): boolean {
 /**
  * Check for a `references/` subdirectory within a skill directory and return
  * a formatted listing of available `.md` reference files with full absolute
- * paths. Returns `null` if no references exist. Files are listed in
- * alphabetical order. Non-`.md` files are ignored. Symlinks that resolve
+ * paths. Returns `null` if no references exist. Files are discovered
+ * recursively through subdirectories and listed alphabetically within each
+ * directory level. Non-`.md` files are ignored. Symlinks that resolve
  * outside the skill directory are skipped.
  */
 export function listReferenceFiles(directoryPath: string): string | null {
@@ -977,7 +978,7 @@ export function listReferenceFiles(directoryPath: string): string | null {
       return null;
     }
 
-    const entries = readdirSync(refsDir);
+    const entries = readdirSync(refsDir, { recursive: true }) as string[];
     const mdFiles = entries
       .filter((f) => f.toLowerCase().endsWith(".md"))
       .filter((f) => !isEscapingSymlink(join(refsDir, f), directoryPath))
@@ -991,8 +992,8 @@ export function listReferenceFiles(directoryPath: string): string | null {
       "The following reference files are available in this skill's directory. Use `file_read` to load any that are relevant to the current task:",
       "",
     ];
-    for (const filename of mdFiles) {
-      lines.push(`- \`${join(refsDir, filename)}\``);
+    for (const filepath of mdFiles) {
+      lines.push(`- \`${join(refsDir, filepath)}\` (references/${filepath})`);
     }
 
     return lines.join("\n");


### PR DESCRIPTION
## Summary
- Modified listReferenceFiles to recursively discover .md files in subdirectories of references/
- Files in nested directories show their relative path from the skill root
- Security boundary (isEscapingSymlink) enforced for all nested files

Part of plan: consolidate-oauth-setup-skills.md (PR 1 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22837" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
