### PR TITLE
fix: persist memory injection blocks across conversation reloads

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -42,6 +42,7 @@ import {
   provenanceFromTrustContext,
   updateConversationContextWindow,
   updateConversationTitle,
+  updateMessageMetadata,
 } from "../memory/conversation-crud.js";
 import {
   rebuildConversationDiskViewFromDbState,
@@ -609,6 +610,22 @@ export async function runAgentLoopImpl(
         onEvent,
       );
       runMessages = graphResult.runMessages;
+
+      // Persist the injected block text in message metadata so it survives
+      // conversation reloads (eviction, restart, fork). loadFromDb re-injects
+      // from metadata.
+      if (graphResult.injectedBlockText) {
+        try {
+          updateMessageMetadata(userMessageId, {
+            memoryInjectedBlock: graphResult.injectedBlockText,
+          });
+        } catch (err) {
+          rlog.warn(
+            { err },
+            "Failed to persist memory injection to metadata (non-fatal)",
+          );
+        }
+      }
 
       try {
         recordMemoryRecallLog({

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -200,6 +200,25 @@ export async function loadFromDb(ctx: LoadFromDbContext): Promise<void> {
 
       content = reinjectImageSourcePaths(content, role, m.metadata);
 
+      // Re-inject persisted memory block from metadata so it survives
+      // conversation reloads (eviction, restart, fork).
+      if (role === "user" && m.metadata) {
+        try {
+          const meta = JSON.parse(m.metadata);
+          if (typeof meta.memoryInjectedBlock === "string") {
+            content = [
+              {
+                type: "text" as const,
+                text: `<memory __injected>\n${meta.memoryInjectedBlock}\n</memory>`,
+              },
+              ...content,
+            ];
+          }
+        } catch {
+          /* ignore parse errors — metadata may be malformed */
+        }
+      }
+
       return { role, content };
     });
 

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -1303,6 +1303,27 @@ export function updateMessageContent(
 }
 
 /**
+ * Merge `updates` into the metadata JSON of an existing message.
+ * Reads the current metadata, shallow-merges the new fields, and writes back.
+ */
+export function updateMessageMetadata(
+  messageId: string,
+  updates: Record<string, unknown>,
+): void {
+  const db = getDb();
+  const row = db
+    .select({ metadata: messages.metadata })
+    .from(messages)
+    .where(eq(messages.id, messageId))
+    .get();
+  const existing = row?.metadata ? JSON.parse(row.metadata) : {};
+  db.update(messages)
+    .set({ metadata: JSON.stringify({ ...existing, ...updates }) })
+    .where(eq(messages.id, messageId))
+    .run();
+}
+
+/**
  * Re-link all attachments from a set of source messages to a target message.
  * Used during message consolidation so that attachments linked to deleted
  * messages survive the ON DELETE CASCADE on message_attachments.

--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -200,6 +200,8 @@ export class ConversationGraphMemory {
     injectedTokens: number;
     latencyMs: number;
     mode: "context-load" | "refresh" | "per-turn" | "none";
+    /** The raw text content of the injected block (without XML wrapper), or null if nothing was injected. */
+    injectedBlockText: string | null;
   }> {
     this.turnCount++;
     this.tracker.advanceTurn();
@@ -209,6 +211,7 @@ export class ConversationGraphMemory {
       injectedTokens: 0,
       latencyMs: 0,
       mode: "none" as const,
+      injectedBlockText: null as string | null,
     };
 
     // Gate: skip for empty/tool-result-only messages — unless we need to
@@ -286,6 +289,7 @@ export class ConversationGraphMemory {
         injectedTokens: 0,
         latencyMs: result.latencyMs,
         mode: "context-load" as const,
+        injectedBlockText: null,
       };
     }
 
@@ -303,6 +307,7 @@ export class ConversationGraphMemory {
         injectedTokens: 0,
         latencyMs: result.latencyMs,
         mode: "context-load" as const,
+        injectedBlockText: null,
       };
     }
 
@@ -333,6 +338,7 @@ export class ConversationGraphMemory {
       injectedTokens,
       latencyMs: result.latencyMs,
       mode: "context-load" as const,
+      injectedBlockText: contextBlock,
     };
   }
 
@@ -371,6 +377,7 @@ export class ConversationGraphMemory {
         injectedTokens: 0,
         latencyMs: result.latencyMs,
         mode: "refresh" as const,
+        injectedBlockText: null,
       };
     }
 
@@ -384,6 +391,7 @@ export class ConversationGraphMemory {
         injectedTokens: 0,
         latencyMs: result.latencyMs,
         mode: "refresh" as const,
+        injectedBlockText: null,
       };
     }
 
@@ -404,6 +412,7 @@ export class ConversationGraphMemory {
         images.size * ESTIMATED_IMAGE_TOKENS,
       latencyMs: result.latencyMs,
       mode: "refresh" as const,
+      injectedBlockText: injectionBlock,
     };
   }
 
@@ -454,6 +463,7 @@ export class ConversationGraphMemory {
         injectedTokens: 0,
         latencyMs: result.latencyMs,
         mode: "per-turn" as const,
+        injectedBlockText: null,
       };
     }
 
@@ -467,6 +477,7 @@ export class ConversationGraphMemory {
         injectedTokens: 0,
         latencyMs: result.latencyMs,
         mode: "per-turn" as const,
+        injectedBlockText: null,
       };
     }
 
@@ -487,6 +498,7 @@ export class ConversationGraphMemory {
         images.size * ESTIMATED_IMAGE_TOKENS,
       latencyMs: result.latencyMs,
       mode: "per-turn" as const,
+      injectedBlockText: injectionBlock,
     };
   }
 }
@@ -545,10 +557,13 @@ function stripExistingMemoryInjections(messages: Message[]): Message[] {
 function injectTextBlock(messages: Message[], text: string): Message[] {
   if (text.trim().length === 0) return messages;
   if (messages.length === 0) return messages;
-  const userTail = messages[messages.length - 1];
+  // Strip existing memory blocks from the last user message first to prevent
+  // duplicates when the message was loaded from DB with a persisted block.
+  const cleaned = stripExistingMemoryInjections(messages);
+  const userTail = cleaned[cleaned.length - 1];
   if (!userTail || userTail.role !== "user") return messages;
   return [
-    ...messages.slice(0, -1),
+    ...cleaned.slice(0, -1),
     {
       ...userTail,
       content: [
@@ -569,7 +584,10 @@ function injectMemoryBlock(
 ): Message[] {
   if (text.trim().length === 0 && images.size === 0) return messages;
   if (messages.length === 0) return messages;
-  const userTail = messages[messages.length - 1];
+  // Strip existing memory blocks from the last user message first to prevent
+  // duplicates when the message was loaded from DB with a persisted block.
+  const cleaned = stripExistingMemoryInjections(messages);
+  const userTail = cleaned[cleaned.length - 1];
   if (!userTail || userTail.role !== "user") return messages;
 
   const blocks: ContentBlock[] = [
@@ -592,7 +610,7 @@ function injectMemoryBlock(
   }
 
   return [
-    ...messages.slice(0, -1),
+    ...cleaned.slice(0, -1),
     { ...userTail, content: [...blocks, ...userTail.content] },
   ];
 }


### PR DESCRIPTION
## Summary
- Store memory injection text in message metadata (`memoryInjectedBlock`) after `prepareMemory` so it survives DB reloads
- Re-inject persisted blocks in `loadFromDb` when loading conversation from database
- Make `injectTextBlock`/`injectMemoryBlock` idempotent — strip existing blocks before injecting to prevent duplicates

## Original prompt
--yolo it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22944" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
