### PR TITLE
M1: Add source-based subgrouping to Background sidebar section

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
@@ -88,6 +88,8 @@ final class SidebarInteractionState {
     var showAllChannelConversations: [String: Bool] = [:]
     /// Set of schedule sub-group keys (scheduleJobId values) that are currently expanded.
     var expandedScheduleGroups: Set<String> = []
+    /// Set of background sub-group keys (source values) that are currently expanded.
+    var expandedBackgroundGroups: Set<String> = []
     var showAllApps: Bool = false
 
     /// Toggles the expand/collapse state of a section.

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -120,6 +120,20 @@ extension MainWindowView {
     /// to reduce type-checker pressure (the init has many parameters).
     private func makeSectionView(group: ConversationGroup, conversations: [ConversationModel]) -> SidebarSectionView {
         let isScheduled = group.id == ConversationGroup.scheduled.id
+        let isBackground = group.id == ConversationGroup.background.id
+        let countMode: SidebarSectionView.CountMode = isScheduled
+            ? .subGroups(grouper: { $0.scheduleJobId })
+            : isBackground
+                ? .subGroups(grouper: { $0.source })
+                : .items
+        let subGroupLabelProvider: ((String, [ConversationModel]) -> String)? = isBackground
+            ? { key, _ in key.prefix(1).uppercased() + key.dropFirst() }
+            : nil
+        let expandedSubGroups: Binding<Set<String>>? = isScheduled
+            ? Binding(get: { sidebar.expandedScheduleGroups }, set: { sidebar.expandedScheduleGroups = $0 })
+            : isBackground
+                ? Binding(get: { sidebar.expandedBackgroundGroups }, set: { sidebar.expandedBackgroundGroups = $0 })
+                : nil
         return SidebarSectionView(
             group: group,
             conversations: conversations,
@@ -127,7 +141,7 @@ extension MainWindowView {
             showAll: sidebar.showAllInSection.contains(group.id),
             maxCollapsed: 5,
             isDropTarget: sidebar.dropTargetSectionId == group.id,
-            countMode: isScheduled ? .subGroups(grouper: { $0.scheduleJobId }) : .items,
+            countMode: countMode,
             isRenaming: sidebar.renamingGroupId == group.id,
             renamingName: Binding(
                 get: { sidebar.renamingGroupName },
@@ -151,10 +165,8 @@ extension MainWindowView {
             onToggleExpand: { sidebar.toggleSection(group.id) },
             onToggleShowAll: { sidebar.toggleShowAll(group.id) },
             makeRow: { makeSidebarRow(conversation: $0) },
-            expandedScheduleGroups: isScheduled ? Binding(
-                get: { sidebar.expandedScheduleGroups },
-                set: { sidebar.expandedScheduleGroups = $0 }
-            ) : nil,
+            expandedScheduleGroups: expandedSubGroups,
+            subGroupLabelProvider: subGroupLabelProvider,
             sidebar: sidebar,
             conversationManager: conversationManager
         )

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
@@ -16,6 +16,9 @@ struct ConversationSwitcherDrawer: View {
     /// Tracks which sections have been expanded via "Show more".
     @State private var expandedSections: Set<String> = []
 
+    /// Tracks which sub-groups (schedule/background) are expanded in the drawer.
+    @State private var expandedSubGroups: Set<String> = []
+
     /// Group entries filtered by flags: custom groups and Background merged into ungrouped when their flags are off.
     private var drawerEntries: [(group: ConversationGroup?, conversations: [ConversationModel])] {
         let raw = conversationManager.groupedConversations
@@ -109,6 +112,7 @@ struct ConversationSwitcherDrawer: View {
                             }
                             sectionContent(
                                 sectionId: sectionId,
+                                group: entry.group,
                                 title: entry.group?.name ?? "Conversations",
                                 conversations: conversations,
                                 isExpanded: isExpanded
@@ -152,6 +156,7 @@ struct ConversationSwitcherDrawer: View {
     @ViewBuilder
     private func sectionContent(
         sectionId: String,
+        group: ConversationGroup?,
         title: String,
         conversations: [ConversationModel],
         isExpanded: Bool
@@ -168,31 +173,179 @@ struct ConversationSwitcherDrawer: View {
         .padding(.horizontal, VSpacing.sm)
         .padding(.top, VSpacing.xs)
 
-        let displayed = isExpanded ? conversations : Array(conversations.prefix(maxPerSection))
-        ForEach(displayed) { conversation in
-            makeRow(conversation)
-                .equatable()
-                .id(ConversationRowIdentity(conversationId: conversation.id, groupId: conversation.groupId))
-        }
+        let isScheduled = group?.id == ConversationGroup.scheduled.id
+        let isBackground = group?.id == ConversationGroup.background.id
 
-        if conversations.count > maxPerSection {
-            HStack {
-                VButton(
-                    label: isExpanded ? "Show less" : "Show more (\(conversations.count - maxPerSection))",
-                    style: .ghost,
-                    size: .compact
-                ) {
-                    withAnimation(VAnimation.fast) {
-                        if isExpanded {
-                            expandedSections.remove(sectionId)
-                        } else {
-                            expandedSections.insert(sectionId)
-                        }
+        if isScheduled || isBackground {
+            let grouper: (ConversationModel) -> String? = isScheduled ? { $0.scheduleJobId } : { $0.source }
+            let labelProvider: ((String, [ConversationModel]) -> String)? = isBackground
+                ? { key, _ in key.prefix(1).uppercased() + key.dropFirst() }
+                : nil
+            let subGroups = buildDrawerSubGroups(conversations: conversations, grouper: grouper, labelProvider: labelProvider)
+            let displayed = isExpanded ? subGroups : Array(subGroups.prefix(maxPerSection))
+
+            ForEach(displayed) { subGroup in
+                if subGroup.conversations.count == 1, let conversation = subGroup.conversations.first {
+                    makeRow(conversation)
+                        .equatable()
+                        .id(ConversationRowIdentity(conversationId: conversation.id, groupId: conversation.groupId))
+                } else {
+                    drawerSubGroupDisclosure(subGroup)
+                }
+            }
+
+            if subGroups.count > maxPerSection {
+                drawerShowMoreLess(sectionId: sectionId, totalCount: subGroups.count, isExpanded: isExpanded)
+            }
+        } else {
+            let displayed = isExpanded ? conversations : Array(conversations.prefix(maxPerSection))
+            ForEach(displayed) { conversation in
+                makeRow(conversation)
+                    .equatable()
+                    .id(ConversationRowIdentity(conversationId: conversation.id, groupId: conversation.groupId))
+            }
+
+            if conversations.count > maxPerSection {
+                drawerShowMoreLess(sectionId: sectionId, totalCount: conversations.count, isExpanded: isExpanded)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func drawerShowMoreLess(sectionId: String, totalCount: Int, isExpanded: Bool) -> some View {
+        HStack {
+            VButton(
+                label: isExpanded ? "Show less" : "Show more (\(totalCount - maxPerSection))",
+                style: .ghost,
+                size: .compact
+            ) {
+                withAnimation(VAnimation.fast) {
+                    if isExpanded {
+                        expandedSections.remove(sectionId)
+                    } else {
+                        expandedSections.insert(sectionId)
                     }
                 }
+            }
+            Spacer()
+        }
+        .padding(.leading, VSpacing.sm)
+    }
+
+    @ViewBuilder
+    private func drawerSubGroupDisclosure(_ subGroup: ScheduleSubGroup) -> some View {
+        let isSubGroupExpanded = expandedSubGroups.contains(subGroup.key)
+        let hasUnread = !isSubGroupExpanded &&
+            subGroup.conversations.contains(where: \.hasUnseenLatestAssistantMessage)
+
+        Button {
+            withAnimation(VAnimation.fast) {
+                if isSubGroupExpanded {
+                    expandedSubGroups.remove(subGroup.key)
+                } else {
+                    expandedSubGroups.insert(subGroup.key)
+                }
+            }
+        } label: {
+            HStack(spacing: VSpacing.xs) {
+                ZStack {
+                    VIconView(.chevronRight, size: 10)
+                        .foregroundStyle(VColor.contentTertiary)
+                        .rotationEffect(.degrees(isSubGroupExpanded ? 90 : 0))
+                        .animation(VAnimation.fast, value: isSubGroupExpanded)
+                    if hasUnread {
+                        Circle()
+                            .fill(VColor.systemMidStrong)
+                            .frame(width: 6, height: 6)
+                            .offset(x: 7, y: -7)
+                            .transition(.opacity)
+                    }
+                }
+                .frame(width: 20, height: 20)
+
+                Text(subGroup.label)
+                    .font(VFont.menuCompact)
+                    .foregroundStyle(VColor.contentDefault)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
                 Spacer()
             }
-            .padding(.leading, VSpacing.sm)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.leading, VSpacing.xs)
+            .padding(.trailing, SidebarLayoutMetrics.trailingIconPadding)
+            .padding(.vertical, SidebarLayoutMetrics.rowVerticalPadding)
+            .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)
+            .contentShape(Rectangle())
+            .overlay(alignment: .trailing) {
+                Text("\(subGroup.conversations.count)")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(VColor.contentTertiary)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(
+                        Capsule()
+                            .fill(VColor.contentTertiary.opacity(0.12))
+                    )
+                    .padding(.trailing, VSpacing.xs)
+            }
+        }
+        .buttonStyle(.plain)
+        .pointerCursor()
+
+        if isSubGroupExpanded {
+            VStack(spacing: 0) {
+                ForEach(subGroup.conversations) { conversation in
+                    makeRow(conversation)
+                        .equatable()
+                        .id(ConversationRowIdentity(conversationId: conversation.id, groupId: conversation.groupId))
+                }
+            }
+            .padding(.vertical, VSpacing.xxs)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(VColor.contentTertiary.opacity(0.03))
+            )
+            .overlay(alignment: .leading) {
+                UnevenRoundedRectangle(
+                    topLeadingRadius: VRadius.md,
+                    bottomLeadingRadius: VRadius.md
+                )
+                .fill(VColor.contentTertiary.opacity(0.12))
+                .frame(width: 2)
+            }
+        }
+    }
+
+    private func buildDrawerSubGroups(
+        conversations: [ConversationModel],
+        grouper: (ConversationModel) -> String?,
+        labelProvider: ((String, [ConversationModel]) -> String)?
+    ) -> [ScheduleSubGroup] {
+        var grouped: [String: [ConversationModel]] = [:]
+        var order: [String] = []
+        for conversation in conversations {
+            let key = grouper(conversation) ?? conversation.id.uuidString
+            if grouped[key] == nil {
+                order.append(key)
+            }
+            grouped[key, default: []].append(conversation)
+        }
+        return order.compactMap { key in
+            guard let convs = grouped[key], let first = convs.first else { return nil }
+            let label: String
+            if let provider = labelProvider {
+                label = provider(key, convs)
+            } else if convs.count > 1 {
+                let base = first.title
+                if let colonRange = base.range(of: ":") {
+                    label = String(base[base.startIndex..<colonRange.lowerBound])
+                } else {
+                    label = base
+                }
+            } else {
+                label = first.title
+            }
+            return ScheduleSubGroup(key: key, label: label, conversations: convs)
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
@@ -190,7 +190,7 @@ struct ConversationSwitcherDrawer: View {
                         .equatable()
                         .id(ConversationRowIdentity(conversationId: conversation.id, groupId: conversation.groupId))
                 } else {
-                    drawerSubGroupDisclosure(subGroup)
+                    drawerSubGroupDisclosure(subGroup, sectionId: sectionId)
                 }
             }
 
@@ -233,17 +233,18 @@ struct ConversationSwitcherDrawer: View {
     }
 
     @ViewBuilder
-    private func drawerSubGroupDisclosure(_ subGroup: ScheduleSubGroup) -> some View {
-        let isSubGroupExpanded = expandedSubGroups.contains(subGroup.key)
+    private func drawerSubGroupDisclosure(_ subGroup: ScheduleSubGroup, sectionId: String) -> some View {
+        let scopedKey = "\(sectionId):\(subGroup.key)"
+        let isSubGroupExpanded = expandedSubGroups.contains(scopedKey)
         let hasUnread = !isSubGroupExpanded &&
             subGroup.conversations.contains(where: \.hasUnseenLatestAssistantMessage)
 
         Button {
             withAnimation(VAnimation.fast) {
                 if isSubGroupExpanded {
-                    expandedSubGroups.remove(subGroup.key)
+                    expandedSubGroups.remove(scopedKey)
                 } else {
-                    expandedSubGroups.insert(subGroup.key)
+                    expandedSubGroups.insert(scopedKey)
                 }
             }
         } label: {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -39,6 +39,10 @@ struct SidebarSectionView: View {
 
     /// Schedule sub-group expand/collapse state.
     var expandedScheduleGroups: Binding<Set<String>>?
+    /// Optional label provider for sub-groups. When set, overrides the default
+    /// title-parsing logic in `buildSubGroups`. Receives the group key and its
+    /// conversations, returns the display label.
+    var subGroupLabelProvider: ((String, [ConversationModel]) -> String)?
     /// Drop delegate plumbing.
     var sidebar: SidebarInteractionState?
     var conversationManager: ConversationManager?
@@ -350,7 +354,9 @@ struct SidebarSectionView: View {
         return order.compactMap { key in
             guard let conversations = grouped[key], let first = conversations.first else { return nil }
             let label: String
-            if conversations.count > 1 {
+            if let provider = subGroupLabelProvider {
+                label = provider(key, conversations)
+            } else if conversations.count > 1 {
                 let base = first.title
                 if let colonRange = base.range(of: ":") {
                     label = String(base[base.startIndex..<colonRange.lowerBound])


### PR DESCRIPTION
## Summary
- Add sub-group support to the Background sidebar section, grouping background conversations by their `source` field (`heartbeat`, `task`, etc.)
- Matches how the Scheduled section groups by `scheduleJobId`
- Background sub-group labels are capitalized source names (e.g. "Heartbeat", "Task") via a `subGroupLabelProvider` closure

## Test plan
- [ ] Verify Background sidebar section shows conversations grouped by source
- [ ] Verify sub-group labels display as capitalized source names
- [ ] Verify sub-groups expand/collapse independently
- [ ] Verify Scheduled section sub-grouping still works unchanged
- [ ] Verify ConversationSwitcherDrawer (collapsed sidebar) also shows background sub-groups

Closes #22951

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22953" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
