### PR TITLE
fix: prevent steady-state timer thrashing in managed credential bootstrap

### DIFF
--- a/gateway/src/credential-watcher.ts
+++ b/gateway/src/credential-watcher.ts
@@ -46,6 +46,7 @@ export class CredentialWatcher {
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private managedBootstrapTimer: ReturnType<typeof setInterval> | null = null;
   private managedBootstrapPollInFlight = false;
+  private managedBootstrapInSteadyState = false;
   private lastConfiguredServices = new Set<string>();
   private lastReadyServices = new Set<string>();
   private lastSerialized: Map<string, string> = new Map();
@@ -121,6 +122,7 @@ export class CredentialWatcher {
       this.managedBootstrapTimer = null;
     }
     this.managedBootstrapPollInFlight = false;
+    this.managedBootstrapInSteadyState = false;
     this.pendingPoll = false;
     for (const watcher of this.watchers) {
       watcher.close();
@@ -174,10 +176,11 @@ export class CredentialWatcher {
 
       await this.pollOnce();
 
-      if (
+      const ready =
         this.lastConfiguredServices.size > 0 &&
-        this.allConfiguredServicesReady()
-      ) {
+        this.allConfiguredServicesReady();
+
+      if (ready && !this.managedBootstrapInSteadyState) {
         // All configured channel services have their credentials loaded.
         // Switch to a slower steady-state poll as a resilient fallback for
         // environments where fs.watch() doesn't propagate across containers.
@@ -188,6 +191,18 @@ export class CredentialWatcher {
           }, MANAGED_BOOTSTRAP_STEADY_POLL_MS);
           this.managedBootstrapTimer.unref?.();
         }
+        this.managedBootstrapInSteadyState = true;
+      } else if (!ready && this.managedBootstrapInSteadyState) {
+        // A configured service lost its credentials — revert to fast polling
+        // so we pick up restored credentials quickly.
+        if (this.managedBootstrapTimer) {
+          clearInterval(this.managedBootstrapTimer);
+          this.managedBootstrapTimer = setInterval(() => {
+            void this.pollManagedBootstrap(baseUrl, serviceToken);
+          }, MANAGED_BOOTSTRAP_POLL_MS);
+          this.managedBootstrapTimer.unref?.();
+        }
+        this.managedBootstrapInSteadyState = false;
       }
     } catch {
       // CES isn't reachable yet. Keep retrying until the sidecar is ready.


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for managed-cred-watcher-fix.md.

**Gap:** Timer thrashing: steady-state interval recreated on every poll tick
**What was expected:** A one-time transition from 1s fast-poll to 30s steady-state interval
**What was found:** The steady-state condition fires on every 30s tick, clearing and recreating the interval unnecessarily
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22910" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
