### PR TITLE
feat: add migration to uninstall standalone OAuth app setup skills from user workspaces

### DIFF
--- a/assistant/src/workspace/migrations/025-remove-oauth-app-setup-skills.ts
+++ b/assistant/src/workspace/migrations/025-remove-oauth-app-setup-skills.ts
@@ -1,0 +1,76 @@
+/**
+ * Workspace migration 025: Remove standalone OAuth app setup skill directories
+ * and their SKILLS.md entries from user workspaces.
+ *
+ * These skills have been consolidated into vellum-oauth-integrations and are
+ * no longer shipped as standalone skills.
+ *
+ * Idempotent: safe to re-run after interruption at any point.
+ */
+
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Skills to remove
+// ---------------------------------------------------------------------------
+
+const DELETED_SKILLS = [
+  "airtable-oauth-app-setup",
+  "asana-oauth-app-setup",
+  "discord-oauth-app-setup",
+  "dropbox-oauth-app-setup",
+  "figma-oauth-app-setup",
+  "github-oauth-app-setup",
+  "google-oauth-app-setup",
+  "hubspot-oauth-app-setup",
+  "linear-oauth-app-setup",
+  "notion-oauth-app-setup",
+  "spotify-oauth-app-setup",
+  "todoist-oauth-app-setup",
+  "twitter-oauth-app-setup",
+];
+
+// ---------------------------------------------------------------------------
+// Migration
+// ---------------------------------------------------------------------------
+
+export const removeOauthAppSetupSkillsMigration: WorkspaceMigration = {
+  id: "025-remove-oauth-app-setup-skills",
+  description:
+    "Remove standalone OAuth app setup skill directories consolidated into vellum-oauth-integrations",
+
+  run(workspaceDir: string): void {
+    const skillsDir = join(workspaceDir, "skills");
+    if (!existsSync(skillsDir)) return;
+
+    // 1. Remove skill directories
+    for (const name of DELETED_SKILLS) {
+      const dir = join(skillsDir, name);
+      if (existsSync(dir)) {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+
+    // 2. Update SKILLS.md to remove entries referencing deleted skills
+    const indexPath = join(skillsDir, "SKILLS.md");
+    if (existsSync(indexPath)) {
+      let content = readFileSync(indexPath, "utf-8");
+      for (const name of DELETED_SKILLS) {
+        content = content.replace(
+          new RegExp(`^[\\t ]*-\\s*${name}\\s*\\n?`, "gm"),
+          "",
+        );
+      }
+      writeFileSync(indexPath, content, "utf-8");
+    }
+  },
+
+  down(_workspaceDir: string): void {
+    // Deleted skills cannot be restored since they have been removed from the
+    // repo. Users would need to reinstall the `vellum-oauth-integrations`
+    // skill to regain the consolidated OAuth setup functionality.
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -21,6 +21,7 @@ import { moveSignalsToWorkspaceMigration } from "./021-move-signals-to-workspace
 import { moveHooksToWorkspaceMigration } from "./022-move-hooks-to-workspace.js";
 import { moveConfigFilesToWorkspaceMigration } from "./023-move-config-files-to-workspace.js";
 import { moveRuntimeFilesToWorkspaceMigration } from "./024-move-runtime-files-to-workspace.js";
+import { removeOauthAppSetupSkillsMigration } from "./025-remove-oauth-app-setup-skills.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -53,4 +54,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   moveHooksToWorkspaceMigration,
   moveConfigFilesToWorkspaceMigration,
   moveRuntimeFilesToWorkspaceMigration,
+  removeOauthAppSetupSkillsMigration,
 ];


### PR DESCRIPTION
## Summary
- Added migration 025-remove-oauth-app-setup-skills to clean up user workspaces
- Removes all 13 standalone *-oauth-app-setup skill directories and SKILLS.md entries
- Follows the same pattern as migration 020 (rename-oauth-skill-dirs)

Part of plan: consolidate-oauth-setup-skills.md (PR 7 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22846" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
