### PR TITLE
feat: wire delete group confirmation modal into sidebar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -145,7 +145,7 @@ extension MainWindowView {
                 sidebar.renamingGroupId = nil
             },
             onDelete: group.isSystemGroup ? nil : {
-                Task<Void, Never> { await conversationManager.deleteGroup(group.id) }
+                groupToDelete = group
             },
             selectedConversationId: conversationManager.activeConversationId,
             onToggleExpand: { sidebar.toggleSection(group.id) },
@@ -427,6 +427,22 @@ extension MainWindowView {
                             value: contentGeo.size.height
                         )
                     })
+            }
+            .sheet(item: $groupToDelete) { group in
+                DeleteGroupConfirmationSheet(
+                    groupName: group.name,
+                    onDelete: {
+                        groupToDelete = nil
+                        Task<Void, Never> { await conversationManager.deleteGroup(group.id) }
+                    },
+                    onArchiveAndDelete: {
+                        groupToDelete = nil
+                        Task<Void, Never> { await conversationManager.deleteGroupAndArchiveConversations(group.id) }
+                    },
+                    onCancel: {
+                        groupToDelete = nil
+                    }
+                )
             }
             .background(GeometryReader { scrollGeo in
                 Color.clear.preference(

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -64,6 +64,7 @@ struct MainWindowView: View {
 
     @State var showConversationSwitcher = false
     @State var conversationSwitcherTriggerFrame: CGRect = .zero
+    @State var groupToDelete: ConversationGroup?
 
     /// Cached assistant display name, refreshed when IDENTITY.md changes on disk.
     @State var cachedAssistantName: String = "Your Assistant"

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
@@ -163,7 +163,7 @@ private struct ConditionalGroupContextMenu: ViewModifier {
                     VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename") { onRename() }
                 }
                 if let onDelete {
-                    VMenuItem(icon: VIcon.trash.rawValue, label: "Delete") { onDelete() }
+                    VMenuItem(icon: VIcon.trash.rawValue, label: "Delete group\u{2026}") { onDelete() }
                 }
             }
         } else {


### PR DESCRIPTION
## Summary
- Replaces immediate group deletion in the sidebar with a `.sheet()` presentation of `DeleteGroupConfirmationSheet`, giving users a confirmation modal with radio options to keep or archive conversations
- Updates the context menu label from "Delete" to "Delete group…" (with Unicode ellipsis per macOS HIG, signaling a confirmation dialog follows)

## Test plan
- [ ] Right-click a custom group in the sidebar and verify the context menu shows "Delete group…" (with ellipsis)
- [ ] Click "Delete group…" and verify the confirmation sheet appears with radio options
- [ ] Select "Keep conversations" and click "Delete group" — verify the group is removed and conversations move to ungrouped
- [ ] Repeat with "Archive conversations" selected — verify conversations are archived
- [ ] Click "Cancel" — verify the sheet dismisses and no deletion occurs
- [ ] Verify system groups (Pinned, Scheduled, Background) still have no delete option in context menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22907" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
