### PR TITLE
fix: remove hardcoded platform URL default — require explicit configuration

### DIFF
--- a/gateway/src/__tests__/remote-feature-flag-sync.test.ts
+++ b/gateway/src/__tests__/remote-feature-flag-sync.test.ts
@@ -114,11 +114,12 @@ afterEach(() => {
 // Tests
 // ---------------------------------------------------------------------------
 describe("RemoteFeatureFlagSync", () => {
-  test("falls back to default platform URL when platform_base_url is missing", async () => {
+  test("skips sync when no platform URL is available from cache or env", async () => {
     fetchMock = mock(async () => Response.json({ flags: { ff1: true } }));
 
     const creds = defaultCredentials();
     delete creds["credential/vellum/platform_base_url"];
+    delete process.env.VELLUM_PLATFORM_URL;
 
     const sync = new RemoteFeatureFlagSync({
       credentials: fakeCredentialCache(creds),
@@ -126,11 +127,8 @@ describe("RemoteFeatureFlagSync", () => {
     await sync.start();
     sync.stop();
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url] = fetchMock.mock.calls[0];
-    expect(url).toBe(
-      "https://platform.vellum.ai/v1/assistants/asst-123/feature-flags/",
-    );
+    // No fetch calls — sync is skipped when platform URL is unavailable
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test("falls back to VELLUM_PLATFORM_URL env var when platform_base_url is missing", async () => {

--- a/gateway/src/__tests__/telegram-webhook-manager.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-manager.test.ts
@@ -457,12 +457,7 @@ describe("reconcileTelegramWebhook", () => {
     delete process.env.PLATFORM_INTERNAL_API_KEY;
   });
 
-  test("uses default platform URL when neither cache nor env var has a value", async () => {
-    const calls: {
-      method: string;
-      body: unknown;
-      headers?: Record<string, string>;
-    }[] = [];
+  test("skips registration when no platform URL is available from cache or env", async () => {
     process.env.IS_CONTAINERIZED = "true";
     process.env.PLATFORM_ASSISTANT_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
     process.env.PLATFORM_INTERNAL_API_KEY = "internal-key-from-env";
@@ -475,58 +470,12 @@ describe("reconcileTelegramWebhook", () => {
       platformAssistantId: undefined,
     });
 
-    fetchMock = mock(
-      async (input: string | URL | Request, init?: RequestInit) => {
-        const url =
-          typeof input === "string"
-            ? input
-            : input instanceof URL
-              ? input.toString()
-              : input.url;
-        if (url.includes("/callback-routes/register/")) {
-          const body = init?.body ? JSON.parse(init.body as string) : null;
-          const headers = init?.headers as Record<string, string>;
-          calls.push({ method: "registerCallbackRoute", body, headers });
-          return new Response(
-            JSON.stringify({
-              callback_url:
-                "https://platform.vellum.ai/v1/gateway/callbacks/aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee/webhooks/telegram/",
-            }),
-            {
-              status: 201,
-              headers: { "content-type": "application/json" },
-            },
-          );
-        }
-        if (url.includes("/getWebhookInfo")) {
-          calls.push({ method: "getWebhookInfo", body: null });
-          return makeTelegramResponse({
-            url: "",
-            has_custom_certificate: false,
-            pending_update_count: 0,
-          });
-        }
-        if (url.includes("/setWebhook")) {
-          const body = init?.body ? JSON.parse(init.body as string) : null;
-          calls.push({ method: "setWebhook", body });
-          return makeTelegramResponse(true);
-        }
-        return new Response("Not found", { status: 404 });
-      },
-    );
+    fetchMock = mock(async () => new Response("", { status: 200 }));
 
     await reconcileTelegramWebhook(caches);
 
-    expect(calls).toHaveLength(3);
-    expect(calls[0].method).toBe("registerCallbackRoute");
-    // Should use Bearer auth with internal key
-    expect(calls[0].headers?.Authorization).toBe(
-      "Bearer internal-key-from-env",
-    );
-    // Registration should hit the default platform URL
-    expect((calls[2].body as any).url).toBe(
-      "https://platform.vellum.ai/v1/gateway/callbacks/aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee/webhooks/telegram/",
-    );
+    // No fetch calls should be made — registration is skipped
+    expect(fetchMock).not.toHaveBeenCalled();
 
     delete process.env.IS_CONTAINERIZED;
     delete process.env.PLATFORM_ASSISTANT_ID;

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -101,7 +101,7 @@ export class RemoteFeatureFlagSync {
     const platformUrl = (
       platformUrlRaw?.trim() ||
       process.env.VELLUM_PLATFORM_URL?.trim() ||
-      "https://platform.vellum.ai"
+      ""
     ).replace(/\/+$/, "");
 
     const platformInternalApiKey =
@@ -117,7 +117,7 @@ export class RemoteFeatureFlagSync {
       process.env.PLATFORM_ASSISTANT_ID?.trim() ||
       undefined;
 
-    if (!authToken || !assistantId) {
+    if (!platformUrl || !authToken || !assistantId) {
       log.debug(
         {
           hasPlatformUrl: !!platformUrl,

--- a/gateway/src/telegram/webhook-manager.ts
+++ b/gateway/src/telegram/webhook-manager.ts
@@ -48,7 +48,7 @@ async function registerManagedTelegramCallbackRoute(
   const platformBaseUrl = (
     platformBaseUrlRaw?.trim() ||
     process.env.VELLUM_PLATFORM_URL?.trim() ||
-    "https://platform.vellum.ai"
+    ""
   ).replace(/\/+$/, "");
 
   const platformInternalApiKey =
@@ -64,7 +64,7 @@ async function registerManagedTelegramCallbackRoute(
     process.env.PLATFORM_ASSISTANT_ID?.trim() ||
     undefined;
 
-  if (!authToken || !assistantId) {
+  if (!platformBaseUrl || !authToken || !assistantId) {
     log.debug(
       {
         hasPlatformBaseUrl: !!platformBaseUrl,


### PR DESCRIPTION
## Summary
Removes the hardcoded https://platform.vellum.ai default from the gateway webhook manager and feature flag sync. When no platform URL is available from the credential cache or VELLUM_PLATFORM_URL env var, the functions now bail out instead of silently targeting production. This prevents dev environments from accidentally registering callbacks against the production platform.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22967" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
