### PR TITLE
feat: add reconnection loop for managed platform assistants

### DIFF
--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -66,6 +66,19 @@ public final class GatewayConnectionManager: ObservableObject {
         #endif
     }
 
+    /// Whether the connected assistant is a managed (platform-hosted) assistant.
+    private var isManaged: Bool {
+        #if os(macOS)
+        guard let id = UserDefaults.standard.string(forKey: "connectedAssistantId"),
+              let assistant = LockfileAssistant.loadByName(id) else {
+            return false
+        }
+        return assistant.isManaged
+        #else
+        return false
+        #endif
+    }
+
     // MARK: - Health Check
 
     private var healthCheckTask: Task<Void, Never>?
@@ -577,11 +590,11 @@ public final class GatewayConnectionManager: ObservableObject {
     // MARK: - Background Reconnection Loop
 
     /// Retries connection with increasing delays after the initial `connect()` fails.
-    /// Only applies to local assistants on macOS. Uses health checks and auto-wake
-    /// to reconnect without calling `connectImpl()` (which would interfere via
+    /// Applies to local and managed assistants on macOS. Uses health checks and auto-wake
+    /// (local only) to reconnect without calling `connectImpl()` (which would interfere via
     /// `disconnectInternal()`). Cancelled on explicit `disconnect()` or `reconfigure()`.
     private func startReconnectionLoop() {
-        guard isLocal, shouldReconnect else { return }
+        guard (isLocal || isManaged), shouldReconnect else { return }
         reconnectionTask?.cancel()
         reconnectionGeneration += 1
         let generation = reconnectionGeneration
@@ -611,6 +624,12 @@ public final class GatewayConnectionManager: ObservableObject {
                 do {
                     try await self.performHealthCheck()
                 } catch {
+                    // Managed assistants have no local gateway to wake — just retry
+                    if self.isManaged {
+                        log.warning("reconnect-loop: health check failed for managed assistant: \(error)")
+                        continue
+                    }
+
                     // Health check failed — try auto-wake if gateway unreachable
                     if let wakeHandler = self.wakeHandler {
                         let reachable = await HealthCheckClient.isReachable()


### PR DESCRIPTION
## Summary
- Add `isManaged` computed property to GatewayConnectionManager for managed assistant detection
- Extend reconnection loop guard to include managed assistants (`isLocal || isManaged`)
- Skip wake handler for managed assistants (no local gateway to wake) — just retry health check with backoff
- Local assistant reconnection behavior is unchanged

Part of plan: platform-hatch-connection.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
