### PR TITLE
Seed system conversation groups on first launch & fix sidebar layout

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -260,8 +260,6 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
 
         // Always include all groups so the view layer can decide visibility.
         // Non-system groups always appear (so "New Group" is visible immediately).
-        // System groups are emitted even when empty so the view can show ghost
-        // headers during drag; the view hides empty system groups when no drag is active.
         var result: [(ConversationGroup?, [ConversationModel])] = []
         for group in sortedGroups {
             result.append((group, buckets[group.id] ?? []))
@@ -371,6 +369,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         enterDraftMode()
         conversationRestorer.delegate = self
         conversationRestorer.startObserving(skipInitialFetch: isFirstLaunch)
+        if isFirstLaunch && groups.isEmpty {
+            groups = [.pinned, .scheduled, .background]
+        }
         Task { @MainActor [weak self] in
             guard let self else { return }
             for await message in self.eventStreamClient.subscribe() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -141,7 +141,7 @@ struct SidebarSectionView: View {
                 conversationManager: conversationManager
             ))
 
-            if isExpanded {
+            if isExpanded && !conversations.isEmpty {
                 VStack(spacing: 0) {
                     sectionContent
                 }


### PR DESCRIPTION
## Summary
Brand new users (first launch after onboarding) never saw system conversation groups (Pinned, Scheduled, Background) during their first session. This was because `skipInitialFetch: true` prevented `fetchConversationList()` from being called, leaving `groups` empty for the entire session. This PR seeds system group defaults on first launch and fixes a related layout shift.

## Changes
- **Seed system groups on first launch**: Added `if isFirstLaunch && groups.isEmpty { groups = [.pinned, .scheduled, .background] }` in `ConversationManager.init` so system groups are available from the first session without an extra network call
- **Remove stale comment**: Removed misleading comment in `groupedConversations` that described unimplemented behavior (hiding empty system groups)
- **Fix empty section layout shift**: Added `!conversations.isEmpty` check in `SidebarSectionView` so expanded but empty group sections don't render a padded background VStack that shifts content below

## Milestone PRs (merged into feature branch)
- #22872: fix: seed system groups on first launch and remove stale comment
- #22873: fix: hide empty expanded section body in sidebar groups

## Project issue
Closes #22868

## Test plan
- [ ] Fresh install / first launch: verify Pinned and Scheduled group headers appear in sidebar
- [ ] Verify no content shift when groups are empty (no unnecessary padding/spacing)
- [ ] Verify drag-and-drop to empty groups still works via the section header
- [ ] Verify second launch correctly fetches groups from daemon and overwrites client defaults
- [ ] Verify Background group visibility respects the `show-background-conversations` feature flag
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22878" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
