### PR TITLE
feat: all skill install paths write install-meta.json with origin and installedBy

### DIFF
--- a/assistant/src/__tests__/install-skill-routing.test.ts
+++ b/assistant/src/__tests__/install-skill-routing.test.ts
@@ -183,6 +183,7 @@ describe("installSkill routing", () => {
       "react-best-practices",
       true, // overwrite
       undefined, // ref
+      undefined, // contactId
     );
     // Should not have called clawhub
     expect(mockClawhubInstall).not.toHaveBeenCalled();
@@ -224,7 +225,8 @@ describe("installSkill routing", () => {
       "repo",
       "my-skill",
       true,
-      undefined,
+      undefined, // ref
+      undefined, // contactId
     );
     expect(mockClawhubInstall).not.toHaveBeenCalled();
   });

--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -496,9 +496,9 @@ describe("atomic write safety", () => {
     });
 
     const skillDir = join(TEST_DIR, "skills", "atomic-overwrite");
-    const files = readdirSync(skillDir);
-    // Only SKILL.md should exist — no .tmp-* leftover files
-    expect(files).toEqual(["SKILL.md"]);
+    const files = readdirSync(skillDir).sort();
+    // SKILL.md and install-meta.json should exist — no .tmp-* leftover files
+    expect(files).toEqual(["SKILL.md", "install-meta.json"]);
 
     const content = readFileSync(join(skillDir, "SKILL.md"), "utf-8");
     expect(content).toContain('name: "V2"');
@@ -649,7 +649,7 @@ describe("version metadata", () => {
     expect(readSkillVersion("no-version")).toBeNull();
   });
 
-  test("createManagedSkill writes version.json when version is provided", () => {
+  test("createManagedSkill writes install-meta.json when version is provided", () => {
     createManagedSkill({
       id: "versioned",
       name: "Versioned",
@@ -662,7 +662,7 @@ describe("version metadata", () => {
     expect(version).toBe("v1:abc123");
   });
 
-  test("version.json contains valid JSON with version and installedAt", () => {
+  test("install-meta.json contains valid JSON with origin, version, and installedAt", () => {
     createManagedSkill({
       id: "version-meta",
       name: "Meta",
@@ -671,16 +671,43 @@ describe("version metadata", () => {
       version: "v1:deadbeef",
     });
 
-    const metaPath = join(TEST_DIR, "skills", "version-meta", "version.json");
+    const metaPath = join(
+      TEST_DIR,
+      "skills",
+      "version-meta",
+      "install-meta.json",
+    );
     expect(existsSync(metaPath)).toBe(true);
     const meta = JSON.parse(readFileSync(metaPath, "utf-8"));
+    expect(meta.origin).toBe("custom");
     expect(meta.version).toBe("v1:deadbeef");
     expect(typeof meta.installedAt).toBe("string");
     // installedAt should be a valid ISO date
     expect(new Date(meta.installedAt).toISOString()).toBe(meta.installedAt);
   });
 
-  test("overwrite updates version.json", () => {
+  test("install-meta.json includes installedBy when contactId is provided", () => {
+    createManagedSkill({
+      id: "with-contact",
+      name: "With Contact",
+      description: "Has contactId",
+      bodyMarkdown: "Body.",
+      contactId: "contact-uuid-456",
+    });
+
+    const metaPath = join(
+      TEST_DIR,
+      "skills",
+      "with-contact",
+      "install-meta.json",
+    );
+    expect(existsSync(metaPath)).toBe(true);
+    const meta = JSON.parse(readFileSync(metaPath, "utf-8"));
+    expect(meta.origin).toBe("custom");
+    expect(meta.installedBy).toBe("contact-uuid-456");
+  });
+
+  test("overwrite updates install-meta.json", () => {
     createManagedSkill({
       id: "update-version",
       name: "V1",
@@ -701,21 +728,21 @@ describe("version metadata", () => {
     expect(readSkillVersion("update-version")).toBe("v1:second");
   });
 
-  test("readSkillVersion returns null for corrupted version.json", () => {
+  test("readSkillVersion returns null for corrupted install-meta.json", () => {
     createManagedSkill({
       id: "corrupt-version",
       name: "Corrupt",
-      description: "Will corrupt version file",
+      description: "Will corrupt meta file",
       bodyMarkdown: "Body.",
       version: "v1:valid",
     });
 
-    // Corrupt the version.json
+    // Corrupt the install-meta.json
     const metaPath = join(
       TEST_DIR,
       "skills",
       "corrupt-version",
-      "version.json",
+      "install-meta.json",
     );
     writeFileSync(metaPath, "{invalid json!!!", "utf-8");
 

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -550,7 +550,12 @@ function looksLikeSkillsShSlug(slug: string): boolean {
 }
 
 export async function installSkill(
-  spec: { slug: string; version?: string; origin?: "clawhub" | "skillssh" },
+  spec: {
+    slug: string;
+    version?: string;
+    origin?: "clawhub" | "skillssh";
+    contactId?: string;
+  },
   ctx: SkillOperationContext,
 ): Promise<{ success: true } | { success: false; error: string }> {
   try {
@@ -599,7 +604,12 @@ export async function installSkill(
       const vellumCatalog = await getCatalog();
       const catalogEntry = vellumCatalog.find((s) => s.id === spec.slug);
       if (catalogEntry) {
-        await installSkillLocally(spec.slug, catalogEntry, true);
+        await installSkillLocally(
+          spec.slug,
+          catalogEntry,
+          true,
+          spec.contactId,
+        );
 
         // Reload skill catalog so the newly installed skill is picked up
         loadSkillCatalog();
@@ -645,6 +655,7 @@ export async function installSkill(
         resolved.skillSlug,
         true /* overwrite */,
         resolved.ref ?? spec.version,
+        spec.contactId,
       );
 
       // Reload skill catalog so the newly installed skill is picked up
@@ -672,7 +683,10 @@ export async function installSkill(
     }
 
     // Install from clawhub (community)
-    const result = await clawhubInstall(spec.slug, { version: spec.version });
+    const result = await clawhubInstall(spec.slug, {
+      version: spec.version,
+      contactId: spec.contactId,
+    });
     if (!result.success) {
       return { success: false, error: result.error ?? "Unknown error" };
     }
@@ -1105,6 +1119,7 @@ export interface CreateSkillParams {
   emoji?: string;
   bodyMarkdown: string;
   overwrite?: boolean;
+  contactId?: string;
 }
 
 export async function createSkill(
@@ -1119,6 +1134,7 @@ export async function createSkill(
       emoji: params.emoji,
       bodyMarkdown: params.bodyMarkdown,
       overwrite: params.overwrite,
+      contactId: params.contactId,
     });
 
     if (!result.created) {

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -211,7 +211,7 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
       responseBody: z.object({
         ok: z.boolean(),
       }),
-      handler: async ({ req }) => {
+      handler: async ({ req, authContext }) => {
         const body = (await req.json()) as {
           slug?: string;
           url?: string;
@@ -227,8 +227,9 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
             400,
           );
         }
+        const contactId = authContext.actorPrincipalId ?? undefined;
         const result = await installSkill(
-          { slug, version: body.version, origin: body.origin },
+          { slug, version: body.version, origin: body.origin, contactId },
           ctx(),
         );
         if (!result.success) {
@@ -330,7 +331,7 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
       responseBody: z.object({
         ok: z.boolean(),
       }),
-      handler: async ({ req }) => {
+      handler: async ({ req, authContext }) => {
         const body = (await req.json()) as CreateSkillParams;
         if (
           !body.skillId ||
@@ -344,7 +345,8 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
             400,
           );
         }
-        const result = await createSkill(body, ctx());
+        const contactId = authContext.actorPrincipalId ?? undefined;
+        const result = await createSkill({ ...body, contactId }, ctx());
         if (!result.success) {
           return httpError("INTERNAL_ERROR", result.error, 500);
         }

--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -16,6 +16,7 @@ import { gunzipSync } from "node:zlib";
 import { getPlatformBaseUrl } from "../config/env.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceSkillsDir, readPlatformToken } from "../util/platform.js";
+import { computeSkillHash, writeInstallMeta } from "./install-meta.js";
 import { deleteSkillCapabilityMemory } from "./skill-memory.js";
 
 const log = getLogger("catalog-install");
@@ -270,6 +271,7 @@ export async function installSkillLocally(
   skillId: string,
   catalogEntry: CatalogSkill,
   overwrite: boolean,
+  contactId?: string,
 ): Promise<void> {
   const skillDir = join(getWorkspaceSkillsDir(), skillId);
   const skillFilePath = join(skillDir, "SKILL.md");
@@ -294,17 +296,14 @@ export async function installSkillLocally(
     await fetchAndExtractSkill(skillId, skillDir);
   }
 
-  // Write version metadata
-  if (catalogEntry.version) {
-    const meta = {
-      version: catalogEntry.version,
-      installedAt: new Date().toISOString(),
-    };
-    atomicWriteFile(
-      join(skillDir, "version.json"),
-      JSON.stringify(meta, null, 2) + "\n",
-    );
-  }
+  // Write install metadata
+  writeInstallMeta(skillDir, {
+    origin: "vellum",
+    installedAt: new Date().toISOString(),
+    ...(catalogEntry.version ? { version: catalogEntry.version } : {}),
+    ...(contactId ? { installedBy: contactId } : {}),
+    contentHash: computeSkillHash(skillDir) ?? undefined,
+  });
 
   // Install npm dependencies if the skill has a package.json
   if (existsSync(join(skillDir, "package.json"))) {

--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -3,7 +3,11 @@ import { dirname, join } from "node:path";
 
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceSkillsDir } from "../util/platform.js";
-import { computeSkillHash } from "./install-meta.js";
+import {
+  computeSkillHash,
+  readInstallMeta,
+  writeInstallMeta,
+} from "./install-meta.js";
 
 const log = getLogger("clawhub");
 
@@ -61,6 +65,10 @@ function saveIntegrityManifest(manifest: IntegrityManifest): void {
  * Record or verify the content hash of an installed skill.
  * On first install: stores the hash (trust-on-first-use).
  * On subsequent installs: compares with stored hash and warns on mismatch.
+ *
+ * Reads/writes `contentHash` from `install-meta.json` when available,
+ * falling back to the legacy `.integrity.json` manifest for skills that
+ * haven't been migrated yet.
  */
 export function verifyAndRecordSkillHash(slug: string): void {
   const skillDir = join(getManagedSkillsDir(), slug);
@@ -70,17 +78,28 @@ export function verifyAndRecordSkillHash(slug: string): void {
     return;
   }
 
-  const manifest = loadIntegrityManifest();
-  const existing = manifest[slug];
+  // Try install-meta.json first for stored hash
+  const installMeta = readInstallMeta(skillDir);
+  let storedHash: string | undefined;
 
-  if (existing) {
-    const storedHash = existing.sha256;
+  if (installMeta?.contentHash) {
+    storedHash = installMeta.contentHash;
+  } else {
+    // Fall back to legacy .integrity.json manifest
+    const manifest = loadIntegrityManifest();
+    const existing = manifest[slug];
+    if (existing) {
+      storedHash =
+        typeof existing.sha256 === "string" ? existing.sha256 : undefined;
+    }
+  }
 
-    // Guard against corrupted manifest entries where sha256 is not a string
+  if (storedHash) {
+    // Guard against corrupted entries where hash is not a string
     if (typeof storedHash !== "string") {
       log.warn(
         { slug },
-        "Integrity manifest entry has non-string sha256 — re-recording hash",
+        "Stored hash has non-string value — re-recording hash",
       );
     } else if (!storedHash.startsWith("v2:")) {
       // Unknown format (not v2: prefix) — warn about integrity mismatch
@@ -107,9 +126,14 @@ export function verifyAndRecordSkillHash(slug: string): void {
     );
   }
 
-  // Always store the latest hash
-  manifest[slug] = { sha256: hash, installedAt: new Date().toISOString() };
-  saveIntegrityManifest(manifest);
+  // Write to install-meta.json if it exists (preferred), otherwise legacy manifest
+  if (installMeta) {
+    writeInstallMeta(skillDir, { ...installMeta, contentHash: hash });
+  } else {
+    const manifest = loadIntegrityManifest();
+    manifest[slug] = { sha256: hash, installedAt: new Date().toISOString() };
+    saveIntegrityManifest(manifest);
+  }
 }
 
 interface ClawhubInstallResult {
@@ -200,7 +224,7 @@ async function runClawhub(
 
 export async function clawhubInstall(
   slug: string,
-  opts?: { version?: string },
+  opts?: { version?: string; contactId?: string },
 ): Promise<ClawhubInstallResult> {
   if (!validateSlug(slug)) {
     return { success: false, error: `Invalid skill slug: ${slug}` };
@@ -216,6 +240,17 @@ export async function clawhubInstall(
         result.stderr.trim() || result.stdout.trim() || "Unknown error";
       return { success: false, error };
     }
+
+    // Write install-meta.json for the installed skill
+    const skillDir = join(getManagedSkillsDir(), slug);
+    writeInstallMeta(skillDir, {
+      origin: "clawhub",
+      slug,
+      installedAt: new Date().toISOString(),
+      ...(opts?.contactId ? { installedBy: opts.contactId } : {}),
+      contentHash: computeSkillHash(skillDir) ?? undefined,
+    });
+
     verifyAndRecordSkillHash(slug);
     return { success: true, skillName: slug };
   } catch (err) {

--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -13,6 +13,7 @@ import { stringify as stringifyYaml } from "yaml";
 
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceSkillsDir } from "../util/platform.js";
+import { writeInstallMeta } from "./install-meta.js";
 import { deleteSkillCapabilityMemory } from "./skill-memory.js";
 
 const log = getLogger("managed-store");
@@ -165,15 +166,20 @@ function getVersionMetaPath(id: string): string {
   return join(getManagedSkillDir(id), "version.json");
 }
 
-function writeVersionMeta(id: string, version: string): void {
-  const meta: SkillVersionMeta = {
-    version,
-    installedAt: new Date().toISOString(),
-  };
-  atomicWriteFile(getVersionMetaPath(id), JSON.stringify(meta, null, 2) + "\n");
-}
-
 export function readSkillVersion(id: string): string | null {
+  // Try install-meta.json first (new format)
+  const installMetaPath = join(getManagedSkillDir(id), "install-meta.json");
+  if (existsSync(installMetaPath)) {
+    try {
+      const raw = readFileSync(installMetaPath, "utf-8");
+      const meta = JSON.parse(raw) as { version?: string };
+      if (meta.version) return meta.version;
+    } catch {
+      // Fall through to legacy path
+    }
+  }
+
+  // Fall back to legacy version.json
   const metaPath = getVersionMetaPath(id);
   if (!existsSync(metaPath)) return null;
   try {
@@ -197,6 +203,7 @@ interface CreateManagedSkillParams {
   addToIndex?: boolean;
   includes?: string[];
   version?: string;
+  contactId?: string;
 }
 
 interface CreateManagedSkillResult {
@@ -259,10 +266,16 @@ export function createManagedSkill(
   mkdirSync(skillDir, { recursive: true });
   atomicWriteFile(skillFilePath, content);
 
-  if (params.version) {
-    writeVersionMeta(params.id, params.version);
-  } else {
-    // Remove stale version metadata when overwriting without a version
+  // Write install metadata
+  writeInstallMeta(skillDir, {
+    origin: "custom",
+    installedAt: new Date().toISOString(),
+    ...(params.version ? { version: params.version } : {}),
+    ...(params.contactId ? { installedBy: params.contactId } : {}),
+  });
+
+  // Clean up legacy version.json if present (superseded by install-meta.json)
+  if (!params.version) {
     const metaPath = getVersionMetaPath(params.id);
     if (existsSync(metaPath)) {
       rmSync(metaPath);

--- a/assistant/src/skills/skillssh-registry.ts
+++ b/assistant/src/skills/skillssh-registry.ts
@@ -5,6 +5,7 @@ import { dirname, join, resolve, sep } from "node:path";
 
 import { getWorkspaceSkillsDir } from "../util/platform.js";
 import { upsertSkillsIndex } from "./catalog-install.js";
+import { computeSkillHash, writeInstallMeta } from "./install-meta.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -434,7 +435,7 @@ export function validateSkillSlug(slug: string): void {
  * 1. Validates the skill slug for path safety
  * 2. Fetches all files from `skills/<skillSlug>/` in the source repo
  * 3. Writes them to `<workspace>/skills/<skillSlug>/` with path traversal protection
- * 4. Writes `version.json` with origin metadata
+ * 4. Writes `install-meta.json` with origin metadata
  * 5. Runs `bun install` if a `package.json` is present
  * 6. Registers the skill in SKILLS.md only after all steps succeed
  */
@@ -444,6 +445,7 @@ export async function installExternalSkill(
   skillSlug: string,
   overwrite: boolean,
   ref?: string,
+  contactId?: string,
 ): Promise<void> {
   // Validate slug before using in filesystem paths
   validateSkillSlug(skillSlug);
@@ -480,18 +482,15 @@ export async function installExternalSkill(
     writeFileSync(destPath, content, "utf-8");
   }
 
-  // Write origin metadata
-  const meta = {
-    origin: "skills.sh",
-    source: `${owner}/${repo}`,
-    skillSlug,
+  // Write install metadata
+  writeInstallMeta(skillDir, {
+    origin: "skillssh",
+    slug: skillSlug,
+    sourceRepo: `${owner}/${repo}`,
     installedAt: new Date().toISOString(),
-  };
-  writeFileSync(
-    join(skillDir, "version.json"),
-    JSON.stringify(meta, null, 2) + "\n",
-    "utf-8",
-  );
+    ...(contactId ? { installedBy: contactId } : {}),
+    contentHash: computeSkillHash(skillDir) ?? undefined,
+  });
 
   // Install npm dependencies if the skill ships a package.json
   if (existsSync(join(skillDir, "package.json"))) {


### PR DESCRIPTION
## Summary
- Updates all 4 install paths (catalog, skillssh, clawhub, custom) to write install-meta.json
- Threads contactId through install flow for installedBy tracking
- Updates hash verification to use install-meta.json with .integrity.json fallback

Part of plan: skills-unify-install.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22895" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
