### PR TITLE
fix: hide empty expanded section body in sidebar groups

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -141,7 +141,7 @@ struct SidebarSectionView: View {
                 conversationManager: conversationManager
             ))
 
-            if isExpanded {
+            if isExpanded && !conversations.isEmpty {
                 VStack(spacing: 0) {
                     sectionContent
                 }


### PR DESCRIPTION
Closes #22871. When system groups (Pinned, Scheduled, Background) are expanded but contain no conversations, they rendered an empty VStack with padding and a background rectangle, creating unnecessary vertical space that shifted content below. This was especially noticeable for brand new users who now see system groups from their first session.

The fix adds a `!conversations.isEmpty` check alongside the `isExpanded` check so the section body only renders when there is content to show. The section header and its drop target remain visible for drag-and-drop.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22873" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
