### PR TITLE
fix: teleport platform target missing org ID and reorder flow

### DIFF
--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -757,7 +757,10 @@ describe("resolveOrHatchTarget", () => {
     findAssistantByNameMock.mockReturnValue(null);
 
     const result = await resolveOrHatchTarget("platform", "nonexistent");
-    expect(hatchAssistantMock).toHaveBeenCalledWith("platform-token");
+    expect(hatchAssistantMock).toHaveBeenCalledWith(
+      "platform-token",
+      "org-123",
+    );
     expect(saveAssistantEntryMock).toHaveBeenCalledWith(
       expect.objectContaining({
         assistantId: "platform-new-id",

--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -1275,3 +1275,166 @@ describe("signed-URL upload flow", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Platform teleport org ID and reordered flow tests
+// ---------------------------------------------------------------------------
+
+describe("platform teleport org ID and reordered flow", () => {
+  test("hatchAssistant is called with the org ID from fetchOrganizationId", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    fetchOrganizationIdMock.mockResolvedValue("test-org-456");
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await teleport();
+
+      // fetchOrganizationId should have been called
+      expect(fetchOrganizationIdMock).toHaveBeenCalled();
+      // hatchAssistant must be called with (token, orgId)
+      expect(hatchAssistantMock).toHaveBeenCalledWith(
+        "platform-token",
+        "test-org-456",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("upload to GCS happens before hatchAssistant for platform targets", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    const callOrder: string[] = [];
+
+    platformRequestUploadUrlMock.mockImplementation(async () => {
+      callOrder.push("platformRequestUploadUrl");
+      return {
+        uploadUrl: "https://storage.googleapis.com/bucket/signed-upload-url",
+        bundleKey: "bundle-key-123",
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      };
+    });
+
+    platformUploadToSignedUrlMock.mockImplementation(async () => {
+      callOrder.push("platformUploadToSignedUrl");
+    });
+
+    hatchAssistantMock.mockImplementation(async () => {
+      callOrder.push("hatchAssistant");
+      return { id: "platform-new-id", name: "platform-new", status: "active" };
+    });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await teleport();
+
+      // Verify ordering: upload steps come before hatch
+      const uploadUrlIdx = callOrder.indexOf("platformRequestUploadUrl");
+      const uploadIdx = callOrder.indexOf("platformUploadToSignedUrl");
+      const hatchIdx = callOrder.indexOf("hatchAssistant");
+
+      expect(uploadUrlIdx).toBeGreaterThanOrEqual(0);
+      expect(uploadIdx).toBeGreaterThanOrEqual(0);
+      expect(hatchIdx).toBeGreaterThanOrEqual(0);
+      expect(uploadUrlIdx).toBeLessThan(hatchIdx);
+      expect(uploadIdx).toBeLessThan(hatchIdx);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("signed-URL fallback: when platformRequestUploadUrl throws 'not available', falls back to inline upload via importToAssistant", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    // Simulate 503 — signed uploads not available
+    platformRequestUploadUrlMock.mockRejectedValue(
+      new Error("Signed uploads are not available on this platform instance"),
+    );
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await teleport();
+
+      // Upload URL was attempted but failed
+      expect(platformRequestUploadUrlMock).toHaveBeenCalled();
+      // No signed URL upload should have happened
+      expect(platformUploadToSignedUrlMock).not.toHaveBeenCalled();
+      // Should NOT use GCS-based import
+      expect(platformImportBundleFromGcsMock).not.toHaveBeenCalled();
+      // Should fall back to inline import
+      expect(platformImportBundleMock).toHaveBeenCalled();
+      // Hatch should still succeed
+      expect(hatchAssistantMock).toHaveBeenCalled();
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Teleport complete"),
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("bundleKey from pre-upload is forwarded to platformImportBundleFromGcs", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    // Return a specific bundle key from the pre-upload step
+    platformRequestUploadUrlMock.mockResolvedValue({
+      uploadUrl: "https://storage.googleapis.com/bucket/signed-upload-url",
+      bundleKey: "pre-uploaded-key-789",
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+    });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = createFetchMock() as unknown as typeof globalThis.fetch;
+
+    try {
+      await teleport();
+
+      // The bundle key from the pre-upload step should be forwarded to GCS import
+      expect(platformImportBundleFromGcsMock).toHaveBeenCalledWith(
+        "pre-uploaded-key-789",
+        "platform-token",
+        expect.any(String),
+        expect.any(String),
+      );
+      // Inline import should NOT be used since signed upload succeeded
+      expect(platformImportBundleMock).not.toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -21,6 +21,7 @@ import { hatchGcp } from "../lib/gcp";
 import type { PollResult, WatchHatchingResult } from "../lib/gcp";
 import { hatchLocal } from "../lib/hatch-local";
 import {
+  fetchOrganizationId,
   getPlatformUrl,
   hatchAssistant,
   readPlatformToken,
@@ -593,7 +594,19 @@ async function hatchVellumPlatform(): Promise<void> {
   console.log("   Hatching assistant on Vellum platform...");
   console.log("");
 
-  const result = await hatchAssistant(token);
+  let orgId: string;
+  try {
+    orgId = await fetchOrganizationId(token);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("401") || msg.includes("403")) {
+      console.error("Authentication failed. Run 'vellum login' to refresh.");
+      process.exit(1);
+    }
+    throw err;
+  }
+
+  const result = await hatchAssistant(token, orgId);
 
   const platformUrl = getPlatformUrl();
 

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -1181,8 +1181,13 @@ export async function teleport(): Promise<void> {
 
     // If targeting an existing platform assistant, use its runtimeUrl for all
     // platform calls so upload, org ID fetch, and import hit the same instance.
+    // Only use the runtimeUrl if the existing target is actually a platform
+    // assistant — otherwise resolveOrHatchTarget will catch the cloud mismatch.
     const existingTarget = targetName ? findAssistantByName(targetName) : null;
-    const targetPlatformUrl = existingTarget?.runtimeUrl;
+    const targetPlatformUrl =
+      existingTarget && resolveCloud(existingTarget) === "vellum"
+        ? existingTarget.runtimeUrl
+        : undefined;
 
     let orgId: string;
     try {

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -1179,9 +1179,14 @@ export async function teleport(): Promise<void> {
       process.exit(1);
     }
 
+    // If targeting an existing platform assistant, use its runtimeUrl for all
+    // platform calls so upload, org ID fetch, and import hit the same instance.
+    const existingTarget = targetName ? findAssistantByName(targetName) : null;
+    const targetPlatformUrl = existingTarget?.runtimeUrl;
+
     let orgId: string;
     try {
-      orgId = await fetchOrganizationId(token);
+      orgId = await fetchOrganizationId(token, targetPlatformUrl);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (msg.includes("401") || msg.includes("403")) {
@@ -1197,6 +1202,7 @@ export async function teleport(): Promise<void> {
       const { uploadUrl, bundleKey: key } = await platformRequestUploadUrl(
         token,
         orgId,
+        targetPlatformUrl,
       );
       bundleKey = key;
       console.log("Uploading bundle to GCS...");

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -632,7 +632,7 @@ async function importToAssistant(
   cloud: string,
   bundleData: Uint8Array<ArrayBuffer>,
   dryRun: boolean,
-  preUploadedBundleKey?: string,
+  preUploadedBundleKey?: string | null,
 ): Promise<void> {
   if (cloud === "vellum") {
     // Platform target
@@ -654,9 +654,12 @@ async function importToAssistant(
       throw err;
     }
 
-    // Use pre-uploaded bundle key if provided, otherwise try signed-URL upload
-    let bundleKey: string | undefined = preUploadedBundleKey;
-    if (bundleKey === undefined) {
+    // Use pre-uploaded bundle key if provided (string), skip upload if null
+    // (signals signed URLs were already tried and unavailable), or try
+    // signed-URL upload if undefined (never attempted).
+    let bundleKey: string | undefined =
+      preUploadedBundleKey === null ? undefined : preUploadedBundleKey;
+    if (preUploadedBundleKey === undefined) {
       try {
         const { uploadUrl, bundleKey: key } = await platformRequestUploadUrl(
           token,
@@ -1179,15 +1182,25 @@ export async function teleport(): Promise<void> {
       process.exit(1);
     }
 
-    // If targeting an existing platform assistant, use its runtimeUrl for all
-    // platform calls so upload, org ID fetch, and import hit the same instance.
-    // Only use the runtimeUrl if the existing target is actually a platform
-    // assistant — otherwise resolveOrHatchTarget will catch the cloud mismatch.
+    // If targeting an existing assistant, validate cloud match early — before
+    // uploading — so we don't waste a GCS upload on an invalid command.
     const existingTarget = targetName ? findAssistantByName(targetName) : null;
-    const targetPlatformUrl =
-      existingTarget && resolveCloud(existingTarget) === "vellum"
-        ? existingTarget.runtimeUrl
-        : undefined;
+    if (existingTarget) {
+      const existingCloud = resolveCloud(existingTarget);
+      if (existingCloud !== "vellum") {
+        const normalizedExisting =
+          existingCloud === "vellum" ? "platform" : existingCloud;
+        console.error(
+          `Error: Assistant '${targetName}' is a ${normalizedExisting} assistant, not platform. ` +
+            `Use --${normalizedExisting} to target it.`,
+        );
+        process.exit(1);
+      }
+    }
+
+    // Use the existing target's runtimeUrl for all platform calls so upload,
+    // org ID fetch, and import hit the same instance.
+    const targetPlatformUrl = existingTarget?.runtimeUrl;
 
     let orgId: string;
     try {
@@ -1202,7 +1215,9 @@ export async function teleport(): Promise<void> {
     }
 
     // Step C — Upload to GCS
-    let bundleKey: string | undefined;
+    // bundleKey: string = uploaded successfully, null = tried but unavailable,
+    // undefined would mean "never tried" (not used here).
+    let bundleKey: string | null = null;
     try {
       const { uploadUrl, bundleKey: key } = await platformRequestUploadUrl(
         token,
@@ -1216,7 +1231,7 @@ export async function teleport(): Promise<void> {
       // If signed uploads unavailable (503), fall back to inline upload later
       const msg = err instanceof Error ? err.message : String(err);
       if (msg.includes("not available")) {
-        bundleKey = undefined;
+        bundleKey = null;
       } else {
         throw err;
       }
@@ -1227,6 +1242,7 @@ export async function teleport(): Promise<void> {
     const toCloud = resolveCloud(toEntry);
 
     // Step E — Import from GCS (or inline fallback)
+    // Pass bundleKey (string) or null to signal "already tried, use inline".
     console.log(`Importing to ${toEntry.assistantId} (${toCloud})...`);
     await importToAssistant(toEntry, toCloud, bundleData, false, bundleKey);
 

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -793,6 +793,7 @@ async function importToAssistant(
 export async function resolveOrHatchTarget(
   targetEnv: "local" | "docker" | "platform",
   targetName?: string,
+  orgId?: string,
 ): Promise<AssistantEntry> {
   // If a name is provided, try to find an existing assistant
   if (targetName) {
@@ -872,19 +873,25 @@ export async function resolveOrHatchTarget(
       process.exit(1);
     }
 
-    let orgId: string;
-    try {
-      orgId = await fetchOrganizationId(token);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      if (msg.includes("401") || msg.includes("403")) {
-        console.error("Authentication failed. Run 'vellum login' to refresh.");
-        process.exit(1);
+    let resolvedOrgId: string;
+    if (orgId) {
+      resolvedOrgId = orgId;
+    } else {
+      try {
+        resolvedOrgId = await fetchOrganizationId(token);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes("401") || msg.includes("403")) {
+          console.error(
+            "Authentication failed. Run 'vellum login' to refresh.",
+          );
+          process.exit(1);
+        }
+        throw err;
       }
-      throw err;
     }
 
-    const result = await hatchAssistant(token, orgId);
+    const result = await hatchAssistant(token, resolvedOrgId);
     const entry: AssistantEntry = {
       assistantId: result.id,
       runtimeUrl: getPlatformUrl(),
@@ -1141,40 +1148,11 @@ export async function teleport(): Promise<void> {
           console.error("Not logged in. Run 'vellum login' first.");
           process.exit(1);
         }
-        let orgId: string;
-        try {
-          orgId = await fetchOrganizationId(token);
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          if (msg.includes("401") || msg.includes("403")) {
-            console.error(
-              "Authentication failed. Run 'vellum login' to refresh.",
-            );
-            process.exit(1);
-          }
-          throw err;
-        }
-        // Check if signed uploads are available
-        let signedUploadsAvailable = true;
-        try {
-          await platformRequestUploadUrl(token, orgId);
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          if (msg.includes("not available")) {
-            signedUploadsAvailable = false;
-          } else {
-            throw err;
-          }
-        }
-        console.log(
-          `  Would upload bundle to GCS${signedUploadsAvailable ? "" : " (signed uploads unavailable — would use inline upload)"}`,
-        );
+        console.log(`  Would upload bundle via signed URL (if available)`);
         console.log(
           `  Would hatch a new ${targetEnv} assistant${targetName ? ` named '${targetName}'` : ""}`,
         );
-        console.log(
-          `  Would import data into the new assistant${signedUploadsAvailable ? " from GCS" : " via inline upload"}`,
-        );
+        console.log(`  Would import data into the new assistant`);
       } else {
         console.log(
           `  Would hatch a new ${targetEnv} assistant${targetName ? ` named '${targetName}'` : ""}`,
@@ -1234,7 +1212,7 @@ export async function teleport(): Promise<void> {
     }
 
     // Step D — Hatch (upload succeeded or fallback to inline — safe to hatch)
-    const toEntry = await resolveOrHatchTarget(targetEnv, targetName);
+    const toEntry = await resolveOrHatchTarget(targetEnv, targetName, orgId);
     const toCloud = resolveCloud(toEntry);
 
     // Step E — Import from GCS (or inline fallback)

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -1146,11 +1146,6 @@ export async function teleport(): Promise<void> {
       console.log(`  Would export data from: ${from} (${fromCloud})`);
       if (targetEnv === "platform") {
         // For platform targets, reflect the reordered flow
-        const token = readPlatformToken();
-        if (!token) {
-          console.error("Not logged in. Run 'vellum login' first.");
-          process.exit(1);
-        }
         console.log(`  Would upload bundle via signed URL (if available)`);
         console.log(
           `  Would hatch a new ${targetEnv} assistant${targetName ? ` named '${targetName}'` : ""}`,
@@ -1188,11 +1183,9 @@ export async function teleport(): Promise<void> {
     if (existingTarget) {
       const existingCloud = resolveCloud(existingTarget);
       if (existingCloud !== "vellum") {
-        const normalizedExisting =
-          existingCloud === "vellum" ? "platform" : existingCloud;
         console.error(
-          `Error: Assistant '${targetName}' is a ${normalizedExisting} assistant, not platform. ` +
-            `Use --${normalizedExisting} to target it.`,
+          `Error: Assistant '${targetName}' is a ${existingCloud} assistant, not platform. ` +
+            `Use --${existingCloud} to target it.`,
         );
         process.exit(1);
       }

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -632,6 +632,7 @@ async function importToAssistant(
   cloud: string,
   bundleData: Uint8Array<ArrayBuffer>,
   dryRun: boolean,
+  preUploadedBundleKey?: string,
 ): Promise<void> {
   if (cloud === "vellum") {
     // Platform target
@@ -653,24 +654,26 @@ async function importToAssistant(
       throw err;
     }
 
-    // Try signed-URL upload for large bundle support
-    let bundleKey: string | undefined;
-    try {
-      const { uploadUrl, bundleKey: key } = await platformRequestUploadUrl(
-        token,
-        orgId,
-        entry.runtimeUrl,
-      );
-      bundleKey = key;
-      console.log("Uploading bundle...");
-      await platformUploadToSignedUrl(uploadUrl, bundleData);
-    } catch (err) {
-      // If signed uploads unavailable (503), fall back to inline upload
-      const msg = err instanceof Error ? err.message : String(err);
-      if (msg.includes("not available")) {
-        bundleKey = undefined;
-      } else {
-        throw err;
+    // Use pre-uploaded bundle key if provided, otherwise try signed-URL upload
+    let bundleKey: string | undefined = preUploadedBundleKey;
+    if (bundleKey === undefined) {
+      try {
+        const { uploadUrl, bundleKey: key } = await platformRequestUploadUrl(
+          token,
+          orgId,
+          entry.runtimeUrl,
+        );
+        bundleKey = key;
+        console.log("Uploading bundle...");
+        await platformUploadToSignedUrl(uploadUrl, bundleData);
+      } catch (err) {
+        // If signed uploads unavailable (503), fall back to inline upload
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes("not available")) {
+          bundleKey = undefined;
+        } else {
+          throw err;
+        }
       }
     }
 
@@ -869,7 +872,19 @@ export async function resolveOrHatchTarget(
       process.exit(1);
     }
 
-    const result = await hatchAssistant(token);
+    let orgId: string;
+    try {
+      orgId = await fetchOrganizationId(token);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes("401") || msg.includes("403")) {
+        console.error("Authentication failed. Run 'vellum login' to refresh.");
+        process.exit(1);
+      }
+      throw err;
+    }
+
+    const result = await hatchAssistant(token, orgId);
     const entry: AssistantEntry = {
       assistantId: result.id,
       runtimeUrl: getPlatformUrl(),
@@ -1119,10 +1134,53 @@ export async function teleport(): Promise<void> {
       // No existing target — just describe what would happen
       console.log("Dry run summary:");
       console.log(`  Would export data from: ${from} (${fromCloud})`);
-      console.log(
-        `  Would hatch a new ${targetEnv} assistant${targetName ? ` named '${targetName}'` : ""}`,
-      );
-      console.log(`  Would import data into the new assistant`);
+      if (targetEnv === "platform") {
+        // For platform targets, reflect the reordered flow
+        const token = readPlatformToken();
+        if (!token) {
+          console.error("Not logged in. Run 'vellum login' first.");
+          process.exit(1);
+        }
+        let orgId: string;
+        try {
+          orgId = await fetchOrganizationId(token);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          if (msg.includes("401") || msg.includes("403")) {
+            console.error(
+              "Authentication failed. Run 'vellum login' to refresh.",
+            );
+            process.exit(1);
+          }
+          throw err;
+        }
+        // Check if signed uploads are available
+        let signedUploadsAvailable = true;
+        try {
+          await platformRequestUploadUrl(token, orgId);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          if (msg.includes("not available")) {
+            signedUploadsAvailable = false;
+          } else {
+            throw err;
+          }
+        }
+        console.log(
+          `  Would upload bundle to GCS${signedUploadsAvailable ? "" : " (signed uploads unavailable — would use inline upload)"}`,
+        );
+        console.log(
+          `  Would hatch a new ${targetEnv} assistant${targetName ? ` named '${targetName}'` : ""}`,
+        );
+        console.log(
+          `  Would import data into the new assistant${signedUploadsAvailable ? " from GCS" : " via inline upload"}`,
+        );
+      } else {
+        console.log(
+          `  Would hatch a new ${targetEnv} assistant${targetName ? ` named '${targetName}'` : ""}`,
+        );
+        console.log(`  Would import data into the new assistant`);
+      }
     }
 
     console.log(`Dry run complete — no changes were made.`);
@@ -1133,6 +1191,62 @@ export async function teleport(): Promise<void> {
   console.log(`Exporting from ${from} (${fromCloud})...`);
   const bundleData = await exportFromAssistant(fromEntry, fromCloud);
 
+  // Platform target: reordered flow — upload to GCS before hatching so that
+  // if upload fails, no empty assistant is left dangling on the platform.
+  if (targetEnv === "platform") {
+    // Step B — Auth + Org ID
+    const token = readPlatformToken();
+    if (!token) {
+      console.error("Not logged in. Run 'vellum login' first.");
+      process.exit(1);
+    }
+
+    let orgId: string;
+    try {
+      orgId = await fetchOrganizationId(token);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes("401") || msg.includes("403")) {
+        console.error("Authentication failed. Run 'vellum login' to refresh.");
+        process.exit(1);
+      }
+      throw err;
+    }
+
+    // Step C — Upload to GCS
+    let bundleKey: string | undefined;
+    try {
+      const { uploadUrl, bundleKey: key } = await platformRequestUploadUrl(
+        token,
+        orgId,
+      );
+      bundleKey = key;
+      console.log("Uploading bundle to GCS...");
+      await platformUploadToSignedUrl(uploadUrl, bundleData);
+    } catch (err) {
+      // If signed uploads unavailable (503), fall back to inline upload later
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes("not available")) {
+        bundleKey = undefined;
+      } else {
+        throw err;
+      }
+    }
+
+    // Step D — Hatch (upload succeeded or fallback to inline — safe to hatch)
+    const toEntry = await resolveOrHatchTarget(targetEnv, targetName);
+    const toCloud = resolveCloud(toEntry);
+
+    // Step E — Import from GCS (or inline fallback)
+    console.log(`Importing to ${toEntry.assistantId} (${toCloud})...`);
+    await importToAssistant(toEntry, toCloud, bundleData, false, bundleKey);
+
+    // Success summary
+    console.log(`Teleport complete: ${from} → ${toEntry.assistantId}`);
+    return;
+  }
+
+  // Non-platform targets (local/docker): existing flow unchanged
   // For local<->docker transfers, stop (sleep) the source to free up ports
   // before hatching the target. We do NOT retire yet — if hatch or import
   // fails, the user can recover by running `vellum wake <source>`.

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -87,14 +87,20 @@ export interface HatchedAssistant {
   status: string;
 }
 
-export async function hatchAssistant(token: string): Promise<HatchedAssistant> {
-  const url = `${getPlatformUrl()}/v1/assistants/hatch/`;
+export async function hatchAssistant(
+  token: string,
+  orgId: string,
+  platformUrl?: string,
+): Promise<HatchedAssistant> {
+  const resolvedUrl = platformUrl || getPlatformUrl();
+  const url = `${resolvedUrl}/v1/assistants/hatch/`;
 
   const response = await fetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
       ...authHeaders(token),
+      "Vellum-Organization-Id": orgId,
     },
     body: JSON.stringify({}),
   });


### PR DESCRIPTION
## Summary
- Fix `hatchAssistant()` to pass `Vellum-Organization-Id` header (was causing "Vellum-Organization-Id header is required" error)
- Reorder platform teleport flow to: export → upload to GCS → hatch → import-from-gcs (prevents dangling empty assistants if upload fails)
- Add `preUploadedBundleKey` parameter to `importToAssistant` to forward the GCS bundle key without re-uploading

## PRs merged into feature branch
- #22860: fix: pass Vellum-Organization-Id header in hatchAssistant CLI call
- #22861: fix: reorder platform teleport to export → upload → hatch → import-from-gcs
- #22862: test: add tests for platform teleport org ID fix and reordered upload flow

Part of plan: teleport-platform-orgid.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22863" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
