### PR TITLE
fix: remove duplicate loadActiveAssistantId() method

### DIFF
--- a/clients/shared/Network/LockfileAssistant.swift
+++ b/clients/shared/Network/LockfileAssistant.swift
@@ -214,14 +214,6 @@ public struct LockfileAssistant {
         return loadByName(id)?.instanceDir
     }
 
-    /// Reads just the `activeAssistant` field from the lockfile JSON without
-    /// parsing all assistant entries. Designed for efficient use by the
-    /// lockfile watcher to detect CLI-driven assistant changes.
-    public static func loadActiveAssistantId() -> String? {
-        guard let json = LockfilePaths.read() else { return nil }
-        return json["activeAssistant"] as? String
-    }
-
     /// Creates or refreshes a managed entry for the given `assistantId`.
     /// Existing entries keep their original `hatchedAt` value but have the
     /// managed runtime URL refreshed so sign-in follows the current platform.


### PR DESCRIPTION
## Summary
Fixes build-breaking duplicate method definition in LockfileAssistant.swift.

**Gap:** Duplicate loadActiveAssistantId() method
**What was expected:** Single method definition
**What was found:** Two identical definitions from PR 1 and PR 3 merge
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22991" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
