### PR TITLE
fix: add env var fallbacks for platform credentials in gateway webhook manager

### DIFF
--- a/gateway/src/__tests__/telegram-webhook-manager.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-manager.test.ts
@@ -293,6 +293,245 @@ describe("reconcileTelegramWebhook", () => {
     delete process.env.IS_CONTAINERIZED;
   });
 
+  test("registers via env vars when credential cache has no platform values", async () => {
+    const calls: {
+      method: string;
+      body: unknown;
+      headers?: Record<string, string>;
+    }[] = [];
+    process.env.IS_CONTAINERIZED = "true";
+    process.env.VELLUM_PLATFORM_URL = "https://env-platform.example.com";
+    process.env.PLATFORM_ASSISTANT_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+    process.env.PLATFORM_INTERNAL_API_KEY = "internal-key-from-env";
+
+    const caches = makeCaches({
+      ingressUrl: undefined,
+      platformBaseUrl: undefined,
+      assistantApiKey: undefined,
+      platformAssistantId: undefined,
+    });
+
+    fetchMock = mock(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        if (url.includes("/callback-routes/register/")) {
+          const body = init?.body ? JSON.parse(init.body as string) : null;
+          const headers = init?.headers as Record<string, string>;
+          calls.push({ method: "registerCallbackRoute", body, headers });
+          return new Response(
+            JSON.stringify({
+              callback_url:
+                "https://env-platform.example.com/v1/gateway/callbacks/aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee/webhooks/telegram/",
+            }),
+            {
+              status: 201,
+              headers: { "content-type": "application/json" },
+            },
+          );
+        }
+        if (url.includes("/getWebhookInfo")) {
+          calls.push({ method: "getWebhookInfo", body: null });
+          return makeTelegramResponse({
+            url: "",
+            has_custom_certificate: false,
+            pending_update_count: 0,
+          });
+        }
+        if (url.includes("/setWebhook")) {
+          const body = init?.body ? JSON.parse(init.body as string) : null;
+          calls.push({ method: "setWebhook", body });
+          return makeTelegramResponse(true);
+        }
+        return new Response("Not found", { status: 404 });
+      },
+    );
+
+    await reconcileTelegramWebhook(caches);
+
+    expect(calls).toHaveLength(3);
+    expect(calls[0].method).toBe("registerCallbackRoute");
+    expect(calls[0].body).toEqual({
+      assistant_id: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+      callback_path: "webhooks/telegram",
+      type: "telegram",
+    });
+    // PLATFORM_INTERNAL_API_KEY should use Bearer auth scheme
+    expect(calls[0].headers?.Authorization).toBe(
+      "Bearer internal-key-from-env",
+    );
+    expect(calls[2].method).toBe("setWebhook");
+    expect((calls[2].body as any).url).toBe(
+      "https://env-platform.example.com/v1/gateway/callbacks/aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee/webhooks/telegram/",
+    );
+
+    delete process.env.IS_CONTAINERIZED;
+    delete process.env.VELLUM_PLATFORM_URL;
+    delete process.env.PLATFORM_ASSISTANT_ID;
+    delete process.env.PLATFORM_INTERNAL_API_KEY;
+  });
+
+  test("credential cache values take precedence over env vars", async () => {
+    const calls: {
+      method: string;
+      body: unknown;
+      headers?: Record<string, string>;
+    }[] = [];
+    process.env.IS_CONTAINERIZED = "true";
+    process.env.VELLUM_PLATFORM_URL = "https://env-platform.example.com";
+    process.env.PLATFORM_ASSISTANT_ID = "env-assistant-id";
+    process.env.PLATFORM_INTERNAL_API_KEY = "env-internal-key";
+
+    const caches = makeCaches({
+      ingressUrl: undefined,
+      platformBaseUrl: "https://cache-platform.example.com",
+      assistantApiKey: "cache-api-key",
+      platformAssistantId: "cache-assistant-id",
+    });
+
+    fetchMock = mock(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        if (url.includes("/callback-routes/register/")) {
+          const body = init?.body ? JSON.parse(init.body as string) : null;
+          const headers = init?.headers as Record<string, string>;
+          calls.push({ method: "registerCallbackRoute", body, headers });
+          return new Response(
+            JSON.stringify({
+              callback_url:
+                "https://cache-platform.example.com/v1/gateway/callbacks/cache-assistant-id/webhooks/telegram/",
+            }),
+            {
+              status: 201,
+              headers: { "content-type": "application/json" },
+            },
+          );
+        }
+        if (url.includes("/getWebhookInfo")) {
+          calls.push({ method: "getWebhookInfo", body: null });
+          return makeTelegramResponse({
+            url: "",
+            has_custom_certificate: false,
+            pending_update_count: 0,
+          });
+        }
+        if (url.includes("/setWebhook")) {
+          const body = init?.body ? JSON.parse(init.body as string) : null;
+          calls.push({ method: "setWebhook", body });
+          return makeTelegramResponse(true);
+        }
+        return new Response("Not found", { status: 404 });
+      },
+    );
+
+    await reconcileTelegramWebhook(caches);
+
+    expect(calls).toHaveLength(3);
+    expect(calls[0].method).toBe("registerCallbackRoute");
+    // Should use credential cache values, not env vars
+    expect(calls[0].body).toEqual({
+      assistant_id: "cache-assistant-id",
+      callback_path: "webhooks/telegram",
+      type: "telegram",
+    });
+    // credential cache assistant_api_key uses Api-Key scheme
+    expect(calls[0].headers?.Authorization).toBe("Api-Key cache-api-key");
+    // Registration URL should use cache platform URL
+    expect((calls[2].body as any).url).toBe(
+      "https://cache-platform.example.com/v1/gateway/callbacks/cache-assistant-id/webhooks/telegram/",
+    );
+
+    delete process.env.IS_CONTAINERIZED;
+    delete process.env.VELLUM_PLATFORM_URL;
+    delete process.env.PLATFORM_ASSISTANT_ID;
+    delete process.env.PLATFORM_INTERNAL_API_KEY;
+  });
+
+  test("uses default platform URL when neither cache nor env var has a value", async () => {
+    const calls: {
+      method: string;
+      body: unknown;
+      headers?: Record<string, string>;
+    }[] = [];
+    process.env.IS_CONTAINERIZED = "true";
+    process.env.PLATFORM_ASSISTANT_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+    process.env.PLATFORM_INTERNAL_API_KEY = "internal-key-from-env";
+    delete process.env.VELLUM_PLATFORM_URL;
+
+    const caches = makeCaches({
+      ingressUrl: undefined,
+      platformBaseUrl: undefined,
+      assistantApiKey: undefined,
+      platformAssistantId: undefined,
+    });
+
+    fetchMock = mock(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        if (url.includes("/callback-routes/register/")) {
+          const body = init?.body ? JSON.parse(init.body as string) : null;
+          const headers = init?.headers as Record<string, string>;
+          calls.push({ method: "registerCallbackRoute", body, headers });
+          return new Response(
+            JSON.stringify({
+              callback_url:
+                "https://platform.vellum.ai/v1/gateway/callbacks/aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee/webhooks/telegram/",
+            }),
+            {
+              status: 201,
+              headers: { "content-type": "application/json" },
+            },
+          );
+        }
+        if (url.includes("/getWebhookInfo")) {
+          calls.push({ method: "getWebhookInfo", body: null });
+          return makeTelegramResponse({
+            url: "",
+            has_custom_certificate: false,
+            pending_update_count: 0,
+          });
+        }
+        if (url.includes("/setWebhook")) {
+          const body = init?.body ? JSON.parse(init.body as string) : null;
+          calls.push({ method: "setWebhook", body });
+          return makeTelegramResponse(true);
+        }
+        return new Response("Not found", { status: 404 });
+      },
+    );
+
+    await reconcileTelegramWebhook(caches);
+
+    expect(calls).toHaveLength(3);
+    expect(calls[0].method).toBe("registerCallbackRoute");
+    // Should use Bearer auth with internal key
+    expect(calls[0].headers?.Authorization).toBe(
+      "Bearer internal-key-from-env",
+    );
+    // Registration should hit the default platform URL
+    expect((calls[2].body as any).url).toBe(
+      "https://platform.vellum.ai/v1/gateway/callbacks/aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee/webhooks/telegram/",
+    );
+
+    delete process.env.IS_CONTAINERIZED;
+    delete process.env.PLATFORM_ASSISTANT_ID;
+    delete process.env.PLATFORM_INTERNAL_API_KEY;
+  });
+
   test("calls setWebhook when current URL is empty", async () => {
     const calls: string[] = [];
 

--- a/gateway/src/telegram/webhook-manager.ts
+++ b/gateway/src/telegram/webhook-manager.ts
@@ -31,24 +31,43 @@ interface PlatformCallbackRouteResponse {
 async function registerManagedTelegramCallbackRoute(
   caches?: WebhookManagerCaches,
 ): Promise<string | undefined> {
-  if (!caches?.credentials) return undefined;
-
+  // Read from credential cache when available
   const [platformBaseUrlRaw, assistantApiKeyRaw, assistantIdRaw] =
-    await Promise.all([
-      caches.credentials.get(credentialKey("vellum", "platform_base_url")),
-      caches.credentials.get(credentialKey("vellum", "assistant_api_key")),
-      caches.credentials.get(credentialKey("vellum", "platform_assistant_id")),
-    ]);
+    caches?.credentials
+      ? await Promise.all([
+          caches.credentials.get(credentialKey("vellum", "platform_base_url")),
+          caches.credentials.get(credentialKey("vellum", "assistant_api_key")),
+          caches.credentials.get(
+            credentialKey("vellum", "platform_assistant_id"),
+          ),
+        ])
+      : [undefined, undefined, undefined];
 
-  const platformBaseUrl = platformBaseUrlRaw?.trim().replace(/\/+$/, "");
-  const assistantApiKey = assistantApiKeyRaw?.trim();
-  const assistantId = assistantIdRaw?.trim();
+  // Fall back to env vars when credential cache values are missing, matching
+  // the daemon's resolvePlatformCallbackRegistrationContext() behaviour.
+  const platformBaseUrl = (
+    platformBaseUrlRaw?.trim() ||
+    process.env.VELLUM_PLATFORM_URL?.trim() ||
+    "https://platform.vellum.ai"
+  ).replace(/\/+$/, "");
 
-  if (!platformBaseUrl || !assistantApiKey || !assistantId) {
+  const assistantApiKey = assistantApiKeyRaw?.trim() || undefined;
+  const platformInternalApiKey = !assistantApiKey
+    ? process.env.PLATFORM_INTERNAL_API_KEY?.trim()
+    : undefined;
+  const apiKey = assistantApiKey || platformInternalApiKey;
+  const authScheme = assistantApiKey ? "Api-Key" : "Bearer";
+
+  const assistantId =
+    assistantIdRaw?.trim() ||
+    process.env.PLATFORM_ASSISTANT_ID?.trim() ||
+    undefined;
+
+  if (!apiKey || !assistantId) {
     log.debug(
       {
         hasPlatformBaseUrl: !!platformBaseUrl,
-        hasAssistantApiKey: !!assistantApiKey,
+        hasApiKey: !!apiKey,
         hasAssistantId: !!assistantId,
       },
       "Managed Telegram callback route registration unavailable",
@@ -61,7 +80,7 @@ async function registerManagedTelegramCallbackRoute(
     {
       method: "POST",
       headers: {
-        Authorization: `Api-Key ${assistantApiKey}`,
+        Authorization: `${authScheme} ${apiKey}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({


### PR DESCRIPTION
## Summary
- Add environment variable fallbacks (VELLUM_PLATFORM_URL, PLATFORM_ASSISTANT_ID, PLATFORM_INTERNAL_API_KEY) to the gateway webhook manager's registerManagedTelegramCallbackRoute() so platform-hosted assistants can register Telegram webhooks without relying on credential store values
- Use Bearer auth scheme when falling back to PLATFORM_INTERNAL_API_KEY (matching daemon behavior)
- Add comprehensive tests for env var fallback paths

Part of plan: platform-connected-baseurl.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22958" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
