### PR TITLE
fix: eliminate double-close race on lockfile watcher fd

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -637,12 +637,8 @@ extension AppDelegate {
             )
         }
 
-        source.setCancelHandler { [weak self] in
-            guard let self else { return }
-            if self.lockfileWatcherFd >= 0 {
-                close(self.lockfileWatcherFd)
-                self.lockfileWatcherFd = -1
-            }
+        source.setCancelHandler {
+            close(fd)
         }
 
         source.resume()
@@ -650,17 +646,15 @@ extension AppDelegate {
         log.info("Lockfile watcher started on \(path, privacy: .public)")
     }
 
-    /// Stops the lockfile watcher and closes the file descriptor.
+    /// Stops the lockfile watcher. The cancel handler on the dispatch source
+    /// is the sole closer of the file descriptor — we only clear the local
+    /// references here to prevent stale re-use.
     func stopLockfileWatcher() {
         if let source = lockfileWatcherSource {
             source.cancel()
             lockfileWatcherSource = nil
         }
-        // The cancel handler closes the fd, but guard against it not firing
-        if lockfileWatcherFd >= 0 {
-            close(lockfileWatcherFd)
-            lockfileWatcherFd = -1
-        }
+        lockfileWatcherFd = -1
     }
 
     // MARK: - CLI Symlink


### PR DESCRIPTION
## Summary
Eliminates double-close race condition on the lockfile watcher file descriptor.

**Gap:** Double-close race on file descriptor
**What was expected:** fd closed exactly once
**What was found:** Both stopLockfileWatcher() and the cancel handler close the fd
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
