### PR TITLE
Add IntegrationsGridView with search, enabled/not-enabled sections

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -491,6 +491,12 @@ struct SettingsPanel: View {
                         providerKey: provider.provider_key
                     )
                 }
+            } else {
+                IntegrationsGridView(
+                    store: store,
+                    authManager: authManager,
+                    showToast: showToast
+                )
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/clients/macos/vellum-assistant/Features/Settings/IntegrationsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/IntegrationsGridView.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct IntegrationsGridView: View {
+    @ObservedObject var store: SettingsStore
+    var authManager: AuthManager
+    var showToast: (String, ToastInfo.Style) -> Void
+
+    @State private var searchText = ""
+    @State private var selectedProviderKey: String? = nil
+
+    private let columns = Array(
+        repeating: GridItem(.flexible(), spacing: VSpacing.md),
+        count: 3
+    )
+
+    // MARK: - Filtering
+
+    private var filteredProviders: [OAuthProviderMetadata] {
+        let providers = store.managedOAuthProviders
+        guard !searchText.isEmpty else { return providers }
+        return providers.filter { provider in
+            let nameMatch = provider.display_name?.localizedCaseInsensitiveContains(searchText) ?? false
+            let descMatch = provider.description?.localizedCaseInsensitiveContains(searchText) ?? false
+            return nameMatch || descMatch
+        }
+    }
+
+    private var enabledProviders: [OAuthProviderMetadata] {
+        filteredProviders.filter { provider in
+            let connections = store.managedOAuthConnections[provider.provider_key] ?? []
+            return !connections.isEmpty
+        }
+    }
+
+    private var notEnabledProviders: [OAuthProviderMetadata] {
+        filteredProviders.filter { provider in
+            let connections = store.managedOAuthConnections[provider.provider_key] ?? []
+            return connections.isEmpty
+        }
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            VSearchBar(placeholder: "Search integrations...", text: $searchText)
+
+            Text("\(filteredProviders.count) integrations")
+                .font(VFont.bodySmallDefault)
+                .foregroundStyle(VColor.contentTertiary)
+
+            if filteredProviders.isEmpty && !searchText.isEmpty {
+                VEmptyState(
+                    title: "No integrations matched",
+                    subtitle: "No integrations matched \"\(searchText)\"",
+                    icon: VIcon.search.rawValue
+                )
+                .frame(maxWidth: .infinity)
+                .padding(.top, VSpacing.xxxl)
+            } else {
+                if !enabledProviders.isEmpty {
+                    sectionView(title: "Enabled", count: enabledProviders.count, providers: enabledProviders)
+                }
+
+                if !notEnabledProviders.isEmpty {
+                    sectionView(title: "Not Enabled", count: notEnabledProviders.count, providers: notEnabledProviders)
+                }
+            }
+        }
+        .onAppear {
+            // Fetch connections for all providers so we can classify enabled vs not-enabled
+            for provider in store.managedOAuthProviders {
+                Task {
+                    await store.fetchManagedOAuthConnections(providerKey: provider.provider_key)
+                }
+            }
+        }
+    }
+
+    // MARK: - Section
+
+    private func sectionView(title: String, count: Int, providers: [OAuthProviderMetadata]) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            HStack(spacing: VSpacing.xs) {
+                Text(title)
+                    .font(VFont.titleSmall)
+                    .foregroundStyle(VColor.contentDefault)
+                Text("\(count)")
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+
+            LazyVGrid(columns: columns, spacing: VSpacing.md) {
+                ForEach(providers, id: \.provider_key) { provider in
+                    IntegrationCard(
+                        providerKey: provider.provider_key,
+                        displayName: provider.display_name ?? provider.provider_key,
+                        description: provider.description,
+                        isEnabled: !(store.managedOAuthConnections[provider.provider_key] ?? []).isEmpty,
+                        action: {
+                            selectedProviderKey = provider.provider_key
+                        }
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds IntegrationsGridView with 3-column LazyVGrid of IntegrationCards
- Search bar filters by provider name and description
- Grid split into Enabled (connected) and Not Enabled sections with counts
- Wired into SettingsPanel behind the integrations grid feature flag

Part of plan: integrations-grid.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22925" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
