### PR TITLE
Add `files:read` scope to Slack app setup manifest

### DIFF
--- a/skills/slack-app-setup/SKILL.md
+++ b/skills/slack-app-setup/SKILL.md
@@ -67,6 +67,7 @@ Generate the manifest JSON:
         "channels:history",
         "channels:read",
         "chat:write",
+        "files:read",
         "files:write",
         "groups:history",
         "groups:read",


### PR DESCRIPTION
## Summary
- Add missing `files:read` OAuth scope to the Slack app setup manifest
- Without this scope, the bot cannot download files shared by users, causing Slack to return an HTML error page instead of the actual file data
- Existing users will need to re-install their Slack app or manually add the scope

Part of plan: fix-slack-image-download.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22998" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
