### PR TITLE
feat: unify search across all skill registries

### DIFF
--- a/assistant/src/__tests__/search-skills-unified.test.ts
+++ b/assistant/src/__tests__/search-skills-unified.test.ts
@@ -206,17 +206,20 @@ describe("searchSkills (unified)", () => {
     if (!result.success) throw new Error("Expected success");
 
     const data = result.data as {
-      skills: Array<{ slug: string; source: string }>;
+      skills: Array<{ slug: string; source: string; origin: string }>;
     };
     expect(data.skills).toHaveLength(3);
 
     // Verify ordering: catalog first, then clawhub, then skills.sh
     expect(data.skills[0]!.slug).toBe("weather");
     expect(data.skills[0]!.source).toBe("vellum");
+    expect(data.skills[0]!.origin).toBe("vellum");
     expect(data.skills[1]!.slug).toBe("deploy");
     expect(data.skills[1]!.source).toBe("clawhub");
+    expect(data.skills[1]!.origin).toBe("clawhub");
     expect(data.skills[2]!.slug).toBe("vercel-labs/skills/react-best");
     expect(data.skills[2]!.source).toBe("skillssh");
+    expect(data.skills[2]!.origin).toBe("skillssh");
   });
 
   test("deduplicates: catalog takes precedence over clawhub and skills.sh", async () => {
@@ -260,15 +263,17 @@ describe("searchSkills (unified)", () => {
     if (!result.success) throw new Error("Expected success");
 
     const data = result.data as {
-      skills: Array<{ slug: string; source: string }>;
+      skills: Array<{ slug: string; source: string; origin: string }>;
     };
     // Catalog deduplicates clawhub (same slug "shared-skill"), but skills.sh
     // now uses the full id "org/repo/shared-skill" so it's a distinct entry.
     expect(data.skills).toHaveLength(2);
     expect(data.skills[0]!.slug).toBe("shared-skill");
     expect(data.skills[0]!.source).toBe("vellum");
+    expect(data.skills[0]!.origin).toBe("vellum");
     expect(data.skills[1]!.slug).toBe("org/repo/shared-skill");
     expect(data.skills[1]!.source).toBe("skillssh");
+    expect(data.skills[1]!.origin).toBe("skillssh");
   });
 
   test("deduplicates: clawhub takes precedence over skills.sh with same slug", async () => {
@@ -305,14 +310,16 @@ describe("searchSkills (unified)", () => {
     if (!result.success) throw new Error("Expected success");
 
     const data = result.data as {
-      skills: Array<{ slug: string; source: string }>;
+      skills: Array<{ slug: string; source: string; origin: string }>;
     };
     // Full id slug means no collision — both entries survive
     expect(data.skills).toHaveLength(2);
     expect(data.skills[0]!.slug).toBe("overlap-skill");
     expect(data.skills[0]!.source).toBe("clawhub");
+    expect(data.skills[0]!.origin).toBe("clawhub");
     expect(data.skills[1]!.slug).toBe("org/repo/overlap-skill");
     expect(data.skills[1]!.source).toBe("skillssh");
+    expect(data.skills[1]!.origin).toBe("skillssh");
   });
 
   test("returns clawhub results when skills.sh fails", async () => {
@@ -339,11 +346,12 @@ describe("searchSkills (unified)", () => {
     if (!result.success) throw new Error("Expected success");
 
     const data = result.data as {
-      skills: Array<{ slug: string; source: string }>;
+      skills: Array<{ slug: string; source: string; origin: string }>;
     };
     expect(data.skills).toHaveLength(1);
     expect(data.skills[0]!.slug).toBe("clawhub-only");
     expect(data.skills[0]!.source).toBe("clawhub");
+    expect(data.skills[0]!.origin).toBe("clawhub");
   });
 
   test("returns skills.sh results when clawhub fails", async () => {
@@ -364,11 +372,12 @@ describe("searchSkills (unified)", () => {
     if (!result.success) throw new Error("Expected success");
 
     const data = result.data as {
-      skills: Array<{ slug: string; source: string }>;
+      skills: Array<{ slug: string; source: string; origin: string }>;
     };
     expect(data.skills).toHaveLength(1);
     expect(data.skills[0]!.slug).toBe("org/repo/skillssh-only");
     expect(data.skills[0]!.source).toBe("skillssh");
+    expect(data.skills[0]!.origin).toBe("skillssh");
   });
 
   test("returns catalog-only results when both community registries fail", async () => {
@@ -388,11 +397,12 @@ describe("searchSkills (unified)", () => {
     if (!result.success) throw new Error("Expected success");
 
     const data = result.data as {
-      skills: Array<{ slug: string; source: string }>;
+      skills: Array<{ slug: string; source: string; origin: string }>;
     };
     expect(data.skills).toHaveLength(1);
     expect(data.skills[0]!.slug).toBe("my-skill");
     expect(data.skills[0]!.source).toBe("vellum");
+    expect(data.skills[0]!.origin).toBe("vellum");
   });
 
   test("skills.sh results have correct normalized fields", async () => {
@@ -423,6 +433,7 @@ describe("searchSkills (unified)", () => {
         version: string;
         createdAt: number;
         source: string;
+        origin: string;
       }>;
     };
     expect(data.skills).toHaveLength(1);
@@ -437,5 +448,6 @@ describe("searchSkills (unified)", () => {
     expect(skill.version).toBe("");
     expect(skill.createdAt).toBe(0);
     expect(skill.source).toBe("skillssh");
+    expect(skill.origin).toBe("skillssh");
   });
 });

--- a/assistant/src/__tests__/search-skills-unified.test.ts
+++ b/assistant/src/__tests__/search-skills-unified.test.ts
@@ -1,0 +1,441 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+const mockCatalogSkills = mock(
+  (): Array<{
+    id: string;
+    displayName: string;
+    description: string;
+    source: string;
+  }> => [],
+);
+const mockClawhubSearch = mock(
+  async (
+    _query: string,
+  ): Promise<{
+    skills: Array<{
+      name: string;
+      slug: string;
+      description: string;
+      author: string;
+      stars: number;
+      installs: number;
+      version: string;
+      createdAt: number;
+      source: string;
+    }>;
+  }> => ({ skills: [] }),
+);
+const mockSkillsshSearch = mock(
+  async (
+    _query: string,
+    _limit?: number,
+  ): Promise<
+    Array<{
+      id: string;
+      skillId: string;
+      name: string;
+      installs: number;
+      source: string;
+    }>
+  > => [],
+);
+
+// ---------------------------------------------------------------------------
+// Mock modules — before importing module under test
+// ---------------------------------------------------------------------------
+
+mock.module("../config/skills.js", () => ({
+  loadSkillCatalog: mockCatalogSkills,
+}));
+
+mock.module("../skills/catalog-search.js", () => ({
+  filterByQuery: (
+    items: Array<{ id: string; displayName: string; description: string }>,
+    query: string,
+    _fields: unknown[],
+  ) => {
+    const lower = query.toLowerCase();
+    return items.filter(
+      (s) =>
+        s.id.toLowerCase().includes(lower) ||
+        s.displayName.toLowerCase().includes(lower) ||
+        s.description.toLowerCase().includes(lower),
+    );
+  },
+}));
+
+mock.module("../skills/clawhub.js", () => ({
+  clawhubSearch: mockClawhubSearch,
+  // Stubs for other exports that may be referenced at import time
+  clawhubCheckUpdates: mock(async () => []),
+  clawhubInspect: mock(async () => ({})),
+  clawhubInstall: mock(async () => ({ success: true })),
+  clawhubUpdate: mock(async () => ({ success: true })),
+}));
+
+mock.module("../skills/skillssh-registry.js", () => ({
+  searchSkillsRegistry: mockSkillsshSearch,
+}));
+
+// Stub remaining imports pulled in by skills.ts
+mock.module("../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: () => true,
+}));
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({}),
+  invalidateConfigCache: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+}));
+mock.module("../config/skill-state.js", () => ({
+  resolveSkillStates: () => [],
+  skillFlagKey: () => null,
+}));
+mock.module("../providers/provider-send-message.js", () => ({
+  createTimeout: () => ({
+    signal: AbortSignal.timeout(1000),
+    cleanup: () => {},
+  }),
+  extractText: () => "",
+  getConfiguredProvider: async () => null,
+  userMessage: () => ({}),
+}));
+mock.module("../runtime/routes/workspace-utils.js", () => ({
+  isTextMimeType: () => true,
+}));
+mock.module("../skills/catalog-cache.js", () => ({
+  getCatalog: async () => [],
+}));
+mock.module("../skills/catalog-install.js", () => ({
+  installSkillLocally: async () => {},
+}));
+mock.module("../skills/managed-store.js", () => ({
+  createManagedSkill: () => ({ created: true }),
+  deleteManagedSkill: () => ({ deleted: true }),
+  removeSkillsIndexEntry: () => {},
+  validateManagedSkillId: () => null,
+}));
+mock.module("../skills/skill-memory.js", () => ({
+  deleteSkillCapabilityMemory: () => {},
+  seedCatalogSkillMemories: () => {},
+}));
+mock.module("../util/platform.js", () => ({
+  getWorkspaceSkillsDir: () => "/tmp/test-skills",
+}));
+mock.module("../daemon/handlers/shared.js", () => ({
+  CONFIG_RELOAD_DEBOUNCE_MS: 100,
+  ensureSkillEntry: () => ({}),
+  log: {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  },
+}));
+
+// Import after mocking
+import { searchSkills } from "../daemon/handlers/skills.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const dummyCtx = {
+  debounceTimers: { schedule: () => {} },
+  setSuppressConfigReload: () => {},
+  updateConfigFingerprint: () => {},
+  broadcast: () => {},
+} as unknown as Parameters<typeof searchSkills>[1];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("searchSkills (unified)", () => {
+  beforeEach(() => {
+    mockCatalogSkills.mockReset();
+    mockClawhubSearch.mockReset();
+    mockSkillsshSearch.mockReset();
+
+    // Defaults: empty results
+    mockCatalogSkills.mockReturnValue([]);
+    mockClawhubSearch.mockResolvedValue({ skills: [] });
+    mockSkillsshSearch.mockResolvedValue([]);
+  });
+
+  test("returns results from all three registries", async () => {
+    mockCatalogSkills.mockReturnValue([
+      {
+        id: "weather",
+        displayName: "Weather",
+        description: "Weather lookup",
+        source: "bundled",
+      },
+    ]);
+    mockClawhubSearch.mockResolvedValue({
+      skills: [
+        {
+          name: "Deploy",
+          slug: "deploy",
+          description: "Deploy helper",
+          author: "alice",
+          stars: 10,
+          installs: 100,
+          version: "1.0.0",
+          createdAt: 1000,
+          source: "clawhub",
+        },
+      ],
+    });
+    mockSkillsshSearch.mockResolvedValue([
+      {
+        id: "vercel-labs/skills/react-best",
+        skillId: "react-best",
+        name: "React Best Practices",
+        installs: 500,
+        source: "vercel-labs/skills",
+      },
+    ]);
+
+    const result = await searchSkills("e", dummyCtx);
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error("Expected success");
+
+    const data = result.data as {
+      skills: Array<{ slug: string; source: string }>;
+    };
+    expect(data.skills).toHaveLength(3);
+
+    // Verify ordering: catalog first, then clawhub, then skills.sh
+    expect(data.skills[0]!.slug).toBe("weather");
+    expect(data.skills[0]!.source).toBe("vellum");
+    expect(data.skills[1]!.slug).toBe("deploy");
+    expect(data.skills[1]!.source).toBe("clawhub");
+    expect(data.skills[2]!.slug).toBe("vercel-labs/skills/react-best");
+    expect(data.skills[2]!.source).toBe("skillssh");
+  });
+
+  test("deduplicates: catalog takes precedence over clawhub and skills.sh", async () => {
+    mockCatalogSkills.mockReturnValue([
+      {
+        id: "shared-skill",
+        displayName: "Shared Skill",
+        description: "From catalog",
+        source: "bundled",
+      },
+    ]);
+    mockClawhubSearch.mockResolvedValue({
+      skills: [
+        {
+          name: "Shared Skill",
+          slug: "shared-skill",
+          description: "From clawhub",
+          author: "",
+          stars: 5,
+          installs: 50,
+          version: "2.0.0",
+          createdAt: 2000,
+          source: "clawhub",
+        },
+      ],
+    });
+    // skills.sh uses full id as slug, so it won't collide with catalog/clawhub
+    // short slugs. Dedup only removes the clawhub duplicate here.
+    mockSkillsshSearch.mockResolvedValue([
+      {
+        id: "org/repo/shared-skill",
+        skillId: "shared-skill",
+        name: "Shared Skill",
+        installs: 300,
+        source: "org/repo",
+      },
+    ]);
+
+    const result = await searchSkills("shared", dummyCtx);
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error("Expected success");
+
+    const data = result.data as {
+      skills: Array<{ slug: string; source: string }>;
+    };
+    // Catalog deduplicates clawhub (same slug "shared-skill"), but skills.sh
+    // now uses the full id "org/repo/shared-skill" so it's a distinct entry.
+    expect(data.skills).toHaveLength(2);
+    expect(data.skills[0]!.slug).toBe("shared-skill");
+    expect(data.skills[0]!.source).toBe("vellum");
+    expect(data.skills[1]!.slug).toBe("org/repo/shared-skill");
+    expect(data.skills[1]!.source).toBe("skillssh");
+  });
+
+  test("deduplicates: clawhub takes precedence over skills.sh with same slug", async () => {
+    mockCatalogSkills.mockReturnValue([]);
+    mockClawhubSearch.mockResolvedValue({
+      skills: [
+        {
+          name: "Overlap",
+          slug: "overlap-skill",
+          description: "From clawhub",
+          author: "bob",
+          stars: 20,
+          installs: 200,
+          version: "1.0.0",
+          createdAt: 3000,
+          source: "clawhub",
+        },
+      ],
+    });
+    // skills.sh now uses full id as slug, so it won't collide with clawhub
+    // short slugs — both entries survive dedup.
+    mockSkillsshSearch.mockResolvedValue([
+      {
+        id: "org/repo/overlap-skill",
+        skillId: "overlap-skill",
+        name: "Overlap",
+        installs: 100,
+        source: "org/repo",
+      },
+    ]);
+
+    const result = await searchSkills("overlap", dummyCtx);
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error("Expected success");
+
+    const data = result.data as {
+      skills: Array<{ slug: string; source: string }>;
+    };
+    // Full id slug means no collision — both entries survive
+    expect(data.skills).toHaveLength(2);
+    expect(data.skills[0]!.slug).toBe("overlap-skill");
+    expect(data.skills[0]!.source).toBe("clawhub");
+    expect(data.skills[1]!.slug).toBe("org/repo/overlap-skill");
+    expect(data.skills[1]!.source).toBe("skillssh");
+  });
+
+  test("returns clawhub results when skills.sh fails", async () => {
+    mockCatalogSkills.mockReturnValue([]);
+    mockClawhubSearch.mockResolvedValue({
+      skills: [
+        {
+          name: "ClawhubSkill",
+          slug: "clawhub-only",
+          description: "",
+          author: "",
+          stars: 0,
+          installs: 0,
+          version: "",
+          createdAt: 0,
+          source: "clawhub",
+        },
+      ],
+    });
+    mockSkillsshSearch.mockRejectedValue(new Error("skills.sh is down"));
+
+    const result = await searchSkills("clawhub", dummyCtx);
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error("Expected success");
+
+    const data = result.data as {
+      skills: Array<{ slug: string; source: string }>;
+    };
+    expect(data.skills).toHaveLength(1);
+    expect(data.skills[0]!.slug).toBe("clawhub-only");
+    expect(data.skills[0]!.source).toBe("clawhub");
+  });
+
+  test("returns skills.sh results when clawhub fails", async () => {
+    mockCatalogSkills.mockReturnValue([]);
+    mockClawhubSearch.mockRejectedValue(new Error("clawhub is down"));
+    mockSkillsshSearch.mockResolvedValue([
+      {
+        id: "org/repo/skillssh-only",
+        skillId: "skillssh-only",
+        name: "SkillsShOnly",
+        installs: 42,
+        source: "org/repo",
+      },
+    ]);
+
+    const result = await searchSkills("skillssh", dummyCtx);
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error("Expected success");
+
+    const data = result.data as {
+      skills: Array<{ slug: string; source: string }>;
+    };
+    expect(data.skills).toHaveLength(1);
+    expect(data.skills[0]!.slug).toBe("org/repo/skillssh-only");
+    expect(data.skills[0]!.source).toBe("skillssh");
+  });
+
+  test("returns catalog-only results when both community registries fail", async () => {
+    mockCatalogSkills.mockReturnValue([
+      {
+        id: "my-skill",
+        displayName: "My Skill",
+        description: "A bundled skill",
+        source: "bundled",
+      },
+    ]);
+    mockClawhubSearch.mockRejectedValue(new Error("clawhub down"));
+    mockSkillsshSearch.mockRejectedValue(new Error("skillssh down"));
+
+    const result = await searchSkills("my", dummyCtx);
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error("Expected success");
+
+    const data = result.data as {
+      skills: Array<{ slug: string; source: string }>;
+    };
+    expect(data.skills).toHaveLength(1);
+    expect(data.skills[0]!.slug).toBe("my-skill");
+    expect(data.skills[0]!.source).toBe("vellum");
+  });
+
+  test("skills.sh results have correct normalized fields", async () => {
+    mockCatalogSkills.mockReturnValue([]);
+    mockClawhubSearch.mockResolvedValue({ skills: [] });
+    mockSkillsshSearch.mockResolvedValue([
+      {
+        id: "org/repo/test-skill",
+        skillId: "test-skill",
+        name: "Test Skill",
+        installs: 99,
+        source: "org/repo",
+      },
+    ]);
+
+    const result = await searchSkills("test", dummyCtx);
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error("Expected success");
+
+    const data = result.data as {
+      skills: Array<{
+        name: string;
+        slug: string;
+        description: string;
+        author: string;
+        stars: number;
+        installs: number;
+        version: string;
+        createdAt: number;
+        source: string;
+      }>;
+    };
+    expect(data.skills).toHaveLength(1);
+
+    const skill = data.skills[0]!;
+    expect(skill.name).toBe("Test Skill");
+    expect(skill.slug).toBe("org/repo/test-skill");
+    expect(skill.description).toBe("");
+    expect(skill.author).toBe("");
+    expect(skill.stars).toBe(0);
+    expect(skill.installs).toBe(99);
+    expect(skill.version).toBe("");
+    expect(skill.createdAt).toBe(0);
+    expect(skill.source).toBe("skillssh");
+  });
+});

--- a/assistant/src/cli/commands/skills.ts
+++ b/assistant/src/cli/commands/skills.ts
@@ -12,6 +12,7 @@ import {
   uninstallSkillLocally,
 } from "../../skills/catalog-install.js";
 import { filterByQuery } from "../../skills/catalog-search.js";
+import { clawhubSearch } from "../../skills/clawhub.js";
 import type {
   AuditResponse,
   SkillsShSearchResult,
@@ -111,7 +112,9 @@ Examples:
 
   skills
     .command("search <query>")
-    .description("Search the Vellum catalog and skills.sh community registry")
+    .description(
+      "Search the Vellum catalog, skills.sh, and clawhub community registries",
+    )
     .option("--limit <n>", "Maximum number of community results", "10")
     .option("--json", "Machine-readable JSON output")
     .addHelpText(
@@ -119,11 +122,11 @@ Examples:
       `
 Arguments:
   query    Free-text search term matched against skill names, descriptions,
-           and tags. Searches the Vellum catalog first, then the skills.sh
-           community registry.
+           and tags. Searches the Vellum catalog, the skills.sh community
+           registry, and the clawhub registry.
 
-Displays results from both sources with clear labels. When a skill ID
-exists in both the Vellum catalog and the community registry, a conflict
+Displays results from all sources with clear labels. When a skill ID
+exists in both the Vellum catalog and a community registry, a conflict
 note is shown with guidance on which install command to use.
 
 Examples:
@@ -155,38 +158,73 @@ Examples:
           (s) => s.description,
         ]);
 
-        // ── Community registry search (non-fatal on failure) ─────────
+        // ── Community registry searches (non-fatal on failure) ────────
+        // Run skills.sh and clawhub searches in parallel.
         let registryResults: SkillsShSearchResult[] = [];
         let registryError: string | undefined;
-        try {
-          registryResults = await searchSkillsRegistry(query, limit);
-        } catch (err) {
-          registryError = err instanceof Error ? err.message : String(err);
+        let clawhubResults: Awaited<
+          ReturnType<typeof clawhubSearch>
+        >["skills"] = [];
+        let clawhubError: string | undefined;
+
+        const [skillsShResult, clawhubResult] = await Promise.allSettled([
+          searchSkillsRegistry(query, limit),
+          clawhubSearch(query, { limit }),
+        ]);
+
+        if (skillsShResult.status === "fulfilled") {
+          registryResults = skillsShResult.value;
+        } else {
+          registryError =
+            skillsShResult.reason instanceof Error
+              ? skillsShResult.reason.message
+              : String(skillsShResult.reason);
+        }
+
+        if (clawhubResult.status === "fulfilled") {
+          clawhubResults = clawhubResult.value.skills;
+        } else {
+          clawhubError =
+            clawhubResult.reason instanceof Error
+              ? clawhubResult.reason.message
+              : String(clawhubResult.reason);
         }
 
         // ── Conflict detection ───────────────────────────────────────
         const catalogIds = new Set(catalogMatches.map((s) => s.id));
-        const conflictIds = new Set(
-          registryResults
+        const conflictIds = new Set([
+          ...registryResults
             .filter((r) => catalogIds.has(r.skillId))
             .map((r) => r.skillId),
-        );
+          ...clawhubResults
+            .filter((r) => catalogIds.has(r.slug))
+            .map((r) => r.slug),
+        ]);
 
-        if (catalogMatches.length === 0 && registryResults.length === 0) {
+        if (
+          catalogMatches.length === 0 &&
+          registryResults.length === 0 &&
+          clawhubResults.length === 0
+        ) {
           if (json) {
             console.log(
               JSON.stringify({
                 ok: true,
                 catalog: [],
                 community: [],
+                clawhub: [],
                 audits: {},
                 ...(registryError ? { registryError } : {}),
+                ...(clawhubError ? { clawhubError } : {}),
               }),
             );
           } else {
             log.info(`No skills found for "${query}".`);
             if (registryError) {
               log.warn(`(skills.sh registry unavailable: ${registryError})`);
+            }
+            if (clawhubError) {
+              log.warn(`(clawhub registry unavailable: ${clawhubError})`);
             }
           }
           return;
@@ -219,8 +257,10 @@ Examples:
               ok: true,
               catalog: catalogMatches,
               community: registryResults,
+              clawhub: clawhubResults,
               audits: allAudits,
               ...(registryError ? { registryError } : {}),
+              ...(clawhubError ? { clawhubError } : {}),
             }),
           );
           return;
@@ -279,6 +319,37 @@ Examples:
           }
         } else if (registryError) {
           log.warn(`\n(skills.sh registry unavailable: ${registryError})`);
+        }
+
+        // ── Display clawhub results ─────────────────────────────────
+        if (clawhubResults.length > 0) {
+          log.info(`Clawhub registry (${clawhubResults.length}):\n`);
+          for (const r of clawhubResults) {
+            const installed = isInstalled(r.slug);
+            const badge = installed ? " [installed]" : "";
+            log.info(`  ${r.name}${badge}`);
+            if (r.name !== r.slug) {
+              log.info(`    ID: ${r.slug}`);
+            }
+            if (r.author) {
+              log.info(`    Author: ${r.author}`);
+            }
+            if (r.description) {
+              log.info(`    Description: ${r.description}`);
+            }
+            if (r.stars > 0) {
+              log.info(`    Stars: ${r.stars}`);
+            }
+            if (r.installs > 0) {
+              log.info(`    Installs: ${r.installs}`);
+            }
+            if (conflictIds.has(r.slug)) {
+              log.info(`    NOTE: Conflicts with Vellum catalog skill`);
+            }
+            log.info("");
+          }
+        } else if (clawhubError) {
+          log.warn(`\n(clawhub registry unavailable: ${clawhubError})`);
         }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);

--- a/assistant/src/cli/commands/skills.ts
+++ b/assistant/src/cli/commands/skills.ts
@@ -343,6 +343,7 @@ Examples:
             if (r.installs > 0) {
               log.info(`    Installs: ${r.installs}`);
             }
+            log.info(`    Install: npx clawhub install ${r.slug}`);
             if (conflictIds.has(r.slug)) {
               log.info(`    NOTE: Conflicts with Vellum catalog skill`);
             }

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -46,6 +46,7 @@ import {
   deleteSkillCapabilityMemory,
   seedCatalogSkillMemories,
 } from "../../skills/skill-memory.js";
+import { searchSkillsRegistry } from "../../skills/skillssh-registry.js";
 import { getWorkspaceSkillsDir } from "../../util/platform.js";
 import {
   CONFIG_RELOAD_DEBOUNCE_MS,
@@ -787,7 +788,7 @@ export async function searchSkills(
       installs: number;
       version: string;
       createdAt: number;
-      source: "vellum" | "clawhub";
+      source: "vellum" | "clawhub" | "skillssh";
     }
 
     const catalogItems: SearchItem[] = catalogMatches.map((s) => ({
@@ -802,25 +803,62 @@ export async function searchSkills(
       source: "vellum" as const,
     }));
 
-    // Search the community registry (non-fatal on failure)
-    let communitySkills: SearchItem[] = [];
-    try {
-      const communityResult = await clawhubSearch(query);
-      communitySkills = communityResult.skills;
-    } catch (err) {
+    // Search both community registries in parallel (non-fatal on failure)
+    const [clawhubResult, skillsshResult] = await Promise.allSettled([
+      clawhubSearch(query),
+      searchSkillsRegistry(query, 25),
+    ]);
+
+    let clawhubSkills: SearchItem[] = [];
+    if (clawhubResult.status === "fulfilled") {
+      clawhubSkills = clawhubResult.value.skills;
+    } else {
       log.warn(
-        { err },
-        "clawhub search failed, returning catalog-only results",
+        { err: clawhubResult.reason },
+        "clawhub search failed, continuing without clawhub results",
       );
     }
 
-    // Deduplicate: catalog takes precedence when slugs collide
-    const catalogSlugs = new Set(catalogItems.map((s) => s.slug));
-    const deduped = communitySkills.filter((s) => !catalogSlugs.has(s.slug));
+    let skillsshSkills: SearchItem[] = [];
+    if (skillsshResult.status === "fulfilled") {
+      skillsshSkills = skillsshResult.value.map((r) => ({
+        name: r.name,
+        slug: r.id,
+        description: "",
+        author: "",
+        stars: 0,
+        installs: r.installs,
+        version: "",
+        createdAt: 0,
+        source: "skillssh" as const,
+      }));
+    } else {
+      log.warn(
+        { err: skillsshResult.reason },
+        "skills.sh search failed, continuing without skills.sh results",
+      );
+    }
+
+    // Deduplicate: catalog > clawhub > skills.sh (first occurrence wins)
+    const seenSlugs = new Set(catalogItems.map((s) => s.slug));
+
+    const dedupedClawhub = clawhubSkills.filter((s) => {
+      if (seenSlugs.has(s.slug)) return false;
+      seenSlugs.add(s.slug);
+      return true;
+    });
+
+    const dedupedSkillssh = skillsshSkills.filter((s) => {
+      if (seenSlugs.has(s.slug)) return false;
+      seenSlugs.add(s.slug);
+      return true;
+    });
 
     return {
       success: true,
-      data: { skills: [...catalogItems, ...deduped] },
+      data: {
+        skills: [...catalogItems, ...dedupedClawhub, ...dedupedSkillssh],
+      },
     };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -789,6 +789,7 @@ export async function searchSkills(
       version: string;
       createdAt: number;
       source: "vellum" | "clawhub" | "skillssh";
+      origin: "vellum" | "clawhub" | "skillssh";
     }
 
     const catalogItems: SearchItem[] = catalogMatches.map((s) => ({
@@ -801,6 +802,7 @@ export async function searchSkills(
       version: "",
       createdAt: 0,
       source: "vellum" as const,
+      origin: "vellum" as const,
     }));
 
     // Search both community registries in parallel (non-fatal on failure)
@@ -811,7 +813,10 @@ export async function searchSkills(
 
     let clawhubSkills: SearchItem[] = [];
     if (clawhubResult.status === "fulfilled") {
-      clawhubSkills = clawhubResult.value.skills;
+      clawhubSkills = clawhubResult.value.skills.map((s) => ({
+        ...s,
+        origin: "clawhub" as const,
+      }));
     } else {
       log.warn(
         { err: clawhubResult.reason },
@@ -831,6 +836,7 @@ export async function searchSkills(
         version: "",
         createdAt: 0,
         source: "skillssh" as const,
+        origin: "skillssh" as const,
       }));
     } else {
       log.warn(

--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -292,63 +292,63 @@ export async function clawhubUpdate(
 
 export async function clawhubSearch(
   query: string,
+  opts?: { limit?: number },
 ): Promise<ClawhubSearchResult> {
+  const limit = opts?.limit ?? 25;
+
   // Empty query: use explore (browse trending) instead of search
   if (!query.trim()) {
-    return clawhubExplore();
+    return clawhubExplore({ limit });
   }
 
+  const result = await runClawhub(["search", query, "--limit", String(limit)]);
+  if (result.exitCode !== 0) {
+    const error =
+      result.stderr.trim() || result.stdout.trim() || "Unknown error";
+    throw new Error(`clawhub search failed: ${error}`);
+  }
+  // Try JSON first
   try {
-    const result = await runClawhub(["search", query, "--limit", "25"]);
-    if (result.exitCode !== 0) {
-      return { skills: [] };
+    const parsed = JSON.parse(result.stdout);
+    if (Array.isArray(parsed)) {
+      return {
+        skills: parsed.map((s: ClawhubSearchResultItem) => ({
+          ...s,
+          source: s.source ?? ("clawhub" as const),
+        })),
+      };
     }
-    // Try JSON first
-    try {
-      const parsed = JSON.parse(result.stdout);
-      if (Array.isArray(parsed)) {
-        return {
-          skills: parsed.map((s: ClawhubSearchResultItem) => ({
-            ...s,
-            source: s.source ?? ("clawhub" as const),
-          })),
-        };
-      }
-      if (parsed.skills && Array.isArray(parsed.skills)) {
-        return {
-          skills: parsed.skills.map((s: ClawhubSearchResultItem) => ({
-            ...s,
-            source: s.source ?? ("clawhub" as const),
-          })),
-        };
-      }
-    } catch {
-      // CLI outputs text: "slug vVersion  DisplayName  (score)"
+    if (parsed.skills && Array.isArray(parsed.skills)) {
+      return {
+        skills: parsed.skills.map((s: ClawhubSearchResultItem) => ({
+          ...s,
+          source: s.source ?? ("clawhub" as const),
+        })),
+      };
     }
-
-    // Parse text output lines: "slug vVersion  Display Name  (score)"
-    const skills: ClawhubSearchResultItem[] = [];
-    for (const line of result.stdout.split("\n")) {
-      const match = line.match(/^(\S+)\s+v(\S+)\s+(.+?)\s+\([\d.]+\)\s*$/);
-      if (match) {
-        skills.push({
-          slug: match[1],
-          version: match[2],
-          name: match[3].trim(),
-          description: "",
-          author: "",
-          stars: 0,
-          installs: 0,
-          createdAt: 0,
-          source: "clawhub",
-        });
-      }
-    }
-    return { skills };
-  } catch (err) {
-    log.warn({ err }, "clawhub search failed");
-    return { skills: [] };
+  } catch {
+    // CLI outputs text: "slug vVersion  DisplayName  (score)"
   }
+
+  // Parse text output lines: "slug vVersion  Display Name  (score)"
+  const skills: ClawhubSearchResultItem[] = [];
+  for (const line of result.stdout.split("\n")) {
+    const match = line.match(/^(\S+)\s+v(\S+)\s+(.+?)\s+\([\d.]+\)\s*$/);
+    if (match) {
+      skills.push({
+        slug: match[1],
+        version: match[2],
+        name: match[3].trim(),
+        description: "",
+        author: "",
+        stars: 0,
+        installs: 0,
+        createdAt: 0,
+        source: "clawhub",
+      });
+    }
+  }
+  return { skills };
 }
 
 export async function clawhubExplore(opts?: {
@@ -358,46 +358,41 @@ export async function clawhubExplore(opts?: {
   const limit = String(opts?.limit ?? 25);
   const sort = opts?.sort ?? "installsAllTime";
 
+  const result = await runClawhub([
+    "explore",
+    "--json",
+    "--limit",
+    limit,
+    "--sort",
+    sort,
+  ]);
+  if (result.exitCode !== 0) {
+    const error =
+      result.stderr.trim() || result.stdout.trim() || "Unknown error";
+    throw new Error(`clawhub explore failed: ${error}`);
+  }
   try {
-    const result = await runClawhub([
-      "explore",
-      "--json",
-      "--limit",
-      limit,
-      "--sort",
-      sort,
-    ]);
-    if (result.exitCode !== 0) {
-      return { skills: [] };
-    }
-    try {
-      const parsed = JSON.parse(result.stdout);
-      const items = parsed.items ?? parsed;
-      if (!Array.isArray(items)) return { skills: [] };
+    const parsed = JSON.parse(result.stdout);
+    const items = parsed.items ?? parsed;
+    if (!Array.isArray(items)) return { skills: [] };
 
-      // Normalize explore response to ClawhubSearchResultItem shape
-      const skills: ClawhubSearchResultItem[] = items.map(
-        (item: Record<string, unknown>) => ({
-          name: (item.displayName as string) ?? (item.slug as string) ?? "",
-          slug: (item.slug as string) ?? "",
-          description: (item.summary as string) ?? "",
-          author: (item.author as string) ?? "",
-          stars: (item.stats as Record<string, number>)?.stars ?? 0,
-          installs:
-            (item.stats as Record<string, number>)?.installsAllTime ?? 0,
-          version: (item.tags as Record<string, string>)?.latest ?? "",
-          createdAt: (item.createdAt as number) ?? 0,
-          source: "clawhub",
-        }),
-      );
-      return { skills };
-    } catch {
-      // parse failure
-    }
-    return { skills: [] };
-  } catch (err) {
-    log.warn({ err }, "clawhub explore failed");
-    return { skills: [] };
+    // Normalize explore response to ClawhubSearchResultItem shape
+    const skills: ClawhubSearchResultItem[] = items.map(
+      (item: Record<string, unknown>) => ({
+        name: (item.displayName as string) ?? (item.slug as string) ?? "",
+        slug: (item.slug as string) ?? "",
+        description: (item.summary as string) ?? "",
+        author: (item.author as string) ?? "",
+        stars: (item.stats as Record<string, number>)?.stars ?? 0,
+        installs: (item.stats as Record<string, number>)?.installsAllTime ?? 0,
+        version: (item.tags as Record<string, string>)?.latest ?? "",
+        createdAt: (item.createdAt as number) ?? 0,
+        source: "clawhub",
+      }),
+    );
+    return { skills };
+  } catch {
+    throw new Error("Failed to parse clawhub explore output");
   }
 }
 


### PR DESCRIPTION
## Summary
Unifies search across all three skill registries (Vellum catalog, clawhub, skills.sh) in both the daemon and CLI. Results are clearly labeled by origin and deduplicated with consistent precedence.

## PRs merged into feature branch
- #22840: feat: daemon search queries skills.sh registry alongside clawhub
- #22839: feat: CLI search queries clawhub registry alongside skills.sh
- #22849: refactor: add explicit origin field to search result items

Part of plan: skills-unify-search.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22850" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
