### PR TITLE
refactor: update Swift generated types for kind/origin/status model with three sub-objects

### DIFF
--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -3985,46 +3985,24 @@ public struct SkillsListResponse: Codable, Sendable {
     }
 }
 
-public struct SkillsListResponseSkill: Codable, Sendable {
-    public let id: String
-    public let name: String
-    public let description: String
+public struct VellumSkillMeta: Codable, Sendable {
     public let emoji: String?
-    public let homepage: String?
-    public let source: String
-    public let state: String
-    public let installStatus: String?
-    public let installedVersion: String?
-    public let latestVersion: String?
-    public let updateAvailable: Bool
-    public let clawhub: SkillsListResponseSkillClawhub?
-    public let provenance: SkillsListResponseSkillProvenance?
 
-    public init(id: String, name: String, description: String, emoji: String? = nil, homepage: String? = nil, source: String, state: String, installStatus: String? = nil, installedVersion: String? = nil, latestVersion: String? = nil, updateAvailable: Bool, clawhub: SkillsListResponseSkillClawhub? = nil, provenance: SkillsListResponseSkillProvenance? = nil) {
-        self.id = id
-        self.name = name
-        self.description = description
+    public init(emoji: String? = nil) {
         self.emoji = emoji
-        self.homepage = homepage
-        self.source = source
-        self.state = state
-        self.installStatus = installStatus
-        self.installedVersion = installedVersion
-        self.latestVersion = latestVersion
-        self.updateAvailable = updateAvailable
-        self.clawhub = clawhub
-        self.provenance = provenance
     }
 }
 
-public struct SkillsListResponseSkillClawhub: Codable, Sendable {
+public struct ClawhubSkillMeta: Codable, Sendable {
+    public let slug: String
     public let author: String
     public let stars: Int
     public let installs: Int
     public let reports: Int
-    public let publishedAt: String
+    public let publishedAt: String?
 
-    public init(author: String, stars: Int, installs: Int, reports: Int, publishedAt: String) {
+    public init(slug: String, author: String, stars: Int, installs: Int, reports: Int, publishedAt: String? = nil) {
+        self.slug = slug
         self.author = author
         self.stars = stars
         self.installs = installs
@@ -4033,27 +4011,131 @@ public struct SkillsListResponseSkillClawhub: Codable, Sendable {
     }
 }
 
-public struct SkillsListResponseSkillProvenance: Codable, Sendable {
-    public let kind: String
-    public let provider: String?
-    public let originId: String?
-    public let sourceUrl: String?
+public struct SkillsshSkillMeta: Codable, Sendable {
+    public let slug: String
+    public let sourceRepo: String
+    public let installs: Int
 
-    public init(kind: String, provider: String? = nil, originId: String? = nil, sourceUrl: String? = nil) {
+    public init(slug: String, sourceRepo: String, installs: Int) {
+        self.slug = slug
+        self.sourceRepo = sourceRepo
+        self.installs = installs
+    }
+}
+
+public struct SkillsListResponseSkill: Codable, Sendable {
+    public let id: String
+    public let name: String
+    public let description: String
+    public let kind: String
+    public let origin: String
+    public let status: String
+    public let vellum: VellumSkillMeta?
+    public let clawhub: ClawhubSkillMeta?
+    public let skillssh: SkillsshSkillMeta?
+
+    public init(id: String, name: String, description: String, kind: String, origin: String, status: String, vellum: VellumSkillMeta? = nil, clawhub: ClawhubSkillMeta? = nil, skillssh: SkillsshSkillMeta? = nil) {
+        self.id = id
+        self.name = name
+        self.description = description
         self.kind = kind
-        self.provider = provider
-        self.originId = originId
-        self.sourceUrl = sourceUrl
+        self.origin = origin
+        self.status = status
+        self.vellum = vellum
+        self.clawhub = clawhub
+        self.skillssh = skillssh
     }
 }
 
 // MARK: - Skill Detail Response (GET /v1/skills/:id)
 
-public struct SkillDetailHTTPResponse: Codable, Sendable {
-    public let skill: SkillsListResponseSkill
+public struct ClawhubDetailOwner: Codable, Sendable {
+    public let handle: String
+    public let displayName: String
+    public let image: String?
 
-    public init(skill: SkillsListResponseSkill) {
-        self.skill = skill
+    public init(handle: String, displayName: String, image: String? = nil) {
+        self.handle = handle
+        self.displayName = displayName
+        self.image = image
+    }
+}
+
+public struct ClawhubDetailStats: Codable, Sendable {
+    public let stars: Int
+    public let installs: Int
+    public let downloads: Int
+    public let versions: Int
+
+    public init(stars: Int, installs: Int, downloads: Int, versions: Int) {
+        self.stars = stars
+        self.installs = installs
+        self.downloads = downloads
+        self.versions = versions
+    }
+}
+
+public struct ClawhubDetailVersion: Codable, Sendable {
+    public let version: String
+    public let changelog: String?
+
+    public init(version: String, changelog: String? = nil) {
+        self.version = version
+        self.changelog = changelog
+    }
+}
+
+public struct ClawhubDetailMeta: Codable, Sendable {
+    public let slug: String
+    public let author: String
+    public let stars: Int
+    public let installs: Int
+    public let reports: Int
+    public let publishedAt: String?
+    public let owner: ClawhubDetailOwner?
+    public let stats: ClawhubDetailStats?
+    public let latestVersion: ClawhubDetailVersion?
+    public let createdAt: Int?
+    public let updatedAt: Int?
+
+    public init(slug: String, author: String, stars: Int, installs: Int, reports: Int, publishedAt: String? = nil, owner: ClawhubDetailOwner? = nil, stats: ClawhubDetailStats? = nil, latestVersion: ClawhubDetailVersion? = nil, createdAt: Int? = nil, updatedAt: Int? = nil) {
+        self.slug = slug
+        self.author = author
+        self.stars = stars
+        self.installs = installs
+        self.reports = reports
+        self.publishedAt = publishedAt
+        self.owner = owner
+        self.stats = stats
+        self.latestVersion = latestVersion
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}
+
+public struct SkillDetailHTTPResponse: Codable, Sendable {
+    public let id: String
+    public let name: String
+    public let description: String
+    public let kind: String
+    public let origin: String
+    public let status: String
+    public let vellum: VellumSkillMeta?
+    public let clawhub: ClawhubDetailMeta?
+    public let skillssh: SkillsshSkillMeta?
+    public let body: String?
+
+    public init(id: String, name: String, description: String, kind: String, origin: String, status: String, vellum: VellumSkillMeta? = nil, clawhub: ClawhubDetailMeta? = nil, skillssh: SkillsshSkillMeta? = nil, body: String? = nil) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.kind = kind
+        self.origin = origin
+        self.status = status
+        self.vellum = vellum
+        self.clawhub = clawhub
+        self.skillssh = skillssh
+        self.body = body
     }
 }
 

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -895,34 +895,90 @@ extension ErrorMessage {
 /// Backed by generated `AppDataResponse`.
 public typealias AppDataResponseMessage = AppDataResponse
 
-/// ClaWHub metadata for a skill.
-/// Backed by generated `SkillsListResponseSkillClawhub`.
-public typealias ClawhubInfo = SkillsListResponseSkillClawhub
-
-/// Provenance metadata indicating whether a skill is first-party, third-party, or local.
-/// Backed by generated `SkillsListResponseSkillProvenance`.
-public typealias SkillProvenance = SkillsListResponseSkillProvenance
+/// ClaWHub metadata for a skill (slim/list response).
+/// Backed by generated `ClawhubSkillMeta`.
+public typealias ClawhubInfo = ClawhubSkillMeta
 
 /// Full skill info from the daemon's resolved skill list.
 /// Backed by generated `SkillsListResponseSkill`.
 public typealias SkillInfo = SkillsListResponseSkill
 
+/// Legacy provenance type — retained for backward compatibility until all call sites migrate.
+/// Will be removed once downstream views no longer reference `provenance`.
+public struct SkillsListResponseSkillProvenance: Codable, Sendable {
+    public let kind: String
+    public let provider: String?
+    public let originId: String?
+    public let sourceUrl: String?
+
+    public init(kind: String, provider: String? = nil, originId: String? = nil, sourceUrl: String? = nil) {
+        self.kind = kind
+        self.provider = provider
+        self.originId = originId
+        self.sourceUrl = sourceUrl
+    }
+}
+
+/// Legacy type alias for backward compatibility.
+public typealias SkillProvenance = SkillsListResponseSkillProvenance
+
 extension SkillsListResponseSkill: Identifiable {}
 
 extension SkillsListResponseSkill {
-    /// Returns a copy with a different `state`, preserving all other fields including `id`.
-    public func withState(_ newState: String) -> Self {
-        Self(id: id, name: name, description: description, emoji: emoji, homepage: homepage, source: source, state: newState, installStatus: installStatus, installedVersion: installedVersion, latestVersion: latestVersion, updateAvailable: updateAvailable, clawhub: clawhub, provenance: provenance)
+    /// Returns a copy with a different `status`, preserving all other fields including `id`.
+    public func withStatus(_ newStatus: String) -> Self {
+        Self(id: id, name: name, description: description, kind: kind, origin: origin, status: newStatus, vellum: vellum, clawhub: clawhub, skillssh: skillssh)
     }
 
     /// Whether the skill is available from the catalog but not yet installed.
-    public var isAvailable: Bool { installStatus == "available" }
+    public var isAvailable: Bool { status == "available" }
 
     /// Whether the skill is a bundled (core) skill.
-    public var isBundled: Bool { installStatus == "bundled" }
+    public var isBundled: Bool { kind == "bundled" }
 
     /// Whether the skill is currently installed (explicitly installed or bundled).
-    public var isInstalled: Bool { installStatus == "installed" || installStatus == "bundled" }
+    public var isInstalled: Bool { kind == "installed" || kind == "bundled" }
+
+    // MARK: - Backward-compatibility shims (remove when all call sites migrate to new fields)
+
+    /// Legacy `emoji` accessor — reads from the `vellum` sub-object.
+    public var emoji: String? { vellum?.emoji }
+
+    /// Legacy `source` accessor — maps `origin` to the old source vocabulary.
+    public var source: String { origin }
+
+    /// Legacy `state` accessor — maps `status` to the old state vocabulary.
+    public var state: String { status }
+
+    /// Legacy `installStatus` accessor — derives from `kind`/`status`.
+    public var installStatus: String? {
+        switch kind {
+        case "bundled": return "bundled"
+        case "installed": return "installed"
+        case "catalog": return "available"
+        default: return nil
+        }
+    }
+
+    /// Legacy `homepage` accessor — no longer carried on slim responses.
+    public var homepage: String? { nil }
+
+    /// Legacy `installedVersion` accessor — no longer carried on slim responses.
+    public var installedVersion: String? { nil }
+
+    /// Legacy `latestVersion` accessor — no longer carried on slim responses.
+    public var latestVersion: String? { nil }
+
+    /// Legacy `updateAvailable` accessor — no longer carried on slim responses.
+    public var updateAvailable: Bool { false }
+
+    /// Legacy `provenance` accessor — no longer carried on slim responses.
+    public var provenance: SkillsListResponseSkillProvenance? { nil }
+
+    /// Returns a copy with a different `state` (legacy — delegates to withStatus).
+    public func withState(_ newState: String) -> Self {
+        withStatus(newState)
+    }
 }
 
 /// Response containing the list of available skills.


### PR DESCRIPTION
## Summary
- Updates SkillsListResponseSkill to use kind/origin/status with VellumSkillMeta, ClawhubSkillMeta, SkillsshSkillMeta sub-objects
- Adds ClawhubDetailMeta and supporting detail types for the skill detail endpoint
- Removes old Provenance types from GeneratedAPITypes.swift (compat shim in MessageTypes.swift for downstream views)
- Adds backward-compatibility computed properties on SkillsListResponseSkill so existing call sites compile

Part of plan: skills-api-schemas.md (PR 4 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22916" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
