### PR TITLE
Add IntegrationCard reusable component for grid display

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/IntegrationCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/IntegrationCard.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct IntegrationCard: View {
+    let providerKey: String
+    let displayName: String
+    let description: String?
+    let isEnabled: Bool
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: VSpacing.md) {
+                IntegrationIcon.image(for: providerKey, size: 24)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(displayName)
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(VColor.contentDefault)
+                        .lineLimit(1)
+                    if let description, !description.isEmpty {
+                        Text(description)
+                            .font(VFont.bodySmallDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                            .lineLimit(1)
+                    }
+                }
+                Spacer()
+                VIconView(.chevronRight, size: 12)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.sm)
+            .background(isHovered ? VColor.surfaceActive : VColor.surfaceBase)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .stroke(VColor.borderBase, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds IntegrationCard SwiftUI component for the integrations grid
- Displays provider icon, name, optional description, and chevron
- Hover highlight effect for interactive feedback

Part of plan: integrations-grid.md (PR 4 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22924" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
