### PR TITLE
Revert: re-enable heartbeat by default

### DIFF
--- a/assistant/src/config/schemas/heartbeat.ts
+++ b/assistant/src/config/schemas/heartbeat.ts
@@ -6,7 +6,7 @@ export const HeartbeatConfigSchema = z
   .object({
     enabled: z
       .boolean({ error: "heartbeat.enabled must be a boolean" })
-      .default(false)
+      .default(true)
       .describe("Whether periodic heartbeat checks are enabled"),
     intervalMs: z
       .number({ error: "heartbeat.intervalMs must be a number" })


### PR DESCRIPTION
## Summary
- Reverts commit 630da00 which disabled heartbeat by default
- Changes `heartbeat.enabled` default from `false` back to `true` in `HeartbeatConfigSchema`
- Background conversation UX has been improved (subgrouping, flag removal), so heartbeat can be re-enabled

## Original prompt
Revert commit 630da00 — re-enable heartbeat by default.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22981" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
