### PR TITLE
feat: daemon search queries skills.sh registry alongside clawhub

### DIFF
--- a/assistant/src/__tests__/search-skills-unified.test.ts
+++ b/assistant/src/__tests__/search-skills-unified.test.ts
@@ -215,7 +215,7 @@ describe("searchSkills (unified)", () => {
     expect(data.skills[0]!.source).toBe("vellum");
     expect(data.skills[1]!.slug).toBe("deploy");
     expect(data.skills[1]!.source).toBe("clawhub");
-    expect(data.skills[2]!.slug).toBe("react-best");
+    expect(data.skills[2]!.slug).toBe("vercel-labs/skills/react-best");
     expect(data.skills[2]!.source).toBe("skillssh");
   });
 
@@ -243,6 +243,8 @@ describe("searchSkills (unified)", () => {
         },
       ],
     });
+    // skills.sh uses full id as slug, so it won't collide with catalog/clawhub
+    // short slugs. Dedup only removes the clawhub duplicate here.
     mockSkillsshSearch.mockResolvedValue([
       {
         id: "org/repo/shared-skill",
@@ -260,13 +262,16 @@ describe("searchSkills (unified)", () => {
     const data = result.data as {
       skills: Array<{ slug: string; source: string }>;
     };
-    // Only the catalog version should survive
-    expect(data.skills).toHaveLength(1);
+    // Catalog deduplicates clawhub (same slug "shared-skill"), but skills.sh
+    // now uses the full id "org/repo/shared-skill" so it's a distinct entry.
+    expect(data.skills).toHaveLength(2);
     expect(data.skills[0]!.slug).toBe("shared-skill");
     expect(data.skills[0]!.source).toBe("vellum");
+    expect(data.skills[1]!.slug).toBe("org/repo/shared-skill");
+    expect(data.skills[1]!.source).toBe("skillssh");
   });
 
-  test("deduplicates: clawhub takes precedence over skills.sh", async () => {
+  test("deduplicates: clawhub takes precedence over skills.sh with same slug", async () => {
     mockCatalogSkills.mockReturnValue([]);
     mockClawhubSearch.mockResolvedValue({
       skills: [
@@ -283,6 +288,8 @@ describe("searchSkills (unified)", () => {
         },
       ],
     });
+    // skills.sh now uses full id as slug, so it won't collide with clawhub
+    // short slugs — both entries survive dedup.
     mockSkillsshSearch.mockResolvedValue([
       {
         id: "org/repo/overlap-skill",
@@ -300,9 +307,12 @@ describe("searchSkills (unified)", () => {
     const data = result.data as {
       skills: Array<{ slug: string; source: string }>;
     };
-    expect(data.skills).toHaveLength(1);
+    // Full id slug means no collision — both entries survive
+    expect(data.skills).toHaveLength(2);
     expect(data.skills[0]!.slug).toBe("overlap-skill");
     expect(data.skills[0]!.source).toBe("clawhub");
+    expect(data.skills[1]!.slug).toBe("org/repo/overlap-skill");
+    expect(data.skills[1]!.source).toBe("skillssh");
   });
 
   test("returns clawhub results when skills.sh fails", async () => {
@@ -357,7 +367,7 @@ describe("searchSkills (unified)", () => {
       skills: Array<{ slug: string; source: string }>;
     };
     expect(data.skills).toHaveLength(1);
-    expect(data.skills[0]!.slug).toBe("skillssh-only");
+    expect(data.skills[0]!.slug).toBe("org/repo/skillssh-only");
     expect(data.skills[0]!.source).toBe("skillssh");
   });
 
@@ -419,7 +429,7 @@ describe("searchSkills (unified)", () => {
 
     const skill = data.skills[0]!;
     expect(skill.name).toBe("Test Skill");
-    expect(skill.slug).toBe("test-skill");
+    expect(skill.slug).toBe("org/repo/test-skill");
     expect(skill.description).toBe("");
     expect(skill.author).toBe("");
     expect(skill.stars).toBe(0);

--- a/assistant/src/__tests__/search-skills-unified.test.ts
+++ b/assistant/src/__tests__/search-skills-unified.test.ts
@@ -126,7 +126,7 @@ mock.module("../skills/skill-memory.js", () => ({
 mock.module("../util/platform.js", () => ({
   getWorkspaceSkillsDir: () => "/tmp/test-skills",
 }));
-mock.module("./shared.js", () => ({
+mock.module("../daemon/handlers/shared.js", () => ({
   CONFIG_RELOAD_DEBOUNCE_MS: 100,
   ensureSkillEntry: () => ({}),
   log: {

--- a/assistant/src/__tests__/search-skills-unified.test.ts
+++ b/assistant/src/__tests__/search-skills-unified.test.ts
@@ -1,0 +1,431 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+const mockCatalogSkills = mock(
+  (): Array<{
+    id: string;
+    displayName: string;
+    description: string;
+    source: string;
+  }> => [],
+);
+const mockClawhubSearch = mock(
+  async (
+    _query: string,
+  ): Promise<{
+    skills: Array<{
+      name: string;
+      slug: string;
+      description: string;
+      author: string;
+      stars: number;
+      installs: number;
+      version: string;
+      createdAt: number;
+      source: string;
+    }>;
+  }> => ({ skills: [] }),
+);
+const mockSkillsshSearch = mock(
+  async (
+    _query: string,
+    _limit?: number,
+  ): Promise<
+    Array<{
+      id: string;
+      skillId: string;
+      name: string;
+      installs: number;
+      source: string;
+    }>
+  > => [],
+);
+
+// ---------------------------------------------------------------------------
+// Mock modules — before importing module under test
+// ---------------------------------------------------------------------------
+
+mock.module("../config/skills.js", () => ({
+  loadSkillCatalog: mockCatalogSkills,
+}));
+
+mock.module("../skills/catalog-search.js", () => ({
+  filterByQuery: (
+    items: Array<{ id: string; displayName: string; description: string }>,
+    query: string,
+    _fields: unknown[],
+  ) => {
+    const lower = query.toLowerCase();
+    return items.filter(
+      (s) =>
+        s.id.toLowerCase().includes(lower) ||
+        s.displayName.toLowerCase().includes(lower) ||
+        s.description.toLowerCase().includes(lower),
+    );
+  },
+}));
+
+mock.module("../skills/clawhub.js", () => ({
+  clawhubSearch: mockClawhubSearch,
+  // Stubs for other exports that may be referenced at import time
+  clawhubCheckUpdates: mock(async () => []),
+  clawhubInspect: mock(async () => ({})),
+  clawhubInstall: mock(async () => ({ success: true })),
+  clawhubUpdate: mock(async () => ({ success: true })),
+}));
+
+mock.module("../skills/skillssh-registry.js", () => ({
+  searchSkillsRegistry: mockSkillsshSearch,
+}));
+
+// Stub remaining imports pulled in by skills.ts
+mock.module("../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: () => true,
+}));
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({}),
+  invalidateConfigCache: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+}));
+mock.module("../config/skill-state.js", () => ({
+  resolveSkillStates: () => [],
+  skillFlagKey: () => null,
+}));
+mock.module("../providers/provider-send-message.js", () => ({
+  createTimeout: () => ({
+    signal: AbortSignal.timeout(1000),
+    cleanup: () => {},
+  }),
+  extractText: () => "",
+  getConfiguredProvider: async () => null,
+  userMessage: () => ({}),
+}));
+mock.module("../runtime/routes/workspace-utils.js", () => ({
+  isTextMimeType: () => true,
+}));
+mock.module("../skills/catalog-cache.js", () => ({
+  getCatalog: async () => [],
+}));
+mock.module("../skills/catalog-install.js", () => ({
+  installSkillLocally: async () => {},
+}));
+mock.module("../skills/managed-store.js", () => ({
+  createManagedSkill: () => ({ created: true }),
+  deleteManagedSkill: () => ({ deleted: true }),
+  removeSkillsIndexEntry: () => {},
+  validateManagedSkillId: () => null,
+}));
+mock.module("../skills/skill-memory.js", () => ({
+  deleteSkillCapabilityMemory: () => {},
+  seedCatalogSkillMemories: () => {},
+}));
+mock.module("../util/platform.js", () => ({
+  getWorkspaceSkillsDir: () => "/tmp/test-skills",
+}));
+mock.module("./shared.js", () => ({
+  CONFIG_RELOAD_DEBOUNCE_MS: 100,
+  ensureSkillEntry: () => ({}),
+  log: {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  },
+}));
+
+// Import after mocking
+import { searchSkills } from "../daemon/handlers/skills.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const dummyCtx = {
+  debounceTimers: { schedule: () => {} },
+  setSuppressConfigReload: () => {},
+  updateConfigFingerprint: () => {},
+  broadcast: () => {},
+} as unknown as Parameters<typeof searchSkills>[1];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("searchSkills (unified)", () => {
+  beforeEach(() => {
+    mockCatalogSkills.mockReset();
+    mockClawhubSearch.mockReset();
+    mockSkillsshSearch.mockReset();
+
+    // Defaults: empty results
+    mockCatalogSkills.mockReturnValue([]);
+    mockClawhubSearch.mockResolvedValue({ skills: [] });
+    mockSkillsshSearch.mockResolvedValue([]);
+  });
+
+  test("returns results from all three registries", async () => {
+    mockCatalogSkills.mockReturnValue([
+      {
+        id: "weather",
+        displayName: "Weather",
+        description: "Weather lookup",
+        source: "bundled",
+      },
+    ]);
+    mockClawhubSearch.mockResolvedValue({
+      skills: [
+        {
+          name: "Deploy",
+          slug: "deploy",
+          description: "Deploy helper",
+          author: "alice",
+          stars: 10,
+          installs: 100,
+          version: "1.0.0",
+          createdAt: 1000,
+          source: "clawhub",
+        },
+      ],
+    });
+    mockSkillsshSearch.mockResolvedValue([
+      {
+        id: "vercel-labs/skills/react-best",
+        skillId: "react-best",
+        name: "React Best Practices",
+        installs: 500,
+        source: "vercel-labs/skills",
+      },
+    ]);
+
+    const result = await searchSkills("e", dummyCtx);
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error("Expected success");
+
+    const data = result.data as {
+      skills: Array<{ slug: string; source: string }>;
+    };
+    expect(data.skills).toHaveLength(3);
+
+    // Verify ordering: catalog first, then clawhub, then skills.sh
+    expect(data.skills[0]!.slug).toBe("weather");
+    expect(data.skills[0]!.source).toBe("vellum");
+    expect(data.skills[1]!.slug).toBe("deploy");
+    expect(data.skills[1]!.source).toBe("clawhub");
+    expect(data.skills[2]!.slug).toBe("react-best");
+    expect(data.skills[2]!.source).toBe("skillssh");
+  });
+
+  test("deduplicates: catalog takes precedence over clawhub and skills.sh", async () => {
+    mockCatalogSkills.mockReturnValue([
+      {
+        id: "shared-skill",
+        displayName: "Shared Skill",
+        description: "From catalog",
+        source: "bundled",
+      },
+    ]);
+    mockClawhubSearch.mockResolvedValue({
+      skills: [
+        {
+          name: "Shared Skill",
+          slug: "shared-skill",
+          description: "From clawhub",
+          author: "",
+          stars: 5,
+          installs: 50,
+          version: "2.0.0",
+          createdAt: 2000,
+          source: "clawhub",
+        },
+      ],
+    });
+    mockSkillsshSearch.mockResolvedValue([
+      {
+        id: "org/repo/shared-skill",
+        skillId: "shared-skill",
+        name: "Shared Skill",
+        installs: 300,
+        source: "org/repo",
+      },
+    ]);
+
+    const result = await searchSkills("shared", dummyCtx);
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error("Expected success");
+
+    const data = result.data as {
+      skills: Array<{ slug: string; source: string }>;
+    };
+    // Only the catalog version should survive
+    expect(data.skills).toHaveLength(1);
+    expect(data.skills[0]!.slug).toBe("shared-skill");
+    expect(data.skills[0]!.source).toBe("vellum");
+  });
+
+  test("deduplicates: clawhub takes precedence over skills.sh", async () => {
+    mockCatalogSkills.mockReturnValue([]);
+    mockClawhubSearch.mockResolvedValue({
+      skills: [
+        {
+          name: "Overlap",
+          slug: "overlap-skill",
+          description: "From clawhub",
+          author: "bob",
+          stars: 20,
+          installs: 200,
+          version: "1.0.0",
+          createdAt: 3000,
+          source: "clawhub",
+        },
+      ],
+    });
+    mockSkillsshSearch.mockResolvedValue([
+      {
+        id: "org/repo/overlap-skill",
+        skillId: "overlap-skill",
+        name: "Overlap",
+        installs: 100,
+        source: "org/repo",
+      },
+    ]);
+
+    const result = await searchSkills("overlap", dummyCtx);
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error("Expected success");
+
+    const data = result.data as {
+      skills: Array<{ slug: string; source: string }>;
+    };
+    expect(data.skills).toHaveLength(1);
+    expect(data.skills[0]!.slug).toBe("overlap-skill");
+    expect(data.skills[0]!.source).toBe("clawhub");
+  });
+
+  test("returns clawhub results when skills.sh fails", async () => {
+    mockCatalogSkills.mockReturnValue([]);
+    mockClawhubSearch.mockResolvedValue({
+      skills: [
+        {
+          name: "ClawhubSkill",
+          slug: "clawhub-only",
+          description: "",
+          author: "",
+          stars: 0,
+          installs: 0,
+          version: "",
+          createdAt: 0,
+          source: "clawhub",
+        },
+      ],
+    });
+    mockSkillsshSearch.mockRejectedValue(new Error("skills.sh is down"));
+
+    const result = await searchSkills("clawhub", dummyCtx);
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error("Expected success");
+
+    const data = result.data as {
+      skills: Array<{ slug: string; source: string }>;
+    };
+    expect(data.skills).toHaveLength(1);
+    expect(data.skills[0]!.slug).toBe("clawhub-only");
+    expect(data.skills[0]!.source).toBe("clawhub");
+  });
+
+  test("returns skills.sh results when clawhub fails", async () => {
+    mockCatalogSkills.mockReturnValue([]);
+    mockClawhubSearch.mockRejectedValue(new Error("clawhub is down"));
+    mockSkillsshSearch.mockResolvedValue([
+      {
+        id: "org/repo/skillssh-only",
+        skillId: "skillssh-only",
+        name: "SkillsShOnly",
+        installs: 42,
+        source: "org/repo",
+      },
+    ]);
+
+    const result = await searchSkills("skillssh", dummyCtx);
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error("Expected success");
+
+    const data = result.data as {
+      skills: Array<{ slug: string; source: string }>;
+    };
+    expect(data.skills).toHaveLength(1);
+    expect(data.skills[0]!.slug).toBe("skillssh-only");
+    expect(data.skills[0]!.source).toBe("skillssh");
+  });
+
+  test("returns catalog-only results when both community registries fail", async () => {
+    mockCatalogSkills.mockReturnValue([
+      {
+        id: "my-skill",
+        displayName: "My Skill",
+        description: "A bundled skill",
+        source: "bundled",
+      },
+    ]);
+    mockClawhubSearch.mockRejectedValue(new Error("clawhub down"));
+    mockSkillsshSearch.mockRejectedValue(new Error("skillssh down"));
+
+    const result = await searchSkills("my", dummyCtx);
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error("Expected success");
+
+    const data = result.data as {
+      skills: Array<{ slug: string; source: string }>;
+    };
+    expect(data.skills).toHaveLength(1);
+    expect(data.skills[0]!.slug).toBe("my-skill");
+    expect(data.skills[0]!.source).toBe("vellum");
+  });
+
+  test("skills.sh results have correct normalized fields", async () => {
+    mockCatalogSkills.mockReturnValue([]);
+    mockClawhubSearch.mockResolvedValue({ skills: [] });
+    mockSkillsshSearch.mockResolvedValue([
+      {
+        id: "org/repo/test-skill",
+        skillId: "test-skill",
+        name: "Test Skill",
+        installs: 99,
+        source: "org/repo",
+      },
+    ]);
+
+    const result = await searchSkills("test", dummyCtx);
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error("Expected success");
+
+    const data = result.data as {
+      skills: Array<{
+        name: string;
+        slug: string;
+        description: string;
+        author: string;
+        stars: number;
+        installs: number;
+        version: string;
+        createdAt: number;
+        source: string;
+      }>;
+    };
+    expect(data.skills).toHaveLength(1);
+
+    const skill = data.skills[0]!;
+    expect(skill.name).toBe("Test Skill");
+    expect(skill.slug).toBe("test-skill");
+    expect(skill.description).toBe("");
+    expect(skill.author).toBe("");
+    expect(skill.stars).toBe(0);
+    expect(skill.installs).toBe(99);
+    expect(skill.version).toBe("");
+    expect(skill.createdAt).toBe(0);
+    expect(skill.source).toBe("skillssh");
+  });
+});

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -823,7 +823,7 @@ export async function searchSkills(
     if (skillsshResult.status === "fulfilled") {
       skillsshSkills = skillsshResult.value.map((r) => ({
         name: r.name,
-        slug: r.skillId,
+        slug: r.id,
         description: "",
         author: "",
         stars: 0,

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -46,6 +46,7 @@ import {
   deleteSkillCapabilityMemory,
   seedCatalogSkillMemories,
 } from "../../skills/skill-memory.js";
+import { searchSkillsRegistry } from "../../skills/skillssh-registry.js";
 import { getWorkspaceSkillsDir } from "../../util/platform.js";
 import {
   CONFIG_RELOAD_DEBOUNCE_MS,
@@ -787,7 +788,7 @@ export async function searchSkills(
       installs: number;
       version: string;
       createdAt: number;
-      source: "vellum" | "clawhub";
+      source: "vellum" | "clawhub" | "skillssh";
     }
 
     const catalogItems: SearchItem[] = catalogMatches.map((s) => ({
@@ -802,25 +803,62 @@ export async function searchSkills(
       source: "vellum" as const,
     }));
 
-    // Search the community registry (non-fatal on failure)
-    let communitySkills: SearchItem[] = [];
-    try {
-      const communityResult = await clawhubSearch(query);
-      communitySkills = communityResult.skills;
-    } catch (err) {
+    // Search both community registries in parallel (non-fatal on failure)
+    const [clawhubResult, skillsshResult] = await Promise.allSettled([
+      clawhubSearch(query),
+      searchSkillsRegistry(query),
+    ]);
+
+    let clawhubSkills: SearchItem[] = [];
+    if (clawhubResult.status === "fulfilled") {
+      clawhubSkills = clawhubResult.value.skills;
+    } else {
       log.warn(
-        { err },
-        "clawhub search failed, returning catalog-only results",
+        { err: clawhubResult.reason },
+        "clawhub search failed, continuing without clawhub results",
       );
     }
 
-    // Deduplicate: catalog takes precedence when slugs collide
-    const catalogSlugs = new Set(catalogItems.map((s) => s.slug));
-    const deduped = communitySkills.filter((s) => !catalogSlugs.has(s.slug));
+    let skillsshSkills: SearchItem[] = [];
+    if (skillsshResult.status === "fulfilled") {
+      skillsshSkills = skillsshResult.value.map((r) => ({
+        name: r.name,
+        slug: r.skillId,
+        description: "",
+        author: "",
+        stars: 0,
+        installs: r.installs,
+        version: "",
+        createdAt: 0,
+        source: "skillssh" as const,
+      }));
+    } else {
+      log.warn(
+        { err: skillsshResult.reason },
+        "skills.sh search failed, continuing without skills.sh results",
+      );
+    }
+
+    // Deduplicate: catalog > clawhub > skills.sh (first occurrence wins)
+    const seenSlugs = new Set(catalogItems.map((s) => s.slug));
+
+    const dedupedClawhub = clawhubSkills.filter((s) => {
+      if (seenSlugs.has(s.slug)) return false;
+      seenSlugs.add(s.slug);
+      return true;
+    });
+
+    const dedupedSkillssh = skillsshSkills.filter((s) => {
+      if (seenSlugs.has(s.slug)) return false;
+      seenSlugs.add(s.slug);
+      return true;
+    });
 
     return {
       success: true,
-      data: { skills: [...catalogItems, ...deduped] },
+      data: {
+        skills: [...catalogItems, ...dedupedClawhub, ...dedupedSkillssh],
+      },
     };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -806,7 +806,7 @@ export async function searchSkills(
     // Search both community registries in parallel (non-fatal on failure)
     const [clawhubResult, skillsshResult] = await Promise.allSettled([
       clawhubSearch(query),
-      searchSkillsRegistry(query),
+      searchSkillsRegistry(query, 25),
     ]);
 
     let clawhubSkills: SearchItem[] = [];


### PR DESCRIPTION
## Summary
- Add skills.sh registry search alongside clawhub in daemon searchSkills handler
- Run both community searches in parallel with Promise.allSettled for resilience
- Deduplicate by slug with precedence: catalog > clawhub > skills.sh

Part of plan: skills-unify-search.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22840" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
