### PR TITLE
feat: fix feature flag persistence for managed assistants

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -618,6 +618,7 @@ extension AppDelegate {
         SentryDeviceInfo.updateUserTag(nil)
         UserDefaults.standard.removeObject(forKey: "lastActivePanel")
         UserDefaults.standard.removeObject(forKey: "managedServiceModesInitialized")
+        AssistantFeatureFlagResolver.clearCachedFlags()
 
         connectionManager.disconnect()
         actorTokenBootstrapTask?.cancel()

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -464,6 +464,11 @@ extension AppDelegate {
         //    UserDefaults so the assistant can initialize its LLM providers.
         syncApiKeysToAssistant(assistant)
 
+        // Clear the UserDefaults feature-flag cache before reloading so
+        // that stale cached values from the previous assistant do not
+        // override the new assistant's remote/persisted flags.
+        AssistantFeatureFlagResolver.clearCachedFlags()
+
         // Reload cached feature flags so SoundManager reads the new
         // assistant's resolved values instead of stale ones from the
         // previous assistant (the resolver reads instance-aware paths

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -47,11 +47,14 @@ extension AppDelegate {
         // If the assistant changed (e.g. user hatched a new one via CLI),
         // clear the stale actor token so ensureActorCredentials() triggers
         // a fresh bootstrap against the new assistant's JWT secret.
-        if let storedId, storedId != assistant.assistantId, ActorTokenManager.hasToken {
+        if let storedId, storedId != assistant.assistantId {
             log.info("Assistant changed from \(storedId, privacy: .public) to \(assistant.assistantId, privacy: .public) — clearing stale actor token")
-            actorTokenBootstrapTask?.cancel()
-            actorTokenBootstrapTask = nil
-            ActorTokenManager.deleteToken()
+            if ActorTokenManager.hasToken {
+                actorTokenBootstrapTask?.cancel()
+                actorTokenBootstrapTask = nil
+                ActorTokenManager.deleteToken()
+            }
+            AssistantFeatureFlagResolver.clearCachedFlags()
         }
 
         UserDefaults.standard.set(assistant.assistantId, forKey: "connectedAssistantId")

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -55,6 +55,7 @@ extension AppDelegate {
                 ActorTokenManager.deleteToken()
             }
             AssistantFeatureFlagResolver.clearCachedFlags()
+            featureFlagStore.reloadFromDisk()
         }
 
         UserDefaults.standard.set(assistant.assistantId, forKey: "connectedAssistantId")

--- a/clients/macos/vellum-assistant/App/ManagedAssistantConnectionCoordinator.swift
+++ b/clients/macos/vellum-assistant/App/ManagedAssistantConnectionCoordinator.swift
@@ -121,6 +121,10 @@ final class ManagedAssistantConnectionCoordinator {
         }
         userDefaults.set(true, forKey: "tosAccepted")
 
+        // Clear stale cached feature flags from any previous assistant so the
+        // new managed assistant resolves flags from its own configuration.
+        AssistantFeatureFlagResolver.clearCachedFlags()
+
         updateAssistantTag(assistant.id)
 
         return ManagedAssistantConnectionResult(

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -911,6 +911,9 @@ struct SettingsDeveloperTab: View {
         assistantFlagsError = nil
         do {
             assistantFlags = try await featureFlagClient.getFeatureFlags()
+            // Cache the fetched flag state for persistence across restarts
+            let cacheValues = Dictionary(uniqueKeysWithValues: assistantFlags.map { ($0.key, $0.enabled) })
+            AssistantFeatureFlagResolver.writeCachedFlags(cacheValues)
         } catch {
             // Fall back to the bundled registry + local persisted overrides
             if let registry = loadFeatureFlagRegistry() {
@@ -954,7 +957,11 @@ struct SettingsDeveloperTab: View {
                 scope: .macos
             )
         }
-        return (fromAssistant + fromMacOS).sorted { $0.label.localizedCaseInsensitiveCompare($1.label) == .orderedAscending }
+        // Deduplicate: if a flag key exists in both macOS and assistant scopes,
+        // keep the macOS entry and drop the assistant duplicate.
+        let macOSKeys = Set(fromMacOS.map { $0.key })
+        let dedupedAssistant = fromAssistant.filter { !macOSKeys.contains($0.key) }
+        return (dedupedAssistant + fromMacOS).sorted { $0.label.localizedCaseInsensitiveCompare($1.label) == .orderedAscending }
     }
 
     private var filteredUnifiedFlags: [UnifiedFeatureFlag] {
@@ -1058,6 +1065,7 @@ struct SettingsDeveloperTab: View {
                         object: nil,
                         userInfo: ["key": flag.key, "enabled": newValue]
                     )
+                    AssistantFeatureFlagResolver.mergeCachedFlag(key: flag.key, enabled: newValue)
                     Task {
                         do {
                             try await featureFlagClient.setFeatureFlag(key: flag.key, enabled: newValue)
@@ -1071,6 +1079,7 @@ struct SettingsDeveloperTab: View {
                                     label: flag.label
                                 )
                             }
+                            AssistantFeatureFlagResolver.mergeCachedFlag(key: flag.key, enabled: !newValue)
                             NotificationCenter.default.post(
                                 name: .assistantFeatureFlagDidChange,
                                 object: nil,

--- a/clients/macos/vellum-assistant/Services/AssistantFeatureFlagResolver.swift
+++ b/clients/macos/vellum-assistant/Services/AssistantFeatureFlagResolver.swift
@@ -10,6 +10,51 @@ import VellumAssistantShared
 /// format is: `{ "version": 1, "values": { "flagKey": true/false } }`.
 enum AssistantFeatureFlagResolver {
 
+    // MARK: - UserDefaults cache
+
+    private static let cachePrefix = "AssistantFeatureFlagCache."
+
+    /// Reads all cached feature flags from UserDefaults, stripping the cache prefix.
+    static func readCachedFlags() -> [String: Bool] {
+        let defaults = UserDefaults.standard
+        var result: [String: Bool] = [:]
+        for key in defaults.dictionaryRepresentation().keys where key.hasPrefix(cachePrefix) {
+            let name = String(key.dropFirst(cachePrefix.count))
+            guard !name.isEmpty else { continue }
+            result[name] = defaults.bool(forKey: key)
+        }
+        return result
+    }
+
+    /// Replaces all cached feature flags in UserDefaults with the given dictionary.
+    static func writeCachedFlags(_ flags: [String: Bool]) {
+        let defaults = UserDefaults.standard
+        // Remove all existing cached keys
+        for key in defaults.dictionaryRepresentation().keys where key.hasPrefix(cachePrefix) {
+            defaults.removeObject(forKey: key)
+        }
+        // Write new values
+        for (key, value) in flags {
+            defaults.set(value, forKey: "\(cachePrefix)\(key)")
+        }
+    }
+
+    /// Merges a single flag into the UserDefaults cache.
+    static func mergeCachedFlag(key: String, enabled: Bool) {
+        UserDefaults.standard.set(enabled, forKey: "\(cachePrefix)\(key)")
+    }
+
+    /// Removes all cached feature flags from UserDefaults.
+    ///
+    /// Call this when the connected assistant changes so that stale cached
+    /// values from the previous assistant do not leak into the new one.
+    static func clearCachedFlags() {
+        let defaults = UserDefaults.standard
+        for key in defaults.dictionaryRepresentation().keys where key.hasPrefix(cachePrefix) {
+            defaults.removeObject(forKey: key)
+        }
+    }
+
     // MARK: - Protected feature-flags file path
 
     /// Resolves the path to the protected feature-flags file for the currently
@@ -110,12 +155,14 @@ enum AssistantFeatureFlagResolver {
     static func resolvedFlags(
         registryDefaults: [String: Bool]
     ) -> [String: Bool] {
+        let persisted = readPersistedFlags()
+        let cached = readCachedFlags()
         let remote = readRemoteFlags()
-        let persistedFlags = readPersistedFlags()
-        // Priority: persisted > remote > defaults
+        // Priority: persisted > cached > remote > defaults
         return registryDefaults
-            .merging(remote) { _, remote in remote }
-            .merging(persistedFlags) { _, persisted in persisted }
+            .merging(remote) { _, new in new }
+            .merging(cached) { _, new in new }
+            .merging(persisted) { _, new in new }
     }
 
     static func resolvedFlags(


### PR DESCRIPTION
## Summary
Fix three feature flag bugs for managed/cloud-hosted assistants:
- **Flags reset on restart** — adds UserDefaults cache layer to `AssistantFeatureFlagResolver` with `persisted > cached > remote > defaults` priority chain
- **Toggles don't persist** — caches gateway flag responses on fetch and persists toggle changes to UserDefaults for restart resilience, with cache clear on assistant switch to prevent cross-instance leakage
- **Duplicate flags** — deduplicates overlapping assistant/macOS flags in Developer settings tab

## PRs merged into feature branch
- #22970: feat: fix feature flag persistence for managed assistants

Part of plan: ff-persist-managed.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22980" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
