### PR TITLE
feat: seed capability memories for uninstalled catalog skills (release backport)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.0.0
 info:
   title: Vellum Assistant API
-  version: 0.5.16
+  version: 0.6.0
   description: Auto-generated OpenAPI specification for the Vellum Assistant runtime HTTP server.
 servers:
   - url: http://127.0.0.1:7821

--- a/assistant/src/__tests__/skill-memory.test.ts
+++ b/assistant/src/__tests__/skill-memory.test.ts
@@ -28,6 +28,12 @@ mock.module("../config/skills.js", () => ({
   loadSkillCatalog: (..._args: unknown[]) => mockLoadSkillCatalog(),
 }));
 
+// Mock catalog-cache so the prune guard sees the cache as populated
+mock.module("../skills/catalog-cache.js", () => ({
+  getCachedCatalogSync: () => [],
+  isCatalogCachePopulated: () => true,
+}));
+
 // Controllable mock for isAssistantFeatureFlagEnabled used by resolveSkillStates
 let mockIsFeatureFlagEnabled: (key: string) => boolean = () => true;
 

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -710,6 +710,9 @@ export async function uninstallSkill(
       saveConfigWithSuppression(raw, ctx);
     }
 
+    // Re-seed so the uninstalled catalog skill becomes discoverable for auto-install
+    void seedUninstalledCatalogSkillMemories().catch(() => {});
+
     ctx.broadcast({
       type: "skills_state_changed",
       name: skillId,

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -45,6 +45,7 @@ import {
 import {
   deleteSkillCapabilityMemory,
   seedCatalogSkillMemories,
+  seedUninstalledCatalogSkillMemories,
 } from "../../skills/skill-memory.js";
 import { getWorkspaceSkillsDir } from "../../util/platform.js";
 import {
@@ -482,6 +483,7 @@ export function enableSkill(
       state: "enabled",
     });
     seedCatalogSkillMemories();
+    void seedUninstalledCatalogSkillMemories().catch(() => {});
     return { success: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -577,6 +579,7 @@ export async function installSkill(
         );
       }
       seedCatalogSkillMemories();
+      void seedUninstalledCatalogSkillMemories().catch(() => {});
       return { success: true };
     }
 
@@ -608,6 +611,7 @@ export async function installSkill(
         }
 
         seedCatalogSkillMemories();
+        void seedUninstalledCatalogSkillMemories().catch(() => {});
         return { success: true };
       }
     } catch (err) {
@@ -644,6 +648,7 @@ export async function installSkill(
     }
 
     seedCatalogSkillMemories();
+    void seedUninstalledCatalogSkillMemories().catch(() => {});
     return { success: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -1043,6 +1048,7 @@ export async function createSkill(
     }
 
     seedCatalogSkillMemories();
+    void seedUninstalledCatalogSkillMemories().catch(() => {});
     return { success: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -82,7 +82,10 @@ import {
   setCesClient,
   setCesReconnect,
 } from "../security/secure-keys.js";
-import { seedCatalogSkillMemories } from "../skills/skill-memory.js";
+import {
+  seedCatalogSkillMemories,
+  seedUninstalledCatalogSkillMemories,
+} from "../skills/skill-memory.js";
 import { UsageTelemetryReporter } from "../telemetry/usage-telemetry-reporter.js";
 import { getDeviceId } from "../util/device-id.js";
 import { getLogger, initLogger } from "../util/logger.js";
@@ -649,6 +652,15 @@ export async function runDaemon(): Promise<void> {
       } catch (err) {
         log.warn({ err }, "Catalog skill memory seeding failed — continuing");
       }
+
+      // Seed memories for catalog skills not yet installed so they're
+      // discoverable via memory injection and can be auto-installed.
+      void seedUninstalledCatalogSkillMemories().catch((err) =>
+        log.warn(
+          { err },
+          "Uninstalled catalog skill memory seeding failed — continuing",
+        ),
+      );
 
       try {
         seedCliCommandMemories();

--- a/assistant/src/skills/catalog-cache.ts
+++ b/assistant/src/skills/catalog-cache.ts
@@ -37,6 +37,11 @@ export async function getCatalog(): Promise<CatalogSkill[]> {
   return catalog;
 }
 
+/** Return the cached catalog synchronously, or [] if no cache exists yet. */
+export function getCachedCatalogSync(): CatalogSkill[] {
+  return cachedCatalog ?? [];
+}
+
 /** Invalidate the cache (for testing or forced refresh). */
 export function invalidateCatalogCache(): void {
   cachedCatalog = null;

--- a/assistant/src/skills/catalog-cache.ts
+++ b/assistant/src/skills/catalog-cache.ts
@@ -42,6 +42,11 @@ export function getCachedCatalogSync(): CatalogSkill[] {
   return cachedCatalog ?? [];
 }
 
+/** Whether the catalog cache has been populated at least once. */
+export function isCatalogCachePopulated(): boolean {
+  return cachedCatalog !== null;
+}
+
 /** Invalidate the cache (for testing or forced refresh). */
 export function invalidateCatalogCache(): void {
   cachedCatalog = null;

--- a/assistant/src/skills/skill-memory.ts
+++ b/assistant/src/skills/skill-memory.ts
@@ -10,7 +10,10 @@ import { computeMemoryFingerprint } from "../memory/fingerprint.js";
 import { enqueueMemoryJob } from "../memory/jobs-store.js";
 import { memoryItems } from "../memory/schema.js";
 import { getLogger } from "../util/logger.js";
-import { getCachedCatalogSync } from "./catalog-cache.js";
+import {
+  getCachedCatalogSync,
+  isCatalogCachePopulated,
+} from "./catalog-cache.js";
 import type { CatalogSkill } from "./catalog-install.js";
 
 const log = getLogger("skill-memory");
@@ -264,12 +267,20 @@ export function seedCatalogSkillMemories(): void {
     const cachedCatalogIds = new Set(
       getCachedCatalogSync().map((s) => s.id),
     );
+    // When the catalog cache hasn't been populated yet, skip pruning
+    // uninstalled catalog skill memories to avoid a wasteful
+    // soft-delete → re-create → re-embed cycle on every startup.
+    const cachePopulated = isCatalogCachePopulated();
 
     const now = Date.now();
     for (const item of allCapabilities) {
       if (!item.subject.startsWith("skill:")) continue;
       const itemSkillId = item.subject.replace("skill:", "");
-      if (!catalogIds.has(itemSkillId) && !cachedCatalogIds.has(itemSkillId)) {
+      if (
+        !catalogIds.has(itemSkillId) &&
+        cachePopulated &&
+        !cachedCatalogIds.has(itemSkillId)
+      ) {
         db.update(memoryItems)
           .set({ status: "deleted", lastSeenAt: now })
           .where(eq(memoryItems.id, item.id))

--- a/assistant/src/skills/skill-memory.ts
+++ b/assistant/src/skills/skill-memory.ts
@@ -1,6 +1,7 @@
 import { and, eq } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
 import { resolveSkillStates } from "../config/skill-state.js";
 import { loadSkillCatalog, type SkillSummary } from "../config/skills.js";
@@ -9,6 +10,8 @@ import { computeMemoryFingerprint } from "../memory/fingerprint.js";
 import { enqueueMemoryJob } from "../memory/jobs-store.js";
 import { memoryItems } from "../memory/schema.js";
 import { getLogger } from "../util/logger.js";
+import { getCachedCatalogSync } from "./catalog-cache.js";
+import type { CatalogSkill } from "./catalog-install.js";
 
 const log = getLogger("skill-memory");
 
@@ -36,6 +39,20 @@ export function fromSkillSummary(entry: SkillSummary): SkillCapabilityInput {
     description: entry.description,
     activationHints: entry.activationHints,
     avoidWhen: entry.avoidWhen,
+  };
+}
+
+/**
+ * Convert a CatalogSkill to a SkillCapabilityInput.
+ * CatalogSkill stores display-name and hints inside nested metadata.
+ */
+export function fromCatalogSkill(entry: CatalogSkill): SkillCapabilityInput {
+  return {
+    id: entry.id,
+    displayName: entry.metadata?.vellum?.["display-name"] ?? entry.name,
+    description: entry.description,
+    activationHints: entry.metadata?.vellum?.["activation-hints"],
+    avoidWhen: entry.metadata?.vellum?.["avoid-when"],
   };
 }
 
@@ -244,11 +261,15 @@ export function seedCatalogSkillMemories(): void {
       )
       .all();
 
+    const cachedCatalogIds = new Set(
+      getCachedCatalogSync().map((s) => s.id),
+    );
+
     const now = Date.now();
     for (const item of allCapabilities) {
       if (!item.subject.startsWith("skill:")) continue;
       const itemSkillId = item.subject.replace("skill:", "");
-      if (!catalogIds.has(itemSkillId)) {
+      if (!catalogIds.has(itemSkillId) && !cachedCatalogIds.has(itemSkillId)) {
         db.update(memoryItems)
           .set({ status: "deleted", lastSeenAt: now })
           .where(eq(memoryItems.id, item.id))
@@ -257,5 +278,35 @@ export function seedCatalogSkillMemories(): void {
     }
   } catch (err) {
     log.warn({ err }, "Failed to seed catalog skill memories");
+  }
+}
+
+/**
+ * Seed capability memories for catalog skills that are not yet installed.
+ * This makes uninstalled skills discoverable via memory injection so the LLM
+ * can auto-install them via skill_load when relevant.
+ * Best-effort: errors are logged but never thrown.
+ */
+export async function seedUninstalledCatalogSkillMemories(): Promise<void> {
+  try {
+    const { getCatalog } = await import("./catalog-cache.js");
+    const fullCatalog = await getCatalog();
+    if (fullCatalog.length === 0) return;
+
+    const installedCatalog = loadSkillCatalog();
+    const installedIds = new Set(installedCatalog.map((s) => s.id));
+
+    const config = getConfig();
+    for (const entry of fullCatalog) {
+      if (installedIds.has(entry.id)) continue;
+
+      const flagKey = entry.metadata?.vellum?.["feature-flag"];
+      if (flagKey && !isAssistantFeatureFlagEnabled(flagKey, config)) continue;
+
+      const input = fromCatalogSkill(entry);
+      upsertSkillCapabilityMemory(entry.id, input);
+    }
+  } catch (err) {
+    log.warn({ err }, "Failed to seed uninstalled catalog skill memories");
   }
 }

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -465,6 +465,13 @@
           "display-name": "Telegram Setup",
           "includes": [
             "public-ingress"
+          ],
+          "activation-hints": [
+            "Telegram bot setup, webhook configuration, or BotFather token",
+            "User wants to connect Telegram to the assistant"
+          ],
+          "avoid-when": [
+            "User wants to send/receive Telegram messages (use messaging skill instead)"
           ]
         }
       },

--- a/skills/telegram-setup/SKILL.md
+++ b/skills/telegram-setup/SKILL.md
@@ -8,6 +8,11 @@ metadata:
     display-name: "Telegram Setup"
     includes:
       - public-ingress
+    activation-hints:
+      - "Telegram bot setup, webhook configuration, or BotFather token"
+      - "User wants to connect Telegram to the assistant"
+    avoid-when:
+      - "User wants to send/receive Telegram messages (use messaging skill instead)"
 ---
 
 You are helping your user connect a Telegram bot to the Vellum Assistant gateway. Walk through each step below.


### PR DESCRIPTION
## Summary

- Port of main #22952 + #22954 to `release/v0.6.0`, adapted for the `memoryItems` API (release branch doesn't have the `memoryGraphNodes` graph system)
- Add `seedUninstalledCatalogSkillMemories()` — async function that fetches the full catalog and creates capability memories for skills not yet installed
- Update pruning in `seedCatalogSkillMemories()` to preserve catalog skill memories
- Add `getCachedCatalogSync()` to `catalog-cache.ts` for pruning protection
- Add activation-hints and avoid-when to `telegram-setup` SKILL.md and catalog.json
- Wire up async seeding at daemon startup and after skill install/uninstall/enable/disable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22960" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
