### PR TITLE
feat: GA the Contacts feature flag

### DIFF
--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -12,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 // Test-scoped config state
 // ---------------------------------------------------------------------------
 
-const DECLARED_FLAG_ID = "contacts";
+const DECLARED_FLAG_ID = "sounds";
 const DECLARED_FLAG_KEY = DECLARED_FLAG_ID;
 
 const { isAssistantFeatureFlagEnabled, _setOverridesForTesting } =
@@ -54,7 +54,7 @@ describe("isAssistantFeatureFlagEnabled", () => {
 
   test("missing persisted value falls back to defaults registry defaultEnabled", () => {
     // No explicit config at all — should fall back to defaults registry
-    // which has defaultEnabled: true for contacts
+    // which has defaultEnabled: true for sounds
     const config = {} as any;
 
     expect(isAssistantFeatureFlagEnabled(DECLARED_FLAG_KEY, config)).toBe(true);

--- a/assistant/src/__tests__/credential-execution-feature-gates.test.ts
+++ b/assistant/src/__tests__/credential-execution-feature-gates.test.ts
@@ -180,7 +180,7 @@ describe("CES flags do not affect unrelated flags", () => {
     expect(isAssistantFeatureFlagEnabled("browser", config)).toBe(true);
   });
 
-  test("enabling all CES flags does not change contacts flag (defaultEnabled: true)", () => {
+  test("enabling all CES flags does not change sounds flag (defaultEnabled: true)", () => {
     const overrides: Record<string, boolean> = {};
     for (const key of ALL_CES_FLAG_KEYS) {
       overrides[key] = true;
@@ -188,7 +188,7 @@ describe("CES flags do not affect unrelated flags", () => {
     _setOverridesForTesting(overrides);
     const config = makeConfig();
 
-    // contacts defaults to true in the registry and should stay true
-    expect(isAssistantFeatureFlagEnabled("contacts", config)).toBe(true);
+    // sounds defaults to true in the registry and should stay true
+    expect(isAssistantFeatureFlagEnabled("sounds", config)).toBe(true);
   });
 });

--- a/assistant/src/__tests__/skill-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags-integration.test.ts
@@ -28,16 +28,16 @@ import { parseFrontmatterFields } from "../skills/frontmatter.js";
 // Fixtures
 // ---------------------------------------------------------------------------
 
-/** A SKILL.md with `feature-flag: contacts` declared in its vellum metadata. */
+/** A SKILL.md with `feature-flag: email-channel` declared in its vellum metadata. */
 const SKILL_MD_WITH_FLAG = `---
-name: "Contacts"
-description: "View and manage contacts"
+name: "Email Setup"
+description: "Set up email integration"
 metadata:
   vellum:
-    feature-flag: contacts
+    feature-flag: email-channel
 ---
 
-Instructions for the contacts skill.
+Instructions for the email setup skill.
 `;
 
 /** A SKILL.md with no feature-flag field at all. */
@@ -128,16 +128,16 @@ describe("frontmatter feature-flag integration", () => {
     expect(metadataObj).toBeTruthy();
 
     const vellum = metadataObj.vellum as Record<string, unknown>;
-    expect(vellum["feature-flag"]).toBe("contacts");
+    expect(vellum["feature-flag"]).toBe("email-channel");
   });
 
   test("skillFlagKey returns correct key for parsed skill", () => {
-    const skill = buildSkillSummary("contacts", SKILL_MD_WITH_FLAG);
+    const skill = buildSkillSummary("email-setup", SKILL_MD_WITH_FLAG);
     expect(skill).not.toBeNull();
-    expect(skill!.featureFlag).toBe("contacts");
+    expect(skill!.featureFlag).toBe("email-channel");
 
     const key = skillFlagKey(skill!);
-    expect(key).toBe("contacts");
+    expect(key).toBe("email-channel");
   });
 
   test("skillFlagKey returns undefined for skill without feature-flag", () => {
@@ -149,27 +149,26 @@ describe("frontmatter feature-flag integration", () => {
     expect(key).toBeUndefined();
   });
 
-  test("resolveSkillStates includes skill with featureFlag when flag defaults to ON", () => {
-    const skill = buildSkillSummary("contacts", SKILL_MD_WITH_FLAG)!;
-    // "contacts" is in the registry with defaultEnabled: true
-    const config = makeConfig();
-
-    const resolved = resolveSkillStates([skill], config);
-    // Flag defaults to true → skill passes through
-    expect(resolved.length).toBe(1);
-    expect(resolved[0].summary.id).toBe("contacts");
-  });
-
   test("resolveSkillStates includes skill with featureFlag when flag is ON", () => {
     _setOverridesForTesting({
-      contacts: true,
+      "email-channel": true,
     });
-    const skill = buildSkillSummary("contacts", SKILL_MD_WITH_FLAG)!;
+    const skill = buildSkillSummary("email-setup", SKILL_MD_WITH_FLAG)!;
     const config = makeConfig();
 
     const resolved = resolveSkillStates([skill], config);
     expect(resolved.length).toBe(1);
-    expect(resolved[0].summary.id).toBe("contacts");
+    expect(resolved[0].summary.id).toBe("email-setup");
+  });
+
+  test("resolveSkillStates excludes skill with featureFlag when flag defaults to OFF", () => {
+    const skill = buildSkillSummary("email-setup", SKILL_MD_WITH_FLAG)!;
+    // "email-channel" is in the registry with defaultEnabled: false
+    const config = makeConfig();
+
+    const resolved = resolveSkillStates([skill], config);
+    // Flag defaults to false → skill is filtered out
+    expect(resolved.length).toBe(0);
   });
 
   test("resolveSkillStates never gates skill without featureFlag", () => {
@@ -192,26 +191,34 @@ describe("frontmatter feature-flag integration", () => {
     const metadataObj = parsed!.fields.metadata as Record<string, unknown>;
     const vellum = metadataObj.vellum as Record<string, unknown>;
     const flagId = vellum["feature-flag"];
-    expect(flagId).toBe("contacts");
+    expect(flagId).toBe("email-channel");
 
     // Step 2: Build SkillSummary (as the catalog loader would)
-    const skill = buildSkillSummary("contacts", SKILL_MD_WITH_FLAG)!;
-    expect(skill.featureFlag).toBe("contacts");
+    const skill = buildSkillSummary("email-setup", SKILL_MD_WITH_FLAG)!;
+    expect(skill.featureFlag).toBe("email-channel");
 
     // Step 3: Derive the flag key
     const key = skillFlagKey(skill);
-    expect(key).toBe("contacts");
+    expect(key).toBe("email-channel");
 
-    // Step 4: Check flag state — "contacts" has defaultEnabled: true in registry
+    // Step 4: Check flag state — "email-channel" has defaultEnabled: false in registry
     const configDefault = makeConfig();
-    expect(isAssistantFeatureFlagEnabled(key!, configDefault)).toBe(true);
+    expect(isAssistantFeatureFlagEnabled(key!, configDefault)).toBe(false);
 
-    // Step 5: resolveSkillStates includes it by default
+    // Step 5: resolveSkillStates excludes it by default (flag is off)
     const resolvedDefault = resolveSkillStates([skill], configDefault);
-    expect(resolvedDefault.length).toBe(1);
-    expect(resolvedDefault[0].summary.id).toBe("contacts");
+    expect(resolvedDefault.length).toBe(0);
 
-    // Step 6: With override disabled, skill is filtered out
+    // Step 6: With override enabled, skill passes through
+    _setOverridesForTesting({ [key!]: true });
+    const configOn = makeConfig();
+    expect(isAssistantFeatureFlagEnabled(key!, configOn)).toBe(true);
+
+    const resolvedOn = resolveSkillStates([skill], configOn);
+    expect(resolvedOn.length).toBe(1);
+    expect(resolvedOn[0].summary.id).toBe("email-setup");
+
+    // Step 7: With override disabled, skill is filtered out
     _setOverridesForTesting({ [key!]: false });
     const configOff = makeConfig();
     expect(isAssistantFeatureFlagEnabled(key!, configOff)).toBe(false);

--- a/assistant/src/__tests__/skill-feature-flags.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags.test.ts
@@ -16,9 +16,9 @@ afterEach(() => {
   _setOverridesForTesting({});
 });
 
-const DECLARED_FLAG_ID = "contacts";
+const DECLARED_FLAG_ID = "sounds";
 const DECLARED_FLAG_KEY = DECLARED_FLAG_ID;
-const DECLARED_SKILL_ID = "contacts";
+const DECLARED_SKILL_ID = "sounds";
 const APP_BUILDER_MULTIFILE_FLAG_KEY = "app-builder-multifile";
 // ---------------------------------------------------------------------------
 // Helpers
@@ -144,7 +144,7 @@ describe("isAssistantFeatureFlagEnabled", () => {
 
   test("falls back to registry default when no override", () => {
     const config = makeConfig();
-    // contacts defaults to true in the registry
+    // sounds defaults to true in the registry
     expect(isAssistantFeatureFlagEnabled(DECLARED_FLAG_KEY, config)).toBe(true);
   });
 
@@ -214,7 +214,7 @@ describe("resolveSkillStates with feature flags", () => {
     const config = makeConfig();
 
     const resolved = resolveSkillStates(catalog, config);
-    // contacts registry default is true, so it passes through
+    // sounds registry default is true, so it passes through
     expect(resolved.length).toBe(1);
     expect(resolved[0].summary.id).toBe(DECLARED_SKILL_ID);
   });
@@ -272,7 +272,7 @@ describe("resolveSkillStates with feature flags", () => {
     const resolved = resolveSkillStates(catalog, config);
     const ids = resolved.map((r) => r.summary.id);
 
-    // contacts and deploy explicitly false; browser explicitly true
+    // sounds and deploy explicitly false; browser explicitly true
     expect(ids).toEqual(["browser"]);
   });
 });
@@ -283,7 +283,7 @@ describe("resolveSkillStates with feature flags", () => {
 
 describe("resolveSkillStates with frontmatter featureFlag", () => {
   test("skill with featureFlag (defaultEnabled: true) is included when no config override", () => {
-    // contacts has defaultEnabled: true in the registry
+    // sounds has defaultEnabled: true in the registry
     const catalog = [makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID)];
     const config = makeConfig();
 

--- a/assistant/src/__tests__/skill-load-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-load-feature-flag.test.ts
@@ -12,8 +12,8 @@ const TEST_DIR = process.env.VELLUM_WORKSPACE_DIR!;
 
 let currentConfig: Record<string, unknown> = {};
 
-const DECLARED_SKILL_ID = "contacts";
-const DECLARED_FLAG_KEY = "contacts";
+const DECLARED_SKILL_ID = "sounds";
+const DECLARED_FLAG_KEY = "sounds";
 
 const noopLogger = new Proxy({} as Record<string, unknown>, {
   get: (_target, prop) => (prop === "child" ? () => noopLogger : () => {}),
@@ -86,8 +86,8 @@ describe("skill_load feature flag enforcement", () => {
   test("returns deterministic error for flag OFF skill", async () => {
     writeSkill(
       DECLARED_SKILL_ID,
-      "Contacts",
-      "Toggle contacts behavior",
+      "Sounds",
+      "Toggle sounds behavior",
       "Use the feature.",
     );
     writeFileSync(
@@ -107,8 +107,8 @@ describe("skill_load feature flag enforcement", () => {
   test("loads skill normally when flag is ON", async () => {
     writeSkill(
       DECLARED_SKILL_ID,
-      "Contacts",
-      "Toggle contacts behavior",
+      "Sounds",
+      "Toggle sounds behavior",
       "Use the feature.",
     );
     writeFileSync(
@@ -121,14 +121,14 @@ describe("skill_load feature flag enforcement", () => {
     const result = await executeSkillLoad({ skill: DECLARED_SKILL_ID });
 
     expect(result.isError).toBe(false);
-    expect(result.content).toContain("Skill: Contacts");
+    expect(result.content).toContain("Skill: Sounds");
   });
 
   test("loads skill when flag key is absent (registry defaults to enabled)", async () => {
     writeSkill(
       DECLARED_SKILL_ID,
-      "Contacts",
-      "Toggle contacts behavior",
+      "Sounds",
+      "Toggle sounds behavior",
       "Use the feature.",
     );
     writeFileSync(
@@ -140,8 +140,8 @@ describe("skill_load feature flag enforcement", () => {
 
     const result = await executeSkillLoad({ skill: DECLARED_SKILL_ID });
 
-    // contacts is declared in the registry with defaultEnabled: true
+    // sounds is declared in the registry with defaultEnabled: true
     expect(result.isError).toBe(false);
-    expect(result.content).toContain("Skill: Contacts");
+    expect(result.content).toContain("Skill: Sounds");
   });
 });

--- a/assistant/src/config/bundled-skills/contacts/SKILL.md
+++ b/assistant/src/config/bundled-skills/contacts/SKILL.md
@@ -6,7 +6,6 @@ metadata:
   emoji: "👥"
   vellum:
     display-name: "Contacts"
-    feature-flag: "contacts"
 ---
 
 Manage the user's contacts, relationship graph, access control (trusted contacts), and invite links. This skill covers contact CRUD with multi-channel tracking, controlling who can message the assistant through external channels (Telegram, phone), and creating/managing invite links that grant access.

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -17,11 +17,9 @@ struct IntelligencePanel: View {
 
     @State private var selectedTab: IntelligenceTab
     @State private var cachedAssistantName: String = "Your Assistant"
-    @State private var isContactsEnabled: Bool = false
     @State private var isEmailEnabled: Bool = false
     @Binding var pendingSkillId: String?
     @State private var pendingFilePath: String?
-    private static let contactsFeatureFlagKey = "contacts"
     private static let emailFeatureFlagKey = "email-channel"
 
     init(onClose: @escaping () -> Void, onInvokeSkill: ((SkillInfo) -> Void)? = nil, onCreateSkill: (() -> Void)? = nil, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient? = nil, store: SettingsStore? = nil, conversationManager: ConversationManager? = nil, showToast: ((String, ToastInfo.Style) -> Void)? = nil, initialTab: String? = nil, pendingMemoryId: Binding<String?> = .constant(nil), pendingSkillId: Binding<String?> = .constant(nil)) {
@@ -69,17 +67,12 @@ struct IntelligencePanel: View {
         .task {
             let info = await IdentityInfo.loadAsync()
             cachedAssistantName = AssistantDisplayName.resolve(info?.name, fallback: "Your Assistant")
-            await loadContactsFeatureFlag()
+            await loadFeatureFlags()
         }
         .onReceive(NotificationCenter.default.publisher(for: .assistantFeatureFlagDidChange)) { notification in
             if let key = notification.userInfo?["key"] as? String,
                let enabled = notification.userInfo?["enabled"] as? Bool {
-                if key == Self.contactsFeatureFlagKey {
-                    isContactsEnabled = enabled
-                    if !enabled && selectedTab == .contacts {
-                        selectedTab = .identity
-                    }
-                } else if key == Self.emailFeatureFlagKey {
+                if key == Self.emailFeatureFlagKey {
                     isEmailEnabled = enabled
                 }
             }
@@ -87,19 +80,13 @@ struct IntelligencePanel: View {
     }
 
     private var visibleTabs: [IntelligenceTab] {
-        IntelligenceTab.allCases.filter { tab in
-            if tab == .contacts { return isContactsEnabled }
-            return true
-        }
+        IntelligenceTab.allCases
     }
 
-    private func loadContactsFeatureFlag() async {
+    private func loadFeatureFlags() async {
         let featureFlagClient: FeatureFlagClientProtocol = FeatureFlagClient()
         do {
             let flags = try await featureFlagClient.getFeatureFlags()
-            if let contactsFlag = flags.first(where: { $0.key == Self.contactsFeatureFlagKey }) {
-                isContactsEnabled = contactsFlag.enabled
-            }
             if let emailFlag = flags.first(where: { $0.key == Self.emailFeatureFlagKey }) {
                 isEmailEnabled = emailFlag.enabled
             }
@@ -108,9 +95,6 @@ struct IntelligencePanel: View {
             let resolved = AssistantFeatureFlagResolver.resolvedFlags(
                 registry: loadFeatureFlagRegistry()
             )
-            if let contactsEnabled = resolved[Self.contactsFeatureFlagKey] {
-                isContactsEnabled = contactsEnabled
-            }
             if let emailEnabled = resolved[Self.emailFeatureFlagKey] {
                 isEmailEnabled = emailEnabled
             }

--- a/gateway/src/__tests__/feature-flags-route.test.ts
+++ b/gateway/src/__tests__/feature-flags-route.test.ts
@@ -39,11 +39,11 @@ const TEST_REGISTRY = {
       defaultEnabled: true,
     },
     {
-      id: "contacts",
+      id: "email-channel",
       scope: "assistant",
-      key: "contacts",
-      label: "Contacts",
-      description: "Contacts management",
+      key: "email-channel",
+      label: "Email Channel",
+      description: "Email channel integration",
       defaultEnabled: false,
     },
     {
@@ -262,19 +262,19 @@ describe("GET /v1/feature-flags handler", () => {
   });
 
   test("remote values fill in when no local override exists", async () => {
-    // Write a remote store with contacts enabled (overriding registry default of false)
+    // Write a remote store with email-channel enabled (overriding registry default of false)
     writeFileSync(
       remoteFeatureFlagStorePath,
       JSON.stringify({
         version: 1,
         values: {
-          contacts: true,
+          "email-channel": true,
         },
       }),
     );
     clearRemoteFeatureFlagStoreCache();
 
-    // No local override for contacts
+    // No local override for email-channel
     if (existsSync(featureFlagStorePath)) {
       rmSync(featureFlagStorePath);
     }
@@ -288,12 +288,12 @@ describe("GET /v1/feature-flags handler", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
 
-    const contactsFlag = body.flags.find(
-      (f: { key: string }) => f.key === "contacts",
+    const emailFlag = body.flags.find(
+      (f: { key: string }) => f.key === "email-channel",
     );
-    expect(contactsFlag).toBeDefined();
+    expect(emailFlag).toBeDefined();
     // Remote value (true) overrides registry default (false)
-    expect(contactsFlag.enabled).toBe(true);
+    expect(emailFlag.enabled).toBe(true);
   });
 
   test("local overrides take precedence over remote values", async () => {
@@ -303,7 +303,7 @@ describe("GET /v1/feature-flags handler", () => {
       JSON.stringify({
         version: 1,
         values: {
-          contacts: true,
+          "email-channel": true,
         },
       }),
     );
@@ -315,7 +315,7 @@ describe("GET /v1/feature-flags handler", () => {
       JSON.stringify({
         version: 1,
         values: {
-          contacts: false,
+          "email-channel": false,
         },
       }),
     );
@@ -329,12 +329,12 @@ describe("GET /v1/feature-flags handler", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
 
-    const contactsFlag = body.flags.find(
-      (f: { key: string }) => f.key === "contacts",
+    const emailFlag = body.flags.find(
+      (f: { key: string }) => f.key === "email-channel",
     );
-    expect(contactsFlag).toBeDefined();
+    expect(emailFlag).toBeDefined();
     // Local override (false) takes precedence over remote (true)
-    expect(contactsFlag.enabled).toBe(false);
+    expect(emailFlag.enabled).toBe(false);
   });
 
   test("registry default used when neither local nor remote is set", async () => {
@@ -358,13 +358,13 @@ describe("GET /v1/feature-flags handler", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
 
-    // contacts has defaultEnabled: false in registry
-    const contactsFlag = body.flags.find(
-      (f: { key: string }) => f.key === "contacts",
+    // email-channel has defaultEnabled: false in registry
+    const emailFlag = body.flags.find(
+      (f: { key: string }) => f.key === "email-channel",
     );
-    expect(contactsFlag).toBeDefined();
-    expect(contactsFlag.enabled).toBe(false);
-    expect(contactsFlag.defaultEnabled).toBe(false);
+    expect(emailFlag).toBeDefined();
+    expect(emailFlag.enabled).toBe(false);
+    expect(emailFlag.defaultEnabled).toBe(false);
 
     // browser has defaultEnabled: true in registry
     const browserFlag = body.flags.find(
@@ -408,7 +408,7 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
       JSON.stringify({
         version: 1,
         values: {
-          contacts: true,
+          "email-channel": true,
         },
       }),
     );
@@ -427,7 +427,7 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
     // Both old and new values should be persisted
     clearFeatureFlagStoreCache();
     const persisted = readPersistedFeatureFlags();
-    expect(persisted["contacts"]).toBe(true);
+    expect(persisted["email-channel"]).toBe(true);
     expect(persisted["browser"]).toBe(true);
   });
 
@@ -543,7 +543,7 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
   test("accepts valid declared kebab-case key formats", async () => {
     const handler = createFeatureFlagsPatchHandler();
 
-    const validKeys = ["browser", "contacts"];
+    const validKeys = ["browser", "email-channel"];
 
     for (const key of validKeys) {
       clearFeatureFlagStoreCache();
@@ -614,7 +614,7 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
       featureFlagStorePath,
       JSON.stringify({
         version: 1,
-        values: { contacts: true },
+        values: { "email-channel": true },
       }),
     );
     clearFeatureFlagStoreCache();
@@ -633,7 +633,7 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
     const raw = readFileSync(featureFlagStorePath, "utf-8");
     const data = JSON.parse(raw);
     expect(data.version).toBe(1);
-    expect(data.values["contacts"]).toBe(true);
+    expect(data.values["email-channel"]).toBe(true);
     expect(data.values["browser"]).toBe(false);
 
     // Verify no temp files left behind
@@ -647,7 +647,7 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
     const handler = createFeatureFlagsPatchHandler();
 
     // Fire multiple concurrent PATCH requests at the same time
-    const flagKeys = ["browser", "contacts"];
+    const flagKeys = ["browser", "email-channel"];
 
     const results = await Promise.all(
       flagKeys.map((key) =>

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -26,14 +26,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "contacts",
-      "scope": "assistant",
-      "key": "contacts",
-      "label": "Contacts",
-      "description": "Show the Contacts tab in Settings for viewing and managing contacts",
-      "defaultEnabled": true
-    },
-    {
       "id": "email-channel",
       "scope": "assistant",
       "key": "email-channel",


### PR DESCRIPTION
## Summary
- Removes the `contacts` feature flag from the registry and all gating code so the Contacts tab is always visible in Settings
- Removes the `feature-flag: contacts` metadata from the contacts skill's SKILL.md so the skill always loads regardless of flag state
- Cleans up the macOS IntelligencePanel.swift to remove contacts-specific flag loading, notification handling, and tab filtering
- Updates tests in skill-feature-flags-integration, credential-execution-feature-gates, and feature-flags-route to use other existing flags (`email-channel`, `sounds`) instead of `contacts`

## Original prompt
GA the Contacts feature flag
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22957" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
