### PR TITLE
perf(macos): add equatable chat button firewall for message-list VButtons

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -1022,13 +1022,22 @@ private struct StepDetailRow: View {
             )
 
             ChatEquatableButton(
-                label: copyLabel,
-                iconOnly: VIcon.copy.rawValue,
-                iconColorRole: .contentTertiary
+                config: ChatButtonConfig(
+                    label: copyLabel,
+                    iconOnly: VIcon.copy.rawValue,
+                    style: .ghost,
+                    size: .regular,
+                    iconSize: 24,
+                    iconColorRole: .contentTertiary,
+                    tooltip: nil,
+                    isDisabled: false,
+                    closureIdentity: copyText.hashValue
+                )
             ) {
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString(copyText, forType: .string)
             }
+            .equatable()
             .padding(VSpacing.xs)
         }
     }

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -1021,7 +1021,11 @@ private struct StepDetailRow: View {
                     .stroke(VColor.borderBase, lineWidth: 0.5)
             )
 
-            VButton(label: copyLabel, iconOnly: VIcon.copy.rawValue, style: .ghost, iconSize: 24, iconColor: VColor.contentTertiary) {
+            ChatEquatableButton(
+                label: copyLabel,
+                iconOnly: VIcon.copy.rawValue,
+                iconColorRole: .contentTertiary
+            ) {
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString(copyText, forType: .string)
             }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -449,7 +449,7 @@ struct ChatBubble: View, Equatable {
             Text("Failed to send")
                 .font(VFont.labelDefault)
                 .foregroundStyle(VColor.systemNegativeStrong)
-            VButton(label: "Retry", style: .ghost, size: .inline) {
+            ChatEquatableButton(textLabel: "Retry", style: .ghost, size: .inline) {
                 onRetryFailedMessage?(message.id)
             }
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -452,6 +452,7 @@ struct ChatBubble: View, Equatable {
             ChatEquatableButton(textLabel: "Retry", style: .ghost, size: .inline) {
                 onRetryFailedMessage?(message.id)
             }
+            .equatable()
         }
         .textSelection(.disabled)
     }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleOverflowMenu.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleOverflowMenu.swift
@@ -99,6 +99,10 @@ struct ChatBubbleOverflowMenu: View {
 
     // MARK: - Body
 
+    // The opacity approach constructs buttons even when hidden, but the
+    // ChatEquatableButton firewall prevents body re-evaluation during
+    // unrelated parent cascades. This preserves the fade animation while
+    // eliminating the primary performance cost (repeated VButton body work).
     var body: some View {
         if hasOverflowActions {
             menuContent
@@ -114,12 +118,10 @@ struct ChatBubbleOverflowMenu: View {
                 .foregroundStyle(VColor.contentTertiary)
                 .help(detailedTimestamp)
             if hasCopyableText {
-                VButton(
+                ChatEquatableButton(
                     label: showCopyConfirmation ? "Copied" : "Copy message",
                     iconOnly: (showCopyConfirmation ? VIcon.check : VIcon.copy).rawValue,
-                    style: .ghost,
-                    iconSize: 24,
-                    iconColor: showCopyConfirmation ? VColor.systemPositiveStrong : VColor.contentTertiary
+                    iconColorRole: showCopyConfirmation ? .systemPositiveStrong : .contentTertiary
                 ) {
                     copyMessageText()
                 }
@@ -130,24 +132,18 @@ struct ChatBubbleOverflowMenu: View {
                 ttsButton
             }
             if let onForkFromMessage, let daemonMessageId = message.daemonMessageId, !message.isStreaming {
-                VButton(
+                ChatEquatableButton(
                     label: "Fork from here",
-                    iconOnly: VIcon.gitBranch.rawValue,
-                    style: .ghost,
-                    iconSize: 24,
-                    iconColor: VColor.contentTertiary
+                    iconOnly: VIcon.gitBranch.rawValue
                 ) {
                     onForkFromMessage(daemonMessageId)
                 }
                 .vTooltip("Fork from here", edge: .bottom)
             }
             if showInspectButton, !isUser, let daemonMsgId = message.daemonMessageId {
-                VButton(
+                ChatEquatableButton(
                     label: "Inspect LLM context",
-                    iconOnly: VIcon.fileCode.rawValue,
-                    style: .ghost,
-                    iconSize: 24,
-                    iconColor: VColor.contentTertiary
+                    iconOnly: VIcon.fileCode.rawValue
                 ) {
                     onInspectMessage?(daemonMsgId)
                 }
@@ -179,12 +175,10 @@ struct ChatBubbleOverflowMenu: View {
                 .frame(width: 24, height: 24)
                 .tint(VColor.contentTertiary)
         } else if audioPlayer.isPlaying {
-            VButton(
+            ChatEquatableButton(
                 label: "Stop audio",
                 iconOnly: VIcon.square.rawValue,
-                style: .ghost,
-                iconSize: 24,
-                iconColor: VColor.systemPositiveStrong
+                iconColorRole: .systemPositiveStrong
             ) {
                 audioPlayer.stop()
             }
@@ -195,12 +189,10 @@ struct ChatBubbleOverflowMenu: View {
 
     @ViewBuilder
     private func ttsIdleButton(daemonMessageId: String) -> some View {
-        let button = VButton(
+        let button = ChatEquatableButton(
             label: "Play as audio",
             iconOnly: VIcon.volume2.rawValue,
-            style: .ghost,
-            iconSize: 24,
-            iconColor: audioPlayer.error != nil ? VColor.systemNegativeStrong : VColor.contentTertiary
+            iconColorRole: audioPlayer.error != nil ? .systemNegativeStrong : .contentTertiary
         ) {
             Task {
                 await audioPlayer.playMessage(

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleOverflowMenu.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleOverflowMenu.swift
@@ -125,6 +125,7 @@ struct ChatBubbleOverflowMenu: View {
                 ) {
                     copyMessageText()
                 }
+                .equatable()
                 .vTooltip(showCopyConfirmation ? "Copied" : "Copy", edge: .bottom)
                 .animation(VAnimation.fast, value: showCopyConfirmation)
             }
@@ -138,6 +139,7 @@ struct ChatBubbleOverflowMenu: View {
                 ) {
                     onForkFromMessage(daemonMessageId)
                 }
+                .equatable()
                 .vTooltip("Fork from here", edge: .bottom)
             }
             if showInspectButton, !isUser, let daemonMsgId = message.daemonMessageId {
@@ -147,6 +149,7 @@ struct ChatBubbleOverflowMenu: View {
                 ) {
                     onInspectMessage?(daemonMsgId)
                 }
+                .equatable()
                 .vTooltip("Inspect", edge: .bottom)
             }
         }
@@ -182,6 +185,7 @@ struct ChatBubbleOverflowMenu: View {
             ) {
                 audioPlayer.stop()
             }
+            .equatable()
         } else if let daemonMessageId = message.daemonMessageId {
             ttsIdleButton(daemonMessageId: daemonMessageId)
         }
@@ -207,14 +211,17 @@ struct ChatBubbleOverflowMenu: View {
 
         if audioPlayer.isNotConfigured {
             button
+                .equatable()
                 .popover(isPresented: $showTTSSetupPopover, arrowEdge: .bottom) {
                     ttsSetupPopoverContent
                 }
         } else if audioPlayer.isFeatureDisabled {
             button
+                .equatable()
                 .vTooltip("Text-to-speech is not enabled", edge: .bottom)
         } else {
             button
+                .equatable()
                 .vTooltip("Read aloud", edge: .bottom)
         }
     }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatButtonFirewall.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatButtonFirewall.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+import VellumAssistantShared
+
+// MARK: - Color Role
+
+/// Equatable token-to-color mapping for chat-only button tones.
+/// Using an enum instead of raw `Color` makes the intent explicit at call sites
+/// and avoids comparing resolved color values that might differ across appearances.
+enum ChatButtonColorRole: Equatable, Hashable {
+    case contentTertiary
+    case systemPositiveStrong
+    case systemNegativeStrong
+
+    var resolved: Color {
+        switch self {
+        case .contentTertiary: VColor.contentTertiary
+        case .systemPositiveStrong: VColor.systemPositiveStrong
+        case .systemNegativeStrong: VColor.systemNegativeStrong
+        }
+    }
+}
+
+// MARK: - Config
+
+/// Equatable config surface for a chat button's render identity.
+/// Captures every VButton property that affects visual output in the chat
+/// message-list path. Closures are intentionally excluded so that SwiftUI
+/// can skip body re-evaluation when only the closure reference changes.
+struct ChatButtonConfig: Equatable {
+    let label: String
+    let iconOnly: String?
+    let style: VButton.Style
+    let size: VButton.Size
+    let iconSize: CGFloat?
+    let iconColorRole: ChatButtonColorRole?
+    let tooltip: String?
+    let isDisabled: Bool
+}
+
+// MARK: - Equatable Button
+
+/// Chat-local `View, Equatable` wrapper that renders a `VButton` from
+/// `ChatButtonConfig` and compares only render-relevant config, ignoring
+/// closure identity. This prevents unnecessary VButton body evaluations
+/// when unrelated parent views invalidate.
+struct ChatEquatableButton: View, Equatable {
+    let config: ChatButtonConfig
+    let action: () -> Void
+
+    static func == (lhs: ChatEquatableButton, rhs: ChatEquatableButton) -> Bool {
+        lhs.config == rhs.config
+    }
+
+    var body: some View {
+        VButton(
+            label: config.label,
+            iconOnly: config.iconOnly,
+            style: config.style,
+            size: config.size,
+            isDisabled: config.isDisabled,
+            iconSize: config.iconSize,
+            tooltip: config.tooltip,
+            iconColor: config.iconColorRole?.resolved,
+            action: action
+        )
+    }
+}
+
+// MARK: - Convenience Initializers
+
+extension ChatEquatableButton {
+    /// Icon-only button used by the overflow menu (copy, TTS, fork, inspect).
+    init(
+        label: String,
+        iconOnly: String,
+        iconColorRole: ChatButtonColorRole = .contentTertiary,
+        iconSize: CGFloat = 24,
+        action: @escaping () -> Void
+    ) {
+        self.config = ChatButtonConfig(
+            label: label,
+            iconOnly: iconOnly,
+            style: .ghost,
+            size: .regular,
+            iconSize: iconSize,
+            iconColorRole: iconColorRole,
+            tooltip: nil,
+            isDisabled: false
+        )
+        self.action = action
+    }
+
+    /// Inline text button used by sendFailedIndicator retry.
+    /// Uses `textLabel` to disambiguate from the icon-only initializer.
+    init(
+        textLabel: String,
+        style: VButton.Style,
+        size: VButton.Size,
+        action: @escaping () -> Void
+    ) {
+        self.config = ChatButtonConfig(
+            label: textLabel,
+            iconOnly: nil,
+            style: style,
+            size: size,
+            iconSize: nil,
+            iconColorRole: nil,
+            tooltip: nil,
+            isDisabled: false
+        )
+        self.action = action
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/ChatButtonFirewall.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatButtonFirewall.swift
@@ -26,6 +26,10 @@ enum ChatButtonColorRole: Equatable, Hashable {
 /// Captures every VButton property that affects visual output in the chat
 /// message-list path. Closures are intentionally excluded so that SwiftUI
 /// can skip body re-evaluation when only the closure reference changes.
+///
+/// When a closure captures mutable state (e.g. streaming `copyText`),
+/// set `closureIdentity` to a value that changes alongside the captured
+/// state so the firewall re-evaluates and picks up the fresh closure.
 struct ChatButtonConfig: Equatable {
     let label: String
     let iconOnly: String?
@@ -35,6 +39,10 @@ struct ChatButtonConfig: Equatable {
     let iconColorRole: ChatButtonColorRole?
     let tooltip: String?
     let isDisabled: Bool
+    /// Opaque identity for the closure's captured state. When this changes,
+    /// the firewall treats the button as different, forcing a body re-evaluation
+    /// that picks up the new closure. Defaults to 0 (stable).
+    var closureIdentity: Int = 0
 }
 
 // MARK: - Equatable Button

--- a/clients/macos/vellum-assistantTests/ChatBubbleOverflowMenuModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatBubbleOverflowMenuModelTests.swift
@@ -1,0 +1,147 @@
+import Testing
+import SwiftUI
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+// MARK: - Overflow Menu Decision Logic
+
+/// Tests for the decision logic that drives `ChatBubbleOverflowMenu`.
+/// These validate the computed properties (`hasOverflowActions`, `showOverflowMenu`)
+/// using a lightweight model struct to avoid constructing full `ChatMessage` instances.
+
+/// Mirror of the overflow menu's decision inputs, decoupled from ChatMessage.
+private struct OverflowMenuDecision: Equatable {
+    let hasCopyableText: Bool
+    let canInspectMessage: Bool
+    let canForkFromMessage: Bool
+    let isStreaming: Bool
+    let isHovered: Bool
+    let showCopyConfirmation: Bool
+    let audioIsPlaying: Bool
+    let audioIsLoading: Bool
+    let showTTSSetupPopover: Bool
+
+    var hasOverflowActions: Bool {
+        hasCopyableText || canInspectMessage || canForkFromMessage
+    }
+
+    var showOverflowMenu: Bool {
+        hasOverflowActions && !isStreaming && (isHovered || showCopyConfirmation || audioIsPlaying || audioIsLoading || showTTSSetupPopover)
+    }
+}
+
+@Suite("ChatBubbleOverflowMenu — hasOverflowActions")
+struct OverflowMenuHasActionsTests {
+
+    @Test func trueWhenCopyable() {
+        let decision = OverflowMenuDecision(
+            hasCopyableText: true, canInspectMessage: false, canForkFromMessage: false,
+            isStreaming: false, isHovered: false, showCopyConfirmation: false,
+            audioIsPlaying: false, audioIsLoading: false, showTTSSetupPopover: false
+        )
+        #expect(decision.hasOverflowActions)
+    }
+
+    @Test func trueWhenCanInspect() {
+        let decision = OverflowMenuDecision(
+            hasCopyableText: false, canInspectMessage: true, canForkFromMessage: false,
+            isStreaming: false, isHovered: false, showCopyConfirmation: false,
+            audioIsPlaying: false, audioIsLoading: false, showTTSSetupPopover: false
+        )
+        #expect(decision.hasOverflowActions)
+    }
+
+    @Test func trueWhenCanFork() {
+        let decision = OverflowMenuDecision(
+            hasCopyableText: false, canInspectMessage: false, canForkFromMessage: true,
+            isStreaming: false, isHovered: false, showCopyConfirmation: false,
+            audioIsPlaying: false, audioIsLoading: false, showTTSSetupPopover: false
+        )
+        #expect(decision.hasOverflowActions)
+    }
+
+    @Test func falseWhenNoneAvailable() {
+        let decision = OverflowMenuDecision(
+            hasCopyableText: false, canInspectMessage: false, canForkFromMessage: false,
+            isStreaming: false, isHovered: false, showCopyConfirmation: false,
+            audioIsPlaying: false, audioIsLoading: false, showTTSSetupPopover: false
+        )
+        #expect(!decision.hasOverflowActions)
+    }
+}
+
+@Suite("ChatBubbleOverflowMenu — showOverflowMenu")
+struct OverflowMenuVisibilityTests {
+
+    @Test func shownOnHover() {
+        let decision = OverflowMenuDecision(
+            hasCopyableText: true, canInspectMessage: false, canForkFromMessage: false,
+            isStreaming: false, isHovered: true, showCopyConfirmation: false,
+            audioIsPlaying: false, audioIsLoading: false, showTTSSetupPopover: false
+        )
+        #expect(decision.showOverflowMenu)
+    }
+
+    @Test func shownDuringCopyConfirmation() {
+        let decision = OverflowMenuDecision(
+            hasCopyableText: true, canInspectMessage: false, canForkFromMessage: false,
+            isStreaming: false, isHovered: false, showCopyConfirmation: true,
+            audioIsPlaying: false, audioIsLoading: false, showTTSSetupPopover: false
+        )
+        #expect(decision.showOverflowMenu)
+    }
+
+    @Test func shownDuringAudioPlayback() {
+        let decision = OverflowMenuDecision(
+            hasCopyableText: true, canInspectMessage: false, canForkFromMessage: false,
+            isStreaming: false, isHovered: false, showCopyConfirmation: false,
+            audioIsPlaying: true, audioIsLoading: false, showTTSSetupPopover: false
+        )
+        #expect(decision.showOverflowMenu)
+    }
+
+    @Test func shownDuringAudioLoading() {
+        let decision = OverflowMenuDecision(
+            hasCopyableText: true, canInspectMessage: false, canForkFromMessage: false,
+            isStreaming: false, isHovered: false, showCopyConfirmation: false,
+            audioIsPlaying: false, audioIsLoading: true, showTTSSetupPopover: false
+        )
+        #expect(decision.showOverflowMenu)
+    }
+
+    @Test func shownDuringTTSSetupPopover() {
+        let decision = OverflowMenuDecision(
+            hasCopyableText: true, canInspectMessage: false, canForkFromMessage: false,
+            isStreaming: false, isHovered: false, showCopyConfirmation: false,
+            audioIsPlaying: false, audioIsLoading: false, showTTSSetupPopover: true
+        )
+        #expect(decision.showOverflowMenu)
+    }
+
+    @Test func hiddenWhenStreaming() {
+        let decision = OverflowMenuDecision(
+            hasCopyableText: true, canInspectMessage: false, canForkFromMessage: false,
+            isStreaming: true, isHovered: true, showCopyConfirmation: false,
+            audioIsPlaying: false, audioIsLoading: false, showTTSSetupPopover: false
+        )
+        #expect(!decision.showOverflowMenu)
+    }
+
+    @Test func hiddenWhenNoActions() {
+        let decision = OverflowMenuDecision(
+            hasCopyableText: false, canInspectMessage: false, canForkFromMessage: false,
+            isStreaming: false, isHovered: true, showCopyConfirmation: false,
+            audioIsPlaying: false, audioIsLoading: false, showTTSSetupPopover: false
+        )
+        #expect(!decision.showOverflowMenu)
+    }
+
+    @Test func hiddenWhenNoVisibilityTrigger() {
+        let decision = OverflowMenuDecision(
+            hasCopyableText: true, canInspectMessage: false, canForkFromMessage: false,
+            isStreaming: false, isHovered: false, showCopyConfirmation: false,
+            audioIsPlaying: false, audioIsLoading: false, showTTSSetupPopover: false
+        )
+        #expect(!decision.showOverflowMenu)
+    }
+}

--- a/clients/macos/vellum-assistantTests/ChatButtonFirewallTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatButtonFirewallTests.swift
@@ -315,4 +315,57 @@ struct OutputCopyConfigTests {
         )
         #expect(a == b)
     }
+
+    @Test func differentClosureIdentityForcesReevaluation() {
+        let a = ChatButtonConfig(
+            label: "Copy live output",
+            iconOnly: VIcon.copy.rawValue,
+            style: .ghost,
+            size: .regular,
+            iconSize: 24,
+            iconColorRole: .contentTertiary,
+            tooltip: nil,
+            isDisabled: false,
+            closureIdentity: "partial output".hashValue
+        )
+        let b = ChatButtonConfig(
+            label: "Copy live output",
+            iconOnly: VIcon.copy.rawValue,
+            style: .ghost,
+            size: .regular,
+            iconSize: 24,
+            iconColorRole: .contentTertiary,
+            tooltip: nil,
+            isDisabled: false,
+            closureIdentity: "partial output extended".hashValue
+        )
+        #expect(a != b)
+    }
+
+    @Test func sameClosureIdentityStaysEqual() {
+        let text = "some output"
+        let a = ChatButtonConfig(
+            label: "Copy live output",
+            iconOnly: VIcon.copy.rawValue,
+            style: .ghost,
+            size: .regular,
+            iconSize: 24,
+            iconColorRole: .contentTertiary,
+            tooltip: nil,
+            isDisabled: false,
+            closureIdentity: text.hashValue
+        )
+        let b = ChatButtonConfig(
+            label: "Copy live output",
+            iconOnly: VIcon.copy.rawValue,
+            style: .ghost,
+            size: .regular,
+            iconSize: 24,
+            iconColorRole: .contentTertiary,
+            tooltip: nil,
+            isDisabled: false,
+            closureIdentity: text.hashValue
+        )
+        #expect(a == b)
+    }
 }

--- a/clients/macos/vellum-assistantTests/ChatButtonFirewallTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatButtonFirewallTests.swift
@@ -1,0 +1,318 @@
+import Testing
+import SwiftUI
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+// MARK: - ChatButtonConfig Equality
+
+@Suite("ChatButtonConfig — Equality semantics")
+struct ChatButtonConfigEqualityTests {
+
+    private static let baseConfig = ChatButtonConfig(
+        label: "Copy message",
+        iconOnly: VIcon.copy.rawValue,
+        style: .ghost,
+        size: .regular,
+        iconSize: 24,
+        iconColorRole: .contentTertiary,
+        tooltip: nil,
+        isDisabled: false
+    )
+
+    @Test func identicalConfigsAreEqual() {
+        let a = Self.baseConfig
+        let b = Self.baseConfig
+        #expect(a == b)
+    }
+
+    @Test func differentLabelMakesUnequal() {
+        let a = Self.baseConfig
+        let b = ChatButtonConfig(
+            label: "Copied",
+            iconOnly: VIcon.copy.rawValue,
+            style: .ghost,
+            size: .regular,
+            iconSize: 24,
+            iconColorRole: .contentTertiary,
+            tooltip: nil,
+            isDisabled: false
+        )
+        #expect(a != b)
+    }
+
+    @Test func differentIconMakesUnequal() {
+        let a = Self.baseConfig
+        let b = ChatButtonConfig(
+            label: "Copy message",
+            iconOnly: VIcon.check.rawValue,
+            style: .ghost,
+            size: .regular,
+            iconSize: 24,
+            iconColorRole: .contentTertiary,
+            tooltip: nil,
+            isDisabled: false
+        )
+        #expect(a != b)
+    }
+
+    @Test func differentColorRoleMakesUnequal() {
+        let a = Self.baseConfig
+        let b = ChatButtonConfig(
+            label: "Copy message",
+            iconOnly: VIcon.copy.rawValue,
+            style: .ghost,
+            size: .regular,
+            iconSize: 24,
+            iconColorRole: .systemPositiveStrong,
+            tooltip: nil,
+            isDisabled: false
+        )
+        #expect(a != b)
+    }
+
+    @Test func differentStyleMakesUnequal() {
+        let a = Self.baseConfig
+        let b = ChatButtonConfig(
+            label: "Copy message",
+            iconOnly: VIcon.copy.rawValue,
+            style: .primary,
+            size: .regular,
+            iconSize: 24,
+            iconColorRole: .contentTertiary,
+            tooltip: nil,
+            isDisabled: false
+        )
+        #expect(a != b)
+    }
+
+    @Test func differentSizeMakesUnequal() {
+        let a = Self.baseConfig
+        let b = ChatButtonConfig(
+            label: "Copy message",
+            iconOnly: VIcon.copy.rawValue,
+            style: .ghost,
+            size: .inline,
+            iconSize: 24,
+            iconColorRole: .contentTertiary,
+            tooltip: nil,
+            isDisabled: false
+        )
+        #expect(a != b)
+    }
+
+    @Test func differentIconSizeMakesUnequal() {
+        let a = Self.baseConfig
+        let b = ChatButtonConfig(
+            label: "Copy message",
+            iconOnly: VIcon.copy.rawValue,
+            style: .ghost,
+            size: .regular,
+            iconSize: 16,
+            iconColorRole: .contentTertiary,
+            tooltip: nil,
+            isDisabled: false
+        )
+        #expect(a != b)
+    }
+
+    @Test func nilVsNonNilIconSizeMakesUnequal() {
+        let a = Self.baseConfig
+        let b = ChatButtonConfig(
+            label: "Copy message",
+            iconOnly: VIcon.copy.rawValue,
+            style: .ghost,
+            size: .regular,
+            iconSize: nil,
+            iconColorRole: .contentTertiary,
+            tooltip: nil,
+            isDisabled: false
+        )
+        #expect(a != b)
+    }
+
+    @Test func differentDisabledStateMakesUnequal() {
+        let a = Self.baseConfig
+        let b = ChatButtonConfig(
+            label: "Copy message",
+            iconOnly: VIcon.copy.rawValue,
+            style: .ghost,
+            size: .regular,
+            iconSize: 24,
+            iconColorRole: .contentTertiary,
+            tooltip: nil,
+            isDisabled: true
+        )
+        #expect(a != b)
+    }
+
+    @Test func differentTooltipMakesUnequal() {
+        let a = Self.baseConfig
+        let b = ChatButtonConfig(
+            label: "Copy message",
+            iconOnly: VIcon.copy.rawValue,
+            style: .ghost,
+            size: .regular,
+            iconSize: 24,
+            iconColorRole: .contentTertiary,
+            tooltip: "Copy",
+            isDisabled: false
+        )
+        #expect(a != b)
+    }
+}
+
+// MARK: - ChatButtonColorRole
+
+@Suite("ChatButtonColorRole — Token resolution")
+struct ChatButtonColorRoleTests {
+
+    @Test func contentTertiaryResolvesCorrectly() {
+        #expect(ChatButtonColorRole.contentTertiary.resolved == VColor.contentTertiary)
+    }
+
+    @Test func systemPositiveStrongResolvesCorrectly() {
+        #expect(ChatButtonColorRole.systemPositiveStrong.resolved == VColor.systemPositiveStrong)
+    }
+
+    @Test func systemNegativeStrongResolvesCorrectly() {
+        #expect(ChatButtonColorRole.systemNegativeStrong.resolved == VColor.systemNegativeStrong)
+    }
+}
+
+// MARK: - ChatEquatableButton Equality
+
+@Suite("ChatEquatableButton — Closure-agnostic equality")
+struct ChatEquatableButtonEqualityTests {
+
+    @Test func sameConfigDifferentClosuresAreEqual() {
+        let a = ChatEquatableButton(label: "Copy", iconOnly: VIcon.copy.rawValue) { }
+        let b = ChatEquatableButton(label: "Copy", iconOnly: VIcon.copy.rawValue) { print("different") }
+        #expect(a == b)
+    }
+
+    @Test func differentConfigSameClosureAreUnequal() {
+        let closure: () -> Void = {}
+        let a = ChatEquatableButton(label: "Copy", iconOnly: VIcon.copy.rawValue, action: closure)
+        let b = ChatEquatableButton(
+            label: "Copied",
+            iconOnly: VIcon.check.rawValue,
+            iconColorRole: .systemPositiveStrong,
+            action: closure
+        )
+        #expect(a != b)
+    }
+}
+
+// MARK: - Copy Button Toggle
+
+@Suite("ChatButtonConfig — Copy button state transitions")
+struct CopyButtonConfigTests {
+
+    @Test func idleAndConfirmedConfigsAreUnequal() {
+        let idle = ChatButtonConfig(
+            label: "Copy message",
+            iconOnly: VIcon.copy.rawValue,
+            style: .ghost,
+            size: .regular,
+            iconSize: 24,
+            iconColorRole: .contentTertiary,
+            tooltip: nil,
+            isDisabled: false
+        )
+        let confirmed = ChatButtonConfig(
+            label: "Copied",
+            iconOnly: VIcon.check.rawValue,
+            style: .ghost,
+            size: .regular,
+            iconSize: 24,
+            iconColorRole: .systemPositiveStrong,
+            tooltip: nil,
+            isDisabled: false
+        )
+        #expect(idle != confirmed)
+    }
+}
+
+// MARK: - Retry Button Config (PR 3)
+
+@Suite("ChatButtonConfig — Retry button stability")
+struct RetryButtonConfigTests {
+
+    @Test func retryConfigIsStatic() {
+        let a = ChatButtonConfig(
+            label: "Retry",
+            iconOnly: nil,
+            style: .ghost,
+            size: .inline,
+            iconSize: nil,
+            iconColorRole: nil,
+            tooltip: nil,
+            isDisabled: false
+        )
+        let b = ChatButtonConfig(
+            label: "Retry",
+            iconOnly: nil,
+            style: .ghost,
+            size: .inline,
+            iconSize: nil,
+            iconColorRole: nil,
+            tooltip: nil,
+            isDisabled: false
+        )
+        #expect(a == b)
+    }
+}
+
+// MARK: - Output Copy Label Variation (PR 3)
+
+@Suite("ChatButtonConfig — Output copy label variation")
+struct OutputCopyConfigTests {
+
+    @Test func differentCopyLabelsMakeUnequal() {
+        let live = ChatButtonConfig(
+            label: "Copy live output",
+            iconOnly: VIcon.copy.rawValue,
+            style: .ghost,
+            size: .regular,
+            iconSize: 24,
+            iconColorRole: .contentTertiary,
+            tooltip: nil,
+            isDisabled: false
+        )
+        let done = ChatButtonConfig(
+            label: "Copy output",
+            iconOnly: VIcon.copy.rawValue,
+            style: .ghost,
+            size: .regular,
+            iconSize: 24,
+            iconColorRole: .contentTertiary,
+            tooltip: nil,
+            isDisabled: false
+        )
+        #expect(live != done)
+    }
+
+    @Test func sameCopyLabelIsStable() {
+        let a = ChatButtonConfig(
+            label: "Copy output",
+            iconOnly: VIcon.copy.rawValue,
+            style: .ghost,
+            size: .regular,
+            iconSize: 24,
+            iconColorRole: .contentTertiary,
+            tooltip: nil,
+            isDisabled: false
+        )
+        let b = ChatButtonConfig(
+            label: "Copy output",
+            iconOnly: VIcon.copy.rawValue,
+            style: .ghost,
+            size: .regular,
+            iconSize: 24,
+            iconColorRole: .contentTertiary,
+            tooltip: nil,
+            isDisabled: false
+        )
+        #expect(a == b)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ChatEquatableButton` (a `View, Equatable` wrapper) that captures render-relevant VButton config in an equatable struct, ignoring closure identity — lets SwiftUI skip body re-evaluation during unrelated parent cascades (e.g. sidebar hover)
- Adopts the firewall across all chat message-list VButton call sites: overflow menu (copy, TTS stop/idle, fork, inspect), send-failed retry, and tool-output copy
- Adds 24 unit tests covering config equality semantics, closure-agnostic equality, color role resolution, copy button state transitions, and overflow menu decision logic

## Test plan
- [ ] Run `./build.sh test --filter "ChatButtonFirewall|ChatBubbleOverflowMenuModel"` — all new tests pass
- [ ] Build and launch app, open a populated chat
- [ ] Hover sidebar conversations — verify no visible glitches or layout jumps in chat
- [ ] Hover chat bubbles — verify overflow menu fades in/out, copy/fork/inspect/TTS actions work
- [ ] Click copy — verify "Copied" confirmation with checkmark appears and reverts
- [ ] Trigger send failure — verify "Failed to send" with Retry button works
- [ ] (Optional) Profile with Instruments: VButton body evaluations during sidebar hover should be near 0

Closes LUM-572

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22901" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
