### PR TITLE
fix: seed system groups on first launch and remove stale comment

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -260,8 +260,6 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
 
         // Always include all groups so the view layer can decide visibility.
         // Non-system groups always appear (so "New Group" is visible immediately).
-        // System groups are emitted even when empty so the view can show ghost
-        // headers during drag; the view hides empty system groups when no drag is active.
         var result: [(ConversationGroup?, [ConversationModel])] = []
         for group in sortedGroups {
             result.append((group, buckets[group.id] ?? []))
@@ -371,6 +369,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         enterDraftMode()
         conversationRestorer.delegate = self
         conversationRestorer.startObserving(skipInitialFetch: isFirstLaunch)
+        if isFirstLaunch && groups.isEmpty {
+            groups = [.pinned, .scheduled, .background]
+        }
         Task { @MainActor [weak self] in
             guard let self else { return }
             for await message in self.eventStreamClient.subscribe() {


### PR DESCRIPTION
Closes #22869. Brand new users (first launch after onboarding) never saw system groups (Pinned, Scheduled, Background) during their first session because skipInitialFetch prevented fetchConversationList from being called. Seeds system group defaults in ConversationManager.init when isFirstLaunch is true. Also removes a stale comment that described unimplemented behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22872" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
