### PR TITLE
M1: Remove show-background-conversations flag and all references

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Drawers.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Drawers.swift
@@ -153,7 +153,6 @@ extension MainWindowView {
                 windowState: windowState,
                 sidebar: sidebar,
                 customGroupsEnabled: assistantFeatureFlagStore.isEnabled("conversation-groups-ui"),
-                backgroundEnabled: assistantFeatureFlagStore.isEnabled("show-background-conversations"),
                 selectConversation: { selectConversation($0) },
                 onDismiss: { showConversationSwitcher = false }
             )

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -240,18 +240,14 @@ extension MainWindowView {
             }
 
             let customGroupsEnabled = assistantFeatureFlagStore.isEnabled("conversation-groups-ui")
-            let backgroundEnabled = assistantFeatureFlagStore.isEnabled("show-background-conversations")
             let groupEntries: [SidebarGroupEntry] = {
                 let raw = conversationManager.groupedConversations
                 var entries: [SidebarGroupEntry] = []
                 var extraUngrouped: [ConversationModel] = []
                 for entry in raw {
                     if let group = entry.group {
-                        // Hide Background group when its flag is off
-                        if group.id == ConversationGroup.background.id && !backgroundEnabled {
-                            extraUngrouped.append(contentsOf: entry.conversations)
                         // Hide custom groups when custom groups flag is off
-                        } else if !group.isSystemGroup && !customGroupsEnabled {
+                        if !group.isSystemGroup && !customGroupsEnabled {
                             extraUngrouped.append(contentsOf: entry.conversations)
                         } else {
                             entries.append(SidebarGroupEntry(id: group.id, group: group, conversations: entry.conversations))

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
@@ -6,7 +6,6 @@ struct ConversationSwitcherDrawer: View {
     @ObservedObject var windowState: MainWindowState
     var sidebar: SidebarInteractionState
     var customGroupsEnabled: Bool = false
-    var backgroundEnabled: Bool = false
     let selectConversation: (ConversationModel) -> Void
     let onDismiss: () -> Void
 
@@ -26,9 +25,7 @@ struct ConversationSwitcherDrawer: View {
         var extraUngrouped: [ConversationModel] = []
         for entry in raw {
             if let group = entry.group {
-                if group.id == ConversationGroup.background.id && !backgroundEnabled {
-                    extraUngrouped.append(contentsOf: entry.conversations)
-                } else if !group.isSystemGroup && !customGroupsEnabled {
+                if !group.isSystemGroup && !customGroupsEnabled {
                     extraUngrouped.append(contentsOf: entry.conversations)
                 } else {
                     entries.append(entry)

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -234,14 +234,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "show-background-conversations",
-      "scope": "assistant",
-      "key": "show-background-conversations",
-      "label": "Show Background Conversations",
-      "description": "Include background conversations (heartbeat, tasks) in the sidebar conversation list",
-      "defaultEnabled": false
-    },
-    {
       "id": "voice-mode",
       "scope": "assistant",
       "key": "voice-mode",


### PR DESCRIPTION
## Summary
- Remove the `show-background-conversations` feature flag entry from `feature-flag-registry.json`
- Remove all conditional checks gating Background group visibility in the sidebar and conversation switcher drawer
- Background conversations are now always visible (treated like Pinned and Scheduled groups)

Closes #22977.

## Test plan
- [ ] Verify Background conversations group appears in the expanded sidebar without needing any feature flag
- [ ] Verify Background conversations appear in the collapsed sidebar's conversation switcher drawer
- [ ] Verify no references to `show-background-conversations` or `backgroundEnabled` remain in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
