### PR TITLE
fix: add per-image error handling in resolveInjectionImages

### DIFF
--- a/assistant/src/memory/graph/injection.ts
+++ b/assistant/src/memory/graph/injection.ts
@@ -3,6 +3,7 @@
 // ---------------------------------------------------------------------------
 
 import { optimizeImageForTransport } from "../../agent/image-optimize.js";
+import { getLogger } from "../../util/logger.js";
 import { loadImageRefData } from "./image-ref-utils.js";
 import type { MemoryNode, ScoredNode } from "./types.js";
 
@@ -371,25 +372,32 @@ export async function resolveInjectionImages(
   nodes: ScoredNode[],
   maxImages: number,
 ): Promise<Map<string, ResolvedImage>> {
+  const log = getLogger("memory-graph");
   const result = new Map<string, ResolvedImage>();
   for (const scored of nodes) {
     if (result.size >= maxImages) break;
     const refs = scored.node.imageRefs;
     if (!refs || refs.length === 0) continue;
 
-    const data = await loadImageRefData(refs[0]!);
-    if (!data) continue;
+    try {
+      const data = await loadImageRefData(refs[0]!);
+      if (!data) continue;
 
-    const optimized = optimizeImageForTransport(
-      data.data.toString("base64"),
-      data.mimeType,
-    );
+      const optimized = optimizeImageForTransport(
+        data.data.toString("base64"),
+        data.mimeType,
+      );
 
-    result.set(scored.node.id, {
-      base64Data: optimized.data,
-      mediaType: optimized.mediaType,
-      description: refs[0]!.description,
-    });
+      result.set(scored.node.id, {
+        base64Data: optimized.data,
+        mediaType: optimized.mediaType,
+        description: refs[0]!.description,
+      });
+    } catch (err) {
+      log.warn(
+        `Skipping image for node ${scored.node.id}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
   return result;
 }


### PR DESCRIPTION
## Summary
Fixes a bug where a single corrupt image ref could kill the entire memory injection pipeline.

**Gap:** resolveInjectionImages lacked try/catch around the per-node loop body, so any error in loadImageRefData or optimizeImageForTransport would propagate up and prevent all memory injection (text included).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22931" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
