### PR TITLE
refactor: add explicit origin field to search result items

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -789,6 +789,7 @@ export async function searchSkills(
       version: string;
       createdAt: number;
       source: "vellum" | "clawhub" | "skillssh";
+      origin: "vellum" | "clawhub" | "skillssh";
     }
 
     const catalogItems: SearchItem[] = catalogMatches.map((s) => ({
@@ -801,6 +802,7 @@ export async function searchSkills(
       version: "",
       createdAt: 0,
       source: "vellum" as const,
+      origin: "vellum" as const,
     }));
 
     // Search both community registries in parallel (non-fatal on failure)
@@ -811,7 +813,10 @@ export async function searchSkills(
 
     let clawhubSkills: SearchItem[] = [];
     if (clawhubResult.status === "fulfilled") {
-      clawhubSkills = clawhubResult.value.skills;
+      clawhubSkills = clawhubResult.value.skills.map((s) => ({
+        ...s,
+        origin: "clawhub" as const,
+      }));
     } else {
       log.warn(
         { err: clawhubResult.reason },
@@ -831,6 +836,7 @@ export async function searchSkills(
         version: "",
         createdAt: 0,
         source: "skillssh" as const,
+        origin: "skillssh" as const,
       }));
     } else {
       log.warn(


### PR DESCRIPTION
## Summary
- Add `origin` field to `SearchItem` interface in `searchSkills()` with type `"vellum" | "clawhub" | "skillssh"`
- Update all result mappings (vellum, clawhub, skillssh) to set the correct `origin` value
- Keep existing `source` field for wire format backwards compatibility
- Prepares internal types for the four-origin data model

Part of plan: skills-unify-search.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22849" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
