### PR TITLE
fix: update bundled skills to load vellum-oauth-integrations instead of standalone OAuth setup skills

### DIFF
--- a/assistant/src/config/bundled-skills/gmail/SKILL.md
+++ b/assistant/src/config/bundled-skills/gmail/SKILL.md
@@ -28,22 +28,14 @@ Do not offer AgentMail as an option or mention it unless the user specifically a
 ### Gmail
 
 1. **Try connecting directly first.** Run `assistant oauth status google`. This will show whether or not the user had previously connected their google account. If so, they are ready to go.
-2. **If no connections are found:** The user needs to either use Vellum's managed google integration or set up their own google oauth app. 
-   - Call `skill_load` with `skill: "vellum-oauth-integrations"` with `provider-key: google` throughout.
-   - To use `your-own` mode, you will need to call `skill_load` with `skill: google-oauth-app-setup`. In this case:
-      - Tell the user Gmail isn't connected yet and briefly explain what the setup involves, then use `ui_show` with `surface_type: "confirmation"` to ask for permission to start:
-      - **message:** "Ready to set up Gmail?"
-      - **detail:** "I'll open a few pages in your browser and walk you through setting up Google Cloud credentials - creating a project, enabling APIs, and connecting your account. Takes about 5 minutes.\n\n**Your emails stay under your control** — I only ever create drafts. Nothing gets sent without your explicit say-so."
-      - **confirmLabel:** "Get Started"
-      - **cancelLabel:** "Not Now"
-      - If the user confirms, briefly acknowledge (e.g., "Setting up Gmail now...") and proceed with the setup guide. If they decline, acknowledge and let them know they can set it up later.
+2. **If no connections are found:** Call `skill_load` with `skill: "vellum-oauth-integrations"`. The skill will evaluate whether managed or your-own mode is appropriate and guide the user accordingly.
 
 ## Error Recovery
 
 When a Gmail tool fails with a token or authorization error:
 
 1. **Try to reconnect silently.** Call `assistant oauth ping google`. This often resolves expired tokens automatically.
-2. **If reconnection fails, go straight to setup.** Don't present options, ask which route the user prefers, or explain what went wrong technically. Just tell the user briefly (e.g., "Gmail needs to be reconnected - let me set that up") and immediately follow the connection setup flow for Gmail (e.g., install and load **google-oauth-app-setup**). The user came to you to get something done, not to troubleshoot OAuth - make it seamless.
+2. **If reconnection fails, go straight to setup.** Don't present options, ask which route the user prefers, or explain what went wrong technically. Just tell the user briefly (e.g., "Gmail needs to be reconnected - let me set that up") and immediately load **vellum-oauth-integrations**. The user came to you to get something done, not to troubleshoot OAuth - make it seamless.
 3. **Never try alternative approaches.** Don't use bash, curl, browser automation, or any workaround. If the Gmail tools can't do it, the reconnection flow is the answer.
 4. **Never expose error details.** The user doesn't need to see error messages about tokens, OAuth, or API failures. Translate errors into plain language.
 

--- a/assistant/src/config/bundled-skills/google-calendar/SKILL.md
+++ b/assistant/src/config/bundled-skills/google-calendar/SKILL.md
@@ -15,15 +15,7 @@ You are a Google Calendar assistant with full access to the user's calendar. Use
 Before using any Calendar tool, verify that Google Calendar is connected by attempting a lightweight call (e.g., `calendar_list_events` with a narrow date range). If the call fails with a token/authorization error:
 
 1. **Try connecting directly first.** Run `assistant oauth status google`. This will show whether or not the user had previously connected their google account. If so, they are ready to go.
-2. **If no connections are found:** The user needs to either use Vellum's managed google integration or set up their own google oauth app. 
-   - Call `skill_load` with `skill: "vellum-oauth-integrations"` with `provider-key: google` throughout.
-   - To use `your-own` mode, you will need to call `skill_load` with `skill: google-oauth-app-setup`. In this case:
-      - Tell the user Google account isn't connected yet and briefly explain what the setup involves, then use `ui_show` with `surface_type: "confirmation"` to ask for permission to start:
-      - **message:** "Ready to set up Google Calendar?"
-      - **detail:** "I'll open a few pages in your browser and walk you through setting up Google Cloud credentials - creating a project, enabling APIs, and connecting your account. Takes about 5 minutes.\n\n**Your emails stay under your control** — I only ever create drafts. Nothing gets sent without your explicit say-so."
-      - **confirmLabel:** "Get Started"
-      - **cancelLabel:** "Not Now"
-      - If the user confirms, briefly acknowledge (e.g., "Setting up Google Calendar now...") and proceed with the setup guide. If they decline, acknowledge and let them know they can set it up later.
+2. **If no connections are found:** Call `skill_load` with `skill: "vellum-oauth-integrations"`. The skill will evaluate whether managed or your-own mode is appropriate and guide the user accordingly.
 
 ## Capabilities
 

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -44,7 +44,7 @@ Before using any messaging tool, verify that the platform is connected by callin
 
 ### Public Ingress (required for Telegram)
 
-Telegram setup requires webhook routing, but it does **not** always require ngrok. Before suggesting public ingress for Telegram, check managed callback availability with `assistant platform status --json`. If that reports `containerized: true` with a non-empty `assistantId` and `available: true`, use the platform callback route flow and do not prompt for ngrok. Only use the **public-ingress** skill for local assistants that genuinely need a public gateway URL. Slack uses Socket Mode and does not require public ingress. Gmail/Outlook on the desktop app uses a loopback callback and does not require public ingress; the channel path (Path B in the google-oauth-app-setup skill) handles public ingress internally when needed.
+Telegram setup requires webhook routing, but it does **not** always require ngrok. Before suggesting public ingress for Telegram, check managed callback availability with `assistant platform status --json`. If that reports `containerized: true` with a non-empty `assistantId` and `available: true`, use the platform callback route flow and do not prompt for ngrok. Only use the **public-ingress** skill for local assistants that genuinely need a public gateway URL. Slack uses Socket Mode and does not require public ingress. Gmail/Outlook on the desktop app uses a loopback callback and does not require public ingress; the channel path (Path B in the vellum-oauth-integrations skill) handles public ingress internally when needed.
 
 ### Email Connection Flow
 
@@ -57,21 +57,12 @@ When the user asks to "connect my email", "set up email", "manage my email", or 
 ### Gmail
 
 1. **Try connecting directly first.** Run `assistant oauth status google`. This will show whether or not the user had previously connected their google account. If so, they are ready to go.
-2. **If no connections are found:** The user needs to either use Vellum's managed google integration or set up their own google oauth app.
-   - Call `skill_load` with `skill: "vellum-oauth-integrations"` with `provider-key: google` throughout.
-   - To use `your-own` mode, you will need to call `skill_load` with `skill: google-oauth-app-setup`. In this case:
-     - Tell the user Gmail isn't connected yet and briefly explain what the setup involves, then use `ui_show` with `surface_type: "confirmation"` to ask for permission to start:
-     - **message:** "Ready to set up Gmail?"
-     - **detail:** "I'll open a few pages in your browser and walk you through setting up Google Cloud credentials - creating a project, enabling APIs, and connecting your account. Takes about 5 minutes."
-     - **confirmLabel:** "Get Started"
-     - **cancelLabel:** "Not Now"
-     - If the user confirms, briefly acknowledge (e.g., "Setting up Gmail now...") and proceed with the setup guide. If they decline, acknowledge and let them know they can set it up later.
+2. **If no connections are found:** Call `skill_load` with `skill: "vellum-oauth-integrations"`. The skill will evaluate whether managed or your-own mode is appropriate and guide the user accordingly.
 
 ### Outlook
 
 1. **Try connecting directly first.** Run `assistant oauth status outlook`. This will show whether the user has previously connected their Outlook account.
-2. **If no connections are found:** The user needs to either use Vellum's managed outlook integration or set up their own azure oauth app.
-   - Call `skill_load` with `skill: "vellum-oauth-integrations"` with `provider-key: outlook` throughout.
+2. **If no connections are found:** Call `skill_load` with `skill: "vellum-oauth-integrations"`. The skill will evaluate whether managed or your-own mode is appropriate and guide the user accordingly.
 
 ### Slack
 
@@ -102,7 +93,7 @@ The guardian-verify-setup skill handles the full outbound verification flow for 
 When a messaging tool fails with a token or authorization error:
 
 1. **Try to reconnect silently.** Run `assistant oauth ping <provider>`. This often resolves expired tokens automatically.
-2. **If reconnection fails, go straight to setup.** Don't present options, ask which route the user prefers, or explain what went wrong technically. Just tell the user briefly (e.g., "Gmail needs to be reconnected - let me set that up") and immediately follow the connection setup flow for that platform (e.g., install and load **google-oauth-app-setup** for Gmail). The user came to you to get something done, not to troubleshoot OAuth - make it seamless.
+2. **If reconnection fails, go straight to setup.** Don't present options, ask which route the user prefers, or explain what went wrong technically. Just tell the user briefly (e.g., "Gmail needs to be reconnected - let me set that up") and immediately load **vellum-oauth-integrations**. The user came to you to get something done, not to troubleshoot OAuth - make it seamless.
 3. **Never try alternative approaches.** Don't use bash, curl, browser automation, or any workaround. If the messaging tools can't do it, the reconnection flow is the answer.
 4. **Never expose error details.** The user doesn't need to see error messages about tokens, OAuth, or API failures. Translate errors into plain language.
 

--- a/assistant/src/config/bundled-skills/outlook-calendar/SKILL.md
+++ b/assistant/src/config/bundled-skills/outlook-calendar/SKILL.md
@@ -15,15 +15,7 @@ You are an Outlook Calendar assistant with full access to the user's calendar. U
 Before using any Outlook Calendar tool, verify that Outlook is connected by attempting a lightweight call (e.g., `outlook_calendar_list_events` with a narrow date range). If the call fails with a token/authorization error:
 
 1. **Try connecting directly first.** Run `assistant oauth status outlook`. This will show whether or not the user had previously connected their Outlook account. If so, they are ready to go.
-2. **If no connections are found:** The user needs to either use Vellum's managed Outlook integration or set up their own OAuth app.
-   - Call `skill_load` with `skill: "vellum-oauth-integrations"` with `provider-key: outlook` throughout.
-   - To use `your-own` mode, you will need to call `skill_load` with `skill: outlook-oauth-app-setup`. In this case:
-      - Tell the user Outlook account isn't connected yet and briefly explain what the setup involves, then use `ui_show` with `surface_type: "confirmation"` to ask for permission to start:
-      - **message:** "Ready to set up Outlook Calendar?"
-      - **detail:** "I'll open a few pages in your browser and walk you through setting up Microsoft Azure credentials - registering an app, configuring permissions, and connecting your account. Takes about 5 minutes.\n\n**Your emails stay under your control** — I only ever create drafts. Nothing gets sent without your explicit say-so."
-      - **confirmLabel:** "Get Started"
-      - **cancelLabel:** "Not Now"
-      - If the user confirms, briefly acknowledge (e.g., "Setting up Outlook Calendar now...") and proceed with the setup guide. If they decline, acknowledge and let them know they can set it up later.
+2. **If no connections are found:** Call `skill_load` with `skill: "vellum-oauth-integrations"`. The skill will evaluate whether managed or your-own mode is appropriate and guide the user accordingly.
 
 ## Capabilities
 

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -23,7 +23,7 @@ Look for an entry with `service: "notion"`. The credential may be stored under o
 - `field: "internal_secret"` - Internal integration (new default setup)
 - `field: "access_token"` - OAuth/Public integration (legacy setup)
 
-If neither exists, tell the user: "Notion is not connected yet. Load the **notion-oauth-app-setup** skill to set it up first."
+If neither exists, tell the user: "Notion is not connected yet. Load the **vellum-oauth-integrations** skill to set it up first."
 
 **Step 2 - Make authenticated API calls:**
 
@@ -249,7 +249,7 @@ When a response includes `"has_more": true`, pass `"start_cursor": response.next
 
 ## Error Handling
 
-- **401 Unauthorized**: The token is missing, invalid, or expired. For Internal integrations, ask the user to re-run the **notion-oauth-app-setup** skill. For OAuth connections, the access token may need to be refreshed or re-authorized.
+- **401 Unauthorized**: The token is missing, invalid, or expired. For Internal integrations, ask the user to re-run the **vellum-oauth-integrations** skill. For OAuth connections, the access token may need to be refreshed or re-authorized.
 - **403 Forbidden**: The integration doesn't have access to the requested page or database. Remind the user that they need to share the page/database with the "Vellum Assistant" integration in Notion (via the Share menu → "Add connections").
 - **404 Not Found**: The page or database ID doesn't exist or the integration can't see it. Verify the ID and check sharing settings.
 - **400 Bad Request**: Check the request body structure. The Notion API error response includes a `message` field with details.


### PR DESCRIPTION
## Summary
- Updated gmail, google-calendar, outlook-calendar, messaging, and notion skills
- All connection setup flows now direct to vellum-oauth-integrations as the single entry point
- Removed all references to standalone *-oauth-app-setup skills

Part of plan: consolidate-oauth-setup-skills.md (PR 6 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
