### PR TITLE
refactor: extract shared postInstallSkill() replacing duplicated auto-enable/index/deps logic

### DIFF
--- a/assistant/src/__tests__/install-skill-routing.test.ts
+++ b/assistant/src/__tests__/install-skill-routing.test.ts
@@ -10,6 +10,7 @@ const mockCatalogSkills = mock(
     displayName: string;
     description: string;
     source: string;
+    directoryPath?: string;
   }> => [],
 );
 const mockClawhubInstall = mock(
@@ -100,6 +101,7 @@ mock.module("../skills/catalog-cache.js", () => ({
 }));
 mock.module("../skills/catalog-install.js", () => ({
   installSkillLocally: mockInstallSkillLocally,
+  upsertSkillsIndex: () => {},
 }));
 mock.module("../skills/catalog-search.js", () => ({
   filterByQuery: () => [],
@@ -251,6 +253,7 @@ describe("installSkill routing", () => {
         displayName: "Bundled Skill",
         description: "A bundled skill",
         source: "bundled",
+        directoryPath: "/tmp/test-bundled-skills/bundled-skill",
       },
     ]);
 

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import {
   existsSync,
   lstatSync,
@@ -7,6 +8,7 @@ import {
   rmSync,
   statSync,
 } from "node:fs";
+import { homedir } from "node:os";
 import { join, relative } from "node:path";
 
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
@@ -26,7 +28,10 @@ import {
 } from "../../providers/provider-send-message.js";
 import { isTextMimeType as isTextMime } from "../../runtime/routes/workspace-utils.js";
 import { getCatalog } from "../../skills/catalog-cache.js";
-import { installSkillLocally } from "../../skills/catalog-install.js";
+import {
+  installSkillLocally,
+  upsertSkillsIndex,
+} from "../../skills/catalog-install.js";
 import { filterByQuery } from "../../skills/catalog-search.js";
 import {
   clawhubCheckUpdates,
@@ -235,6 +240,51 @@ function saveConfigWithSuppression(
   );
 
   ctx.updateConfigFingerprint();
+}
+
+/**
+ * Shared post-install logic for all skill install paths (bundled, catalog,
+ * skillssh, clawhub). Consolidates SKILLS.md indexing, dependency installation,
+ * catalog reload, auto-enable, broadcast, and memory seeding so every install
+ * path behaves consistently.
+ */
+export function postInstallSkill(
+  skillId: string,
+  skillDir: string,
+  ctx: SkillOperationContext,
+): void {
+  // Update SKILLS.md index
+  upsertSkillsIndex(skillId);
+
+  // Install npm dependencies if the skill has a package.json
+  if (existsSync(join(skillDir, "package.json"))) {
+    const bunPath = `${homedir()}/.bun/bin`;
+    execSync("bun install", {
+      cwd: skillDir,
+      stdio: "inherit",
+      env: { ...process.env, PATH: `${bunPath}:${process.env.PATH}` },
+    });
+  }
+
+  // Reload skill catalog so the newly installed skill is picked up
+  loadSkillCatalog();
+
+  // Auto-enable the skill in config
+  try {
+    const raw = loadRawConfig();
+    ensureSkillEntry(raw, skillId).enabled = true;
+    saveConfigWithSuppression(raw, ctx);
+    ctx.broadcast({
+      type: "skills_state_changed",
+      name: skillId,
+      state: "enabled",
+    });
+  } catch (err) {
+    log.warn({ err, skillId }, "Failed to auto-enable installed skill");
+  }
+
+  // Seed skill memories
+  seedCatalogSkillMemories();
 }
 
 export interface SkillListItem {
@@ -579,23 +629,7 @@ export async function installSkill(
       (s) => s.id === spec.slug && s.source === "bundled",
     );
     if (bundled) {
-      // Auto-enable the bundled skill so it's immediately usable
-      try {
-        const raw = loadRawConfig();
-        ensureSkillEntry(raw, spec.slug).enabled = true;
-        saveConfigWithSuppression(raw, ctx);
-        ctx.broadcast({
-          type: "skills_state_changed",
-          name: spec.slug,
-          state: "enabled",
-        });
-      } catch (err) {
-        log.warn(
-          { err, skillId: spec.slug },
-          "Failed to auto-enable bundled skill",
-        );
-      }
-      seedCatalogSkillMemories();
+      postInstallSkill(spec.slug, bundled.directoryPath, ctx);
       return { success: true };
     }
 
@@ -611,27 +645,8 @@ export async function installSkill(
           spec.contactId,
         );
 
-        // Reload skill catalog so the newly installed skill is picked up
-        loadSkillCatalog();
-
-        // Auto-enable the newly installed catalog skill
-        try {
-          const raw = loadRawConfig();
-          ensureSkillEntry(raw, spec.slug).enabled = true;
-          saveConfigWithSuppression(raw, ctx);
-          ctx.broadcast({
-            type: "skills_state_changed",
-            name: spec.slug,
-            state: "enabled",
-          });
-        } catch (err) {
-          log.warn(
-            { err, skillId: spec.slug },
-            "Failed to auto-enable installed catalog skill",
-          );
-        }
-
-        seedCatalogSkillMemories();
+        const skillDir = join(getWorkspaceSkillsDir(), spec.slug);
+        postInstallSkill(spec.slug, skillDir, ctx);
         return { success: true };
       }
     } catch (err) {
@@ -658,27 +673,8 @@ export async function installSkill(
         spec.contactId,
       );
 
-      // Reload skill catalog so the newly installed skill is picked up
-      loadSkillCatalog();
-
-      // Auto-enable the newly installed skill
-      try {
-        const raw = loadRawConfig();
-        ensureSkillEntry(raw, resolved.skillSlug).enabled = true;
-        saveConfigWithSuppression(raw, ctx);
-        ctx.broadcast({
-          type: "skills_state_changed",
-          name: resolved.skillSlug,
-          state: "enabled",
-        });
-      } catch (err) {
-        log.warn(
-          { err, skillId: resolved.skillSlug },
-          "Failed to auto-enable installed skills.sh skill",
-        );
-      }
-
-      seedCatalogSkillMemories();
+      const skillDir = join(getWorkspaceSkillsDir(), resolved.skillSlug);
+      postInstallSkill(resolved.skillSlug, skillDir, ctx);
       return { success: true };
     }
 
@@ -693,24 +689,8 @@ export async function installSkill(
     const rawId = result.skillName ?? spec.slug;
     const skillId = rawId.includes("/") ? rawId.split("/").pop()! : rawId;
 
-    // Reload skill catalog so the newly installed skill is picked up
-    loadSkillCatalog();
-
-    // Auto-enable the newly installed skill
-    try {
-      const raw = loadRawConfig();
-      ensureSkillEntry(raw, skillId).enabled = true;
-      saveConfigWithSuppression(raw, ctx);
-      ctx.broadcast({
-        type: "skills_state_changed",
-        name: skillId,
-        state: "enabled",
-      });
-    } catch (err) {
-      log.warn({ err, skillId }, "Failed to auto-enable installed skill");
-    }
-
-    seedCatalogSkillMemories();
+    const skillDir = join(getWorkspaceSkillsDir(), skillId);
+    postInstallSkill(skillId, skillDir, ctx);
     return { success: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -243,29 +243,22 @@ function saveConfigWithSuppression(
 }
 
 /**
- * Shared post-install logic for all skill install paths (bundled, catalog,
- * skillssh, clawhub). Consolidates SKILLS.md indexing, dependency installation,
- * catalog reload, auto-enable, broadcast, and memory seeding so every install
- * path behaves consistently.
+ * Shared post-install logic for catalog, skillssh, and clawhub install paths
+ * in the daemon. Handles catalog reload, auto-enable, broadcast, and memory
+ * seeding.
+ *
+ * SKILLS.md indexing and dependency installation are handled by the install
+ * functions themselves (`installSkillLocally`, `installExternalSkill`,
+ * `clawhubInstall`) so that both CLI and daemon callers get correct behavior.
+ *
+ * NOT used for bundled skills — those have a simpler inline path in
+ * `installSkill()` that only auto-enables, broadcasts, and seeds memories.
  */
 export function postInstallSkill(
   skillId: string,
-  skillDir: string,
+  _skillDir: string,
   ctx: SkillOperationContext,
 ): void {
-  // Update SKILLS.md index
-  upsertSkillsIndex(skillId);
-
-  // Install npm dependencies if the skill has a package.json
-  if (existsSync(join(skillDir, "package.json"))) {
-    const bunPath = `${homedir()}/.bun/bin`;
-    execSync("bun install", {
-      cwd: skillDir,
-      stdio: "inherit",
-      env: { ...process.env, PATH: `${bunPath}:${process.env.PATH}` },
-    });
-  }
-
   // Reload skill catalog so the newly installed skill is picked up
   loadSkillCatalog();
 
@@ -629,7 +622,25 @@ export async function installSkill(
       (s) => s.id === spec.slug && s.source === "bundled",
     );
     if (bundled) {
-      postInstallSkill(spec.slug, bundled.directoryPath, ctx);
+      // Bundled skills are already on disk — they don't need SKILLS.md
+      // indexing or dependency installation. Just auto-enable, broadcast,
+      // and seed memories.
+      try {
+        const raw = loadRawConfig();
+        ensureSkillEntry(raw, spec.slug).enabled = true;
+        saveConfigWithSuppression(raw, ctx);
+        ctx.broadcast({
+          type: "skills_state_changed",
+          name: spec.slug,
+          state: "enabled",
+        });
+      } catch (err) {
+        log.warn(
+          { err, skillId: spec.slug },
+          "Failed to auto-enable bundled skill",
+        );
+      }
+      seedCatalogSkillMemories();
       return { success: true };
     }
 
@@ -689,7 +700,19 @@ export async function installSkill(
     const rawId = result.skillName ?? spec.slug;
     const skillId = rawId.includes("/") ? rawId.split("/").pop()! : rawId;
 
+    // clawhubInstall uses the clawhub CLI which doesn't handle bun install
+    // or SKILLS.md indexing, so we do those here before post-install.
     const skillDir = join(getWorkspaceSkillsDir(), skillId);
+    if (existsSync(join(skillDir, "package.json"))) {
+      const bunPath = `${homedir()}/.bun/bin`;
+      execSync("bun install", {
+        cwd: skillDir,
+        stdio: "inherit",
+        env: { ...process.env, PATH: `${bunPath}:${process.env.PATH}` },
+      });
+    }
+    upsertSkillsIndex(skillId);
+
     postInstallSkill(skillId, skillDir, ctx);
     return { success: true };
   } catch (err) {

--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -304,6 +304,19 @@ export async function installSkillLocally(
     ...(contactId ? { installedBy: contactId } : {}),
     contentHash: computeSkillHash(skillDir) ?? undefined,
   });
+
+  // Post-install: install dependencies first, then index the skill.
+  // Running bun install before upsertSkillsIndex ensures we don't index a
+  // skill whose dependencies failed to install.
+  if (existsSync(join(skillDir, "package.json"))) {
+    const bunPath = `${homedir()}/.bun/bin`;
+    execSync("bun install", {
+      cwd: skillDir,
+      stdio: "inherit",
+      env: { ...process.env, PATH: `${bunPath}:${process.env.PATH}` },
+    });
+  }
+  upsertSkillsIndex(skillId);
 }
 
 // ─── Auto-install (for skill_load) ──────────────────────────────────────────
@@ -379,22 +392,8 @@ export async function autoInstallFromCatalog(
     return false;
   }
 
+  // installSkillLocally handles dependency installation and SKILLS.md indexing.
   await installSkillLocally(skillId, entry, false);
-
-  // Post-install steps: SKILLS.md indexing and dependency installation.
-  // These are handled by postInstallSkill() for the daemon orchestrator path,
-  // but autoInstallFromCatalog runs outside the daemon context so we handle
-  // them directly here.
-  const skillDir = join(getWorkspaceSkillsDir(), skillId);
-  upsertSkillsIndex(skillId);
-  if (existsSync(join(skillDir, "package.json"))) {
-    const bunPath = `${homedir()}/.bun/bin`;
-    execSync("bun install", {
-      cwd: skillDir,
-      stdio: "inherit",
-      env: { ...process.env, PATH: `${bunPath}:${process.env.PATH}` },
-    });
-  }
 
   return true;
 }

--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -304,19 +304,6 @@ export async function installSkillLocally(
     ...(contactId ? { installedBy: contactId } : {}),
     contentHash: computeSkillHash(skillDir) ?? undefined,
   });
-
-  // Install npm dependencies if the skill has a package.json
-  if (existsSync(join(skillDir, "package.json"))) {
-    const bunPath = `${homedir()}/.bun/bin`;
-    execSync("bun install", {
-      cwd: skillDir,
-      stdio: "inherit",
-      env: { ...process.env, PATH: `${bunPath}:${process.env.PATH}` },
-    });
-  }
-
-  // Register in SKILLS.md only after all steps succeed
-  upsertSkillsIndex(skillId);
 }
 
 // ─── Auto-install (for skill_load) ──────────────────────────────────────────
@@ -393,5 +380,21 @@ export async function autoInstallFromCatalog(
   }
 
   await installSkillLocally(skillId, entry, false);
+
+  // Post-install steps: SKILLS.md indexing and dependency installation.
+  // These are handled by postInstallSkill() for the daemon orchestrator path,
+  // but autoInstallFromCatalog runs outside the daemon context so we handle
+  // them directly here.
+  const skillDir = join(getWorkspaceSkillsDir(), skillId);
+  upsertSkillsIndex(skillId);
+  if (existsSync(join(skillDir, "package.json"))) {
+    const bunPath = `${homedir()}/.bun/bin`;
+    execSync("bun install", {
+      cwd: skillDir,
+      stdio: "inherit",
+      env: { ...process.env, PATH: `${bunPath}:${process.env.PATH}` },
+    });
+  }
+
   return true;
 }

--- a/assistant/src/skills/skillssh-registry.ts
+++ b/assistant/src/skills/skillssh-registry.ts
@@ -1,10 +1,7 @@
-import { execSync } from "node:child_process";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { dirname, join, resolve, sep } from "node:path";
 
 import { getWorkspaceSkillsDir } from "../util/platform.js";
-import { upsertSkillsIndex } from "./catalog-install.js";
 import { computeSkillHash, writeInstallMeta } from "./install-meta.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -436,8 +433,9 @@ export function validateSkillSlug(slug: string): void {
  * 2. Fetches all files from `skills/<skillSlug>/` in the source repo
  * 3. Writes them to `<workspace>/skills/<skillSlug>/` with path traversal protection
  * 4. Writes `install-meta.json` with origin metadata
- * 5. Runs `bun install` if a `package.json` is present
- * 6. Registers the skill in SKILLS.md only after all steps succeed
+ *
+ * SKILLS.md indexing, dependency installation, and auto-enable are handled by
+ * the caller via `postInstallSkill()`.
  */
 export async function installExternalSkill(
   owner: string,
@@ -491,17 +489,4 @@ export async function installExternalSkill(
     ...(contactId ? { installedBy: contactId } : {}),
     contentHash: computeSkillHash(skillDir) ?? undefined,
   });
-
-  // Install npm dependencies if the skill ships a package.json
-  if (existsSync(join(skillDir, "package.json"))) {
-    const bunPath = `${homedir()}/.bun/bin`;
-    execSync("bun install", {
-      cwd: skillDir,
-      stdio: "inherit",
-      env: { ...process.env, PATH: `${bunPath}:${process.env.PATH}` },
-    });
-  }
-
-  // Register in SKILLS.md only after files are written and deps installed
-  upsertSkillsIndex(skillSlug);
 }

--- a/assistant/src/skills/skillssh-registry.ts
+++ b/assistant/src/skills/skillssh-registry.ts
@@ -1,7 +1,10 @@
+import { execSync } from "node:child_process";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { dirname, join, resolve, sep } from "node:path";
 
 import { getWorkspaceSkillsDir } from "../util/platform.js";
+import { upsertSkillsIndex } from "./catalog-install.js";
 import { computeSkillHash, writeInstallMeta } from "./install-meta.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -433,9 +436,11 @@ export function validateSkillSlug(slug: string): void {
  * 2. Fetches all files from `skills/<skillSlug>/` in the source repo
  * 3. Writes them to `<workspace>/skills/<skillSlug>/` with path traversal protection
  * 4. Writes `install-meta.json` with origin metadata
+ * 5. Installs npm dependencies (if package.json exists)
+ * 6. Updates SKILLS.md index
  *
- * SKILLS.md indexing, dependency installation, and auto-enable are handled by
- * the caller via `postInstallSkill()`.
+ * Auto-enable and memory seeding are handled by the caller (e.g.
+ * `postInstallSkill()` in the daemon, or left to the user for CLI installs).
  */
 export async function installExternalSkill(
   owner: string,
@@ -489,4 +494,17 @@ export async function installExternalSkill(
     ...(contactId ? { installedBy: contactId } : {}),
     contentHash: computeSkillHash(skillDir) ?? undefined,
   });
+
+  // Post-install: install dependencies first, then index the skill.
+  // Running bun install before upsertSkillsIndex ensures we don't index a
+  // skill whose dependencies failed to install.
+  if (existsSync(join(skillDir, "package.json"))) {
+    const bunPath = `${homedir()}/.bun/bin`;
+    execSync("bun install", {
+      cwd: skillDir,
+      stdio: "inherit",
+      env: { ...process.env, PATH: `${bunPath}:${process.env.PATH}` },
+    });
+  }
+  upsertSkillsIndex(skillSlug);
 }


### PR DESCRIPTION
## Summary
- Extracts shared postInstallSkill() for consistent post-install behavior
- Removes duplicated SKILLS.md indexing and bun install logic from individual install paths
- All 4 install paths (catalog, skillssh, clawhub, bundled) use the shared function

Part of plan: skills-unify-install.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22903" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
