### PR TITLE
refactor: remove .integrity.json write fallback, keep read-only for migration compat

### DIFF
--- a/assistant/src/__tests__/clawhub.test.ts
+++ b/assistant/src/__tests__/clawhub.test.ts
@@ -1,4 +1,10 @@
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 import { mock } from "bun:test";
@@ -15,9 +21,9 @@ mock.module("../util/logger.js", () => ({
 import {
   clawhubInspect,
   clawhubInstall,
-  loadIntegrityManifest,
   verifyAndRecordSkillHash,
 } from "../skills/clawhub.js";
+import type { SkillInstallMeta } from "../skills/install-meta.js";
 
 // ---------------------------------------------------------------------------
 // Slug validation (exercised through public API)
@@ -92,15 +98,20 @@ describe("clawhubInspect slug validation", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Integrity manifest edge cases — tested via verifyAndRecordSkillHash
-// which is the code path that reads/writes the manifest.
+// Content hash verification — tested via verifyAndRecordSkillHash
+// which reads legacy .integrity.json but always writes to install-meta.json.
 // ---------------------------------------------------------------------------
 
-describe("integrity manifest", () => {
+describe("content hash verification", () => {
   function createSkillFiles(slug: string): void {
     const skillDir = join(TEST_DIR, "skills", slug);
     mkdirSync(skillDir, { recursive: true });
     writeFileSync(join(skillDir, "SKILL.md"), "# Test Skill\n", "utf-8");
+  }
+
+  function readSkillInstallMeta(slug: string): SkillInstallMeta {
+    const metaPath = join(TEST_DIR, "skills", slug, "install-meta.json");
+    return JSON.parse(readFileSync(metaPath, "utf-8")) as SkillInstallMeta;
   }
 
   test("malformed integrity JSON is handled gracefully", () => {
@@ -109,41 +120,43 @@ describe("integrity manifest", () => {
     writeFileSync(integrityPath, "{not valid json!!!", "utf-8");
     createSkillFiles("valid-slug");
 
-    // Should not throw — malformed manifest is replaced with a fresh one
+    // Should not throw — malformed legacy manifest is ignored; install-meta.json is created
     verifyAndRecordSkillHash("valid-slug");
 
-    // Manifest should now contain a valid entry
-    const manifest = loadIntegrityManifest();
-    expect(manifest["valid-slug"]).toBeDefined();
-    expect(manifest["valid-slug"].sha256).toMatch(/^v2:[0-9a-f]{64}$/);
+    // install-meta.json should now contain a valid hash
+    const meta = readSkillInstallMeta("valid-slug");
+    expect(meta.contentHash).toMatch(/^v2:[0-9a-f]{64}$/);
+    expect(meta.origin).toBe("clawhub");
+    expect(meta.slug).toBe("valid-slug");
   });
 
-  test("missing integrity manifest is created on first install", () => {
+  test("install-meta.json is created on first hash verification for skills without one", () => {
     const skillsDir = join(TEST_DIR, "skills");
     mkdirSync(skillsDir, { recursive: true });
-    const integrityPath = join(skillsDir, ".integrity.json");
-    // Remove any manifest left by earlier tests so we test the fresh-creation path
-    rmSync(integrityPath, { force: true });
-    expect(existsSync(integrityPath)).toBe(false);
     createSkillFiles("new-skill");
+    const metaPath = join(skillsDir, "new-skill", "install-meta.json");
+    // Remove any install-meta left by earlier tests
+    rmSync(metaPath, { force: true });
+    expect(existsSync(metaPath)).toBe(false);
 
     verifyAndRecordSkillHash("new-skill");
 
-    // Manifest should now exist with the skill's hash
-    expect(existsSync(integrityPath)).toBe(true);
-    const manifest = loadIntegrityManifest();
-    expect(manifest["new-skill"]).toBeDefined();
-    expect(manifest["new-skill"].sha256).toMatch(/^v2:[0-9a-f]{64}$/);
+    // install-meta.json should now exist with the skill's hash
+    expect(existsSync(metaPath)).toBe(true);
+    const meta = readSkillInstallMeta("new-skill");
+    expect(meta.contentHash).toMatch(/^v2:[0-9a-f]{64}$/);
+    expect(meta.origin).toBe("clawhub");
+    expect(meta.slug).toBe("new-skill");
   });
 
   test("re-install with same content preserves hash", () => {
     createSkillFiles("stable-skill");
 
     verifyAndRecordSkillHash("stable-skill");
-    const first = loadIntegrityManifest()["stable-skill"].sha256;
+    const first = readSkillInstallMeta("stable-skill").contentHash;
 
     verifyAndRecordSkillHash("stable-skill");
-    const second = loadIntegrityManifest()["stable-skill"].sha256;
+    const second = readSkillInstallMeta("stable-skill").contentHash;
 
     expect(first).toBe(second);
   });
@@ -151,7 +164,7 @@ describe("integrity manifest", () => {
   test("re-install with changed content updates hash", () => {
     createSkillFiles("changing-skill");
     verifyAndRecordSkillHash("changing-skill");
-    const first = loadIntegrityManifest()["changing-skill"].sha256;
+    const first = readSkillInstallMeta("changing-skill").contentHash;
 
     // Modify skill content
     writeFileSync(
@@ -160,8 +173,25 @@ describe("integrity manifest", () => {
       "utf-8",
     );
     verifyAndRecordSkillHash("changing-skill");
-    const second = loadIntegrityManifest()["changing-skill"].sha256;
+    const second = readSkillInstallMeta("changing-skill").contentHash;
 
     expect(first).not.toBe(second);
+  });
+
+  test(".integrity.json is never written to", () => {
+    const skillsDir = join(TEST_DIR, "skills");
+    mkdirSync(skillsDir, { recursive: true });
+    const integrityPath = join(skillsDir, ".integrity.json");
+    // Remove any legacy manifest
+    rmSync(integrityPath, { force: true });
+    createSkillFiles("no-integrity-write");
+
+    verifyAndRecordSkillHash("no-integrity-write");
+
+    // .integrity.json should NOT have been created
+    expect(existsSync(integrityPath)).toBe(false);
+    // But install-meta.json should exist
+    const metaPath = join(skillsDir, "no-integrity-write", "install-meta.json");
+    expect(existsSync(metaPath)).toBe(true);
   });
 });

--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 import { getLogger } from "../util/logger.js";
@@ -53,22 +53,15 @@ export function loadIntegrityManifest(): IntegrityManifest {
   }
 }
 
-function saveIntegrityManifest(manifest: IntegrityManifest): void {
-  writeFileSync(
-    getIntegrityPath(),
-    JSON.stringify(manifest, null, 2) + "\n",
-    "utf-8",
-  );
-}
-
 /**
  * Record or verify the content hash of an installed skill.
  * On first install: stores the hash (trust-on-first-use).
  * On subsequent installs: compares with stored hash and warns on mismatch.
  *
- * Reads/writes `contentHash` from `install-meta.json` when available,
- * falling back to the legacy `.integrity.json` manifest for skills that
- * haven't been migrated yet.
+ * Always writes to `install-meta.json`. For skills that don't have one yet,
+ * creates a new `install-meta.json` with minimal metadata. Reads from the
+ * legacy `.integrity.json` manifest as a read-only fallback for stored hashes
+ * from skills that haven't been migrated yet.
  */
 export function verifyAndRecordSkillHash(slug: string): void {
   const skillDir = join(getManagedSkillsDir(), slug);
@@ -126,13 +119,17 @@ export function verifyAndRecordSkillHash(slug: string): void {
     );
   }
 
-  // Write to install-meta.json if it exists (preferred), otherwise legacy manifest
+  // Write to install-meta.json (preferred). If no install-meta exists yet,
+  // create one with minimal metadata rather than falling back to .integrity.json.
   if (installMeta) {
     writeInstallMeta(skillDir, { ...installMeta, contentHash: hash });
   } else {
-    const manifest = loadIntegrityManifest();
-    manifest[slug] = { sha256: hash, installedAt: new Date().toISOString() };
-    saveIntegrityManifest(manifest);
+    writeInstallMeta(skillDir, {
+      origin: "clawhub",
+      installedAt: new Date().toISOString(),
+      slug,
+      contentHash: hash,
+    });
   }
 }
 

--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -120,7 +120,7 @@ export function verifyAndRecordSkillHash(slug: string): void {
   }
 
   // Write to install-meta.json (preferred). If no install-meta exists yet,
-  // create one with minimal metadata rather than falling back to .integrity.json.
+  // create one with minimal metadata.
   if (installMeta) {
     writeInstallMeta(skillDir, { ...installMeta, contentHash: hash });
   } else {


### PR DESCRIPTION
## Summary
- Remove the else branch in verifyAndRecordSkillHash() that writes to .integrity.json
- Create install-meta.json instead for edge-case skills without one
- Remove saveIntegrityManifest() function (no longer called)
- Update tests to expect install-meta.json writes instead of .integrity.json

Part of plan: skills-api-final-cleanup.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22974" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
