### PR TITLE
fix: Remove unused isEnabled property from IntegrationCard

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/IntegrationCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/IntegrationCard.swift
@@ -5,7 +5,6 @@ struct IntegrationCard: View {
     let providerKey: String
     let displayName: String
     let description: String?
-    let isEnabled: Bool
     let action: () -> Void
 
     @State private var isHovered = false

--- a/clients/macos/vellum-assistant/Features/Settings/IntegrationsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/IntegrationsGridView.swift
@@ -117,7 +117,6 @@ struct IntegrationsGridView: View {
                         providerKey: provider.provider_key,
                         displayName: provider.display_name ?? provider.provider_key,
                         description: provider.description,
-                        isEnabled: !(store.managedOAuthConnections[provider.provider_key] ?? []).isEmpty,
                         action: {
                             selectedProviderKey = provider.provider_key
                         }


### PR DESCRIPTION
## Summary
Removes dead code: IntegrationCard.isEnabled was declared but never read in the view body.

Fixes gap identified during plan review for integrations-grid.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
