### PR TITLE
fix: platform-hosted assistants show connected: false when app is closed

### DIFF
--- a/gateway/src/__tests__/remote-feature-flag-sync.test.ts
+++ b/gateway/src/__tests__/remote-feature-flag-sync.test.ts
@@ -183,7 +183,7 @@ describe("RemoteFeatureFlagSync", () => {
     expect(headers.Authorization).toBe("Bearer internal-key-123");
   });
 
-  test("prefers PLATFORM_INTERNAL_API_KEY over assistant_api_key", async () => {
+  test("prefers assistant_api_key over PLATFORM_INTERNAL_API_KEY for public API", async () => {
     fetchMock = mock(async () => Response.json({ flags: {} }));
     process.env.PLATFORM_INTERNAL_API_KEY = "internal-key-123";
 
@@ -196,7 +196,9 @@ describe("RemoteFeatureFlagSync", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [, init] = fetchMock.mock.calls[0];
     const headers = init?.headers as Record<string, string>;
-    expect(headers.Authorization).toBe("Bearer internal-key-123");
+    // Feature flag sync hits the public platform API, so Api-Key auth
+    // (assistant_api_key) takes precedence over Bearer (internal key).
+    expect(headers.Authorization).toBe("Api-Key test-api-key");
   });
 
   test("skips sync when platform_assistant_id is missing and no PLATFORM_ASSISTANT_ID", async () => {

--- a/gateway/src/__tests__/remote-feature-flag-sync.test.ts
+++ b/gateway/src/__tests__/remote-feature-flag-sync.test.ts
@@ -69,8 +69,17 @@ function defaultCredentials(): Record<string, string> {
 // ---------------------------------------------------------------------------
 // Setup / teardown
 // ---------------------------------------------------------------------------
+const savedVellumPlatformUrl = process.env.VELLUM_PLATFORM_URL;
+const savedPlatformAssistantId = process.env.PLATFORM_ASSISTANT_ID;
+const savedPlatformInternalApiKey = process.env.PLATFORM_INTERNAL_API_KEY;
+
 beforeEach(() => {
   process.env.BASE_DATA_DIR = testDir;
+  // Clear env vars that the production code falls back to, so tests remain
+  // deterministic unless they explicitly set them.
+  delete process.env.VELLUM_PLATFORM_URL;
+  delete process.env.PLATFORM_ASSISTANT_ID;
+  delete process.env.PLATFORM_INTERNAL_API_KEY;
   mkdirSync(protectedDir, { recursive: true });
   clearRemoteFeatureFlagStoreCache();
   fetchMock = mock(async () => new Response());
@@ -82,6 +91,17 @@ afterEach(() => {
   } else {
     process.env.BASE_DATA_DIR = savedBaseDataDir;
   }
+  // Restore env vars
+  const restoreEnv = (key: string, saved: string | undefined): void => {
+    if (saved === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = saved;
+    }
+  };
+  restoreEnv("VELLUM_PLATFORM_URL", savedVellumPlatformUrl);
+  restoreEnv("PLATFORM_ASSISTANT_ID", savedPlatformAssistantId);
+  restoreEnv("PLATFORM_INTERNAL_API_KEY", savedPlatformInternalApiKey);
   try {
     rmSync(testDir, { recursive: true, force: true });
   } catch {
@@ -94,7 +114,9 @@ afterEach(() => {
 // Tests
 // ---------------------------------------------------------------------------
 describe("RemoteFeatureFlagSync", () => {
-  test("skips sync when platform_base_url is missing", async () => {
+  test("falls back to default platform URL when platform_base_url is missing", async () => {
+    fetchMock = mock(async () => Response.json({ flags: { ff1: true } }));
+
     const creds = defaultCredentials();
     delete creds["credential/vellum/platform_base_url"];
 
@@ -104,10 +126,34 @@ describe("RemoteFeatureFlagSync", () => {
     await sync.start();
     sync.stop();
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe(
+      "https://platform.vellum.ai/v1/assistants/asst-123/feature-flags/",
+    );
   });
 
-  test("skips sync when assistant_api_key is missing", async () => {
+  test("falls back to VELLUM_PLATFORM_URL env var when platform_base_url is missing", async () => {
+    fetchMock = mock(async () => Response.json({ flags: {} }));
+    process.env.VELLUM_PLATFORM_URL = "https://env-platform.example.com";
+
+    const creds = defaultCredentials();
+    delete creds["credential/vellum/platform_base_url"];
+
+    const sync = new RemoteFeatureFlagSync({
+      credentials: fakeCredentialCache(creds),
+    });
+    await sync.start();
+    sync.stop();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe(
+      "https://env-platform.example.com/v1/assistants/asst-123/feature-flags/",
+    );
+  });
+
+  test("skips sync when assistant_api_key is missing and no PLATFORM_INTERNAL_API_KEY", async () => {
     const creds = defaultCredentials();
     delete creds["credential/vellum/assistant_api_key"];
 
@@ -120,7 +166,42 @@ describe("RemoteFeatureFlagSync", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  test("skips sync when platform_assistant_id is missing", async () => {
+  test("falls back to PLATFORM_INTERNAL_API_KEY with Bearer auth when assistant_api_key is missing", async () => {
+    fetchMock = mock(async () => Response.json({ flags: {} }));
+    process.env.PLATFORM_INTERNAL_API_KEY = "internal-key-123";
+
+    const creds = defaultCredentials();
+    delete creds["credential/vellum/assistant_api_key"];
+
+    const sync = new RemoteFeatureFlagSync({
+      credentials: fakeCredentialCache(creds),
+    });
+    await sync.start();
+    sync.stop();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0];
+    const headers = init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer internal-key-123");
+  });
+
+  test("prefers assistant_api_key over PLATFORM_INTERNAL_API_KEY", async () => {
+    fetchMock = mock(async () => Response.json({ flags: {} }));
+    process.env.PLATFORM_INTERNAL_API_KEY = "internal-key-123";
+
+    const sync = new RemoteFeatureFlagSync({
+      credentials: fakeCredentialCache(defaultCredentials()),
+    });
+    await sync.start();
+    sync.stop();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0];
+    const headers = init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Api-Key test-api-key");
+  });
+
+  test("skips sync when platform_assistant_id is missing and no PLATFORM_ASSISTANT_ID", async () => {
     const creds = defaultCredentials();
     delete creds["credential/vellum/platform_assistant_id"];
 
@@ -131,6 +212,24 @@ describe("RemoteFeatureFlagSync", () => {
     sync.stop();
 
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("falls back to PLATFORM_ASSISTANT_ID env var when credential cache is empty", async () => {
+    fetchMock = mock(async () => Response.json({ flags: {} }));
+    process.env.PLATFORM_ASSISTANT_ID = "env-asst-456";
+
+    const creds = defaultCredentials();
+    delete creds["credential/vellum/platform_assistant_id"];
+
+    const sync = new RemoteFeatureFlagSync({
+      credentials: fakeCredentialCache(creds),
+    });
+    await sync.start();
+    sync.stop();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain("/v1/assistants/env-asst-456/feature-flags/");
   });
 
   test("fetches and caches flags on successful response", async () => {

--- a/gateway/src/__tests__/remote-feature-flag-sync.test.ts
+++ b/gateway/src/__tests__/remote-feature-flag-sync.test.ts
@@ -114,11 +114,12 @@ afterEach(() => {
 // Tests
 // ---------------------------------------------------------------------------
 describe("RemoteFeatureFlagSync", () => {
-  test("falls back to default platform URL when platform_base_url is missing", async () => {
+  test("skips sync when no platform URL is available from cache or env", async () => {
     fetchMock = mock(async () => Response.json({ flags: { ff1: true } }));
 
     const creds = defaultCredentials();
     delete creds["credential/vellum/platform_base_url"];
+    delete process.env.VELLUM_PLATFORM_URL;
 
     const sync = new RemoteFeatureFlagSync({
       credentials: fakeCredentialCache(creds),
@@ -126,11 +127,8 @@ describe("RemoteFeatureFlagSync", () => {
     await sync.start();
     sync.stop();
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url] = fetchMock.mock.calls[0];
-    expect(url).toBe(
-      "https://platform.vellum.ai/v1/assistants/asst-123/feature-flags/",
-    );
+    // No fetch calls — sync is skipped when platform URL is unavailable
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test("falls back to VELLUM_PLATFORM_URL env var when platform_base_url is missing", async () => {

--- a/gateway/src/__tests__/remote-feature-flag-sync.test.ts
+++ b/gateway/src/__tests__/remote-feature-flag-sync.test.ts
@@ -164,7 +164,7 @@ describe("RemoteFeatureFlagSync", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  test("falls back to PLATFORM_INTERNAL_API_KEY with Bearer auth when assistant_api_key is missing", async () => {
+  test("does not use PLATFORM_INTERNAL_API_KEY when assistant_api_key is missing", async () => {
     fetchMock = mock(async () => Response.json({ flags: {} }));
     process.env.PLATFORM_INTERNAL_API_KEY = "internal-key-123";
 
@@ -177,28 +177,9 @@ describe("RemoteFeatureFlagSync", () => {
     await sync.start();
     sync.stop();
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [, init] = fetchMock.mock.calls[0];
-    const headers = init?.headers as Record<string, string>;
-    expect(headers.Authorization).toBe("Bearer internal-key-123");
-  });
-
-  test("prefers assistant_api_key over PLATFORM_INTERNAL_API_KEY for public API", async () => {
-    fetchMock = mock(async () => Response.json({ flags: {} }));
-    process.env.PLATFORM_INTERNAL_API_KEY = "internal-key-123";
-
-    const sync = new RemoteFeatureFlagSync({
-      credentials: fakeCredentialCache(defaultCredentials()),
-    });
-    await sync.start();
-    sync.stop();
-
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [, init] = fetchMock.mock.calls[0];
-    const headers = init?.headers as Record<string, string>;
-    // Feature flag sync hits the public platform API, so Api-Key auth
-    // (assistant_api_key) takes precedence over Bearer (internal key).
-    expect(headers.Authorization).toBe("Api-Key test-api-key");
+    // PLATFORM_INTERNAL_API_KEY is only for internal gateway endpoints —
+    // feature flag sync requires assistant_api_key (Api-Key auth).
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test("skips sync when platform_assistant_id is missing and no PLATFORM_ASSISTANT_ID", async () => {

--- a/gateway/src/__tests__/remote-feature-flag-sync.test.ts
+++ b/gateway/src/__tests__/remote-feature-flag-sync.test.ts
@@ -185,7 +185,7 @@ describe("RemoteFeatureFlagSync", () => {
     expect(headers.Authorization).toBe("Bearer internal-key-123");
   });
 
-  test("prefers assistant_api_key over PLATFORM_INTERNAL_API_KEY", async () => {
+  test("prefers PLATFORM_INTERNAL_API_KEY over assistant_api_key", async () => {
     fetchMock = mock(async () => Response.json({ flags: {} }));
     process.env.PLATFORM_INTERNAL_API_KEY = "internal-key-123";
 
@@ -198,7 +198,7 @@ describe("RemoteFeatureFlagSync", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [, init] = fetchMock.mock.calls[0];
     const headers = init?.headers as Record<string, string>;
-    expect(headers.Authorization).toBe("Api-Key test-api-key");
+    expect(headers.Authorization).toBe("Bearer internal-key-123");
   });
 
   test("skips sync when platform_assistant_id is missing and no PLATFORM_ASSISTANT_ID", async () => {

--- a/gateway/src/__tests__/telegram-webhook-manager.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-manager.test.ts
@@ -457,12 +457,7 @@ describe("reconcileTelegramWebhook", () => {
     delete process.env.PLATFORM_INTERNAL_API_KEY;
   });
 
-  test("uses default platform URL when neither cache nor env var has a value", async () => {
-    const calls: {
-      method: string;
-      body: unknown;
-      headers?: Record<string, string>;
-    }[] = [];
+  test("skips registration when no platform URL is available from cache or env", async () => {
     process.env.IS_CONTAINERIZED = "true";
     process.env.PLATFORM_ASSISTANT_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
     process.env.PLATFORM_INTERNAL_API_KEY = "internal-key-from-env";
@@ -475,58 +470,12 @@ describe("reconcileTelegramWebhook", () => {
       platformAssistantId: undefined,
     });
 
-    fetchMock = mock(
-      async (input: string | URL | Request, init?: RequestInit) => {
-        const url =
-          typeof input === "string"
-            ? input
-            : input instanceof URL
-              ? input.toString()
-              : input.url;
-        if (url.includes("/callback-routes/register/")) {
-          const body = init?.body ? JSON.parse(init.body as string) : null;
-          const headers = init?.headers as Record<string, string>;
-          calls.push({ method: "registerCallbackRoute", body, headers });
-          return new Response(
-            JSON.stringify({
-              callback_url:
-                "https://platform.vellum.ai/v1/gateway/callbacks/aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee/webhooks/telegram/",
-            }),
-            {
-              status: 201,
-              headers: { "content-type": "application/json" },
-            },
-          );
-        }
-        if (url.includes("/getWebhookInfo")) {
-          calls.push({ method: "getWebhookInfo", body: null });
-          return makeTelegramResponse({
-            url: "",
-            has_custom_certificate: false,
-            pending_update_count: 0,
-          });
-        }
-        if (url.includes("/setWebhook")) {
-          const body = init?.body ? JSON.parse(init.body as string) : null;
-          calls.push({ method: "setWebhook", body });
-          return makeTelegramResponse(true);
-        }
-        return new Response("Not found", { status: 404 });
-      },
-    );
+    fetchMock = mock(async () => new Response("", { status: 200 }));
 
     await reconcileTelegramWebhook(caches);
 
-    expect(calls).toHaveLength(3);
-    expect(calls[0].method).toBe("registerCallbackRoute");
-    // Should use Bearer auth with internal key
-    expect(calls[0].headers?.Authorization).toBe(
-      "Bearer internal-key-from-env",
-    );
-    // Registration should hit the default platform URL
-    expect((calls[2].body as any).url).toBe(
-      "https://platform.vellum.ai/v1/gateway/callbacks/aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee/webhooks/telegram/",
-    );
+    // No fetch calls should be made — registration is skipped
+    expect(fetchMock).not.toHaveBeenCalled();
 
     delete process.env.IS_CONTAINERIZED;
     delete process.env.PLATFORM_ASSISTANT_ID;

--- a/gateway/src/__tests__/telegram-webhook-manager.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-manager.test.ts
@@ -375,7 +375,7 @@ describe("reconcileTelegramWebhook", () => {
     delete process.env.PLATFORM_INTERNAL_API_KEY;
   });
 
-  test("credential cache values take precedence over env vars", async () => {
+  test("env vars take precedence for auth key and assistant ID, cache for base URL", async () => {
     const calls: {
       method: string;
       body: unknown;
@@ -408,7 +408,7 @@ describe("reconcileTelegramWebhook", () => {
           return new Response(
             JSON.stringify({
               callback_url:
-                "https://cache-platform.example.com/v1/gateway/callbacks/cache-assistant-id/webhooks/telegram/",
+                "https://cache-platform.example.com/v1/gateway/callbacks/env-assistant-id/webhooks/telegram/",
             }),
             {
               status: 201,
@@ -437,18 +437,18 @@ describe("reconcileTelegramWebhook", () => {
 
     expect(calls).toHaveLength(3);
     expect(calls[0].method).toBe("registerCallbackRoute");
-    // platform_base_url and platform_assistant_id: credential cache takes precedence
+    // platform_base_url: credential cache takes precedence over env var
+    // PLATFORM_ASSISTANT_ID and PLATFORM_INTERNAL_API_KEY: env var takes
+    // precedence, matching the daemon's resolvePlatformCallbackRegistrationContext().
     expect(calls[0].body).toEqual({
-      assistant_id: "cache-assistant-id",
+      assistant_id: "env-assistant-id",
       callback_path: "webhooks/telegram",
       type: "telegram",
     });
-    // PLATFORM_INTERNAL_API_KEY (env var, Bearer) takes precedence over
-    // assistant_api_key from credential cache, matching the daemon's behaviour.
     expect(calls[0].headers?.Authorization).toBe("Bearer env-internal-key");
     // Registration URL should use cache platform URL
     expect((calls[2].body as any).url).toBe(
-      "https://cache-platform.example.com/v1/gateway/callbacks/cache-assistant-id/webhooks/telegram/",
+      "https://cache-platform.example.com/v1/gateway/callbacks/env-assistant-id/webhooks/telegram/",
     );
 
     delete process.env.IS_CONTAINERIZED;

--- a/gateway/src/__tests__/telegram-webhook-manager.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-manager.test.ts
@@ -293,6 +293,245 @@ describe("reconcileTelegramWebhook", () => {
     delete process.env.IS_CONTAINERIZED;
   });
 
+  test("registers via env vars when credential cache has no platform values", async () => {
+    const calls: {
+      method: string;
+      body: unknown;
+      headers?: Record<string, string>;
+    }[] = [];
+    process.env.IS_CONTAINERIZED = "true";
+    process.env.VELLUM_PLATFORM_URL = "https://env-platform.example.com";
+    process.env.PLATFORM_ASSISTANT_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+    process.env.PLATFORM_INTERNAL_API_KEY = "internal-key-from-env";
+
+    const caches = makeCaches({
+      ingressUrl: undefined,
+      platformBaseUrl: undefined,
+      assistantApiKey: undefined,
+      platformAssistantId: undefined,
+    });
+
+    fetchMock = mock(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        if (url.includes("/callback-routes/register/")) {
+          const body = init?.body ? JSON.parse(init.body as string) : null;
+          const headers = init?.headers as Record<string, string>;
+          calls.push({ method: "registerCallbackRoute", body, headers });
+          return new Response(
+            JSON.stringify({
+              callback_url:
+                "https://env-platform.example.com/v1/gateway/callbacks/aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee/webhooks/telegram/",
+            }),
+            {
+              status: 201,
+              headers: { "content-type": "application/json" },
+            },
+          );
+        }
+        if (url.includes("/getWebhookInfo")) {
+          calls.push({ method: "getWebhookInfo", body: null });
+          return makeTelegramResponse({
+            url: "",
+            has_custom_certificate: false,
+            pending_update_count: 0,
+          });
+        }
+        if (url.includes("/setWebhook")) {
+          const body = init?.body ? JSON.parse(init.body as string) : null;
+          calls.push({ method: "setWebhook", body });
+          return makeTelegramResponse(true);
+        }
+        return new Response("Not found", { status: 404 });
+      },
+    );
+
+    await reconcileTelegramWebhook(caches);
+
+    expect(calls).toHaveLength(3);
+    expect(calls[0].method).toBe("registerCallbackRoute");
+    expect(calls[0].body).toEqual({
+      assistant_id: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+      callback_path: "webhooks/telegram",
+      type: "telegram",
+    });
+    // PLATFORM_INTERNAL_API_KEY should use Bearer auth scheme
+    expect(calls[0].headers?.Authorization).toBe(
+      "Bearer internal-key-from-env",
+    );
+    expect(calls[2].method).toBe("setWebhook");
+    expect((calls[2].body as any).url).toBe(
+      "https://env-platform.example.com/v1/gateway/callbacks/aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee/webhooks/telegram/",
+    );
+
+    delete process.env.IS_CONTAINERIZED;
+    delete process.env.VELLUM_PLATFORM_URL;
+    delete process.env.PLATFORM_ASSISTANT_ID;
+    delete process.env.PLATFORM_INTERNAL_API_KEY;
+  });
+
+  test("credential cache values take precedence over env vars", async () => {
+    const calls: {
+      method: string;
+      body: unknown;
+      headers?: Record<string, string>;
+    }[] = [];
+    process.env.IS_CONTAINERIZED = "true";
+    process.env.VELLUM_PLATFORM_URL = "https://env-platform.example.com";
+    process.env.PLATFORM_ASSISTANT_ID = "env-assistant-id";
+    process.env.PLATFORM_INTERNAL_API_KEY = "env-internal-key";
+
+    const caches = makeCaches({
+      ingressUrl: undefined,
+      platformBaseUrl: "https://cache-platform.example.com",
+      assistantApiKey: "cache-api-key",
+      platformAssistantId: "cache-assistant-id",
+    });
+
+    fetchMock = mock(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        if (url.includes("/callback-routes/register/")) {
+          const body = init?.body ? JSON.parse(init.body as string) : null;
+          const headers = init?.headers as Record<string, string>;
+          calls.push({ method: "registerCallbackRoute", body, headers });
+          return new Response(
+            JSON.stringify({
+              callback_url:
+                "https://cache-platform.example.com/v1/gateway/callbacks/cache-assistant-id/webhooks/telegram/",
+            }),
+            {
+              status: 201,
+              headers: { "content-type": "application/json" },
+            },
+          );
+        }
+        if (url.includes("/getWebhookInfo")) {
+          calls.push({ method: "getWebhookInfo", body: null });
+          return makeTelegramResponse({
+            url: "",
+            has_custom_certificate: false,
+            pending_update_count: 0,
+          });
+        }
+        if (url.includes("/setWebhook")) {
+          const body = init?.body ? JSON.parse(init.body as string) : null;
+          calls.push({ method: "setWebhook", body });
+          return makeTelegramResponse(true);
+        }
+        return new Response("Not found", { status: 404 });
+      },
+    );
+
+    await reconcileTelegramWebhook(caches);
+
+    expect(calls).toHaveLength(3);
+    expect(calls[0].method).toBe("registerCallbackRoute");
+    // Should use credential cache values, not env vars
+    expect(calls[0].body).toEqual({
+      assistant_id: "cache-assistant-id",
+      callback_path: "webhooks/telegram",
+      type: "telegram",
+    });
+    // credential cache assistant_api_key uses Api-Key scheme
+    expect(calls[0].headers?.Authorization).toBe("Api-Key cache-api-key");
+    // Registration URL should use cache platform URL
+    expect((calls[2].body as any).url).toBe(
+      "https://cache-platform.example.com/v1/gateway/callbacks/cache-assistant-id/webhooks/telegram/",
+    );
+
+    delete process.env.IS_CONTAINERIZED;
+    delete process.env.VELLUM_PLATFORM_URL;
+    delete process.env.PLATFORM_ASSISTANT_ID;
+    delete process.env.PLATFORM_INTERNAL_API_KEY;
+  });
+
+  test("uses default platform URL when neither cache nor env var has a value", async () => {
+    const calls: {
+      method: string;
+      body: unknown;
+      headers?: Record<string, string>;
+    }[] = [];
+    process.env.IS_CONTAINERIZED = "true";
+    process.env.PLATFORM_ASSISTANT_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+    process.env.PLATFORM_INTERNAL_API_KEY = "internal-key-from-env";
+    delete process.env.VELLUM_PLATFORM_URL;
+
+    const caches = makeCaches({
+      ingressUrl: undefined,
+      platformBaseUrl: undefined,
+      assistantApiKey: undefined,
+      platformAssistantId: undefined,
+    });
+
+    fetchMock = mock(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        if (url.includes("/callback-routes/register/")) {
+          const body = init?.body ? JSON.parse(init.body as string) : null;
+          const headers = init?.headers as Record<string, string>;
+          calls.push({ method: "registerCallbackRoute", body, headers });
+          return new Response(
+            JSON.stringify({
+              callback_url:
+                "https://platform.vellum.ai/v1/gateway/callbacks/aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee/webhooks/telegram/",
+            }),
+            {
+              status: 201,
+              headers: { "content-type": "application/json" },
+            },
+          );
+        }
+        if (url.includes("/getWebhookInfo")) {
+          calls.push({ method: "getWebhookInfo", body: null });
+          return makeTelegramResponse({
+            url: "",
+            has_custom_certificate: false,
+            pending_update_count: 0,
+          });
+        }
+        if (url.includes("/setWebhook")) {
+          const body = init?.body ? JSON.parse(init.body as string) : null;
+          calls.push({ method: "setWebhook", body });
+          return makeTelegramResponse(true);
+        }
+        return new Response("Not found", { status: 404 });
+      },
+    );
+
+    await reconcileTelegramWebhook(caches);
+
+    expect(calls).toHaveLength(3);
+    expect(calls[0].method).toBe("registerCallbackRoute");
+    // Should use Bearer auth with internal key
+    expect(calls[0].headers?.Authorization).toBe(
+      "Bearer internal-key-from-env",
+    );
+    // Registration should hit the default platform URL
+    expect((calls[2].body as any).url).toBe(
+      "https://platform.vellum.ai/v1/gateway/callbacks/aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee/webhooks/telegram/",
+    );
+
+    delete process.env.IS_CONTAINERIZED;
+    delete process.env.PLATFORM_ASSISTANT_ID;
+    delete process.env.PLATFORM_INTERNAL_API_KEY;
+  });
+
   test("calls setWebhook when current URL is empty", async () => {
     const calls: string[] = [];
 

--- a/gateway/src/__tests__/telegram-webhook-manager.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-manager.test.ts
@@ -437,14 +437,15 @@ describe("reconcileTelegramWebhook", () => {
 
     expect(calls).toHaveLength(3);
     expect(calls[0].method).toBe("registerCallbackRoute");
-    // Should use credential cache values, not env vars
+    // platform_base_url and platform_assistant_id: credential cache takes precedence
     expect(calls[0].body).toEqual({
       assistant_id: "cache-assistant-id",
       callback_path: "webhooks/telegram",
       type: "telegram",
     });
-    // credential cache assistant_api_key uses Api-Key scheme
-    expect(calls[0].headers?.Authorization).toBe("Api-Key cache-api-key");
+    // PLATFORM_INTERNAL_API_KEY (env var, Bearer) takes precedence over
+    // assistant_api_key from credential cache, matching the daemon's behaviour.
+    expect(calls[0].headers?.Authorization).toBe("Bearer env-internal-key");
     // Registration URL should use cache platform URL
     expect((calls[2].body as any).url).toBe(
       "https://cache-platform.example.com/v1/gateway/callbacks/cache-assistant-id/webhooks/telegram/",

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -101,7 +101,7 @@ export class RemoteFeatureFlagSync {
     const platformUrl = (
       platformUrlRaw?.trim() ||
       process.env.VELLUM_PLATFORM_URL?.trim() ||
-      "https://platform.vellum.ai"
+      ""
     ).replace(/\/+$/, "");
 
     const platformInternalApiKey =
@@ -117,7 +117,7 @@ export class RemoteFeatureFlagSync {
       process.env.PLATFORM_ASSISTANT_ID?.trim() ||
       undefined;
 
-    if (!authToken || !assistantId) {
+    if (!platformUrl || !authToken || !assistantId) {
       log.debug(
         {
           hasPlatformUrl: !!platformUrl,

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -113,8 +113,8 @@ export class RemoteFeatureFlagSync {
     const authScheme = platformInternalApiKey ? "Bearer" : "Api-Key";
 
     const assistantId =
-      assistantIdRaw?.trim() ||
       process.env.PLATFORM_ASSISTANT_ID?.trim() ||
+      assistantIdRaw?.trim() ||
       undefined;
 
     if (!platformUrl || !authToken || !assistantId) {

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -96,21 +96,22 @@ export class RemoteFeatureFlagSync {
         this.credentials.get(credentialKey("vellum", "assistant_api_key")),
       ]);
 
-    // Fall back to env vars when credential cache values are missing, matching
-    // the daemon's resolvePlatformCallbackRegistrationContext() behaviour.
+    // Fall back to env vars when credential cache values are missing.
     const platformUrl = (
       platformUrlRaw?.trim() ||
       process.env.VELLUM_PLATFORM_URL?.trim() ||
       ""
     ).replace(/\/+$/, "");
 
-    const platformInternalApiKey =
-      process.env.PLATFORM_INTERNAL_API_KEY?.trim() || undefined;
-    const assistantApiKey = !platformInternalApiKey
-      ? assistantApiKeyRaw?.trim() || undefined
+    // Feature flag sync hits the public platform API (/v1/assistants/…), not
+    // an internal gateway endpoint, so prefer Api-Key auth (assistant_api_key)
+    // over Bearer auth (PLATFORM_INTERNAL_API_KEY).
+    const assistantApiKey = assistantApiKeyRaw?.trim() || undefined;
+    const platformInternalApiKey = !assistantApiKey
+      ? process.env.PLATFORM_INTERNAL_API_KEY?.trim() || undefined
       : undefined;
-    const authToken = platformInternalApiKey || assistantApiKey;
-    const authScheme = platformInternalApiKey ? "Bearer" : "Api-Key";
+    const authToken = assistantApiKey || platformInternalApiKey;
+    const authScheme = assistantApiKey ? "Api-Key" : "Bearer";
 
     const assistantId =
       process.env.PLATFORM_ASSISTANT_ID?.trim() ||

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -89,23 +89,39 @@ export class RemoteFeatureFlagSync {
     string,
     boolean
   > | null> {
-    const [platformUrlRaw, assistantIdRaw, platformApiKeyRaw] =
+    const [platformUrlRaw, assistantIdRaw, assistantApiKeyRaw] =
       await Promise.all([
         this.credentials.get(credentialKey("vellum", "platform_base_url")),
         this.credentials.get(credentialKey("vellum", "platform_assistant_id")),
         this.credentials.get(credentialKey("vellum", "assistant_api_key")),
       ]);
 
-    const platformUrl = platformUrlRaw?.trim().replace(/\/+$/, "");
-    const assistantId = assistantIdRaw?.trim();
-    const platformApiKey = platformApiKeyRaw?.trim();
+    // Fall back to env vars when credential cache values are missing, matching
+    // the daemon's resolvePlatformCallbackRegistrationContext() behaviour.
+    const platformUrl = (
+      platformUrlRaw?.trim() ||
+      process.env.VELLUM_PLATFORM_URL?.trim() ||
+      "https://platform.vellum.ai"
+    ).replace(/\/+$/, "");
 
-    if (!platformUrl || !assistantId || !platformApiKey) {
+    const assistantApiKey = assistantApiKeyRaw?.trim() || undefined;
+    const platformInternalApiKey = !assistantApiKey
+      ? process.env.PLATFORM_INTERNAL_API_KEY?.trim()
+      : undefined;
+    const apiKey = assistantApiKey || platformInternalApiKey;
+    const authScheme = assistantApiKey ? "Api-Key" : "Bearer";
+
+    const assistantId =
+      assistantIdRaw?.trim() ||
+      process.env.PLATFORM_ASSISTANT_ID?.trim() ||
+      undefined;
+
+    if (!apiKey || !assistantId) {
       log.debug(
         {
           hasPlatformUrl: !!platformUrl,
+          hasApiKey: !!apiKey,
           hasAssistantId: !!assistantId,
-          hasPlatformApiKey: !!platformApiKey,
         },
         "Remote feature flag sync skipped: missing credentials",
       );
@@ -118,7 +134,7 @@ export class RemoteFeatureFlagSync {
     const response = await fetchImpl(url, {
       method: "GET",
       headers: {
-        Authorization: `Api-Key ${platformApiKey}`,
+        Authorization: `${authScheme} ${apiKey}`,
         Accept: "application/json",
       },
       signal: AbortSignal.timeout(10_000),

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -103,26 +103,21 @@ export class RemoteFeatureFlagSync {
       ""
     ).replace(/\/+$/, "");
 
-    // Feature flag sync hits the public platform API (/v1/assistants/…), not
-    // an internal gateway endpoint, so prefer Api-Key auth (assistant_api_key)
-    // over Bearer auth (PLATFORM_INTERNAL_API_KEY).
+    // Feature flag sync hits the public platform API (/v1/assistants/…),
+    // which requires Api-Key auth. PLATFORM_INTERNAL_API_KEY is only valid
+    // for internal gateway endpoints and would produce 401s here.
     const assistantApiKey = assistantApiKeyRaw?.trim() || undefined;
-    const platformInternalApiKey = !assistantApiKey
-      ? process.env.PLATFORM_INTERNAL_API_KEY?.trim() || undefined
-      : undefined;
-    const authToken = assistantApiKey || platformInternalApiKey;
-    const authScheme = assistantApiKey ? "Api-Key" : "Bearer";
 
     const assistantId =
       process.env.PLATFORM_ASSISTANT_ID?.trim() ||
       assistantIdRaw?.trim() ||
       undefined;
 
-    if (!platformUrl || !authToken || !assistantId) {
+    if (!platformUrl || !assistantApiKey || !assistantId) {
       log.debug(
         {
           hasPlatformUrl: !!platformUrl,
-          hasApiKey: !!authToken,
+          hasApiKey: !!assistantApiKey,
           hasAssistantId: !!assistantId,
         },
         "Remote feature flag sync skipped: missing credentials",
@@ -136,7 +131,7 @@ export class RemoteFeatureFlagSync {
     const response = await fetchImpl(url, {
       method: "GET",
       headers: {
-        Authorization: `${authScheme} ${authToken}`,
+        Authorization: `Api-Key ${assistantApiKey}`,
         Accept: "application/json",
       },
       signal: AbortSignal.timeout(10_000),

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -104,23 +104,24 @@ export class RemoteFeatureFlagSync {
       "https://platform.vellum.ai"
     ).replace(/\/+$/, "");
 
-    const assistantApiKey = assistantApiKeyRaw?.trim() || undefined;
-    const platformInternalApiKey = !assistantApiKey
-      ? process.env.PLATFORM_INTERNAL_API_KEY?.trim()
+    const platformInternalApiKey =
+      process.env.PLATFORM_INTERNAL_API_KEY?.trim() || undefined;
+    const assistantApiKey = !platformInternalApiKey
+      ? assistantApiKeyRaw?.trim() || undefined
       : undefined;
-    const apiKey = assistantApiKey || platformInternalApiKey;
-    const authScheme = assistantApiKey ? "Api-Key" : "Bearer";
+    const authToken = platformInternalApiKey || assistantApiKey;
+    const authScheme = platformInternalApiKey ? "Bearer" : "Api-Key";
 
     const assistantId =
       assistantIdRaw?.trim() ||
       process.env.PLATFORM_ASSISTANT_ID?.trim() ||
       undefined;
 
-    if (!apiKey || !assistantId) {
+    if (!authToken || !assistantId) {
       log.debug(
         {
           hasPlatformUrl: !!platformUrl,
-          hasApiKey: !!apiKey,
+          hasApiKey: !!authToken,
           hasAssistantId: !!assistantId,
         },
         "Remote feature flag sync skipped: missing credentials",
@@ -134,7 +135,7 @@ export class RemoteFeatureFlagSync {
     const response = await fetchImpl(url, {
       method: "GET",
       headers: {
-        Authorization: `${authScheme} ${apiKey}`,
+        Authorization: `${authScheme} ${authToken}`,
         Accept: "application/json",
       },
       signal: AbortSignal.timeout(10_000),

--- a/gateway/src/telegram/webhook-manager.ts
+++ b/gateway/src/telegram/webhook-manager.ts
@@ -48,7 +48,7 @@ async function registerManagedTelegramCallbackRoute(
   const platformBaseUrl = (
     platformBaseUrlRaw?.trim() ||
     process.env.VELLUM_PLATFORM_URL?.trim() ||
-    "https://platform.vellum.ai"
+    ""
   ).replace(/\/+$/, "");
 
   const platformInternalApiKey =
@@ -64,7 +64,7 @@ async function registerManagedTelegramCallbackRoute(
     process.env.PLATFORM_ASSISTANT_ID?.trim() ||
     undefined;
 
-  if (!authToken || !assistantId) {
+  if (!platformBaseUrl || !authToken || !assistantId) {
     log.debug(
       {
         hasPlatformBaseUrl: !!platformBaseUrl,

--- a/gateway/src/telegram/webhook-manager.ts
+++ b/gateway/src/telegram/webhook-manager.ts
@@ -31,24 +31,43 @@ interface PlatformCallbackRouteResponse {
 async function registerManagedTelegramCallbackRoute(
   caches?: WebhookManagerCaches,
 ): Promise<string | undefined> {
-  if (!caches?.credentials) return undefined;
-
+  // Read from credential cache when available
   const [platformBaseUrlRaw, assistantApiKeyRaw, assistantIdRaw] =
-    await Promise.all([
-      caches.credentials.get(credentialKey("vellum", "platform_base_url")),
-      caches.credentials.get(credentialKey("vellum", "assistant_api_key")),
-      caches.credentials.get(credentialKey("vellum", "platform_assistant_id")),
-    ]);
+    caches?.credentials
+      ? await Promise.all([
+          caches.credentials.get(credentialKey("vellum", "platform_base_url")),
+          caches.credentials.get(credentialKey("vellum", "assistant_api_key")),
+          caches.credentials.get(
+            credentialKey("vellum", "platform_assistant_id"),
+          ),
+        ])
+      : [undefined, undefined, undefined];
 
-  const platformBaseUrl = platformBaseUrlRaw?.trim().replace(/\/+$/, "");
-  const assistantApiKey = assistantApiKeyRaw?.trim();
-  const assistantId = assistantIdRaw?.trim();
+  // Fall back to env vars when credential cache values are missing, matching
+  // the daemon's resolvePlatformCallbackRegistrationContext() behaviour.
+  const platformBaseUrl = (
+    platformBaseUrlRaw?.trim() ||
+    process.env.VELLUM_PLATFORM_URL?.trim() ||
+    "https://platform.vellum.ai"
+  ).replace(/\/+$/, "");
 
-  if (!platformBaseUrl || !assistantApiKey || !assistantId) {
+  const assistantApiKey = assistantApiKeyRaw?.trim() || undefined;
+  const platformInternalApiKey = !assistantApiKey
+    ? process.env.PLATFORM_INTERNAL_API_KEY?.trim()
+    : undefined;
+  const apiKey = assistantApiKey || platformInternalApiKey;
+  const authScheme = assistantApiKey ? "Api-Key" : "Bearer";
+
+  const assistantId =
+    assistantIdRaw?.trim() ||
+    process.env.PLATFORM_ASSISTANT_ID?.trim() ||
+    undefined;
+
+  if (!apiKey || !assistantId) {
     log.debug(
       {
         hasPlatformBaseUrl: !!platformBaseUrl,
-        hasAssistantApiKey: !!assistantApiKey,
+        hasApiKey: !!apiKey,
         hasAssistantId: !!assistantId,
       },
       "Managed Telegram callback route registration unavailable",
@@ -61,7 +80,7 @@ async function registerManagedTelegramCallbackRoute(
     {
       method: "POST",
       headers: {
-        Authorization: `Api-Key ${assistantApiKey}`,
+        Authorization: `${authScheme} ${apiKey}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({

--- a/gateway/src/telegram/webhook-manager.ts
+++ b/gateway/src/telegram/webhook-manager.ts
@@ -60,8 +60,8 @@ async function registerManagedTelegramCallbackRoute(
   const authScheme = platformInternalApiKey ? "Bearer" : "Api-Key";
 
   const assistantId =
-    assistantIdRaw?.trim() ||
     process.env.PLATFORM_ASSISTANT_ID?.trim() ||
+    assistantIdRaw?.trim() ||
     undefined;
 
   if (!platformBaseUrl || !authToken || !assistantId) {

--- a/gateway/src/telegram/webhook-manager.ts
+++ b/gateway/src/telegram/webhook-manager.ts
@@ -51,23 +51,24 @@ async function registerManagedTelegramCallbackRoute(
     "https://platform.vellum.ai"
   ).replace(/\/+$/, "");
 
-  const assistantApiKey = assistantApiKeyRaw?.trim() || undefined;
-  const platformInternalApiKey = !assistantApiKey
-    ? process.env.PLATFORM_INTERNAL_API_KEY?.trim()
+  const platformInternalApiKey =
+    process.env.PLATFORM_INTERNAL_API_KEY?.trim() || undefined;
+  const assistantApiKey = !platformInternalApiKey
+    ? assistantApiKeyRaw?.trim() || undefined
     : undefined;
-  const apiKey = assistantApiKey || platformInternalApiKey;
-  const authScheme = assistantApiKey ? "Api-Key" : "Bearer";
+  const authToken = platformInternalApiKey || assistantApiKey;
+  const authScheme = platformInternalApiKey ? "Bearer" : "Api-Key";
 
   const assistantId =
     assistantIdRaw?.trim() ||
     process.env.PLATFORM_ASSISTANT_ID?.trim() ||
     undefined;
 
-  if (!apiKey || !assistantId) {
+  if (!authToken || !assistantId) {
     log.debug(
       {
         hasPlatformBaseUrl: !!platformBaseUrl,
-        hasApiKey: !!apiKey,
+        hasApiKey: !!authToken,
         hasAssistantId: !!assistantId,
       },
       "Managed Telegram callback route registration unavailable",
@@ -80,7 +81,7 @@ async function registerManagedTelegramCallbackRoute(
     {
       method: "POST",
       headers: {
-        Authorization: `${authScheme} ${apiKey}`,
+        Authorization: `${authScheme} ${authToken}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({


### PR DESCRIPTION
## Summary
Platform-hosted assistants report `connected: false` for Telegram when the macOS app is closed because the gateway's webhook manager reads platform credentials exclusively from the credential store with no fallback to environment variables. The daemon's `platform-callback-registration.ts` already has proper env var fallbacks, but the gateway's `webhook-manager.ts` did not.

This PR adds environment variable fallbacks (`VELLUM_PLATFORM_URL`, `PLATFORM_ASSISTANT_ID`, `PLATFORM_INTERNAL_API_KEY`) to the gateway's `registerManagedTelegramCallbackRoute()` so platform-hosted assistants can register Telegram webhooks using env vars provisioned during hatch, without depending on credential store values injected by the macOS app.

## PRs merged into feature branch
- #22958: fix: add env var fallbacks for platform credentials in gateway webhook manager

Part of plan: platform-connected-baseurl.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22959" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
