### PR TITLE
fix: align settings page teleport-to-platform with CLI flow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -339,11 +339,36 @@ struct TeleportSection: View {
         phase = .transferring(step: "Exporting assistant data...")
         let bundleData = try await exportAssistantBundle()
 
-        // Step 2 — Ensure managed assistant exists on platform
+        // Step 2 — Upload to GCS via signed URL (with inline fallback)
+        phase = .transferring(step: "Uploading data to cloud...")
+        let bundleKey: String?
+        do {
+            let uploadInfo = try await PlatformMigrationClient.requestUploadUrl()
+            try await PlatformMigrationClient.uploadToSignedUrl(uploadInfo.uploadUrl, bundleData: bundleData)
+            bundleKey = uploadInfo.bundleKey
+        } catch let error as PlatformMigrationClient.PlatformMigrationError {
+            if case .signedUrlsNotAvailable = error {
+                bundleKey = nil
+            } else {
+                throw error
+            }
+        }
+
+        // Step 3 — Ensure managed assistant exists on platform via direct hatch
         phase = .transferring(step: "Setting up cloud assistant...")
-        let outcome = try await ManagedAssistantBootstrapService.shared.ensureManagedAssistant()
+        let organizationId: String
+        if let storedOrgId = UserDefaults.standard.string(forKey: "connectedOrganizationId"), !storedOrgId.isEmpty {
+            organizationId = storedOrgId
+        } else {
+            let orgs = try await AuthService.shared.getOrganizations()
+            guard let firstOrg = orgs.first else {
+                throw TeleportError.notSignedIn
+            }
+            organizationId = firstOrg.id
+        }
+        let hatchResult = try await AuthService.shared.hatchAssistant(organizationId: organizationId)
         let platformAssistant: PlatformAssistant
-        switch outcome {
+        switch hatchResult {
         case .reusedExisting(let assistant):
             platformAssistant = assistant
         case .createdNew(let assistant):
@@ -358,18 +383,18 @@ struct TeleportSection: View {
             throw TeleportError.importFailed(message: "Failed to save managed assistant configuration to lockfile.")
         }
 
-        // Step 3 — Import bundle to managed assistant
-        phase = .transferring(step: "Uploading data to cloud...")
-        try await importBundleToManaged(bundleData: bundleData)
+        // Step 4 — Import bundle to managed assistant
+        phase = .transferring(step: "Importing data to cloud...")
+        try await importBundleToManaged(bundleData: bundleData, bundleKey: bundleKey)
 
-        // Step 4 — Resolve managed assistant for later switch
+        // Step 5 — Resolve managed assistant for later switch
         guard let managedAssistant = LockfileAssistant.loadAll().first(where: { $0.assistantId == platformAssistant.id && $0.isManaged }) else {
             throw TeleportError.managedEntryNotFound
         }
         targetAssistant = managedAssistant
         transferTask = nil
 
-        // Step 5 — Verification phase (do NOT retire or switch yet)
+        // Step 6 — Verification phase (do NOT retire or switch yet)
         phase = .verifying
     }
 
@@ -457,11 +482,36 @@ struct TeleportSection: View {
         phase = .transferring(step: "Exporting assistant data...")
         let bundleData = try await exportAssistantBundle()
 
-        // Step 2 — Ensure managed assistant exists on platform
+        // Step 2 — Upload to GCS via signed URL (with inline fallback)
+        phase = .transferring(step: "Uploading data to cloud...")
+        let bundleKey: String?
+        do {
+            let uploadInfo = try await PlatformMigrationClient.requestUploadUrl()
+            try await PlatformMigrationClient.uploadToSignedUrl(uploadInfo.uploadUrl, bundleData: bundleData)
+            bundleKey = uploadInfo.bundleKey
+        } catch let error as PlatformMigrationClient.PlatformMigrationError {
+            if case .signedUrlsNotAvailable = error {
+                bundleKey = nil
+            } else {
+                throw error
+            }
+        }
+
+        // Step 3 — Ensure managed assistant exists on platform via direct hatch
         phase = .transferring(step: "Setting up cloud assistant...")
-        let outcome = try await ManagedAssistantBootstrapService.shared.ensureManagedAssistant()
+        let organizationId: String
+        if let storedOrgId = UserDefaults.standard.string(forKey: "connectedOrganizationId"), !storedOrgId.isEmpty {
+            organizationId = storedOrgId
+        } else {
+            let orgs = try await AuthService.shared.getOrganizations()
+            guard let firstOrg = orgs.first else {
+                throw TeleportError.notSignedIn
+            }
+            organizationId = firstOrg.id
+        }
+        let hatchResult = try await AuthService.shared.hatchAssistant(organizationId: organizationId)
         let platformAssistant: PlatformAssistant
-        switch outcome {
+        switch hatchResult {
         case .reusedExisting(let assistant):
             platformAssistant = assistant
         case .createdNew(let assistant):
@@ -476,18 +526,18 @@ struct TeleportSection: View {
             throw TeleportError.importFailed(message: "Failed to save managed assistant configuration to lockfile.")
         }
 
-        // Step 3 — Import bundle to managed assistant
-        phase = .transferring(step: "Uploading data to cloud...")
-        try await importBundleToManaged(bundleData: bundleData)
+        // Step 4 — Import bundle to managed assistant
+        phase = .transferring(step: "Importing data to cloud...")
+        try await importBundleToManaged(bundleData: bundleData, bundleKey: bundleKey)
 
-        // Step 4 — Resolve managed assistant for later switch
+        // Step 5 — Resolve managed assistant for later switch
         guard let managedAssistant = LockfileAssistant.loadAll().first(where: { $0.assistantId == platformAssistant.id && $0.isManaged }) else {
             throw TeleportError.managedEntryNotFound
         }
         targetAssistant = managedAssistant
         transferTask = nil
 
-        // Step 5 — Verification phase (do NOT retire or switch yet)
+        // Step 6 — Verification phase (do NOT retire or switch yet)
         phase = .verifying
     }
 
@@ -505,19 +555,22 @@ struct TeleportSection: View {
         return response.data
     }
 
-    /// Imports a `.vbundle` archive into the managed assistant via the signed URL upload flow.
+    /// Imports a `.vbundle` archive into the managed assistant.
     ///
-    /// Uses 3 steps: request signed URL → upload to GCS → trigger import from GCS.
+    /// If `bundleKey` is non-nil, triggers import from GCS (the bundle was already uploaded
+    /// via a signed URL). Otherwise, falls back to inline import by sending the raw bundle
+    /// data directly to the platform.
+    ///
     /// All endpoints are org-scoped, so no `connectedAssistantId` swap is needed.
-    private func importBundleToManaged(bundleData: Data) async throws {
-        // Step 1: Request a signed upload URL from the platform
-        let uploadInfo = try await PlatformMigrationClient.requestUploadUrl()
+    private func importBundleToManaged(bundleData: Data, bundleKey: String?) async throws {
+        let statusCode: Int
+        let data: Data
 
-        // Step 2: Upload bundle directly to GCS via signed URL
-        try await PlatformMigrationClient.uploadToSignedUrl(uploadInfo.uploadUrl, bundleData: bundleData)
-
-        // Step 3: Trigger import from GCS
-        let (statusCode, data) = try await PlatformMigrationClient.importFromGcs(bundleKey: uploadInfo.bundleKey)
+        if let bundleKey {
+            (statusCode, data) = try await PlatformMigrationClient.importFromGcs(bundleKey: bundleKey)
+        } else {
+            (statusCode, data) = try await PlatformMigrationClient.importInline(bundleData: bundleData)
+        }
 
         guard (200..<300).contains(statusCode) else {
             if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -50,6 +50,8 @@ private enum TeleportError: LocalizedError {
     case managedEntryNotFound
     case localAssistantNotFound
     case dockerAssistantNotFound
+    case noOrganizations
+    case multipleOrganizations
 
     var errorDescription: String? {
         switch self {
@@ -69,6 +71,10 @@ private enum TeleportError: LocalizedError {
             return "Could not find or create a local assistant"
         case .dockerAssistantNotFound:
             return "Could not find or create a Docker assistant"
+        case .noOrganizations:
+            return "No organizations found for this account"
+        case .multipleOrganizations:
+            return "Multiple organizations found — please select one in account settings first"
         }
     }
 }
@@ -339,7 +345,11 @@ struct TeleportSection: View {
         phase = .transferring(step: "Exporting assistant data...")
         let bundleData = try await exportAssistantBundle()
 
-        // Step 2 — Upload to GCS via signed URL (with inline fallback)
+        // Step 2 — Resolve and validate org ID before upload (upload reads org from UserDefaults)
+        phase = .transferring(step: "Resolving organization...")
+        let organizationId = try await resolveOrganizationId()
+
+        // Step 3 — Upload to GCS via signed URL (with inline fallback)
         phase = .transferring(step: "Uploading data to cloud...")
         let bundleKey: String?
         do {
@@ -354,18 +364,8 @@ struct TeleportSection: View {
             }
         }
 
-        // Step 3 — Ensure managed assistant exists on platform via direct hatch
+        // Step 4 — Ensure managed assistant exists on platform via direct hatch
         phase = .transferring(step: "Setting up cloud assistant...")
-        let organizationId: String
-        if let storedOrgId = UserDefaults.standard.string(forKey: "connectedOrganizationId"), !storedOrgId.isEmpty {
-            organizationId = storedOrgId
-        } else {
-            let orgs = try await AuthService.shared.getOrganizations()
-            guard let firstOrg = orgs.first else {
-                throw TeleportError.notSignedIn
-            }
-            organizationId = firstOrg.id
-        }
         let hatchResult = try await AuthService.shared.hatchAssistant(organizationId: organizationId)
         let platformAssistant: PlatformAssistant
         switch hatchResult {
@@ -383,18 +383,18 @@ struct TeleportSection: View {
             throw TeleportError.importFailed(message: "Failed to save managed assistant configuration to lockfile.")
         }
 
-        // Step 4 — Import bundle to managed assistant
+        // Step 5 — Import bundle to managed assistant
         phase = .transferring(step: "Importing data to cloud...")
         try await importBundleToManaged(bundleData: bundleData, bundleKey: bundleKey)
 
-        // Step 5 — Resolve managed assistant for later switch
+        // Step 6 — Resolve managed assistant for later switch
         guard let managedAssistant = LockfileAssistant.loadAll().first(where: { $0.assistantId == platformAssistant.id && $0.isManaged }) else {
             throw TeleportError.managedEntryNotFound
         }
         targetAssistant = managedAssistant
         transferTask = nil
 
-        // Step 6 — Verification phase (do NOT retire or switch yet)
+        // Step 7 — Verification phase (do NOT retire or switch yet)
         phase = .verifying
     }
 
@@ -482,7 +482,11 @@ struct TeleportSection: View {
         phase = .transferring(step: "Exporting assistant data...")
         let bundleData = try await exportAssistantBundle()
 
-        // Step 2 — Upload to GCS via signed URL (with inline fallback)
+        // Step 2 — Resolve and validate org ID before upload (upload reads org from UserDefaults)
+        phase = .transferring(step: "Resolving organization...")
+        let organizationId = try await resolveOrganizationId()
+
+        // Step 3 — Upload to GCS via signed URL (with inline fallback)
         phase = .transferring(step: "Uploading data to cloud...")
         let bundleKey: String?
         do {
@@ -497,18 +501,8 @@ struct TeleportSection: View {
             }
         }
 
-        // Step 3 — Ensure managed assistant exists on platform via direct hatch
+        // Step 4 — Ensure managed assistant exists on platform via direct hatch
         phase = .transferring(step: "Setting up cloud assistant...")
-        let organizationId: String
-        if let storedOrgId = UserDefaults.standard.string(forKey: "connectedOrganizationId"), !storedOrgId.isEmpty {
-            organizationId = storedOrgId
-        } else {
-            let orgs = try await AuthService.shared.getOrganizations()
-            guard let firstOrg = orgs.first else {
-                throw TeleportError.notSignedIn
-            }
-            organizationId = firstOrg.id
-        }
         let hatchResult = try await AuthService.shared.hatchAssistant(organizationId: organizationId)
         let platformAssistant: PlatformAssistant
         switch hatchResult {
@@ -526,22 +520,56 @@ struct TeleportSection: View {
             throw TeleportError.importFailed(message: "Failed to save managed assistant configuration to lockfile.")
         }
 
-        // Step 4 — Import bundle to managed assistant
+        // Step 5 — Import bundle to managed assistant
         phase = .transferring(step: "Importing data to cloud...")
         try await importBundleToManaged(bundleData: bundleData, bundleKey: bundleKey)
 
-        // Step 5 — Resolve managed assistant for later switch
+        // Step 6 — Resolve managed assistant for later switch
         guard let managedAssistant = LockfileAssistant.loadAll().first(where: { $0.assistantId == platformAssistant.id && $0.isManaged }) else {
             throw TeleportError.managedEntryNotFound
         }
         targetAssistant = managedAssistant
         transferTask = nil
 
-        // Step 6 — Verification phase (do NOT retire or switch yet)
+        // Step 7 — Verification phase (do NOT retire or switch yet)
         phase = .verifying
     }
 
     // MARK: - Helpers
+
+    /// Resolves and validates the organization ID, mirroring the logic in
+    /// `ManagedAssistantBootstrapService.resolveOrganizationId()`.
+    ///
+    /// Always fetches orgs from the API and validates any persisted value.
+    /// Persists the resolved org ID to UserDefaults so downstream callers
+    /// (e.g. `PlatformMigrationClient.requestUploadUrl()`) can read it.
+    private func resolveOrganizationId() async throws -> String {
+        let orgs = try await AuthService.shared.getOrganizations()
+        let persistedOrgId = UserDefaults.standard.string(forKey: "connectedOrganizationId")
+
+        // If a persisted org ID exists and is valid, use it
+        if let persistedOrgId, !persistedOrgId.isEmpty, orgs.contains(where: { $0.id == persistedOrgId }) {
+            log.info("[teleport] Validated persisted organization: \(persistedOrgId, privacy: .public)")
+            return persistedOrgId
+        }
+
+        if persistedOrgId != nil {
+            log.warning("[teleport] Persisted organization ID not found in user's orgs — re-resolving")
+        }
+
+        // Re-resolve from the org list
+        switch orgs.count {
+        case 0:
+            throw TeleportError.noOrganizations
+        case 1:
+            let orgId = orgs[0].id
+            UserDefaults.standard.set(orgId, forKey: "connectedOrganizationId")
+            log.info("[teleport] Resolved organization: \(orgId, privacy: .public)")
+            return orgId
+        default:
+            throw TeleportError.multipleOrganizations
+        }
+    }
 
     /// Exports the current assistant's data as a `.vbundle` binary archive.
     private func exportAssistantBundle() async throws -> Data {

--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -141,6 +141,37 @@ public enum PlatformMigrationClient {
         return (statusCode: statusCode, data: data)
     }
 
+    /// Imports a migration bundle by sending the raw data directly to the platform.
+    ///
+    /// This is the fallback path when signed URL uploads are not available. It matches
+    /// the CLI's `platformImportBundle()` function: POST to `/v1/migrations/import/`
+    /// with the bundle data as an octet-stream body.
+    ///
+    /// - Parameter bundleData: The raw bundle data to import.
+    /// - Returns: A tuple of the HTTP status code and raw response data.
+    /// - Throws: `PlatformMigrationError` on auth failures, or network errors from `URLSession`.
+    public static func importInline(bundleData: Data) async throws -> (statusCode: Int, data: Data) {
+        let (baseURL, token, orgId) = try resolveAuthContext()
+
+        guard let url = URL(string: "\(baseURL)/v1/migrations/import/") else {
+            throw PlatformMigrationError.requestFailed(statusCode: 0, detail: "Invalid URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 120
+        request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
+        request.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        if let orgId {
+            request.setValue(orgId, forHTTPHeaderField: "Vellum-Organization-Id")
+        }
+        request.httpBody = bundleData
+
+        let (data, statusCode) = try await executeWithRetry(request: request, label: "import-inline")
+
+        return (statusCode: statusCode, data: data)
+    }
+
     // MARK: - Internals
 
     /// Status codes that indicate a transient server error worth retrying.


### PR DESCRIPTION
## Summary
Align the Settings page "Move to Cloud (Platform)" teleport button with the working CLI `vellum teleport --platform` flow. The Settings page had several differences that caused failures:

- **Reorder operations**: Export → Upload → Hatch → Import (matching CLI), instead of Export → Hatch → Upload → Import. This prevents orphaned platform assistants if upload fails.
- **Replace `ManagedAssistantBootstrapService`** with direct `AuthService.hatchAssistant()` to avoid clearing `connectedAssistantId` mid-flow (which broke recovery on failure).
- **Add inline import fallback** when signed URLs are unavailable (503/404), matching the CLI's graceful degradation.

## PRs merged into feature branch
- #22943: feat: add inline import method to PlatformMigrationClient for signed URL fallback
- #22946: fix: align settings page teleport-to-platform with CLI flow order and fallback

Part of plan: teleport-plat-settings-fix.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22949" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
