### PR TITLE
fix: truncate conversation title in header on narrow windows

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
@@ -26,6 +26,8 @@ struct ConversationTitleActionsControl: View {
                     showDrawer.toggle()
                 }
             }
+            .lineLimit(1)
+            .fixedSize(horizontal: false, vertical: true)
 
             if let parentTitle = presentation.forkParentTitle, presentation.showsForkParentLink {
                 Button(action: onOpenForkParent) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -528,6 +528,7 @@ struct MainWindowView: View {
                 } action: { newFrame in
                     conversationTitleFrame = newFrame
                 }
+                .padding(.horizontal, 120)
                 // Shift the title right so it centers above the chat content area
                 // (not the full window). Content starts after outer padding (16) +
                 // sidebar + spacing (16), so its center is offset from the window


### PR DESCRIPTION
## Summary
- Add .lineLimit(1) to conversation title VButton so long titles truncate with ellipsis
- Add .fixedSize(horizontal: false, vertical: true) to ensure text truncates instead of expanding the button
- Add .padding(.horizontal, 120) to the title overlay to prevent overlap with toolbar controls

Part of plan: title-overflow-header.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22891" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
