### PR TITLE
fix: remove unused trigger variable in store test

### DIFF
--- a/assistant/src/memory/graph/store.test.ts
+++ b/assistant/src/memory/graph/store.test.ts
@@ -933,7 +933,7 @@ describe("updateNode event trigger sync", () => {
     const originalDate = 1712534400000;
     const newDate = 1712620800000;
     const node = createNode(makeNewNode({ eventDate: originalDate }));
-    const trigger = createTrigger({
+    createTrigger({
       nodeId: node.id,
       type: "event",
       schedule: null,


### PR DESCRIPTION
## Summary
- Removed unused `trigger` variable assignment in `store.test.ts` — the return value from `createTrigger()` is not used in the test (it verifies via `getTriggersForNode` instead), causing an `@typescript-eslint/no-unused-vars` lint error.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23864910968/job/69581305356