### PR TITLE
fix: inherit imageRefs in supersedeNode for consistency with consolidation merge

### DIFF
--- a/assistant/src/memory/graph/store.ts
+++ b/assistant/src/memory/graph/store.ts
@@ -510,6 +510,7 @@ export function supersedeNode(
     ),
     significance: Math.max(newNode.significance, oldNode.significance),
     eventDate: newNode.eventDate ?? oldNode.eventDate,
+    imageRefs: newNode.imageRefs ?? oldNode.imageRefs,
   };
 
   const created = createNode(inherited);


### PR DESCRIPTION
## Summary
Adds imageRefs inheritance to supersedeNode, matching the pattern used for eventDate and the consolidation merge handler.

**Gap:** supersedeNode inherited stability, reinforcementCount, significance, and eventDate but not imageRefs from the old node.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22930" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
