### PR TITLE
feat: respect lockfile activeAssistant field in assistant resolution

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -30,6 +30,9 @@ extension AppDelegate {
 
         if let storedId, let found = LockfileAssistant.loadByName(storedId) {
             assistant = found
+        } else if let activeId = LockfileAssistant.loadActiveAssistantId(),
+                  let active = LockfileAssistant.loadByName(activeId) {
+            assistant = active
         } else {
             assistant = LockfileAssistant.loadLatest()
         }

--- a/clients/shared/Network/LockfileAssistant.swift
+++ b/clients/shared/Network/LockfileAssistant.swift
@@ -196,6 +196,13 @@ public struct LockfileAssistant {
         }
     }
 
+    /// Reads the `activeAssistant` field from the lockfile, returning
+    /// the assistant ID string the CLI designated as currently active.
+    public static func loadActiveAssistantId() -> String? {
+        guard let json = LockfilePaths.read() else { return nil }
+        return json["activeAssistant"] as? String
+    }
+
     /// Find an assistant by its ID in the lockfile.
     public static func loadByName(_ name: String) -> LockfileAssistant? {
         loadAll().first { $0.assistantId == name }


### PR DESCRIPTION
## Summary
- Add `LockfileAssistant.loadActiveAssistantId()` to read the `activeAssistant` field from the lockfile
- Modify `loadAssistantFromLockfile()` to use `activeAssistant` as intermediate fallback between UserDefaults and `loadLatest()`
- Ensures app picks up CLI's intended active assistant on restart or after logout/login

Part of plan: platform-hatch-connection.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22986" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
