### PR TITLE
feat: add timestamps to recall tool results

### DIFF
--- a/assistant/src/memory/graph/tool-handlers.ts
+++ b/assistant/src/memory/graph/tool-handlers.ts
@@ -51,6 +51,7 @@ export interface RecallResult {
     confidence: number;
     significance: number;
     score: number;
+    created: number;
   }>;
   mode: "memory" | "archive";
   query: string;
@@ -135,6 +136,7 @@ async function handleMemoryRecall(
         confidence: node.confidence,
         significance: node.significance,
         score: r.score,
+        created: node.created,
       },
     ];
   });
@@ -182,6 +184,7 @@ async function handleArchiveRecall(
         confidence: 1.0,
         significance: 0,
         score: 1.0,
+        created: r.created_at,
       })),
       mode: "archive",
       query: input.query,

--- a/assistant/src/tools/memory/register.ts
+++ b/assistant/src/tools/memory/register.ts
@@ -70,16 +70,29 @@ class RecallTool implements Tool {
 
     const formatted = result.results
       .map((r) => {
+        const ts = formatTimestamp(r.created);
         const meta =
           result.mode === "memory"
-            ? `[${r.type}] (confidence: ${r.confidence.toFixed(2)}, score: ${r.score.toFixed(3)})`
-            : `[archive]`;
+            ? `[${r.type}] ${ts} (confidence: ${r.confidence.toFixed(2)}, score: ${r.score.toFixed(3)})`
+            : `[archive] ${ts}`;
         return `${meta}\n${r.content}`;
       })
       .join("\n\n---\n\n");
 
     return { content: formatted, isError: false };
   }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function formatTimestamp(epochMs: number): string {
+  const d = new Date(epochMs);
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  const yy = String(d.getFullYear()).slice(-2);
+  const hh = String(d.getHours()).padStart(2, "0");
+  const min = String(d.getMinutes()).padStart(2, "0");
+  return `${mm}/${dd}/${yy} ${hh}:${min}`;
 }
 
 // ── Exported tool instances ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Added `created` field to `RecallResult` interface, populated from graph node `created` (memory mode) and `created_at` (archive mode)
- Added `MM/DD/YY HH:MM` timestamp to the formatted output of both memory and archive recall results