### PR TITLE
feat: daemon installSkill() supports skills.sh origin with correct routing

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6087,6 +6087,12 @@ paths:
                   description: Skill spec
                 version:
                   type: string
+                origin:
+                  description: Which registry to install from. When omitted, the install flow auto-detects based on slug format.
+                  type: string
+                  enum:
+                    - clawhub
+                    - skillssh
               required:
                 - slug
                 - url

--- a/assistant/src/__tests__/install-skill-routing.test.ts
+++ b/assistant/src/__tests__/install-skill-routing.test.ts
@@ -1,0 +1,284 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+const mockCatalogSkills = mock(
+  (): Array<{
+    id: string;
+    displayName: string;
+    description: string;
+    source: string;
+  }> => [],
+);
+const mockClawhubInstall = mock(
+  async (
+    _slug: string,
+    _opts?: { version?: string },
+  ): Promise<{ success: boolean; error?: string; skillName?: string }> => ({
+    success: true,
+  }),
+);
+const mockInstallExternalSkill = mock(
+  async (
+    _owner: string,
+    _repo: string,
+    _skillSlug: string,
+    _overwrite: boolean,
+    _ref?: string,
+  ): Promise<void> => {},
+);
+const mockGetCatalog = mock(async () => []);
+const mockInstallSkillLocally = mock(async () => {});
+const mockSeedCatalogSkillMemories = mock(() => {});
+const mockEnsureSkillEntry = mock(
+  (_raw: Record<string, unknown>, _id: string) => ({
+    enabled: false,
+  }),
+);
+
+// ---------------------------------------------------------------------------
+// Mock modules — before importing module under test
+// ---------------------------------------------------------------------------
+
+mock.module("../config/skills.js", () => ({
+  loadSkillCatalog: mockCatalogSkills,
+}));
+
+mock.module("../skills/clawhub.js", () => ({
+  clawhubCheckUpdates: mock(async () => []),
+  clawhubInspect: mock(async () => ({})),
+  clawhubInstall: mockClawhubInstall,
+  clawhubSearch: mock(async () => ({ skills: [] })),
+  clawhubUpdate: mock(async () => ({ success: true })),
+}));
+
+mock.module("../skills/skillssh-registry.js", () => ({
+  installExternalSkill: mockInstallExternalSkill,
+  resolveSkillSource: (source: string) => {
+    const parts = source.split("/");
+    if (parts.length >= 3) {
+      return {
+        owner: parts[0]!,
+        repo: parts[1]!,
+        skillSlug: parts.slice(2).join("/"),
+      };
+    }
+    throw new Error(`Invalid skill source "${source}"`);
+  },
+  searchSkillsRegistry: mock(async () => []),
+}));
+
+mock.module("../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: () => true,
+}));
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({}),
+  invalidateConfigCache: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+}));
+mock.module("../config/skill-state.js", () => ({
+  resolveSkillStates: () => [],
+  skillFlagKey: () => null,
+}));
+mock.module("../providers/provider-send-message.js", () => ({
+  createTimeout: () => ({
+    signal: AbortSignal.timeout(1000),
+    cleanup: () => {},
+  }),
+  extractText: () => "",
+  getConfiguredProvider: async () => null,
+  userMessage: () => ({}),
+}));
+mock.module("../runtime/routes/workspace-utils.js", () => ({
+  isTextMimeType: () => true,
+}));
+mock.module("../skills/catalog-cache.js", () => ({
+  getCatalog: mockGetCatalog,
+}));
+mock.module("../skills/catalog-install.js", () => ({
+  installSkillLocally: mockInstallSkillLocally,
+}));
+mock.module("../skills/catalog-search.js", () => ({
+  filterByQuery: () => [],
+}));
+mock.module("../skills/managed-store.js", () => ({
+  createManagedSkill: () => ({ created: true }),
+  deleteManagedSkill: () => ({ deleted: true }),
+  removeSkillsIndexEntry: () => {},
+  validateManagedSkillId: () => null,
+}));
+mock.module("../skills/skill-memory.js", () => ({
+  deleteSkillCapabilityMemory: () => {},
+  seedCatalogSkillMemories: mockSeedCatalogSkillMemories,
+}));
+mock.module("../util/platform.js", () => ({
+  getWorkspaceSkillsDir: () => "/tmp/test-skills",
+}));
+mock.module("../daemon/handlers/shared.js", () => ({
+  CONFIG_RELOAD_DEBOUNCE_MS: 100,
+  ensureSkillEntry: mockEnsureSkillEntry,
+  log: {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  },
+}));
+
+// Import after mocking
+import { installSkill } from "../daemon/handlers/skills.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const dummyCtx = {
+  debounceTimers: { schedule: () => {} },
+  setSuppressConfigReload: () => {},
+  updateConfigFingerprint: () => {},
+  broadcast: () => {},
+} as unknown as Parameters<typeof installSkill>[1];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("installSkill routing", () => {
+  beforeEach(() => {
+    mockCatalogSkills.mockReset();
+    mockClawhubInstall.mockReset();
+    mockInstallExternalSkill.mockReset();
+    mockGetCatalog.mockReset();
+    mockInstallSkillLocally.mockReset();
+    mockSeedCatalogSkillMemories.mockReset();
+    mockEnsureSkillEntry.mockReset();
+
+    // Defaults
+    mockCatalogSkills.mockReturnValue([]);
+    mockClawhubInstall.mockResolvedValue({ success: true });
+    mockInstallExternalSkill.mockResolvedValue(undefined);
+    mockGetCatalog.mockResolvedValue([]);
+    mockInstallSkillLocally.mockResolvedValue(undefined);
+    mockSeedCatalogSkillMemories.mockReturnValue(undefined);
+    mockEnsureSkillEntry.mockReturnValue({ enabled: false });
+  });
+
+  test("install with origin: 'skillssh' and multi-segment slug routes to installExternalSkill", async () => {
+    const result = await installSkill(
+      {
+        slug: "vercel-labs/agent-skills/react-best-practices",
+        origin: "skillssh",
+      },
+      dummyCtx,
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockInstallExternalSkill).toHaveBeenCalledTimes(1);
+    expect(mockInstallExternalSkill).toHaveBeenCalledWith(
+      "vercel-labs",
+      "agent-skills",
+      "react-best-practices",
+      true, // overwrite
+      undefined, // ref
+    );
+    // Should not have called clawhub
+    expect(mockClawhubInstall).not.toHaveBeenCalled();
+  });
+
+  test("install without origin falls through to clawhub for simple slugs", async () => {
+    const result = await installSkill({ slug: "some-clawhub-skill" }, dummyCtx);
+
+    expect(result.success).toBe(true);
+    expect(mockClawhubInstall).toHaveBeenCalledTimes(1);
+    expect(mockClawhubInstall).toHaveBeenCalledWith("some-clawhub-skill", {
+      version: undefined,
+    });
+    // Should not have called installExternalSkill
+    expect(mockInstallExternalSkill).not.toHaveBeenCalled();
+  });
+
+  test("install with origin: 'clawhub' routes directly to clawhub without trying skills.sh", async () => {
+    const result = await installSkill(
+      { slug: "my-skill", origin: "clawhub" },
+      dummyCtx,
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockClawhubInstall).toHaveBeenCalledTimes(1);
+    expect(mockInstallExternalSkill).not.toHaveBeenCalled();
+  });
+
+  test("multi-segment slug without explicit origin auto-routes to skills.sh", async () => {
+    const result = await installSkill(
+      { slug: "owner/repo/my-skill" },
+      dummyCtx,
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockInstallExternalSkill).toHaveBeenCalledTimes(1);
+    expect(mockInstallExternalSkill).toHaveBeenCalledWith(
+      "owner",
+      "repo",
+      "my-skill",
+      true,
+      undefined,
+    );
+    expect(mockClawhubInstall).not.toHaveBeenCalled();
+  });
+
+  test("multi-segment slug with origin: 'clawhub' skips skills.sh and routes to clawhub", async () => {
+    // Even though the slug looks like skills.sh format, explicit origin: "clawhub"
+    // should override the auto-detection and go to clawhub
+    const result = await installSkill(
+      { slug: "owner/repo/my-skill", origin: "clawhub" },
+      dummyCtx,
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockClawhubInstall).toHaveBeenCalledTimes(1);
+    expect(mockInstallExternalSkill).not.toHaveBeenCalled();
+  });
+
+  test("bundled skills are auto-enabled regardless of origin", async () => {
+    mockCatalogSkills.mockReturnValue([
+      {
+        id: "bundled-skill",
+        displayName: "Bundled Skill",
+        description: "A bundled skill",
+        source: "bundled",
+      },
+    ]);
+
+    const result = await installSkill(
+      { slug: "bundled-skill", origin: "skillssh" },
+      dummyCtx,
+    );
+
+    expect(result.success).toBe(true);
+    // Should have auto-enabled via ensureSkillEntry, not called external install
+    expect(mockInstallExternalSkill).not.toHaveBeenCalled();
+    expect(mockClawhubInstall).not.toHaveBeenCalled();
+  });
+
+  test("skills.sh install failure propagates error", async () => {
+    mockInstallExternalSkill.mockRejectedValue(
+      new Error("Skill not found in repo"),
+    );
+
+    const result = await installSkill(
+      {
+        slug: "owner/repo/nonexistent-skill",
+        origin: "skillssh",
+      },
+      dummyCtx,
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("Skill not found in repo");
+    }
+  });
+});

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -644,7 +644,7 @@ export async function installSkill(
         resolved.repo,
         resolved.skillSlug,
         true /* overwrite */,
-        resolved.ref,
+        resolved.ref ?? spec.version,
       );
 
       // Reload skill catalog so the newly installed skill is picked up

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -46,7 +46,11 @@ import {
   deleteSkillCapabilityMemory,
   seedCatalogSkillMemories,
 } from "../../skills/skill-memory.js";
-import { searchSkillsRegistry } from "../../skills/skillssh-registry.js";
+import {
+  installExternalSkill,
+  resolveSkillSource,
+  searchSkillsRegistry,
+} from "../../skills/skillssh-registry.js";
 import { getWorkspaceSkillsDir } from "../../util/platform.js";
 import {
   CONFIG_RELOAD_DEBOUNCE_MS,
@@ -537,8 +541,16 @@ export function configureSkill(
   }
 }
 
+/**
+ * Check whether a slug looks like a skills.sh multi-segment format
+ * (e.g. `owner/repo/skill-name` — three or more `/`-separated segments).
+ */
+function looksLikeSkillsShSlug(slug: string): boolean {
+  return slug.split("/").length >= 3;
+}
+
 export async function installSkill(
-  spec: { slug: string; version?: string },
+  spec: { slug: string; version?: string; origin?: "clawhub" | "skillssh" },
   ctx: SkillOperationContext,
 ): Promise<{ success: true } | { success: false; error: string }> {
   try {
@@ -613,11 +625,50 @@ export async function installSkill(
         return { success: true };
       }
     } catch (err) {
-      // If catalog lookup/install fails, fall through to clawhub
+      // If catalog lookup/install fails, fall through to community registries
       log.warn(
         { err, skillId: spec.slug },
         "Vellum catalog install failed, falling back to community registry",
       );
+    }
+
+    // skills.sh install path: route here when origin is explicitly "skillssh"
+    // or when the slug looks like a skills.sh multi-segment format (owner/repo/skill)
+    if (
+      spec.origin === "skillssh" ||
+      (spec.origin !== "clawhub" && looksLikeSkillsShSlug(spec.slug))
+    ) {
+      const resolved = resolveSkillSource(spec.slug);
+      await installExternalSkill(
+        resolved.owner,
+        resolved.repo,
+        resolved.skillSlug,
+        true /* overwrite */,
+        resolved.ref,
+      );
+
+      // Reload skill catalog so the newly installed skill is picked up
+      loadSkillCatalog();
+
+      // Auto-enable the newly installed skill
+      try {
+        const raw = loadRawConfig();
+        ensureSkillEntry(raw, resolved.skillSlug).enabled = true;
+        saveConfigWithSuppression(raw, ctx);
+        ctx.broadcast({
+          type: "skills_state_changed",
+          name: resolved.skillSlug,
+          state: "enabled",
+        });
+      } catch (err) {
+        log.warn(
+          { err, skillId: resolved.skillSlug },
+          "Failed to auto-enable installed skills.sh skill",
+        );
+      }
+
+      seedCatalogSkillMemories();
+      return { success: true };
     }
 
     // Install from clawhub (community)

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -201,6 +201,12 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
         url: z.string().describe("Skill URL"),
         spec: z.string().describe("Skill spec"),
         version: z.string(),
+        origin: z
+          .enum(["clawhub", "skillssh"])
+          .optional()
+          .describe(
+            "Which registry to install from. When omitted, the install flow auto-detects based on slug format.",
+          ),
       }),
       responseBody: z.object({
         ok: z.boolean(),
@@ -211,6 +217,7 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
           url?: string;
           spec?: string;
           version?: string;
+          origin?: "clawhub" | "skillssh";
         };
         const slug = body.slug ?? body.url ?? body.spec;
         if (!slug || typeof slug !== "string") {
@@ -221,7 +228,7 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
           );
         }
         const result = await installSkill(
-          { slug, version: body.version },
+          { slug, version: body.version, origin: body.origin },
           ctx(),
         );
         if (!result.success) {


### PR DESCRIPTION
## Summary
- Adds optional `origin` field to `POST /skills/install` request body (`"clawhub"` | `"skillssh"`)
- Routes skills.sh slugs to `installExternalSkill` when origin is `skillssh` or slug has 3+ segments
- Preserves existing install flow (bundled → catalog → clawhub) when no origin specified
- Adds routing tests for all install paths

Part of plan: skills-unify-install.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22887" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
