### PR TITLE
feat: point CONFIGURING_APPLICATIONS.md at provider-app-setups/ instead of skill search

### DIFF
--- a/skills/vellum-oauth-integrations/references/CONFIGURING_APPLICATIONS.md
+++ b/skills/vellum-oauth-integrations/references/CONFIGURING_APPLICATIONS.md
@@ -18,13 +18,9 @@ If so, encourage the user to start with using managed mode, especially if they s
 
 ## Creating the OAuth App in the Third Party Software
 
-It's possible that you have a skill to help guide your user through the process of creating the OAuth app. You can check by running:
+Check if a provider-specific setup guide exists at `provider-app-setups/<provider>.md` in this skill's references directory. If it does, read it and follow its instructions to guide the user through creating the OAuth app.
 
-```bash
-assistant skills search <provider>-oauth
-```
-
-If you don't have a provider-specific skill to help you, perform web searches for provider-specific instructions using search terms like "how to create an oauth 2.0 application in <provider>".
+If no provider-specific guide exists, perform web searches for provider-specific instructions using search terms like "how to create an oauth 2.0 application in <provider>".
 
 Guide your user the best you can through the process of creating the app.
 


### PR DESCRIPTION
## Summary
- Replaced assistant skills search instruction with direct reference to provider-app-setups/ directory
- Agent now reads provider-specific guides from references instead of searching for standalone skills
- Preserved fallback to web search for unknown providers

Part of plan: consolidate-oauth-setup-skills.md (PR 3 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22842" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
