### PR TITLE
fix: update hatch.ts caller and test assertion for hatchAssistant orgId param

### DIFF
--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -757,7 +757,10 @@ describe("resolveOrHatchTarget", () => {
     findAssistantByNameMock.mockReturnValue(null);
 
     const result = await resolveOrHatchTarget("platform", "nonexistent");
-    expect(hatchAssistantMock).toHaveBeenCalledWith("platform-token");
+    expect(hatchAssistantMock).toHaveBeenCalledWith(
+      "platform-token",
+      "org-123",
+    );
     expect(saveAssistantEntryMock).toHaveBeenCalledWith(
       expect.objectContaining({
         assistantId: "platform-new-id",

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -21,6 +21,7 @@ import { hatchGcp } from "../lib/gcp";
 import type { PollResult, WatchHatchingResult } from "../lib/gcp";
 import { hatchLocal } from "../lib/hatch-local";
 import {
+  fetchOrganizationId,
   getPlatformUrl,
   hatchAssistant,
   readPlatformToken,
@@ -593,7 +594,19 @@ async function hatchVellumPlatform(): Promise<void> {
   console.log("   Hatching assistant on Vellum platform...");
   console.log("");
 
-  const result = await hatchAssistant(token);
+  let orgId: string;
+  try {
+    orgId = await fetchOrganizationId(token);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("401") || msg.includes("403")) {
+      console.error("Authentication failed. Run 'vellum login' to refresh.");
+      process.exit(1);
+    }
+    throw err;
+  }
+
+  const result = await hatchAssistant(token, orgId);
 
   const platformUrl = getPlatformUrl();
 


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for teleport-platform-orgid.md.

**Gap 1:** hatch.ts calls hatchAssistant(token) without required orgId — added fetchOrganizationId call
**Gap 2:** teleport.test.ts assertion didn't match new hatchAssistant(token, orgId) signature — updated
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22865" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
