### PR TITLE
feat: add lockfile file-system watcher for CLI-driven assistant changes

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -252,6 +252,7 @@ extension AppDelegate {
             } else {
                 // Managed (platform): full teardown — close everything and
                 // show the reauth screen.
+                stopLockfileWatcher()
                 let detachedWindow = mainWindow?.detachWindow()
                 mainWindow = nil
                 conversationBadgeCancellable?.cancel()

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -135,6 +135,9 @@ extension AppDelegate {
         // Subscribe to SSE event stream for UI event routing.
         startEventSubscription()
 
+        // Watch the lockfile for CLI-driven assistant changes (e.g. vellum hatch).
+        startLockfileWatcher()
+
         Task {
             // Import guardian token from CLI file before connecting, so the
             // health check has valid credentials in the credential store.
@@ -570,6 +573,91 @@ extension AppDelegate {
             await self.vellumCli.stop()
         }
         updateManager.startAutomaticChecks()
+    }
+
+    // MARK: - Lockfile Watcher
+
+    /// Starts a file-system watcher on the lockfile to detect CLI-driven
+    /// assistant changes (e.g. `vellum hatch --remote vellum`). When the
+    /// lockfile's `activeAssistant` field changes and differs from the
+    /// current `connectedAssistantId`, the app auto-switches to the new
+    /// assistant.
+    func startLockfileWatcher() {
+        // Guard against re-starting if already active
+        guard lockfileWatcherSource == nil else { return }
+
+        let path = LockfilePaths.primaryPath
+        let fd = open(path, O_EVTONLY)
+        guard fd >= 0 else {
+            // Lockfile doesn't exist yet — no-op, can be called again later
+            log.info("Lockfile watcher: file not found at \(path, privacy: .public), skipping")
+            return
+        }
+
+        lockfileWatcherFd = fd
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .rename],
+            queue: DispatchQueue.global(qos: .utility)
+        )
+
+        // Debounce work item — 0.5s delay to coalesce rapid writes
+        var debounceWorkItem: DispatchWorkItem?
+
+        source.setEventHandler { [weak self] in
+            debounceWorkItem?.cancel()
+            let workItem = DispatchWorkItem { [weak self] in
+                guard let self else { return }
+
+                guard let activeId = LockfileAssistant.loadActiveAssistantId() else { return }
+
+                let currentId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+                guard activeId != currentId else { return }
+
+                // Verify the target assistant exists in the lockfile
+                guard let targetAssistant = LockfileAssistant.loadByName(activeId) else {
+                    log.info("Lockfile watcher: activeAssistant '\(activeId, privacy: .public)' not found in lockfile assistants, ignoring")
+                    return
+                }
+
+                log.info("Lockfile watcher: activeAssistant changed from '\(currentId ?? "<none>", privacy: .public)' to '\(activeId, privacy: .public)' — switching")
+
+                Task { @MainActor [weak self] in
+                    self?.performSwitchAssistant(to: targetAssistant)
+                }
+            }
+            debounceWorkItem = workItem
+            DispatchQueue.global(qos: .utility).asyncAfter(
+                deadline: .now() + 0.5,
+                execute: workItem
+            )
+        }
+
+        source.setCancelHandler { [weak self] in
+            guard let self else { return }
+            if self.lockfileWatcherFd >= 0 {
+                close(self.lockfileWatcherFd)
+                self.lockfileWatcherFd = -1
+            }
+        }
+
+        source.resume()
+        lockfileWatcherSource = source
+        log.info("Lockfile watcher started on \(path, privacy: .public)")
+    }
+
+    /// Stops the lockfile watcher and closes the file descriptor.
+    func stopLockfileWatcher() {
+        if let source = lockfileWatcherSource {
+            source.cancel()
+            lockfileWatcherSource = nil
+        }
+        // The cancel handler closes the fd, but guard against it not firing
+        if lockfileWatcherFd >= 0 {
+            close(lockfileWatcherFd)
+            lockfileWatcherFd = -1
+        }
     }
 
     // MARK: - CLI Symlink

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -77,6 +77,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     let debugStateWriter = DebugStateWriter()
     private let telemetryClient: any TelemetryClientProtocol = TelemetryClient()
     private var metricKitManager: MetricKitManager?
+    var lockfileWatcherSource: DispatchSourceFileSystemObject?
+    var lockfileWatcherFd: Int32 = -1
 
     // Forwarding accessors — ownership lives in `services`.
     var connectionManager: GatewayConnectionManager { services.connectionManager }

--- a/clients/shared/Network/LockfileAssistant.swift
+++ b/clients/shared/Network/LockfileAssistant.swift
@@ -207,6 +207,14 @@ public struct LockfileAssistant {
         return loadByName(id)?.instanceDir
     }
 
+    /// Reads just the `activeAssistant` field from the lockfile JSON without
+    /// parsing all assistant entries. Designed for efficient use by the
+    /// lockfile watcher to detect CLI-driven assistant changes.
+    public static func loadActiveAssistantId() -> String? {
+        guard let json = LockfilePaths.read() else { return nil }
+        return json["activeAssistant"] as? String
+    }
+
     /// Creates or refreshes a managed entry for the given `assistantId`.
     /// Existing entries keep their original `hatchedAt` value but have the
     /// managed runtime URL refreshed so sign-in follows the current platform.


### PR DESCRIPTION
## Summary
- Add a DispatchSource file-system watcher on the lockfile to detect when the CLI hatches a new assistant
- When `activeAssistant` in the lockfile changes, auto-switch to the new assistant via `performSwitchAssistant`
- Debounce rapid consecutive writes (0.5s) to avoid duplicate switches
- Add `LockfileAssistant.loadActiveAssistantId()` for efficient active assistant lookup

Part of plan: platform-hatch-connection.md (PR 1 of 3)

## Test plan
- [ ] While connected to a local assistant, run `vellum hatch --remote vellum` from the CLI and verify the app auto-switches to the new platform assistant within ~1 second
- [ ] Verify rapid consecutive lockfile writes (e.g. `saveAssistantEntry` + `setActiveAssistant`) result in a single switch, not two
- [ ] Verify logging out stops the watcher and logging back in re-establishes it
- [ ] Verify no switch occurs when `activeAssistant` matches the current `connectedAssistantId`
- [ ] Verify no switch occurs when `activeAssistant` references an ID not in the lockfile's assistants array

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22988" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
