### PR TITLE
refactor: replace skill.state usage with skill.status in iOS views, remove compat alias

### DIFF
--- a/clients/ios/Views/Intelligence/InstalledSkillsView.swift
+++ b/clients/ios/Views/Intelligence/InstalledSkillsView.swift
@@ -50,7 +50,7 @@ struct InstalledSkillsView: View {
                     skillRow(skill)
                 }
                 .swipeActions(edge: .leading) {
-                    if skill.state == "enabled" {
+                    if skill.status == "enabled" {
                         Button {
                             skillsStore.disableSkill(name: skill.name)
                         } label: {
@@ -93,7 +93,7 @@ struct InstalledSkillsView: View {
                         .font(VFont.bodyMediumLighter)
                         .foregroundStyle(VColor.contentDefault)
 
-                    stateBadge(skill.state)
+                    stateBadge(skill.status)
                 }
 
                 if !skill.description.isEmpty {
@@ -109,7 +109,7 @@ struct InstalledSkillsView: View {
         }
         .padding(.vertical, 2)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("Skill: \(skill.name), \(skill.state)")
+        .accessibilityLabel("Skill: \(skill.name), \(skill.status)")
         .accessibilityHint("Opens skill details")
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -311,7 +311,7 @@ struct IdentityPanel: View {
         Task {
             let response = await SkillsClient().fetchSkillsList(includeCatalog: false)
             if let response {
-                let enabled = response.skills.filter { $0.state == "enabled" }
+                let enabled = response.skills.filter { $0.status == "enabled" }
                 skills = enabled
                 var map: [String: SkillCategory] = [:]
                 map.reserveCapacity(enabled.count)

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -926,9 +926,6 @@ extension SkillsListResponseSkill {
 
     /// Reads emoji from the `vellum` sub-object for display.
     public var emoji: String? { vellum?.emoji }
-
-    /// Alias for `status` — used by views that reference `state`.
-    public var state: String { status }
 }
 
 /// Response containing the list of available skills.


### PR DESCRIPTION
## Summary
- Replace three skill.state references with skill.status in InstalledSkillsView.swift
- Replace skill.state reference with skill.status in IdentityPanel.swift (macOS)
- Remove the state computed property compat alias from SkillsListResponseSkill extension

Part of plan: skills-api-final-cleanup.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22973" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
