### PR TITLE
fix: prefer Api-Key auth for feature flag sync (public API endpoint)

### DIFF
--- a/gateway/src/__tests__/remote-feature-flag-sync.test.ts
+++ b/gateway/src/__tests__/remote-feature-flag-sync.test.ts
@@ -183,7 +183,7 @@ describe("RemoteFeatureFlagSync", () => {
     expect(headers.Authorization).toBe("Bearer internal-key-123");
   });
 
-  test("prefers PLATFORM_INTERNAL_API_KEY over assistant_api_key", async () => {
+  test("prefers assistant_api_key over PLATFORM_INTERNAL_API_KEY for public API", async () => {
     fetchMock = mock(async () => Response.json({ flags: {} }));
     process.env.PLATFORM_INTERNAL_API_KEY = "internal-key-123";
 
@@ -196,7 +196,9 @@ describe("RemoteFeatureFlagSync", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [, init] = fetchMock.mock.calls[0];
     const headers = init?.headers as Record<string, string>;
-    expect(headers.Authorization).toBe("Bearer internal-key-123");
+    // Feature flag sync hits the public platform API, so Api-Key auth
+    // (assistant_api_key) takes precedence over Bearer (internal key).
+    expect(headers.Authorization).toBe("Api-Key test-api-key");
   });
 
   test("skips sync when platform_assistant_id is missing and no PLATFORM_ASSISTANT_ID", async () => {

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -96,21 +96,22 @@ export class RemoteFeatureFlagSync {
         this.credentials.get(credentialKey("vellum", "assistant_api_key")),
       ]);
 
-    // Fall back to env vars when credential cache values are missing, matching
-    // the daemon's resolvePlatformCallbackRegistrationContext() behaviour.
+    // Fall back to env vars when credential cache values are missing.
     const platformUrl = (
       platformUrlRaw?.trim() ||
       process.env.VELLUM_PLATFORM_URL?.trim() ||
       ""
     ).replace(/\/+$/, "");
 
-    const platformInternalApiKey =
-      process.env.PLATFORM_INTERNAL_API_KEY?.trim() || undefined;
-    const assistantApiKey = !platformInternalApiKey
-      ? assistantApiKeyRaw?.trim() || undefined
+    // Feature flag sync hits the public platform API (/v1/assistants/…), not
+    // an internal gateway endpoint, so prefer Api-Key auth (assistant_api_key)
+    // over Bearer auth (PLATFORM_INTERNAL_API_KEY).
+    const assistantApiKey = assistantApiKeyRaw?.trim() || undefined;
+    const platformInternalApiKey = !assistantApiKey
+      ? process.env.PLATFORM_INTERNAL_API_KEY?.trim() || undefined
       : undefined;
-    const authToken = platformInternalApiKey || assistantApiKey;
-    const authScheme = platformInternalApiKey ? "Bearer" : "Api-Key";
+    const authToken = assistantApiKey || platformInternalApiKey;
+    const authScheme = assistantApiKey ? "Api-Key" : "Bearer";
 
     const assistantId =
       process.env.PLATFORM_ASSISTANT_ID?.trim() ||


### PR DESCRIPTION
## Summary
Feature flag sync hits the public platform API (/v1/assistants/{id}/feature-flags/), not an internal gateway endpoint. Api-Key auth (assistant_api_key) should take precedence over Bearer auth (PLATFORM_INTERNAL_API_KEY) here, unlike webhook-manager which calls the internal callback route registration endpoint.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22972" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
