### PR TITLE
fix: keep managed credential bootstrap retry active until channel services are configured

### DIFF
--- a/gateway/src/__tests__/credential-watcher-managed-bootstrap.test.ts
+++ b/gateway/src/__tests__/credential-watcher-managed-bootstrap.test.ts
@@ -221,4 +221,58 @@ describe("gateway managed credential bootstrap retry", () => {
 
     expect(status).toBe(401);
   }, 20_000);
+
+  test("detects new Slack credentials when metadata is written after startup with no initial channel services", async () => {
+    // Start with NO channel service metadata — only non-channel credentials
+    // (simulates a fresh assistant that has platform credentials but no channels).
+    mkdirSync(testDir, { recursive: true });
+    writeCredentialMetadata([
+      metadataRecord("api-key-1", "vellum", "assistant_api_key"),
+    ]);
+
+    startFakeCes({
+      credentials: {
+        "credential/vellum/assistant_api_key": "fake-api-key",
+        "credential/slack_channel/bot_token": "xoxb-fake-bot-token",
+        "credential/slack_channel/app_token": "xapp-fake-app-token",
+      },
+    });
+
+    await startGateway();
+
+    // Slack deliver should be 503 since no Slack credentials are configured.
+    const base = `http://localhost:${gatewayPort}`;
+    const before = await fetch(`${base}/deliver/slack`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+    });
+    expect(before.status).toBe(503);
+
+    // Now write Slack channel metadata (simulating the daemon storing
+    // credentials after the user completes the Slack setup flow).
+    writeCredentialMetadata([
+      metadataRecord("api-key-1", "vellum", "assistant_api_key"),
+      metadataRecord("bt-1", "slack_channel", "bot_token"),
+      metadataRecord("at-1", "slack_channel", "app_token"),
+    ]);
+
+    // The managed bootstrap retry should still be polling (since no channel
+    // services were configured at startup), so the new metadata should be
+    // detected within a few seconds even without fs.watch() working.
+    const deadline = Date.now() + 5_000;
+    let status = before.status;
+    while (Date.now() < deadline) {
+      const resp = await fetch(`${base}/deliver/slack`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+      });
+      status = resp.status;
+      // 401 means Slack is configured but the deliver auth check failed
+      // (which is expected since we didn't provide a valid bearer token).
+      if (status === 401) break;
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+
+    expect(status).toBe(401);
+  }, 20_000);
 });

--- a/gateway/src/credential-watcher.ts
+++ b/gateway/src/credential-watcher.ts
@@ -30,6 +30,7 @@ const log = getLogger("credential-watcher");
 const DEBOUNCE_MS = 500;
 const MANAGED_BOOTSTRAP_POLL_MS = 1_000;
 const MANAGED_BOOTSTRAP_TIMEOUT_MS = 1_000;
+const MANAGED_BOOTSTRAP_STEADY_POLL_MS = 30_000;
 
 export type CredentialChangeEvent = {
   /** Map from service name to resolved credentials (null if unavailable) */
@@ -173,9 +174,20 @@ export class CredentialWatcher {
 
       await this.pollOnce();
 
-      if (this.allConfiguredServicesReady() && this.managedBootstrapTimer) {
-        clearInterval(this.managedBootstrapTimer);
-        this.managedBootstrapTimer = null;
+      if (
+        this.lastConfiguredServices.size > 0 &&
+        this.allConfiguredServicesReady()
+      ) {
+        // All configured channel services have their credentials loaded.
+        // Switch to a slower steady-state poll as a resilient fallback for
+        // environments where fs.watch() doesn't propagate across containers.
+        if (this.managedBootstrapTimer) {
+          clearInterval(this.managedBootstrapTimer);
+          this.managedBootstrapTimer = setInterval(() => {
+            void this.pollManagedBootstrap(baseUrl, serviceToken);
+          }, MANAGED_BOOTSTRAP_STEADY_POLL_MS);
+          this.managedBootstrapTimer.unref?.();
+        }
       }
     } catch {
       // CES isn't reachable yet. Keep retrying until the sidecar is ready.

--- a/gateway/src/credential-watcher.ts
+++ b/gateway/src/credential-watcher.ts
@@ -46,6 +46,7 @@ export class CredentialWatcher {
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private managedBootstrapTimer: ReturnType<typeof setInterval> | null = null;
   private managedBootstrapPollInFlight = false;
+  private managedBootstrapInSteadyState = false;
   private lastConfiguredServices = new Set<string>();
   private lastReadyServices = new Set<string>();
   private lastSerialized: Map<string, string> = new Map();
@@ -121,6 +122,7 @@ export class CredentialWatcher {
       this.managedBootstrapTimer = null;
     }
     this.managedBootstrapPollInFlight = false;
+    this.managedBootstrapInSteadyState = false;
     this.pendingPoll = false;
     for (const watcher of this.watchers) {
       watcher.close();
@@ -174,10 +176,11 @@ export class CredentialWatcher {
 
       await this.pollOnce();
 
-      if (
+      const ready =
         this.lastConfiguredServices.size > 0 &&
-        this.allConfiguredServicesReady()
-      ) {
+        this.allConfiguredServicesReady();
+
+      if (ready && !this.managedBootstrapInSteadyState) {
         // All configured channel services have their credentials loaded.
         // Switch to a slower steady-state poll as a resilient fallback for
         // environments where fs.watch() doesn't propagate across containers.
@@ -188,6 +191,18 @@ export class CredentialWatcher {
           }, MANAGED_BOOTSTRAP_STEADY_POLL_MS);
           this.managedBootstrapTimer.unref?.();
         }
+        this.managedBootstrapInSteadyState = true;
+      } else if (!ready && this.managedBootstrapInSteadyState) {
+        // A configured service lost its credentials — revert to fast polling
+        // so we pick up restored credentials quickly.
+        if (this.managedBootstrapTimer) {
+          clearInterval(this.managedBootstrapTimer);
+          this.managedBootstrapTimer = setInterval(() => {
+            void this.pollManagedBootstrap(baseUrl, serviceToken);
+          }, MANAGED_BOOTSTRAP_POLL_MS);
+          this.managedBootstrapTimer.unref?.();
+        }
+        this.managedBootstrapInSteadyState = false;
       }
     } catch {
       // CES isn't reachable yet. Keep retrying until the sidecar is ready.


### PR DESCRIPTION
## Summary
Fix a bug where the gateway's credential watcher in managed (Kubernetes) deployments stops its CES bootstrap polling timer immediately at startup when no channel services are configured. This happens because `allConfiguredServicesReady()` returns `true` vacuously for an empty set. When a user later configures Slack credentials, the only remaining detection mechanism is `fs.watch()`, which doesn't reliably propagate inotify events across containers sharing a PVC via subPath bind mounts — leaving `slackReady` permanently false and causing `/deliver/slack` to return 503 "Slack integration not configured".

The fix:
- Keeps polling at 1s until at least one channel service is configured and ready
- Switches to a 30s steady-state poll once all configured services are ready (resilient fallback for unreliable `fs.watch()`)
- Adds an integration test reproducing the exact user-reported scenario

## PRs merged into feature branch
- #22905: fix: keep managed credential bootstrap retry active until channel services are configured

Part of plan: managed-cred-watcher-fix.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
