### PR TITLE
fix: retry session validation on network errors instead of immediately requiring re-login

### DIFF
--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -65,6 +65,8 @@ public final class AuthManager {
                     state = .unauthenticated
                     return
                 }
+            } catch is CancellationError {
+                return
             } catch {
                 lastError = error
                 log.warning("Session check attempt \(attempt)/3 failed: \(error.localizedDescription, privacy: .public)")

--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -66,13 +66,14 @@ public final class AuthManager {
                     return
                 }
             } catch is CancellationError {
+                state = .unauthenticated
                 return
             } catch {
                 lastError = error
                 log.warning("Session check attempt \(attempt)/3 failed: \(error.localizedDescription, privacy: .public)")
                 if attempt < 3 {
                     try? await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds between retries
-                    guard !Task.isCancelled else { return }
+                    guard !Task.isCancelled else { state = .unauthenticated; return }
                 }
             }
         }

--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -70,6 +70,7 @@ public final class AuthManager {
                 log.warning("Session check attempt \(attempt)/3 failed: \(error.localizedDescription, privacy: .public)")
                 if attempt < 3 {
                     try? await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds between retries
+                    guard !Task.isCancelled else { return }
                 }
             }
         }

--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -53,17 +53,29 @@ public final class AuthManager {
             return
         }
 
-        do {
-            let response = try await authService.getSession()
-            if response.status == 200, response.meta?.is_authenticated != false, let user = response.data?.user {
-                state = .authenticated(user)
-            } else {
-                state = .unauthenticated
+        var lastError: Error?
+        for attempt in 1...3 {
+            do {
+                let response = try await authService.getSession()
+                if response.status == 200, response.meta?.is_authenticated != false, let user = response.data?.user {
+                    state = .authenticated(user)
+                    return
+                } else {
+                    // Server responded but session is invalid — no retry needed
+                    state = .unauthenticated
+                    return
+                }
+            } catch {
+                lastError = error
+                log.warning("Session check attempt \(attempt)/3 failed: \(error.localizedDescription, privacy: .public)")
+                if attempt < 3 {
+                    try? await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds between retries
+                }
             }
-        } catch {
-            log.error("Session check failed: baseURL=\(self.authService.baseURL, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
-            state = .unauthenticated
         }
+        // All retries exhausted — network likely still unavailable
+        log.error("Session check failed after 3 attempts: baseURL=\(self.authService.baseURL, privacy: .public) error=\(lastError?.localizedDescription ?? "unknown", privacy: .public)")
+        state = .unauthenticated
     }
 
     public func startWorkOSLogin() async {


### PR DESCRIPTION
## Summary
- Add retry logic (3 attempts, 2s apart) to AuthManager.checkSession() for network errors
- Server-side rejections (invalid session) still fail immediately without retrying
- Fixes issue where laptop sleep/wake would force re-login on managed assistants due to WiFi not being reconnected yet

Part of plan: managed-reauth-after-sleep.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
