### PR TITLE
feat: add DeleteGroupConfirmationSheet and archive-on-delete method

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -1461,14 +1461,76 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
     func deleteGroupAndArchiveConversations(_ groupId: String) async {
         guard let idx = groups.firstIndex(where: { $0.id == groupId }),
               !groups[idx].isSystemGroup else { return }
-        // Archive all conversations in this group
-        let conversationsToArchive = conversations.filter { $0.groupId == groupId }
-        for conversation in conversationsToArchive {
-            archiveConversation(id: conversation.id)
+
+        // Collect the local IDs of conversations to archive before mutating state.
+        let idsToArchive = conversations
+            .filter { $0.groupId == groupId }
+            .map(\.id)
+
+        // Batch-mutate a copy to avoid per-element SwiftUI re-renders.
+        var updated = conversations
+        var newlyArchivedServerIds = Set<String>()
+        for i in updated.indices where updated[i].groupId == groupId {
+            updated[i].isArchived = true
+            updated[i].displayOrder = nil
+            updated[i].groupId = nil
+            if let cid = updated[i].conversationId {
+                newlyArchivedServerIds.insert(cid)
+            }
         }
-        // Then delete the group (conversations already archived, so the nil-out in deleteGroup is fine)
-        _ = await groupClient.deleteGroup(groupId: groupId)
+        conversations = updated
+
+        // Persist archived IDs in one shot.
+        if !newlyArchivedServerIds.isEmpty {
+            var archived = archivedConversationIds
+            archived.formUnion(newlyArchivedServerIds)
+            archivedConversationIds = archived
+        }
+
+        // Tear down view models / pop-out windows for each archived conversation.
+        for id in idsToArchive {
+            AppDelegate.shared?.threadWindowManager?.closeThread(conversationLocalId: id)
+            pinnedViewModelIds.remove(id)
+
+            if let convIndex = conversations.firstIndex(where: { $0.id == id }) {
+                if conversations[convIndex].conversationId != nil {
+                    chatViewModels[id]?.stopGenerating()
+                    chatViewModels.removeValue(forKey: id)
+                    unsubscribeAllForConversation(id: id)
+                    if let accessIdx = vmAccessOrder.firstIndex(of: id) {
+                        vmAccessOrder.remove(at: accessIdx)
+                    }
+                } else if chatViewModels[id]?.messages.contains(where: { $0.role == .user }) != true
+                            && chatViewModels[id]?.isBootstrapping != true {
+                    chatViewModels[id]?.stopGenerating()
+                    chatViewModels.removeValue(forKey: id)
+                    unsubscribeAllForConversation(id: id)
+                    if let accessIdx = vmAccessOrder.firstIndex(of: id) {
+                        vmAccessOrder.remove(at: accessIdx)
+                    }
+                } else {
+                    chatViewModels[id]?.cancelPendingMessage()
+                }
+            }
+        }
+
+        // Handle active conversation switching if the active one was archived.
+        if let activeId = activeConversationId, idsToArchive.contains(activeId) {
+            if visibleConversations.isEmpty {
+                enterDraftMode()
+            } else {
+                activeConversationId = visibleConversations.first?.id
+            }
+        } else if visibleConversations.isEmpty {
+            enterDraftMode()
+        }
+
+        Self.clearRenderCaches()
+
+        // Remove the group and fire the server delete — idx captured before mutations,
+        // but groups array is untouched so it is still valid.
         groups.remove(at: idx)
+        _ = await groupClient.deleteGroup(groupId: groupId)
         sendReorderConversations()
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -1458,6 +1458,20 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         sendReorderConversations()
     }
 
+    func deleteGroupAndArchiveConversations(_ groupId: String) async {
+        guard let idx = groups.firstIndex(where: { $0.id == groupId }),
+              !groups[idx].isSystemGroup else { return }
+        // Archive all conversations in this group
+        let conversationsToArchive = conversations.filter { $0.groupId == groupId }
+        for conversation in conversationsToArchive {
+            archiveConversation(id: conversation.id)
+        }
+        // Then delete the group (conversations already archived, so the nil-out in deleteGroup is fine)
+        _ = await groupClient.deleteGroup(groupId: groupId)
+        groups.remove(at: idx)
+        sendReorderConversations()
+    }
+
     func reorderGroups(_ updates: [(groupId: String, sortPosition: Double)]) async {
         for update in updates {
             if let idx = groups.firstIndex(where: { $0.id == update.groupId }) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DeleteGroupConfirmationSheet.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DeleteGroupConfirmationSheet.swift
@@ -63,11 +63,11 @@ struct DeleteGroupConfirmationSheet: View {
     ) -> some View {
         Button(action: action) {
             HStack(alignment: .top, spacing: VSpacing.md) {
-                Image(systemName: selected ? "circle.fill" : "circle")
-                    .font(.system(size: 14))
-                    .foregroundStyle(selected ? VColor.primaryBase : VColor.contentTertiary)
-                    .frame(width: 18, height: 18)
-                    .padding(.top, 1)
+                Circle()
+                    .fill(selected ? VColor.primaryBase : Color.clear)
+                    .overlay(Circle().stroke(selected ? VColor.primaryBase : VColor.contentTertiary, lineWidth: 1.5))
+                    .frame(width: 14, height: 14)
+                    .padding(.top, 3)
 
                 VStack(alignment: .leading, spacing: VSpacing.xxs) {
                     Text(label)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DeleteGroupConfirmationSheet.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DeleteGroupConfirmationSheet.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct DeleteGroupConfirmationSheet: View {
+    let groupName: String
+    var onDelete: () -> Void
+    var onArchiveAndDelete: () -> Void
+    var onCancel: () -> Void
+
+    @State private var archiveConversations = false
+
+    var body: some View {
+        VModal(title: "Delete \"\(groupName)\"?") {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                Text("Choose what happens to the conversations in this group.")
+                    .font(VFont.bodyMediumLighter)
+                    .foregroundStyle(VColor.contentSecondary)
+
+                VStack(spacing: VSpacing.sm) {
+                    optionRow(
+                        selected: !archiveConversations,
+                        label: "Keep conversations",
+                        description: "Conversations will be moved to the main list"
+                    ) {
+                        archiveConversations = false
+                    }
+
+                    optionRow(
+                        selected: archiveConversations,
+                        label: "Archive conversations",
+                        description: "Conversations will be archived"
+                    ) {
+                        archiveConversations = true
+                    }
+                }
+            }
+        } footer: {
+            HStack {
+                Spacer()
+                VButton(label: "Cancel", style: .outlined) {
+                    onCancel()
+                }
+                VButton(label: "Delete group", style: .danger) {
+                    if archiveConversations {
+                        onArchiveAndDelete()
+                    } else {
+                        onDelete()
+                    }
+                }
+            }
+        }
+        .frame(width: 380)
+    }
+
+    // MARK: - Radio Option Row
+
+    @ViewBuilder
+    private func optionRow(
+        selected: Bool,
+        label: String,
+        description: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(alignment: .top, spacing: VSpacing.md) {
+                Image(systemName: selected ? "circle.fill" : "circle")
+                    .font(.system(size: 14))
+                    .foregroundStyle(selected ? VColor.primaryBase : VColor.contentTertiary)
+                    .frame(width: 18, height: 18)
+                    .padding(.top, 1)
+
+                VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                    Text(label)
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(VColor.contentDefault)
+                    Text(description)
+                        .font(VFont.bodyMediumLighter)
+                        .foregroundStyle(VColor.contentSecondary)
+                }
+
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.sm)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(selected ? VColor.surfaceBase : Color.clear)
+            )
+        }
+        .buttonStyle(.plain)
+        .contentShape(Rectangle())
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `DeleteGroupConfirmationSheet` SwiftUI view with radio-style options for keeping or archiving conversations when deleting a group. Uses VModal, VButton, and design tokens (VFont, VColor, VSpacing, VRadius).
- Adds `deleteGroupAndArchiveConversations(_:)` method to `ConversationManager` that archives all conversations in a group before deleting it.

## Test plan
- [ ] Verify `DeleteGroupConfirmationSheet` renders correctly with group name in title
- [ ] Verify radio selection toggles between keep/archive options
- [ ] Verify Cancel calls `onCancel`, Delete calls `onDelete` when "Keep" is selected, and `onArchiveAndDelete` when "Archive" is selected
- [ ] Verify `deleteGroupAndArchiveConversations` archives conversations and removes the group

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22902" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
