### PR TITLE
fix: prewarm NSFontManager-dependent tokens on MainActor instead of background thread

### DIFF
--- a/clients/macos/vellum-assistant/App/FontWarmupCoordinator.swift
+++ b/clients/macos/vellum-assistant/App/FontWarmupCoordinator.swift
@@ -42,6 +42,10 @@ final class FontWarmupCoordinator {
             logger.info("[fontWarmup] prewarm done")
 
             await MainActor.run {
+                // Prewarm NSFontManager-dependent tokens on the main thread.
+                // NSFontManager.shared is an AppKit class that must not be
+                // accessed from a background thread.
+                VFont.prewarmNSFontManagerTokens()
                 self.markReady()
             }
         }

--- a/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
@@ -182,8 +182,12 @@ public enum VFont {
 
     /// Eagerly accesses every static font token, forcing CoreText to resolve and cache them.
     ///
-    /// Safe to call from any thread — Swift static lets are thread-safe.
+    /// Safe to call from any thread — uses only CoreText (thread-safe).
     /// Called by `FontWarmupCoordinator` during off-main warmup.
+    ///
+    /// **Note:** `nsMonoBold` and `nsMonoItalic` are excluded because they use
+    /// `NSFontManager.shared` which must be accessed on the main thread.
+    /// Use `prewarmNSFontManagerTokens()` on MainActor for those.
     public static func prewarmForAppLaunch() {
         // SwiftUI Font tokens
         _ = brandMedium
@@ -205,13 +209,27 @@ public enum VFont {
         _ = menuCompact
         _ = chat
 
-        // NSFont tokens (macOS only)
+        // NSFont tokens (macOS only — CoreText-only, no AppKit dependency)
         #if os(macOS)
         _ = nsChat
         _ = nsBodyMediumDefault
         _ = nsMono
-        _ = nsMonoBold
-        _ = nsMonoItalic
+        // NOTE: nsMonoBold and nsMonoItalic are intentionally excluded here.
+        // They use NSFontManager.shared.convert() which requires the main thread.
+        // See prewarmNSFontManagerTokens() instead.
         #endif
     }
+
+    #if os(macOS)
+    /// Prewarms font tokens that depend on `NSFontManager.shared`.
+    ///
+    /// **Must be called on the main thread** — `NSFontManager` is an AppKit class
+    /// without documented thread-safety guarantees.
+    /// Called by `FontWarmupCoordinator` on `MainActor` before marking ready.
+    @MainActor
+    public static func prewarmNSFontManagerTokens() {
+        _ = nsMonoBold
+        _ = nsMonoItalic
+    }
+    #endif
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for font-warmup-gate.md.

**Gap:** NSFontManager.shared accessed from background thread during prewarm
**What was expected:** AppKit operations should happen on the main thread
**What was found:** nsMonoBold and nsMonoItalic were prewarmed in Task.detached, triggering NSFontManager.shared.convert() off-main
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22845" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
