### PR TITLE
feat: move provider OAuth app setup guides into vellum-oauth-integrations/references

### DIFF
--- a/skills/vellum-oauth-integrations/references/provider-app-setups/airtable-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/airtable-path-b.md
@@ -1,0 +1,95 @@
+# Path B: Manual Channel Setup (Telegram, Slack, etc.)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17329) is not reachable from a remote channel.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Airtable from chat**
+>
+> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+>
+> 1. An Airtable account
+> 2. About 5 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Ensure Public Ingress
+
+Before proceeding, resolve the redirect URI:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+## Path B Step 3: Register an OAuth Integration
+
+Tell the user:
+
+> **Step 1: Register an OAuth integration**
+>
+> Open this link:
+> `https://airtable.com/create/oauth`
+>
+> 1. Click **Register new OAuth integration**
+> 2. Set the name to **Vellum Assistant**
+> 3. Click **Register integration**
+>
+> Let me know when the integration is created.
+
+## Path B Step 4: Add Scopes
+
+Tell the user:
+
+> **Step 2: Add permissions**
+>
+> In the integration settings, find the **Scopes** section and add each of these scopes:
+>
+> `data.records:read`, `data.records:write`, `schema.bases:read`
+>
+> That's 3 scopes total.
+>
+> Let me know when they're all added.
+
+## Path B Step 5: Add Redirect URL
+
+Tell the user:
+
+> **Step 3: Add redirect URL**
+>
+> In the integration settings, find the **OAuth redirect URL** field.
+>
+> 1. Paste this exact URL: `OAUTH_CALLBACK_URL`
+> 2. Save the settings
+>
+> Let me know when it's saved.
+
+## Path B Step 6: Get Credentials
+
+Tell the user:
+
+> **Step 4: Get your integration credentials**
+>
+> On the integration settings page, find the **Client ID** and the **OAuth secret**.
+>
+> Send me your **Client ID** first.
+
+Wait for the Client ID. Then ask for the secret:
+
+> Now send me the **OAuth secret**. You may need to click **Show** or **Generate** to reveal it. Send it as a standalone message with no other text.
+
+Note: Airtable OAuth secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+
+## Path B Step 7: Authorize and Verify
+
+Follow the `vellum-oauth-integrations` workflow to register the OAuth app, connect, and verify.
+
+Send the returned auth URL to the user. Tell them to click **Grant access** on the Airtable consent page.
+
+After authorization:
+
+> **Airtable is connected!** You can now ask me to read and update records in your Airtable bases.

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/airtable.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/airtable.md
@@ -1,0 +1,106 @@
+You are helping your user set up Airtable OAuth credentials so the Airtable integration can connect to their bases.
+
+The included `vellum-oauth-integrations` skill handles the generic parts of the flow (credential collection, app registration, connection, and verification). This file defines only the Airtable-specific steps.
+
+## Provider Details
+
+- **Provider key:** `airtable`
+- **Dashboard:** `https://airtable.com/create/oauth`
+- **Ping URL:** `https://api.airtable.com/v0/meta/whoami`
+- **Callback transport:** Loopback (port 17329)
+- **Token endpoint auth method:** secret via POST body
+- **Requires secret:** Yes (token endpoint needs both client ID and app secret)
+
+## Airtable-Specific Flow
+
+The flow has 7 steps total, takes about 3-5 minutes.
+
+### Step 0: Prerequisite Check
+
+> Before we start - do you have an Airtable account? You'll need one to create an OAuth integration.
+
+If no account, direct them to `https://airtable.com/signup` to create one first.
+
+---
+
+### Step 1: Open Airtable OAuth Page
+
+Open: `https://airtable.com/create/oauth`
+
+> I've opened the Airtable OAuth page. If it's asking you to sign in, go ahead and do that first - then let me know.
+
+---
+
+### Step 2: Register a New OAuth Integration
+
+> Look for the **Register new OAuth integration** button and click it.
+
+Then:
+
+> Set the name to **Vellum Assistant**. Then click **Register integration**.
+
+**Known issues:**
+
+- If you don't see the registration option, make sure you're on a plan that supports OAuth integrations (most plans do)
+
+**Milestone (2 of 7):** "Integration registered - now let's configure the redirect URL."
+
+---
+
+### Step 3: Set Up Redirect URL
+
+> Find the **OAuth redirect URL** field, paste this URL, and save:
+>
+> `http://localhost:17329/oauth/callback`
+
+---
+
+### Step 4: Add Scopes
+
+> Now let's add the permissions this integration needs. Look for the **Scopes** section.
+>
+> You'll need to add each of these scopes:
+>
+> - `data.records:read` - read records from bases
+> - `data.records:write` - create and update records
+> - `schema.bases:read` - view base structure and field info
+>
+> Select each scope from the list and make sure all three are added.
+
+Wait for the user to confirm all 3 scopes are added.
+
+**Milestone (4 of 7):** "Scopes configured - now let's grab the credentials."
+
+---
+
+### Step 5: Get Client ID and OAuth Secret
+
+> Now let's grab the credentials. You should see the **Client ID** on this page.
+
+> Also look for the **OAuth secret** - you may need to click a button to reveal or generate it.
+
+**Milestone (5 of 7):** "Almost there - just need to save these credentials."
+
+---
+
+### Step 6: Store Credentials, Authorize, and Verify
+
+Follow the `vellum-oauth-integrations` workflow to collect credentials, register the OAuth app, connect, and verify.
+
+> I'll start the Airtable authorization flow now. You should see a consent page asking you to allow **Vellum Assistant** to access your Airtable data.
+>
+> Review the permissions and click **Grant access**.
+
+**On success:** "Airtable is connected! You can now ask me to read and update records in your Airtable bases."
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [airtable-path-b.md](airtable-path-b.md).
+
+Key Airtable-specific differences for Path B:
+
+- Loopback callback won't work from a remote channel - need public ingress configured
+- Add the ingress-based redirect URI under the OAuth redirect URL field on the integration page
+- Airtable OAuth secrets don't have a known prefix that triggers scanners, but still use `credential_store prompt` or `credential_store store` for security

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/asana-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/asana-path-b.md
@@ -1,0 +1,83 @@
+# Path B: Manual Channel Setup (Asana)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17328) is not reachable from a remote channel.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Asana from chat**
+>
+> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+>
+> 1. An Asana account with permission to create developer apps
+> 2. About 5 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Ensure Public Ingress
+
+Before proceeding, resolve the redirect URI:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+## Path B Step 3: Create an Asana App
+
+Tell the user:
+
+> **Step 1: Create an Asana App**
+>
+> Open this link:
+> `https://app.asana.com/0/my-apps`
+>
+> 1. Click **Create New App**
+> 2. Set the app name to **Vellum Assistant**
+> 3. Select a purpose (e.g., "Build an integration")
+> 4. Click **Create app**
+>
+> Let me know when the app is created.
+
+## Path B Step 4: Add Redirect URL
+
+Tell the user:
+
+> **Step 2: Add redirect URL**
+>
+> In the app settings, go to the **OAuth** section.
+>
+> 1. Under **Redirect URLs**, click **Add redirect URL**
+> 2. Paste this exact URL: `OAUTH_CALLBACK_URL`
+> 3. Save the changes
+>
+> Let me know when it's saved.
+
+## Path B Step 5: Get Credentials
+
+Tell the user:
+
+> **Step 3: Get your app credentials**
+>
+> In the **OAuth** section of your app settings, you should see the **Client ID** and the app **secret**.
+>
+> Send me your **Client ID** first.
+
+Wait for the Client ID. Then ask for the secret:
+
+> Now send me the **app secret**. You may need to click **Show** to reveal it. Send it as a standalone message with no other text.
+
+Note: Asana app secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+
+## Path B Step 6: Authorize and Verify
+
+Follow the `vellum-oauth-integrations` workflow to register the OAuth app, connect, and verify.
+
+Send the returned auth URL to the user. Tell them to click **Allow** on the Asana consent page.
+
+After authorization:
+
+> **Asana is connected!** You can now ask me to check your Asana tasks, create projects, manage assignments, and track your work.

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/asana.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/asana.md
@@ -1,0 +1,90 @@
+You are helping your user set up Asana OAuth credentials so the Asana integration can connect to their workspace.
+
+The included `vellum-oauth-integrations` skill handles the generic parts of the flow (credential collection, app registration, connection, and verification). This file defines only the Asana-specific steps.
+
+## Provider Details
+
+- **Provider key:** `asana`
+- **Dashboard:** `https://app.asana.com/0/my-apps`
+- **Ping URL:** `https://app.asana.com/api/1.0/users/me`
+- **Callback transport:** Loopback (port 17328)
+- **Requires secret:** Yes (token endpoint needs both client ID and secret)
+- **Scopes:** `default` (Asana uses a single default scope)
+
+## Asana-Specific Flow
+
+The flow has 6 steps total, takes about 3-5 minutes.
+
+### Step 0: Prerequisite Check
+
+> Before we start - do you have an Asana account? You'll need to be able to create developer apps in your Asana workspace.
+
+If no account, direct them to sign up at `https://asana.com`. If they're unsure about permissions, suggest proceeding - most Asana accounts allow creating personal apps.
+
+---
+
+### Step 1: Open Asana Developer Console
+
+Open: `https://app.asana.com/0/my-apps`
+
+> I've opened the Asana Developer Console (My Apps). If it's asking you to sign in, go ahead and do that first - then let me know.
+
+---
+
+### Step 2: Create a New App
+
+> Look for the **Create New App** button. Go ahead and click it.
+
+After the user clicks:
+
+> Set the app name to **Vellum Assistant**. You'll also need to select a purpose - pick whichever fits best (e.g., "Build an integration" or "Personal use"). Then click **Create app**.
+
+**Known issues:**
+
+- If the user is part of multiple workspaces, the app will be tied to their default workspace - that's fine for personal use
+
+**Milestone (2 of 6):** "App created - now let's set up the redirect URL."
+
+---
+
+### Step 3: Set Up Redirect URL
+
+> In the app settings, look for the **OAuth** section or tab. Under **Redirect URLs**, click **Add redirect URL**, paste this URL, and save:
+>
+> `http://localhost:17328/oauth/callback`
+
+**Milestone (3 of 6):** "Redirect URL is configured - now let's grab the credentials."
+
+---
+
+### Step 4: Get Client ID and App Secret
+
+> Now let's grab the credentials. In the app settings, look for the **OAuth** section. You should see the **Client ID** and the app **secret** listed there.
+
+> You may need to click a reveal or show button to see the secret.
+
+**Milestone (4 of 6):** "Almost there - just need to save these credentials."
+
+---
+
+### Step 5: Store Credentials, Authorize, and Verify
+
+Follow the `vellum-oauth-integrations` workflow to collect credentials, register the OAuth app, connect, and verify.
+
+> I'll start the Asana authorization flow now. You should see an Asana consent page asking you to allow **Vellum Assistant** to access your account.
+>
+> Review the permissions and click **Allow**.
+
+**On success:** "Asana is connected! You can now ask me to check your Asana tasks, create projects, manage assignments, and track your work."
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [asana-path-b.md](asana-path-b.md).
+
+Key Asana-specific differences for Path B:
+
+- Loopback callback won't work from a remote channel - need public ingress configured
+- Add the ingress-based redirect URI under the **OAuth** section of the app settings
+- The app secret doesn't have a known prefix that triggers scanners, but still use `credential_store prompt` or `credential_store store` for security

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/discord-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/discord-path-b.md
@@ -1,0 +1,95 @@
+# Path B: Manual Channel Setup (Discord)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17326) is not reachable from a remote channel.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Discord from chat**
+>
+> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+>
+> 1. A Discord account
+> 2. About 5 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Ensure Public Ingress
+
+Before proceeding, resolve the redirect URI:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+## Path B Step 3: Create a Discord Application
+
+Tell the user:
+
+> **Step 1: Create a Discord Application**
+>
+> Open this link:
+> `https://discord.com/developers/applications`
+>
+> 1. Click **New Application**
+> 2. Set the name to **Vellum Assistant**
+> 3. Accept the Developer Terms of Service and Developer Policy
+> 4. Click **Create**
+>
+> Let me know when the application is created.
+
+## Path B Step 4: Navigate to OAuth2
+
+Tell the user:
+
+> **Step 2: Open OAuth2 settings**
+>
+> In the left sidebar, click **OAuth2**.
+>
+> Let me know when you're on that page.
+
+## Path B Step 5: Add Redirect URL
+
+Tell the user:
+
+> **Step 3: Add redirect URL**
+>
+> On the **OAuth2** page, scroll down to the **Redirects** section.
+>
+> 1. Click **Add Redirect**
+> 2. Paste this exact URL: `OAUTH_CALLBACK_URL`
+> 3. Click **Save Changes** at the bottom of the page
+>
+> Let me know when it's saved.
+
+## Path B Step 6: Get Credentials
+
+Tell the user:
+
+> **Step 4: Get your app credentials**
+>
+> On the **OAuth2** page, you should see the **Client ID** near the top.
+>
+> Send me your **Client ID** first.
+
+Wait for the Client ID. Then ask for the secret:
+
+> Now click **Reset Secret** on the OAuth2 page. Confirm the reset when prompted. Copy the revealed secret and send it here as a standalone message with no other text.
+
+Note: Discord app secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+
+## Path B Step 7: Authorize and Verify
+
+Follow the `vellum-oauth-integrations` workflow to register the OAuth app, connect, and verify.
+
+Scopes to request: `identify guilds guilds.members.read messages.read`
+
+Send the returned auth URL to the user. Tell them to click **Authorize** on the Discord consent page.
+
+After authorization:
+
+> **Discord is connected!** You can now ask me to check your Discord servers, read messages, and look up server members.

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/discord.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/discord.md
@@ -1,0 +1,117 @@
+You are helping your user set up Discord OAuth credentials so the Discord integration can connect to their account and servers.
+
+The included `vellum-oauth-integrations` skill handles the generic parts of the flow (credential collection, app registration, connection, and verification). This file defines only the Discord-specific steps.
+
+## Provider Details
+
+- **Provider key:** `discord`
+- **Dashboard:** `https://discord.com/developers/applications`
+- **Ping URL:** `https://discord.com/api/v10/users/@me`
+- **Callback transport:** Loopback (port 17326)
+- **Requires secret:** Yes (token endpoint needs both client ID and app secret)
+
+## Discord-Specific Flow
+
+The flow has 8 steps total, takes about 3-5 minutes.
+
+### Step 0: Prerequisite Check
+
+> Before we start - do you have a Discord account? You don't need any special permissions; any Discord user can create applications in the Developer Portal.
+
+If no account, direct them to `https://discord.com/register` first.
+
+---
+
+### Step 1: Open Discord Developer Portal
+
+Open: `https://discord.com/developers/applications`
+
+> I've opened the Discord Developer Portal. If it's asking you to sign in, go ahead and do that first - then let me know.
+
+---
+
+### Step 2: Create a New Application
+
+> Look for the **New Application** button (top-right area). Go ahead and click it.
+
+After the user clicks:
+
+> Set the application name to **Vellum Assistant**, accept the Developer Terms of Service and Developer Policy, then click **Create**.
+
+**Known issues:**
+
+- If the user already has an application named "Vellum Assistant", they can either reuse it or pick a different name
+- Discord may show a CAPTCHA during creation
+
+**Milestone (2 of 8):** "Application created - now let's head to the OAuth2 settings."
+
+---
+
+### Step 3: Navigate to OAuth2
+
+> In the left sidebar, click **OAuth2**. This is where we'll configure the credentials and scopes.
+
+Open: the application's **OAuth2** page via the left sidebar.
+
+**Milestone (3 of 8):** "OAuth2 page open - let's grab the Client ID."
+
+---
+
+### Step 4: Copy Client ID
+
+> You should see the **Client ID** near the top of the OAuth2 page. Copy it and paste it here in the chat.
+
+Wait for the user to provide the Client ID.
+
+---
+
+### Step 5: Reset and Copy the App Secret
+
+> Now we need the app secret. Click the **Reset Secret** button. Discord will ask you to confirm - go ahead and confirm it.
+
+> **Important:** Once the secret is shown, you'll only be able to see it this once. I'll prompt you to paste it securely in a moment.
+
+**Known issues:**
+
+- If the user has 2FA enabled, Discord will ask for a 2FA code before revealing the secret
+- The old secret (if any) will stop working immediately after reset
+
+**Milestone (5 of 8):** "Credentials in hand - now let's set up the redirect URL."
+
+---
+
+### Step 6: Add Redirect URL
+
+> Still on the **OAuth2** page, scroll down to the **Redirects** section. Click **Add Redirect**, paste this URL:
+>
+> `http://localhost:17326/oauth/callback`
+>
+> Then click **Save Changes** at the bottom.
+
+**Milestone (6 of 8):** "Redirect URL is set - time to save the credentials."
+
+---
+
+### Step 7: Store Credentials, Authorize, and Verify
+
+Follow the `vellum-oauth-integrations` workflow to collect credentials, register the OAuth app, connect, and verify.
+
+Scopes to request: `identify guilds guilds.members.read messages.read`
+
+> I'll start the Discord authorization flow now. You should see a Discord consent page asking you to authorize **Vellum Assistant** to access your account.
+>
+> Review the permissions and click **Authorize**.
+
+**On success:** "Discord is connected! You can now ask me to check your Discord servers, read messages, and look up server members."
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [discord-path-b.md](discord-path-b.md).
+
+Key Discord-specific differences for Path B:
+
+- Loopback callback won't work from a remote channel - need public ingress configured
+- Add the ingress-based redirect URI under **Redirects** on the OAuth2 page
+- Discord app secrets don't have a known prefix that triggers scanners, but still use `credential_store prompt` or `credential_store store` for security

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/dropbox-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/dropbox-path-b.md
@@ -1,0 +1,97 @@
+# Path B: Manual Channel Setup (Dropbox)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17327) is not reachable from a remote channel.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Dropbox from chat**
+>
+> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+>
+> 1. A Dropbox account (free is fine)
+> 2. About 5 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Ensure Public Ingress
+
+Before proceeding, resolve the redirect URI:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+## Path B Step 3: Create a Dropbox App
+
+Tell the user:
+
+> **Step 1: Create a Dropbox App**
+>
+> Open this link:
+> `https://www.dropbox.com/developers/apps`
+>
+> 1. Click **Create app**
+> 2. Choose **Scoped access**
+> 3. Choose **Full Dropbox** access type
+> 4. Name it **Vellum Assistant**
+> 5. Click **Create app**
+>
+> Let me know when the app is created.
+
+## Path B Step 4: Set Permissions
+
+Tell the user:
+
+> **Step 2: Set permissions**
+>
+> Click the **Permissions** tab at the top of the app page. Check the boxes for each of these scopes:
+>
+> `files.metadata.read`, `files.content.read`, `files.content.write`, `sharing.read`
+>
+> That's 4 scopes total. After checking all four, click **Submit** to save.
+>
+> Let me know when they're saved.
+
+## Path B Step 5: Add Redirect URL
+
+Tell the user:
+
+> **Step 3: Add redirect URL**
+>
+> Click the **Settings** tab. Scroll down to the **OAuth 2** section and find **Redirect URIs**.
+>
+> 1. Paste this exact URL: `OAUTH_CALLBACK_URL`
+> 2. Click **Add**
+>
+> Let me know when it's saved.
+
+## Path B Step 6: Get Credentials
+
+Tell the user:
+
+> **Step 4: Get your app credentials**
+>
+> Still on the **Settings** tab, find the **App key** and **App secret** in the OAuth 2 section.
+>
+> Send me your **App key** first.
+
+Wait for the App key. Then ask for the secret:
+
+> Now send me the **App secret**. You may need to click **Show** to reveal it. Send it as a standalone message with no other text.
+
+Note: Dropbox app secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+
+## Path B Step 7: Authorize and Verify
+
+Follow the `vellum-oauth-integrations` workflow to register the OAuth app, connect, and verify.
+
+Send the returned auth URL to the user. Tell them to click **Allow** on the Dropbox consent page.
+
+After authorization:
+
+> **Dropbox is connected!** You can now ask me to read files, upload documents, and browse your Dropbox.

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/dropbox.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/dropbox.md
@@ -1,0 +1,126 @@
+You are helping your user set up Dropbox OAuth credentials so the Dropbox integration can connect to their account.
+
+The included `vellum-oauth-integrations` skill handles the generic parts of the flow (credential collection, app registration, connection, and verification). This file defines only the Dropbox-specific steps.
+
+## Provider Details
+
+- **Provider key:** `dropbox`
+- **Dashboard:** `https://www.dropbox.com/developers/apps`
+- **Ping URL:** `https://api.dropboxapi.com/2/users/get_current_account` (POST, no body)
+- **Callback transport:** Loopback (port 17327)
+- **Requires secret:** Yes (token endpoint needs both client ID and app secret)
+- **Extra params:** `token_access_type=offline`
+
+## Dropbox-Specific Flow
+
+The flow has 8 steps total, takes about 3-5 minutes.
+
+### Step 0: Prerequisite Check
+
+> Before we start - do you have a Dropbox account? A free account works fine.
+
+If no account, direct them to `https://www.dropbox.com` to create one first.
+
+---
+
+### Step 1: Open Dropbox App Console
+
+Open: `https://www.dropbox.com/developers/apps`
+
+> I've opened the Dropbox App Console. If it's asking you to sign in, go ahead and do that first - then let me know.
+
+---
+
+### Step 2: Create a New App
+
+> Look for the **Create app** button. Go ahead and click it.
+
+After the user clicks:
+
+> You should see a setup form. Choose these options:
+>
+> 1. **Choose an API:** Select **Scoped access**
+> 2. **Choose the type of access:** Select **Full Dropbox**
+> 3. **Name your app:** Enter **Vellum Assistant**
+
+Then:
+
+> Click **Create app** to finish.
+
+**Known issues:**
+
+- App names must be globally unique on Dropbox - if "Vellum Assistant" is taken, suggest adding a suffix like "Vellum Assistant - Personal"
+- If the user sees "You have reached the limit for the number of apps," they'll need to delete an unused app first
+
+**Milestone (2 of 8):** "App created - now let's set the permissions."
+
+---
+
+### Step 3: Set Permissions
+
+> Click the **Permissions** tab at the top of the app page.
+>
+> You'll need to check the boxes for each of these scopes:
+>
+> - `files.metadata.read` - view file and folder metadata
+> - `files.content.read` - read file content
+> - `files.content.write` - create and update files
+> - `sharing.read` - view shared files and folders
+>
+> Make sure each one is checked.
+
+Wait for the user to confirm all 4 scopes are enabled.
+
+---
+
+### Step 4: Save Permissions
+
+> Now click the **Submit** button at the bottom to save the permissions.
+
+**Important:** Permissions must be saved before the authorization step, otherwise the token will not include the requested scopes.
+
+**Milestone (4 of 8):** "Permissions saved - now let's set up the redirect URL."
+
+---
+
+### Step 5: Set Up Redirect URI
+
+> Click the **Settings** tab. Scroll down to the **OAuth 2** section and find the **Redirect URIs** field.
+>
+> Paste this URI and click **Add**:
+>
+> `http://localhost:17327/oauth/callback`
+
+---
+
+### Step 6: Get App Key and App Secret
+
+> Stay on the **Settings** tab. Scroll up to the **App key** and **App secret** fields in the same OAuth 2 section.
+>
+> The App key is shown in plain text. The App secret is hidden - click **Show** to reveal it.
+
+**Milestone (6 of 8):** "Found the credentials - now let's save them."
+
+---
+
+### Step 7: Store Credentials, Authorize, and Verify
+
+Follow the `vellum-oauth-integrations` workflow to collect credentials, register the OAuth app, connect, and verify.
+
+> I'll start the Dropbox authorization flow now. You should see a Dropbox consent page asking you to allow **Vellum Assistant** to access your Dropbox.
+>
+> Review the permissions and click **Allow**.
+
+**On success:** "Dropbox is connected! You can now ask me to read files, upload documents, and browse your Dropbox."
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [dropbox-path-b.md](dropbox-path-b.md).
+
+Key Dropbox-specific differences for Path B:
+
+- Loopback callback won't work from a remote channel - need public ingress configured
+- Add the ingress-based redirect URI under **Redirect URIs** on the Settings tab
+- App secrets don't have a known prefix that triggers scanners, but still use `credential_store prompt` or `credential_store store` for security

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/figma-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/figma-path-b.md
@@ -1,0 +1,86 @@
+# Path B: Manual Channel Setup (Figma)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17331) is not reachable from a remote channel.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Figma from chat**
+>
+> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+>
+> 1. A Figma account
+> 2. About 3-5 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Ensure Public Ingress
+
+Before proceeding, resolve the redirect URI:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+## Path B Step 3: Create a Figma App
+
+Tell the user:
+
+> **Step 1: Create a Figma App**
+>
+> Open this link:
+> `https://www.figma.com/developers/apps`
+>
+> 1. Click **Create a new app** (or the **+** button)
+> 2. Set the app name to **Vellum Assistant**
+> 3. Set the website URL to any URL (e.g., `https://vellum.ai`)
+> 4. Click **Save** or **Create**
+>
+> Let me know when the app is created.
+
+## Path B Step 4: Configure Scopes and Callback URL
+
+Tell the user:
+
+> **Step 2: Set up scopes and callback URL**
+>
+> On the app settings page:
+>
+> 1. Find the **Scopes** section and enable:
+>    - `files:read`
+>    - `file_comments:write`
+> 2. Find the **Callback URL** field and paste this exact URL:
+>    `OAUTH_CALLBACK_URL`
+> 3. Click **Save**
+>
+> Let me know when it's saved.
+
+## Path B Step 5: Get Credentials
+
+Tell the user:
+
+> **Step 3: Get your app credentials**
+>
+> On the app settings page, find the **Client ID** and **App Secret**.
+>
+> Send me your **Client ID** first.
+
+Wait for the Client ID. Then ask for the secret:
+
+> Now send me the **App Secret**. You may need to click **Show** to reveal it. Send it as a standalone message with no other text.
+
+Note: Figma app secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+
+## Path B Step 6: Authorize and Verify
+
+Follow the `vellum-oauth-integrations` workflow to register the OAuth app, connect, and verify.
+
+Send the returned auth URL to the user. Tell them to click **Allow access** on the Figma consent page.
+
+After authorization:
+
+> **Figma is connected!** You can now ask me to browse your design files, inspect components, and post comments.

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/figma.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/figma.md
@@ -1,0 +1,111 @@
+You are helping your user set up Figma OAuth credentials so the Figma integration can access their design files and comments.
+
+The included `vellum-oauth-integrations` skill handles the generic parts of the flow (credential collection, app registration, connection, and verification). This file defines only the Figma-specific steps.
+
+## Provider Details
+
+- **Provider key:** `figma`
+- **Dashboard:** `https://www.figma.com/developers/apps`
+- **Ping URL:** `https://api.figma.com/v1/me`
+- **Callback transport:** Loopback (port 17331)
+- **Requires secret:** Yes (token endpoint needs both client ID and app secret)
+
+## Figma-Specific Flow
+
+The flow has 7 steps total, takes about 3-5 minutes.
+
+### Step 0: Prerequisite Check
+
+> Before we start - do you have a Figma account? You'll need one to create a Figma app for OAuth access.
+
+If the user doesn't have a Figma account, point them to `https://www.figma.com/signup` and wait for them to sign up.
+
+---
+
+### Step 1: Open Figma Developers Page
+
+Open: `https://www.figma.com/developers/apps`
+
+> I've opened the Figma developers page. If it's asking you to sign in, go ahead and do that first - then let me know.
+
+---
+
+### Step 2: Create a New Figma App
+
+> Look for the **Create a new app** button (or a **+** button). Go ahead and click it.
+
+After the user clicks:
+
+> Fill in the following details:
+>
+> - **App name:** Vellum Assistant
+> - **Website URL:** any URL is fine (e.g., `https://vellum.ai`)
+>
+> Then click **Save** or **Create**.
+
+**Known issues:**
+
+- If the page looks different or the button isn't visible, the user may need to scroll down or check that they're on the correct page at `https://www.figma.com/developers/apps`
+
+**Milestone (2 of 7):** "App created - now let's set up the callback URL."
+
+---
+
+### Step 3: Set Up Redirect URI
+
+> On the app settings page, find the **Callback URL** or **Redirect URI** field. Paste in this URL:
+>
+> `http://localhost:17331/oauth/callback`
+>
+> Then click **Save**.
+
+**Milestone (3 of 7):** "Callback URL is set - now let's configure the scopes."
+
+---
+
+### Step 4: Configure Scopes
+
+> Now let's make sure the right scopes are enabled. On the app settings page, look for a **Scopes** or **Permissions** section.
+>
+> Enable these scopes:
+>
+> - `files:read` - read access to files and projects
+> - `file_comments:write` - ability to post comments on files
+>
+> Save your changes if there's a save button.
+
+Wait for the user to confirm scopes are set.
+
+**Milestone (4 of 7):** "Scopes are configured - now let's grab the credentials."
+
+---
+
+### Step 5: Get Client ID and App Secret
+
+> On the app settings page, you should see your **Client ID** and **App Secret** (sometimes called just "Secret"). These are the credentials we need.
+
+**Milestone (5 of 7):** "Almost there - just need to save these credentials."
+
+---
+
+### Step 6: Store Credentials, Authorize, and Verify
+
+Follow the `vellum-oauth-integrations` workflow to collect credentials, register the OAuth app, connect, and verify.
+
+> I'll start the Figma authorization flow now. You should see a Figma consent page asking you to allow **Vellum Assistant** to access your account.
+>
+> Review the permissions and click **Allow access**.
+
+**On success:** "Figma is connected! You can now ask me to browse your design files, inspect components, and post comments."
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [figma-path-b.md](figma-path-b.md).
+
+Key Figma-specific differences for Path B:
+
+- Loopback callback won't work from a remote channel - need public ingress configured
+- Add the ingress-based redirect URI in the **Callback URL** field on the app settings page
+- The app secret doesn't have a known prefix that triggers scanners, but still use `credential_store prompt` or `credential_store store` for security

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/github-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/github-path-b.md
@@ -1,0 +1,72 @@
+# Path B: Manual Channel Setup (GitHub)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17332) is not reachable from a remote channel.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up GitHub from chat**
+>
+> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+>
+> 1. A GitHub account
+> 2. About 3-5 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Ensure Public Ingress
+
+Before proceeding, resolve the redirect URI:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+## Path B Step 3: Create a GitHub OAuth App
+
+Tell the user:
+
+> **Step 1: Create an OAuth App**
+>
+> Open this link:
+> `https://github.com/settings/developers`
+>
+> 1. Click the **OAuth Apps** tab if not already selected
+> 2. Click **New OAuth App**
+> 3. Fill in:
+>    - **Application name:** `Vellum Assistant`
+>    - **Homepage URL:** `https://vellum.ai`
+>    - **Authorization callback URL:** `OAUTH_CALLBACK_URL`
+> 4. Click **Register application**
+>
+> Let me know when the app is created.
+
+## Path B Step 4: Get Credentials
+
+Tell the user:
+
+> **Step 2: Get your app credentials**
+>
+> You should be on the app's settings page now. The **Client ID** is shown near the top.
+>
+> Send me your **Client ID** first.
+
+Wait for the Client ID. Then ask for the secret:
+
+> Now click **Generate a new client secret**. GitHub will show it only once, so copy it immediately. Send it as a standalone message with no other text.
+
+Note: GitHub app secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+
+## Path B Step 5: Authorize and Verify
+
+Follow the `vellum-oauth-integrations` workflow to register the OAuth app, connect, and verify.
+
+Send the returned auth URL to the user. Tell them to click **Authorize** on the GitHub consent page.
+
+After authorization:
+
+> **GitHub is connected!** You can now ask me to check your repositories, notifications, pull requests, and issues.

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/github.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/github.md
@@ -1,0 +1,109 @@
+You are helping your user set up GitHub OAuth credentials so the GitHub integration can connect to their account.
+
+The included `vellum-oauth-integrations` skill handles the generic parts of the flow (credential collection, app registration, connection, and verification). This file defines only the GitHub-specific steps.
+
+## Provider Details
+
+- **Provider key:** `github`
+- **Dashboard:** `https://github.com/settings/developers`
+- **Ping URL:** `https://api.github.com/user`
+- **Callback transport:** Loopback (port 17332)
+- **Requires secret:** Yes (token endpoint needs both client ID and app secret)
+
+## GitHub-Specific Flow
+
+The flow has 6 steps total, takes about 3-5 minutes.
+
+### Step 0: Prerequisite Check
+
+> Before we start - do you have a GitHub account? You'll need one to create an OAuth App.
+
+If no account, direct them to `https://github.com/signup` and wait for them to finish before continuing.
+
+---
+
+### Step 1: Open GitHub Developer Settings
+
+Open: `https://github.com/settings/developers`
+
+> I've opened the GitHub Developer Settings page. If it's asking you to sign in, go ahead and do that first - then let me know.
+
+---
+
+### Step 2: Create a New OAuth App
+
+> Look for the **New OAuth App** button (top-right area of the OAuth Apps tab). Go ahead and click it.
+
+After the user clicks:
+
+> Fill in the following fields:
+>
+> - **Application name:** `Vellum Assistant`
+> - **Homepage URL:** `https://vellum.ai` (or any URL you prefer)
+> - **Authorization callback URL:** We need to look this up first - hold on.
+
+Resolve the callback URL:
+
+```
+bash:
+  command: assistant oauth providers get github --json
+```
+
+Use the `redirectUri` from the JSON response:
+
+- If it is a concrete URL (e.g. `http://localhost:…/oauth/callback`), tell the user to enter that exact URL as the **Authorization callback URL**.
+- If it is `null`, stop and help the user configure public ingress first.
+
+Then:
+
+> Once all three fields are filled in, click **Register application**.
+
+**Milestone (2 of 6):** "App registered - now let's grab the credentials."
+
+---
+
+### Step 3: Copy Client ID
+
+> You should now be on the app's settings page. The **Client ID** is displayed near the top. Copy it - we'll need it in a moment.
+
+**Milestone (3 of 6):** "Client ID is ready - now we need the app secret."
+
+---
+
+### Step 4: Generate App Secret
+
+> Below the Client ID, you should see a **Generate a new client secret** button. Click it.
+>
+> GitHub will show the secret only once, so copy it right away before navigating away from the page.
+
+**Milestone (4 of 6):** "Secret generated - now let's store both credentials."
+
+---
+
+### Steps 5-6: Store Credentials, Authorize, and Verify
+
+Follow the `vellum-oauth-integrations` workflow to collect credentials, register the OAuth app, connect, and verify.
+
+> I'll start the GitHub authorization flow now. You should see a GitHub consent page asking you to allow **Vellum Assistant** to access your account.
+>
+> Review the permissions and click **Authorize**.
+
+The scopes requested will include:
+
+- `repo` - full access to repositories
+- `read:user` - read user profile info
+- `notifications` - access notifications
+
+**On success:** "GitHub is connected! You can now ask me to check your repositories, notifications, pull requests, and issues."
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [github-path-b.md](github-path-b.md).
+
+Key GitHub-specific differences for Path B:
+
+- Loopback callback won't work from a remote channel - need public ingress configured
+- Set the **Authorization callback URL** to the ingress-based OAuth callback URL when creating the app
+- App secrets don't have a known prefix that triggers scanners, but still use `credential_store prompt` or `credential_store store` for security

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/google-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/google-path-b.md
@@ -1,0 +1,149 @@
+# Path B: Manual Channel Setup (Telegram, Slack, etc.)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path uses **Web application** credentials because the OAuth callback goes through the public gateway URL.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Gmail & Calendar from chat**
+>
+> Fair warning - this involves Google's developer console, which can feel pretty technical. Don't worry about that - you don't need to understand any of it. I'll give you a direct link for every step and tell you exactly what to do. If anything looks confusing, just let me know and I'll help you through it.
+>
+> One thing worth knowing upfront: even after setup, I'll only ever create email drafts — I won't send anything without your explicit say-so.
+>
+> Since I can't open pages in your browser from here, you'll need:
+>
+> 1. A Google account with access to Google Cloud Console
+> 2. About 5 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Create or Select a Project
+
+Tell the user:
+
+> **Step 1: Select or create a Google Cloud project**
+>
+> Open this link to see your existing projects:
+> `https://console.cloud.google.com/cloud-resource-manager`
+>
+> If you have a project you'd like to use, send me the **project ID** (second column in the table, looks like `my-project-123456`).
+>
+> If you want to create a new one, open:
+> `https://console.cloud.google.com/projectcreate`
+>
+> Set the name to **Vellum Assistant** and click **Create**. Then send me the project ID.
+
+Wait for confirmation. Record the project ID for subsequent steps.
+
+## Path B Step 3: Enable APIs
+
+Tell the user:
+
+> **Step 2: Enable Gmail and Calendar APIs**
+>
+> Open each link below and click **Enable**:
+>
+> 1. Gmail API: `https://console.cloud.google.com/apis/library/gmail.googleapis.com?project=PROJECT_ID`
+> 2. Calendar API: `https://console.cloud.google.com/apis/library/calendar-json.googleapis.com?project=PROJECT_ID`
+>
+> Let me know when both are enabled.
+
+## Path B Step 4: Configure OAuth Consent Screen
+
+Tell the user:
+
+> **Step 3: Configure the OAuth consent screen**
+>
+> Open: `https://console.cloud.google.com/auth/branding?project=PROJECT_ID`
+>
+> **If you see a setup wizard** (numbered steps: App Information -> Audience -> Contact Information -> Finish):
+>
+> 1. **App Information:** Set app name to **Vellum Assistant**
+> 2. **Audience:** Select **External**
+> 3. **Contact Information:** Enter your email
+> 4. Click **Create**
+>
+> After the wizard completes, open `https://console.cloud.google.com/auth/audience?project=PROJECT_ID` and scroll to **Test users** -> click **+ Add users** -> add your email -> **Save**.
+>
+> **If you see a Branding page** (with fields for App name, support email, etc.):
+>
+> - **3a. Branding** - Fill in:
+>   - App name: **Vellum Assistant**
+>   - User support email: **your email**
+>   - Developer contact email: **your email**
+>   - Click **Save**
+> - **3b. Audience** - Open: `https://console.cloud.google.com/auth/audience?project=PROJECT_ID`
+>   - Set user type to **External** if not already set
+>   - Scroll to **Test users**, click **+ Add users**, add **your email**, click **Save**
+>
+> **Then, regardless of which flow you saw:**
+>
+> - **Scopes** - Open: `https://console.cloud.google.com/auth/scopes?project=PROJECT_ID`
+>   - Click **Add or Remove Scopes** - a panel will open
+>   - Scroll down to the **"Manually add scopes"** text box and paste these (comma-separated):
+>     `https://www.googleapis.com/auth/gmail.readonly,https://www.googleapis.com/auth/gmail.modify,https://www.googleapis.com/auth/gmail.send,https://www.googleapis.com/auth/calendar.readonly,https://www.googleapis.com/auth/calendar.events,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/contacts.readonly`
+>   - Click **Update** at the bottom of the panel
+>   - Back on the main page, scroll down and click **Save**
+>
+> **Quick note on email safety:** The `gmail.modify` and `gmail.send` scopes let me create drafts and, when you explicitly ask, send them. By default I only create drafts — nothing leaves your outbox without your approval. If you'd rather I only have read access to your email for now, you can remove those two from the list before pasting - everything else will still work fine, and you can always add them later.
+>
+> Let me know when all parts are done.
+
+## Path B Step 5: Create Web Application Credentials
+
+Before sending the next step, resolve the concrete callback URL:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+Tell the user:
+
+> **Step 4: Create OAuth credentials**
+>
+> Open: `https://console.cloud.google.com/auth/clients/create?project=PROJECT_ID`
+>
+> Use this exact redirect URI:
+> `OAUTH_CALLBACK_URL`
+>
+> 1. Application type: **Web application**
+> 2. Name: **Vellum Assistant**
+> 3. Under **Authorized redirect URIs**, click **Add URI** and paste the redirect URI shown above
+> 4. Click **Create**
+>
+> When the dialog appears, copy the Client ID and Client Secret. You'll send them to me next.
+
+## Path B Step 6: Store Credentials
+
+### Path B Step 6a: Client ID
+
+Tell the user:
+
+> **Step 5a: Send your Client ID**
+>
+> Send me the **Client ID** from the dialog. It looks like `123456789-xxxxx.apps.googleusercontent.com`.
+
+### Path B Step 6b: Client Secret Split Entry
+
+The Google client secret starts with `GOCSPX-`, which can trigger channel secret scanners. Ask for only the suffix.
+
+Tell the user:
+
+> **Step 5b: Send your Client Secret**
+>
+> Your Client Secret starts with `GOCSPX-`. Please send me only the part **after** `GOCSPX-` as a standalone message with no other text.
+
+After the user sends the suffix, reconstruct the full secret as `GOCSPX-<suffix>`.
+
+## Path B Step 7: Register, Authorize, and Verify
+
+Follow the `vellum-oauth-integrations` workflow to register the OAuth app, connect, and verify.
+
+Send the returned auth URL to the user. If they see **This app isn't verified**, tell them to click **Advanced** and continue to **Vellum Assistant**.
+
+**On success:** "Gmail and Calendar are connected!"

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/google.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/google.md
@@ -1,0 +1,218 @@
+You are helping your user set up Google Cloud OAuth credentials so Gmail and Google Calendar integrations can connect.
+
+The included `vellum-oauth-integrations` skill handles the generic parts of the flow (credential collection, app registration, connection, and verification). This file defines only the Google-specific steps.
+
+## Provider Details
+
+- **Provider key:** `google`
+- **Provider search keys:** `google`
+- **Credential type (Path A):** Desktop app
+- **Credential type (Path B):** Web application (callback through public gateway)
+
+## Path A: macOS Desktop App
+
+On the macOS desktop app, this is a collaborative Google Chrome flow. For every `Open:` URL in this file:
+
+- Use `host_bash` plus `osascript` to activate Google Chrome and navigate the user's existing browser window to that URL
+- Wait for the user to confirm they are done before moving to the next step
+- Never use `browser_*`, CDP, the browser skill, or `computer_use_*` for Google Cloud Console or Google OAuth pages
+- If Chrome is unavailable or AppleScript navigation fails, tell the user the URL and continue manually; do not switch to browser automation
+
+Use this exact pattern:
+
+```
+host_bash:
+  command: |
+    osascript -e '
+    tell application "Google Chrome"
+      activate
+      if (count of windows) = 0 then
+        make new window
+      end if
+      set URL of active tab of front window to "TARGET_URL"
+    end tell'
+```
+
+Replace `TARGET_URL` with the actual URL for that step. The point of Path A is to keep the flow in the user's real Chrome profile and avoid automated-browser rejections.
+
+## Google-Specific Flow
+
+The flow has 9 steps total, takes about 3-5 minutes.
+
+### Step 0: Prerequisite Check
+
+> Before we start - fair warning: this setup involves Google's developer console, which can feel pretty technical. Don't worry about that - you don't need to understand any of it. I'll open every page for you and tell you exactly what to click. If anything looks confusing or different from what I describe, just tell me and I'll figure it out.
+>
+> One thing worth knowing upfront: even after setup, I'll only ever create email drafts — I won't send anything without your explicit say-so.
+>
+> Do you have a Google account you'd like to use for this?
+
+If no Google account -> guide them to create one or defer.
+
+---
+
+### Step 1: Open Google Cloud Console
+
+Open: `https://console.cloud.google.com`
+
+> I've opened the Google Cloud Console. If it's asking you to sign in, go ahead and do that first.
+
+---
+
+### Step 2: Select or Create a Project
+
+Open: `https://console.cloud.google.com/cloud-resource-manager`
+
+> I've opened your project list. If you see an existing project you'd like to use, let me know its name. Otherwise I'll walk you through creating a new one.
+
+**New project:** Open `https://console.cloud.google.com/projectcreate` -> name it `vellum-assistant` -> click Create -> get the project ID.
+
+**Known issues:**
+
+- Workspace accounts may show an Organization/Location dropdown - leave as-is
+- Project quota limit -> suggest requesting increase, deleting unused, or reusing existing
+
+Record the **project ID** for all subsequent URLs.
+
+---
+
+### Step 3: Enable Gmail API
+
+Open: `https://console.cloud.google.com/apis/library/gmail.googleapis.com?project=PROJECT_ID`
+
+> You should see the Gmail API page. Look for a blue **Enable** button and click it.
+
+If already enabled ("Manage" shown), skip ahead.
+
+---
+
+### Step 4: Enable Google Calendar API
+
+Open: `https://console.cloud.google.com/apis/library/calendar-json.googleapis.com?project=PROJECT_ID`
+
+> Same thing - click **Enable** for the Google Calendar API.
+
+**Milestone (4 of 9):** "APIs are enabled - now we'll set up the OAuth consent screen."
+
+---
+
+### Step 5: Configure OAuth Consent Screen
+
+Google has two different flows depending on whether the consent screen has been configured before.
+
+#### Sidebar Reference (previously configured projects)
+
+| Sidebar Item    | URL Path         |
+| --------------- | ---------------- |
+| **Overview**    | `/auth/overview` |
+| **Branding**    | `/auth/branding` |
+| **Audience**    | `/auth/audience` |
+| **Data Access** | `/auth/scopes`   |
+| **Clients**     | `/auth/clients`  |
+
+#### Step 5a: Open the consent screen
+
+Open: `https://console.cloud.google.com/auth/branding?project=PROJECT_ID`
+
+**Case 1 - Wizard flow** (new/unconfigured projects, URL shows `/auth/overview/create`):
+
+> It looks like Google is showing the setup wizard. Let's walk through it:
+>
+> **Step 1 - App Information:** App name: `Vellum Assistant`, leave the rest
+> **Step 2 - Audience:** Select **External**
+> **Step 3 - Contact Information:** Enter your email
+>
+> Then click **Create**.
+
+After the wizard, skip Step 5b. Open `https://console.cloud.google.com/auth/audience?project=PROJECT_ID` to add test users (scroll to **Test users** -> **+ Add users** -> enter email -> Save), then go to Step 5c.
+
+**Case 2 - Branding page** (already configured projects):
+
+If needs setup: fill in App name (`Vellum Assistant`), User support email, Developer contact email -> Save. If already filled, skip to Step 5b.
+
+#### Step 5b: Audience and test users (skip if wizard was used)
+
+Open: `https://console.cloud.google.com/auth/audience?project=PROJECT_ID`
+
+1. Set user type to **External** if not already
+2. Scroll to **Test users** -> **+ Add users** -> enter email -> Save
+
+#### Step 5c: Add scopes
+
+Open: `https://console.cloud.google.com/auth/scopes?project=PROJECT_ID`
+
+On macOS desktop, before proceeding, copy the comma-separated scope string below to the user's clipboard using `pbcopy`.
+
+> I've opened **Data Access**.
+>
+> 1. Click **Add or Remove Scopes** -> scroll to **"Manually add scopes"** -> paste the comma-separated scopes below -> click **Update**
+> 2. Back on the main page, scroll down and click **Save**
+
+The scopes to paste:
+
+```
+https://www.googleapis.com/auth/gmail.readonly,https://www.googleapis.com/auth/gmail.modify,https://www.googleapis.com/auth/gmail.send,https://www.googleapis.com/auth/calendar.readonly,https://www.googleapis.com/auth/calendar.events,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/contacts.readonly
+```
+
+> You should see all 7 scopes listed across the three categories (Non-sensitive, Sensitive, Restricted):
+>
+> - `userinfo.email`
+> - `contacts.readonly`
+> - `calendar.readonly`
+> - `calendar.events`
+> - `gmail.send`
+> - `gmail.modify`
+> - `gmail.readonly`
+>
+> **Note:** GCP may categorize these scopes differently than you'd expect — that's fine, as long as all 7 are present.
+>
+> **Quick note on email safety:** The `gmail.modify` and `gmail.send` scopes let me create drafts and, when you explicitly ask, send them. By default I only create drafts — nothing leaves your outbox without your approval. If you'd rather I only have read access to your email for now, you can uncheck those two - everything else will still work fine, and you can always come back and add them later.
+
+**Milestone (5 of 9):** "Over halfway - the fiddliest part is behind us."
+
+---
+
+### Step 6: Create OAuth Client Credentials
+
+Open: `https://console.cloud.google.com/auth/clients/create?project=PROJECT_ID`
+
+> Select **Desktop app** as the application type. You can name it "Vellum Assistant" or leave the default. Click **Create**.
+
+A modal should appear with the **Client ID** and **Client Secret**. Tell the user to keep it open.
+
+> **Heads up:** Google sometimes has a slight delay, so the modal may only show your Client ID without the Client Secret. If that happens, don't worry - close the modal and navigate to `https://console.cloud.google.com/auth/clients?project=PROJECT_ID`. Click on the client you just created (look for the name you used, e.g. "Vellum Assistant"). Under **Client secrets**, find the row with a copy button, click it, and paste the secret into the secure credential input when prompted.
+
+---
+
+### Steps 7-9: Store Credentials, Authorize, and Verify
+
+Follow the `vellum-oauth-integrations` workflow to collect credentials, register the OAuth app, and verify the connection.
+
+Google-specific override for macOS desktop app:
+
+1. Before app registration, check the provider mode and set it to `your-own` if needed with `assistant oauth mode google --set your-own`.
+2. Register the OAuth app normally via `assistant oauth apps upsert`.
+3. For authorization, do **not** use the default browser behavior.
+4. Instead, run `assistant oauth connect google --no-browser` so the command returns the authorization URL.
+5. Open that returned authorization URL in Google Chrome using the same `host_bash` + `osascript` pattern as every other `Open:` step in this skill.
+6. Never use browser automation or computer-use for the Google consent screen.
+
+> I'll start the Google authorization flow now.
+>
+> If you see **"This app isn't verified"**, click **Advanced** then **Go to Vellum Assistant (unsafe)**. This is normal for apps in testing mode.
+>
+> Review the permissions and click **Allow**.
+
+**On success:** "Gmail and Calendar are connected! You can now ask me to check your inbox, manage emails, or look at your calendar."
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [google-path-b.md](google-path-b.md).
+
+Key Google-specific differences for Path B:
+
+- Use **Web application** credentials (not Desktop app)
+- Add redirect URI under **Authorized redirect URIs**
+- Client Secret prefix is `GOCSPX-` - use split entry to avoid channel scanners

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/hubspot-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/hubspot-path-b.md
@@ -1,0 +1,97 @@
+# Path B: Manual Channel Setup (HubSpot)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17330) is not reachable from a remote channel.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up HubSpot from chat**
+>
+> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+>
+> 1. A HubSpot account (free tier works)
+> 2. About 5 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Ensure Public Ingress
+
+Before proceeding, resolve the redirect URI:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+## Path B Step 3: Create a Developer Account and App
+
+Tell the user:
+
+> **Step 1: Create a HubSpot App**
+>
+> Open this link:
+> `https://app.hubspot.com/developer`
+>
+> 1. Sign in or create a free developer account if needed
+> 2. Click **Create app** (choose public app if prompted)
+> 3. Set the app name to **Vellum Assistant**
+> 4. Click **Save**
+>
+> Let me know when the app is created.
+
+## Path B Step 4: Add Scopes
+
+Tell the user:
+
+> **Step 2: Add permissions**
+>
+> Click on the **Auth** tab at the top of the app page. Scroll down to the **Scopes** section and add each of these scopes:
+>
+> `crm.objects.contacts.read`, `crm.objects.contacts.write`, `crm.objects.deals.read`, `crm.objects.deals.write`, `crm.objects.companies.read`
+>
+> That's 5 scopes total. Use the search box to find each one and check the box next to it. Click **Save** when done.
+>
+> Let me know when they're all added.
+
+## Path B Step 5: Add Redirect URL
+
+Tell the user:
+
+> **Step 3: Add redirect URL**
+>
+> Still on the **Auth** tab, scroll to the **Redirect URLs** section.
+>
+> 1. Click **Add URL**
+> 2. Paste this exact URL: `OAUTH_CALLBACK_URL`
+> 3. Click **Save**
+>
+> Let me know when it's saved.
+
+## Path B Step 6: Get Credentials
+
+Tell the user:
+
+> **Step 4: Get your app credentials**
+>
+> Still on the **Auth** tab, look near the top for the **Client ID** and **App Secret**.
+>
+> Send me your **Client ID** first.
+
+Wait for the Client ID.
+
+Then ask for the secret:
+
+> Now send me the **App Secret**. Send it as a standalone message with no other text.
+
+Note: HubSpot app secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+
+## Path B Step 7: Authorize and Verify
+
+Follow the `vellum-oauth-integrations` workflow to register the OAuth app, connect, and verify.
+
+Send the returned auth URL to the user. Tell them to select their HubSpot account and click **Grant access** on the consent page.
+
+> **HubSpot is connected!** You can now ask me to look up contacts, manage deals, and browse company records in your HubSpot CRM.

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/hubspot.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/hubspot.md
@@ -1,0 +1,124 @@
+You are helping your user set up HubSpot OAuth credentials so the HubSpot CRM integration can connect to their account.
+
+The included `vellum-oauth-integrations` skill handles the generic parts of the flow (credential collection, app registration, connection, and verification). This file defines only the HubSpot-specific steps.
+
+## Provider Details
+
+- **Provider key:** `hubspot`
+- **Dashboard:** `https://app.hubspot.com/developer`
+- **Ping URL:** `https://api.hubapi.com/crm/v3/objects/contacts?limit=1`
+- **Callback transport:** Loopback (port 17330)
+- **Requires secret:** Yes (token endpoint needs both client ID and app secret)
+
+## HubSpot-Specific Flow
+
+The flow has 10 steps total, takes about 3-5 minutes.
+
+### Step 0: Prerequisite Check
+
+> Before we start - do you have a HubSpot account? You'll need one to create a developer app.
+
+If no account, direct them to sign up at `https://app.hubspot.com/signup/developers` and come back once they're logged in.
+
+---
+
+### Step 1: Open HubSpot Developer Portal
+
+Open: `https://app.hubspot.com/developer`
+
+> I've opened the HubSpot developer portal. If it's asking you to sign in, go ahead and do that first - then let me know.
+
+---
+
+### Step 2: Create a Developer Account (if needed)
+
+> If this is your first time here, HubSpot may ask you to create a developer account. Go ahead and follow the prompts to set one up - it's free.
+
+If the user already has a developer account, skip to the next step.
+
+**Milestone (2 of 10):** "Developer account ready - now let's create an app."
+
+---
+
+### Step 3: Create a New App
+
+> Look for the **Create app** button. Go ahead and click it.
+
+**Known issues:**
+
+- If the user doesn't see a Create app button, they may need to navigate to **Apps** in the top navigation first
+- Some accounts may show "Create a public app" vs "Create a private app" - choose **public app** (required for OAuth)
+
+**Milestone (3 of 10):** "App created - now let's configure it."
+
+---
+
+### Step 4: Fill In App Details
+
+> Set the app name to **Vellum Assistant**. You can leave the other fields (description, logo, etc.) blank for now. Click **Save**.
+
+---
+
+### Step 5: Go to the Auth Tab
+
+> Now click on the **Auth** tab at the top of the app page. This is where we'll configure OAuth settings.
+
+**Milestone (5 of 10):** "Auth tab open - let's set up the redirect URL and scopes."
+
+---
+
+### Step 6: Add Redirect URL
+
+> On the **Auth** tab, find the **Redirect URLs** section. Click **Add URL**, paste this URL, and click **Save**:
+>
+> `http://localhost:17330/oauth/callback`
+
+---
+
+### Step 7: Add Scopes
+
+> Still on the **Auth** tab, scroll down to the **Scopes** section. You'll need to add each of these scopes:
+>
+> - `crm.objects.contacts.read` - read contact records
+> - `crm.objects.contacts.write` - create and update contacts
+> - `crm.objects.deals.read` - read deal records
+> - `crm.objects.deals.write` - create and update deals
+> - `crm.objects.companies.read` - read company records
+>
+> Use the search box to find each scope, then check the box next to it. Click **Save** when all five are added.
+
+Wait for the user to confirm all 5 scopes are added.
+
+**Milestone (7 of 10):** "Scopes configured - now let's grab the credentials."
+
+---
+
+### Step 8: Get Client ID and App Secret
+
+> Still on the **Auth** tab, you should see the **Client ID** and **App Secret** near the top of the page.
+
+**Milestone (8 of 10):** "Almost there - just need to save these credentials."
+
+---
+
+### Step 9: Store Credentials, Authorize, and Verify
+
+Follow the `vellum-oauth-integrations` workflow to collect credentials, register the OAuth app, connect, and verify.
+
+> I'll start the HubSpot authorization flow now. You should see a HubSpot consent page asking you to allow **Vellum Assistant** to access your account.
+>
+> Select the HubSpot account you want to connect, review the permissions, and click **Grant access**.
+
+**On success:** "HubSpot is connected! You can now ask me to look up contacts, manage deals, and browse company records in your HubSpot CRM."
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [hubspot-path-b.md](hubspot-path-b.md).
+
+Key HubSpot-specific differences for Path B:
+
+- Loopback callback won't work from a remote channel - need public ingress configured
+- Add the ingress-based redirect URI under **Redirect URLs** on the Auth tab
+- App secrets don't have a known prefix that triggers scanners, but still use `credential_store prompt` or `credential_store store` for security

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/linear-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/linear-path-b.md
@@ -1,0 +1,68 @@
+# Path B: Manual Channel Setup (Linear)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17324) is not reachable from a remote channel.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Linear from chat**
+>
+> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+>
+> 1. A Linear account with workspace access
+> 2. About 3-5 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Ensure Public Ingress
+
+Before proceeding, resolve the redirect URI:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+## Path B Step 3: Create a Linear OAuth Application
+
+Tell the user:
+
+> **Step 1: Create a Linear OAuth application**
+>
+> Open this link:
+> `https://linear.app/settings/api`
+>
+> 1. Scroll down to the **OAuth Applications** section
+> 2. Click **Create new OAuth application**
+> 3. Set the application name to **Vellum Assistant**
+> 4. Set the **Redirect URL** to `OAUTH_CALLBACK_URL`
+> 5. Click **Create**
+>
+> Let me know when the app is created.
+
+## Path B Step 4: Get Credentials
+
+Tell the user:
+
+> **Step 2: Get your app credentials**
+>
+> You should now see the application details. Send me the **Client ID** (also called **Application ID**) first.
+
+Wait for the Client ID.
+
+Then ask for the secret:
+
+> Now send me the **app secret**. It's shown only once right after creation. If you can still see it, copy and send it as a standalone message with no other text.
+
+Note: If the user navigated away and can no longer see the secret, they'll need to regenerate it from the application settings page.
+
+## Path B Step 5: Authorize and Verify
+
+Follow the `vellum-oauth-integrations` workflow to register the OAuth app, connect, and verify.
+
+Send the returned auth URL to the user. Tell them to click **Authorize** on the Linear consent page.
+
+> **Linear is connected!** You can now ask me to create issues, check your assignments, search across projects, and manage your Linear workflow.

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/linear.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/linear.md
@@ -1,0 +1,111 @@
+You are helping your user set up Linear OAuth credentials so the Linear integration can connect to their workspace.
+
+The included `vellum-oauth-integrations` skill handles the generic parts of the flow (credential collection, app registration, connection, and verification). This file defines only the Linear-specific steps.
+
+## Provider Details
+
+- **Provider key:** `linear`
+- **Auth URL:** `https://linear.app/oauth/authorize`
+- **Token URL:** `https://api.linear.app/oauth/token`
+- **Ping URL:** `https://api.linear.app/graphql`
+- **Callback transport:** Loopback (port 17324)
+- **Requires secret:** Yes (token endpoint needs both client ID and secret)
+- **Extra params:** `prompt=consent`
+
+## Linear-Specific Flow
+
+The flow has 7 steps total, takes about 3-5 minutes.
+
+### Step 0: Prerequisite Check
+
+> Before we start - do you have a Linear account with access to a workspace?
+
+If no account, direct them to sign up at `https://linear.app`. If they have an account but aren't sure about permissions, explain that they'll need workspace access to create OAuth applications under Settings > API.
+
+---
+
+### Step 1: Open Linear API Settings
+
+Open: `https://linear.app/settings/api`
+
+> I've opened the Linear API settings page. If it's asking you to sign in, go ahead and do that first - then let me know.
+
+---
+
+### Step 2: Create a New OAuth Application
+
+> Scroll down to the **OAuth Applications** section. Click **Create new OAuth application**.
+
+After the user clicks:
+
+> Set the **Application name** to **Vellum Assistant**.
+
+> For the **Redirect URL**, enter `http://localhost:17324/oauth/callback`.
+
+> Now click **Create**.
+
+**Known issues:**
+
+- If the user sees an error about duplicate application names, suggest a variant like "Vellum Assistant (Personal)"
+
+**Milestone (2 of 7):** "App created - now let's grab the credentials."
+
+---
+
+### Step 3: Copy the Client ID
+
+> You should now see the application details page. Look for the **Client ID** (sometimes labeled **Application ID**). Copy it and paste it here in the chat.
+
+Wait for the user to provide the Client ID.
+
+**Milestone (3 of 7):** "Got the Client ID - now let's grab the secret."
+
+---
+
+### Step 4: Copy the OAuth Secret
+
+> The app secret is shown **only once** right after creation. If you can still see it on the page, copy it now.
+
+If the user missed it:
+
+> If you navigated away and the secret is no longer visible, you'll need to generate a new one. Look for a **Regenerate** or **New secret** option on the application details page.
+
+**Milestone (4 of 7):** "Credentials captured - let's add the scopes next."
+
+---
+
+### Step 5: Configure Scopes
+
+> Now let's make sure the right scopes are requested. The Linear OAuth flow requests scopes at authorization time, so I'll handle that automatically. The scopes we'll request are:
+>
+> - `read` - read access to your Linear data
+> - `write` - write access to update issues, projects, etc.
+> - `issues:create` - create new issues
+>
+> You don't need to configure these in the Linear dashboard - I'll include them in the authorization request.
+
+**Milestone (5 of 7):** "Scopes are set - now let's save everything."
+
+---
+
+### Step 6: Store Credentials, Authorize, and Verify
+
+Follow the `vellum-oauth-integrations` workflow to collect credentials, register the OAuth app, connect, and verify.
+
+> I'll start the Linear authorization flow now. You should see a Linear consent page asking you to allow **Vellum Assistant** to access your workspace.
+>
+> Review the permissions and click **Authorize**.
+
+**On success:** "Linear is connected! You can now ask me to create issues, check your assignments, search across projects, and manage your Linear workflow."
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [linear-path-b.md](linear-path-b.md).
+
+Key Linear-specific differences for Path B:
+
+- Loopback callback won't work from a remote channel - need public ingress configured
+- The redirect URL must be set when creating the OAuth application (or updated afterwards in the app settings)
+- The app secret is shown only once at creation time - if the user misses it, they'll need to regenerate it

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/notion-non-admin.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/notion-non-admin.md
@@ -1,0 +1,25 @@
+# Non-Admin Alternatives for Notion Integration Setup
+
+The user doesn't have admin permissions on their Notion workspace. Only workspace admins can create Internal integrations, so the standard Step 2 won't work for them.
+
+Present these options:
+
+1. **Ask a workspace admin to create the integration** — The admin creates an Internal integration named "Vellum Assistant", copies the secret token (`ntn_...`), and shares it with the user. The user can then grant it access to their own pages. This is the easiest path.
+2. **Use a different workspace** — If the user has a personal Notion workspace (or any workspace where they're admin), they can set up the integration there instead.
+3. **Request admin permissions** — The user can ask their workspace admin to grant them admin access, then retry Step 2.
+
+Suggested message:
+
+> No worries — you don't need to be an admin yourself. The easiest path is to ask a workspace admin to create the integration and send you the secret token. You can then grant it access to your own pages.
+>
+> Here are your options:
+>
+> 1. **Ask your admin** to create an Internal integration named "Vellum Assistant" and share the secret token with you
+> 2. **Use a different workspace** where you're an admin (e.g., a personal workspace)
+> 3. **Request admin access** from your workspace admin, then come back to this step
+
+After the user picks an option, adapt the flow:
+
+- **Option 1 (admin shares token):** When the user has the secret, skip directly to Step 3a (collect the secret via `credential_store prompt`) and then 3b (grant page access on their own pages).
+- **Option 2 (different workspace):** Restart from Step 1 targeting the new workspace.
+- **Option 3 (request admin access):** Pause the flow. Tell them to come back when they have admin access and you'll pick up where you left off.

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/notion-path-b-public.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/notion-path-b-public.md
@@ -1,0 +1,94 @@
+# Public Integration (OAuth) Setup
+
+Use this path only when the user explicitly needs multi-workspace OAuth distribution. For single-workspace use, the Internal integration flow in [notion.md](notion.md) is simpler and preferred.
+
+## Overview
+
+Public integrations use OAuth 2.0 and require:
+
+- Converting the integration from Internal to Public (via Notion's integration settings)
+- A redirect URI for the OAuth callback
+- OAuth Client ID and Client Secret (different from the Internal secret)
+
+## Important: Notion UI for Public Integrations
+
+As of early 2026, Notion does **not** offer a "Type" selector during integration creation - all integrations start as Internal. To convert to Public:
+
+1. Create the integration as Internal (per the main flow)
+2. Look for a way to convert to Public in the integration settings - Notion docs reference this option but the exact UI location may vary
+3. Once converted, a **Distribution** tab should appear with OAuth settings
+
+## Provider Details (Public)
+
+- **Token endpoint auth:** `client_secret_basic` (client secret always required)
+- **Scopes:** None (Notion does not use explicit OAuth scopes)
+- **Extra params:** `owner=user`
+- **Callback transport:** Loopback (port 17323) for interactive channels; public ingress for remote channels
+- **Redirect URI (interactive):** `http://localhost:17323/oauth/callback`
+- **Redirect URI (remote/Path B):** `<ingress.publicBaseUrl>/webhooks/oauth/callback` - resolve from the configured public gateway URL
+
+## Public Integration Steps
+
+### Step 1: Convert to Public
+
+Guide the user to find the conversion option in their integration settings. Once converted:
+
+- A **Distribution** tab should appear
+- OAuth Client ID and Client Secret become available in the **Secrets** section
+
+### Step 2: Configure OAuth Redirect URI
+
+Determine the correct redirect URI based on the channel:
+
+- **Interactive (macOS app, local):** Use `http://localhost:17323/oauth/callback`
+- **Remote channel (Telegram, Slack, etc.):** Read the configured public gateway URL from `ingress.publicBaseUrl`. If missing, load and run the `public-ingress` skill first. Build the URI as `<publicBaseUrl>/webhooks/oauth/callback`.
+
+Copy the resolved redirect URI to clipboard:
+
+```
+host_bash:
+  command: |
+    echo -n "<resolved redirect URI>" | pbcopy
+```
+
+Guide the user to the **Distribution** tab to paste the redirect URI and save.
+
+### Step 3: Copy Client ID and Client Secret
+
+> In the **Secrets** section, copy the **OAuth Client ID** and paste it here.
+
+After receiving the Client ID, collect the secret securely:
+
+```
+credential_store prompt:
+  service: "notion"
+  field: "client_secret"
+  label: "Notion OAuth Client Secret"
+  description: "Copy the Client Secret from the Notion integration page and paste it here."
+  placeholder: "secret_..."
+```
+
+### Step 4: Store Credentials and Authorize
+
+```
+bash:
+  command: |
+    assistant oauth apps upsert --provider notion --client-id $(cat <<'EOF'
+    <client-id>
+    EOF
+    ) --client-secret-credential-path "notion:client_secret"
+```
+
+```
+bash:
+  command: |
+    assistant oauth connect notion
+```
+
+### Step 5: Verify Connection
+
+```
+bash:
+  command: |
+    assistant oauth ping notion
+```

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/notion-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/notion-path-b.md
@@ -1,0 +1,107 @@
+# Path B: Manual Channel Setup (Telegram, Slack, etc.)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. No OAuth or public ingress is needed for Internal integrations.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Notion integration from chat**
+>
+> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+>
+> 1. A Notion account with a workspace you want to connect
+> 2. About 2 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Create an Internal Integration
+
+Tell the user:
+
+> **Step 1: Create a Notion integration**
+>
+> Open this link to go to your Notion integrations page:
+> `https://www.notion.so/profile/integrations`
+>
+> If you need to sign in, do that first.
+>
+> Then:
+>
+> 1. Click **"New integration"** (or the **"+"** button)
+> 2. Set the name to **Vellum Assistant**
+> 3. Select your workspace from the **Associated workspace** dropdown
+> 4. Click **Create**
+>
+> The integration will be created as Internal by default - that's exactly what we want.
+>
+> Let me know when the integration is created, or if you run into any issues.
+
+If the user reports they can't create the integration due to missing admin permissions, see [notion-non-admin.md](notion-non-admin.md). If they receive a secret from their admin, skip directly to Path B Step 3.
+
+## Path B Step 3: Copy the Internal Integration Secret
+
+Tell the user:
+
+> **Step 2: Copy your integration secret**
+>
+> On the integration's Configuration page, you should see an **"Internal integration secret"** field.
+>
+> Click **Show** to reveal it, then copy the secret. It starts with `ntn_`.
+>
+> Send it as a standalone message with no other text.
+
+After the user sends the secret:
+
+```
+credential_store prompt:
+  service: "notion"
+  field: "internal_secret"
+  label: "Notion Internal Integration Secret"
+  description: "Paste the Internal Integration Secret."
+  placeholder: "ntn_..."
+```
+
+If using `credential_store store` instead (when the user sent it as plaintext):
+
+```
+credential_store store:
+  service: "notion"
+  field: "internal_secret"
+  value: "<the secret the user sent>"
+```
+
+## Path B Step 4: Grant Page Access
+
+Tell the user:
+
+> **Step 3: Grant page access**
+>
+> Now you need to share your Notion pages with the integration:
+>
+> 1. Open any Notion page you want to connect
+> 2. Click the **"..."** menu (top-right) or the **Share** button
+> 3. Click **"Add connections"** (or **"Connect to"**)
+> 4. Search for **Vellum Assistant** and select it
+>
+> Repeat for any pages or databases you want accessible. You can always add more later.
+>
+> Let me know when you've shared at least one page.
+
+## Path B Step 5: Verify and Done
+
+Verify the connection:
+
+```
+bash:
+  command: |
+    curl -s -H "Authorization: Bearer $(assistant credentials reveal --service notion --field internal_secret)" \
+      -H "Notion-Version: 2022-06-28" \
+      "https://api.notion.com/v1/users/me"
+```
+
+On success:
+
+> **Notion is connected!** You can now ask me to read and write pages and databases in your Notion workspace.

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/notion.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/notion.md
@@ -1,0 +1,124 @@
+You are helping your user set up Notion credentials so the Notion integration can connect to their workspace.
+
+The included `vellum-oauth-integrations` skill handles the generic parts of the flow (credential collection, app registration, connection, and verification). This file defines only the Notion-specific steps.
+
+## Provider Details
+
+- **Provider key:** `notion`
+- **Default credential type:** Internal integration (API token)
+- **No OAuth flow required** for the default path - just copy the integration secret and grant page access
+
+## Prerequisites
+
+No OAuth, redirect URIs, or public ingress needed for Internal integrations. The user just needs a Notion account and workspace.
+
+## Choosing the Flow
+
+- **Internal integration (default):** Single-workspace, simple setup. Follow the steps below.
+- **Public integration (OAuth):** Multi-workspace distribution. Only guide to this path if the user explicitly needs OAuth for multi-workspace access. See [notion-path-b-public.md](notion-path-b-public.md) for that flow.
+
+## Internal Integration Flow
+
+The flow has 4 steps total, takes about 1-2 minutes.
+
+### Step 0: Prerequisite Check
+
+> Before we start - do you have a Notion account and workspace you'd like to connect?
+
+If no Notion account, guide them to create one at `https://www.notion.so/signup` or defer.
+
+---
+
+### Step 1: Open Notion Integrations
+
+Open: `https://www.notion.so/profile/integrations`
+
+This is the first navigation - wait a few seconds for the page to load, then take a screenshot to see the actual layout. Use what you see to give the user specific guidance. If the page is asking them to sign in, tell them to do that first.
+
+---
+
+### Step 2: Create a New Integration
+
+> Look for the **"New integration"** button (or a **"+"** button) and click it.
+>
+> On the creation form:
+>
+> 1. Set the name to **Vellum Assistant**
+> 2. Select your workspace from the **Associated workspace** dropdown
+> 3. Click **Create**
+
+There is no Type selector on the creation form - integrations are created as **Internal by default**, which is what we want.
+
+**Known issues:**
+
+- If they already have an integration named "Vellum Assistant", ask if they'd like to reuse it - skip ahead to Step 3
+- **Missing admin permissions:** Only workspace **admins** can create integrations. If the user can't find the "New integration" button, sees a disabled/grayed-out option, gets a permissions error, or tells you they aren't an admin — see [notion-non-admin.md](notion-non-admin.md).
+
+**Milestone (2 of 4):** "Integration created - now let's grab the secret and grant page access."
+
+---
+
+### Step 3: Copy Internal Integration Secret and Grant Page Access
+
+After creation, the user lands on the integration's Configuration page.
+
+#### 3a: Copy the secret
+
+> You should now see the **Configuration** tab with an **"Internal integration secret"** field. Click **Show** to reveal it, then **Copy** to copy the secret.
+
+Collect the secret securely:
+
+```
+credential_store prompt:
+  service: "notion"
+  field: "internal_secret"
+  label: "Notion Internal Integration Secret"
+  description: "Paste the Internal Integration Secret you just copied."
+  placeholder: "ntn_..."
+```
+
+#### 3b: Grant page access
+
+> Now you need to grant the integration access to the Notion pages you want to use.
+>
+> 1. Go to any Notion page you want to connect
+> 2. Click the **"..."** menu (top-right) or the **Share** button
+> 3. Click **"Add connections"** (or **"Connect to"**)
+> 4. Search for **Vellum Assistant** and select it
+> 5. Repeat for any other pages or databases you want accessible
+>
+> You can always add more pages later by repeating this step.
+
+**Milestone (3 of 4):** "Secret stored and pages connected - let's verify."
+
+---
+
+### Step 4: Verify Connection
+
+Verify the connection works by calling the Notion API with the stored secret:
+
+```
+bash:
+  command: |
+    curl -s -H "Authorization: Bearer $(assistant credentials reveal --service notion --field internal_secret)" \
+      -H "Notion-Version: 2022-06-28" \
+      "https://api.notion.com/v1/users/me"
+```
+
+**On success:** "Notion is connected! You can now ask me to read and write pages and databases in your Notion workspace."
+
+**On failure (401):** The secret may have been copied incorrectly. Offer to redo Step 3a.
+
+**On failure (other):** Check the error message and guide accordingly.
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [notion-path-b.md](notion-path-b.md).
+
+Key Notion-specific differences for Path B:
+
+- No OAuth flow or redirect URIs needed for Internal integrations
+- The user copies their Internal Integration Secret and sends it via chat
+- The secret prefix is `ntn_` - use `credential_store prompt` to collect it securely

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/spotify-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/spotify-path-b.md
@@ -1,0 +1,72 @@
+# Path B: Manual Channel Setup (Spotify)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17333) is not reachable from a remote channel.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Spotify from chat**
+>
+> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+>
+> 1. A Spotify account (free or premium)
+> 2. About 5 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Ensure Public Ingress
+
+Before proceeding, resolve the redirect URI:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+## Path B Step 3: Create a Spotify App
+
+Tell the user:
+
+> **Step 1: Create a Spotify App**
+>
+> Open this link:
+> `https://developer.spotify.com/dashboard`
+>
+> 1. Click **Create App**
+> 2. Set the app name to **Vellum Assistant**
+> 3. Set the description to **Personal assistant integration**
+> 4. Set the redirect URI to `OAUTH_CALLBACK_URL`
+> 5. Under **Which API/SDKs are you planning to use?**, check **Web API**
+> 6. Check the terms of service box
+> 7. Click **Save**
+>
+> Let me know when the app is created.
+
+## Path B Step 4: Get Credentials
+
+Tell the user:
+
+> **Step 2: Get your app credentials**
+>
+> On the app overview page, click **Settings** in the top-right area.
+>
+> You should see your **Client ID** and a hidden **app secret**.
+>
+> Send me your **Client ID** first.
+
+Wait for the Client ID, then ask for the secret:
+
+> Now click **View app secret** to reveal it, then send it to me. Send it as a standalone message with no other text.
+
+Note: Spotify app secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+
+## Path B Step 5: Register, Authorize, and Verify
+
+Once you have both the Client ID and app secret, follow the `vellum-oauth-integrations` workflow to register the OAuth app, connect, and verify.
+
+Send the returned auth URL to the user. Tell them to click **Agree** on the Spotify consent page.
+
+**On success:** "Spotify is connected! You can now ask me to control playback, manage your playlists, check what's playing, and browse your library."

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/spotify.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/spotify.md
@@ -1,0 +1,116 @@
+You are helping your user set up Spotify OAuth credentials so the Spotify integration can control playback, manage playlists, and access their library.
+
+The included `vellum-oauth-integrations` skill handles the generic parts of the flow (credential collection, app registration, connection, and verification). This file defines only the Spotify-specific steps.
+
+## Provider Details
+
+- **Provider key:** `spotify`
+- **Dashboard:** `https://developer.spotify.com/dashboard`
+- **Ping URL:** `https://api.spotify.com/v1/me`
+- **Callback transport:** Loopback
+- **Requires secret:** Yes (token endpoint needs both client ID and app secret)
+
+## Spotify-Specific Flow
+
+The flow has 7 steps total, takes about 3-5 minutes.
+
+### Step 0: Prerequisite Check
+
+> Before we start - do you have a Spotify account? Any Spotify account (free or premium) can create developer apps.
+
+If the user doesn't have a Spotify account, direct them to sign up at `https://www.spotify.com/signup` first.
+
+---
+
+### Step 1: Open Spotify Developer Dashboard
+
+Open: `https://developer.spotify.com/dashboard`
+
+> I've opened the Spotify Developer Dashboard. If it's asking you to sign in, go ahead and do that first - then let me know.
+
+---
+
+### Step 2: Create a New App
+
+> Look for the **Create App** button. Go ahead and click it.
+
+After the user clicks:
+
+> Fill in the following:
+>
+> - **App name:** Vellum Assistant
+> - **App description:** Personal assistant integration
+> - **Redirect URI:** (I'll get the right URL for you in a moment)
+
+Before providing the redirect URI, resolve it:
+
+```
+bash:
+  command: assistant oauth providers get spotify --json
+```
+
+- If the `redirectUri` is a concrete URL (e.g. `http://localhost:…/oauth/callback`), tell the user to enter that exact URL as the redirect URI.
+- If it is `null`, stop and help the user configure public ingress first.
+
+Then:
+
+> For **Which API/SDKs are you planning to use?**, check **Web API**.
+>
+> Check the terms of service box, then click **Save**.
+
+**Known issues:**
+
+- If the dashboard shows a "You need to verify your email" banner, the user must verify their Spotify email first
+- Free and premium accounts both have access to the developer dashboard
+
+**Milestone (2 of 7):** "App created - now let's grab the credentials."
+
+---
+
+### Step 3: Get Client ID and App Secret
+
+> You should now be on the app's overview page. The **Client ID** is shown right there.
+>
+> To find the app secret, click **Settings** in the top-right area of the app page.
+
+Open: the app's **Settings** page.
+
+> On the Settings page, you should see the **Client ID** and a hidden **app secret**. Click **View app secret** to reveal it.
+
+**Milestone (3 of 7):** "Credentials are visible - let's save them."
+
+---
+
+### Steps 4-6: Store Credentials, Authorize, and Verify
+
+Follow the `vellum-oauth-integrations` workflow to collect credentials, register the OAuth app, connect, and verify.
+
+> I'll start the Spotify authorization flow now. You should see a Spotify consent page asking you to allow **Vellum Assistant** to access your account.
+>
+> Review the permissions and click **Agree**.
+
+The scopes requested will include:
+
+- `user-read-playback-state` - see what's playing
+- `user-modify-playback-state` - play, pause, skip tracks
+- `user-read-currently-playing` - see the current track
+- `user-read-recently-played` - see listening history
+- `playlist-read-private` - view private playlists
+- `playlist-modify-public` - create and edit public playlists
+- `playlist-modify-private` - create and edit private playlists
+- `user-library-read` - view saved tracks and albums
+- `user-library-modify` - save and remove tracks and albums
+
+**On success:** "Spotify is connected! You can now ask me to control playback, manage your playlists, check what's playing, and browse your library."
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [spotify-path-b.md](spotify-path-b.md).
+
+Key Spotify-specific differences for Path B:
+
+- Loopback callback won't work from a remote channel - need public ingress configured
+- Add the ingress-based redirect URI in the app's Settings page under **Redirect URIs**
+- The app secret doesn't have a known prefix that triggers scanners, but still use `credential_store prompt` or `credential_store store` for security

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/todoist-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/todoist-path-b.md
@@ -1,0 +1,81 @@
+# Path B: Manual Channel Setup (Todoist)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the loopback callback (port 17325) is not reachable from a remote channel.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Todoist from chat**
+>
+> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+>
+> 1. A Todoist account
+> 2. About 3 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Ensure Public Ingress
+
+Before proceeding, resolve the redirect URI:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+## Path B Step 3: Create a Todoist App
+
+Tell the user:
+
+> **Step 1: Create a Todoist App**
+>
+> Open this link:
+> `https://developer.todoist.com/appconsole.html`
+>
+> 1. Click **Create a new app**
+> 2. Set the app name to **Vellum Assistant**
+> 3. Click **Create app**
+>
+> Let me know when the app is created.
+
+## Path B Step 4: Add Redirect URL
+
+Tell the user:
+
+> **Step 2: Add redirect URL**
+>
+> In the app settings, find the **OAuth redirect URL** field.
+>
+> 1. Paste this exact URL: `OAUTH_CALLBACK_URL`
+> 2. Click **Save settings**
+>
+> Let me know when it's saved.
+
+## Path B Step 5: Get Credentials
+
+Tell the user:
+
+> **Step 3: Get your app credentials**
+>
+> On the app settings page, you should see the **Client ID** and **App secret** displayed.
+>
+> Send me your **Client ID** first.
+
+Wait for the Client ID.
+
+Then ask for the secret:
+
+> Now send me the **app secret**. Send it as a standalone message with no other text.
+
+Note: Todoist app secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+
+## Path B Step 6: Authorize and Verify
+
+Follow the `vellum-oauth-integrations` workflow to register the OAuth app, connect, and verify.
+
+Send the returned auth URL to the user. Tell them to click **Agree** on the Todoist consent page.
+
+> **Todoist is connected!** You can now ask me to manage your tasks, create projects, and organize your to-do lists.

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/todoist.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/todoist.md
@@ -1,0 +1,86 @@
+You are helping your user set up Todoist OAuth credentials so the Todoist integration can connect to their account.
+
+The included `vellum-oauth-integrations` skill handles the generic parts of the flow (credential collection, app registration, connection, and verification). This file defines only the Todoist-specific steps.
+
+## Provider Details
+
+- **Provider key:** `todoist`
+- **Dashboard:** `https://developer.todoist.com/appconsole.html`
+- **Scopes:** `data:read_write`
+- **Callback transport:** Loopback (port 17325)
+- **Requires secret:** Yes (token endpoint needs both client ID and app secret)
+- **Ping URL:** `https://api.todoist.com/rest/v2/projects`
+
+## Todoist-Specific Flow
+
+The flow has 6 steps total, takes about 2-3 minutes.
+
+### Step 0: Prerequisite Check
+
+> Before we start - do you have a Todoist account? You'll need one to create a developer app.
+
+If no account, direct them to `https://todoist.com/users/showregister` to sign up first.
+
+---
+
+### Step 1: Open Todoist App Console
+
+Open: `https://developer.todoist.com/appconsole.html`
+
+> I've opened the Todoist App Console. If it's asking you to sign in, go ahead and do that first - then let me know.
+
+---
+
+### Step 2: Create a New App
+
+> Look for the **Create a new app** button and click it.
+
+Then:
+
+> Set the app name to **Vellum Assistant** and click **Create app**.
+
+**Milestone (2 of 6):** "App created - now let's set up the redirect URL."
+
+---
+
+### Step 3: Set Up OAuth Redirect URL
+
+> In the app settings, find the **OAuth redirect URL** field and paste in this URL:
+>
+> `http://localhost:17325/oauth/callback`
+>
+> Then click **Save settings**.
+
+**Milestone (3 of 6):** "Redirect URL is set - now let's grab the credentials."
+
+---
+
+### Step 4: Copy Client ID and App Secret
+
+> You should see the **Client ID** and **App secret** displayed in the app settings page.
+
+**Milestone (4 of 6):** "Credentials are visible - let's save them."
+
+---
+
+### Step 5: Store Credentials, Authorize, and Verify
+
+Follow the `vellum-oauth-integrations` workflow to collect credentials, register the OAuth app, connect, and verify.
+
+> I'll start the Todoist authorization flow now. You should see a Todoist consent page asking you to allow **Vellum Assistant** to access your account.
+>
+> Review the permissions and click **Agree**.
+
+**On success:** "Todoist is connected! You can now ask me to manage your tasks, create projects, and organize your to-do lists."
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [todoist-path-b.md](todoist-path-b.md).
+
+Key Todoist-specific differences for Path B:
+
+- Loopback callback won't work from a remote channel - need public ingress configured
+- Add the ingress-based redirect URI under **OAuth redirect URL** in the app settings
+- The app secret doesn't have a known prefix that triggers scanners, but still use `credential_store prompt` or `credential_store store` for security

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/twitter-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/twitter-path-b.md
@@ -1,0 +1,94 @@
+# Path B: Manual Channel Setup (Telegram, Slack, etc.)
+
+When the user is on a non-interactive channel, walk them through a text-based setup. The channel path requires **public ingress** because the gateway callback is not reachable without it.
+
+## Path B Step 1: Confirm and Explain
+
+Tell the user:
+
+> **Setting up Twitter / X from chat**
+>
+> Since I can't open pages in your browser from here, I'll walk you through each step with direct links. You'll need:
+>
+> 1. A Twitter/X account with access to the Developer Portal
+> 2. About 5 minutes
+>
+> Ready to start?
+
+If the user declines, stop.
+
+## Path B Step 2: Ensure Public Ingress
+
+Before proceeding, resolve the redirect URI:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+- Replace `OAUTH_CALLBACK_URL` below with that concrete value. Never send the placeholder literally.
+
+## Path B Step 3: Create a Project and App
+
+Tell the user:
+
+> **Step 1: Create a Project and App**
+>
+> Open this link to the Twitter Developer Portal:
+> `https://developer.x.com/en/portal/dashboard`
+>
+> 1. In the left sidebar, find **Projects & Apps**
+> 2. Click **+ Add Project** (if you already have a project, you can reuse it)
+> 3. Set the project name to **Vellum Assistant**
+> 4. For the use case, pick **Making a bot** or **Exploring the API**
+> 5. Add a brief description and click through each step
+> 6. When prompted, create a new app named **Vellum Assistant**
+>
+> You may see API Key, API Secret, and Bearer Token - save them if you like, but we won't use them. Navigate to your app's settings page.
+>
+> Let me know when the app is created.
+
+## Path B Step 4: Configure OAuth 2.0
+
+Tell the user:
+
+> **Step 2: Configure OAuth 2.0 settings**
+>
+> On your app's settings page, scroll down to **User authentication settings** and click **Set up** (or **Edit** if already configured).
+>
+> Fill in:
+>
+> 1. **App permissions:** Select **Read and write**
+> 2. **Type of App:** Select **Web App, Automated App or Bot**
+> 3. **Callback URI / Redirect URL:** `OAUTH_CALLBACK_URL`
+> 4. **Website URL:** `https://vellum.ai` (or any website you own)
+>
+> Click **Save**.
+>
+> Let me know when it's saved.
+
+## Path B Step 5: Get Credentials
+
+Tell the user:
+
+> **Step 3: Get your app credentials**
+>
+> Go to the **Keys and tokens** tab at the top of your app page. Scroll down to the **OAuth 2.0 Client ID and Client Secret** section.
+>
+> If you don't see a Client Secret, click **Regenerate** next to it and confirm.
+>
+> Send me your **Client ID** first.
+
+Wait for the Client ID, then ask for the secret:
+
+> Now send me the **Client Secret**. Send it as a standalone message with no other text.
+
+Note: Twitter OAuth 2.0 Client Secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+
+## Path B Step 6: Authorize and Done
+
+Follow the `vellum-oauth-integrations` workflow to register the OAuth app, connect, and verify.
+
+Send the returned auth URL to the user. Tell them to review the permissions and click **Authorize app**.
+
+After authorization:
+
+> **Twitter is connected!** You can now ask me to read your timeline, post tweets, and check your profile.

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/twitter.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/twitter.md
@@ -1,0 +1,153 @@
+You are helping your user set up Twitter/X OAuth credentials so the Twitter integration can post tweets, read timelines, and access user data.
+
+The included `vellum-oauth-integrations` skill handles the generic parts of the flow (credential collection, app registration, connection, and verification). This file defines only the Twitter-specific steps.
+
+## Provider Details
+
+- **Provider key:** `twitter`
+- **Auth URL:** `https://twitter.com/i/oauth2/authorize`
+- **Token URL:** `https://api.x.com/2/oauth2/token`
+- **Ping URL:** `https://api.x.com/2/users/me`
+- **Base URL:** `https://api.x.com`
+- **Default scopes:** `tweet.read`, `tweet.write`, `users.read`, `offline.access`
+- **Token endpoint auth method:** `client_secret_basic`
+- **Callback transport:** Gateway (requires public ingress)
+- **Requires secret:** Yes (token endpoint uses `client_secret_basic`, so both Client ID and Client Secret are needed)
+
+## Twitter-Specific Flow
+
+The flow has 7 steps total, takes about 3-5 minutes.
+
+### Step 0: Prerequisite Check
+
+> Before we start - do you have a Twitter/X account you'd like to use for this? You'll also need access to the Twitter Developer Portal.
+
+If no account -> guide them to create one or defer.
+If no developer account -> they'll be prompted to sign up during Step 1. Free tier is sufficient.
+
+---
+
+### Step 1: Open Twitter Developer Portal
+
+Open: `https://developer.x.com/en/portal/dashboard`
+
+> I've opened the Twitter Developer Portal. If it's asking you to sign in, go ahead and do that first.
+
+**Known issues:**
+
+- First-time developers will see a sign-up flow - they need to agree to the developer agreement and describe their use case. "Personal project" or "Building a tool" works fine for the description.
+- Free tier is sufficient for OAuth 2.0 with PKCE.
+
+---
+
+### Step 2: Create a Project
+
+> Look for **Projects & Apps** in the left sidebar. If you already have a project you'd like to use, let me know. Otherwise, click **+ Add Project**.
+
+Guide through project creation:
+
+> 1. **Project name:** `Vellum Assistant` (or whatever you prefer)
+> 2. **Use case:** Select **Making a bot** or **Exploring the API** - either works
+> 3. **Project description:** Something brief like "Personal assistant integration"
+> 4. Click **Next** through each step
+
+**Known issues:**
+
+- Free tier allows only one project - if the user already has one, reuse it
+- If they see "You've reached your project limit", use the existing project
+
+**Milestone (2 of 7):** "Project created - now let's set up an app inside it."
+
+---
+
+### Step 3: Create an App (or select existing)
+
+If the project creation wizard prompts to create an app immediately, follow along. Otherwise:
+
+> Inside your project, look for an **+ Add App** button or a prompt to create a new app.
+>
+> Set the app name to **Vellum Assistant** and click **Next** or **Create**.
+
+After creation, the portal may show API keys (API Key and Secret, Bearer Token). These are for OAuth 1.0a - we don't need them for OAuth 2.0, but it doesn't hurt to save them somewhere safe.
+
+> You may see API Key, API Secret, and Bearer Token on this screen. You can save these somewhere safe if you like, but we won't need them - we're using OAuth 2.0. Go ahead and click **App Settings** or navigate to your app's settings page.
+
+---
+
+### Step 4: Configure OAuth 2.0 Settings
+
+Navigate to the app's settings. If not already there:
+
+> In the left sidebar under your project, click on your app name, then look for **Settings** or **Edit** under the **User authentication settings** section.
+
+Open the User Authentication Settings:
+
+> Scroll down to **User authentication settings** and click **Set up** or **Edit**.
+
+Guide through the OAuth 2.0 configuration:
+
+> You should see an authentication setup page. Here's what to fill in:
+>
+> 1. **App permissions:** Select **Read and write** (this covers tweet.read, tweet.write, and users.read)
+> 2. **Type of App:** Select **Web App, Automated App or Bot**
+> 3. **App info:**
+>    - **Callback URI / Redirect URL:** I'll give you the URL in a moment
+>    - **Website URL:** You can use `https://vellum.ai` or any URL you own
+
+Before providing the redirect URI, resolve it:
+
+```
+bash:
+  command: assistant oauth providers list --provider-key "twitter" --json
+```
+
+Check the redirect URI situation. Since callbackTransport is `gateway`, public ingress must be configured:
+
+- Read the configured public gateway URL from `ingress.publicBaseUrl`.
+- If it is missing, load and run the `public-ingress` skill first: call `skill_load` with `skill: "public-ingress"`, then follow its instructions.
+- Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
+
+> For the **Callback URI / Redirect URL**, paste this exact URL:
+> `OAUTH_CALLBACK_URL`
+>
+> For the **Website URL**, you can enter `https://vellum.ai` or any website you own.
+>
+> Then click **Save**.
+
+**Milestone (4 of 7):** "OAuth settings configured - now let's grab the credentials."
+
+---
+
+### Step 5: Get Client ID and Client Secret
+
+> After saving, you should be back on the app settings page. Look for the **Keys and tokens** tab at the top of the page, then scroll down to **OAuth 2.0 Client ID and Client Secret**.
+>
+> If you don't see a Client Secret, click **Regenerate** next to it. You may need to confirm by typing "Yes" in a dialog.
+
+Note: The token endpoint auth method (`basic`) requires both a Client ID and a secret, so the skill collects both.
+
+**Milestone (5 of 7):** "Almost there - just need to save these credentials."
+
+---
+
+### Step 6: Store Credentials, Authorize, and Verify
+
+Follow the `vellum-oauth-integrations` workflow to collect credentials, register the OAuth app, connect, and verify.
+
+> You should see a Twitter consent page asking you to authorize **Vellum Assistant** to access your account.
+>
+> Review the permissions - it will ask for permission to read your tweets, post tweets, and read your profile info. Click **Authorize app**.
+
+**On success:** "Twitter is connected! You can now ask me to read your timeline, post tweets, and check your profile."
+
+---
+
+## Path B: Manual Channel Setup
+
+For non-interactive channels, see [twitter-path-b.md](twitter-path-b.md).
+
+Key Twitter-specific differences for Path B:
+
+- Gateway callback requires public ingress - must be configured before starting
+- OAuth 2.0 Client Secret doesn't have a known prefix that triggers channel scanners, but still use `credential_store store` for security
+- App type must be **Web App, Automated App or Bot** (same as Path A, since gateway transport is used in both paths)


### PR DESCRIPTION
## Summary
- Copied all 13 provider-specific OAuth setup guides into vellum-oauth-integrations/references/provider-app-setups/
- Stripped YAML frontmatter and preserved all content including sub-references (path-b files, non-admin alternatives)
- Updated internal links to reflect new file locations

Part of plan: consolidate-oauth-setup-skills.md (PR 2 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22841" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
