### PR TITLE
fix: eliminate redundant orgId fetch and remove dry-run side effect

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -21,6 +21,7 @@ import { hatchGcp } from "../lib/gcp";
 import type { PollResult, WatchHatchingResult } from "../lib/gcp";
 import { hatchLocal } from "../lib/hatch-local";
 import {
+  fetchOrganizationId,
   getPlatformUrl,
   hatchAssistant,
   readPlatformToken,
@@ -593,7 +594,19 @@ async function hatchVellumPlatform(): Promise<void> {
   console.log("   Hatching assistant on Vellum platform...");
   console.log("");
 
-  const result = await hatchAssistant(token);
+  let orgId: string;
+  try {
+    orgId = await fetchOrganizationId(token);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("401") || msg.includes("403")) {
+      console.error("Authentication failed. Run 'vellum login' to refresh.");
+      process.exit(1);
+    }
+    throw err;
+  }
+
+  const result = await hatchAssistant(token, orgId);
 
   const platformUrl = getPlatformUrl();
 

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -793,6 +793,7 @@ async function importToAssistant(
 export async function resolveOrHatchTarget(
   targetEnv: "local" | "docker" | "platform",
   targetName?: string,
+  orgId?: string,
 ): Promise<AssistantEntry> {
   // If a name is provided, try to find an existing assistant
   if (targetName) {
@@ -872,19 +873,25 @@ export async function resolveOrHatchTarget(
       process.exit(1);
     }
 
-    let orgId: string;
-    try {
-      orgId = await fetchOrganizationId(token);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      if (msg.includes("401") || msg.includes("403")) {
-        console.error("Authentication failed. Run 'vellum login' to refresh.");
-        process.exit(1);
+    let resolvedOrgId: string;
+    if (orgId) {
+      resolvedOrgId = orgId;
+    } else {
+      try {
+        resolvedOrgId = await fetchOrganizationId(token);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes("401") || msg.includes("403")) {
+          console.error(
+            "Authentication failed. Run 'vellum login' to refresh.",
+          );
+          process.exit(1);
+        }
+        throw err;
       }
-      throw err;
     }
 
-    const result = await hatchAssistant(token, orgId);
+    const result = await hatchAssistant(token, resolvedOrgId);
     const entry: AssistantEntry = {
       assistantId: result.id,
       runtimeUrl: getPlatformUrl(),
@@ -1141,40 +1148,11 @@ export async function teleport(): Promise<void> {
           console.error("Not logged in. Run 'vellum login' first.");
           process.exit(1);
         }
-        let orgId: string;
-        try {
-          orgId = await fetchOrganizationId(token);
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          if (msg.includes("401") || msg.includes("403")) {
-            console.error(
-              "Authentication failed. Run 'vellum login' to refresh.",
-            );
-            process.exit(1);
-          }
-          throw err;
-        }
-        // Check if signed uploads are available
-        let signedUploadsAvailable = true;
-        try {
-          await platformRequestUploadUrl(token, orgId);
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          if (msg.includes("not available")) {
-            signedUploadsAvailable = false;
-          } else {
-            throw err;
-          }
-        }
-        console.log(
-          `  Would upload bundle to GCS${signedUploadsAvailable ? "" : " (signed uploads unavailable — would use inline upload)"}`,
-        );
+        console.log(`  Would upload bundle via signed URL (if available)`);
         console.log(
           `  Would hatch a new ${targetEnv} assistant${targetName ? ` named '${targetName}'` : ""}`,
         );
-        console.log(
-          `  Would import data into the new assistant${signedUploadsAvailable ? " from GCS" : " via inline upload"}`,
-        );
+        console.log(`  Would import data into the new assistant`);
       } else {
         console.log(
           `  Would hatch a new ${targetEnv} assistant${targetName ? ` named '${targetName}'` : ""}`,
@@ -1234,7 +1212,7 @@ export async function teleport(): Promise<void> {
     }
 
     // Step D — Hatch (upload succeeded or fallback to inline — safe to hatch)
-    const toEntry = await resolveOrHatchTarget(targetEnv, targetName);
+    const toEntry = await resolveOrHatchTarget(targetEnv, targetName, orgId);
     const toCloud = resolveCloud(toEntry);
 
     // Step E — Import from GCS (or inline fallback)


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for teleport-platform-orgid.md.

**Gap 3:** fetchOrganizationId called twice — added optional orgId param to resolveOrHatchTarget to avoid redundant fetch
**Gap 4:** dry-run path was calling platformRequestUploadUrl (real network call) — replaced with descriptive message
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22866" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
