### PR TITLE
fix: platform assistant connection after hatch with existing local assistant

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -30,6 +30,9 @@ extension AppDelegate {
 
         if let storedId, let found = LockfileAssistant.loadByName(storedId) {
             assistant = found
+        } else if let activeId = LockfileAssistant.loadActiveAssistantId(),
+                  let active = LockfileAssistant.loadByName(activeId) {
+            assistant = active
         } else {
             assistant = LockfileAssistant.loadLatest()
         }

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -66,6 +66,19 @@ public final class GatewayConnectionManager: ObservableObject {
         #endif
     }
 
+    /// Whether the connected assistant is a managed (platform-hosted) assistant.
+    private var isManaged: Bool {
+        #if os(macOS)
+        guard let id = UserDefaults.standard.string(forKey: "connectedAssistantId"),
+              let assistant = LockfileAssistant.loadByName(id) else {
+            return false
+        }
+        return assistant.isManaged
+        #else
+        return false
+        #endif
+    }
+
     // MARK: - Health Check
 
     private var healthCheckTask: Task<Void, Never>?
@@ -577,11 +590,11 @@ public final class GatewayConnectionManager: ObservableObject {
     // MARK: - Background Reconnection Loop
 
     /// Retries connection with increasing delays after the initial `connect()` fails.
-    /// Only applies to local assistants on macOS. Uses health checks and auto-wake
-    /// to reconnect without calling `connectImpl()` (which would interfere via
+    /// Applies to local and managed assistants on macOS. Uses health checks and auto-wake
+    /// (local only) to reconnect without calling `connectImpl()` (which would interfere via
     /// `disconnectInternal()`). Cancelled on explicit `disconnect()` or `reconfigure()`.
     private func startReconnectionLoop() {
-        guard isLocal, shouldReconnect else { return }
+        guard (isLocal || isManaged), shouldReconnect else { return }
         reconnectionTask?.cancel()
         reconnectionGeneration += 1
         let generation = reconnectionGeneration
@@ -611,6 +624,12 @@ public final class GatewayConnectionManager: ObservableObject {
                 do {
                     try await self.performHealthCheck()
                 } catch {
+                    // Managed assistants have no local gateway to wake — just retry
+                    if self.isManaged {
+                        log.warning("reconnect-loop: health check failed for managed assistant: \(error)")
+                        continue
+                    }
+
                     // Health check failed — try auto-wake if gateway unreachable
                     if let wakeHandler = self.wakeHandler {
                         let reachable = await HealthCheckClient.isReachable()

--- a/clients/shared/Network/LockfileAssistant.swift
+++ b/clients/shared/Network/LockfileAssistant.swift
@@ -196,6 +196,13 @@ public struct LockfileAssistant {
         }
     }
 
+    /// Reads the `activeAssistant` field from the lockfile, returning
+    /// the assistant ID string the CLI designated as currently active.
+    public static func loadActiveAssistantId() -> String? {
+        guard let json = LockfilePaths.read() else { return nil }
+        return json["activeAssistant"] as? String
+    }
+
     /// Find an assistant by its ID in the lockfile.
     public static func loadByName(_ name: String) -> LockfileAssistant? {
         loadAll().first { $0.assistantId == name }


### PR DESCRIPTION
## Summary
- Fix bug where switching to a platform assistant fails to connect (no retry on initial health check failure)
- Add reconnection loop for managed (platform) assistants — previously only local assistants retried on connection failure
- Respect lockfile `activeAssistant` field as fallback in assistant resolution

## Changes
- **Managed reconnection** (`GatewayConnectionManager.swift`): Add `isManaged` computed property and extend `startReconnectionLoop()` guard from `isLocal` to `isLocal || isManaged`. Managed assistants skip the wake handler and simply retry health checks with exponential backoff (3s, 5s, 10s, 15s).
- **activeAssistant resolution** (`LockfileAssistant.swift`, `AppDelegate+ConnectionSetup.swift`): Add `loadActiveAssistantId()` and use the lockfile's `activeAssistant` field as an intermediate fallback between UserDefaults and `loadLatest()`.

Part of plan: platform-hatch-connection.md