### PR TITLE
refactor: search endpoint returns { skills: SlimSkillResponse[] } instead of { data: { skills } }

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6129,13 +6129,89 @@ paths:
               schema:
                 type: object
                 properties:
-                  data:
-                    type: object
-                    properties: {}
-                    additionalProperties: {}
-                    description: Search results
+                  skills:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        description:
+                          type: string
+                        kind:
+                          type: string
+                          enum:
+                            - bundled
+                            - installed
+                            - catalog
+                        origin:
+                          type: string
+                          enum:
+                            - vellum
+                            - clawhub
+                            - skillssh
+                            - custom
+                        status:
+                          type: string
+                          enum:
+                            - enabled
+                            - disabled
+                            - available
+                        vellum:
+                          type: object
+                          properties:
+                            emoji:
+                              type: string
+                          additionalProperties: false
+                        clawhub:
+                          type: object
+                          properties:
+                            slug:
+                              type: string
+                            author:
+                              type: string
+                            stars:
+                              type: number
+                            installs:
+                              type: number
+                            reports:
+                              type: number
+                            publishedAt:
+                              type: string
+                          required:
+                            - slug
+                            - author
+                            - stars
+                            - installs
+                            - reports
+                          additionalProperties: false
+                        skillssh:
+                          type: object
+                          properties:
+                            slug:
+                              type: string
+                            sourceRepo:
+                              type: string
+                            installs:
+                              type: number
+                          required:
+                            - slug
+                            - sourceRepo
+                            - installs
+                          additionalProperties: false
+                      required:
+                        - id
+                        - name
+                        - description
+                        - kind
+                        - origin
+                        - status
+                      additionalProperties: false
+                    description: Skill objects matching the search query
                 required:
-                  - data
+                  - skills
                 additionalProperties: false
       parameters:
         - name: q

--- a/assistant/src/__tests__/search-skills-unified.test.ts
+++ b/assistant/src/__tests__/search-skills-unified.test.ts
@@ -210,27 +210,19 @@ describe("searchSkills (unified)", () => {
     expect(result.success).toBe(true);
     if (!result.success) throw new Error("Expected success");
 
-    const data = result.data as {
-      skills: Array<{
-        id: string;
-        origin: string;
-        kind: string;
-        status: string;
-      }>;
-    };
-    expect(data.skills).toHaveLength(3);
+    expect(result.skills).toHaveLength(3);
 
     // Verify ordering: catalog first, then clawhub, then skills.sh
-    expect(data.skills[0]!.id).toBe("weather");
-    expect(data.skills[0]!.origin).toBe("vellum");
-    expect(data.skills[0]!.kind).toBe("catalog");
-    expect(data.skills[0]!.status).toBe("available");
-    expect(data.skills[1]!.id).toBe("deploy");
-    expect(data.skills[1]!.origin).toBe("clawhub");
-    expect(data.skills[1]!.kind).toBe("catalog");
-    expect(data.skills[2]!.id).toBe("vercel-labs/skills/react-best");
-    expect(data.skills[2]!.origin).toBe("skillssh");
-    expect(data.skills[2]!.kind).toBe("catalog");
+    expect(result.skills[0]!.id).toBe("weather");
+    expect(result.skills[0]!.origin).toBe("vellum");
+    expect(result.skills[0]!.kind).toBe("catalog");
+    expect(result.skills[0]!.status).toBe("available");
+    expect(result.skills[1]!.id).toBe("deploy");
+    expect(result.skills[1]!.origin).toBe("clawhub");
+    expect(result.skills[1]!.kind).toBe("catalog");
+    expect(result.skills[2]!.id).toBe("vercel-labs/skills/react-best");
+    expect(result.skills[2]!.origin).toBe("skillssh");
+    expect(result.skills[2]!.kind).toBe("catalog");
   });
 
   test("deduplicates: catalog takes precedence over clawhub and skills.sh", async () => {
@@ -273,16 +265,13 @@ describe("searchSkills (unified)", () => {
     expect(result.success).toBe(true);
     if (!result.success) throw new Error("Expected success");
 
-    const data = result.data as {
-      skills: Array<{ id: string; origin: string }>;
-    };
     // Catalog deduplicates clawhub (same slug "shared-skill"), but skills.sh
     // now uses the full id "org/repo/shared-skill" so it's a distinct entry.
-    expect(data.skills).toHaveLength(2);
-    expect(data.skills[0]!.id).toBe("shared-skill");
-    expect(data.skills[0]!.origin).toBe("vellum");
-    expect(data.skills[1]!.id).toBe("org/repo/shared-skill");
-    expect(data.skills[1]!.origin).toBe("skillssh");
+    expect(result.skills).toHaveLength(2);
+    expect(result.skills[0]!.id).toBe("shared-skill");
+    expect(result.skills[0]!.origin).toBe("vellum");
+    expect(result.skills[1]!.id).toBe("org/repo/shared-skill");
+    expect(result.skills[1]!.origin).toBe("skillssh");
   });
 
   test("deduplicates: clawhub takes precedence over skills.sh with same slug", async () => {
@@ -318,15 +307,12 @@ describe("searchSkills (unified)", () => {
     expect(result.success).toBe(true);
     if (!result.success) throw new Error("Expected success");
 
-    const data = result.data as {
-      skills: Array<{ id: string; origin: string }>;
-    };
     // Full id slug means no collision — both entries survive
-    expect(data.skills).toHaveLength(2);
-    expect(data.skills[0]!.id).toBe("overlap-skill");
-    expect(data.skills[0]!.origin).toBe("clawhub");
-    expect(data.skills[1]!.id).toBe("org/repo/overlap-skill");
-    expect(data.skills[1]!.origin).toBe("skillssh");
+    expect(result.skills).toHaveLength(2);
+    expect(result.skills[0]!.id).toBe("overlap-skill");
+    expect(result.skills[0]!.origin).toBe("clawhub");
+    expect(result.skills[1]!.id).toBe("org/repo/overlap-skill");
+    expect(result.skills[1]!.origin).toBe("skillssh");
   });
 
   test("returns clawhub results when skills.sh fails", async () => {
@@ -352,12 +338,9 @@ describe("searchSkills (unified)", () => {
     expect(result.success).toBe(true);
     if (!result.success) throw new Error("Expected success");
 
-    const data = result.data as {
-      skills: Array<{ id: string; origin: string }>;
-    };
-    expect(data.skills).toHaveLength(1);
-    expect(data.skills[0]!.id).toBe("clawhub-only");
-    expect(data.skills[0]!.origin).toBe("clawhub");
+    expect(result.skills).toHaveLength(1);
+    expect(result.skills[0]!.id).toBe("clawhub-only");
+    expect(result.skills[0]!.origin).toBe("clawhub");
   });
 
   test("returns skills.sh results when clawhub fails", async () => {
@@ -377,12 +360,9 @@ describe("searchSkills (unified)", () => {
     expect(result.success).toBe(true);
     if (!result.success) throw new Error("Expected success");
 
-    const data = result.data as {
-      skills: Array<{ id: string; origin: string }>;
-    };
-    expect(data.skills).toHaveLength(1);
-    expect(data.skills[0]!.id).toBe("org/repo/skillssh-only");
-    expect(data.skills[0]!.origin).toBe("skillssh");
+    expect(result.skills).toHaveLength(1);
+    expect(result.skills[0]!.id).toBe("org/repo/skillssh-only");
+    expect(result.skills[0]!.origin).toBe("skillssh");
   });
 
   test("returns catalog-only results when both community registries fail", async () => {
@@ -401,12 +381,9 @@ describe("searchSkills (unified)", () => {
     expect(result.success).toBe(true);
     if (!result.success) throw new Error("Expected success");
 
-    const data = result.data as {
-      skills: Array<{ id: string; origin: string }>;
-    };
-    expect(data.skills).toHaveLength(1);
-    expect(data.skills[0]!.id).toBe("my-skill");
-    expect(data.skills[0]!.origin).toBe("vellum");
+    expect(result.skills).toHaveLength(1);
+    expect(result.skills[0]!.id).toBe("my-skill");
+    expect(result.skills[0]!.origin).toBe("vellum");
   });
 
   test("skills.sh results have correct normalized fields", async () => {
@@ -426,24 +403,9 @@ describe("searchSkills (unified)", () => {
     expect(result.success).toBe(true);
     if (!result.success) throw new Error("Expected success");
 
-    const data = result.data as {
-      skills: Array<{
-        id: string;
-        name: string;
-        description: string;
-        kind: string;
-        origin: string;
-        status: string;
-        skillssh?: {
-          slug: string;
-          sourceRepo: string;
-          installs: number;
-        };
-      }>;
-    };
-    expect(data.skills).toHaveLength(1);
+    expect(result.skills).toHaveLength(1);
 
-    const skill = data.skills[0]!;
+    const skill = result.skills[0]!;
     expect(skill.id).toBe("org/repo/test-skill");
     expect(skill.name).toBe("Test Skill");
     expect(skill.description).toBe("");

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -839,7 +839,7 @@ export async function searchSkills(
   query: string,
   _ctx: SkillOperationContext,
 ): Promise<
-  | { success: true; data: { skills: SlimSkillResponse[] } }
+  | { success: true; skills: SlimSkillResponse[] }
   | { success: false; error: string }
 > {
   try {
@@ -938,9 +938,7 @@ export async function searchSkills(
 
     return {
       success: true,
-      data: {
-        skills: [...catalogItems, ...dedupedClawhub, ...dedupedSkillssh],
-      },
+      skills: [...catalogItems, ...dedupedClawhub, ...dedupedSkillssh],
     };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -279,7 +279,40 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
         },
       ],
       responseBody: z.object({
-        data: z.object({}).passthrough().describe("Search results"),
+        skills: z
+          .array(
+            z.object({
+              id: z.string(),
+              name: z.string(),
+              description: z.string(),
+              kind: z.enum(["bundled", "installed", "catalog"]),
+              origin: z.enum(["vellum", "clawhub", "skillssh", "custom"]),
+              status: z.enum(["enabled", "disabled", "available"]),
+              vellum: z
+                .object({
+                  emoji: z.string().optional(),
+                })
+                .optional(),
+              clawhub: z
+                .object({
+                  slug: z.string(),
+                  author: z.string(),
+                  stars: z.number(),
+                  installs: z.number(),
+                  reports: z.number(),
+                  publishedAt: z.string().optional(),
+                })
+                .optional(),
+              skillssh: z
+                .object({
+                  slug: z.string(),
+                  sourceRepo: z.string(),
+                  installs: z.number(),
+                })
+                .optional(),
+            }),
+          )
+          .describe("Skill objects matching the search query"),
       }),
       handler: async ({ url }) => {
         const query = url.searchParams.get("q") ?? "";
@@ -290,7 +323,7 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
         if (!result.success) {
           return httpError("INTERNAL_ERROR", result.error, 500);
         }
-        return Response.json({ data: result.data });
+        return Response.json({ skills: result.skills });
       },
     },
 


### PR DESCRIPTION
## Summary
- Flattens search endpoint response from { data: { skills } } to { skills: SlimSkillResponse[] }
- Updates Zod schema and route handler
- Regenerates OpenAPI spec

Part of plan: skills-api-schemas.md (PR 2 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22914" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
