### PR TITLE
fix: invert auth key priority in RemoteFeatureFlagSync to match daemon and webhook-manager

### DIFF
--- a/gateway/src/__tests__/remote-feature-flag-sync.test.ts
+++ b/gateway/src/__tests__/remote-feature-flag-sync.test.ts
@@ -185,7 +185,7 @@ describe("RemoteFeatureFlagSync", () => {
     expect(headers.Authorization).toBe("Bearer internal-key-123");
   });
 
-  test("prefers assistant_api_key over PLATFORM_INTERNAL_API_KEY", async () => {
+  test("prefers PLATFORM_INTERNAL_API_KEY over assistant_api_key", async () => {
     fetchMock = mock(async () => Response.json({ flags: {} }));
     process.env.PLATFORM_INTERNAL_API_KEY = "internal-key-123";
 
@@ -198,7 +198,7 @@ describe("RemoteFeatureFlagSync", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [, init] = fetchMock.mock.calls[0];
     const headers = init?.headers as Record<string, string>;
-    expect(headers.Authorization).toBe("Api-Key test-api-key");
+    expect(headers.Authorization).toBe("Bearer internal-key-123");
   });
 
   test("skips sync when platform_assistant_id is missing and no PLATFORM_ASSISTANT_ID", async () => {

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -104,23 +104,24 @@ export class RemoteFeatureFlagSync {
       "https://platform.vellum.ai"
     ).replace(/\/+$/, "");
 
-    const assistantApiKey = assistantApiKeyRaw?.trim() || undefined;
-    const platformInternalApiKey = !assistantApiKey
-      ? process.env.PLATFORM_INTERNAL_API_KEY?.trim()
+    const platformInternalApiKey =
+      process.env.PLATFORM_INTERNAL_API_KEY?.trim() || undefined;
+    const assistantApiKey = !platformInternalApiKey
+      ? assistantApiKeyRaw?.trim() || undefined
       : undefined;
-    const apiKey = assistantApiKey || platformInternalApiKey;
-    const authScheme = assistantApiKey ? "Api-Key" : "Bearer";
+    const authToken = platformInternalApiKey || assistantApiKey;
+    const authScheme = platformInternalApiKey ? "Bearer" : "Api-Key";
 
     const assistantId =
       assistantIdRaw?.trim() ||
       process.env.PLATFORM_ASSISTANT_ID?.trim() ||
       undefined;
 
-    if (!apiKey || !assistantId) {
+    if (!authToken || !assistantId) {
       log.debug(
         {
           hasPlatformUrl: !!platformUrl,
-          hasApiKey: !!apiKey,
+          hasApiKey: !!authToken,
           hasAssistantId: !!assistantId,
         },
         "Remote feature flag sync skipped: missing credentials",
@@ -134,7 +135,7 @@ export class RemoteFeatureFlagSync {
     const response = await fetchImpl(url, {
       method: "GET",
       headers: {
-        Authorization: `${authScheme} ${apiKey}`,
+        Authorization: `${authScheme} ${authToken}`,
         Accept: "application/json",
       },
       signal: AbortSignal.timeout(10_000),


### PR DESCRIPTION
## Summary
Fixes auth key priority inconsistency in remote-feature-flag-sync.ts.

**Gap:** PLATFORM_INTERNAL_API_KEY (Bearer) should take precedence over assistant_api_key (Api-Key), matching the daemon and webhook-manager
**What was found:** assistant_api_key was checked first, PLATFORM_INTERNAL_API_KEY only used as fallback
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22965" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
