### PR TITLE
fix: address self-review gaps — migration rollback safety, cleanup logic, comments

### DIFF
--- a/assistant/src/cli/commands/skills.ts
+++ b/assistant/src/cli/commands/skills.ts
@@ -488,8 +488,8 @@ Arguments:
 
 Notes:
   Fetches the skill's SKILL.md and supporting files from the specified GitHub
-  repository and installs them into the workspace skills directory. A
-  version.json file is written with origin metadata for provenance tracking.
+  repository and installs them into the workspace skills directory. An
+  install-meta.json file is written with origin metadata for provenance tracking.
 
 Examples:
   $ assistant skills add vercel-labs/skills@find-skills

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -622,9 +622,12 @@ export async function installSkill(
       (s) => s.id === spec.slug && s.source === "bundled",
     );
     if (bundled) {
-      // Bundled skills are already on disk — they don't need SKILLS.md
-      // indexing or dependency installation. Just auto-enable, broadcast,
-      // and seed memories.
+      // Intentional divergence from postInstallSkill(): bundled skills are
+      // shipped with the assistant binary and are already on disk. They skip
+      // SKILLS.md indexing (they're discovered via the bundled catalog, not
+      // the workspace index), dependency installation (deps are pre-bundled),
+      // and catalog reload (the catalog already includes them). Only
+      // auto-enable, broadcast, and seed memories are needed.
       try {
         const raw = loadRawConfig();
         ensureSkillEntry(raw, spec.slug).enabled = true;

--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -241,7 +241,9 @@ export async function clawhubInstall(
       return { success: false, error };
     }
 
-    // Write install-meta.json for the installed skill
+    // Write install-meta.json for the installed skill.
+    // contentHash is included here, so there's no need to call
+    // verifyAndRecordSkillHash() — it would just rewrite the same data.
     const skillDir = join(getManagedSkillsDir(), slug);
     writeInstallMeta(skillDir, {
       origin: "clawhub",
@@ -251,7 +253,6 @@ export async function clawhubInstall(
       contentHash: computeSkillHash(skillDir) ?? undefined,
     });
 
-    verifyAndRecordSkillHash(slug);
     return { success: true, skillName: slug };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/skills/install-meta.ts
+++ b/assistant/src/skills/install-meta.ts
@@ -15,7 +15,8 @@ import { dirname, join } from "node:path";
 export interface SkillInstallMeta {
   origin: "vellum" | "clawhub" | "skillssh" | "custom";
   installedAt: string; // ISO 8601
-  installedBy?: string; // contact.id from SQLite contacts table
+  installedBy?: string; // actorPrincipalId from auth context (identifies who initiated the install)
+  backfilledBy?: string; // set by migration that backfilled this file (e.g. "migration-026")
   version?: string; // semver if known
   slug?: string; // registry slug
   sourceRepo?: string; // GitHub repo (e.g. "vercel-labs/agent-skills")

--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -275,11 +275,9 @@ export function createManagedSkill(
   });
 
   // Clean up legacy version.json if present (superseded by install-meta.json)
-  if (!params.version) {
-    const metaPath = getVersionMetaPath(params.id);
-    if (existsSync(metaPath)) {
-      rmSync(metaPath);
-    }
+  const metaPath = getVersionMetaPath(params.id);
+  if (existsSync(metaPath)) {
+    rmSync(metaPath);
   }
 
   log.info(

--- a/assistant/src/workspace/migrations/026-backfill-install-meta.ts
+++ b/assistant/src/workspace/migrations/026-backfill-install-meta.ts
@@ -40,6 +40,7 @@ interface SkillInstallMeta {
   origin: "vellum" | "clawhub" | "skillssh" | "custom";
   installedAt: string;
   installedBy?: string;
+  backfilledBy?: string;
   version?: string;
   slug?: string;
   sourceRepo?: string;
@@ -282,8 +283,9 @@ export const backfillInstallMetaMigration: WorkspaceMigration = {
 
       const meta = inferInstallMeta(skillDir, name, integrityManifest);
 
-      // installedBy is left undefined for all backfilled skills
-      writeInstallMeta(skillDir, meta);
+      // Mark as backfilled so down() can safely identify and remove only
+      // migration-created files without touching CLI-installed ones.
+      writeInstallMeta(skillDir, { ...meta, backfilledBy: "migration-026" });
     }
   },
 
@@ -308,10 +310,10 @@ export const backfillInstallMetaMigration: WorkspaceMigration = {
             readFileSync(installMetaPath, "utf-8"),
           ) as SkillInstallMeta;
 
-          // Only remove install-meta.json that were backfilled (no installedBy).
-          // If installedBy is present, the file was written by the new install
-          // flow and should be preserved.
-          if (meta.installedBy === undefined) {
+          // Only remove install-meta.json that were backfilled by this migration.
+          // Files written by the normal install flow (CLI, daemon, etc.) won't
+          // have backfilledBy set and are safely preserved on rollback.
+          if (meta.backfilledBy === "migration-026") {
             unlinkSync(installMetaPath);
           }
         } catch {


### PR DESCRIPTION
## Summary
- Fix migration down() to use backfilledBy sentinel instead of installedBy check
- Fix managed-store.ts version.json cleanup condition
- Update CLI help text from version.json to install-meta.json
- Remove redundant verifyAndRecordSkillHash from clawhubInstall
- Fix installedBy comment to reference actorPrincipalId
- Add documentation comment for bundled skill path divergence

Part of plan: skills-unify-install.md (self-review fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22911" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
