### PR TITLE
refactor: update SkillsStore for new types and kind/origin/status model

### DIFF
--- a/clients/shared/Features/Skills/SkillsStore.swift
+++ b/clients/shared/Features/Skills/SkillsStore.swift
@@ -15,10 +15,10 @@ public final class SkillsStore: ObservableObject {
     @Published public var loadedBodies: [String: String] = [:]
     @Published public var isLoading = false
 
-    @Published public var searchResults: [ClawhubSkillItem] = []
+    @Published public var searchResults: [ClawhubSearchItem] = []
     @Published public var isSearching = false
 
-    @Published public var inspectedSkill: ClawhubInspectData?
+    @Published public var inspectedSkill: SkillsInspectResponseData?
     @Published public var isInspecting = false
     @Published public var inspectError: String?
 
@@ -88,7 +88,7 @@ public final class SkillsStore: ObservableObject {
     // MARK: - Private State
 
     private let skillsClient: SkillsClientProtocol
-    private var inspectCache: [String: ClawhubInspectData] = [:]
+    private var inspectCache: [String: SkillsInspectResponseData] = [:]
     private var currentInspectSlug: String?
     private var lastSearchQuery: String?
     private var draftTask: Task<Void, Never>?


### PR DESCRIPTION
## Summary
- Updates SkillsStore to use kind/origin/status instead of source/state/installStatus
- Removes updateAvailable and provenance references
- Uses new convenience properties (isEnabled, isInstalled, isBundled, isAvailable)

Part of plan: skills-api-schemas.md (PR 7 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22922" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
