### PR TITLE
fix: increment triggersDeleted in applyDiff inline trigger sync

### DIFF
--- a/assistant/src/memory/graph/store.ts
+++ b/assistant/src/memory/graph/store.ts
@@ -611,6 +611,7 @@ export function applyDiff(diff: MemoryDiff): ApplyDiffResult {
             tx.delete(memoryGraphTriggers)
               .where(eq(memoryGraphTriggers.id, trigger.id))
               .run();
+            result.triggersDeleted++;
           } else {
             // eventDate changed — sync trigger
             tx.update(memoryGraphTriggers)


### PR DESCRIPTION
## Summary
Add missing result.triggersDeleted++ when applyDiff's inline trigger sync deletes orphaned event triggers.

Fixes accounting gap from event-date-memory-nodes plan review round 9.