### PR TITLE
fix: use local timezone for memory detail timestamps

### DIFF
--- a/clients/ios/Views/Intelligence/MemoryItemDetailView.swift
+++ b/clients/ios/Views/Intelligence/MemoryItemDetailView.swift
@@ -327,6 +327,7 @@ struct MemoryItemDetailView: View {
 
     private func formatDate(_ date: Date) -> String {
         let formatter = DateFormatter()
+        formatter.timeZone = .autoupdatingCurrent
         formatter.dateStyle = .medium
         formatter.timeStyle = .short
         return formatter.string(from: date)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet+Helpers.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet+Helpers.swift
@@ -28,6 +28,7 @@ extension MemoryItemDetailSheet {
 
     func formattedDate(_ date: Date) -> String {
         let formatter = DateFormatter()
+        formatter.timeZone = ChatTimestampTimeZone.resolve()
         formatter.dateStyle = .medium
         formatter.timeStyle = .short
         return formatter.string(from: date)


### PR DESCRIPTION
## Summary
- Memory item detail views ("First seen" / "Last seen") were displaying timestamps in UTC instead of the user's local timezone
- macOS: set `formatter.timeZone = ChatTimestampTimeZone.resolve()` — same pattern already used by chat timestamps
- iOS: set `formatter.timeZone = .autoupdatingCurrent`