### PR TITLE
feat: seed capability memories for uninstalled catalog skills

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -50,6 +50,7 @@ import {
 import {
   deleteSkillCapabilityMemory,
   seedCatalogSkillMemories,
+  seedUninstalledCatalogSkillMemories,
 } from "../../skills/skill-memory.js";
 import {
   installExternalSkill,
@@ -280,6 +281,7 @@ export function postInstallSkill(
 
   // Seed skill memories
   seedCatalogSkillMemories();
+  void seedUninstalledCatalogSkillMemories().catch(() => {});
 }
 
 export interface SkillListItem {
@@ -532,6 +534,7 @@ export function enableSkill(
       state: "enabled",
     });
     seedCatalogSkillMemories();
+    void seedUninstalledCatalogSkillMemories().catch(() => {});
     return { success: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -554,6 +557,7 @@ export function disableSkill(
       state: "disabled",
     });
     seedCatalogSkillMemories();
+    void seedUninstalledCatalogSkillMemories().catch(() => {});
     return { success: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -646,6 +650,7 @@ export async function installSkill(
         );
       }
       seedCatalogSkillMemories();
+      void seedUninstalledCatalogSkillMemories().catch(() => {});
       return { success: true };
     }
 
@@ -1174,6 +1179,7 @@ export async function createSkill(
     }
 
     seedCatalogSkillMemories();
+    void seedUninstalledCatalogSkillMemories().catch(() => {});
     return { success: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -82,7 +82,10 @@ import {
   setCesClient,
   setCesReconnect,
 } from "../security/secure-keys.js";
-import { seedCatalogSkillMemories } from "../skills/skill-memory.js";
+import {
+  seedCatalogSkillMemories,
+  seedUninstalledCatalogSkillMemories,
+} from "../skills/skill-memory.js";
 import { UsageTelemetryReporter } from "../telemetry/usage-telemetry-reporter.js";
 import { getDeviceId } from "../util/device-id.js";
 import { getLogger, initLogger } from "../util/logger.js";
@@ -650,6 +653,15 @@ export async function runDaemon(): Promise<void> {
         log.warn({ err }, "Catalog skill memory seeding failed — continuing");
       }
 
+      // Seed memories for catalog skills not yet installed so they're
+      // discoverable via memory injection and can be auto-installed.
+      void seedUninstalledCatalogSkillMemories().catch((err) =>
+        log.warn(
+          { err },
+          "Uninstalled catalog skill memory seeding failed — continuing",
+        ),
+      );
+
       try {
         seedCliCommandMemories();
       } catch (err) {
@@ -658,10 +670,20 @@ export async function runDaemon(): Promise<void> {
 
       // Seed capability graph nodes (new memory graph system)
       try {
-        const { seedSkillGraphNodes, seedCliGraphNodes } =
-          await import("../memory/graph/capability-seed.js");
+        const {
+          seedSkillGraphNodes,
+          seedCliGraphNodes,
+          seedUninstalledSkillGraphNodes,
+        } = await import("../memory/graph/capability-seed.js");
         seedSkillGraphNodes();
         seedCliGraphNodes();
+
+        void seedUninstalledSkillGraphNodes().catch((err) =>
+          log.warn(
+            { err },
+            "Uninstalled skill graph node seeding failed — continuing",
+          ),
+        );
       } catch (err) {
         log.warn({ err }, "Graph capability seeding failed — continuing");
       }

--- a/assistant/src/memory/graph/capability-seed.ts
+++ b/assistant/src/memory/graph/capability-seed.ts
@@ -12,7 +12,10 @@ import { buildCliProgram } from "../../cli/program.js";
 import { getConfig } from "../../config/loader.js";
 import { resolveSkillStates } from "../../config/skill-state.js";
 import { loadSkillCatalog } from "../../config/skills.js";
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
+import { getCachedCatalogSync } from "../../skills/catalog-cache.js";
 import {
+  fromCatalogSkill,
   fromSkillSummary,
   type SkillCapabilityInput,
 } from "../../skills/skill-memory.js";
@@ -107,9 +110,43 @@ export function seedSkillGraphNodes(): void {
       seenKeys.add(`${SKILL_SOURCE_PREFIX}${summary.id}`);
     }
 
+    // Include catalog skill keys so pruning doesn't remove them
+    for (const entry of getCachedCatalogSync()) {
+      seenKeys.add(`${SKILL_SOURCE_PREFIX}${entry.id}`);
+    }
+
     pruneStaleCapabilities(SKILL_SOURCE_PREFIX, seenKeys);
   } catch (err) {
     log.warn({ err }, "Failed to seed skill graph nodes");
+  }
+}
+
+/**
+ * Seed graph nodes for catalog skills that are not yet installed.
+ * Makes uninstalled skills discoverable via semantic retrieval so the LLM
+ * can auto-install them via skill_load when relevant.
+ */
+export async function seedUninstalledSkillGraphNodes(): Promise<void> {
+  try {
+    const { getCatalog } = await import("../../skills/catalog-cache.js");
+    const fullCatalog = await getCatalog();
+    if (fullCatalog.length === 0) return;
+
+    const installedCatalog = loadSkillCatalog();
+    const installedIds = new Set(installedCatalog.map((s) => s.id));
+
+    const config = getConfig();
+    for (const entry of fullCatalog) {
+      if (installedIds.has(entry.id)) continue;
+
+      const flagKey = entry.metadata?.vellum?.["feature-flag"];
+      if (flagKey && !isAssistantFeatureFlagEnabled(flagKey, config)) continue;
+
+      const input = fromCatalogSkill(entry);
+      upsertSkillCapabilityNode(entry.id, input);
+    }
+  } catch (err) {
+    log.warn({ err }, "Failed to seed uninstalled skill graph nodes");
   }
 }
 

--- a/assistant/src/skills/catalog-cache.ts
+++ b/assistant/src/skills/catalog-cache.ts
@@ -37,6 +37,11 @@ export async function getCatalog(): Promise<CatalogSkill[]> {
   return catalog;
 }
 
+/** Return the cached catalog synchronously, or [] if no cache exists yet. */
+export function getCachedCatalogSync(): CatalogSkill[] {
+  return cachedCatalog ?? [];
+}
+
 /** Invalidate the cache (for testing or forced refresh). */
 export function invalidateCatalogCache(): void {
   cachedCatalog = null;

--- a/assistant/src/skills/skill-memory.ts
+++ b/assistant/src/skills/skill-memory.ts
@@ -1,6 +1,7 @@
 import { and, eq, like, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
 import { resolveSkillStates } from "../config/skill-state.js";
 import { loadSkillCatalog, type SkillSummary } from "../config/skills.js";
@@ -8,6 +9,8 @@ import { getDb } from "../memory/db.js";
 import { enqueueMemoryJob } from "../memory/jobs-store.js";
 import { memoryGraphNodes } from "../memory/schema.js";
 import { getLogger } from "../util/logger.js";
+import { getCachedCatalogSync } from "./catalog-cache.js";
+import type { CatalogSkill } from "./catalog-install.js";
 
 const log = getLogger("skill-memory");
 
@@ -41,6 +44,20 @@ export function fromSkillSummary(entry: SkillSummary): SkillCapabilityInput {
     description: entry.description,
     activationHints: entry.activationHints,
     avoidWhen: entry.avoidWhen,
+  };
+}
+
+/**
+ * Convert a CatalogSkill to a SkillCapabilityInput.
+ * CatalogSkill stores display-name and hints inside nested metadata.
+ */
+export function fromCatalogSkill(entry: CatalogSkill): SkillCapabilityInput {
+  return {
+    id: entry.id,
+    displayName: entry.metadata?.vellum?.["display-name"] ?? entry.name,
+    description: entry.description,
+    activationHints: entry.metadata?.vellum?.["activation-hints"],
+    avoidWhen: entry.metadata?.vellum?.["avoid-when"],
   };
 }
 
@@ -240,6 +257,7 @@ export function seedCatalogSkillMemories(): void {
     }
 
     // Prune stale capability memories for skills no longer in the enabled set
+    // and not available in the remote/local catalog.
     const db = getDb();
     const allCapabilities = db
       .select()
@@ -253,11 +271,15 @@ export function seedCatalogSkillMemories(): void {
       )
       .all();
 
+    const cachedCatalogIds = new Set(
+      getCachedCatalogSync().map((s) => s.id),
+    );
+
     const now = Date.now();
     for (const item of allCapabilities) {
       if (!item.content.startsWith("skill:")) continue;
       const itemSkillId = item.content.split("\n")[0].replace("skill:", "");
-      if (!catalogIds.has(itemSkillId)) {
+      if (!catalogIds.has(itemSkillId) && !cachedCatalogIds.has(itemSkillId)) {
         db.update(memoryGraphNodes)
           .set({ fidelity: "gone", lastAccessed: now })
           .where(eq(memoryGraphNodes.id, item.id))
@@ -266,5 +288,35 @@ export function seedCatalogSkillMemories(): void {
     }
   } catch (err) {
     log.warn({ err }, "Failed to seed catalog skill memories");
+  }
+}
+
+/**
+ * Seed capability memories for catalog skills that are not yet installed.
+ * This makes uninstalled skills discoverable via memory injection so the LLM
+ * can auto-install them via skill_load when relevant.
+ * Best-effort: errors are logged but never thrown.
+ */
+export async function seedUninstalledCatalogSkillMemories(): Promise<void> {
+  try {
+    const { getCatalog } = await import("./catalog-cache.js");
+    const fullCatalog = await getCatalog();
+    if (fullCatalog.length === 0) return;
+
+    const installedCatalog = loadSkillCatalog();
+    const installedIds = new Set(installedCatalog.map((s) => s.id));
+
+    const config = getConfig();
+    for (const entry of fullCatalog) {
+      if (installedIds.has(entry.id)) continue;
+
+      const flagKey = entry.metadata?.vellum?.["feature-flag"];
+      if (flagKey && !isAssistantFeatureFlagEnabled(flagKey, config)) continue;
+
+      const input = fromCatalogSkill(entry);
+      upsertSkillCapabilityMemory(entry.id, input);
+    }
+  } catch (err) {
+    log.warn({ err }, "Failed to seed uninstalled catalog skill memories");
   }
 }

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -290,6 +290,13 @@
           "display-name": "Telegram Setup",
           "includes": [
             "public-ingress"
+          ],
+          "activation-hints": [
+            "Telegram bot setup, webhook configuration, or BotFather token",
+            "User wants to connect Telegram to the assistant"
+          ],
+          "avoid-when": [
+            "User wants to send/receive Telegram messages (use messaging skill instead)"
           ]
         }
       },

--- a/skills/telegram-setup/SKILL.md
+++ b/skills/telegram-setup/SKILL.md
@@ -8,6 +8,11 @@ metadata:
     display-name: "Telegram Setup"
     includes:
       - public-ingress
+    activation-hints:
+      - "Telegram bot setup, webhook configuration, or BotFather token"
+      - "User wants to connect Telegram to the assistant"
+    avoid-when:
+      - "User wants to send/receive Telegram messages (use messaging skill instead)"
 ---
 
 You are helping your user connect a Telegram bot to the Vellum Assistant gateway. Walk through each step below.


### PR DESCRIPTION
## Summary

- Add `seedUninstalledCatalogSkillMemories()` and `seedUninstalledSkillGraphNodes()` — async functions that fetch the full catalog and create capability memories for skills not yet installed in the workspace
- Update pruning in both `seedCatalogSkillMemories()` and `seedSkillGraphNodes()` to preserve catalog skill memories instead of marking them as stale
- Add activation-hints and avoid-when to `telegram-setup` SKILL.md and catalog.json for better routing cues
- Wire up async seeding at daemon startup and after skill install/uninstall/enable/disable operations

## Original prompt

Implement the plan at /Users/sidd/.claude/plans/calm-booping-dewdrop.md — seed capability memories for uninstalled catalog skills so they're discoverable via memory injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22952" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
