### PR TITLE
feat: introduce SkillDetailResponse for GET /skills/:id with enriched fields

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5846,7 +5846,7 @@ paths:
     get:
       operationId: skills_by_id_get
       summary: Get skill
-      description: Return a single skill by ID.
+      description: Return a single skill by ID with enriched detail fields.
       tags:
         - skills
       responses:

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -59,7 +59,9 @@ import {
 } from "../../skills/skillssh-registry.js";
 import { getWorkspaceSkillsDir } from "../../util/platform.js";
 import type {
+  ClawhubDetailMeta,
   ClawhubSkillMeta,
+  SkillDetailResponse,
   SkillsshSkillMeta,
   SlimSkillResponse,
   VellumSkillMeta,
@@ -409,15 +411,63 @@ function findSkillById(
   return { item, summary: r.summary };
 }
 
-export function getSkill(
+export async function getSkill(
   skillId: string,
   _ctx: SkillOperationContext,
-): { skill: SlimSkillResponse } | { error: string; status: number } {
+): Promise<{ skill: SkillDetailResponse } | { error: string; status: number }> {
   const found = findSkillById(skillId);
   if (!found) {
     return { error: `Skill "${skillId}" not found`, status: 404 };
   }
-  return { skill: found.item };
+
+  const slim = found.item;
+
+  // Read SKILL.md body from disk
+  let body: string | undefined;
+  const skillMdPath = join(found.summary.directoryPath, "SKILL.md");
+  try {
+    if (existsSync(skillMdPath)) {
+      body = readFileSync(skillMdPath, "utf-8");
+    }
+  } catch {
+    // Best-effort: body is optional
+  }
+
+  // Build the detail response, starting from the slim shape
+  const detail: SkillDetailResponse = {
+    id: slim.id,
+    name: slim.name,
+    description: slim.description,
+    kind: slim.kind,
+    origin: slim.origin,
+    status: slim.status,
+    ...(slim.vellum ? { vellum: slim.vellum } : {}),
+    ...(slim.skillssh ? { skillssh: slim.skillssh } : {}),
+    ...(body !== undefined ? { body } : {}),
+  };
+
+  // For clawhub-origin skills, enrich with inspect data
+  if (slim.origin === "clawhub" && slim.clawhub) {
+    const enriched: ClawhubDetailMeta = { ...slim.clawhub };
+    try {
+      const inspectResult = await clawhubInspect(slim.clawhub.slug);
+      if (inspectResult.data) {
+        const data = inspectResult.data;
+        enriched.owner = data.owner;
+        enriched.stats = data.stats;
+        enriched.latestVersion = data.latestVersion;
+        enriched.createdAt = data.createdAt;
+        enriched.updatedAt = data.updatedAt;
+      }
+    } catch (err) {
+      log.warn({ err, skillId }, "Failed to enrich clawhub skill detail");
+    }
+    detail.clawhub = enriched;
+  } else if (slim.clawhub) {
+    detail.clawhub = slim.clawhub;
+  }
+
+  return { skill: detail };
 }
 
 // ─── Skill file listing ──────────────────────────────────────────────────────

--- a/assistant/src/daemon/message-types/skills.ts
+++ b/assistant/src/daemon/message-types/skills.ts
@@ -126,12 +126,40 @@ export interface SkillsOperationResponse {
   data?: unknown;
 }
 
-export interface SkillDetailResponse {
+export interface SkillBodyResponse {
   type: "skill_detail_response";
   skillId: string;
   body: string;
   icon?: string;
   error?: string;
+}
+
+// ─── Detail endpoint response (HTTP API) ──────────────────────────────────
+
+export interface ClawhubDetailMeta extends ClawhubSkillMeta {
+  owner?: { handle: string; displayName: string; image?: string } | null;
+  stats?: {
+    stars: number;
+    installs: number;
+    downloads: number;
+    versions: number;
+  } | null;
+  latestVersion?: { version: string; changelog?: string } | null;
+  createdAt?: number | null;
+  updatedAt?: number | null;
+}
+
+export interface SkillDetailResponse {
+  id: string;
+  name: string;
+  description: string;
+  kind: "bundled" | "installed" | "catalog";
+  origin: "vellum" | "clawhub" | "skillssh" | "custom";
+  status: "enabled" | "disabled" | "available";
+  vellum?: VellumSkillMeta;
+  clawhub?: ClawhubDetailMeta;
+  skillssh?: SkillsshSkillMeta;
+  body?: string;
 }
 
 export interface SkillsDraftResponse {
@@ -188,7 +216,7 @@ export type _SkillsClientMessages =
 
 export type _SkillsServerMessages =
   | SkillsListResponse
-  | SkillDetailResponse
+  | SkillBodyResponse
   | SkillStateChanged
   | SkillsOperationResponse
   | SkillsInspectResponse

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -410,10 +410,10 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
       method: "GET",
       policyKey: "skills",
       summary: "Get skill",
-      description: "Return a single skill by ID.",
+      description: "Return a single skill by ID with enriched detail fields.",
       tags: ["skills"],
-      handler: ({ params }) => {
-        const result = getSkill(params.id, ctx());
+      handler: async ({ params }) => {
+        const result = await getSkill(params.id, ctx());
         if ("error" in result) {
           if (result.status === 404) {
             return httpError("NOT_FOUND", result.error, 404);


### PR DESCRIPTION
## Summary
- Defines SkillDetailResponse with enriched clawhub fields (owner, stats, latestVersion) and body content
- Renames old SkillDetailResponse to SkillBodyResponse to avoid naming collision
- Updates getSkill() to populate enriched fields from clawhub inspect API

Part of plan: skills-api-schemas.md (PR 3 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22915" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
