### PR TITLE
Conversation group polish: icons, count badges, and count fix

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
@@ -47,12 +47,8 @@ final class SidebarInteractionState {
         if let saved = defaults.stringArray(forKey: "sidebar.expandedSections") {
             initial = Set(saved)
         } else {
-            // First-launch defaults: all system groups expanded.
-            initial = [
-                ConversationGroup.pinned.id,
-                ConversationGroup.scheduled.id,
-                ConversationGroup.background.id,
-            ]
+            // First-launch defaults: all groups collapsed.
+            initial = []
         }
 
         // Clean up old keys (one-time migration).

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -154,17 +154,10 @@ struct SidebarConversationItem: View, Equatable {
                             .frame(width: 20, height: 20)
                             .nativeTooltip("Unread")
                             .transition(.opacity)
-                    } else if conversation.isPinned {
-                        VIconView(.pin, size: 13)
-                            .foregroundStyle(VColor.contentTertiary)
-                            .rotationEffect(.degrees(-45))
-                            .frame(width: 20, height: 20)
-                            .nativeTooltip("Pinned")
-                            .accessibilityLabel("Pinned")
-                            .transition(.opacity)
                     } else {
                         Color.clear
                             .frame(width: 20, height: 20)
+                            .accessibilityLabel(conversation.isPinned ? "Pinned" : "")
                     }
                 }
             }
@@ -260,14 +253,7 @@ struct SidebarConversationItem: View, Equatable {
             return NSItemProvider(object: conversation.id.uuidString as NSString)
         } preview: {
             HStack(spacing: VSpacing.xs) {
-                if conversation.isPinned {
-                    VIconView(.pin, size: 13)
-                        .foregroundStyle(VColor.contentTertiary)
-                        .rotationEffect(.degrees(-45))
-                        .frame(width: 20, height: 20)
-                } else {
-                    Color.clear.frame(width: 20, height: 20)
-                }
+                Color.clear.frame(width: 20, height: 20)
                 Text(conversation.title)
                     .font(VFont.menuCompact)
                     .foregroundStyle(VColor.contentDefault)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
@@ -37,11 +37,29 @@ struct SidebarSectionHeader: View {
     @FocusState private var isRenameFocused: Bool
     @State private var isHeaderHovered: Bool = false
 
+    private var isGroupPinned: Bool {
+        group.id == ConversationGroup.pinned.id
+    }
+
+    /// Icon to show when the header is NOT hovered. System groups get distinctive icons;
+    /// custom groups keep the folder open/closed behaviour.
+    private var groupIcon: VIcon {
+        if group.id == ConversationGroup.pinned.id {
+            return .pin
+        } else if group.id == ConversationGroup.scheduled.id {
+            return .calendar
+        } else if group.id == ConversationGroup.background.id {
+            return .layers
+        } else {
+            return isExpanded ? .folderOpen : .folderClosed
+        }
+    }
+
     var body: some View {
         HStack(spacing: VSpacing.xs) {
-            VIconView(isHeaderHovered ? .chevronRight : (isExpanded ? .folderOpen : .folderClosed), size: isHeaderHovered ? SidebarLayoutMetrics.sectionChevronSize : 13)
+            VIconView(isHeaderHovered ? .chevronRight : groupIcon, size: isHeaderHovered ? SidebarLayoutMetrics.sectionChevronSize : 13)
                 .foregroundStyle(VColor.contentTertiary)
-                .rotationEffect(.degrees(isHeaderHovered && isExpanded ? 90 : 0))
+                .rotationEffect(.degrees(isHeaderHovered && isExpanded ? 90 : (isGroupPinned && !isHeaderHovered ? -45 : 0)))
                 .animation(VAnimation.fast, value: isExpanded)
                 .animation(VAnimation.fast, value: isHeaderHovered)
                 .frame(width: SidebarLayoutMetrics.iconSlotSize, height: SidebarLayoutMetrics.iconSlotSize)
@@ -84,11 +102,17 @@ struct SidebarSectionHeader: View {
                 case .idle:
                     EmptyView()
                 }
-                if conversationCount > 0 {
-                    Text("\(conversationCount)")
-                        .font(.caption2)
-                        .foregroundStyle(VColor.contentTertiary)
-                }
+            }
+            if conversationCount > 0 {
+                Text("\(conversationCount)")
+                    .font(VFont.labelSmall)
+                    .foregroundStyle(VColor.contentTertiary)
+                    .padding(.horizontal, VSpacing.sm - VSpacing.xxs)
+                    .padding(.vertical, VSpacing.xxs)
+                    .background(
+                        Capsule()
+                            .fill(VColor.contentTertiary.opacity(0.12))
+                    )
             }
         }
         .padding(.leading, VSpacing.xs)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
@@ -103,6 +103,13 @@ struct SidebarSectionHeader: View {
                     EmptyView()
                 }
             }
+        }
+        .padding(.leading, VSpacing.xs)
+        .padding(.trailing, SidebarLayoutMetrics.trailingIconPadding)
+        .padding(.vertical, SidebarLayoutMetrics.rowVerticalPadding)
+        .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)
+        .contentShape(Rectangle())
+        .overlay(alignment: .trailing) {
             if conversationCount > 0 {
                 Text("\(conversationCount)")
                     .font(VFont.labelSmall)
@@ -113,13 +120,9 @@ struct SidebarSectionHeader: View {
                         Capsule()
                             .fill(VColor.contentTertiary.opacity(0.12))
                     )
+                    .padding(.trailing, VSpacing.xs)
             }
         }
-        .padding(.leading, VSpacing.xs)
-        .padding(.trailing, VSpacing.sm)
-        .padding(.vertical, SidebarLayoutMetrics.rowVerticalPadding)
-        .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)
-        .contentShape(Rectangle())
         .onTapGesture { withAnimation(VAnimation.fast) { onToggleExpand() } }
         .pointerCursor(onHover: { hovering in
             isHeaderHovered = hovering

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -100,20 +100,7 @@ struct SidebarSectionView: View {
     }
 
     private var displayCount: Int {
-        switch countMode {
-        case .items:
-            return conversations.count
-        case .subGroups(let grouper):
-            var seen = Set<String>()
-            for c in conversations {
-                if let key = grouper(c) {
-                    seen.insert(key)
-                } else {
-                    seen.insert(c.id.uuidString)
-                }
-            }
-            return seen.count
-        }
+        return conversations.count
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary
- Group-specific icons: pin for Pinned, calendar for Scheduled, layers for Background (custom groups keep folder icons)
- Capsule-style count badges on group headers (always visible, matching subgroup badge style)
- Removed redundant static pin icon for conversations inside the Pinned group (unpin button still shows on hover)
- Fixed group count for Scheduled (and any group with subgroups) to show total conversations instead of unique subgroup keys

## Changes
- `SidebarSectionHeader.swift` — group-specific icon logic, capsule count badge with design tokens
- `SidebarConversationItem.swift` — removed static pin icon in Pinned group, preserved a11y label
- `SidebarSectionView.swift` — simplified displayCount to always return total conversation count

## Milestone PRs (merged into feature branch)
- #22859: M1: Group-specific icons and count badge styling
- #22864: M2: Hide pin icon for conversations in Pinned group
- #22867: M3: Fix recursive conversation count for groups with subgroups

## Project issue
Closes #22854

## Test plan
- [ ] Verify Pinned group shows pin icon in header, Scheduled shows calendar, Background shows layers
- [ ] Verify count badge appears as capsule style on all group headers (expanded and collapsed)
- [ ] Verify conversations in Pinned group do not show static pin icon; unpin shows on hover
- [ ] Verify Scheduled group count shows total conversations (not unique schedule IDs)
- [ ] Verify VoiceOver announces "Pinned" for pinned conversations via accessibility label
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22870" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
