### PR TITLE
Gate OAuth provider cards behind integrations grid feature flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -114,6 +114,7 @@ struct SettingsPanel: View {
     @State private var isDeveloperEnabled: Bool = false
     @State private var isSoundsEnabled: Bool = true
     @State private var isEmbeddingProviderEnabled: Bool = false
+    @State private var isIntegrationsGridEnabled: Bool = false
     @State private var showingDevUnlock: Bool = false
     @State private var devUnlockText: String = ""
     @State private var devUnlockMonitor: Any?
@@ -124,6 +125,7 @@ struct SettingsPanel: View {
     private static let developerFeatureFlagKey = "settings-developer-nav"
     private static let embeddingProviderFeatureFlagKey = "settings-embedding-provider"
     private static let soundsFeatureFlagKey = "sounds"
+    private static let integrationsGridFeatureFlagKey = "settings-integrations-grid"
 
     var body: some View {
         VStack(spacing: 0) {
@@ -476,17 +478,19 @@ struct SettingsPanel: View {
             }
 
             // OAUTH PROVIDERS (dynamic from API)
-            ForEach(store.managedOAuthProviders, id: \.provider_key) { provider in
-                Divider()
-                    .background(VColor.borderBase)
-                    .padding(.vertical, VSpacing.sm)
+            if !isIntegrationsGridEnabled {
+                ForEach(store.managedOAuthProviders, id: \.provider_key) { provider in
+                    Divider()
+                        .background(VColor.borderBase)
+                        .padding(.vertical, VSpacing.sm)
 
-                OAuthProviderServiceCard(
-                    store: store,
-                    authManager: authManager,
-                    showToast: showToast,
-                    providerKey: provider.provider_key
-                )
+                    OAuthProviderServiceCard(
+                        store: store,
+                        authManager: authManager,
+                        showToast: showToast,
+                        providerKey: provider.provider_key
+                    )
+                }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -639,6 +643,9 @@ struct SettingsPanel: View {
                 if let schedulesFlag = flags.first(where: { $0.key == Self.schedulesFeatureFlagKey }) {
                     isSchedulesEnabled = schedulesFlag.enabled
                 }
+                if let integrationsGridFlag = flags.first(where: { $0.key == Self.integrationsGridFeatureFlagKey }) {
+                    isIntegrationsGridEnabled = integrationsGridFlag.enabled
+                }
                 consumeDeferredDeepLinkIfVisible()
                 return
             } catch {
@@ -662,6 +669,7 @@ struct SettingsPanel: View {
         if let schedulesEnabled = resolved[Self.schedulesFeatureFlagKey] {
             isSchedulesEnabled = schedulesEnabled
         }
+        isIntegrationsGridEnabled = resolved[Self.integrationsGridFeatureFlagKey] ?? false
 
         consumeDeferredDeepLinkIfVisible()
     }


### PR DESCRIPTION
## Summary
- Adds `isIntegrationsGridEnabled` state driven by `settings-integrations-grid` feature flag
- Wraps existing OAuth provider cards in a conditional so the grid view can replace them
- When flag is off (default), behavior is unchanged

Part of plan: integrations-grid.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22923" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
