### PR TITLE
M2: Hide pin icon for conversations in Pinned group

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -154,14 +154,6 @@ struct SidebarConversationItem: View, Equatable {
                             .frame(width: 20, height: 20)
                             .nativeTooltip("Unread")
                             .transition(.opacity)
-                    } else if conversation.isPinned {
-                        VIconView(.pin, size: 13)
-                            .foregroundStyle(VColor.contentTertiary)
-                            .rotationEffect(.degrees(-45))
-                            .frame(width: 20, height: 20)
-                            .nativeTooltip("Pinned")
-                            .accessibilityLabel("Pinned")
-                            .transition(.opacity)
                     } else {
                         Color.clear
                             .frame(width: 20, height: 20)
@@ -260,14 +252,7 @@ struct SidebarConversationItem: View, Equatable {
             return NSItemProvider(object: conversation.id.uuidString as NSString)
         } preview: {
             HStack(spacing: VSpacing.xs) {
-                if conversation.isPinned {
-                    VIconView(.pin, size: 13)
-                        .foregroundStyle(VColor.contentTertiary)
-                        .rotationEffect(.degrees(-45))
-                        .frame(width: 20, height: 20)
-                } else {
-                    Color.clear.frame(width: 20, height: 20)
-                }
+                Color.clear.frame(width: 20, height: 20)
                 Text(conversation.title)
                     .font(VFont.menuCompact)
                     .foregroundStyle(VColor.contentDefault)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -157,6 +157,7 @@ struct SidebarConversationItem: View, Equatable {
                     } else {
                         Color.clear
                             .frame(width: 20, height: 20)
+                            .accessibilityLabel(conversation.isPinned ? "Pinned" : "")
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Removes the static pin icon from conversations in the `.idle` state when `isPinned` is true, replacing it with `Color.clear` (same as unpinned conversations)
- Removes the pin icon from the drag preview for pinned conversations
- The interactive pin/unpin button on hover is unchanged

Part of #22854.

## Test plan
- [ ] Verify pinned conversations in the Pinned group no longer show a static pin icon when idle
- [ ] Verify the unread dot badge still appears for pinned conversations with unread messages
- [ ] Verify hovering over a pinned conversation still shows the unpin button
- [ ] Verify the drag preview for pinned conversations no longer shows a pin icon
- [ ] Verify processing/waitingForInput/error states are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22864" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
