### PR TITLE
fix: fall back to text embedding when multimodal embed fails in embedGraphNodeDirect

### DIFF
--- a/assistant/src/memory/graph/graph-search.ts
+++ b/assistant/src/memory/graph/graph-search.ts
@@ -126,16 +126,24 @@ export async function embedGraphNodeDirect(
     if (multimodalAvailable) {
       const imageData = await loadImageRefData(node.imageRefs[0]);
       if (imageData) {
-        const input: EmbeddingInput = {
-          type: "image",
-          data: imageData.data,
-          mimeType: imageData.mimeType,
-        };
-        await embedAndUpsert(config, "graph_node", node.id, input, {
-          ...extraPayload,
-          has_image: true,
-        });
-        return;
+        try {
+          const input: EmbeddingInput = {
+            type: "image",
+            data: imageData.data,
+            mimeType: imageData.mimeType,
+          };
+          await embedAndUpsert(config, "graph_node", node.id, input, {
+            ...extraPayload,
+            has_image: true,
+          });
+          return;
+        } catch (err) {
+          log.warn(
+            "Multimodal embed failed for node %s, falling back to text: %s",
+            node.id,
+            err instanceof Error ? err.message : String(err),
+          );
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
When Gemini image embedding fails (dimension mismatch, API error, timeout), the node was left with no embedding at all. Now catches the error, logs a warning, and falls through to the text embedding path so the node is still searchable via text.

**Gap:** embedGraphNodeDirect had no try/catch around the multimodal embedAndUpsert call
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22938" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
