### PR TITLE
fix: re-establish lockfile watcher after atomic writes

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -601,7 +601,7 @@ extension AppDelegate {
 
         let source = DispatchSource.makeFileSystemObjectSource(
             fileDescriptor: fd,
-            eventMask: [.write, .rename],
+            eventMask: [.write, .delete, .rename],
             queue: DispatchQueue.global(qos: .utility)
         )
 
@@ -609,6 +609,8 @@ extension AppDelegate {
         var debounceWorkItem: DispatchWorkItem?
 
         source.setEventHandler { [weak self] in
+            let flags = source.data
+
             debounceWorkItem?.cancel()
             let workItem = DispatchWorkItem { [weak self] in
                 guard let self else { return }
@@ -635,6 +637,16 @@ extension AppDelegate {
                 deadline: .now() + 0.5,
                 execute: workItem
             )
+
+            // Atomic writes replace the file inode (.rename/.delete), so the
+            // current fd is stale. Re-establish the watcher on the new inode.
+            if flags.contains(.delete) || flags.contains(.rename) {
+                log.info("Lockfile watcher: inode replaced (atomic write), re-establishing watcher")
+                Task { @MainActor [weak self] in
+                    self?.stopLockfileWatcher()
+                    self?.startLockfileWatcher()
+                }
+            }
         }
 
         source.setCancelHandler { [weak self] in


### PR DESCRIPTION
## Summary
Re-establishes the lockfile DispatchSource watcher after atomic writes that replace the file inode.

**Gap:** Lockfile watcher dies after atomic writes
**What was expected:** Watcher continues working after file replacement
**What was found:** Atomic writes create new inode, leaving watcher pointing at deleted file
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22992" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
