### PR TITLE
Skills Cleanup Part 2: Unify Install Paths & Write Origin

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6087,6 +6087,12 @@ paths:
                   description: Skill spec
                 version:
                   type: string
+                origin:
+                  description: Which registry to install from. When omitted, the install flow auto-detects based on slug format.
+                  type: string
+                  enum:
+                    - clawhub
+                    - skillssh
               required:
                 - slug
                 - url

--- a/assistant/src/__tests__/install-meta.test.ts
+++ b/assistant/src/__tests__/install-meta.test.ts
@@ -1,0 +1,506 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  collectFileContents,
+  computeSkillHash,
+  readInstallMeta,
+  type SkillInstallMeta,
+  writeInstallMeta,
+} from "../skills/install-meta.js";
+
+const testDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "install-meta-test-"));
+  testDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of testDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ─── writeInstallMeta ───────────────────────────────────────────────────────
+
+describe("writeInstallMeta", () => {
+  test("writes a valid install-meta.json with all required fields", () => {
+    const dir = makeTempDir();
+    const meta: SkillInstallMeta = {
+      origin: "vellum",
+      installedAt: "2025-01-15T10:30:00.000Z",
+      version: "1.2.3",
+    };
+
+    writeInstallMeta(dir, meta);
+
+    const filePath = join(dir, "install-meta.json");
+    expect(existsSync(filePath)).toBe(true);
+
+    const parsed = JSON.parse(readFileSync(filePath, "utf-8"));
+    expect(parsed.origin).toBe("vellum");
+    expect(parsed.installedAt).toBe("2025-01-15T10:30:00.000Z");
+    expect(parsed.version).toBe("1.2.3");
+  });
+
+  test("writes install-meta.json with optional installedBy field", () => {
+    const dir = makeTempDir();
+    const meta: SkillInstallMeta = {
+      origin: "clawhub",
+      installedAt: "2025-02-20T14:00:00.000Z",
+      slug: "my-cool-skill",
+      installedBy: "contact-uuid-123",
+    };
+
+    writeInstallMeta(dir, meta);
+
+    const parsed = JSON.parse(
+      readFileSync(join(dir, "install-meta.json"), "utf-8"),
+    );
+    expect(parsed.installedBy).toBe("contact-uuid-123");
+    expect(parsed.origin).toBe("clawhub");
+    expect(parsed.slug).toBe("my-cool-skill");
+  });
+
+  test("writes install-meta.json with skillssh origin and sourceRepo", () => {
+    const dir = makeTempDir();
+    const meta: SkillInstallMeta = {
+      origin: "skillssh",
+      installedAt: "2025-03-01T00:00:00.000Z",
+      sourceRepo: "vercel-labs/agent-skills",
+      slug: "vercel-react-best-practices",
+    };
+
+    writeInstallMeta(dir, meta);
+
+    const parsed = JSON.parse(
+      readFileSync(join(dir, "install-meta.json"), "utf-8"),
+    );
+    expect(parsed.origin).toBe("skillssh");
+    expect(parsed.sourceRepo).toBe("vercel-labs/agent-skills");
+    expect(parsed.slug).toBe("vercel-react-best-practices");
+  });
+
+  test("writes install-meta.json with contentHash", () => {
+    const dir = makeTempDir();
+    const meta: SkillInstallMeta = {
+      origin: "vellum",
+      installedAt: "2025-04-01T00:00:00.000Z",
+      contentHash: "v2:abc123def456",
+    };
+
+    writeInstallMeta(dir, meta);
+
+    const parsed = JSON.parse(
+      readFileSync(join(dir, "install-meta.json"), "utf-8"),
+    );
+    expect(parsed.contentHash).toBe("v2:abc123def456");
+  });
+
+  test("overwrites existing install-meta.json", () => {
+    const dir = makeTempDir();
+    writeInstallMeta(dir, {
+      origin: "vellum",
+      installedAt: "2025-01-01T00:00:00.000Z",
+      version: "1.0.0",
+    });
+    writeInstallMeta(dir, {
+      origin: "vellum",
+      installedAt: "2025-06-01T00:00:00.000Z",
+      version: "2.0.0",
+    });
+
+    const parsed = JSON.parse(
+      readFileSync(join(dir, "install-meta.json"), "utf-8"),
+    );
+    expect(parsed.version).toBe("2.0.0");
+    expect(parsed.installedAt).toBe("2025-06-01T00:00:00.000Z");
+  });
+
+  test("creates parent directories if needed", () => {
+    const dir = makeTempDir();
+    const nested = join(dir, "nested", "skill");
+    // nested doesn't exist yet
+    writeInstallMeta(nested, {
+      origin: "custom",
+      installedAt: "2025-01-01T00:00:00.000Z",
+    });
+    expect(existsSync(join(nested, "install-meta.json"))).toBe(true);
+  });
+});
+
+// ─── readInstallMeta ────────────────────────────────────────────────────────
+
+describe("readInstallMeta", () => {
+  test("reads install-meta.json when it exists", () => {
+    const dir = makeTempDir();
+    const meta: SkillInstallMeta = {
+      origin: "clawhub",
+      installedAt: "2025-01-15T10:30:00.000Z",
+      slug: "find-skills",
+      installedBy: "contact-42",
+    };
+    writeInstallMeta(dir, meta);
+
+    const result = readInstallMeta(dir);
+    expect(result).not.toBeNull();
+    expect(result!.origin).toBe("clawhub");
+    expect(result!.installedAt).toBe("2025-01-15T10:30:00.000Z");
+    expect(result!.slug).toBe("find-skills");
+    expect(result!.installedBy).toBe("contact-42");
+  });
+
+  test("returns null when neither file exists", () => {
+    const dir = makeTempDir();
+    expect(readInstallMeta(dir)).toBeNull();
+  });
+
+  test("returns null for malformed install-meta.json when no version.json exists", () => {
+    const dir = makeTempDir();
+    writeFileSync(
+      join(dir, "install-meta.json"),
+      "{not valid json!!!",
+      "utf-8",
+    );
+    expect(readInstallMeta(dir)).toBeNull();
+  });
+
+  test("falls back to version.json when install-meta.json is malformed", () => {
+    const dir = makeTempDir();
+    // Write a malformed install-meta.json
+    writeFileSync(
+      join(dir, "install-meta.json"),
+      "{not valid json!!!",
+      "utf-8",
+    );
+    // Write a valid legacy version.json
+    writeFileSync(
+      join(dir, "version.json"),
+      JSON.stringify({
+        version: "v1:abc123",
+        installedAt: "2025-02-01T08:00:00.000Z",
+      }),
+      "utf-8",
+    );
+
+    const result = readInstallMeta(dir);
+    expect(result).not.toBeNull();
+    expect(result!.origin).toBe("vellum");
+    expect(result!.version).toBe("v1:abc123");
+    expect(result!.installedAt).toBe("2025-02-01T08:00:00.000Z");
+  });
+
+  // ─── Legacy version.json fallback ──────────────────────────────────────
+
+  describe("legacy version.json fallback", () => {
+    test("infers skillssh origin from version.json with origin: skills.sh", () => {
+      const dir = makeTempDir();
+      writeFileSync(
+        join(dir, "version.json"),
+        JSON.stringify({
+          origin: "skills.sh",
+          source: "vercel-labs/agent-skills",
+          skillSlug: "vercel-react-best-practices",
+          installedAt: "2025-01-10T12:00:00.000Z",
+        }),
+        "utf-8",
+      );
+
+      const result = readInstallMeta(dir);
+      expect(result).not.toBeNull();
+      expect(result!.origin).toBe("skillssh");
+      expect(result!.sourceRepo).toBe("vercel-labs/agent-skills");
+      expect(result!.slug).toBe("vercel-react-best-practices");
+      expect(result!.installedAt).toBe("2025-01-10T12:00:00.000Z");
+      expect(result!.installedBy).toBeUndefined();
+    });
+
+    test("infers vellum origin from version.json with version but no origin", () => {
+      const dir = makeTempDir();
+      writeFileSync(
+        join(dir, "version.json"),
+        JSON.stringify({
+          version: "v1:abc123",
+          installedAt: "2025-02-01T08:00:00.000Z",
+        }),
+        "utf-8",
+      );
+
+      const result = readInstallMeta(dir);
+      expect(result).not.toBeNull();
+      expect(result!.origin).toBe("vellum");
+      expect(result!.version).toBe("v1:abc123");
+      expect(result!.installedAt).toBe("2025-02-01T08:00:00.000Z");
+      expect(result!.installedBy).toBeUndefined();
+    });
+
+    test("infers custom origin from version.json without version or origin", () => {
+      const dir = makeTempDir();
+      writeFileSync(
+        join(dir, "version.json"),
+        JSON.stringify({
+          installedAt: "2025-03-15T00:00:00.000Z",
+          someOtherField: "data",
+        }),
+        "utf-8",
+      );
+
+      const result = readInstallMeta(dir);
+      expect(result).not.toBeNull();
+      expect(result!.origin).toBe("custom");
+      expect(result!.installedAt).toBe("2025-03-15T00:00:00.000Z");
+      expect(result!.installedBy).toBeUndefined();
+    });
+
+    test("handles version.json with unknown origin field as custom", () => {
+      const dir = makeTempDir();
+      writeFileSync(
+        join(dir, "version.json"),
+        JSON.stringify({
+          origin: "unknown-registry",
+          installedAt: "2025-04-01T00:00:00.000Z",
+        }),
+        "utf-8",
+      );
+
+      const result = readInstallMeta(dir);
+      expect(result).not.toBeNull();
+      expect(result!.origin).toBe("custom");
+    });
+
+    test("returns null for malformed version.json", () => {
+      const dir = makeTempDir();
+      writeFileSync(join(dir, "version.json"), "{bad json!", "utf-8");
+      expect(readInstallMeta(dir)).toBeNull();
+    });
+
+    test("prefers install-meta.json over version.json when both exist", () => {
+      const dir = makeTempDir();
+      writeInstallMeta(dir, {
+        origin: "clawhub",
+        installedAt: "2025-06-01T00:00:00.000Z",
+        slug: "from-install-meta",
+      });
+      writeFileSync(
+        join(dir, "version.json"),
+        JSON.stringify({
+          origin: "skills.sh",
+          source: "other/repo",
+          skillSlug: "from-version-json",
+          installedAt: "2025-01-01T00:00:00.000Z",
+        }),
+        "utf-8",
+      );
+
+      const result = readInstallMeta(dir);
+      expect(result).not.toBeNull();
+      expect(result!.origin).toBe("clawhub");
+      expect(result!.slug).toBe("from-install-meta");
+    });
+
+    test("falls back when installedAt is missing in legacy version.json", () => {
+      const dir = makeTempDir();
+      writeFileSync(
+        join(dir, "version.json"),
+        JSON.stringify({ version: "1.0.0" }),
+        "utf-8",
+      );
+
+      const result = readInstallMeta(dir);
+      expect(result).not.toBeNull();
+      expect(result!.origin).toBe("vellum");
+      // Should have a generated installedAt since the file lacked one
+      expect(typeof result!.installedAt).toBe("string");
+      expect(new Date(result!.installedAt).getTime()).not.toBeNaN();
+    });
+  });
+});
+
+// ─── computeSkillHash ───────────────────────────────────────────────────────
+
+describe("computeSkillHash", () => {
+  test("returns a v2: prefixed sha256 hash", () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "SKILL.md"), "# My Skill\n");
+    const hash = computeSkillHash(dir);
+    expect(hash).toMatch(/^v2:[0-9a-f]{64}$/);
+  });
+
+  test("is deterministic for same content", () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "SKILL.md"), "# My Skill\n");
+    writeFileSync(join(dir, "executor.ts"), "export const run = () => {};");
+    const hash1 = computeSkillHash(dir);
+    const hash2 = computeSkillHash(dir);
+    expect(hash1).toBe(hash2);
+  });
+
+  test("changes when file content changes", () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "executor.ts"), 'export const run = () => "v1";');
+    const hash1 = computeSkillHash(dir);
+
+    writeFileSync(join(dir, "executor.ts"), 'export const run = () => "v2";');
+    const hash2 = computeSkillHash(dir);
+
+    expect(hash1).not.toBe(hash2);
+  });
+
+  test("changes when a new file is added", () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "SKILL.md"), "# Skill\n");
+    const hash1 = computeSkillHash(dir);
+
+    writeFileSync(join(dir, "extra.ts"), "export {};");
+    const hash2 = computeSkillHash(dir);
+
+    expect(hash1).not.toBe(hash2);
+  });
+
+  test("is insensitive to file creation order", () => {
+    const dir1 = makeTempDir();
+    writeFileSync(join(dir1, "b.ts"), "b");
+    writeFileSync(join(dir1, "a.ts"), "a");
+
+    const dir2 = makeTempDir();
+    writeFileSync(join(dir2, "a.ts"), "a");
+    writeFileSync(join(dir2, "b.ts"), "b");
+
+    expect(computeSkillHash(dir1)).toBe(computeSkillHash(dir2));
+  });
+
+  test("returns null for non-existent directory", () => {
+    expect(computeSkillHash("/tmp/nonexistent-dir-xyz")).toBeNull();
+  });
+
+  test("returns null for a file path (not a directory)", () => {
+    const dir = makeTempDir();
+    const filePath = join(dir, "not-a-dir.txt");
+    writeFileSync(filePath, "hello");
+    expect(computeSkillHash(filePath)).toBeNull();
+  });
+
+  test("returns null for empty directory", () => {
+    const dir = makeTempDir();
+    expect(computeSkillHash(dir)).toBeNull();
+  });
+
+  test("includes subdirectory files", () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "SKILL.md"), "# Skill\n");
+    const hash1 = computeSkillHash(dir);
+
+    mkdirSync(join(dir, "tools"), { recursive: true });
+    writeFileSync(join(dir, "tools", "helper.ts"), "export {};");
+    const hash2 = computeSkillHash(dir);
+
+    expect(hash1).not.toBe(hash2);
+  });
+
+  test("excludes install-meta.json and version.json from the hash", () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "SKILL.md"), "# My Skill\n");
+    const hashBefore = computeSkillHash(dir);
+
+    // Adding install-meta.json should not change the hash
+    writeFileSync(
+      join(dir, "install-meta.json"),
+      JSON.stringify({
+        origin: "vellum",
+        installedAt: "2025-01-01T00:00:00.000Z",
+        contentHash: hashBefore,
+      }),
+      "utf-8",
+    );
+    expect(computeSkillHash(dir)).toBe(hashBefore);
+
+    // Adding version.json should not change the hash either
+    writeFileSync(
+      join(dir, "version.json"),
+      JSON.stringify({ version: "v1:abc123" }),
+      "utf-8",
+    );
+    expect(computeSkillHash(dir)).toBe(hashBefore);
+  });
+});
+
+// ─── collectFileContents ────────────────────────────────────────────────────
+
+describe("collectFileContents", () => {
+  test("returns empty array for non-existent directory", () => {
+    expect(collectFileContents("/tmp/nonexistent-xyz")).toEqual([]);
+  });
+
+  test("returns empty array for empty directory", () => {
+    const dir = makeTempDir();
+    expect(collectFileContents(dir)).toEqual([]);
+  });
+
+  test("collects files sorted by relative path", () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "c.txt"), "c");
+    writeFileSync(join(dir, "a.txt"), "a");
+    writeFileSync(join(dir, "b.txt"), "b");
+
+    const results = collectFileContents(dir);
+    expect(results.map((r) => r.relPath)).toEqual(["a.txt", "b.txt", "c.txt"]);
+  });
+
+  test("includes files from subdirectories", () => {
+    const dir = makeTempDir();
+    mkdirSync(join(dir, "sub"));
+    writeFileSync(join(dir, "root.txt"), "root");
+    writeFileSync(join(dir, "sub", "nested.txt"), "nested");
+
+    const results = collectFileContents(dir);
+    expect(results.map((r) => r.relPath)).toEqual([
+      "root.txt",
+      "sub/nested.txt",
+    ]);
+  });
+
+  test("reads correct file content", () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "hello.txt"), "Hello, World!");
+
+    const results = collectFileContents(dir);
+    expect(results).toHaveLength(1);
+    expect(results[0].content.toString("utf-8")).toBe("Hello, World!");
+  });
+
+  test("excludes install-meta.json and version.json at root level", () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "SKILL.md"), "# Skill\n");
+    writeFileSync(join(dir, "install-meta.json"), '{"origin":"vellum"}');
+    writeFileSync(join(dir, "version.json"), '{"version":"1.0.0"}');
+
+    const results = collectFileContents(dir);
+    const names = results.map((r) => r.relPath);
+    expect(names).toEqual(["SKILL.md"]);
+    expect(names).not.toContain("install-meta.json");
+    expect(names).not.toContain("version.json");
+  });
+
+  test("does not exclude install-meta.json or version.json in subdirectories", () => {
+    const dir = makeTempDir();
+    mkdirSync(join(dir, "sub"));
+    writeFileSync(join(dir, "sub", "install-meta.json"), "nested");
+    writeFileSync(join(dir, "sub", "version.json"), "nested");
+
+    const results = collectFileContents(dir);
+    const names = results.map((r) => r.relPath);
+    expect(names).toContain("sub/install-meta.json");
+    expect(names).toContain("sub/version.json");
+  });
+});

--- a/assistant/src/__tests__/install-skill-routing.test.ts
+++ b/assistant/src/__tests__/install-skill-routing.test.ts
@@ -183,6 +183,7 @@ describe("installSkill routing", () => {
       "react-best-practices",
       true, // overwrite
       undefined, // ref
+      undefined, // contactId
     );
     // Should not have called clawhub
     expect(mockClawhubInstall).not.toHaveBeenCalled();
@@ -224,7 +225,8 @@ describe("installSkill routing", () => {
       "repo",
       "my-skill",
       true,
-      undefined,
+      undefined, // ref
+      undefined, // contactId
     );
     expect(mockClawhubInstall).not.toHaveBeenCalled();
   });

--- a/assistant/src/__tests__/install-skill-routing.test.ts
+++ b/assistant/src/__tests__/install-skill-routing.test.ts
@@ -1,0 +1,284 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+const mockCatalogSkills = mock(
+  (): Array<{
+    id: string;
+    displayName: string;
+    description: string;
+    source: string;
+  }> => [],
+);
+const mockClawhubInstall = mock(
+  async (
+    _slug: string,
+    _opts?: { version?: string },
+  ): Promise<{ success: boolean; error?: string; skillName?: string }> => ({
+    success: true,
+  }),
+);
+const mockInstallExternalSkill = mock(
+  async (
+    _owner: string,
+    _repo: string,
+    _skillSlug: string,
+    _overwrite: boolean,
+    _ref?: string,
+  ): Promise<void> => {},
+);
+const mockGetCatalog = mock(async () => []);
+const mockInstallSkillLocally = mock(async () => {});
+const mockSeedCatalogSkillMemories = mock(() => {});
+const mockEnsureSkillEntry = mock(
+  (_raw: Record<string, unknown>, _id: string) => ({
+    enabled: false,
+  }),
+);
+
+// ---------------------------------------------------------------------------
+// Mock modules — before importing module under test
+// ---------------------------------------------------------------------------
+
+mock.module("../config/skills.js", () => ({
+  loadSkillCatalog: mockCatalogSkills,
+}));
+
+mock.module("../skills/clawhub.js", () => ({
+  clawhubCheckUpdates: mock(async () => []),
+  clawhubInspect: mock(async () => ({})),
+  clawhubInstall: mockClawhubInstall,
+  clawhubSearch: mock(async () => ({ skills: [] })),
+  clawhubUpdate: mock(async () => ({ success: true })),
+}));
+
+mock.module("../skills/skillssh-registry.js", () => ({
+  installExternalSkill: mockInstallExternalSkill,
+  resolveSkillSource: (source: string) => {
+    const parts = source.split("/");
+    if (parts.length >= 3) {
+      return {
+        owner: parts[0]!,
+        repo: parts[1]!,
+        skillSlug: parts.slice(2).join("/"),
+      };
+    }
+    throw new Error(`Invalid skill source "${source}"`);
+  },
+  searchSkillsRegistry: mock(async () => []),
+}));
+
+mock.module("../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: () => true,
+}));
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({}),
+  invalidateConfigCache: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+}));
+mock.module("../config/skill-state.js", () => ({
+  resolveSkillStates: () => [],
+  skillFlagKey: () => null,
+}));
+mock.module("../providers/provider-send-message.js", () => ({
+  createTimeout: () => ({
+    signal: AbortSignal.timeout(1000),
+    cleanup: () => {},
+  }),
+  extractText: () => "",
+  getConfiguredProvider: async () => null,
+  userMessage: () => ({}),
+}));
+mock.module("../runtime/routes/workspace-utils.js", () => ({
+  isTextMimeType: () => true,
+}));
+mock.module("../skills/catalog-cache.js", () => ({
+  getCatalog: mockGetCatalog,
+}));
+mock.module("../skills/catalog-install.js", () => ({
+  installSkillLocally: mockInstallSkillLocally,
+}));
+mock.module("../skills/catalog-search.js", () => ({
+  filterByQuery: () => [],
+}));
+mock.module("../skills/managed-store.js", () => ({
+  createManagedSkill: () => ({ created: true }),
+  deleteManagedSkill: () => ({ deleted: true }),
+  removeSkillsIndexEntry: () => {},
+  validateManagedSkillId: () => null,
+}));
+mock.module("../skills/skill-memory.js", () => ({
+  deleteSkillCapabilityMemory: () => {},
+  seedCatalogSkillMemories: mockSeedCatalogSkillMemories,
+}));
+mock.module("../util/platform.js", () => ({
+  getWorkspaceSkillsDir: () => "/tmp/test-skills",
+}));
+mock.module("../daemon/handlers/shared.js", () => ({
+  CONFIG_RELOAD_DEBOUNCE_MS: 100,
+  ensureSkillEntry: mockEnsureSkillEntry,
+  log: {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  },
+}));
+
+// Import after mocking
+import { installSkill } from "../daemon/handlers/skills.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const dummyCtx = {
+  debounceTimers: { schedule: () => {} },
+  setSuppressConfigReload: () => {},
+  updateConfigFingerprint: () => {},
+  broadcast: () => {},
+} as unknown as Parameters<typeof installSkill>[1];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("installSkill routing", () => {
+  beforeEach(() => {
+    mockCatalogSkills.mockReset();
+    mockClawhubInstall.mockReset();
+    mockInstallExternalSkill.mockReset();
+    mockGetCatalog.mockReset();
+    mockInstallSkillLocally.mockReset();
+    mockSeedCatalogSkillMemories.mockReset();
+    mockEnsureSkillEntry.mockReset();
+
+    // Defaults
+    mockCatalogSkills.mockReturnValue([]);
+    mockClawhubInstall.mockResolvedValue({ success: true });
+    mockInstallExternalSkill.mockResolvedValue(undefined);
+    mockGetCatalog.mockResolvedValue([]);
+    mockInstallSkillLocally.mockResolvedValue(undefined);
+    mockSeedCatalogSkillMemories.mockReturnValue(undefined);
+    mockEnsureSkillEntry.mockReturnValue({ enabled: false });
+  });
+
+  test("install with origin: 'skillssh' and multi-segment slug routes to installExternalSkill", async () => {
+    const result = await installSkill(
+      {
+        slug: "vercel-labs/agent-skills/react-best-practices",
+        origin: "skillssh",
+      },
+      dummyCtx,
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockInstallExternalSkill).toHaveBeenCalledTimes(1);
+    expect(mockInstallExternalSkill).toHaveBeenCalledWith(
+      "vercel-labs",
+      "agent-skills",
+      "react-best-practices",
+      true, // overwrite
+      undefined, // ref
+    );
+    // Should not have called clawhub
+    expect(mockClawhubInstall).not.toHaveBeenCalled();
+  });
+
+  test("install without origin falls through to clawhub for simple slugs", async () => {
+    const result = await installSkill({ slug: "some-clawhub-skill" }, dummyCtx);
+
+    expect(result.success).toBe(true);
+    expect(mockClawhubInstall).toHaveBeenCalledTimes(1);
+    expect(mockClawhubInstall).toHaveBeenCalledWith("some-clawhub-skill", {
+      version: undefined,
+    });
+    // Should not have called installExternalSkill
+    expect(mockInstallExternalSkill).not.toHaveBeenCalled();
+  });
+
+  test("install with origin: 'clawhub' routes directly to clawhub without trying skills.sh", async () => {
+    const result = await installSkill(
+      { slug: "my-skill", origin: "clawhub" },
+      dummyCtx,
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockClawhubInstall).toHaveBeenCalledTimes(1);
+    expect(mockInstallExternalSkill).not.toHaveBeenCalled();
+  });
+
+  test("multi-segment slug without explicit origin auto-routes to skills.sh", async () => {
+    const result = await installSkill(
+      { slug: "owner/repo/my-skill" },
+      dummyCtx,
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockInstallExternalSkill).toHaveBeenCalledTimes(1);
+    expect(mockInstallExternalSkill).toHaveBeenCalledWith(
+      "owner",
+      "repo",
+      "my-skill",
+      true,
+      undefined,
+    );
+    expect(mockClawhubInstall).not.toHaveBeenCalled();
+  });
+
+  test("multi-segment slug with origin: 'clawhub' skips skills.sh and routes to clawhub", async () => {
+    // Even though the slug looks like skills.sh format, explicit origin: "clawhub"
+    // should override the auto-detection and go to clawhub
+    const result = await installSkill(
+      { slug: "owner/repo/my-skill", origin: "clawhub" },
+      dummyCtx,
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockClawhubInstall).toHaveBeenCalledTimes(1);
+    expect(mockInstallExternalSkill).not.toHaveBeenCalled();
+  });
+
+  test("bundled skills are auto-enabled regardless of origin", async () => {
+    mockCatalogSkills.mockReturnValue([
+      {
+        id: "bundled-skill",
+        displayName: "Bundled Skill",
+        description: "A bundled skill",
+        source: "bundled",
+      },
+    ]);
+
+    const result = await installSkill(
+      { slug: "bundled-skill", origin: "skillssh" },
+      dummyCtx,
+    );
+
+    expect(result.success).toBe(true);
+    // Should have auto-enabled via ensureSkillEntry, not called external install
+    expect(mockInstallExternalSkill).not.toHaveBeenCalled();
+    expect(mockClawhubInstall).not.toHaveBeenCalled();
+  });
+
+  test("skills.sh install failure propagates error", async () => {
+    mockInstallExternalSkill.mockRejectedValue(
+      new Error("Skill not found in repo"),
+    );
+
+    const result = await installSkill(
+      {
+        slug: "owner/repo/nonexistent-skill",
+        origin: "skillssh",
+      },
+      dummyCtx,
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("Skill not found in repo");
+    }
+  });
+});

--- a/assistant/src/__tests__/install-skill-routing.test.ts
+++ b/assistant/src/__tests__/install-skill-routing.test.ts
@@ -10,6 +10,7 @@ const mockCatalogSkills = mock(
     displayName: string;
     description: string;
     source: string;
+    directoryPath?: string;
   }> => [],
 );
 const mockClawhubInstall = mock(
@@ -100,6 +101,7 @@ mock.module("../skills/catalog-cache.js", () => ({
 }));
 mock.module("../skills/catalog-install.js", () => ({
   installSkillLocally: mockInstallSkillLocally,
+  upsertSkillsIndex: () => {},
 }));
 mock.module("../skills/catalog-search.js", () => ({
   filterByQuery: () => [],
@@ -251,6 +253,7 @@ describe("installSkill routing", () => {
         displayName: "Bundled Skill",
         description: "A bundled skill",
         source: "bundled",
+        directoryPath: "/tmp/test-bundled-skills/bundled-skill",
       },
     ]);
 

--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -496,9 +496,9 @@ describe("atomic write safety", () => {
     });
 
     const skillDir = join(TEST_DIR, "skills", "atomic-overwrite");
-    const files = readdirSync(skillDir);
-    // Only SKILL.md should exist — no .tmp-* leftover files
-    expect(files).toEqual(["SKILL.md"]);
+    const files = readdirSync(skillDir).sort();
+    // SKILL.md and install-meta.json should exist — no .tmp-* leftover files
+    expect(files).toEqual(["SKILL.md", "install-meta.json"]);
 
     const content = readFileSync(join(skillDir, "SKILL.md"), "utf-8");
     expect(content).toContain('name: "V2"');
@@ -649,7 +649,7 @@ describe("version metadata", () => {
     expect(readSkillVersion("no-version")).toBeNull();
   });
 
-  test("createManagedSkill writes version.json when version is provided", () => {
+  test("createManagedSkill writes install-meta.json when version is provided", () => {
     createManagedSkill({
       id: "versioned",
       name: "Versioned",
@@ -662,7 +662,7 @@ describe("version metadata", () => {
     expect(version).toBe("v1:abc123");
   });
 
-  test("version.json contains valid JSON with version and installedAt", () => {
+  test("install-meta.json contains valid JSON with origin, version, and installedAt", () => {
     createManagedSkill({
       id: "version-meta",
       name: "Meta",
@@ -671,16 +671,43 @@ describe("version metadata", () => {
       version: "v1:deadbeef",
     });
 
-    const metaPath = join(TEST_DIR, "skills", "version-meta", "version.json");
+    const metaPath = join(
+      TEST_DIR,
+      "skills",
+      "version-meta",
+      "install-meta.json",
+    );
     expect(existsSync(metaPath)).toBe(true);
     const meta = JSON.parse(readFileSync(metaPath, "utf-8"));
+    expect(meta.origin).toBe("custom");
     expect(meta.version).toBe("v1:deadbeef");
     expect(typeof meta.installedAt).toBe("string");
     // installedAt should be a valid ISO date
     expect(new Date(meta.installedAt).toISOString()).toBe(meta.installedAt);
   });
 
-  test("overwrite updates version.json", () => {
+  test("install-meta.json includes installedBy when contactId is provided", () => {
+    createManagedSkill({
+      id: "with-contact",
+      name: "With Contact",
+      description: "Has contactId",
+      bodyMarkdown: "Body.",
+      contactId: "contact-uuid-456",
+    });
+
+    const metaPath = join(
+      TEST_DIR,
+      "skills",
+      "with-contact",
+      "install-meta.json",
+    );
+    expect(existsSync(metaPath)).toBe(true);
+    const meta = JSON.parse(readFileSync(metaPath, "utf-8"));
+    expect(meta.origin).toBe("custom");
+    expect(meta.installedBy).toBe("contact-uuid-456");
+  });
+
+  test("overwrite updates install-meta.json", () => {
     createManagedSkill({
       id: "update-version",
       name: "V1",
@@ -701,21 +728,21 @@ describe("version metadata", () => {
     expect(readSkillVersion("update-version")).toBe("v1:second");
   });
 
-  test("readSkillVersion returns null for corrupted version.json", () => {
+  test("readSkillVersion returns null for corrupted install-meta.json", () => {
     createManagedSkill({
       id: "corrupt-version",
       name: "Corrupt",
-      description: "Will corrupt version file",
+      description: "Will corrupt meta file",
       bodyMarkdown: "Body.",
       version: "v1:valid",
     });
 
-    // Corrupt the version.json
+    // Corrupt the install-meta.json
     const metaPath = join(
       TEST_DIR,
       "skills",
       "corrupt-version",
-      "version.json",
+      "install-meta.json",
     );
     writeFileSync(metaPath, "{invalid json!!!", "utf-8");
 

--- a/assistant/src/__tests__/workspace-migration-026-backfill-install-meta.test.ts
+++ b/assistant/src/__tests__/workspace-migration-026-backfill-install-meta.test.ts
@@ -1,0 +1,558 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { backfillInstallMetaMigration } from "../workspace/migrations/026-backfill-install-meta.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let workspaceDir: string;
+let skillsDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-026-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  skillsDir = join(workspaceDir, "skills");
+  mkdirSync(skillsDir, { recursive: true });
+}
+
+function createSkillDir(
+  name: string,
+  opts?: {
+    skillMd?: string;
+    versionJson?: Record<string, unknown>;
+    installMetaJson?: Record<string, unknown>;
+    extraFiles?: Record<string, string>;
+  },
+): string {
+  const dir = join(skillsDir, name);
+  mkdirSync(dir, { recursive: true });
+
+  if (opts?.skillMd !== undefined) {
+    writeFileSync(join(dir, "SKILL.md"), opts.skillMd, "utf-8");
+  } else {
+    // Default: create a SKILL.md so the dir is recognized as a skill
+    writeFileSync(join(dir, "SKILL.md"), `# ${name}\n`, "utf-8");
+  }
+
+  if (opts?.versionJson) {
+    writeFileSync(
+      join(dir, "version.json"),
+      JSON.stringify(opts.versionJson, null, 2),
+      "utf-8",
+    );
+  }
+
+  if (opts?.installMetaJson) {
+    writeFileSync(
+      join(dir, "install-meta.json"),
+      JSON.stringify(opts.installMetaJson, null, 2),
+      "utf-8",
+    );
+  }
+
+  if (opts?.extraFiles) {
+    for (const [filePath, content] of Object.entries(opts.extraFiles)) {
+      const fullPath = join(dir, filePath);
+      mkdirSync(join(fullPath, ".."), { recursive: true });
+      writeFileSync(fullPath, content, "utf-8");
+    }
+  }
+
+  return dir;
+}
+
+function writeIntegrityManifest(
+  manifest: Record<string, { sha256: string; installedAt: string }>,
+): void {
+  writeFileSync(
+    join(skillsDir, ".integrity.json"),
+    JSON.stringify(manifest, null, 2),
+    "utf-8",
+  );
+}
+
+function readInstallMeta(skillName: string): Record<string, unknown> | null {
+  const path = join(skillsDir, skillName, "install-meta.json");
+  if (!existsSync(path)) return null;
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+const dirs: string[] = [];
+
+beforeEach(() => {
+  freshWorkspace();
+  dirs.push(workspaceDir);
+});
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("026-backfill-install-meta migration", () => {
+  test("has correct migration id", () => {
+    expect(backfillInstallMetaMigration.id).toBe("026-backfill-install-meta");
+  });
+
+  // ─── No-op cases ────────────────────────────────────────────────────────
+
+  test("no-op when skills dir does not exist", () => {
+    rmSync(skillsDir, { recursive: true, force: true });
+    // Should not throw
+    backfillInstallMetaMigration.run(workspaceDir);
+  });
+
+  test("no-op when skills dir is empty", () => {
+    backfillInstallMetaMigration.run(workspaceDir);
+    // No install-meta.json should be created
+  });
+
+  test("skips directories without SKILL.md", () => {
+    const dir = join(skillsDir, "not-a-skill");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "README.md"), "# Not a skill", "utf-8");
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    expect(existsSync(join(dir, "install-meta.json"))).toBe(false);
+  });
+
+  test("skips non-directory entries", () => {
+    writeFileSync(join(skillsDir, "some-file.txt"), "not a dir", "utf-8");
+
+    backfillInstallMetaMigration.run(workspaceDir);
+    // Should not throw
+  });
+
+  // ─── Idempotency ───────────────────────────────────────────────────────
+
+  test("skips skills that already have install-meta.json", () => {
+    const existingMeta = {
+      origin: "clawhub",
+      installedAt: "2025-01-01T00:00:00.000Z",
+      installedBy: "user-123",
+      slug: "existing-skill",
+    };
+    createSkillDir("my-skill", { installMetaJson: existingMeta });
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const meta = readInstallMeta("my-skill");
+    expect(meta).not.toBeNull();
+    expect(meta!.installedBy).toBe("user-123"); // preserved, not overwritten
+    expect(meta!.origin).toBe("clawhub");
+  });
+
+  test("is idempotent — running twice produces same result", () => {
+    createSkillDir("my-skill", {
+      versionJson: {
+        version: "1.0.0",
+        installedAt: "2025-03-01T00:00:00.000Z",
+      },
+    });
+
+    backfillInstallMetaMigration.run(workspaceDir);
+    const meta1 = readInstallMeta("my-skill");
+
+    backfillInstallMetaMigration.run(workspaceDir);
+    const meta2 = readInstallMeta("my-skill");
+
+    expect(meta1).toEqual(meta2);
+  });
+
+  // ─── Case 1: skills.sh origin ──────────────────────────────────────────
+
+  test("infers skillssh origin from version.json with origin: skills.sh", () => {
+    createSkillDir("skillssh-skill", {
+      versionJson: {
+        origin: "skills.sh",
+        source: "vercel-labs/agent-skills",
+        skillSlug: "react-best-practices",
+        installedAt: "2025-02-15T12:00:00.000Z",
+      },
+    });
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const meta = readInstallMeta("skillssh-skill");
+    expect(meta).not.toBeNull();
+    expect(meta!.origin).toBe("skillssh");
+    expect(meta!.sourceRepo).toBe("vercel-labs/agent-skills");
+    expect(meta!.slug).toBe("react-best-practices");
+    expect(meta!.installedAt).toBe("2025-02-15T12:00:00.000Z");
+    expect(meta!.installedBy).toBeUndefined();
+    expect(meta!.contentHash).toMatch(/^v2:[0-9a-f]{64}$/);
+  });
+
+  // ─── Case 2: version with no origin (vellum or clawhub) ───────────────
+
+  test("infers vellum origin from version.json with version and no origin", () => {
+    createSkillDir("vellum-skill", {
+      versionJson: {
+        version: "v1:abc123",
+        installedAt: "2025-01-20T08:00:00.000Z",
+      },
+    });
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const meta = readInstallMeta("vellum-skill");
+    expect(meta).not.toBeNull();
+    expect(meta!.origin).toBe("vellum");
+    expect(meta!.version).toBe("v1:abc123");
+    expect(meta!.installedAt).toBe("2025-01-20T08:00:00.000Z");
+    expect(meta!.installedBy).toBeUndefined();
+    expect(meta!.contentHash).toMatch(/^v2:[0-9a-f]{64}$/);
+  });
+
+  test("infers clawhub origin when version.json has version, no origin, and integrity entry exists", () => {
+    createSkillDir("clawhub-skill", {
+      versionJson: {
+        version: "1.2.3",
+        installedAt: "2025-03-10T10:00:00.000Z",
+      },
+    });
+    writeIntegrityManifest({
+      "clawhub-skill": {
+        sha256:
+          "v2:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+        installedAt: "2025-03-10T10:00:00.000Z",
+      },
+    });
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const meta = readInstallMeta("clawhub-skill");
+    expect(meta).not.toBeNull();
+    expect(meta!.origin).toBe("clawhub");
+    expect(meta!.version).toBe("1.2.3");
+    expect(meta!.installedAt).toBe("2025-03-10T10:00:00.000Z");
+    expect(meta!.installedBy).toBeUndefined();
+  });
+
+  // ─── Case 3: version.json with unknown pattern ─────────────────────────
+
+  test("infers custom origin from version.json with unrecognized structure", () => {
+    createSkillDir("weird-skill", {
+      versionJson: {
+        origin: "some-unknown-registry",
+        installedAt: "2025-04-01T00:00:00.000Z",
+      },
+    });
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const meta = readInstallMeta("weird-skill");
+    expect(meta).not.toBeNull();
+    expect(meta!.origin).toBe("custom");
+    expect(meta!.installedAt).toBe("2025-04-01T00:00:00.000Z");
+    expect(meta!.installedBy).toBeUndefined();
+  });
+
+  test("infers custom origin from version.json with version AND origin fields", () => {
+    createSkillDir("both-fields", {
+      versionJson: {
+        origin: "some-origin",
+        version: "2.0.0",
+        installedAt: "2025-05-01T00:00:00.000Z",
+      },
+    });
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const meta = readInstallMeta("both-fields");
+    expect(meta).not.toBeNull();
+    // Has `origin` field (not "skills.sh") AND `version` -> doesn't match case 2
+    // (case 2 requires no `origin` field), falls through to case 3 (custom)
+    expect(meta!.origin).toBe("custom");
+  });
+
+  // ─── Case 4: no version.json ──────────────────────────────────────────
+
+  test("infers clawhub origin when no version.json but integrity entry exists", () => {
+    createSkillDir("clawhub-no-version", {});
+    writeIntegrityManifest({
+      "clawhub-no-version": {
+        sha256:
+          "v2:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+        installedAt: "2025-06-01T00:00:00.000Z",
+      },
+    });
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const meta = readInstallMeta("clawhub-no-version");
+    expect(meta).not.toBeNull();
+    expect(meta!.origin).toBe("clawhub");
+    expect(meta!.installedBy).toBeUndefined();
+    // installedAt should be directory mtime (an ISO string)
+    expect(typeof meta!.installedAt).toBe("string");
+    expect(new Date(meta!.installedAt as string).getTime()).not.toBeNaN();
+  });
+
+  test("infers custom origin when no version.json and no integrity entry", () => {
+    createSkillDir("custom-skill", {});
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const meta = readInstallMeta("custom-skill");
+    expect(meta).not.toBeNull();
+    expect(meta!.origin).toBe("custom");
+    expect(meta!.installedBy).toBeUndefined();
+    expect(typeof meta!.installedAt).toBe("string");
+  });
+
+  // ─── Malformed version.json ───────────────────────────────────────────
+
+  test("handles malformed version.json gracefully", () => {
+    const dir = createSkillDir("bad-version");
+    writeFileSync(join(dir, "version.json"), "{bad json!", "utf-8");
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const meta = readInstallMeta("bad-version");
+    expect(meta).not.toBeNull();
+    expect(meta!.origin).toBe("custom");
+    expect(meta!.installedBy).toBeUndefined();
+  });
+
+  test("handles malformed version.json with integrity entry as clawhub", () => {
+    const dir = createSkillDir("bad-version-clawhub");
+    writeFileSync(join(dir, "version.json"), "{{{", "utf-8");
+    writeIntegrityManifest({
+      "bad-version-clawhub": {
+        sha256: "v2:aaa",
+        installedAt: "2025-01-01T00:00:00.000Z",
+      },
+    });
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const meta = readInstallMeta("bad-version-clawhub");
+    expect(meta).not.toBeNull();
+    expect(meta!.origin).toBe("clawhub");
+  });
+
+  // ─── Content hash ─────────────────────────────────────────────────────
+
+  test("computes contentHash for all backfilled skills", () => {
+    createSkillDir("hash-test", {
+      versionJson: {
+        version: "1.0.0",
+        installedAt: "2025-01-01T00:00:00.000Z",
+      },
+      extraFiles: { "executor.ts": "export const run = () => {};" },
+    });
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const meta = readInstallMeta("hash-test");
+    expect(meta).not.toBeNull();
+    expect(meta!.contentHash).toMatch(/^v2:[0-9a-f]{64}$/);
+  });
+
+  // ─── Legacy file preservation ─────────────────────────────────────────
+
+  test("preserves legacy version.json after backfill", () => {
+    const versionData = {
+      version: "1.0.0",
+      installedAt: "2025-01-01T00:00:00.000Z",
+    };
+    const dir = createSkillDir("preserve-version", {
+      versionJson: versionData,
+    });
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    // version.json should still exist
+    const versionPath = join(dir, "version.json");
+    expect(existsSync(versionPath)).toBe(true);
+    const preserved = JSON.parse(readFileSync(versionPath, "utf-8"));
+    expect(preserved.version).toBe("1.0.0");
+  });
+
+  test("preserves .integrity.json after backfill", () => {
+    createSkillDir("preserve-integrity", {
+      versionJson: {
+        version: "1.0.0",
+        installedAt: "2025-01-01T00:00:00.000Z",
+      },
+    });
+    const manifestData = {
+      "preserve-integrity": {
+        sha256: "v2:abc",
+        installedAt: "2025-01-01T00:00:00.000Z",
+      },
+    };
+    writeIntegrityManifest(manifestData);
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const integrityPath = join(skillsDir, ".integrity.json");
+    expect(existsSync(integrityPath)).toBe(true);
+    const preserved = JSON.parse(readFileSync(integrityPath, "utf-8"));
+    expect(preserved["preserve-integrity"]).toBeDefined();
+  });
+
+  // ─── Multiple skills ──────────────────────────────────────────────────
+
+  test("processes multiple skill directories in a single run", () => {
+    createSkillDir("skill-a", {
+      versionJson: {
+        version: "1.0.0",
+        installedAt: "2025-01-01T00:00:00.000Z",
+      },
+    });
+    createSkillDir("skill-b", {
+      versionJson: {
+        origin: "skills.sh",
+        source: "org/repo",
+        skillSlug: "slug-b",
+        installedAt: "2025-02-01T00:00:00.000Z",
+      },
+    });
+    createSkillDir("skill-c", {}); // no version.json
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const metaA = readInstallMeta("skill-a");
+    const metaB = readInstallMeta("skill-b");
+    const metaC = readInstallMeta("skill-c");
+
+    expect(metaA).not.toBeNull();
+    expect(metaA!.origin).toBe("vellum");
+
+    expect(metaB).not.toBeNull();
+    expect(metaB!.origin).toBe("skillssh");
+
+    expect(metaC).not.toBeNull();
+    expect(metaC!.origin).toBe("custom");
+  });
+
+  // ─── installedAt fallback ─────────────────────────────────────────────
+
+  test("uses directory mtime as installedAt when version.json lacks it", () => {
+    createSkillDir("no-installed-at", {
+      versionJson: { version: "1.0.0" },
+    });
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const meta = readInstallMeta("no-installed-at");
+    expect(meta).not.toBeNull();
+    // Should be an ISO date from dir mtime
+    expect(typeof meta!.installedAt).toBe("string");
+    expect(new Date(meta!.installedAt as string).getTime()).not.toBeNaN();
+  });
+
+  test("uses directory mtime as installedAt when no version.json exists", () => {
+    createSkillDir("mtime-fallback", {});
+
+    backfillInstallMetaMigration.run(workspaceDir);
+
+    const meta = readInstallMeta("mtime-fallback");
+    expect(meta).not.toBeNull();
+    expect(typeof meta!.installedAt).toBe("string");
+    expect(new Date(meta!.installedAt as string).getTime()).not.toBeNaN();
+  });
+
+  // ─── down() rollback ──────────────────────────────────────────────────
+
+  describe("down()", () => {
+    test("removes backfilled install-meta.json files", () => {
+      createSkillDir("rollback-skill", {
+        versionJson: {
+          version: "1.0.0",
+          installedAt: "2025-01-01T00:00:00.000Z",
+        },
+      });
+
+      backfillInstallMetaMigration.run(workspaceDir);
+      expect(
+        existsSync(join(skillsDir, "rollback-skill", "install-meta.json")),
+      ).toBe(true);
+
+      backfillInstallMetaMigration.down(workspaceDir);
+      expect(
+        existsSync(join(skillsDir, "rollback-skill", "install-meta.json")),
+      ).toBe(false);
+    });
+
+    test("preserves install-meta.json with installedBy (not backfilled)", () => {
+      createSkillDir("keep-skill", {
+        installMetaJson: {
+          origin: "clawhub",
+          installedAt: "2025-01-01T00:00:00.000Z",
+          installedBy: "user-abc",
+          slug: "my-skill",
+        },
+      });
+
+      backfillInstallMetaMigration.down(workspaceDir);
+
+      expect(
+        existsSync(join(skillsDir, "keep-skill", "install-meta.json")),
+      ).toBe(true);
+    });
+
+    test("is idempotent — calling down() twice is safe", () => {
+      createSkillDir("double-down", {
+        versionJson: {
+          version: "1.0.0",
+          installedAt: "2025-01-01T00:00:00.000Z",
+        },
+      });
+
+      backfillInstallMetaMigration.run(workspaceDir);
+      backfillInstallMetaMigration.down(workspaceDir);
+      backfillInstallMetaMigration.down(workspaceDir); // second call
+
+      expect(
+        existsSync(join(skillsDir, "double-down", "install-meta.json")),
+      ).toBe(false);
+    });
+
+    test("no-op when skills dir does not exist", () => {
+      rmSync(skillsDir, { recursive: true, force: true });
+      // Should not throw
+      backfillInstallMetaMigration.down(workspaceDir);
+    });
+
+    test("no-op when skills dir is empty", () => {
+      // Should not throw
+      backfillInstallMetaMigration.down(workspaceDir);
+    });
+
+    test("handles malformed install-meta.json in down() gracefully", () => {
+      const dir = createSkillDir("bad-meta");
+      writeFileSync(join(dir, "install-meta.json"), "{not valid}", "utf-8");
+
+      // Should not throw
+      backfillInstallMetaMigration.down(workspaceDir);
+
+      // The malformed file is left in place (skip, not crash)
+      expect(existsSync(join(dir, "install-meta.json"))).toBe(true);
+    });
+  });
+});

--- a/assistant/src/cli/commands/skills.ts
+++ b/assistant/src/cli/commands/skills.ts
@@ -488,8 +488,8 @@ Arguments:
 
 Notes:
   Fetches the skill's SKILL.md and supporting files from the specified GitHub
-  repository and installs them into the workspace skills directory. A
-  version.json file is written with origin metadata for provenance tracking.
+  repository and installs them into the workspace skills directory. An
+  install-meta.json file is written with origin metadata for provenance tracking.
 
 Examples:
   $ assistant skills add vercel-labs/skills@find-skills

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import {
   existsSync,
   lstatSync,
@@ -7,6 +8,7 @@ import {
   rmSync,
   statSync,
 } from "node:fs";
+import { homedir } from "node:os";
 import { join, relative } from "node:path";
 
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
@@ -26,7 +28,10 @@ import {
 } from "../../providers/provider-send-message.js";
 import { isTextMimeType as isTextMime } from "../../runtime/routes/workspace-utils.js";
 import { getCatalog } from "../../skills/catalog-cache.js";
-import { installSkillLocally } from "../../skills/catalog-install.js";
+import {
+  installSkillLocally,
+  upsertSkillsIndex,
+} from "../../skills/catalog-install.js";
 import { filterByQuery } from "../../skills/catalog-search.js";
 import {
   clawhubCheckUpdates,
@@ -235,6 +240,44 @@ function saveConfigWithSuppression(
   );
 
   ctx.updateConfigFingerprint();
+}
+
+/**
+ * Shared post-install logic for catalog, skillssh, and clawhub install paths
+ * in the daemon. Handles catalog reload, auto-enable, broadcast, and memory
+ * seeding.
+ *
+ * SKILLS.md indexing and dependency installation are handled by the install
+ * functions themselves (`installSkillLocally`, `installExternalSkill`,
+ * `clawhubInstall`) so that both CLI and daemon callers get correct behavior.
+ *
+ * NOT used for bundled skills — those have a simpler inline path in
+ * `installSkill()` that only auto-enables, broadcasts, and seeds memories.
+ */
+export function postInstallSkill(
+  skillId: string,
+  _skillDir: string,
+  ctx: SkillOperationContext,
+): void {
+  // Reload skill catalog so the newly installed skill is picked up
+  loadSkillCatalog();
+
+  // Auto-enable the skill in config
+  try {
+    const raw = loadRawConfig();
+    ensureSkillEntry(raw, skillId).enabled = true;
+    saveConfigWithSuppression(raw, ctx);
+    ctx.broadcast({
+      type: "skills_state_changed",
+      name: skillId,
+      state: "enabled",
+    });
+  } catch (err) {
+    log.warn({ err, skillId }, "Failed to auto-enable installed skill");
+  }
+
+  // Seed skill memories
+  seedCatalogSkillMemories();
 }
 
 export interface SkillListItem {
@@ -579,7 +622,9 @@ export async function installSkill(
       (s) => s.id === spec.slug && s.source === "bundled",
     );
     if (bundled) {
-      // Auto-enable the bundled skill so it's immediately usable
+      // Bundled skills are already on disk — they don't need SKILLS.md
+      // indexing or dependency installation. Just auto-enable, broadcast,
+      // and seed memories.
       try {
         const raw = loadRawConfig();
         ensureSkillEntry(raw, spec.slug).enabled = true;
@@ -611,27 +656,8 @@ export async function installSkill(
           spec.contactId,
         );
 
-        // Reload skill catalog so the newly installed skill is picked up
-        loadSkillCatalog();
-
-        // Auto-enable the newly installed catalog skill
-        try {
-          const raw = loadRawConfig();
-          ensureSkillEntry(raw, spec.slug).enabled = true;
-          saveConfigWithSuppression(raw, ctx);
-          ctx.broadcast({
-            type: "skills_state_changed",
-            name: spec.slug,
-            state: "enabled",
-          });
-        } catch (err) {
-          log.warn(
-            { err, skillId: spec.slug },
-            "Failed to auto-enable installed catalog skill",
-          );
-        }
-
-        seedCatalogSkillMemories();
+        const skillDir = join(getWorkspaceSkillsDir(), spec.slug);
+        postInstallSkill(spec.slug, skillDir, ctx);
         return { success: true };
       }
     } catch (err) {
@@ -658,27 +684,8 @@ export async function installSkill(
         spec.contactId,
       );
 
-      // Reload skill catalog so the newly installed skill is picked up
-      loadSkillCatalog();
-
-      // Auto-enable the newly installed skill
-      try {
-        const raw = loadRawConfig();
-        ensureSkillEntry(raw, resolved.skillSlug).enabled = true;
-        saveConfigWithSuppression(raw, ctx);
-        ctx.broadcast({
-          type: "skills_state_changed",
-          name: resolved.skillSlug,
-          state: "enabled",
-        });
-      } catch (err) {
-        log.warn(
-          { err, skillId: resolved.skillSlug },
-          "Failed to auto-enable installed skills.sh skill",
-        );
-      }
-
-      seedCatalogSkillMemories();
+      const skillDir = join(getWorkspaceSkillsDir(), resolved.skillSlug);
+      postInstallSkill(resolved.skillSlug, skillDir, ctx);
       return { success: true };
     }
 
@@ -693,24 +700,20 @@ export async function installSkill(
     const rawId = result.skillName ?? spec.slug;
     const skillId = rawId.includes("/") ? rawId.split("/").pop()! : rawId;
 
-    // Reload skill catalog so the newly installed skill is picked up
-    loadSkillCatalog();
-
-    // Auto-enable the newly installed skill
-    try {
-      const raw = loadRawConfig();
-      ensureSkillEntry(raw, skillId).enabled = true;
-      saveConfigWithSuppression(raw, ctx);
-      ctx.broadcast({
-        type: "skills_state_changed",
-        name: skillId,
-        state: "enabled",
+    // clawhubInstall uses the clawhub CLI which doesn't handle bun install
+    // or SKILLS.md indexing, so we do those here before post-install.
+    const skillDir = join(getWorkspaceSkillsDir(), skillId);
+    if (existsSync(join(skillDir, "package.json"))) {
+      const bunPath = `${homedir()}/.bun/bin`;
+      execSync("bun install", {
+        cwd: skillDir,
+        stdio: "inherit",
+        env: { ...process.env, PATH: `${bunPath}:${process.env.PATH}` },
       });
-    } catch (err) {
-      log.warn({ err, skillId }, "Failed to auto-enable installed skill");
     }
+    upsertSkillsIndex(skillId);
 
-    seedCatalogSkillMemories();
+    postInstallSkill(skillId, skillDir, ctx);
     return { success: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -550,7 +550,12 @@ function looksLikeSkillsShSlug(slug: string): boolean {
 }
 
 export async function installSkill(
-  spec: { slug: string; version?: string; origin?: "clawhub" | "skillssh" },
+  spec: {
+    slug: string;
+    version?: string;
+    origin?: "clawhub" | "skillssh";
+    contactId?: string;
+  },
   ctx: SkillOperationContext,
 ): Promise<{ success: true } | { success: false; error: string }> {
   try {
@@ -599,7 +604,12 @@ export async function installSkill(
       const vellumCatalog = await getCatalog();
       const catalogEntry = vellumCatalog.find((s) => s.id === spec.slug);
       if (catalogEntry) {
-        await installSkillLocally(spec.slug, catalogEntry, true);
+        await installSkillLocally(
+          spec.slug,
+          catalogEntry,
+          true,
+          spec.contactId,
+        );
 
         // Reload skill catalog so the newly installed skill is picked up
         loadSkillCatalog();
@@ -645,6 +655,7 @@ export async function installSkill(
         resolved.skillSlug,
         true /* overwrite */,
         resolved.ref ?? spec.version,
+        spec.contactId,
       );
 
       // Reload skill catalog so the newly installed skill is picked up
@@ -672,7 +683,10 @@ export async function installSkill(
     }
 
     // Install from clawhub (community)
-    const result = await clawhubInstall(spec.slug, { version: spec.version });
+    const result = await clawhubInstall(spec.slug, {
+      version: spec.version,
+      contactId: spec.contactId,
+    });
     if (!result.success) {
       return { success: false, error: result.error ?? "Unknown error" };
     }
@@ -1105,6 +1119,7 @@ export interface CreateSkillParams {
   emoji?: string;
   bodyMarkdown: string;
   overwrite?: boolean;
+  contactId?: string;
 }
 
 export async function createSkill(
@@ -1119,6 +1134,7 @@ export async function createSkill(
       emoji: params.emoji,
       bodyMarkdown: params.bodyMarkdown,
       overwrite: params.overwrite,
+      contactId: params.contactId,
     });
 
     if (!result.created) {

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -622,9 +622,12 @@ export async function installSkill(
       (s) => s.id === spec.slug && s.source === "bundled",
     );
     if (bundled) {
-      // Bundled skills are already on disk — they don't need SKILLS.md
-      // indexing or dependency installation. Just auto-enable, broadcast,
-      // and seed memories.
+      // Intentional divergence from postInstallSkill(): bundled skills are
+      // shipped with the assistant binary and are already on disk. They skip
+      // SKILLS.md indexing (they're discovered via the bundled catalog, not
+      // the workspace index), dependency installation (deps are pre-bundled),
+      // and catalog reload (the catalog already includes them). Only
+      // auto-enable, broadcast, and seed memories are needed.
       try {
         const raw = loadRawConfig();
         ensureSkillEntry(raw, spec.slug).enabled = true;

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -46,7 +46,11 @@ import {
   deleteSkillCapabilityMemory,
   seedCatalogSkillMemories,
 } from "../../skills/skill-memory.js";
-import { searchSkillsRegistry } from "../../skills/skillssh-registry.js";
+import {
+  installExternalSkill,
+  resolveSkillSource,
+  searchSkillsRegistry,
+} from "../../skills/skillssh-registry.js";
 import { getWorkspaceSkillsDir } from "../../util/platform.js";
 import {
   CONFIG_RELOAD_DEBOUNCE_MS,
@@ -537,8 +541,16 @@ export function configureSkill(
   }
 }
 
+/**
+ * Check whether a slug looks like a skills.sh multi-segment format
+ * (e.g. `owner/repo/skill-name` — three or more `/`-separated segments).
+ */
+function looksLikeSkillsShSlug(slug: string): boolean {
+  return slug.split("/").length >= 3;
+}
+
 export async function installSkill(
-  spec: { slug: string; version?: string },
+  spec: { slug: string; version?: string; origin?: "clawhub" | "skillssh" },
   ctx: SkillOperationContext,
 ): Promise<{ success: true } | { success: false; error: string }> {
   try {
@@ -613,11 +625,50 @@ export async function installSkill(
         return { success: true };
       }
     } catch (err) {
-      // If catalog lookup/install fails, fall through to clawhub
+      // If catalog lookup/install fails, fall through to community registries
       log.warn(
         { err, skillId: spec.slug },
         "Vellum catalog install failed, falling back to community registry",
       );
+    }
+
+    // skills.sh install path: route here when origin is explicitly "skillssh"
+    // or when the slug looks like a skills.sh multi-segment format (owner/repo/skill)
+    if (
+      spec.origin === "skillssh" ||
+      (spec.origin !== "clawhub" && looksLikeSkillsShSlug(spec.slug))
+    ) {
+      const resolved = resolveSkillSource(spec.slug);
+      await installExternalSkill(
+        resolved.owner,
+        resolved.repo,
+        resolved.skillSlug,
+        true /* overwrite */,
+        resolved.ref ?? spec.version,
+      );
+
+      // Reload skill catalog so the newly installed skill is picked up
+      loadSkillCatalog();
+
+      // Auto-enable the newly installed skill
+      try {
+        const raw = loadRawConfig();
+        ensureSkillEntry(raw, resolved.skillSlug).enabled = true;
+        saveConfigWithSuppression(raw, ctx);
+        ctx.broadcast({
+          type: "skills_state_changed",
+          name: resolved.skillSlug,
+          state: "enabled",
+        });
+      } catch (err) {
+        log.warn(
+          { err, skillId: resolved.skillSlug },
+          "Failed to auto-enable installed skills.sh skill",
+        );
+      }
+
+      seedCatalogSkillMemories();
+      return { success: true };
     }
 
     // Install from clawhub (community)

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -211,7 +211,7 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
       responseBody: z.object({
         ok: z.boolean(),
       }),
-      handler: async ({ req }) => {
+      handler: async ({ req, authContext }) => {
         const body = (await req.json()) as {
           slug?: string;
           url?: string;
@@ -227,8 +227,9 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
             400,
           );
         }
+        const contactId = authContext.actorPrincipalId ?? undefined;
         const result = await installSkill(
-          { slug, version: body.version, origin: body.origin },
+          { slug, version: body.version, origin: body.origin, contactId },
           ctx(),
         );
         if (!result.success) {
@@ -330,7 +331,7 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
       responseBody: z.object({
         ok: z.boolean(),
       }),
-      handler: async ({ req }) => {
+      handler: async ({ req, authContext }) => {
         const body = (await req.json()) as CreateSkillParams;
         if (
           !body.skillId ||
@@ -344,7 +345,8 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
             400,
           );
         }
-        const result = await createSkill(body, ctx());
+        const contactId = authContext.actorPrincipalId ?? undefined;
+        const result = await createSkill({ ...body, contactId }, ctx());
         if (!result.success) {
           return httpError("INTERNAL_ERROR", result.error, 500);
         }

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -201,6 +201,12 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
         url: z.string().describe("Skill URL"),
         spec: z.string().describe("Skill spec"),
         version: z.string(),
+        origin: z
+          .enum(["clawhub", "skillssh"])
+          .optional()
+          .describe(
+            "Which registry to install from. When omitted, the install flow auto-detects based on slug format.",
+          ),
       }),
       responseBody: z.object({
         ok: z.boolean(),
@@ -211,6 +217,7 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
           url?: string;
           spec?: string;
           version?: string;
+          origin?: "clawhub" | "skillssh";
         };
         const slug = body.slug ?? body.url ?? body.spec;
         if (!slug || typeof slug !== "string") {
@@ -221,7 +228,7 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
           );
         }
         const result = await installSkill(
-          { slug, version: body.version },
+          { slug, version: body.version, origin: body.origin },
           ctx(),
         );
         if (!result.success) {

--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -16,6 +16,7 @@ import { gunzipSync } from "node:zlib";
 import { getPlatformBaseUrl } from "../config/env.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceSkillsDir, readPlatformToken } from "../util/platform.js";
+import { computeSkillHash, writeInstallMeta } from "./install-meta.js";
 import { deleteSkillCapabilityMemory } from "./skill-memory.js";
 
 const log = getLogger("catalog-install");
@@ -270,6 +271,7 @@ export async function installSkillLocally(
   skillId: string,
   catalogEntry: CatalogSkill,
   overwrite: boolean,
+  contactId?: string,
 ): Promise<void> {
   const skillDir = join(getWorkspaceSkillsDir(), skillId);
   const skillFilePath = join(skillDir, "SKILL.md");
@@ -294,17 +296,14 @@ export async function installSkillLocally(
     await fetchAndExtractSkill(skillId, skillDir);
   }
 
-  // Write version metadata
-  if (catalogEntry.version) {
-    const meta = {
-      version: catalogEntry.version,
-      installedAt: new Date().toISOString(),
-    };
-    atomicWriteFile(
-      join(skillDir, "version.json"),
-      JSON.stringify(meta, null, 2) + "\n",
-    );
-  }
+  // Write install metadata
+  writeInstallMeta(skillDir, {
+    origin: "vellum",
+    installedAt: new Date().toISOString(),
+    ...(catalogEntry.version ? { version: catalogEntry.version } : {}),
+    ...(contactId ? { installedBy: contactId } : {}),
+    contentHash: computeSkillHash(skillDir) ?? undefined,
+  });
 
   // Install npm dependencies if the skill has a package.json
   if (existsSync(join(skillDir, "package.json"))) {

--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -305,7 +305,9 @@ export async function installSkillLocally(
     contentHash: computeSkillHash(skillDir) ?? undefined,
   });
 
-  // Install npm dependencies if the skill has a package.json
+  // Post-install: install dependencies first, then index the skill.
+  // Running bun install before upsertSkillsIndex ensures we don't index a
+  // skill whose dependencies failed to install.
   if (existsSync(join(skillDir, "package.json"))) {
     const bunPath = `${homedir()}/.bun/bin`;
     execSync("bun install", {
@@ -314,8 +316,6 @@ export async function installSkillLocally(
       env: { ...process.env, PATH: `${bunPath}:${process.env.PATH}` },
     });
   }
-
-  // Register in SKILLS.md only after all steps succeed
   upsertSkillsIndex(skillId);
 }
 
@@ -392,6 +392,8 @@ export async function autoInstallFromCatalog(
     return false;
   }
 
+  // installSkillLocally handles dependency installation and SKILLS.md indexing.
   await installSkillLocally(skillId, entry, false);
+
   return true;
 }

--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -1,14 +1,9 @@
-import {
-  existsSync,
-  readdirSync,
-  readFileSync,
-  statSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceSkillsDir } from "../util/platform.js";
+import { computeSkillHash } from "./install-meta.js";
 
 const log = getLogger("clawhub");
 
@@ -60,49 +55,6 @@ function saveIntegrityManifest(manifest: IntegrityManifest): void {
     JSON.stringify(manifest, null, 2) + "\n",
     "utf-8",
   );
-}
-
-/** Collect all file contents in a directory tree, sorted by relative path for determinism. */
-function collectFileContents(
-  dir: string,
-  prefix = "",
-): Array<{ relPath: string; content: Buffer }> {
-  const results: Array<{ relPath: string; content: Buffer }> = [];
-  if (!existsSync(dir)) return results;
-
-  const entries = readdirSync(dir, { withFileTypes: true });
-  for (const entry of entries) {
-    const relPath = prefix ? `${prefix}/${entry.name}` : entry.name;
-    const fullPath = join(dir, entry.name);
-    if (entry.isDirectory()) {
-      results.push(...collectFileContents(fullPath, relPath));
-    } else if (entry.isFile()) {
-      results.push({ relPath, content: readFileSync(fullPath) });
-    }
-  }
-  return results.sort((a, b) => a.relPath.localeCompare(b.relPath));
-}
-
-/**
- * Compute a SHA-256 hash over all files in a skill directory.
- * Returns format: "v2:sha256hex" (version prefix added to support hash format evolution).
- */
-function computeSkillHash(skillDir: string): string | null {
-  if (!existsSync(skillDir) || !statSync(skillDir).isDirectory()) return null;
-
-  const files = collectFileContents(skillDir);
-  if (files.length === 0) return null;
-
-  const hasher = new Bun.CryptoHasher("sha256");
-  for (const file of files) {
-    // Length-prefix each segment to prevent boundary ambiguity collisions
-    const pathBuf = Buffer.from(file.relPath, "utf-8");
-    hasher.update(`${pathBuf.length}:`);
-    hasher.update(pathBuf);
-    hasher.update(`${file.content.length}:`);
-    hasher.update(file.content);
-  }
-  return `v2:${hasher.digest("hex")}`;
 }
 
 /**

--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -241,7 +241,9 @@ export async function clawhubInstall(
       return { success: false, error };
     }
 
-    // Write install-meta.json for the installed skill
+    // Write install-meta.json for the installed skill.
+    // contentHash is included here, so there's no need to call
+    // verifyAndRecordSkillHash() — it would just rewrite the same data.
     const skillDir = join(getManagedSkillsDir(), slug);
     writeInstallMeta(skillDir, {
       origin: "clawhub",
@@ -251,7 +253,6 @@ export async function clawhubInstall(
       contentHash: computeSkillHash(skillDir) ?? undefined,
     });
 
-    verifyAndRecordSkillHash(slug);
     return { success: true, skillName: slug };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -3,7 +3,11 @@ import { dirname, join } from "node:path";
 
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceSkillsDir } from "../util/platform.js";
-import { computeSkillHash } from "./install-meta.js";
+import {
+  computeSkillHash,
+  readInstallMeta,
+  writeInstallMeta,
+} from "./install-meta.js";
 
 const log = getLogger("clawhub");
 
@@ -61,6 +65,10 @@ function saveIntegrityManifest(manifest: IntegrityManifest): void {
  * Record or verify the content hash of an installed skill.
  * On first install: stores the hash (trust-on-first-use).
  * On subsequent installs: compares with stored hash and warns on mismatch.
+ *
+ * Reads/writes `contentHash` from `install-meta.json` when available,
+ * falling back to the legacy `.integrity.json` manifest for skills that
+ * haven't been migrated yet.
  */
 export function verifyAndRecordSkillHash(slug: string): void {
   const skillDir = join(getManagedSkillsDir(), slug);
@@ -70,17 +78,28 @@ export function verifyAndRecordSkillHash(slug: string): void {
     return;
   }
 
-  const manifest = loadIntegrityManifest();
-  const existing = manifest[slug];
+  // Try install-meta.json first for stored hash
+  const installMeta = readInstallMeta(skillDir);
+  let storedHash: string | undefined;
 
-  if (existing) {
-    const storedHash = existing.sha256;
+  if (installMeta?.contentHash) {
+    storedHash = installMeta.contentHash;
+  } else {
+    // Fall back to legacy .integrity.json manifest
+    const manifest = loadIntegrityManifest();
+    const existing = manifest[slug];
+    if (existing) {
+      storedHash =
+        typeof existing.sha256 === "string" ? existing.sha256 : undefined;
+    }
+  }
 
-    // Guard against corrupted manifest entries where sha256 is not a string
+  if (storedHash) {
+    // Guard against corrupted entries where hash is not a string
     if (typeof storedHash !== "string") {
       log.warn(
         { slug },
-        "Integrity manifest entry has non-string sha256 — re-recording hash",
+        "Stored hash has non-string value — re-recording hash",
       );
     } else if (!storedHash.startsWith("v2:")) {
       // Unknown format (not v2: prefix) — warn about integrity mismatch
@@ -107,9 +126,14 @@ export function verifyAndRecordSkillHash(slug: string): void {
     );
   }
 
-  // Always store the latest hash
-  manifest[slug] = { sha256: hash, installedAt: new Date().toISOString() };
-  saveIntegrityManifest(manifest);
+  // Write to install-meta.json if it exists (preferred), otherwise legacy manifest
+  if (installMeta) {
+    writeInstallMeta(skillDir, { ...installMeta, contentHash: hash });
+  } else {
+    const manifest = loadIntegrityManifest();
+    manifest[slug] = { sha256: hash, installedAt: new Date().toISOString() };
+    saveIntegrityManifest(manifest);
+  }
 }
 
 interface ClawhubInstallResult {
@@ -200,7 +224,7 @@ async function runClawhub(
 
 export async function clawhubInstall(
   slug: string,
-  opts?: { version?: string },
+  opts?: { version?: string; contactId?: string },
 ): Promise<ClawhubInstallResult> {
   if (!validateSlug(slug)) {
     return { success: false, error: `Invalid skill slug: ${slug}` };
@@ -216,6 +240,17 @@ export async function clawhubInstall(
         result.stderr.trim() || result.stdout.trim() || "Unknown error";
       return { success: false, error };
     }
+
+    // Write install-meta.json for the installed skill
+    const skillDir = join(getManagedSkillsDir(), slug);
+    writeInstallMeta(skillDir, {
+      origin: "clawhub",
+      slug,
+      installedAt: new Date().toISOString(),
+      ...(opts?.contactId ? { installedBy: opts.contactId } : {}),
+      contentHash: computeSkillHash(skillDir) ?? undefined,
+    });
+
     verifyAndRecordSkillHash(slug);
     return { success: true, skillName: slug };
   } catch (err) {

--- a/assistant/src/skills/install-meta.ts
+++ b/assistant/src/skills/install-meta.ts
@@ -1,0 +1,204 @@
+import { randomUUID } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+// ─── SkillInstallMeta type ──────────────────────────────────────────────────
+
+export interface SkillInstallMeta {
+  origin: "vellum" | "clawhub" | "skillssh" | "custom";
+  installedAt: string; // ISO 8601
+  installedBy?: string; // contact.id from SQLite contacts table
+  version?: string; // semver if known
+  slug?: string; // registry slug
+  sourceRepo?: string; // GitHub repo (e.g. "vercel-labs/agent-skills")
+  contentHash?: string; // SHA-256 content hash (v2:hex format)
+}
+
+// ─── Atomic write helper ────────────────────────────────────────────────────
+
+function atomicWriteFile(filePath: string, content: string): void {
+  const dir = dirname(filePath);
+  mkdirSync(dir, { recursive: true });
+  const tmpPath = join(dir, `.tmp-${randomUUID()}`);
+  writeFileSync(tmpPath, content, "utf-8");
+  renameSync(tmpPath, filePath);
+}
+
+// ─── Write install-meta.json ────────────────────────────────────────────────
+
+const INSTALL_META_FILENAME = "install-meta.json";
+const LEGACY_VERSION_FILENAME = "version.json";
+
+/**
+ * Atomically write `install-meta.json` inside the skill directory.
+ */
+export function writeInstallMeta(
+  skillDir: string,
+  meta: SkillInstallMeta,
+): void {
+  const filePath = join(skillDir, INSTALL_META_FILENAME);
+  atomicWriteFile(filePath, JSON.stringify(meta, null, 2) + "\n");
+}
+
+// ─── Read install-meta.json (with legacy fallback) ──────────────────────────
+
+/**
+ * Reads `install-meta.json` from the skill directory. If not found, falls
+ * back to reading legacy `version.json` and inferring the origin:
+ *
+ * - Has `origin: "skills.sh"` -> `origin: "skillssh"`, copies `source` as
+ *   `sourceRepo` and `skillSlug` as `slug`.
+ * - Has `version` but no `origin` field -> `origin: "vellum"`.
+ * - Otherwise -> `origin: "custom"`.
+ *
+ * Legacy files never have `installedBy`, so it will be `undefined` for
+ * backfilled skills.
+ *
+ * If neither file exists, returns `null`.
+ */
+export function readInstallMeta(skillDir: string): SkillInstallMeta | null {
+  // Try install-meta.json first
+  const metaPath = join(skillDir, INSTALL_META_FILENAME);
+  if (existsSync(metaPath)) {
+    try {
+      return JSON.parse(readFileSync(metaPath, "utf-8")) as SkillInstallMeta;
+    } catch {
+      // Malformed install-meta.json (partial write, manual edit, etc.) —
+      // fall through to the legacy version.json path so we don't lose
+      // provenance info when a valid legacy file exists.
+    }
+  }
+
+  // Fall back to legacy version.json
+  const legacyPath = join(skillDir, LEGACY_VERSION_FILENAME);
+  if (!existsSync(legacyPath)) {
+    return null;
+  }
+
+  try {
+    const raw = JSON.parse(readFileSync(legacyPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    return inferFromLegacyVersionJson(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Infer a SkillInstallMeta from a legacy version.json object.
+ */
+function inferFromLegacyVersionJson(
+  raw: Record<string, unknown>,
+): SkillInstallMeta {
+  // skills.sh origin: has `origin: "skills.sh"`
+  if (raw.origin === "skills.sh") {
+    return {
+      origin: "skillssh",
+      installedAt:
+        typeof raw.installedAt === "string"
+          ? raw.installedAt
+          : new Date().toISOString(),
+      sourceRepo: typeof raw.source === "string" ? raw.source : undefined,
+      slug: typeof raw.skillSlug === "string" ? raw.skillSlug : undefined,
+    };
+  }
+
+  // Vellum (first-party catalog) origin: has `version` but no `origin` field
+  if (typeof raw.version === "string" && !("origin" in raw)) {
+    return {
+      origin: "vellum",
+      installedAt:
+        typeof raw.installedAt === "string"
+          ? raw.installedAt
+          : new Date().toISOString(),
+      version: raw.version,
+    };
+  }
+
+  // Unknown format -> custom
+  return {
+    origin: "custom",
+    installedAt:
+      typeof raw.installedAt === "string"
+        ? raw.installedAt
+        : new Date().toISOString(),
+  };
+}
+
+// ─── Content hash computation ───────────────────────────────────────────────
+
+/**
+ * Metadata files excluded from content hashing. These are written by the
+ * installer and must not contribute to the content hash — otherwise the hash
+ * stored inside `install-meta.json` would change after writing the file.
+ */
+const METADATA_FILENAMES = new Set([
+  INSTALL_META_FILENAME, // install-meta.json
+  LEGACY_VERSION_FILENAME, // version.json
+]);
+
+/**
+ * Collect all file contents in a directory tree, sorted by relative path
+ * for determinism. Metadata files (`install-meta.json`, `version.json`) at
+ * the root level are excluded so the content hash covers only actual skill
+ * content.
+ */
+export function collectFileContents(
+  dir: string,
+  prefix = "",
+): Array<{ relPath: string; content: Buffer }> {
+  const results: Array<{ relPath: string; content: Buffer }> = [];
+  if (!existsSync(dir)) return results;
+
+  const entries = readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    // Exclude metadata files at the root level (prefix === "")
+    if (!prefix && METADATA_FILENAMES.has(entry.name)) continue;
+
+    const relPath = prefix ? `${prefix}/${entry.name}` : entry.name;
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectFileContents(fullPath, relPath));
+    } else if (entry.isFile()) {
+      results.push({ relPath, content: readFileSync(fullPath) });
+    }
+  }
+  return results.sort((a, b) => a.relPath.localeCompare(b.relPath));
+}
+
+/**
+ * Compute a SHA-256 hash over all files in a skill directory.
+ * Returns format: "v2:sha256hex" (version prefix added to support hash format
+ * evolution).
+ *
+ * This is the content hash used by the integrity manifest (trust-on-first-use).
+ * It differs from `computeSkillVersionHash` in `version-hash.ts`, which uses a
+ * different hashing strategy (v1: prefix) for version identity.
+ */
+export function computeSkillHash(skillDir: string): string | null {
+  if (!existsSync(skillDir) || !statSync(skillDir).isDirectory()) return null;
+
+  const files = collectFileContents(skillDir);
+  if (files.length === 0) return null;
+
+  const hasher = new Bun.CryptoHasher("sha256");
+  for (const file of files) {
+    // Length-prefix each segment to prevent boundary ambiguity collisions
+    const pathBuf = Buffer.from(file.relPath, "utf-8");
+    hasher.update(`${pathBuf.length}:`);
+    hasher.update(pathBuf);
+    hasher.update(`${file.content.length}:`);
+    hasher.update(file.content);
+  }
+  return `v2:${hasher.digest("hex")}`;
+}

--- a/assistant/src/skills/install-meta.ts
+++ b/assistant/src/skills/install-meta.ts
@@ -15,7 +15,8 @@ import { dirname, join } from "node:path";
 export interface SkillInstallMeta {
   origin: "vellum" | "clawhub" | "skillssh" | "custom";
   installedAt: string; // ISO 8601
-  installedBy?: string; // contact.id from SQLite contacts table
+  installedBy?: string; // actorPrincipalId from auth context (identifies who initiated the install)
+  backfilledBy?: string; // set by migration that backfilled this file (e.g. "migration-026")
   version?: string; // semver if known
   slug?: string; // registry slug
   sourceRepo?: string; // GitHub repo (e.g. "vercel-labs/agent-skills")

--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -13,6 +13,7 @@ import { stringify as stringifyYaml } from "yaml";
 
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceSkillsDir } from "../util/platform.js";
+import { writeInstallMeta } from "./install-meta.js";
 import { deleteSkillCapabilityMemory } from "./skill-memory.js";
 
 const log = getLogger("managed-store");
@@ -165,15 +166,20 @@ function getVersionMetaPath(id: string): string {
   return join(getManagedSkillDir(id), "version.json");
 }
 
-function writeVersionMeta(id: string, version: string): void {
-  const meta: SkillVersionMeta = {
-    version,
-    installedAt: new Date().toISOString(),
-  };
-  atomicWriteFile(getVersionMetaPath(id), JSON.stringify(meta, null, 2) + "\n");
-}
-
 export function readSkillVersion(id: string): string | null {
+  // Try install-meta.json first (new format)
+  const installMetaPath = join(getManagedSkillDir(id), "install-meta.json");
+  if (existsSync(installMetaPath)) {
+    try {
+      const raw = readFileSync(installMetaPath, "utf-8");
+      const meta = JSON.parse(raw) as { version?: string };
+      if (meta.version) return meta.version;
+    } catch {
+      // Fall through to legacy path
+    }
+  }
+
+  // Fall back to legacy version.json
   const metaPath = getVersionMetaPath(id);
   if (!existsSync(metaPath)) return null;
   try {
@@ -197,6 +203,7 @@ interface CreateManagedSkillParams {
   addToIndex?: boolean;
   includes?: string[];
   version?: string;
+  contactId?: string;
 }
 
 interface CreateManagedSkillResult {
@@ -259,10 +266,16 @@ export function createManagedSkill(
   mkdirSync(skillDir, { recursive: true });
   atomicWriteFile(skillFilePath, content);
 
-  if (params.version) {
-    writeVersionMeta(params.id, params.version);
-  } else {
-    // Remove stale version metadata when overwriting without a version
+  // Write install metadata
+  writeInstallMeta(skillDir, {
+    origin: "custom",
+    installedAt: new Date().toISOString(),
+    ...(params.version ? { version: params.version } : {}),
+    ...(params.contactId ? { installedBy: params.contactId } : {}),
+  });
+
+  // Clean up legacy version.json if present (superseded by install-meta.json)
+  if (!params.version) {
     const metaPath = getVersionMetaPath(params.id);
     if (existsSync(metaPath)) {
       rmSync(metaPath);

--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -275,11 +275,9 @@ export function createManagedSkill(
   });
 
   // Clean up legacy version.json if present (superseded by install-meta.json)
-  if (!params.version) {
-    const metaPath = getVersionMetaPath(params.id);
-    if (existsSync(metaPath)) {
-      rmSync(metaPath);
-    }
+  const metaPath = getVersionMetaPath(params.id);
+  if (existsSync(metaPath)) {
+    rmSync(metaPath);
   }
 
   log.info(

--- a/assistant/src/skills/skillssh-registry.ts
+++ b/assistant/src/skills/skillssh-registry.ts
@@ -5,6 +5,7 @@ import { dirname, join, resolve, sep } from "node:path";
 
 import { getWorkspaceSkillsDir } from "../util/platform.js";
 import { upsertSkillsIndex } from "./catalog-install.js";
+import { computeSkillHash, writeInstallMeta } from "./install-meta.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -434,7 +435,7 @@ export function validateSkillSlug(slug: string): void {
  * 1. Validates the skill slug for path safety
  * 2. Fetches all files from `skills/<skillSlug>/` in the source repo
  * 3. Writes them to `<workspace>/skills/<skillSlug>/` with path traversal protection
- * 4. Writes `version.json` with origin metadata
+ * 4. Writes `install-meta.json` with origin metadata
  * 5. Runs `bun install` if a `package.json` is present
  * 6. Registers the skill in SKILLS.md only after all steps succeed
  */
@@ -444,6 +445,7 @@ export async function installExternalSkill(
   skillSlug: string,
   overwrite: boolean,
   ref?: string,
+  contactId?: string,
 ): Promise<void> {
   // Validate slug before using in filesystem paths
   validateSkillSlug(skillSlug);
@@ -480,18 +482,15 @@ export async function installExternalSkill(
     writeFileSync(destPath, content, "utf-8");
   }
 
-  // Write origin metadata
-  const meta = {
-    origin: "skills.sh",
-    source: `${owner}/${repo}`,
-    skillSlug,
+  // Write install metadata
+  writeInstallMeta(skillDir, {
+    origin: "skillssh",
+    slug: skillSlug,
+    sourceRepo: `${owner}/${repo}`,
     installedAt: new Date().toISOString(),
-  };
-  writeFileSync(
-    join(skillDir, "version.json"),
-    JSON.stringify(meta, null, 2) + "\n",
-    "utf-8",
-  );
+    ...(contactId ? { installedBy: contactId } : {}),
+    contentHash: computeSkillHash(skillDir) ?? undefined,
+  });
 
   // Install npm dependencies if the skill ships a package.json
   if (existsSync(join(skillDir, "package.json"))) {

--- a/assistant/src/skills/skillssh-registry.ts
+++ b/assistant/src/skills/skillssh-registry.ts
@@ -436,8 +436,11 @@ export function validateSkillSlug(slug: string): void {
  * 2. Fetches all files from `skills/<skillSlug>/` in the source repo
  * 3. Writes them to `<workspace>/skills/<skillSlug>/` with path traversal protection
  * 4. Writes `install-meta.json` with origin metadata
- * 5. Runs `bun install` if a `package.json` is present
- * 6. Registers the skill in SKILLS.md only after all steps succeed
+ * 5. Installs npm dependencies (if package.json exists)
+ * 6. Updates SKILLS.md index
+ *
+ * Auto-enable and memory seeding are handled by the caller (e.g.
+ * `postInstallSkill()` in the daemon, or left to the user for CLI installs).
  */
 export async function installExternalSkill(
   owner: string,
@@ -492,7 +495,9 @@ export async function installExternalSkill(
     contentHash: computeSkillHash(skillDir) ?? undefined,
   });
 
-  // Install npm dependencies if the skill ships a package.json
+  // Post-install: install dependencies first, then index the skill.
+  // Running bun install before upsertSkillsIndex ensures we don't index a
+  // skill whose dependencies failed to install.
   if (existsSync(join(skillDir, "package.json"))) {
     const bunPath = `${homedir()}/.bun/bin`;
     execSync("bun install", {
@@ -501,7 +506,5 @@ export async function installExternalSkill(
       env: { ...process.env, PATH: `${bunPath}:${process.env.PATH}` },
     });
   }
-
-  // Register in SKILLS.md only after files are written and deps installed
   upsertSkillsIndex(skillSlug);
 }

--- a/assistant/src/workspace/migrations/026-backfill-install-meta.ts
+++ b/assistant/src/workspace/migrations/026-backfill-install-meta.ts
@@ -40,6 +40,7 @@ interface SkillInstallMeta {
   origin: "vellum" | "clawhub" | "skillssh" | "custom";
   installedAt: string;
   installedBy?: string;
+  backfilledBy?: string;
   version?: string;
   slug?: string;
   sourceRepo?: string;
@@ -282,8 +283,9 @@ export const backfillInstallMetaMigration: WorkspaceMigration = {
 
       const meta = inferInstallMeta(skillDir, name, integrityManifest);
 
-      // installedBy is left undefined for all backfilled skills
-      writeInstallMeta(skillDir, meta);
+      // Mark as backfilled so down() can safely identify and remove only
+      // migration-created files without touching CLI-installed ones.
+      writeInstallMeta(skillDir, { ...meta, backfilledBy: "migration-026" });
     }
   },
 
@@ -308,10 +310,10 @@ export const backfillInstallMetaMigration: WorkspaceMigration = {
             readFileSync(installMetaPath, "utf-8"),
           ) as SkillInstallMeta;
 
-          // Only remove install-meta.json that were backfilled (no installedBy).
-          // If installedBy is present, the file was written by the new install
-          // flow and should be preserved.
-          if (meta.installedBy === undefined) {
+          // Only remove install-meta.json that were backfilled by this migration.
+          // Files written by the normal install flow (CLI, daemon, etc.) won't
+          // have backfilledBy set and are safely preserved on rollback.
+          if (meta.backfilledBy === "migration-026") {
             unlinkSync(installMetaPath);
           }
         } catch {

--- a/assistant/src/workspace/migrations/026-backfill-install-meta.ts
+++ b/assistant/src/workspace/migrations/026-backfill-install-meta.ts
@@ -1,0 +1,323 @@
+/**
+ * Workspace migration 026: Backfill install-meta.json for existing skills
+ *
+ * Scans ~/.vellum/workspace/skills/ for installed skill directories and writes
+ * an install-meta.json for each skill that lacks one, inferring the origin
+ * from legacy version.json and .integrity.json files.
+ *
+ * Idempotent: safe to re-run after interruption at any point.
+ */
+
+import { randomUUID } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const INSTALL_META_FILENAME = "install-meta.json";
+const VERSION_JSON_FILENAME = "version.json";
+const INTEGRITY_JSON_FILENAME = ".integrity.json";
+const SKILL_MD_FILENAME = "SKILL.md";
+
+// ---------------------------------------------------------------------------
+// Inlined helpers (self-contained per migrations/AGENTS.md)
+// ---------------------------------------------------------------------------
+
+interface SkillInstallMeta {
+  origin: "vellum" | "clawhub" | "skillssh" | "custom";
+  installedAt: string;
+  installedBy?: string;
+  version?: string;
+  slug?: string;
+  sourceRepo?: string;
+  contentHash?: string;
+}
+
+/**
+ * Atomically write a file: write to a temp file, then rename.
+ */
+function atomicWriteFile(filePath: string, content: string): void {
+  const dir = dirname(filePath);
+  mkdirSync(dir, { recursive: true });
+  const tmpPath = join(dir, `.tmp-${randomUUID()}`);
+  writeFileSync(tmpPath, content, "utf-8");
+  renameSync(tmpPath, filePath);
+}
+
+/**
+ * Write install-meta.json into a skill directory.
+ */
+function writeInstallMeta(skillDir: string, meta: SkillInstallMeta): void {
+  const filePath = join(skillDir, INSTALL_META_FILENAME);
+  atomicWriteFile(filePath, JSON.stringify(meta, null, 2) + "\n");
+}
+
+/**
+ * Metadata files excluded from content hashing.
+ */
+const METADATA_FILENAMES = new Set([
+  INSTALL_META_FILENAME,
+  VERSION_JSON_FILENAME,
+]);
+
+/**
+ * Collect all file contents in a directory tree, sorted by relative path.
+ * Metadata files at root level are excluded.
+ */
+function collectFileContents(
+  dir: string,
+  prefix = "",
+): Array<{ relPath: string; content: Buffer }> {
+  const results: Array<{ relPath: string; content: Buffer }> = [];
+  if (!existsSync(dir)) return results;
+
+  const entries = readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!prefix && METADATA_FILENAMES.has(entry.name)) continue;
+
+    const relPath = prefix ? `${prefix}/${entry.name}` : entry.name;
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectFileContents(fullPath, relPath));
+    } else if (entry.isFile()) {
+      results.push({ relPath, content: readFileSync(fullPath) });
+    }
+  }
+  return results.sort((a, b) => a.relPath.localeCompare(b.relPath));
+}
+
+/**
+ * Compute SHA-256 content hash over all non-metadata files in a skill dir.
+ * Returns format: "v2:sha256hex".
+ */
+function computeSkillHash(skillDir: string): string | null {
+  if (!existsSync(skillDir) || !statSync(skillDir).isDirectory()) return null;
+
+  const files = collectFileContents(skillDir);
+  if (files.length === 0) return null;
+
+  const hasher = new Bun.CryptoHasher("sha256");
+  for (const file of files) {
+    const pathBuf = Buffer.from(file.relPath, "utf-8");
+    hasher.update(`${pathBuf.length}:`);
+    hasher.update(pathBuf);
+    hasher.update(`${file.content.length}:`);
+    hasher.update(file.content);
+  }
+  return `v2:${hasher.digest("hex")}`;
+}
+
+// ---------------------------------------------------------------------------
+// Integrity manifest helpers
+// ---------------------------------------------------------------------------
+
+interface IntegrityRecord {
+  sha256: string;
+  installedAt: string;
+}
+
+type IntegrityManifest = Record<string, IntegrityRecord>;
+
+function loadIntegrityManifest(skillsDir: string): IntegrityManifest {
+  const path = join(skillsDir, INTEGRITY_JSON_FILENAME);
+  if (!existsSync(path)) return {};
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as IntegrityManifest;
+  } catch {
+    return {};
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Origin inference
+// ---------------------------------------------------------------------------
+
+/**
+ * Infer SkillInstallMeta for a skill directory that has no install-meta.json.
+ *
+ * Decision tree:
+ * 1. version.json with `origin: "skills.sh"` -> skillssh
+ * 2. version.json with `version` but no `origin` field:
+ *    - Has entry in .integrity.json -> clawhub
+ *    - Otherwise -> vellum
+ * 3. version.json exists but doesn't match above -> custom
+ * 4. No version.json:
+ *    - Has entry in .integrity.json -> clawhub
+ *    - Otherwise -> custom
+ */
+function inferInstallMeta(
+  skillDir: string,
+  skillId: string,
+  integrityManifest: IntegrityManifest,
+): SkillInstallMeta {
+  const versionJsonPath = join(skillDir, VERSION_JSON_FILENAME);
+  const hasIntegrityEntry = skillId in integrityManifest;
+
+  if (existsSync(versionJsonPath)) {
+    let raw: Record<string, unknown>;
+    try {
+      raw = JSON.parse(readFileSync(versionJsonPath, "utf-8")) as Record<
+        string,
+        unknown
+      >;
+    } catch {
+      // Malformed version.json — treat as if it doesn't exist
+      return buildFallbackMeta(skillDir, skillId, hasIntegrityEntry);
+    }
+
+    // Case 1: skills.sh origin
+    if (raw.origin === "skills.sh") {
+      return {
+        origin: "skillssh",
+        installedAt:
+          typeof raw.installedAt === "string"
+            ? raw.installedAt
+            : getDirectoryMtime(skillDir),
+        sourceRepo: typeof raw.source === "string" ? raw.source : undefined,
+        slug: typeof raw.skillSlug === "string" ? raw.skillSlug : undefined,
+        contentHash: computeSkillHash(skillDir) ?? undefined,
+      };
+    }
+
+    // Case 2: has version but no origin field
+    if (typeof raw.version === "string" && !("origin" in raw)) {
+      return {
+        origin: hasIntegrityEntry ? "clawhub" : "vellum",
+        installedAt:
+          typeof raw.installedAt === "string"
+            ? raw.installedAt
+            : getDirectoryMtime(skillDir),
+        version: raw.version,
+        contentHash: computeSkillHash(skillDir) ?? undefined,
+      };
+    }
+
+    // Case 3: version.json exists but doesn't match known patterns
+    return {
+      origin: "custom",
+      installedAt:
+        typeof raw.installedAt === "string"
+          ? raw.installedAt
+          : getDirectoryMtime(skillDir),
+      contentHash: computeSkillHash(skillDir) ?? undefined,
+    };
+  }
+
+  // Case 4: no version.json
+  return buildFallbackMeta(skillDir, skillId, hasIntegrityEntry);
+}
+
+function buildFallbackMeta(
+  skillDir: string,
+  _skillId: string,
+  hasIntegrityEntry: boolean,
+): SkillInstallMeta {
+  return {
+    origin: hasIntegrityEntry ? "clawhub" : "custom",
+    installedAt: getDirectoryMtime(skillDir),
+    contentHash: computeSkillHash(skillDir) ?? undefined,
+  };
+}
+
+/**
+ * Get directory mtime as ISO 8601 string. Falls back to current time.
+ */
+function getDirectoryMtime(dir: string): string {
+  try {
+    return statSync(dir).mtime.toISOString();
+  } catch {
+    return new Date().toISOString();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Migration
+// ---------------------------------------------------------------------------
+
+export const backfillInstallMetaMigration: WorkspaceMigration = {
+  id: "026-backfill-install-meta",
+  description:
+    "Backfill install-meta.json with origin field for existing skill directories",
+
+  run(workspaceDir: string): void {
+    const skillsDir = join(workspaceDir, "skills");
+    if (!existsSync(skillsDir)) return;
+
+    // Load the integrity manifest once — shared across all skills
+    const integrityManifest = loadIntegrityManifest(skillsDir);
+
+    // Enumerate skill directories (each subdirectory containing a SKILL.md)
+    let dirNames: string[];
+    try {
+      dirNames = readdirSync(skillsDir, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name);
+    } catch {
+      return;
+    }
+
+    for (const name of dirNames) {
+      const skillDir = join(skillsDir, name);
+      const skillMdPath = join(skillDir, SKILL_MD_FILENAME);
+      const installMetaPath = join(skillDir, INSTALL_META_FILENAME);
+
+      // Only process directories that contain SKILL.md
+      if (!existsSync(skillMdPath)) continue;
+
+      // Skip if install-meta.json already exists (idempotency)
+      if (existsSync(installMetaPath)) continue;
+
+      const meta = inferInstallMeta(skillDir, name, integrityManifest);
+
+      // installedBy is left undefined for all backfilled skills
+      writeInstallMeta(skillDir, meta);
+    }
+  },
+
+  down(workspaceDir: string): void {
+    const skillsDir = join(workspaceDir, "skills");
+    if (!existsSync(skillsDir)) return;
+
+    let dirNames: string[];
+    try {
+      dirNames = readdirSync(skillsDir, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name);
+    } catch {
+      return;
+    }
+
+    for (const name of dirNames) {
+      const installMetaPath = join(skillsDir, name, INSTALL_META_FILENAME);
+      if (existsSync(installMetaPath)) {
+        try {
+          const meta = JSON.parse(
+            readFileSync(installMetaPath, "utf-8"),
+          ) as SkillInstallMeta;
+
+          // Only remove install-meta.json that were backfilled (no installedBy).
+          // If installedBy is present, the file was written by the new install
+          // flow and should be preserved.
+          if (meta.installedBy === undefined) {
+            unlinkSync(installMetaPath);
+          }
+        } catch {
+          // Malformed file — skip
+        }
+      }
+    }
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -22,6 +22,7 @@ import { moveHooksToWorkspaceMigration } from "./022-move-hooks-to-workspace.js"
 import { moveConfigFilesToWorkspaceMigration } from "./023-move-config-files-to-workspace.js";
 import { moveRuntimeFilesToWorkspaceMigration } from "./024-move-runtime-files-to-workspace.js";
 import { removeOauthAppSetupSkillsMigration } from "./025-remove-oauth-app-setup-skills.js";
+import { backfillInstallMetaMigration } from "./026-backfill-install-meta.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -55,4 +56,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   moveConfigFilesToWorkspaceMigration,
   moveRuntimeFilesToWorkspaceMigration,
   removeOauthAppSetupSkillsMigration,
+  backfillInstallMetaMigration,
 ];


### PR DESCRIPTION
## Summary
Unifies divergent skill install paths so they all write a consistent `install-meta.json` file with `origin`, `installedBy`, and `contentHash` fields. Fixes the routing gap where skills.sh search results couldn't be installed through the daemon. Extracts shared post-install logic. Adds a workspace migration to backfill origin metadata for existing installs.

## PRs merged into feature branch
- #22888: feat: introduce SkillInstallMeta type with unified read/write for install-meta.json
- #22887: feat: daemon installSkill() supports skills.sh origin with correct routing
- #22895: feat: all skill install paths write install-meta.json with origin and installedBy
- #22894: feat: workspace migration to backfill install-meta.json with origin field
- #22903: refactor: extract shared postInstallSkill() replacing duplicated auto-enable/index/deps logic

Part of plan: skills-unify-install.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22906" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
