### PR TITLE
M3: Fix recursive conversation count for groups with subgroups

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -100,20 +100,7 @@ struct SidebarSectionView: View {
     }
 
     private var displayCount: Int {
-        switch countMode {
-        case .items:
-            return conversations.count
-        case .subGroups(let grouper):
-            var seen = Set<String>()
-            for c in conversations {
-                if let key = grouper(c) {
-                    seen.insert(key)
-                } else {
-                    seen.insert(c.id.uuidString)
-                }
-            }
-            return seen.count
-        }
+        return conversations.count
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary
- The Scheduled group header was showing the number of unique schedule IDs instead of total conversations
- Simplified `displayCount` to always return `conversations.count` regardless of count mode
- The `countMode` enum still controls section content layout (flat vs sub-grouped), but the header count now consistently reflects total conversations

Part of #22854

## Test plan
- [ ] Open the Scheduled group with conversations that share schedule IDs
- [ ] Verify the header count shows total conversations, not unique schedule IDs
- [ ] Verify subgroup disclosure rows still show their own per-subgroup conversation counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22867" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
