### PR TITLE
fix: pass Vellum-Organization-Id header in hatchAssistant CLI call

### DIFF
--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -87,14 +87,20 @@ export interface HatchedAssistant {
   status: string;
 }
 
-export async function hatchAssistant(token: string): Promise<HatchedAssistant> {
-  const url = `${getPlatformUrl()}/v1/assistants/hatch/`;
+export async function hatchAssistant(
+  token: string,
+  orgId: string,
+  platformUrl?: string,
+): Promise<HatchedAssistant> {
+  const resolvedUrl = platformUrl || getPlatformUrl();
+  const url = `${resolvedUrl}/v1/assistants/hatch/`;
 
   const response = await fetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
       ...authHeaders(token),
+      "Vellum-Organization-Id": orgId,
     },
     body: JSON.stringify({}),
   });


### PR DESCRIPTION
## Summary
- Add orgId and platformUrl parameters to hatchAssistant() function
- Send Vellum-Organization-Id header on the POST request to /v1/assistants/hatch/
- Use platformUrl || getPlatformUrl() for URL resolution, consistent with other platform client functions

Part of plan: teleport-platform-orgid.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22860" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
