### PR TITLE
fix: retry session validation on network errors instead of immediately requiring re-login

### DIFF
--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -55,6 +55,7 @@ public final class AuthManager {
 
         var lastError: Error?
         for attempt in 1...3 {
+            guard !Task.isCancelled else { state = .unauthenticated; return }
             do {
                 let response = try await authService.getSession()
                 if response.status == 200, response.meta?.is_authenticated != false, let user = response.data?.user {
@@ -69,6 +70,10 @@ public final class AuthManager {
                 state = .unauthenticated
                 return
             } catch {
+                if Task.isCancelled {
+                    state = .unauthenticated
+                    return
+                }
                 lastError = error
                 log.warning("Session check attempt \(attempt)/3 failed: \(error.localizedDescription, privacy: .public)")
                 if attempt < 3 {

--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -57,7 +57,7 @@ public final class AuthManager {
         for attempt in 1...3 {
             guard !Task.isCancelled else { state = .unauthenticated; return }
             do {
-                let response = try await authService.getSession()
+                let response = try await authService.getSession(timeout: 10)
                 if response.status == 200, response.meta?.is_authenticated != false, let user = response.data?.user {
                     state = .authenticated(user)
                     return

--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -53,17 +53,33 @@ public final class AuthManager {
             return
         }
 
-        do {
-            let response = try await authService.getSession()
-            if response.status == 200, response.meta?.is_authenticated != false, let user = response.data?.user {
-                state = .authenticated(user)
-            } else {
+        var lastError: Error?
+        for attempt in 1...3 {
+            do {
+                let response = try await authService.getSession()
+                if response.status == 200, response.meta?.is_authenticated != false, let user = response.data?.user {
+                    state = .authenticated(user)
+                    return
+                } else {
+                    // Server responded but session is invalid — no retry needed
+                    state = .unauthenticated
+                    return
+                }
+            } catch is CancellationError {
                 state = .unauthenticated
+                return
+            } catch {
+                lastError = error
+                log.warning("Session check attempt \(attempt)/3 failed: \(error.localizedDescription, privacy: .public)")
+                if attempt < 3 {
+                    try? await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds between retries
+                    guard !Task.isCancelled else { state = .unauthenticated; return }
+                }
             }
-        } catch {
-            log.error("Session check failed: baseURL=\(self.authService.baseURL, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
-            state = .unauthenticated
         }
+        // All retries exhausted — network likely still unavailable
+        log.error("Session check failed after 3 attempts: baseURL=\(self.authService.baseURL, privacy: .public) error=\(lastError?.localizedDescription ?? "unknown", privacy: .public)")
+        state = .unauthenticated
     }
 
     public func startWorkOSLogin() async {

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -65,19 +65,22 @@ public final class AuthService {
         let body: Any?
         let headers: [String: String]
         let retryAfterSession410: Bool
+        let timeoutInterval: TimeInterval?
 
         init(
             path: String,
             method: String = "GET",
             body: Any? = nil,
             headers: [String: String] = [:],
-            retryAfterSession410: Bool = false
+            retryAfterSession410: Bool = false,
+            timeoutInterval: TimeInterval? = nil
         ) {
             self.path = path
             self.method = method
             self.body = body
             self.headers = headers
             self.retryAfterSession410 = retryAfterSession410
+            self.timeoutInterval = timeoutInterval
         }
     }
 
@@ -95,8 +98,8 @@ public final class AuthService {
         try await request(AuthRequestConfig(path: "config", retryAfterSession410: true))
     }
 
-    public func getSession() async throws -> AllauthResponse<SessionData> {
-        try await request(AuthRequestConfig(path: "auth/session"))
+    public func getSession(timeout: TimeInterval? = nil) async throws -> AllauthResponse<SessionData> {
+        try await request(AuthRequestConfig(path: "auth/session", timeoutInterval: timeout))
     }
 
     public func logout() async throws -> AllauthResponse<EmptyData> {
@@ -666,6 +669,9 @@ public final class AuthService {
 
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = requestConfig.method
+        if let timeout = requestConfig.timeoutInterval {
+            urlRequest.timeoutInterval = timeout
+        }
         urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
 


### PR DESCRIPTION
## Summary
When a user closes their laptop and reopens the macOS app defaulting to a managed (platform) assistant, they were forced to re-login even though their session token still existed on disk. The root cause was that `checkSession()` made a single network call to validate the session, and if the network wasn't ready yet (WiFi reconnecting after wake), the network error was treated identically to an invalid session.

This adds retry logic (3 attempts, 2 seconds apart) to `AuthManager.checkSession()` so WiFi has time to reconnect after wake. Server-side rejections (invalid session) still fail immediately — only network errors trigger retries. Task cancellation is handled correctly to prevent stale state.

## PRs merged into feature branch
- #22963: fix: retry session validation on network errors instead of immediately requiring re-login

Part of plan: managed-reauth-after-sleep.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22968" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
