### PR TITLE
Remove show-background-conversations feature flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Drawers.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Drawers.swift
@@ -153,7 +153,6 @@ extension MainWindowView {
                 windowState: windowState,
                 sidebar: sidebar,
                 customGroupsEnabled: assistantFeatureFlagStore.isEnabled("conversation-groups-ui"),
-                backgroundEnabled: assistantFeatureFlagStore.isEnabled("show-background-conversations"),
                 selectConversation: { selectConversation($0) },
                 onDismiss: { showConversationSwitcher = false }
             )

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -240,18 +240,14 @@ extension MainWindowView {
             }
 
             let customGroupsEnabled = assistantFeatureFlagStore.isEnabled("conversation-groups-ui")
-            let backgroundEnabled = assistantFeatureFlagStore.isEnabled("show-background-conversations")
             let groupEntries: [SidebarGroupEntry] = {
                 let raw = conversationManager.groupedConversations
                 var entries: [SidebarGroupEntry] = []
                 var extraUngrouped: [ConversationModel] = []
                 for entry in raw {
                     if let group = entry.group {
-                        // Hide Background group when its flag is off
-                        if group.id == ConversationGroup.background.id && !backgroundEnabled {
-                            extraUngrouped.append(contentsOf: entry.conversations)
                         // Hide custom groups when custom groups flag is off
-                        } else if !group.isSystemGroup && !customGroupsEnabled {
+                        if !group.isSystemGroup && !customGroupsEnabled {
                             extraUngrouped.append(contentsOf: entry.conversations)
                         } else {
                             entries.append(SidebarGroupEntry(id: group.id, group: group, conversations: entry.conversations))

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
@@ -6,7 +6,6 @@ struct ConversationSwitcherDrawer: View {
     @ObservedObject var windowState: MainWindowState
     var sidebar: SidebarInteractionState
     var customGroupsEnabled: Bool = false
-    var backgroundEnabled: Bool = false
     let selectConversation: (ConversationModel) -> Void
     let onDismiss: () -> Void
 
@@ -26,9 +25,7 @@ struct ConversationSwitcherDrawer: View {
         var extraUngrouped: [ConversationModel] = []
         for entry in raw {
             if let group = entry.group {
-                if group.id == ConversationGroup.background.id && !backgroundEnabled {
-                    extraUngrouped.append(contentsOf: entry.conversations)
-                } else if !group.isSystemGroup && !customGroupsEnabled {
+                if !group.isSystemGroup && !customGroupsEnabled {
                     extraUngrouped.append(contentsOf: entry.conversations)
                 } else {
                     entries.append(entry)

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -234,14 +234,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "show-background-conversations",
-      "scope": "assistant",
-      "key": "show-background-conversations",
-      "label": "Show Background Conversations",
-      "description": "Include background conversations (heartbeat, tasks) in the sidebar conversation list",
-      "defaultEnabled": false
-    },
-    {
       "id": "voice-mode",
       "scope": "assistant",
       "key": "voice-mode",


### PR DESCRIPTION
## Summary
Removes the `show-background-conversations` feature flag and all conditional checks that gate Background group visibility. Background conversations are now always visible in the sidebar.

## Changes
- Removed flag entry from `meta/feature-flags/feature-flag-registry.json`
- Removed `backgroundEnabled` checks from `MainWindowView+Sidebar.swift`, `MainWindowView+Drawers.swift`, `ConversationSwitcherDrawer.swift`
- 4 files changed, 2 insertions, 18 deletions

## Milestone PRs (merged into feature branch)
- #22978: M1: Remove show-background-conversations flag and all references

## Project issue
Closes #22976

## Test plan
- [ ] Verify Background group is always visible in sidebar without enabling any flag
- [ ] Verify Scheduled and Pinned groups still work correctly
- [ ] Verify conversation switcher drawer also shows Background group
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
