### PR TITLE
feat: introduce SlimSkillResponse with kind/origin/status, polymorphic sub-objects

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5705,59 +5705,74 @@ paths:
                           type: string
                         description:
                           type: string
-                        emoji:
-                          type: string
-                        homepage:
-                          type: string
-                        source:
-                          type: string
-                          enum:
-                            - bundled
-                            - managed
-                            - workspace
-                            - clawhub
-                            - extra
-                            - catalog
-                        state:
-                          type: string
-                          enum:
-                            - enabled
-                            - disabled
-                        installStatus:
+                        kind:
                           type: string
                           enum:
                             - bundled
                             - installed
+                            - catalog
+                        origin:
+                          type: string
+                          enum:
+                            - vellum
+                            - clawhub
+                            - skillssh
+                            - custom
+                        status:
+                          type: string
+                          enum:
+                            - enabled
+                            - disabled
                             - available
-                        updateAvailable:
-                          type: boolean
-                        provenance:
+                        vellum:
                           type: object
                           properties:
-                            kind:
+                            emoji:
                               type: string
-                              enum:
-                                - first-party
-                                - third-party
-                                - local
-                            provider:
+                          additionalProperties: false
+                        clawhub:
+                          type: object
+                          properties:
+                            slug:
                               type: string
-                            originId:
+                            author:
                               type: string
-                            sourceUrl:
+                            stars:
+                              type: number
+                            installs:
+                              type: number
+                            reports:
+                              type: number
+                            publishedAt:
                               type: string
                           required:
-                            - kind
+                            - slug
+                            - author
+                            - stars
+                            - installs
+                            - reports
+                          additionalProperties: false
+                        skillssh:
+                          type: object
+                          properties:
+                            slug:
+                              type: string
+                            sourceRepo:
+                              type: string
+                            installs:
+                              type: number
+                          required:
+                            - slug
+                            - sourceRepo
+                            - installs
                           additionalProperties: false
                       required:
                         - id
                         - name
                         - description
-                        - source
-                        - state
-                        - installStatus
-                        - updateAvailable
-                        - provenance
+                        - kind
+                        - origin
+                        - status
                       additionalProperties: false
                     description: Skill objects
                 required:

--- a/assistant/src/__tests__/install-skill-routing.test.ts
+++ b/assistant/src/__tests__/install-skill-routing.test.ts
@@ -71,6 +71,9 @@ mock.module("../skills/skillssh-registry.js", () => ({
   searchSkillsRegistry: mock(async () => []),
 }));
 
+mock.module("../skills/install-meta.js", () => ({
+  readInstallMeta: () => null,
+}));
 mock.module("../config/assistant-feature-flags.js", () => ({
   isAssistantFeatureFlagEnabled: () => true,
 }));

--- a/assistant/src/__tests__/search-skills-unified.test.ts
+++ b/assistant/src/__tests__/search-skills-unified.test.ts
@@ -81,6 +81,11 @@ mock.module("../skills/skillssh-registry.js", () => ({
   searchSkillsRegistry: mockSkillsshSearch,
 }));
 
+// Stub install-meta (needed by the new origin derivation logic)
+mock.module("../skills/install-meta.js", () => ({
+  readInstallMeta: () => null,
+}));
+
 // Stub remaining imports pulled in by skills.ts
 mock.module("../config/assistant-feature-flags.js", () => ({
   isAssistantFeatureFlagEnabled: () => true,
@@ -206,20 +211,26 @@ describe("searchSkills (unified)", () => {
     if (!result.success) throw new Error("Expected success");
 
     const data = result.data as {
-      skills: Array<{ slug: string; source: string; origin: string }>;
+      skills: Array<{
+        id: string;
+        origin: string;
+        kind: string;
+        status: string;
+      }>;
     };
     expect(data.skills).toHaveLength(3);
 
     // Verify ordering: catalog first, then clawhub, then skills.sh
-    expect(data.skills[0]!.slug).toBe("weather");
-    expect(data.skills[0]!.source).toBe("vellum");
+    expect(data.skills[0]!.id).toBe("weather");
     expect(data.skills[0]!.origin).toBe("vellum");
-    expect(data.skills[1]!.slug).toBe("deploy");
-    expect(data.skills[1]!.source).toBe("clawhub");
+    expect(data.skills[0]!.kind).toBe("catalog");
+    expect(data.skills[0]!.status).toBe("available");
+    expect(data.skills[1]!.id).toBe("deploy");
     expect(data.skills[1]!.origin).toBe("clawhub");
-    expect(data.skills[2]!.slug).toBe("vercel-labs/skills/react-best");
-    expect(data.skills[2]!.source).toBe("skillssh");
+    expect(data.skills[1]!.kind).toBe("catalog");
+    expect(data.skills[2]!.id).toBe("vercel-labs/skills/react-best");
     expect(data.skills[2]!.origin).toBe("skillssh");
+    expect(data.skills[2]!.kind).toBe("catalog");
   });
 
   test("deduplicates: catalog takes precedence over clawhub and skills.sh", async () => {
@@ -263,16 +274,14 @@ describe("searchSkills (unified)", () => {
     if (!result.success) throw new Error("Expected success");
 
     const data = result.data as {
-      skills: Array<{ slug: string; source: string; origin: string }>;
+      skills: Array<{ id: string; origin: string }>;
     };
     // Catalog deduplicates clawhub (same slug "shared-skill"), but skills.sh
     // now uses the full id "org/repo/shared-skill" so it's a distinct entry.
     expect(data.skills).toHaveLength(2);
-    expect(data.skills[0]!.slug).toBe("shared-skill");
-    expect(data.skills[0]!.source).toBe("vellum");
+    expect(data.skills[0]!.id).toBe("shared-skill");
     expect(data.skills[0]!.origin).toBe("vellum");
-    expect(data.skills[1]!.slug).toBe("org/repo/shared-skill");
-    expect(data.skills[1]!.source).toBe("skillssh");
+    expect(data.skills[1]!.id).toBe("org/repo/shared-skill");
     expect(data.skills[1]!.origin).toBe("skillssh");
   });
 
@@ -310,15 +319,13 @@ describe("searchSkills (unified)", () => {
     if (!result.success) throw new Error("Expected success");
 
     const data = result.data as {
-      skills: Array<{ slug: string; source: string; origin: string }>;
+      skills: Array<{ id: string; origin: string }>;
     };
     // Full id slug means no collision — both entries survive
     expect(data.skills).toHaveLength(2);
-    expect(data.skills[0]!.slug).toBe("overlap-skill");
-    expect(data.skills[0]!.source).toBe("clawhub");
+    expect(data.skills[0]!.id).toBe("overlap-skill");
     expect(data.skills[0]!.origin).toBe("clawhub");
-    expect(data.skills[1]!.slug).toBe("org/repo/overlap-skill");
-    expect(data.skills[1]!.source).toBe("skillssh");
+    expect(data.skills[1]!.id).toBe("org/repo/overlap-skill");
     expect(data.skills[1]!.origin).toBe("skillssh");
   });
 
@@ -346,11 +353,10 @@ describe("searchSkills (unified)", () => {
     if (!result.success) throw new Error("Expected success");
 
     const data = result.data as {
-      skills: Array<{ slug: string; source: string; origin: string }>;
+      skills: Array<{ id: string; origin: string }>;
     };
     expect(data.skills).toHaveLength(1);
-    expect(data.skills[0]!.slug).toBe("clawhub-only");
-    expect(data.skills[0]!.source).toBe("clawhub");
+    expect(data.skills[0]!.id).toBe("clawhub-only");
     expect(data.skills[0]!.origin).toBe("clawhub");
   });
 
@@ -372,11 +378,10 @@ describe("searchSkills (unified)", () => {
     if (!result.success) throw new Error("Expected success");
 
     const data = result.data as {
-      skills: Array<{ slug: string; source: string; origin: string }>;
+      skills: Array<{ id: string; origin: string }>;
     };
     expect(data.skills).toHaveLength(1);
-    expect(data.skills[0]!.slug).toBe("org/repo/skillssh-only");
-    expect(data.skills[0]!.source).toBe("skillssh");
+    expect(data.skills[0]!.id).toBe("org/repo/skillssh-only");
     expect(data.skills[0]!.origin).toBe("skillssh");
   });
 
@@ -397,11 +402,10 @@ describe("searchSkills (unified)", () => {
     if (!result.success) throw new Error("Expected success");
 
     const data = result.data as {
-      skills: Array<{ slug: string; source: string; origin: string }>;
+      skills: Array<{ id: string; origin: string }>;
     };
     expect(data.skills).toHaveLength(1);
-    expect(data.skills[0]!.slug).toBe("my-skill");
-    expect(data.skills[0]!.source).toBe("vellum");
+    expect(data.skills[0]!.id).toBe("my-skill");
     expect(data.skills[0]!.origin).toBe("vellum");
   });
 
@@ -424,30 +428,32 @@ describe("searchSkills (unified)", () => {
 
     const data = result.data as {
       skills: Array<{
+        id: string;
         name: string;
-        slug: string;
         description: string;
-        author: string;
-        stars: number;
-        installs: number;
-        version: string;
-        createdAt: number;
-        source: string;
+        kind: string;
         origin: string;
+        status: string;
+        skillssh?: {
+          slug: string;
+          sourceRepo: string;
+          installs: number;
+        };
       }>;
     };
     expect(data.skills).toHaveLength(1);
 
     const skill = data.skills[0]!;
+    expect(skill.id).toBe("org/repo/test-skill");
     expect(skill.name).toBe("Test Skill");
-    expect(skill.slug).toBe("org/repo/test-skill");
     expect(skill.description).toBe("");
-    expect(skill.author).toBe("");
-    expect(skill.stars).toBe(0);
-    expect(skill.installs).toBe(99);
-    expect(skill.version).toBe("");
-    expect(skill.createdAt).toBe(0);
-    expect(skill.source).toBe("skillssh");
+    expect(skill.kind).toBe("catalog");
     expect(skill.origin).toBe("skillssh");
+    expect(skill.status).toBe("available");
+    expect(skill.skillssh).toEqual({
+      slug: "org/repo/test-skill",
+      sourceRepo: "org/repo",
+      installs: 99,
+    });
   });
 });

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -73,7 +73,6 @@ export interface SkillSummary {
   bundled?: boolean;
   icon?: string;
   emoji?: string;
-  homepage?: string;
   source: SkillSource;
   /** Parsed tool manifest metadata, if the skill has a valid TOOLS.json. */
   toolManifest?: SkillToolManifestMeta;

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -41,6 +41,7 @@ import {
   clawhubSearch,
   clawhubUpdate,
 } from "../../skills/clawhub.js";
+import { readInstallMeta } from "../../skills/install-meta.js";
 import {
   createManagedSkill,
   deleteManagedSkill,
@@ -57,6 +58,12 @@ import {
   searchSkillsRegistry,
 } from "../../skills/skillssh-registry.js";
 import { getWorkspaceSkillsDir } from "../../util/platform.js";
+import type {
+  ClawhubSkillMeta,
+  SkillsshSkillMeta,
+  SlimSkillResponse,
+  VellumSkillMeta,
+} from "../message-types/skills.js";
 import {
   CONFIG_RELOAD_DEBOUNCE_MS,
   ensureSkillEntry,
@@ -80,52 +87,6 @@ export interface SkillOperationContext {
   setSuppressConfigReload(value: boolean): void;
   updateConfigFingerprint(): void;
   broadcast: HandlerContext["broadcast"];
-}
-
-// ─── Provenance resolution ──────────────────────────────────────────────────
-
-interface SkillProvenance {
-  kind: "first-party" | "third-party" | "local";
-  provider?: string;
-  originId?: string;
-  sourceUrl?: string;
-}
-
-const CLAWHUB_BASE_URL = "https://skills.sh";
-
-function resolveProvenance(summary: SkillSummary): SkillProvenance {
-  // Bundled skills are always first-party (shipped with Vellum)
-  if (summary.source === "bundled") {
-    return { kind: "first-party", provider: "Vellum" };
-  }
-
-  // Managed skills are third-party (installed from clawhub). The homepage field
-  // confirms provenance.
-  if (summary.source === "managed") {
-    if (
-      summary.homepage?.includes("skills.sh") ||
-      summary.homepage?.includes("clawhub")
-    ) {
-      return {
-        kind: "third-party",
-        provider: "skills.sh",
-        originId: summary.id,
-        sourceUrl:
-          summary.homepage ??
-          `${CLAWHUB_BASE_URL}/skills/${encodeURIComponent(summary.id)}`,
-      };
-    }
-    // No positive evidence of clawhub origin -- likely user-authored.
-    // Default to "local" to avoid mislabeling.
-    return { kind: "local" };
-  }
-
-  // Workspace and extra skills are user-provided
-  if (summary.source === "workspace" || summary.source === "extra") {
-    return { kind: "local" };
-  }
-
-  return { kind: "local" };
 }
 
 // ─── Frontmatter parsing ─────────────────────────────────────────────────────
@@ -280,52 +241,102 @@ export function postInstallSkill(
   seedCatalogSkillMemories();
 }
 
-export interface SkillListItem {
-  id: string;
-  name: string;
-  description: string;
-  emoji?: string;
-  homepage?: string;
-  source: "bundled" | "managed" | "workspace" | "clawhub" | "extra" | "catalog";
-  state: "enabled" | "disabled";
-  installStatus: "bundled" | "installed" | "available";
-  updateAvailable: boolean;
-  provenance: SkillProvenance;
+// ─── Kind / origin / status derivation ───────────────────────────────────────
+
+/** Map the old `source` field to the new `kind` axis. */
+function deriveKind(
+  source: "bundled" | "managed" | "workspace" | "extra" | "catalog",
+): SlimSkillResponse["kind"] {
+  if (source === "bundled") return "bundled";
+  if (source === "catalog") return "catalog";
+  return "installed"; // managed, workspace, extra
 }
 
-/** Sorting rank for provenance-based ordering: first-party first, local last. */
-function provenanceSortRank(p: SkillProvenance): number {
-  if (p.kind === "first-party") return 0;
-  if (p.kind === "third-party" && p.provider) return 1;
-  if (p.kind === "third-party") return 2;
-  return 3; // local
+/** Map a resolved skill to its `origin`, using install-meta.json when available. */
+function deriveOrigin(
+  kind: SlimSkillResponse["kind"],
+  directoryPath: string,
+): SlimSkillResponse["origin"] {
+  if (kind === "bundled") return "vellum";
+  if (kind === "catalog") return "vellum";
+  // For installed skills, read install-meta.json
+  const meta = readInstallMeta(directoryPath);
+  return meta?.origin ?? "custom";
 }
 
-export function listSkills(_ctx: SkillOperationContext): SkillListItem[] {
+/** Build the correct polymorphic sub-object for a given origin. */
+function buildOriginMeta(
+  origin: SlimSkillResponse["origin"],
+  summary: SkillSummary,
+): Pick<SlimSkillResponse, "vellum" | "clawhub" | "skillssh"> {
+  switch (origin) {
+    case "vellum": {
+      const vellumMeta: VellumSkillMeta | undefined = summary.emoji
+        ? { emoji: summary.emoji }
+        : undefined;
+      return vellumMeta ? { vellum: vellumMeta } : {};
+    }
+    case "clawhub": {
+      const installMeta = readInstallMeta(summary.directoryPath);
+      const clawhubMeta: ClawhubSkillMeta = {
+        slug: installMeta?.slug ?? summary.id,
+        author: "",
+        stars: 0,
+        installs: 0,
+        reports: 0,
+      };
+      return { clawhub: clawhubMeta };
+    }
+    case "skillssh": {
+      const installMeta = readInstallMeta(summary.directoryPath);
+      const skillsshMeta: SkillsshSkillMeta = {
+        slug: installMeta?.slug ?? summary.id,
+        sourceRepo: installMeta?.sourceRepo ?? "",
+        installs: 0,
+      };
+      return { skillssh: skillsshMeta };
+    }
+    default:
+      return {};
+  }
+}
+
+/** Sort rank by kind: bundled first, then catalog, then installed. */
+function kindSortRank(kind: SlimSkillResponse["kind"]): number {
+  if (kind === "bundled") return 0;
+  if (kind === "catalog") return 1;
+  return 2; // installed
+}
+
+/** Convert a resolved skill to a SlimSkillResponse. */
+function toSlimSkillResponse(
+  summary: SkillSummary,
+  state: "enabled" | "disabled",
+): SlimSkillResponse {
+  const kind = deriveKind(summary.source);
+  const origin = deriveOrigin(kind, summary.directoryPath);
+  const status: SlimSkillResponse["status"] = state;
+  return {
+    id: summary.id,
+    name: summary.displayName,
+    description: summary.description,
+    kind,
+    origin,
+    status,
+    ...buildOriginMeta(origin, summary),
+  };
+}
+
+export function listSkills(_ctx: SkillOperationContext): SlimSkillResponse[] {
   const config = getConfig();
   const catalog = loadSkillCatalog();
   const resolved = resolveSkillStates(catalog, config);
 
-  const items = resolved.map((r) => ({
-    id: r.summary.id,
-    name: r.summary.displayName,
-    description: r.summary.description,
-    emoji: r.summary.emoji,
-    homepage: r.summary.homepage,
-    source: r.summary.source,
-    state: r.state,
-    installStatus: (r.summary.source === "bundled"
-      ? "bundled"
-      : "installed") as SkillListItem["installStatus"],
-    updateAvailable: false,
-    provenance: resolveProvenance(r.summary),
-  }));
+  const items = resolved.map((r) => toSlimSkillResponse(r.summary, r.state));
 
-  // Sort: first-party > third-party with provider > third-party without > local,
-  // alphabetical by name within each tier.
+  // Sort by kind rank, then alphabetical by name within each tier.
   items.sort((a, b) => {
-    const rankDiff =
-      provenanceSortRank(a.provenance) - provenanceSortRank(b.provenance);
+    const rankDiff = kindSortRank(a.kind) - kindSortRank(b.kind);
     if (rankDiff !== 0) return rankDiff;
     return a.name.localeCompare(b.name);
   });
@@ -339,7 +350,7 @@ export function listSkills(_ctx: SkillOperationContext): SkillListItem[] {
  */
 export async function listSkillsWithCatalog(
   ctx: SkillOperationContext,
-): Promise<SkillListItem[]> {
+): Promise<SlimSkillResponse[]> {
   const installed = listSkills(ctx);
   const installedIds = new Set(installed.map((s) => s.id));
 
@@ -352,28 +363,30 @@ export async function listSkillsWithCatalog(
   }
 
   // All entries from the Vellum platform API are first-party.
-  // Create SkillListItems for catalog skills not already installed.
-  const available: SkillListItem[] = catalogSkills
+  // Create SlimSkillResponses for catalog skills not already installed.
+  const available: SlimSkillResponse[] = catalogSkills
     .filter((cs) => !installedIds.has(cs.id))
-    .map((cs) => ({
-      id: cs.id,
-      name: cs.metadata?.vellum?.["display-name"] ?? cs.name,
-      description: cs.description,
-      emoji: cs.emoji,
-      homepage: undefined,
-      source: "catalog" as const,
-      state: "disabled" as const,
-      installStatus: "available" as const,
-      updateAvailable: false,
-      provenance: { kind: "first-party" as const, provider: "Vellum" },
-    }));
+    .map((cs) => {
+      const emoji = cs.emoji;
+      const result: SlimSkillResponse = {
+        id: cs.id,
+        name: cs.metadata?.vellum?.["display-name"] ?? cs.name,
+        description: cs.description,
+        kind: "catalog",
+        origin: "vellum",
+        status: "available",
+      };
+      if (emoji) {
+        result.vellum = { emoji };
+      }
+      return result;
+    });
 
   const merged = [...installed, ...available];
 
-  // Sort using the same provenance sort + alphabetical
+  // Sort by kind rank, then alphabetical by name
   merged.sort((a, b) => {
-    const rankDiff =
-      provenanceSortRank(a.provenance) - provenanceSortRank(b.provenance);
+    const rankDiff = kindSortRank(a.kind) - kindSortRank(b.kind);
     if (rankDiff !== 0) return rankDiff;
     return a.name.localeCompare(b.name);
   });
@@ -381,10 +394,10 @@ export async function listSkillsWithCatalog(
   return merged;
 }
 
-/** Look up a single skill by ID from the resolved catalog, returning its SkillListItem. */
+/** Look up a single skill by ID from the resolved catalog, returning its SlimSkillResponse. */
 function findSkillById(
   skillId: string,
-): { item: SkillListItem; summary: SkillSummary } | undefined {
+): { item: SlimSkillResponse; summary: SkillSummary } | undefined {
   const config = getConfig();
   const catalog = loadSkillCatalog();
   const resolved = resolveSkillStates(catalog, config);
@@ -392,25 +405,14 @@ function findSkillById(
   if (!match) return undefined;
 
   const r = match;
-  const item: SkillListItem = {
-    id: r.summary.id,
-    name: r.summary.displayName,
-    description: r.summary.description,
-    emoji: r.summary.emoji,
-    homepage: r.summary.homepage,
-    source: r.summary.source,
-    state: r.state,
-    installStatus: r.summary.source === "bundled" ? "bundled" : "installed",
-    updateAvailable: false,
-    provenance: resolveProvenance(r.summary),
-  };
+  const item = toSlimSkillResponse(r.summary, r.state);
   return { item, summary: r.summary };
 }
 
 export function getSkill(
   skillId: string,
   _ctx: SkillOperationContext,
-): { skill: SkillListItem } | { error: string; status: number } {
+): { skill: SlimSkillResponse } | { error: string; status: number } {
   const found = findSkillById(skillId);
   if (!found) {
     return { error: `Skill "${skillId}" not found`, status: 404 };
@@ -498,7 +500,7 @@ export function getSkillFiles(
   skillId: string,
   _ctx: SkillOperationContext,
 ):
-  | { skill: SkillListItem; files: SkillFileEntry[] }
+  | { skill: SlimSkillResponse; files: SkillFileEntry[] }
   | { error: string; status: number } {
   const found = findSkillById(skillId);
   if (!found) {
@@ -837,7 +839,8 @@ export async function searchSkills(
   query: string,
   _ctx: SkillOperationContext,
 ): Promise<
-  { success: true; data: unknown } | { success: false; error: string }
+  | { success: true; data: { skills: SlimSkillResponse[] } }
+  | { success: false; error: string }
 > {
   try {
     // Search the loaded skill catalog (bundled + installed) for matches
@@ -848,33 +851,20 @@ export async function searchSkills(
       (s) => s.description,
     ]);
 
-    // Shape that matches ClawhubSearchResultItem so the client
-    // (Swift ClawhubSkillItem) can decode results uniformly.
-    interface SearchItem {
-      name: string;
-      slug: string;
-      description: string;
-      author: string;
-      stars: number;
-      installs: number;
-      version: string;
-      createdAt: number;
-      source: "vellum" | "clawhub" | "skillssh";
-      origin: "vellum" | "clawhub" | "skillssh";
-    }
-
-    const catalogItems: SearchItem[] = catalogMatches.map((s) => ({
-      name: s.displayName,
-      slug: s.id,
-      description: s.description,
-      author: "Vellum",
-      stars: 0,
-      installs: 0,
-      version: "",
-      createdAt: 0,
-      source: "vellum" as const,
-      origin: "vellum" as const,
-    }));
+    const catalogItems: SlimSkillResponse[] = catalogMatches.map((s) => {
+      const result: SlimSkillResponse = {
+        id: s.id,
+        name: s.displayName,
+        description: s.description,
+        kind: "catalog",
+        origin: "vellum",
+        status: "available",
+      };
+      if (s.emoji) {
+        result.vellum = { emoji: s.emoji };
+      }
+      return result;
+    });
 
     // Search both community registries in parallel (non-fatal on failure)
     const [clawhubResult, skillsshResult] = await Promise.allSettled([
@@ -882,11 +872,25 @@ export async function searchSkills(
       searchSkillsRegistry(query, 25),
     ]);
 
-    let clawhubSkills: SearchItem[] = [];
+    let clawhubSkills: SlimSkillResponse[] = [];
     if (clawhubResult.status === "fulfilled") {
       clawhubSkills = clawhubResult.value.skills.map((s) => ({
-        ...s,
+        id: s.slug,
+        name: s.name,
+        description: s.description,
+        kind: "catalog" as const,
         origin: "clawhub" as const,
+        status: "available" as const,
+        clawhub: {
+          slug: s.slug,
+          author: s.author,
+          stars: s.stars,
+          installs: s.installs,
+          reports: 0,
+          publishedAt: s.createdAt
+            ? new Date(s.createdAt * 1000).toISOString()
+            : undefined,
+        },
       }));
     } else {
       log.warn(
@@ -895,19 +899,20 @@ export async function searchSkills(
       );
     }
 
-    let skillsshSkills: SearchItem[] = [];
+    let skillsshSkills: SlimSkillResponse[] = [];
     if (skillsshResult.status === "fulfilled") {
       skillsshSkills = skillsshResult.value.map((r) => ({
+        id: r.id,
         name: r.name,
-        slug: r.id,
         description: "",
-        author: "",
-        stars: 0,
-        installs: r.installs,
-        version: "",
-        createdAt: 0,
-        source: "skillssh" as const,
+        kind: "catalog" as const,
         origin: "skillssh" as const,
+        status: "available" as const,
+        skillssh: {
+          slug: r.id,
+          sourceRepo: r.source,
+          installs: r.installs,
+        },
       }));
     } else {
       log.warn(
@@ -917,17 +922,17 @@ export async function searchSkills(
     }
 
     // Deduplicate: catalog > clawhub > skills.sh (first occurrence wins)
-    const seenSlugs = new Set(catalogItems.map((s) => s.slug));
+    const seenSlugs = new Set(catalogItems.map((s) => s.id));
 
     const dedupedClawhub = clawhubSkills.filter((s) => {
-      if (seenSlugs.has(s.slug)) return false;
-      seenSlugs.add(s.slug);
+      if (seenSlugs.has(s.id)) return false;
+      seenSlugs.add(s.id);
       return true;
     });
 
     const dedupedSkillssh = skillsshSkills.filter((s) => {
-      if (seenSlugs.has(s.slug)) return false;
-      seenSlugs.add(s.slug);
+      if (seenSlugs.has(s.id)) return false;
+      seenSlugs.add(s.id);
       return true;
     });
 

--- a/assistant/src/daemon/message-types/skills.ts
+++ b/assistant/src/daemon/message-types/skills.ts
@@ -76,33 +76,40 @@ export interface SkillsCreateRequest {
 
 // === Server → Client ===
 
+export interface VellumSkillMeta {
+  emoji?: string;
+}
+
+export interface ClawhubSkillMeta {
+  slug: string;
+  author: string;
+  stars: number;
+  installs: number;
+  reports: number;
+  publishedAt?: string;
+}
+
+export interface SkillsshSkillMeta {
+  slug: string;
+  sourceRepo: string;
+  installs: number;
+}
+
+export interface SlimSkillResponse {
+  id: string;
+  name: string;
+  description: string;
+  kind: "bundled" | "installed" | "catalog";
+  origin: "vellum" | "clawhub" | "skillssh" | "custom";
+  status: "enabled" | "disabled" | "available";
+  vellum?: VellumSkillMeta;
+  clawhub?: ClawhubSkillMeta;
+  skillssh?: SkillsshSkillMeta;
+}
+
 export interface SkillsListResponse {
   type: "skills_list_response";
-  skills: Array<{
-    id: string;
-    name: string;
-    description: string;
-    emoji?: string;
-    homepage?: string;
-    source: "bundled" | "managed" | "workspace" | "clawhub" | "extra";
-    state: "enabled" | "disabled";
-    installedVersion?: string;
-    latestVersion?: string;
-    updateAvailable: boolean;
-    clawhub?: {
-      author: string;
-      stars: number;
-      installs: number;
-      reports: number;
-      publishedAt: string;
-    };
-    provenance?: {
-      kind: "first-party" | "third-party" | "local";
-      provider?: string;
-      originId?: string;
-      sourceUrl?: string;
-    };
-  }>;
+  skills: SlimSkillResponse[];
 }
 
 export interface SkillStateChanged {

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -66,25 +66,31 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
               id: z.string(),
               name: z.string(),
               description: z.string(),
-              emoji: z.string().optional(),
-              homepage: z.string().optional(),
-              source: z.enum([
-                "bundled",
-                "managed",
-                "workspace",
-                "clawhub",
-                "extra",
-                "catalog",
-              ]),
-              state: z.enum(["enabled", "disabled"]),
-              installStatus: z.enum(["bundled", "installed", "available"]),
-              updateAvailable: z.boolean(),
-              provenance: z.object({
-                kind: z.enum(["first-party", "third-party", "local"]),
-                provider: z.string().optional(),
-                originId: z.string().optional(),
-                sourceUrl: z.string().optional(),
-              }),
+              kind: z.enum(["bundled", "installed", "catalog"]),
+              origin: z.enum(["vellum", "clawhub", "skillssh", "custom"]),
+              status: z.enum(["enabled", "disabled", "available"]),
+              vellum: z
+                .object({
+                  emoji: z.string().optional(),
+                })
+                .optional(),
+              clawhub: z
+                .object({
+                  slug: z.string(),
+                  author: z.string(),
+                  stars: z.number(),
+                  installs: z.number(),
+                  reports: z.number(),
+                  publishedAt: z.string().optional(),
+                })
+                .optional(),
+              skillssh: z
+                .object({
+                  slug: z.string(),
+                  sourceRepo: z.string(),
+                  installs: z.number(),
+                })
+                .optional(),
             }),
           )
           .describe("Skill objects"),


### PR DESCRIPTION
## Summary
- Defines new SlimSkillResponse type with kind/origin/status axes and polymorphic sub-objects (vellum/clawhub/skillssh)
- Replaces old SkillListItem removing dead fields (provenance, installStatus, updateAvailable, homepage, source)
- Updates list and search endpoints to return the new shape

Part of plan: skills-api-schemas.md (PR 1 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22913" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
