### PR TITLE
fix: AgentPanel skillTag shows Available for catalog skills

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -259,7 +259,7 @@ struct SkillItemRow: View {
                             .lineLimit(1)
                             .truncationMode(.tail)
 
-                        skillTag(for: skill.origin)
+                        skillTag(for: skill.origin, status: skill.status)
 
                         Spacer()
                     }
@@ -310,7 +310,7 @@ struct AvailableSkillItemRow: View {
                         .foregroundStyle(VColor.contentSecondary)
                         .lineLimit(1)
                         .truncationMode(.tail)
-                    skillTag(for: skill.origin)
+                    skillTag(for: skill.origin, status: skill.status)
                     Spacer()
                 }
                 Text(skill.description)
@@ -343,7 +343,10 @@ struct AvailableSkillItemRow: View {
 
 // MARK: - Skill Tag Helper
 
-private func skillTag(for origin: String) -> VTag {
+private func skillTag(for origin: String, status: String? = nil) -> VTag {
+    if status == "available" {
+        return VTag("Available", color: VColor.funTeal, icon: .arrowDownToLine)
+    }
     switch origin {
     case "vellum":
         return VTag("Core", color: VColor.contentDefault, icon: .package)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skills-api-schemas.md.

**Gap:** AgentPanel skillTag shows Core instead of Available for catalog skills
**What was expected:** Available catalog skills should display Available tag
**What was found:** `skillTag(for: skill.origin)` returns Core for catalog skills since their origin is vellum
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
