### PR TITLE
fix: Wire integrations grid flag into onAppear/notification handlers and fix connection fetch race

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -183,6 +183,7 @@ struct SettingsPanel: View {
             isBillingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.billingFeatureFlagKey)
             isSoundsEnabled = assistantFeatureFlagStore.isEnabled(Self.soundsFeatureFlagKey)
             isSchedulesEnabled = assistantFeatureFlagStore.isEnabled(Self.schedulesFeatureFlagKey)
+            isIntegrationsGridEnabled = assistantFeatureFlagStore.isEnabled(Self.integrationsGridFeatureFlagKey)
             // The init already consumed pendingSettingsTab into selectedTab.
             // Clear the store value so it doesn't leak into future navigations.
             if store.pendingSettingsTab != nil {
@@ -246,6 +247,8 @@ struct SettingsPanel: View {
                     if !enabled && selectedTab == .schedules {
                         selectedTab = .general
                     }
+                } else if key == Self.integrationsGridFeatureFlagKey {
+                    isIntegrationsGridEnabled = enabled
                 }
             }
         }
@@ -492,6 +495,10 @@ struct SettingsPanel: View {
                     )
                 }
             } else {
+                Divider()
+                    .background(VColor.borderBase)
+                    .padding(.vertical, VSpacing.sm)
+
                 IntegrationsGridView(
                     store: store,
                     authManager: authManager,

--- a/clients/macos/vellum-assistant/Features/Settings/IntegrationsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/IntegrationsGridView.swift
@@ -76,6 +76,16 @@ struct IntegrationsGridView: View {
                 }
             }
         }
+        .onChange(of: store.managedOAuthProviders.map(\.provider_key)) { _, _ in
+            // Providers are fetched asynchronously, so re-trigger connection
+            // fetching when they arrive (onAppear may fire while the list is
+            // still empty).
+            for provider in store.managedOAuthProviders {
+                Task {
+                    await store.fetchManagedOAuthConnections(providerKey: provider.provider_key)
+                }
+            }
+        }
         .sheet(isPresented: isDetailPresented) {
             if let key = selectedProviderKey {
                 IntegrationDetailModal(


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for integrations-grid.md:

- Fix race condition: add onChange(of: managedOAuthProviders) to fetch connections when providers arrive
- Add eager flag resolution in onAppear for integrations grid flag
- Add .assistantFeatureFlagDidChange handler for runtime flag toggles
- Add visual Divider before integrations grid section
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22934" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
