### PR TITLE
fix: invert auth key priority to match daemon — PLATFORM_INTERNAL_API_KEY takes precedence

### DIFF
--- a/gateway/src/__tests__/telegram-webhook-manager.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-manager.test.ts
@@ -437,14 +437,15 @@ describe("reconcileTelegramWebhook", () => {
 
     expect(calls).toHaveLength(3);
     expect(calls[0].method).toBe("registerCallbackRoute");
-    // Should use credential cache values, not env vars
+    // platform_base_url and platform_assistant_id: credential cache takes precedence
     expect(calls[0].body).toEqual({
       assistant_id: "cache-assistant-id",
       callback_path: "webhooks/telegram",
       type: "telegram",
     });
-    // credential cache assistant_api_key uses Api-Key scheme
-    expect(calls[0].headers?.Authorization).toBe("Api-Key cache-api-key");
+    // PLATFORM_INTERNAL_API_KEY (env var, Bearer) takes precedence over
+    // assistant_api_key from credential cache, matching the daemon's behaviour.
+    expect(calls[0].headers?.Authorization).toBe("Bearer env-internal-key");
     // Registration URL should use cache platform URL
     expect((calls[2].body as any).url).toBe(
       "https://cache-platform.example.com/v1/gateway/callbacks/cache-assistant-id/webhooks/telegram/",

--- a/gateway/src/telegram/webhook-manager.ts
+++ b/gateway/src/telegram/webhook-manager.ts
@@ -51,23 +51,24 @@ async function registerManagedTelegramCallbackRoute(
     "https://platform.vellum.ai"
   ).replace(/\/+$/, "");
 
-  const assistantApiKey = assistantApiKeyRaw?.trim() || undefined;
-  const platformInternalApiKey = !assistantApiKey
-    ? process.env.PLATFORM_INTERNAL_API_KEY?.trim()
+  const platformInternalApiKey =
+    process.env.PLATFORM_INTERNAL_API_KEY?.trim() || undefined;
+  const assistantApiKey = !platformInternalApiKey
+    ? assistantApiKeyRaw?.trim() || undefined
     : undefined;
-  const apiKey = assistantApiKey || platformInternalApiKey;
-  const authScheme = assistantApiKey ? "Api-Key" : "Bearer";
+  const authToken = platformInternalApiKey || assistantApiKey;
+  const authScheme = platformInternalApiKey ? "Bearer" : "Api-Key";
 
   const assistantId =
     assistantIdRaw?.trim() ||
     process.env.PLATFORM_ASSISTANT_ID?.trim() ||
     undefined;
 
-  if (!apiKey || !assistantId) {
+  if (!authToken || !assistantId) {
     log.debug(
       {
         hasPlatformBaseUrl: !!platformBaseUrl,
-        hasApiKey: !!apiKey,
+        hasApiKey: !!authToken,
         hasAssistantId: !!assistantId,
       },
       "Managed Telegram callback route registration unavailable",
@@ -80,7 +81,7 @@ async function registerManagedTelegramCallbackRoute(
     {
       method: "POST",
       headers: {
-        Authorization: `${authScheme} ${apiKey}`,
+        Authorization: `${authScheme} ${authToken}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for platform-connected-baseurl.md.

**Gap:** Auth key priority is inverted relative to the daemon
**What was expected:** PLATFORM_INTERNAL_API_KEY (Bearer) should take precedence over assistant_api_key (Api-Key) from credential store, matching the daemon's resolvePlatformCallbackRegistrationContext()
**What was found:** Credential store value was checked first, env var only used as fallback
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22962" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
