### PR TITLE
fix: sync event trigger eventDate when node eventDate is updated

### DIFF
--- a/assistant/src/memory/graph/consolidation.ts
+++ b/assistant/src/memory/graph/consolidation.ts
@@ -21,8 +21,10 @@ import { BackendUnavailableError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
 import { parseEpochMs } from "./extraction.js";
 import {
+  createTrigger,
   deleteNode,
   getEdgesForNode,
+  getTriggersForNode,
   queryNodes,
   updateNode,
 } from "./store.js";
@@ -530,6 +532,28 @@ async function consolidateChunk(
         survivor.eventDate == null
       ) {
         updateNode(merge.survivor_id, { eventDate: deleted.eventDate });
+
+        // The deleted node's triggers will be cascade-deleted when the node
+        // is removed. Ensure the survivor has an event trigger for the
+        // inherited eventDate (updateNode only syncs existing triggers).
+        const survivorTriggers = getTriggersForNode(merge.survivor_id);
+        if (!survivorTriggers.some((t) => t.type === "event")) {
+          createTrigger({
+            nodeId: merge.survivor_id,
+            type: "event",
+            schedule: null,
+            condition: null,
+            conditionEmbedding: null,
+            threshold: null,
+            eventDate: deleted.eventDate,
+            rampDays: 7,
+            followUpDays: 2,
+            recurring: false,
+            consumed: false,
+            cooldownMs: null,
+            lastFired: null,
+          });
+        }
       }
 
       // Preserve imageRefs from deleted node if survivor doesn't have any

--- a/assistant/src/memory/graph/store.test.ts
+++ b/assistant/src/memory/graph/store.test.ts
@@ -9,6 +9,7 @@ import {
   createTrigger,
   deleteEdge,
   deleteNode,
+  deleteTrigger,
   getActiveTriggersByType,
   getEdgesForNode,
   getNode,
@@ -893,5 +894,157 @@ describe("applyDiff", () => {
     expect(result.nodesReinforced).toBe(1);
     expect(getNode(existingNode.id)!.content).toBe("Updated.");
     expect(getNode(existingNode.id)!.reinforcementCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteTrigger
+// ---------------------------------------------------------------------------
+
+describe("deleteTrigger", () => {
+  test("removes a trigger by ID", () => {
+    const node = createNode(makeNewNode());
+    const trigger = createTrigger({
+      nodeId: node.id,
+      type: "event",
+      schedule: null,
+      condition: null,
+      conditionEmbedding: null,
+      threshold: null,
+      eventDate: Date.now(),
+      rampDays: 7,
+      followUpDays: 2,
+      recurring: false,
+      consumed: false,
+      cooldownMs: null,
+      lastFired: null,
+    });
+    deleteTrigger(trigger.id);
+    expect(getTriggersForNode(node.id)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateNode — event trigger sync
+// ---------------------------------------------------------------------------
+
+describe("updateNode event trigger sync", () => {
+  test("syncs event trigger eventDate when node eventDate is updated", () => {
+    const originalDate = 1712534400000;
+    const newDate = 1712620800000;
+    const node = createNode(makeNewNode({ eventDate: originalDate }));
+    const trigger = createTrigger({
+      nodeId: node.id,
+      type: "event",
+      schedule: null,
+      condition: null,
+      conditionEmbedding: null,
+      threshold: null,
+      eventDate: originalDate,
+      rampDays: 7,
+      followUpDays: 2,
+      recurring: false,
+      consumed: false,
+      cooldownMs: null,
+      lastFired: null,
+    });
+
+    updateNode(node.id, { eventDate: newDate });
+
+    const triggers = getTriggersForNode(node.id);
+    expect(triggers).toHaveLength(1);
+    expect(triggers[0].eventDate).toBe(newDate);
+  });
+
+  test("deletes event trigger when node eventDate is cleared to null", () => {
+    const eventDate = 1712534400000;
+    const node = createNode(makeNewNode({ eventDate }));
+    createTrigger({
+      nodeId: node.id,
+      type: "event",
+      schedule: null,
+      condition: null,
+      conditionEmbedding: null,
+      threshold: null,
+      eventDate,
+      rampDays: 7,
+      followUpDays: 2,
+      recurring: false,
+      consumed: false,
+      cooldownMs: null,
+      lastFired: null,
+    });
+
+    updateNode(node.id, { eventDate: null });
+
+    const triggers = getTriggersForNode(node.id);
+    expect(triggers).toHaveLength(0);
+  });
+
+  test("does not affect non-event triggers when eventDate changes", () => {
+    const node = createNode(makeNewNode({ eventDate: 1712534400000 }));
+    createTrigger({
+      nodeId: node.id,
+      type: "event",
+      schedule: null,
+      condition: null,
+      conditionEmbedding: null,
+      threshold: null,
+      eventDate: 1712534400000,
+      rampDays: 7,
+      followUpDays: 2,
+      recurring: false,
+      consumed: false,
+      cooldownMs: null,
+      lastFired: null,
+    });
+    createTrigger({
+      nodeId: node.id,
+      type: "semantic",
+      schedule: null,
+      condition: "cooking topic",
+      conditionEmbedding: null,
+      threshold: 0.7,
+      eventDate: null,
+      rampDays: null,
+      followUpDays: null,
+      recurring: false,
+      consumed: false,
+      cooldownMs: null,
+      lastFired: null,
+    });
+
+    updateNode(node.id, { eventDate: null });
+
+    const triggers = getTriggersForNode(node.id);
+    expect(triggers).toHaveLength(1);
+    expect(triggers[0].type).toBe("semantic");
+  });
+
+  test("does not touch triggers when eventDate is not in changes", () => {
+    const eventDate = 1712534400000;
+    const node = createNode(makeNewNode({ eventDate }));
+    createTrigger({
+      nodeId: node.id,
+      type: "event",
+      schedule: null,
+      condition: null,
+      conditionEmbedding: null,
+      threshold: null,
+      eventDate,
+      rampDays: 7,
+      followUpDays: 2,
+      recurring: false,
+      consumed: false,
+      cooldownMs: null,
+      lastFired: null,
+    });
+
+    // Update something other than eventDate
+    updateNode(node.id, { content: "Updated content." });
+
+    const triggers = getTriggersForNode(node.id);
+    expect(triggers).toHaveLength(1);
+    expect(triggers[0].eventDate).toBe(eventDate);
   });
 });

--- a/assistant/src/memory/graph/store.ts
+++ b/assistant/src/memory/graph/store.ts
@@ -190,6 +190,21 @@ export function updateNode(
     .set(updates)
     .where(eq(memoryGraphNodes.id, id))
     .run();
+
+  // Sync event triggers when eventDate changes
+  if (changes.eventDate !== undefined) {
+    const triggers = getTriggersForNode(id);
+    const eventTriggers = triggers.filter((t) => t.type === "event");
+    for (const trigger of eventTriggers) {
+      if (changes.eventDate === null) {
+        // Clearing eventDate — delete orphaned event trigger
+        deleteTrigger(trigger.id);
+      } else {
+        // Updating eventDate — sync trigger's eventDate
+        updateTrigger(trigger.id, { eventDate: changes.eventDate });
+      }
+    }
+  }
 }
 
 export function deleteNode(id: string): void {
@@ -363,6 +378,13 @@ export function createTrigger(trigger: NewTrigger): MemoryTrigger {
     })
     .run();
   return { ...trigger, id };
+}
+
+export function deleteTrigger(id: string): void {
+  const db = getDb();
+  db.delete(memoryGraphTriggers)
+    .where(eq(memoryGraphTriggers.id, id))
+    .run();
 }
 
 export function updateTrigger(


### PR DESCRIPTION
## Summary
- When a node's eventDate is updated, sync the associated event trigger's eventDate
- When eventDate is cleared to null, delete orphaned event triggers
- Create event trigger on consolidation merge survivor when inheriting eventDate
- Add tests for trigger sync on update and clear

Fixes trigger-node desync from event-date-memory-nodes plan review round 7.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22929" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
