### PR TITLE
feat: CLI search queries clawhub registry alongside skills.sh

### DIFF
--- a/assistant/src/cli/commands/skills.ts
+++ b/assistant/src/cli/commands/skills.ts
@@ -169,7 +169,7 @@ Examples:
 
         const [skillsShResult, clawhubResult] = await Promise.allSettled([
           searchSkillsRegistry(query, limit),
-          clawhubSearch(query),
+          clawhubSearch(query, { limit }),
         ]);
 
         if (skillsShResult.status === "fulfilled") {

--- a/assistant/src/cli/commands/skills.ts
+++ b/assistant/src/cli/commands/skills.ts
@@ -12,6 +12,7 @@ import {
   uninstallSkillLocally,
 } from "../../skills/catalog-install.js";
 import { filterByQuery } from "../../skills/catalog-search.js";
+import { clawhubSearch } from "../../skills/clawhub.js";
 import type {
   AuditResponse,
   SkillsShSearchResult,
@@ -111,7 +112,9 @@ Examples:
 
   skills
     .command("search <query>")
-    .description("Search the Vellum catalog and skills.sh community registry")
+    .description(
+      "Search the Vellum catalog, skills.sh, and clawhub community registries",
+    )
     .option("--limit <n>", "Maximum number of community results", "10")
     .option("--json", "Machine-readable JSON output")
     .addHelpText(
@@ -119,11 +122,11 @@ Examples:
       `
 Arguments:
   query    Free-text search term matched against skill names, descriptions,
-           and tags. Searches the Vellum catalog first, then the skills.sh
-           community registry.
+           and tags. Searches the Vellum catalog, the skills.sh community
+           registry, and the clawhub registry.
 
-Displays results from both sources with clear labels. When a skill ID
-exists in both the Vellum catalog and the community registry, a conflict
+Displays results from all sources with clear labels. When a skill ID
+exists in both the Vellum catalog and a community registry, a conflict
 note is shown with guidance on which install command to use.
 
 Examples:
@@ -155,38 +158,73 @@ Examples:
           (s) => s.description,
         ]);
 
-        // ── Community registry search (non-fatal on failure) ─────────
+        // ── Community registry searches (non-fatal on failure) ────────
+        // Run skills.sh and clawhub searches in parallel.
         let registryResults: SkillsShSearchResult[] = [];
         let registryError: string | undefined;
-        try {
-          registryResults = await searchSkillsRegistry(query, limit);
-        } catch (err) {
-          registryError = err instanceof Error ? err.message : String(err);
+        let clawhubResults: Awaited<
+          ReturnType<typeof clawhubSearch>
+        >["skills"] = [];
+        let clawhubError: string | undefined;
+
+        const [skillsShResult, clawhubResult] = await Promise.allSettled([
+          searchSkillsRegistry(query, limit),
+          clawhubSearch(query),
+        ]);
+
+        if (skillsShResult.status === "fulfilled") {
+          registryResults = skillsShResult.value;
+        } else {
+          registryError =
+            skillsShResult.reason instanceof Error
+              ? skillsShResult.reason.message
+              : String(skillsShResult.reason);
+        }
+
+        if (clawhubResult.status === "fulfilled") {
+          clawhubResults = clawhubResult.value.skills;
+        } else {
+          clawhubError =
+            clawhubResult.reason instanceof Error
+              ? clawhubResult.reason.message
+              : String(clawhubResult.reason);
         }
 
         // ── Conflict detection ───────────────────────────────────────
         const catalogIds = new Set(catalogMatches.map((s) => s.id));
-        const conflictIds = new Set(
-          registryResults
+        const conflictIds = new Set([
+          ...registryResults
             .filter((r) => catalogIds.has(r.skillId))
             .map((r) => r.skillId),
-        );
+          ...clawhubResults
+            .filter((r) => catalogIds.has(r.slug))
+            .map((r) => r.slug),
+        ]);
 
-        if (catalogMatches.length === 0 && registryResults.length === 0) {
+        if (
+          catalogMatches.length === 0 &&
+          registryResults.length === 0 &&
+          clawhubResults.length === 0
+        ) {
           if (json) {
             console.log(
               JSON.stringify({
                 ok: true,
                 catalog: [],
                 community: [],
+                clawhub: [],
                 audits: {},
                 ...(registryError ? { registryError } : {}),
+                ...(clawhubError ? { clawhubError } : {}),
               }),
             );
           } else {
             log.info(`No skills found for "${query}".`);
             if (registryError) {
               log.warn(`(skills.sh registry unavailable: ${registryError})`);
+            }
+            if (clawhubError) {
+              log.warn(`(clawhub registry unavailable: ${clawhubError})`);
             }
           }
           return;
@@ -219,8 +257,10 @@ Examples:
               ok: true,
               catalog: catalogMatches,
               community: registryResults,
+              clawhub: clawhubResults,
               audits: allAudits,
               ...(registryError ? { registryError } : {}),
+              ...(clawhubError ? { clawhubError } : {}),
             }),
           );
           return;
@@ -279,6 +319,37 @@ Examples:
           }
         } else if (registryError) {
           log.warn(`\n(skills.sh registry unavailable: ${registryError})`);
+        }
+
+        // ── Display clawhub results ─────────────────────────────────
+        if (clawhubResults.length > 0) {
+          log.info(`Clawhub registry (${clawhubResults.length}):\n`);
+          for (const r of clawhubResults) {
+            const installed = isInstalled(r.slug);
+            const badge = installed ? " [installed]" : "";
+            log.info(`  ${r.name}${badge}`);
+            if (r.name !== r.slug) {
+              log.info(`    ID: ${r.slug}`);
+            }
+            if (r.author) {
+              log.info(`    Author: ${r.author}`);
+            }
+            if (r.description) {
+              log.info(`    Description: ${r.description}`);
+            }
+            if (r.stars > 0) {
+              log.info(`    Stars: ${r.stars}`);
+            }
+            if (r.installs > 0) {
+              log.info(`    Installs: ${r.installs}`);
+            }
+            if (conflictIds.has(r.slug)) {
+              log.info(`    NOTE: Conflicts with Vellum catalog skill`);
+            }
+            log.info("");
+          }
+        } else if (clawhubError) {
+          log.warn(`\n(clawhub registry unavailable: ${clawhubError})`);
         }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);

--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -292,63 +292,63 @@ export async function clawhubUpdate(
 
 export async function clawhubSearch(
   query: string,
+  opts?: { limit?: number },
 ): Promise<ClawhubSearchResult> {
+  const limit = opts?.limit ?? 25;
+
   // Empty query: use explore (browse trending) instead of search
   if (!query.trim()) {
-    return clawhubExplore();
+    return clawhubExplore({ limit });
   }
 
+  const result = await runClawhub(["search", query, "--limit", String(limit)]);
+  if (result.exitCode !== 0) {
+    const error =
+      result.stderr.trim() || result.stdout.trim() || "Unknown error";
+    throw new Error(`clawhub search failed: ${error}`);
+  }
+  // Try JSON first
   try {
-    const result = await runClawhub(["search", query, "--limit", "25"]);
-    if (result.exitCode !== 0) {
-      return { skills: [] };
+    const parsed = JSON.parse(result.stdout);
+    if (Array.isArray(parsed)) {
+      return {
+        skills: parsed.map((s: ClawhubSearchResultItem) => ({
+          ...s,
+          source: s.source ?? ("clawhub" as const),
+        })),
+      };
     }
-    // Try JSON first
-    try {
-      const parsed = JSON.parse(result.stdout);
-      if (Array.isArray(parsed)) {
-        return {
-          skills: parsed.map((s: ClawhubSearchResultItem) => ({
-            ...s,
-            source: s.source ?? ("clawhub" as const),
-          })),
-        };
-      }
-      if (parsed.skills && Array.isArray(parsed.skills)) {
-        return {
-          skills: parsed.skills.map((s: ClawhubSearchResultItem) => ({
-            ...s,
-            source: s.source ?? ("clawhub" as const),
-          })),
-        };
-      }
-    } catch {
-      // CLI outputs text: "slug vVersion  DisplayName  (score)"
+    if (parsed.skills && Array.isArray(parsed.skills)) {
+      return {
+        skills: parsed.skills.map((s: ClawhubSearchResultItem) => ({
+          ...s,
+          source: s.source ?? ("clawhub" as const),
+        })),
+      };
     }
-
-    // Parse text output lines: "slug vVersion  Display Name  (score)"
-    const skills: ClawhubSearchResultItem[] = [];
-    for (const line of result.stdout.split("\n")) {
-      const match = line.match(/^(\S+)\s+v(\S+)\s+(.+?)\s+\([\d.]+\)\s*$/);
-      if (match) {
-        skills.push({
-          slug: match[1],
-          version: match[2],
-          name: match[3].trim(),
-          description: "",
-          author: "",
-          stars: 0,
-          installs: 0,
-          createdAt: 0,
-          source: "clawhub",
-        });
-      }
-    }
-    return { skills };
-  } catch (err) {
-    log.warn({ err }, "clawhub search failed");
-    return { skills: [] };
+  } catch {
+    // CLI outputs text: "slug vVersion  DisplayName  (score)"
   }
+
+  // Parse text output lines: "slug vVersion  Display Name  (score)"
+  const skills: ClawhubSearchResultItem[] = [];
+  for (const line of result.stdout.split("\n")) {
+    const match = line.match(/^(\S+)\s+v(\S+)\s+(.+?)\s+\([\d.]+\)\s*$/);
+    if (match) {
+      skills.push({
+        slug: match[1],
+        version: match[2],
+        name: match[3].trim(),
+        description: "",
+        author: "",
+        stars: 0,
+        installs: 0,
+        createdAt: 0,
+        source: "clawhub",
+      });
+    }
+  }
+  return { skills };
 }
 
 export async function clawhubExplore(opts?: {
@@ -358,46 +358,41 @@ export async function clawhubExplore(opts?: {
   const limit = String(opts?.limit ?? 25);
   const sort = opts?.sort ?? "installsAllTime";
 
+  const result = await runClawhub([
+    "explore",
+    "--json",
+    "--limit",
+    limit,
+    "--sort",
+    sort,
+  ]);
+  if (result.exitCode !== 0) {
+    const error =
+      result.stderr.trim() || result.stdout.trim() || "Unknown error";
+    throw new Error(`clawhub explore failed: ${error}`);
+  }
   try {
-    const result = await runClawhub([
-      "explore",
-      "--json",
-      "--limit",
-      limit,
-      "--sort",
-      sort,
-    ]);
-    if (result.exitCode !== 0) {
-      return { skills: [] };
-    }
-    try {
-      const parsed = JSON.parse(result.stdout);
-      const items = parsed.items ?? parsed;
-      if (!Array.isArray(items)) return { skills: [] };
+    const parsed = JSON.parse(result.stdout);
+    const items = parsed.items ?? parsed;
+    if (!Array.isArray(items)) return { skills: [] };
 
-      // Normalize explore response to ClawhubSearchResultItem shape
-      const skills: ClawhubSearchResultItem[] = items.map(
-        (item: Record<string, unknown>) => ({
-          name: (item.displayName as string) ?? (item.slug as string) ?? "",
-          slug: (item.slug as string) ?? "",
-          description: (item.summary as string) ?? "",
-          author: (item.author as string) ?? "",
-          stars: (item.stats as Record<string, number>)?.stars ?? 0,
-          installs:
-            (item.stats as Record<string, number>)?.installsAllTime ?? 0,
-          version: (item.tags as Record<string, string>)?.latest ?? "",
-          createdAt: (item.createdAt as number) ?? 0,
-          source: "clawhub",
-        }),
-      );
-      return { skills };
-    } catch {
-      // parse failure
-    }
-    return { skills: [] };
-  } catch (err) {
-    log.warn({ err }, "clawhub explore failed");
-    return { skills: [] };
+    // Normalize explore response to ClawhubSearchResultItem shape
+    const skills: ClawhubSearchResultItem[] = items.map(
+      (item: Record<string, unknown>) => ({
+        name: (item.displayName as string) ?? (item.slug as string) ?? "",
+        slug: (item.slug as string) ?? "",
+        description: (item.summary as string) ?? "",
+        author: (item.author as string) ?? "",
+        stars: (item.stats as Record<string, number>)?.stars ?? 0,
+        installs: (item.stats as Record<string, number>)?.installsAllTime ?? 0,
+        version: (item.tags as Record<string, string>)?.latest ?? "",
+        createdAt: (item.createdAt as number) ?? 0,
+        source: "clawhub",
+      }),
+    );
+    return { skills };
+  } catch {
+    throw new Error("Failed to parse clawhub explore output");
   }
 }
 


### PR DESCRIPTION
## Summary
- Add clawhub registry search alongside skills.sh in CLI search command
- Run both community searches in parallel for resilience
- Display clawhub results in labeled section and include in JSON output

Part of plan: skills-unify-search.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22839" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
