### PR TITLE
fix: search bridge reads skillssh installs for skills.sh results

### DIFF
--- a/clients/shared/Network/SkillsClient.swift
+++ b/clients/shared/Network/SkillsClient.swift
@@ -265,12 +265,15 @@ public struct SkillsClient: SkillsClientProtocol {
                     mapped["name"] = item["name"] ?? ""
                     mapped["description"] = item["description"] ?? ""
                     mapped["source"] = item["origin"] ?? "clawhub"
-                    // Pull detailed fields from the clawhub sub-object when available
+                    // Pull detailed fields from the origin-specific sub-object
                     if let clawhub = item["clawhub"] as? [String: Any] {
                         mapped["slug"] = clawhub["slug"] ?? mapped["slug"]!
                         mapped["author"] = clawhub["author"] ?? ""
                         mapped["stars"] = clawhub["stars"] ?? 0
                         mapped["installs"] = clawhub["installs"] ?? 0
+                    } else if let skillssh = item["skillssh"] as? [String: Any] {
+                        mapped["slug"] = skillssh["slug"] ?? mapped["slug"]!
+                        mapped["installs"] = skillssh["installs"] ?? 0
                     }
                     return mapped
                 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skills-api-schemas.md.

**Gap:** Search results bridge drops installs count for skills.sh results
**What was expected:** Skills.sh search results should preserve installs count through the bridge
**What was found:** Bridge only reads from item[clawhub] for installs, missing skillssh sub-object
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22947" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
