### PR TITLE
perf: font warmup gate for macOS VFont first-access hang

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -435,7 +435,8 @@ extension AppDelegate {
         }
     }
 
-    func registerBundledFonts() {
+    nonisolated static func registerBundledFonts() {
+        let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "AppDelegate+Notifications")
         for name in ["DMMono-Regular", "DMMono-Medium", "DMSans-Regular", "DMSans-Medium", "DMSans-SemiBold", "InstrumentSerif-Regular"] {
             guard let url = ResourceBundle.bundle.url(forResource: name, withExtension: "ttf") else {
                 log.warning("Font file \(name).ttf not found in bundle")

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -204,6 +204,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         // may be a custom dock label (e.g. an assistant name), so we patch
         // both the process name and the main menu items.
         ProcessInfo.processInfo.processName = Self.appName
+
+        FontWarmupCoordinator.shared.start(registerFonts: {
+            AppDelegate.registerBundledFonts()
+        })
     }
 
     /// Installs observers that patch the app menu bar title and items to
@@ -462,7 +466,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         applyThemePreference()
-        registerBundledFonts()
         AvatarAppearanceManager.shared.start()
 
         #if DEBUG
@@ -472,9 +475,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         #endif
 
         if let statusFile = ProcessInfo.processInfo.environment["E2E_STATUS_FILE"] {
-            let overlay = E2EStatusOverlayWindow(statusFilePath: statusFile)
-            overlay.show()
-            self.e2eStatusOverlayWindow = overlay
+            Task { @MainActor in
+                await FontWarmupCoordinator.shared.awaitReady()
+                let overlay = E2EStatusOverlayWindow(statusFilePath: statusFile)
+                overlay.show()
+                self.e2eStatusOverlayWindow = overlay
+            }
         }
 
         // Set up menu bar and hotkeys early so they work regardless of auth state.
@@ -497,13 +503,19 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         log.info("[appLaunch] skipOnboarding=\(skipOnboarding) hasAssistants=\(hasAssistants)")
 
         if !skipOnboarding && !hasAssistants {
-            log.info("[appLaunch] → showOnboarding()")
-            showOnboarding()
+            log.info("[appLaunch] → showOnboarding() (awaiting font warmup)")
+            Task { @MainActor in
+                await FontWarmupCoordinator.shared.awaitReady()
+                self.showOnboarding()
+            }
             return
         }
 
-        log.info("[appLaunch] → startAuthenticatedFlow()")
-        startAuthenticatedFlow()
+        log.info("[appLaunch] → startAuthenticatedFlow() (awaiting font warmup)")
+        Task { @MainActor in
+            await FontWarmupCoordinator.shared.awaitReady()
+            self.startAuthenticatedFlow()
+        }
     }
 
     var hasSetupApp = false

--- a/clients/macos/vellum-assistant/App/FontWarmupCoordinator.swift
+++ b/clients/macos/vellum-assistant/App/FontWarmupCoordinator.swift
@@ -1,0 +1,85 @@
+import Foundation
+import os
+import CoreText
+import VellumAssistantShared
+
+/// Coordinates off-main-thread font registration and warmup at app launch.
+///
+/// Owned by AppDelegate; callers use `awaitReady()` to gate UI creation
+/// until fonts are resolved and cached by CoreText.
+@MainActor
+final class FontWarmupCoordinator {
+
+    static let shared = FontWarmupCoordinator()
+
+    @Published private(set) var isReady = false
+
+    private let logger = Logger(subsystem: Bundle.appBundleIdentifier, category: "fontWarmup")
+
+    /// The detached warmup task — nil until `start()` is called.
+    private var warmupTask: Task<Void, Never>?
+
+    /// Continuations parked by `awaitReady()` callers, resumed when warmup completes.
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    private init() {}
+
+    // MARK: - Public API
+
+    /// Kicks off font registration and prewarm on a detached (non-main) task.
+    ///
+    /// Idempotent — subsequent calls after the first are no-ops.
+    func start(registerFonts: @Sendable @escaping () -> Void) {
+        guard warmupTask == nil else { return }
+
+        logger.info("[fontWarmup] start")
+
+        warmupTask = Task.detached(priority: .userInitiated) { [logger] in
+            registerFonts()
+            logger.info("[fontWarmup] registerFonts done")
+
+            VFont.prewarmForAppLaunch()
+            logger.info("[fontWarmup] prewarm done")
+
+            await MainActor.run {
+                self.markReady()
+            }
+        }
+    }
+
+    /// Suspends the caller until font warmup is complete.
+    ///
+    /// Returns immediately if warmup has already finished.
+    func awaitReady() async {
+        if isReady {
+            logger.info("[fontWarmup] awaitReady: already ready")
+            return
+        }
+
+        logger.info("[fontWarmup] awaitReady: waiting...")
+        let startTime = ContinuousClock.now
+
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            if isReady {
+                continuation.resume()
+            } else {
+                waiters.append(continuation)
+            }
+        }
+
+        let elapsed = ContinuousClock.now - startTime
+        let ms = elapsed.components.seconds * 1000 + elapsed.components.attoseconds / 1_000_000_000_000_000
+        logger.info("[fontWarmup] awaitReady: resumed after \(ms)ms")
+    }
+
+    // MARK: - Private
+
+    private func markReady() {
+        isReady = true
+        logger.info("[fontWarmup] ready")
+        for waiter in waiters {
+            waiter.resume()
+        }
+        waiters.removeAll()
+    }
+}

--- a/clients/macos/vellum-assistant/App/FontWarmupCoordinator.swift
+++ b/clients/macos/vellum-assistant/App/FontWarmupCoordinator.swift
@@ -42,6 +42,10 @@ final class FontWarmupCoordinator {
             logger.info("[fontWarmup] prewarm done")
 
             await MainActor.run {
+                // Prewarm NSFontManager-dependent tokens on the main thread.
+                // NSFontManager.shared is an AppKit class that must not be
+                // accessed from a background thread.
+                VFont.prewarmNSFontManagerTokens()
                 self.markReady()
             }
         }

--- a/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
@@ -182,8 +182,12 @@ public enum VFont {
 
     /// Eagerly accesses every static font token, forcing CoreText to resolve and cache them.
     ///
-    /// Safe to call from any thread — Swift static lets are thread-safe.
+    /// Safe to call from any thread — uses only CoreText (thread-safe).
     /// Called by `FontWarmupCoordinator` during off-main warmup.
+    ///
+    /// **Note:** `nsMonoBold` and `nsMonoItalic` are excluded because they use
+    /// `NSFontManager.shared` which must be accessed on the main thread.
+    /// Use `prewarmNSFontManagerTokens()` on MainActor for those.
     public static func prewarmForAppLaunch() {
         // SwiftUI Font tokens
         _ = brandMedium
@@ -205,13 +209,27 @@ public enum VFont {
         _ = menuCompact
         _ = chat
 
-        // NSFont tokens (macOS only)
+        // NSFont tokens (macOS only — CoreText-only, no AppKit dependency)
         #if os(macOS)
         _ = nsChat
         _ = nsBodyMediumDefault
         _ = nsMono
-        _ = nsMonoBold
-        _ = nsMonoItalic
+        // NOTE: nsMonoBold and nsMonoItalic are intentionally excluded here.
+        // They use NSFontManager.shared.convert() which requires the main thread.
+        // See prewarmNSFontManagerTokens() instead.
         #endif
     }
+
+    #if os(macOS)
+    /// Prewarms font tokens that depend on `NSFontManager.shared`.
+    ///
+    /// **Must be called on the main thread** — `NSFontManager` is an AppKit class
+    /// without documented thread-safety guarantees.
+    /// Called by `FontWarmupCoordinator` on `MainActor` before marking ready.
+    @MainActor
+    public static func prewarmNSFontManagerTokens() {
+        _ = nsMonoBold
+        _ = nsMonoItalic
+    }
+    #endif
 }

--- a/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
@@ -177,4 +177,41 @@ public enum VFont {
         NSFontManager.shared.convert(nsMono, toHaveTrait: .italicFontMask)
     }()
     #endif
+
+    // MARK: - Prewarm
+
+    /// Eagerly accesses every static font token, forcing CoreText to resolve and cache them.
+    ///
+    /// Safe to call from any thread — Swift static lets are thread-safe.
+    /// Called by `FontWarmupCoordinator` during off-main warmup.
+    public static func prewarmForAppLaunch() {
+        // SwiftUI Font tokens
+        _ = brandMedium
+        _ = brandSmall
+        _ = displayLarge
+        _ = titleLarge
+        _ = titleMedium
+        _ = titleSmall
+        _ = bodyLargeLighter
+        _ = bodyLargeDefault
+        _ = bodyLargeEmphasised
+        _ = bodyMediumLighter
+        _ = bodyMediumDefault
+        _ = bodyMediumEmphasised
+        _ = bodySmallDefault
+        _ = bodySmallEmphasised
+        _ = labelDefault
+        _ = labelSmall
+        _ = menuCompact
+        _ = chat
+
+        // NSFont tokens (macOS only)
+        #if os(macOS)
+        _ = nsChat
+        _ = nsBodyMediumDefault
+        _ = nsMono
+        _ = nsMonoBold
+        _ = nsMonoItalic
+        #endif
+    }
 }


### PR DESCRIPTION
## Summary
Move font registration + VFont prewarm to an off-main startup task, then strictly gate all initial SwiftUI window creation on that task completing. This keeps CoreText/XPC warmup out of SwiftUI view updates and satisfies the no-timeout, fail-closed policy.

## PRs merged into feature branch
- #22833: perf: add FontWarmupCoordinator and VFont.prewarmForAppLaunch() for off-main font warmup
- #22835: perf: gate window creation on FontWarmupCoordinator to eliminate first-access font hang

Part of plan: font-warmup-gate.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22838" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
