### PR TITLE
fix: remove duplicate uninstalled skill seeding from capability-seed

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -670,20 +670,10 @@ export async function runDaemon(): Promise<void> {
 
       // Seed capability graph nodes (new memory graph system)
       try {
-        const {
-          seedSkillGraphNodes,
-          seedCliGraphNodes,
-          seedUninstalledSkillGraphNodes,
-        } = await import("../memory/graph/capability-seed.js");
+        const { seedSkillGraphNodes, seedCliGraphNodes } =
+          await import("../memory/graph/capability-seed.js");
         seedSkillGraphNodes();
         seedCliGraphNodes();
-
-        void seedUninstalledSkillGraphNodes().catch((err) =>
-          log.warn(
-            { err },
-            "Uninstalled skill graph node seeding failed — continuing",
-          ),
-        );
       } catch (err) {
         log.warn({ err }, "Graph capability seeding failed — continuing");
       }

--- a/assistant/src/memory/graph/capability-seed.ts
+++ b/assistant/src/memory/graph/capability-seed.ts
@@ -12,10 +12,8 @@ import { buildCliProgram } from "../../cli/program.js";
 import { getConfig } from "../../config/loader.js";
 import { resolveSkillStates } from "../../config/skill-state.js";
 import { loadSkillCatalog } from "../../config/skills.js";
-import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { getCachedCatalogSync } from "../../skills/catalog-cache.js";
 import {
-  fromCatalogSkill,
   fromSkillSummary,
   type SkillCapabilityInput,
 } from "../../skills/skill-memory.js";
@@ -118,35 +116,6 @@ export function seedSkillGraphNodes(): void {
     pruneStaleCapabilities(SKILL_SOURCE_PREFIX, seenKeys);
   } catch (err) {
     log.warn({ err }, "Failed to seed skill graph nodes");
-  }
-}
-
-/**
- * Seed graph nodes for catalog skills that are not yet installed.
- * Makes uninstalled skills discoverable via semantic retrieval so the LLM
- * can auto-install them via skill_load when relevant.
- */
-export async function seedUninstalledSkillGraphNodes(): Promise<void> {
-  try {
-    const { getCatalog } = await import("../../skills/catalog-cache.js");
-    const fullCatalog = await getCatalog();
-    if (fullCatalog.length === 0) return;
-
-    const installedCatalog = loadSkillCatalog();
-    const installedIds = new Set(installedCatalog.map((s) => s.id));
-
-    const config = getConfig();
-    for (const entry of fullCatalog) {
-      if (installedIds.has(entry.id)) continue;
-
-      const flagKey = entry.metadata?.vellum?.["feature-flag"];
-      if (flagKey && !isAssistantFeatureFlagEnabled(flagKey, config)) continue;
-
-      const input = fromCatalogSkill(entry);
-      upsertSkillCapabilityNode(entry.id, input);
-    }
-  } catch (err) {
-    log.warn({ err }, "Failed to seed uninstalled skill graph nodes");
   }
 }
 


### PR DESCRIPTION
## Summary

- Remove `seedUninstalledSkillGraphNodes()` from `capability-seed.ts` — `seedUninstalledCatalogSkillMemories()` in `skill-memory.ts` already handles uninstalled catalog skills
- Remove the corresponding async call from `lifecycle.ts`
- Fixes duplicate memory nodes (one from each seeding system) for uninstalled catalog skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22954" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
