### PR TITLE
feat: workspace migration to backfill install-meta.json with origin field

### DIFF
--- a/assistant/src/__tests__/workspace-migration-026-backfill-install-meta.test.ts
+++ b/assistant/src/__tests__/workspace-migration-026-backfill-install-meta.test.ts
@@ -1,0 +1,558 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { backfillInstallMetaMigration } from "../workspace/migrations/026-backfill-install-meta.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let workspaceDir: string;
+let skillsDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-026-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  skillsDir = join(workspaceDir, "skills");
+  mkdirSync(skillsDir, { recursive: true });
+}
+
+function createSkillDir(
+  name: string,
+  opts?: {
+    skillMd?: string;
+    versionJson?: Record<string, unknown>;
+    installMetaJson?: Record<string, unknown>;
+    extraFiles?: Record<string, string>;
+  },
+): string {
+  const dir = join(skillsDir, name);
+  mkdirSync(dir, { recursive: true });
+
+  if (opts?.skillMd !== undefined) {
+    writeFileSync(join(dir, "SKILL.md"), opts.skillMd, "utf-8");
+  } else {
+    // Default: create a SKILL.md so the dir is recognized as a skill
+    writeFileSync(join(dir, "SKILL.md"), `# ${name}\n`, "utf-8");
+  }
+
+  if (opts?.versionJson) {
+    writeFileSync(
+      join(dir, "version.json"),
+      JSON.stringify(opts.versionJson, null, 2),
+      "utf-8",
+    );
+  }
+
+  if (opts?.installMetaJson) {
+    writeFileSync(
+      join(dir, "install-meta.json"),
+      JSON.stringify(opts.installMetaJson, null, 2),
+      "utf-8",
+    );
+  }
+
+  if (opts?.extraFiles) {
+    for (const [filePath, content] of Object.entries(opts.extraFiles)) {
+      const fullPath = join(dir, filePath);
+      mkdirSync(join(fullPath, ".."), { recursive: true });
+      writeFileSync(fullPath, content, "utf-8");
+    }
+  }
+
+  return dir;
+}
+
+function writeIntegrityManifest(
+  manifest: Record<string, { sha256: string; installedAt: string }>,
+): void {
+  writeFileSync(
+    join(skillsDir, ".integrity.json"),
+    JSON.stringify(manifest, null, 2),
+    "utf-8",
+  );
+}
+
+function readInstallMeta(skillName: string): Record<string, unknown> | null {
+  const path = join(skillsDir, skillName, "install-meta.json");
+  if (!existsSync(path)) return null;
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+const dirs: string[] = [];
+
+beforeEach(() => {
+  freshWorkspace();
+  dirs.push(workspaceDir);
+});
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("026-backfill-install-meta migration", () => {
+  test("has correct migration id", () => {
+    expect(backfillInstallMetaMigration.id).toBe("026-backfill-install-meta");
+  });
+
+  // ─── No-op cases ────────────────────────────────────────────────────────
+
+  test("no-op when skills dir does not exist", () => {
+    rmSync(skillsDir, { recursive: true, force: true });
+    // Should not throw
+    backfillInstallMetaMigration.run(workspaceDir);
+  });
+
+  test("no-op when skills dir is empty", () => {
+    backfillInstallMetaMigration.run(workspaceDir);
+    // No install-meta.json should be created
+  });
+
+  test("skips directories without SKILL.md", () => {
+    const dir = join(skillsDir, "not-a-skill");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "README.md"), "# Not a skill", "utf-8");
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    expect(existsSync(join(dir, "install-meta.json"))).toBe(false);
+  });
+
+  test("skips non-directory entries", () => {
+    writeFileSync(join(skillsDir, "some-file.txt"), "not a dir", "utf-8");
+
+    backfillInstallMetaMigration.run(workspaceDir);
+    // Should not throw
+  });
+
+  // ─── Idempotency ───────────────────────────────────────────────────────
+
+  test("skips skills that already have install-meta.json", () => {
+    const existingMeta = {
+      origin: "clawhub",
+      installedAt: "2025-01-01T00:00:00.000Z",
+      installedBy: "user-123",
+      slug: "existing-skill",
+    };
+    createSkillDir("my-skill", { installMetaJson: existingMeta });
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const meta = readInstallMeta("my-skill");
+    expect(meta).not.toBeNull();
+    expect(meta!.installedBy).toBe("user-123"); // preserved, not overwritten
+    expect(meta!.origin).toBe("clawhub");
+  });
+
+  test("is idempotent — running twice produces same result", () => {
+    createSkillDir("my-skill", {
+      versionJson: {
+        version: "1.0.0",
+        installedAt: "2025-03-01T00:00:00.000Z",
+      },
+    });
+
+    backfillInstallMetaMigration.run(workspaceDir);
+    const meta1 = readInstallMeta("my-skill");
+
+    backfillInstallMetaMigration.run(workspaceDir);
+    const meta2 = readInstallMeta("my-skill");
+
+    expect(meta1).toEqual(meta2);
+  });
+
+  // ─── Case 1: skills.sh origin ──────────────────────────────────────────
+
+  test("infers skillssh origin from version.json with origin: skills.sh", () => {
+    createSkillDir("skillssh-skill", {
+      versionJson: {
+        origin: "skills.sh",
+        source: "vercel-labs/agent-skills",
+        skillSlug: "react-best-practices",
+        installedAt: "2025-02-15T12:00:00.000Z",
+      },
+    });
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const meta = readInstallMeta("skillssh-skill");
+    expect(meta).not.toBeNull();
+    expect(meta!.origin).toBe("skillssh");
+    expect(meta!.sourceRepo).toBe("vercel-labs/agent-skills");
+    expect(meta!.slug).toBe("react-best-practices");
+    expect(meta!.installedAt).toBe("2025-02-15T12:00:00.000Z");
+    expect(meta!.installedBy).toBeUndefined();
+    expect(meta!.contentHash).toMatch(/^v2:[0-9a-f]{64}$/);
+  });
+
+  // ─── Case 2: version with no origin (vellum or clawhub) ───────────────
+
+  test("infers vellum origin from version.json with version and no origin", () => {
+    createSkillDir("vellum-skill", {
+      versionJson: {
+        version: "v1:abc123",
+        installedAt: "2025-01-20T08:00:00.000Z",
+      },
+    });
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const meta = readInstallMeta("vellum-skill");
+    expect(meta).not.toBeNull();
+    expect(meta!.origin).toBe("vellum");
+    expect(meta!.version).toBe("v1:abc123");
+    expect(meta!.installedAt).toBe("2025-01-20T08:00:00.000Z");
+    expect(meta!.installedBy).toBeUndefined();
+    expect(meta!.contentHash).toMatch(/^v2:[0-9a-f]{64}$/);
+  });
+
+  test("infers clawhub origin when version.json has version, no origin, and integrity entry exists", () => {
+    createSkillDir("clawhub-skill", {
+      versionJson: {
+        version: "1.2.3",
+        installedAt: "2025-03-10T10:00:00.000Z",
+      },
+    });
+    writeIntegrityManifest({
+      "clawhub-skill": {
+        sha256:
+          "v2:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+        installedAt: "2025-03-10T10:00:00.000Z",
+      },
+    });
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const meta = readInstallMeta("clawhub-skill");
+    expect(meta).not.toBeNull();
+    expect(meta!.origin).toBe("clawhub");
+    expect(meta!.version).toBe("1.2.3");
+    expect(meta!.installedAt).toBe("2025-03-10T10:00:00.000Z");
+    expect(meta!.installedBy).toBeUndefined();
+  });
+
+  // ─── Case 3: version.json with unknown pattern ─────────────────────────
+
+  test("infers custom origin from version.json with unrecognized structure", () => {
+    createSkillDir("weird-skill", {
+      versionJson: {
+        origin: "some-unknown-registry",
+        installedAt: "2025-04-01T00:00:00.000Z",
+      },
+    });
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const meta = readInstallMeta("weird-skill");
+    expect(meta).not.toBeNull();
+    expect(meta!.origin).toBe("custom");
+    expect(meta!.installedAt).toBe("2025-04-01T00:00:00.000Z");
+    expect(meta!.installedBy).toBeUndefined();
+  });
+
+  test("infers custom origin from version.json with version AND origin fields", () => {
+    createSkillDir("both-fields", {
+      versionJson: {
+        origin: "some-origin",
+        version: "2.0.0",
+        installedAt: "2025-05-01T00:00:00.000Z",
+      },
+    });
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const meta = readInstallMeta("both-fields");
+    expect(meta).not.toBeNull();
+    // Has `origin` field (not "skills.sh") AND `version` -> doesn't match case 2
+    // (case 2 requires no `origin` field), falls through to case 3 (custom)
+    expect(meta!.origin).toBe("custom");
+  });
+
+  // ─── Case 4: no version.json ──────────────────────────────────────────
+
+  test("infers clawhub origin when no version.json but integrity entry exists", () => {
+    createSkillDir("clawhub-no-version", {});
+    writeIntegrityManifest({
+      "clawhub-no-version": {
+        sha256:
+          "v2:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+        installedAt: "2025-06-01T00:00:00.000Z",
+      },
+    });
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const meta = readInstallMeta("clawhub-no-version");
+    expect(meta).not.toBeNull();
+    expect(meta!.origin).toBe("clawhub");
+    expect(meta!.installedBy).toBeUndefined();
+    // installedAt should be directory mtime (an ISO string)
+    expect(typeof meta!.installedAt).toBe("string");
+    expect(new Date(meta!.installedAt as string).getTime()).not.toBeNaN();
+  });
+
+  test("infers custom origin when no version.json and no integrity entry", () => {
+    createSkillDir("custom-skill", {});
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const meta = readInstallMeta("custom-skill");
+    expect(meta).not.toBeNull();
+    expect(meta!.origin).toBe("custom");
+    expect(meta!.installedBy).toBeUndefined();
+    expect(typeof meta!.installedAt).toBe("string");
+  });
+
+  // ─── Malformed version.json ───────────────────────────────────────────
+
+  test("handles malformed version.json gracefully", () => {
+    const dir = createSkillDir("bad-version");
+    writeFileSync(join(dir, "version.json"), "{bad json!", "utf-8");
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const meta = readInstallMeta("bad-version");
+    expect(meta).not.toBeNull();
+    expect(meta!.origin).toBe("custom");
+    expect(meta!.installedBy).toBeUndefined();
+  });
+
+  test("handles malformed version.json with integrity entry as clawhub", () => {
+    const dir = createSkillDir("bad-version-clawhub");
+    writeFileSync(join(dir, "version.json"), "{{{", "utf-8");
+    writeIntegrityManifest({
+      "bad-version-clawhub": {
+        sha256: "v2:aaa",
+        installedAt: "2025-01-01T00:00:00.000Z",
+      },
+    });
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const meta = readInstallMeta("bad-version-clawhub");
+    expect(meta).not.toBeNull();
+    expect(meta!.origin).toBe("clawhub");
+  });
+
+  // ─── Content hash ─────────────────────────────────────────────────────
+
+  test("computes contentHash for all backfilled skills", () => {
+    createSkillDir("hash-test", {
+      versionJson: {
+        version: "1.0.0",
+        installedAt: "2025-01-01T00:00:00.000Z",
+      },
+      extraFiles: { "executor.ts": "export const run = () => {};" },
+    });
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const meta = readInstallMeta("hash-test");
+    expect(meta).not.toBeNull();
+    expect(meta!.contentHash).toMatch(/^v2:[0-9a-f]{64}$/);
+  });
+
+  // ─── Legacy file preservation ─────────────────────────────────────────
+
+  test("preserves legacy version.json after backfill", () => {
+    const versionData = {
+      version: "1.0.0",
+      installedAt: "2025-01-01T00:00:00.000Z",
+    };
+    const dir = createSkillDir("preserve-version", {
+      versionJson: versionData,
+    });
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    // version.json should still exist
+    const versionPath = join(dir, "version.json");
+    expect(existsSync(versionPath)).toBe(true);
+    const preserved = JSON.parse(readFileSync(versionPath, "utf-8"));
+    expect(preserved.version).toBe("1.0.0");
+  });
+
+  test("preserves .integrity.json after backfill", () => {
+    createSkillDir("preserve-integrity", {
+      versionJson: {
+        version: "1.0.0",
+        installedAt: "2025-01-01T00:00:00.000Z",
+      },
+    });
+    const manifestData = {
+      "preserve-integrity": {
+        sha256: "v2:abc",
+        installedAt: "2025-01-01T00:00:00.000Z",
+      },
+    };
+    writeIntegrityManifest(manifestData);
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const integrityPath = join(skillsDir, ".integrity.json");
+    expect(existsSync(integrityPath)).toBe(true);
+    const preserved = JSON.parse(readFileSync(integrityPath, "utf-8"));
+    expect(preserved["preserve-integrity"]).toBeDefined();
+  });
+
+  // ─── Multiple skills ──────────────────────────────────────────────────
+
+  test("processes multiple skill directories in a single run", () => {
+    createSkillDir("skill-a", {
+      versionJson: {
+        version: "1.0.0",
+        installedAt: "2025-01-01T00:00:00.000Z",
+      },
+    });
+    createSkillDir("skill-b", {
+      versionJson: {
+        origin: "skills.sh",
+        source: "org/repo",
+        skillSlug: "slug-b",
+        installedAt: "2025-02-01T00:00:00.000Z",
+      },
+    });
+    createSkillDir("skill-c", {}); // no version.json
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const metaA = readInstallMeta("skill-a");
+    const metaB = readInstallMeta("skill-b");
+    const metaC = readInstallMeta("skill-c");
+
+    expect(metaA).not.toBeNull();
+    expect(metaA!.origin).toBe("vellum");
+
+    expect(metaB).not.toBeNull();
+    expect(metaB!.origin).toBe("skillssh");
+
+    expect(metaC).not.toBeNull();
+    expect(metaC!.origin).toBe("custom");
+  });
+
+  // ─── installedAt fallback ─────────────────────────────────────────────
+
+  test("uses directory mtime as installedAt when version.json lacks it", () => {
+    createSkillDir("no-installed-at", {
+      versionJson: { version: "1.0.0" },
+    });
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const meta = readInstallMeta("no-installed-at");
+    expect(meta).not.toBeNull();
+    // Should be an ISO date from dir mtime
+    expect(typeof meta!.installedAt).toBe("string");
+    expect(new Date(meta!.installedAt as string).getTime()).not.toBeNaN();
+  });
+
+  test("uses directory mtime as installedAt when no version.json exists", () => {
+    createSkillDir("mtime-fallback", {});
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const meta = readInstallMeta("mtime-fallback");
+    expect(meta).not.toBeNull();
+    expect(typeof meta!.installedAt).toBe("string");
+    expect(new Date(meta!.installedAt as string).getTime()).not.toBeNaN();
+  });
+
+  // ─── down() rollback ──────────────────────────────────────────────────
+
+  describe("down()", () => {
+    test("removes backfilled install-meta.json files", () => {
+      createSkillDir("rollback-skill", {
+        versionJson: {
+          version: "1.0.0",
+          installedAt: "2025-01-01T00:00:00.000Z",
+        },
+      });
+
+      backfillInstallMetaMigration.run(workspaceDir);
+      expect(
+        existsSync(join(skillsDir, "rollback-skill", "install-meta.json")),
+      ).toBe(true);
+
+      backfillInstallMetaMigration.down(workspaceDir);
+      expect(
+        existsSync(join(skillsDir, "rollback-skill", "install-meta.json")),
+      ).toBe(false);
+    });
+
+    test("preserves install-meta.json with installedBy (not backfilled)", () => {
+      createSkillDir("keep-skill", {
+        installMetaJson: {
+          origin: "clawhub",
+          installedAt: "2025-01-01T00:00:00.000Z",
+          installedBy: "user-abc",
+          slug: "my-skill",
+        },
+      });
+
+      backfillInstallMetaMigration.down(workspaceDir);
+
+      expect(
+        existsSync(join(skillsDir, "keep-skill", "install-meta.json")),
+      ).toBe(true);
+    });
+
+    test("is idempotent — calling down() twice is safe", () => {
+      createSkillDir("double-down", {
+        versionJson: {
+          version: "1.0.0",
+          installedAt: "2025-01-01T00:00:00.000Z",
+        },
+      });
+
+      backfillInstallMetaMigration.run(workspaceDir);
+      backfillInstallMetaMigration.down(workspaceDir);
+      backfillInstallMetaMigration.down(workspaceDir); // second call
+
+      expect(
+        existsSync(join(skillsDir, "double-down", "install-meta.json")),
+      ).toBe(false);
+    });
+
+    test("no-op when skills dir does not exist", () => {
+      rmSync(skillsDir, { recursive: true, force: true });
+      // Should not throw
+      backfillInstallMetaMigration.down(workspaceDir);
+    });
+
+    test("no-op when skills dir is empty", () => {
+      // Should not throw
+      backfillInstallMetaMigration.down(workspaceDir);
+    });
+
+    test("handles malformed install-meta.json in down() gracefully", () => {
+      const dir = createSkillDir("bad-meta");
+      writeFileSync(join(dir, "install-meta.json"), "{not valid}", "utf-8");
+
+      // Should not throw
+      backfillInstallMetaMigration.down(workspaceDir);
+
+      // The malformed file is left in place (skip, not crash)
+      expect(existsSync(join(dir, "install-meta.json"))).toBe(true);
+    });
+  });
+});

--- a/assistant/src/workspace/migrations/026-backfill-install-meta.ts
+++ b/assistant/src/workspace/migrations/026-backfill-install-meta.ts
@@ -260,17 +260,17 @@ export const backfillInstallMetaMigration: WorkspaceMigration = {
     const integrityManifest = loadIntegrityManifest(skillsDir);
 
     // Enumerate skill directories (each subdirectory containing a SKILL.md)
-    let entries: ReturnType<typeof readdirSync>;
+    let dirNames: string[];
     try {
-      entries = readdirSync(skillsDir, { withFileTypes: true });
+      dirNames = readdirSync(skillsDir, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name);
     } catch {
       return;
     }
 
-    for (const entry of entries) {
-      if (!entry.isDirectory()) continue;
-
-      const skillDir = join(skillsDir, entry.name);
+    for (const name of dirNames) {
+      const skillDir = join(skillsDir, name);
       const skillMdPath = join(skillDir, SKILL_MD_FILENAME);
       const installMetaPath = join(skillDir, INSTALL_META_FILENAME);
 
@@ -280,7 +280,7 @@ export const backfillInstallMetaMigration: WorkspaceMigration = {
       // Skip if install-meta.json already exists (idempotency)
       if (existsSync(installMetaPath)) continue;
 
-      const meta = inferInstallMeta(skillDir, entry.name, integrityManifest);
+      const meta = inferInstallMeta(skillDir, name, integrityManifest);
 
       // installedBy is left undefined for all backfilled skills
       writeInstallMeta(skillDir, meta);
@@ -291,21 +291,17 @@ export const backfillInstallMetaMigration: WorkspaceMigration = {
     const skillsDir = join(workspaceDir, "skills");
     if (!existsSync(skillsDir)) return;
 
-    let entries: ReturnType<typeof readdirSync>;
+    let dirNames: string[];
     try {
-      entries = readdirSync(skillsDir, { withFileTypes: true });
+      dirNames = readdirSync(skillsDir, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name);
     } catch {
       return;
     }
 
-    for (const entry of entries) {
-      if (!entry.isDirectory()) continue;
-
-      const installMetaPath = join(
-        skillsDir,
-        entry.name,
-        INSTALL_META_FILENAME,
-      );
+    for (const name of dirNames) {
+      const installMetaPath = join(skillsDir, name, INSTALL_META_FILENAME);
       if (existsSync(installMetaPath)) {
         try {
           const meta = JSON.parse(

--- a/assistant/src/workspace/migrations/026-backfill-install-meta.ts
+++ b/assistant/src/workspace/migrations/026-backfill-install-meta.ts
@@ -1,0 +1,327 @@
+/**
+ * Workspace migration 026: Backfill install-meta.json for existing skills
+ *
+ * Scans ~/.vellum/workspace/skills/ for installed skill directories and writes
+ * an install-meta.json for each skill that lacks one, inferring the origin
+ * from legacy version.json and .integrity.json files.
+ *
+ * Idempotent: safe to re-run after interruption at any point.
+ */
+
+import { randomUUID } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const INSTALL_META_FILENAME = "install-meta.json";
+const VERSION_JSON_FILENAME = "version.json";
+const INTEGRITY_JSON_FILENAME = ".integrity.json";
+const SKILL_MD_FILENAME = "SKILL.md";
+
+// ---------------------------------------------------------------------------
+// Inlined helpers (self-contained per migrations/AGENTS.md)
+// ---------------------------------------------------------------------------
+
+interface SkillInstallMeta {
+  origin: "vellum" | "clawhub" | "skillssh" | "custom";
+  installedAt: string;
+  installedBy?: string;
+  version?: string;
+  slug?: string;
+  sourceRepo?: string;
+  contentHash?: string;
+}
+
+/**
+ * Atomically write a file: write to a temp file, then rename.
+ */
+function atomicWriteFile(filePath: string, content: string): void {
+  const dir = dirname(filePath);
+  mkdirSync(dir, { recursive: true });
+  const tmpPath = join(dir, `.tmp-${randomUUID()}`);
+  writeFileSync(tmpPath, content, "utf-8");
+  renameSync(tmpPath, filePath);
+}
+
+/**
+ * Write install-meta.json into a skill directory.
+ */
+function writeInstallMeta(skillDir: string, meta: SkillInstallMeta): void {
+  const filePath = join(skillDir, INSTALL_META_FILENAME);
+  atomicWriteFile(filePath, JSON.stringify(meta, null, 2) + "\n");
+}
+
+/**
+ * Metadata files excluded from content hashing.
+ */
+const METADATA_FILENAMES = new Set([
+  INSTALL_META_FILENAME,
+  VERSION_JSON_FILENAME,
+]);
+
+/**
+ * Collect all file contents in a directory tree, sorted by relative path.
+ * Metadata files at root level are excluded.
+ */
+function collectFileContents(
+  dir: string,
+  prefix = "",
+): Array<{ relPath: string; content: Buffer }> {
+  const results: Array<{ relPath: string; content: Buffer }> = [];
+  if (!existsSync(dir)) return results;
+
+  const entries = readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!prefix && METADATA_FILENAMES.has(entry.name)) continue;
+
+    const relPath = prefix ? `${prefix}/${entry.name}` : entry.name;
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectFileContents(fullPath, relPath));
+    } else if (entry.isFile()) {
+      results.push({ relPath, content: readFileSync(fullPath) });
+    }
+  }
+  return results.sort((a, b) => a.relPath.localeCompare(b.relPath));
+}
+
+/**
+ * Compute SHA-256 content hash over all non-metadata files in a skill dir.
+ * Returns format: "v2:sha256hex".
+ */
+function computeSkillHash(skillDir: string): string | null {
+  if (!existsSync(skillDir) || !statSync(skillDir).isDirectory()) return null;
+
+  const files = collectFileContents(skillDir);
+  if (files.length === 0) return null;
+
+  const hasher = new Bun.CryptoHasher("sha256");
+  for (const file of files) {
+    const pathBuf = Buffer.from(file.relPath, "utf-8");
+    hasher.update(`${pathBuf.length}:`);
+    hasher.update(pathBuf);
+    hasher.update(`${file.content.length}:`);
+    hasher.update(file.content);
+  }
+  return `v2:${hasher.digest("hex")}`;
+}
+
+// ---------------------------------------------------------------------------
+// Integrity manifest helpers
+// ---------------------------------------------------------------------------
+
+interface IntegrityRecord {
+  sha256: string;
+  installedAt: string;
+}
+
+type IntegrityManifest = Record<string, IntegrityRecord>;
+
+function loadIntegrityManifest(skillsDir: string): IntegrityManifest {
+  const path = join(skillsDir, INTEGRITY_JSON_FILENAME);
+  if (!existsSync(path)) return {};
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as IntegrityManifest;
+  } catch {
+    return {};
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Origin inference
+// ---------------------------------------------------------------------------
+
+/**
+ * Infer SkillInstallMeta for a skill directory that has no install-meta.json.
+ *
+ * Decision tree:
+ * 1. version.json with `origin: "skills.sh"` -> skillssh
+ * 2. version.json with `version` but no `origin` field:
+ *    - Has entry in .integrity.json -> clawhub
+ *    - Otherwise -> vellum
+ * 3. version.json exists but doesn't match above -> custom
+ * 4. No version.json:
+ *    - Has entry in .integrity.json -> clawhub
+ *    - Otherwise -> custom
+ */
+function inferInstallMeta(
+  skillDir: string,
+  skillId: string,
+  integrityManifest: IntegrityManifest,
+): SkillInstallMeta {
+  const versionJsonPath = join(skillDir, VERSION_JSON_FILENAME);
+  const hasIntegrityEntry = skillId in integrityManifest;
+
+  if (existsSync(versionJsonPath)) {
+    let raw: Record<string, unknown>;
+    try {
+      raw = JSON.parse(readFileSync(versionJsonPath, "utf-8")) as Record<
+        string,
+        unknown
+      >;
+    } catch {
+      // Malformed version.json — treat as if it doesn't exist
+      return buildFallbackMeta(skillDir, skillId, hasIntegrityEntry);
+    }
+
+    // Case 1: skills.sh origin
+    if (raw.origin === "skills.sh") {
+      return {
+        origin: "skillssh",
+        installedAt:
+          typeof raw.installedAt === "string"
+            ? raw.installedAt
+            : getDirectoryMtime(skillDir),
+        sourceRepo: typeof raw.source === "string" ? raw.source : undefined,
+        slug: typeof raw.skillSlug === "string" ? raw.skillSlug : undefined,
+        contentHash: computeSkillHash(skillDir) ?? undefined,
+      };
+    }
+
+    // Case 2: has version but no origin field
+    if (typeof raw.version === "string" && !("origin" in raw)) {
+      return {
+        origin: hasIntegrityEntry ? "clawhub" : "vellum",
+        installedAt:
+          typeof raw.installedAt === "string"
+            ? raw.installedAt
+            : getDirectoryMtime(skillDir),
+        version: raw.version,
+        contentHash: computeSkillHash(skillDir) ?? undefined,
+      };
+    }
+
+    // Case 3: version.json exists but doesn't match known patterns
+    return {
+      origin: "custom",
+      installedAt:
+        typeof raw.installedAt === "string"
+          ? raw.installedAt
+          : getDirectoryMtime(skillDir),
+      contentHash: computeSkillHash(skillDir) ?? undefined,
+    };
+  }
+
+  // Case 4: no version.json
+  return buildFallbackMeta(skillDir, skillId, hasIntegrityEntry);
+}
+
+function buildFallbackMeta(
+  skillDir: string,
+  _skillId: string,
+  hasIntegrityEntry: boolean,
+): SkillInstallMeta {
+  return {
+    origin: hasIntegrityEntry ? "clawhub" : "custom",
+    installedAt: getDirectoryMtime(skillDir),
+    contentHash: computeSkillHash(skillDir) ?? undefined,
+  };
+}
+
+/**
+ * Get directory mtime as ISO 8601 string. Falls back to current time.
+ */
+function getDirectoryMtime(dir: string): string {
+  try {
+    return statSync(dir).mtime.toISOString();
+  } catch {
+    return new Date().toISOString();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Migration
+// ---------------------------------------------------------------------------
+
+export const backfillInstallMetaMigration: WorkspaceMigration = {
+  id: "026-backfill-install-meta",
+  description:
+    "Backfill install-meta.json with origin field for existing skill directories",
+
+  run(workspaceDir: string): void {
+    const skillsDir = join(workspaceDir, "skills");
+    if (!existsSync(skillsDir)) return;
+
+    // Load the integrity manifest once — shared across all skills
+    const integrityManifest = loadIntegrityManifest(skillsDir);
+
+    // Enumerate skill directories (each subdirectory containing a SKILL.md)
+    let entries: ReturnType<typeof readdirSync>;
+    try {
+      entries = readdirSync(skillsDir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+
+      const skillDir = join(skillsDir, entry.name);
+      const skillMdPath = join(skillDir, SKILL_MD_FILENAME);
+      const installMetaPath = join(skillDir, INSTALL_META_FILENAME);
+
+      // Only process directories that contain SKILL.md
+      if (!existsSync(skillMdPath)) continue;
+
+      // Skip if install-meta.json already exists (idempotency)
+      if (existsSync(installMetaPath)) continue;
+
+      const meta = inferInstallMeta(skillDir, entry.name, integrityManifest);
+
+      // installedBy is left undefined for all backfilled skills
+      writeInstallMeta(skillDir, meta);
+    }
+  },
+
+  down(workspaceDir: string): void {
+    const skillsDir = join(workspaceDir, "skills");
+    if (!existsSync(skillsDir)) return;
+
+    let entries: ReturnType<typeof readdirSync>;
+    try {
+      entries = readdirSync(skillsDir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+
+      const installMetaPath = join(
+        skillsDir,
+        entry.name,
+        INSTALL_META_FILENAME,
+      );
+      if (existsSync(installMetaPath)) {
+        try {
+          const meta = JSON.parse(
+            readFileSync(installMetaPath, "utf-8"),
+          ) as SkillInstallMeta;
+
+          // Only remove install-meta.json that were backfilled (no installedBy).
+          // If installedBy is present, the file was written by the new install
+          // flow and should be preserved.
+          if (meta.installedBy === undefined) {
+            unlinkSync(installMetaPath);
+          }
+        } catch {
+          // Malformed file — skip
+        }
+      }
+    }
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -22,6 +22,7 @@ import { moveHooksToWorkspaceMigration } from "./022-move-hooks-to-workspace.js"
 import { moveConfigFilesToWorkspaceMigration } from "./023-move-config-files-to-workspace.js";
 import { moveRuntimeFilesToWorkspaceMigration } from "./024-move-runtime-files-to-workspace.js";
 import { removeOauthAppSetupSkillsMigration } from "./025-remove-oauth-app-setup-skills.js";
+import { backfillInstallMetaMigration } from "./026-backfill-install-meta.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -55,4 +56,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   moveConfigFilesToWorkspaceMigration,
   moveRuntimeFilesToWorkspaceMigration,
   removeOauthAppSetupSkillsMigration,
+  backfillInstallMetaMigration,
 ];


### PR DESCRIPTION
## Summary
- Adds workspace migration 026 to scan existing skill directories and write install-meta.json
- Infers origin from legacy version.json and .integrity.json files (skillssh, vellum, clawhub, or custom)
- Computes contentHash for all backfilled skills; leaves installedBy undefined (no way to determine retroactively)
- Idempotent: skips skills that already have install-meta.json
- Preserves legacy version.json and .integrity.json files
- down() removes only backfilled install-meta.json files (those without installedBy)

Part of plan: skills-unify-install.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22894" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
