### PR TITLE
fix: add install instructions to clawhub search results in CLI

### DIFF
--- a/assistant/src/cli/commands/skills.ts
+++ b/assistant/src/cli/commands/skills.ts
@@ -343,6 +343,7 @@ Examples:
             if (r.installs > 0) {
               log.info(`    Installs: ${r.installs}`);
             }
+            log.info(`    Install: npx clawhub install ${r.slug}`);
             if (conflictIds.has(r.slug)) {
               log.info(`    NOTE: Conflicts with Vellum catalog skill`);
             }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skills-unify-search.md.

**Gap:** CLI clawhub results missing install instructions
**What was expected:** All result sections show install commands
**What was found:** Clawhub results had no install guidance

Adds `Install: npx clawhub install <slug>` to the clawhub search results display section, matching the pattern used by catalog results (`assistant skills install`) and community results (`assistant skills add`).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22851" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
