### PR TITLE
fix: make VTextEditor click area match visual bounds (LUM-513)

### DIFF
--- a/clients/shared/DesignSystem/Core/Inputs/VTextEditor.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VTextEditor.swift
@@ -28,6 +28,8 @@ public struct VTextEditor: View {
             .frame(minHeight: minHeight, maxHeight: maxHeight, alignment: .topLeading)
             .padding(.horizontal, VSpacing.md)
             .padding(.vertical, VSpacing.sm)
+            .contentShape(Rectangle())
+            .simultaneousGesture(TapGesture().onEnded { isFocused = true })
             .vInputChrome(isFocused: isFocused)
     }
 }


### PR DESCRIPTION
## Summary
- Add `.contentShape(Rectangle())` so the entire padded editor area is hittable, not just the text content
- Use `.simultaneousGesture(TapGesture())` to focus the field on tap without stealing the TextField's own caret placement behavior

## Test plan
- [ ] Component gallery: click empty area below text inside editor chrome → editor focuses
- [ ] Feedback form (Help → Share Feedback): click below placeholder → field focuses
- [ ] Contacts notes editors: same behavior
- [ ] Clicking within existing text still positions caret normally (no regression)
- [ ] Tab/keyboard focus flows unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22884" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
