### PR TITLE
M1: Group-specific icons and count badge styling

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
@@ -37,11 +37,29 @@ struct SidebarSectionHeader: View {
     @FocusState private var isRenameFocused: Bool
     @State private var isHeaderHovered: Bool = false
 
+    private var isGroupPinned: Bool {
+        group.id == ConversationGroup.pinned.id
+    }
+
+    /// Icon to show when the header is NOT hovered. System groups get distinctive icons;
+    /// custom groups keep the folder open/closed behaviour.
+    private var groupIcon: VIcon {
+        if group.id == ConversationGroup.pinned.id {
+            return .pin
+        } else if group.id == ConversationGroup.scheduled.id {
+            return .calendar
+        } else if group.id == ConversationGroup.background.id {
+            return .layers
+        } else {
+            return isExpanded ? .folderOpen : .folderClosed
+        }
+    }
+
     var body: some View {
         HStack(spacing: VSpacing.xs) {
-            VIconView(isHeaderHovered ? .chevronRight : (isExpanded ? .folderOpen : .folderClosed), size: isHeaderHovered ? SidebarLayoutMetrics.sectionChevronSize : 13)
+            VIconView(isHeaderHovered ? .chevronRight : groupIcon, size: isHeaderHovered ? SidebarLayoutMetrics.sectionChevronSize : 13)
                 .foregroundStyle(VColor.contentTertiary)
-                .rotationEffect(.degrees(isHeaderHovered && isExpanded ? 90 : 0))
+                .rotationEffect(.degrees(isHeaderHovered && isExpanded ? 90 : (isGroupPinned && !isHeaderHovered ? -45 : 0)))
                 .animation(VAnimation.fast, value: isExpanded)
                 .animation(VAnimation.fast, value: isHeaderHovered)
                 .frame(width: SidebarLayoutMetrics.iconSlotSize, height: SidebarLayoutMetrics.iconSlotSize)
@@ -84,11 +102,17 @@ struct SidebarSectionHeader: View {
                 case .idle:
                     EmptyView()
                 }
-                if conversationCount > 0 {
-                    Text("\(conversationCount)")
-                        .font(.caption2)
-                        .foregroundStyle(VColor.contentTertiary)
-                }
+            }
+            if conversationCount > 0 {
+                Text("\(conversationCount)")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(VColor.contentTertiary)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(
+                        Capsule()
+                            .fill(VColor.contentTertiary.opacity(0.12))
+                    )
             }
         }
         .padding(.leading, VSpacing.xs)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
@@ -105,10 +105,10 @@ struct SidebarSectionHeader: View {
             }
             if conversationCount > 0 {
                 Text("\(conversationCount)")
-                    .font(.system(size: 10, weight: .medium))
+                    .font(VFont.labelSmall)
                     .foregroundStyle(VColor.contentTertiary)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
+                    .padding(.horizontal, VSpacing.sm - VSpacing.xxs)
+                    .padding(.vertical, VSpacing.xxs)
                     .background(
                         Capsule()
                             .fill(VColor.contentTertiary.opacity(0.12))


### PR DESCRIPTION
## Summary
- Replace generic folder icons with group-specific icons for system groups: pinned (`.pin` rotated -45°), scheduled (`.calendar`), background (`.layers`)
- Replace plain text conversation count with capsule-style badge matching subgroup badges
- Count badge now visible in both expanded and collapsed states; aggregate state indicators remain collapsed-only

Part of #22854.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22859" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
