### PR TITLE
fix: sync event triggers in applyDiff when eventDate is updated

### DIFF
--- a/assistant/src/memory/graph/store.ts
+++ b/assistant/src/memory/graph/store.ts
@@ -591,6 +591,35 @@ export function applyDiff(diff: MemoryDiff): ApplyDiffResult {
           .run();
         result.nodesUpdated++;
       }
+
+      // Sync event triggers when eventDate changes
+      if (c.eventDate !== undefined) {
+        const triggers = tx
+          .select()
+          .from(memoryGraphTriggers)
+          .where(
+            and(
+              eq(memoryGraphTriggers.nodeId, update.id),
+              eq(memoryGraphTriggers.type, "event"),
+            ),
+          )
+          .all();
+
+        for (const trigger of triggers) {
+          if (c.eventDate == null) {
+            // eventDate cleared — delete orphaned event trigger
+            tx.delete(memoryGraphTriggers)
+              .where(eq(memoryGraphTriggers.id, trigger.id))
+              .run();
+          } else {
+            // eventDate changed — sync trigger
+            tx.update(memoryGraphTriggers)
+              .set({ eventDate: c.eventDate })
+              .where(eq(memoryGraphTriggers.id, trigger.id))
+              .run();
+          }
+        }
+      }
     }
 
     // Reinforce nodes


### PR DESCRIPTION
## Summary
Add inline trigger sync to applyDiff's update-nodes loop using the transaction handle. When an update changes eventDate, associated event triggers are synced (updated or deleted) within the same transaction. This complements the standalone updateNode() trigger sync added in round 7.

Fixes applyDiff trigger desync from event-date-memory-nodes plan review round 8.