### PR TITLE
Improve Delete Group flow with confirmation modal

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -1458,6 +1458,82 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         sendReorderConversations()
     }
 
+    func deleteGroupAndArchiveConversations(_ groupId: String) async {
+        guard let idx = groups.firstIndex(where: { $0.id == groupId }),
+              !groups[idx].isSystemGroup else { return }
+
+        // Collect the local IDs of conversations to archive before mutating state.
+        let idsToArchive = conversations
+            .filter { $0.groupId == groupId }
+            .map(\.id)
+
+        // Batch-mutate a copy to avoid per-element SwiftUI re-renders.
+        var updated = conversations
+        var newlyArchivedServerIds = Set<String>()
+        for i in updated.indices where updated[i].groupId == groupId {
+            updated[i].isArchived = true
+            updated[i].displayOrder = nil
+            updated[i].groupId = nil
+            if let cid = updated[i].conversationId {
+                newlyArchivedServerIds.insert(cid)
+            }
+        }
+        conversations = updated
+
+        // Persist archived IDs in one shot.
+        if !newlyArchivedServerIds.isEmpty {
+            var archived = archivedConversationIds
+            archived.formUnion(newlyArchivedServerIds)
+            archivedConversationIds = archived
+        }
+
+        // Tear down view models / pop-out windows for each archived conversation.
+        for id in idsToArchive {
+            AppDelegate.shared?.threadWindowManager?.closeThread(conversationLocalId: id)
+            pinnedViewModelIds.remove(id)
+
+            if let convIndex = conversations.firstIndex(where: { $0.id == id }) {
+                if conversations[convIndex].conversationId != nil {
+                    chatViewModels[id]?.stopGenerating()
+                    chatViewModels.removeValue(forKey: id)
+                    unsubscribeAllForConversation(id: id)
+                    if let accessIdx = vmAccessOrder.firstIndex(of: id) {
+                        vmAccessOrder.remove(at: accessIdx)
+                    }
+                } else if chatViewModels[id]?.messages.contains(where: { $0.role == .user }) != true
+                            && chatViewModels[id]?.isBootstrapping != true {
+                    chatViewModels[id]?.stopGenerating()
+                    chatViewModels.removeValue(forKey: id)
+                    unsubscribeAllForConversation(id: id)
+                    if let accessIdx = vmAccessOrder.firstIndex(of: id) {
+                        vmAccessOrder.remove(at: accessIdx)
+                    }
+                } else {
+                    chatViewModels[id]?.cancelPendingMessage()
+                }
+            }
+        }
+
+        // Handle active conversation switching if the active one was archived.
+        if let activeId = activeConversationId, idsToArchive.contains(activeId) {
+            if visibleConversations.isEmpty {
+                enterDraftMode()
+            } else {
+                activeConversationId = visibleConversations.first?.id
+            }
+        } else if visibleConversations.isEmpty {
+            enterDraftMode()
+        }
+
+        Self.clearRenderCaches()
+
+        // Remove the group and fire the server delete — idx captured before mutations,
+        // but groups array is untouched so it is still valid.
+        groups.remove(at: idx)
+        _ = await groupClient.deleteGroup(groupId: groupId)
+        sendReorderConversations()
+    }
+
     func reorderGroups(_ updates: [(groupId: String, sortPosition: Double)]) async {
         for update in updates {
             if let idx = groups.firstIndex(where: { $0.id == update.groupId }) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -145,7 +145,7 @@ extension MainWindowView {
                 sidebar.renamingGroupId = nil
             },
             onDelete: group.isSystemGroup ? nil : {
-                Task<Void, Never> { await conversationManager.deleteGroup(group.id) }
+                groupToDelete = group
             },
             selectedConversationId: conversationManager.activeConversationId,
             onToggleExpand: { sidebar.toggleSection(group.id) },
@@ -427,6 +427,22 @@ extension MainWindowView {
                             value: contentGeo.size.height
                         )
                     })
+            }
+            .sheet(item: $groupToDelete) { group in
+                DeleteGroupConfirmationSheet(
+                    groupName: group.name,
+                    onDelete: {
+                        groupToDelete = nil
+                        Task<Void, Never> { await conversationManager.deleteGroup(group.id) }
+                    },
+                    onArchiveAndDelete: {
+                        groupToDelete = nil
+                        Task<Void, Never> { await conversationManager.deleteGroupAndArchiveConversations(group.id) }
+                    },
+                    onCancel: {
+                        groupToDelete = nil
+                    }
+                )
             }
             .background(GeometryReader { scrollGeo in
                 Color.clear.preference(

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -64,6 +64,7 @@ struct MainWindowView: View {
 
     @State var showConversationSwitcher = false
     @State var conversationSwitcherTriggerFrame: CGRect = .zero
+    @State var groupToDelete: ConversationGroup?
 
     /// Cached assistant display name, refreshed when IDENTITY.md changes on disk.
     @State var cachedAssistantName: String = "Your Assistant"

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DeleteGroupConfirmationSheet.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DeleteGroupConfirmationSheet.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct DeleteGroupConfirmationSheet: View {
+    let groupName: String
+    var onDelete: () -> Void
+    var onArchiveAndDelete: () -> Void
+    var onCancel: () -> Void
+
+    @State private var archiveConversations = false
+
+    var body: some View {
+        VModal(title: "Delete \"\(groupName)\"?") {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                Text("Choose what happens to the conversations in this group.")
+                    .font(VFont.bodyMediumLighter)
+                    .foregroundStyle(VColor.contentSecondary)
+
+                VStack(spacing: VSpacing.sm) {
+                    optionRow(
+                        selected: !archiveConversations,
+                        label: "Keep conversations",
+                        description: "Conversations will be moved to the main list"
+                    ) {
+                        archiveConversations = false
+                    }
+
+                    optionRow(
+                        selected: archiveConversations,
+                        label: "Archive conversations",
+                        description: "Conversations will be archived"
+                    ) {
+                        archiveConversations = true
+                    }
+                }
+            }
+        } footer: {
+            HStack {
+                Spacer()
+                VButton(label: "Cancel", style: .outlined) {
+                    onCancel()
+                }
+                VButton(label: "Delete group", style: .danger) {
+                    if archiveConversations {
+                        onArchiveAndDelete()
+                    } else {
+                        onDelete()
+                    }
+                }
+            }
+        }
+        .frame(width: 380)
+    }
+
+    // MARK: - Radio Option Row
+
+    @ViewBuilder
+    private func optionRow(
+        selected: Bool,
+        label: String,
+        description: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(alignment: .top, spacing: VSpacing.md) {
+                Circle()
+                    .fill(selected ? VColor.primaryBase : Color.clear)
+                    .overlay(Circle().stroke(selected ? VColor.primaryBase : VColor.contentTertiary, lineWidth: 1.5))
+                    .frame(width: 14, height: 14)
+                    .padding(.top, 3)
+
+                VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                    Text(label)
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(VColor.contentDefault)
+                    Text(description)
+                        .font(VFont.bodyMediumLighter)
+                        .foregroundStyle(VColor.contentSecondary)
+                }
+
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.sm)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(selected ? VColor.surfaceBase : Color.clear)
+            )
+        }
+        .buttonStyle(.plain)
+        .contentShape(Rectangle())
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
@@ -163,7 +163,7 @@ private struct ConditionalGroupContextMenu: ViewModifier {
                     VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename") { onRename() }
                 }
                 if let onDelete {
-                    VMenuItem(icon: VIcon.trash.rawValue, label: "Delete") { onDelete() }
+                    VMenuItem(icon: VIcon.trash.rawValue, label: "Delete group\u{2026}") { onDelete() }
                 }
             }
         } else {


### PR DESCRIPTION
## Summary
Replaces the immediate group deletion with a confirmation modal that lets users choose what happens to their conversations. The modal presents two radio-style options: keep conversations in the main list (default, safest) or archive them. Uses human-friendly language throughout.

## Changes
- **New `DeleteGroupConfirmationSheet`** — VModal-based confirmation dialog with radio-style option selection (Keep conversations / Archive conversations), using VButton, VColor, VFont, VSpacing, VRadius design tokens
- **New `deleteGroupAndArchiveConversations()`** — Batch-archive method in ConversationManager that archives all group conversations in a single SwiftUI re-render pass, then deletes the group
- **Sidebar wiring** — `onDelete` now sets `groupToDelete` state to present the sheet instead of deleting immediately
- **Context menu label** — Changed from "Delete" to "Delete group…" (macOS HIG ellipsis convention)

## Milestone PRs (merged into feature branch)
- #22902: feat: add DeleteGroupConfirmationSheet and archive-on-delete method
- #22907: feat: wire delete group confirmation modal into sidebar

## Project issue
Closes #22898

## Test plan
- [ ] Right-click a custom group → context menu shows "Delete group…" (with ellipsis)
- [ ] Click "Delete group…" → confirmation sheet appears with group name in title
- [ ] "Keep conversations" is selected by default
- [ ] Select "Keep conversations" + "Delete group" → group deleted, conversations remain in ungrouped list
- [ ] Select "Archive conversations" + "Delete group" → group deleted, conversations archived
- [ ] Click "Cancel" → sheet dismissed, no changes
- [ ] Verify system groups (Pinned, Scheduled, Background) do NOT show "Delete group…" in context menu
- [ ] Verify modal uses design tokens (no raw hex, no raw font sizes, no Image(systemName:))
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22909" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
