### PR TITLE
Add `settings-integrations-grid` feature flag

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -178,6 +178,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "settings-integrations-grid",
+      "scope": "assistant",
+      "key": "settings-integrations-grid",
+      "label": "Integrations Grid",
+      "description": "Show the Integrations grid in Models & Services settings, replacing individual OAuth provider cards",
+      "defaultEnabled": false
+    },
+    {
       "id": "quick-input",
       "scope": "macos",
       "key": "quick-input",


### PR DESCRIPTION
## Summary
- Adds a new `settings-integrations-grid` feature flag to the registry
- Scoped to assistant, defaultEnabled: false
- Will gate the new Integrations grid UI in Models & Services settings

Part of plan: integrations-grid.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
