### PR TITLE
fix: address post-merge review feedback on install-meta changes

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -247,9 +247,11 @@ function saveConfigWithSuppression(
  * in the daemon. Handles catalog reload, auto-enable, broadcast, and memory
  * seeding.
  *
- * SKILLS.md indexing and dependency installation are handled by the install
- * functions themselves (`installSkillLocally`, `installExternalSkill`,
- * `clawhubInstall`) so that both CLI and daemon callers get correct behavior.
+ * SKILLS.md indexing and dependency installation are handled separately:
+ * `installSkillLocally` and `installExternalSkill` handle them internally
+ * (so both CLI and daemon callers get correct behavior), while the clawhub
+ * path handles them inline in `installSkill()` since `clawhubInstall` only
+ * runs the clawhub CLI and writes metadata.
  *
  * NOT used for bundled skills — those have a simpler inline path in
  * `installSkill()` that only auto-enables, broadcasts, and seeds memories.
@@ -647,29 +649,33 @@ export async function installSkill(
       return { success: true };
     }
 
-    // Check the Vellum catalog (first-party skills hosted on the platform)
-    try {
-      const vellumCatalog = await getCatalog();
-      const catalogEntry = vellumCatalog.find((s) => s.id === spec.slug);
-      if (catalogEntry) {
-        await installSkillLocally(
-          spec.slug,
-          catalogEntry,
-          true,
-          spec.contactId,
-        );
+    // Check the Vellum catalog (first-party skills hosted on the platform).
+    // Skip when the caller explicitly specified an origin — this prevents
+    // slug collisions where a catalog skill shadows a community skill the
+    // user selected from search results.
+    if (!spec.origin)
+      try {
+        const vellumCatalog = await getCatalog();
+        const catalogEntry = vellumCatalog.find((s) => s.id === spec.slug);
+        if (catalogEntry) {
+          await installSkillLocally(
+            spec.slug,
+            catalogEntry,
+            true,
+            spec.contactId,
+          );
 
-        const skillDir = join(getWorkspaceSkillsDir(), spec.slug);
-        postInstallSkill(spec.slug, skillDir, ctx);
-        return { success: true };
+          const skillDir = join(getWorkspaceSkillsDir(), spec.slug);
+          postInstallSkill(spec.slug, skillDir, ctx);
+          return { success: true };
+        }
+      } catch (err) {
+        // If catalog lookup/install fails, fall through to community registries
+        log.warn(
+          { err, skillId: spec.slug },
+          "Vellum catalog install failed, falling back to community registry",
+        );
       }
-    } catch (err) {
-      // If catalog lookup/install fails, fall through to community registries
-      log.warn(
-        { err, skillId: spec.slug },
-        "Vellum catalog install failed, falling back to community registry",
-      );
-    }
 
     // skills.sh install path: route here when origin is explicitly "skillssh"
     // or when the slug looks like a skills.sh multi-segment format (owner/repo/skill)

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -650,10 +650,10 @@ export async function installSkill(
     }
 
     // Check the Vellum catalog (first-party skills hosted on the platform).
-    // Skip when the caller explicitly specified an origin — this prevents
-    // slug collisions where a catalog skill shadows a community skill the
-    // user selected from search results.
-    if (!spec.origin)
+    // Skip when the caller explicitly specified a community origin — this
+    // prevents slug collisions where a catalog skill shadows a community
+    // skill the user selected from search results.
+    if (spec.origin !== "clawhub" && spec.origin !== "skillssh")
       try {
         const vellumCatalog = await getCatalog();
         const catalogEntry = vellumCatalog.find((s) => s.id === spec.slug);

--- a/assistant/src/skills/install-meta.ts
+++ b/assistant/src/skills/install-meta.ts
@@ -163,8 +163,11 @@ export function collectFileContents(
 
   const entries = readdirSync(dir, { withFileTypes: true });
   for (const entry of entries) {
-    // Exclude metadata files at the root level (prefix === "")
-    if (!prefix && METADATA_FILENAMES.has(entry.name)) continue;
+    // Exclude metadata files at the root level (prefix === "").
+    // Only exclude actual files — a directory with a metadata name should
+    // still be traversed so nested content contributes to the hash.
+    if (!prefix && entry.isFile() && METADATA_FILENAMES.has(entry.name))
+      continue;
 
     const relPath = prefix ? `${prefix}/${entry.name}` : entry.name;
     const fullPath = join(dir, entry.name);


### PR DESCRIPTION
## Summary
- Fix metadata exclusion in `collectFileContents` to check `isFile()` before excluding — prevents directories named `install-meta.json` or `version.json` from being silently skipped in content hash
- Skip Vellum catalog lookup when caller explicitly specifies `origin` (skillssh/clawhub) — prevents slug collisions where a catalog skill shadows the community skill the user selected
- Fix `postInstallSkill` docstring that incorrectly claimed `clawhubInstall` handles SKILLS.md indexing and deps

## Original prompt
fixes to all relevant concerns
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22912" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
