### PR TITLE
fix: remove PLATFORM_INTERNAL_API_KEY fallback from feature flag sync

### DIFF
--- a/gateway/src/__tests__/remote-feature-flag-sync.test.ts
+++ b/gateway/src/__tests__/remote-feature-flag-sync.test.ts
@@ -164,7 +164,7 @@ describe("RemoteFeatureFlagSync", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  test("falls back to PLATFORM_INTERNAL_API_KEY with Bearer auth when assistant_api_key is missing", async () => {
+  test("does not use PLATFORM_INTERNAL_API_KEY when assistant_api_key is missing", async () => {
     fetchMock = mock(async () => Response.json({ flags: {} }));
     process.env.PLATFORM_INTERNAL_API_KEY = "internal-key-123";
 
@@ -177,28 +177,9 @@ describe("RemoteFeatureFlagSync", () => {
     await sync.start();
     sync.stop();
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [, init] = fetchMock.mock.calls[0];
-    const headers = init?.headers as Record<string, string>;
-    expect(headers.Authorization).toBe("Bearer internal-key-123");
-  });
-
-  test("prefers assistant_api_key over PLATFORM_INTERNAL_API_KEY for public API", async () => {
-    fetchMock = mock(async () => Response.json({ flags: {} }));
-    process.env.PLATFORM_INTERNAL_API_KEY = "internal-key-123";
-
-    const sync = new RemoteFeatureFlagSync({
-      credentials: fakeCredentialCache(defaultCredentials()),
-    });
-    await sync.start();
-    sync.stop();
-
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [, init] = fetchMock.mock.calls[0];
-    const headers = init?.headers as Record<string, string>;
-    // Feature flag sync hits the public platform API, so Api-Key auth
-    // (assistant_api_key) takes precedence over Bearer (internal key).
-    expect(headers.Authorization).toBe("Api-Key test-api-key");
+    // PLATFORM_INTERNAL_API_KEY is only for internal gateway endpoints —
+    // feature flag sync requires assistant_api_key (Api-Key auth).
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test("skips sync when platform_assistant_id is missing and no PLATFORM_ASSISTANT_ID", async () => {

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -103,26 +103,21 @@ export class RemoteFeatureFlagSync {
       ""
     ).replace(/\/+$/, "");
 
-    // Feature flag sync hits the public platform API (/v1/assistants/…), not
-    // an internal gateway endpoint, so prefer Api-Key auth (assistant_api_key)
-    // over Bearer auth (PLATFORM_INTERNAL_API_KEY).
+    // Feature flag sync hits the public platform API (/v1/assistants/…),
+    // which requires Api-Key auth. PLATFORM_INTERNAL_API_KEY is only valid
+    // for internal gateway endpoints and would produce 401s here.
     const assistantApiKey = assistantApiKeyRaw?.trim() || undefined;
-    const platformInternalApiKey = !assistantApiKey
-      ? process.env.PLATFORM_INTERNAL_API_KEY?.trim() || undefined
-      : undefined;
-    const authToken = assistantApiKey || platformInternalApiKey;
-    const authScheme = assistantApiKey ? "Api-Key" : "Bearer";
 
     const assistantId =
       process.env.PLATFORM_ASSISTANT_ID?.trim() ||
       assistantIdRaw?.trim() ||
       undefined;
 
-    if (!platformUrl || !authToken || !assistantId) {
+    if (!platformUrl || !assistantApiKey || !assistantId) {
       log.debug(
         {
           hasPlatformUrl: !!platformUrl,
-          hasApiKey: !!authToken,
+          hasApiKey: !!assistantApiKey,
           hasAssistantId: !!assistantId,
         },
         "Remote feature flag sync skipped: missing credentials",
@@ -136,7 +131,7 @@ export class RemoteFeatureFlagSync {
     const response = await fetchImpl(url, {
       method: "GET",
       headers: {
-        Authorization: `${authScheme} ${authToken}`,
+        Authorization: `Api-Key ${assistantApiKey}`,
         Accept: "application/json",
       },
       signal: AbortSignal.timeout(10_000),


### PR DESCRIPTION
## Summary
PLATFORM_INTERNAL_API_KEY is only valid for internal gateway endpoints. Using it against the public /v1/assistants/{id}/feature-flags/ endpoint would just produce 401s. Feature flag sync now requires assistant_api_key and skips cleanly when it's unavailable.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
