### PR TITLE
fix: add SkillSearchResult and SkillOperationResult to manual type allowlist

### DIFF
--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -42,6 +42,10 @@ import Foundation
 // │                                 │ code generator cannot express it        │
 // │ HostCuResultPayload             │ Posted back to daemon; hand-maintained  │
 // │                                 │ alongside HostCuRequest                 │
+// │ SkillSearchResult               │ Client-only result wrapper for search;  │
+// │                                 │ not a wire type                         │
+// │ SkillOperationResult            │ Client-only result wrapper for skill    │
+// │                                 │ operations; not a wire type             │
 // └─────────────────────────────────┴──────────────────────────────────────────┘
 //
 // **Do not add new manual structs** without documenting the reason here.


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skills-api-final-cleanup.md.

**Gap:** New hand-maintained structs not documented in the Manual Type Allowlist table
**What was expected:** New structs should be documented in the allowlist per convention
**What was found:** SkillSearchResult and SkillOperationResult were missing from the table
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22995" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
