### PR TITLE
Add `validateDownloadedContent` utility for channel file downloads

### DIFF
--- a/gateway/src/download-validation.test.ts
+++ b/gateway/src/download-validation.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ContentMismatchError,
+  validateDownloadedContent,
+} from "./download-validation.js";
+
+/** Create a minimal valid PNG buffer that file-type can detect. */
+function makePngBuffer(): Uint8Array {
+  return new Uint8Array([
+    // PNG signature
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    // IHDR chunk: length (13)
+    0x00, 0x00, 0x00, 0x0d,
+    // IHDR type
+    0x49, 0x48, 0x44, 0x52,
+    // Width: 1
+    0x00, 0x00, 0x00, 0x01,
+    // Height: 1
+    0x00, 0x00, 0x00, 0x01,
+    // Bit depth, color type, compression, filter, interlace
+    0x08, 0x02, 0x00, 0x00, 0x00,
+    // CRC (placeholder)
+    0x90, 0x77, 0x53, 0xde,
+  ]);
+}
+
+function htmlBuffer(html: string): Uint8Array {
+  return new TextEncoder().encode(html);
+}
+
+describe("validateDownloadedContent", () => {
+  test("throws ContentMismatchError when HTML is received instead of image/png", async () => {
+    const buffer = htmlBuffer(
+      "<!DOCTYPE html><html><body><h1>Access Denied</h1></body></html>",
+    );
+
+    await expect(
+      validateDownloadedContent(buffer, "image/png", "F001"),
+    ).rejects.toThrow(ContentMismatchError);
+
+    await expect(
+      validateDownloadedContent(buffer, "image/png", "F001"),
+    ).rejects.toThrow(
+      "File F001 declared as image/png but content is HTML (likely an auth/error page)",
+    );
+  });
+
+  test("throws ContentMismatchError for HTML with leading whitespace and BOM", async () => {
+    // UTF-8 BOM (EF BB BF) + whitespace + HTML
+    const bom = new Uint8Array([0xef, 0xbb, 0xbf]);
+    const html = new TextEncoder().encode(
+      "  \n  <!DOCTYPE html><html><body>Error</body></html>",
+    );
+    const buffer = new Uint8Array(bom.length + html.length);
+    buffer.set(bom, 0);
+    buffer.set(html, bom.length);
+
+    await expect(
+      validateDownloadedContent(buffer, "image/jpeg", "F002"),
+    ).rejects.toThrow(ContentMismatchError);
+  });
+
+  test("passes for valid PNG buffer with declared image/png", async () => {
+    const buffer = makePngBuffer();
+
+    // Should not throw
+    await validateDownloadedContent(buffer, "image/png", "F003");
+  });
+
+  test("passes for valid PNG buffer with declared image/jpeg (same image family)", async () => {
+    const buffer = makePngBuffer();
+
+    // file-type detects it as image/png, which still starts with "image/"
+    // so it should pass even though declared as image/jpeg
+    await validateDownloadedContent(buffer, "image/jpeg", "F004");
+  });
+
+  test("passes for plain text buffer with declared text/plain (non-binary)", async () => {
+    const buffer = new TextEncoder().encode("hello world");
+
+    // text/plain is not a binary MIME type, so no validation is performed
+    await validateDownloadedContent(
+      new Uint8Array(buffer),
+      "text/plain",
+      "F005",
+    );
+  });
+
+  test("passes for empty buffer with declared image/png", async () => {
+    const buffer = new Uint8Array(0);
+
+    // Empty buffer: looksLikeHtml returns false, fileTypeFromBuffer returns
+    // undefined, so we allow it through and let downstream handle it
+    await validateDownloadedContent(buffer, "image/png", "F006");
+  });
+});

--- a/gateway/src/download-validation.ts
+++ b/gateway/src/download-validation.ts
@@ -1,0 +1,92 @@
+import { fileTypeFromBuffer } from "file-type";
+
+export class ContentMismatchError extends Error {
+  override name = "ContentMismatchError";
+}
+
+/**
+ * Check whether a buffer looks like an HTML page by inspecting the first
+ * non-whitespace / non-BOM bytes for common HTML markers.
+ */
+export function looksLikeHtml(buffer: Uint8Array): boolean {
+  // Skip leading whitespace and UTF-8 BOM (0xEF 0xBB 0xBF)
+  let offset = 0;
+  // Skip UTF-8 BOM if present
+  if (
+    buffer.length >= 3 &&
+    buffer[0] === 0xef &&
+    buffer[1] === 0xbb &&
+    buffer[2] === 0xbf
+  ) {
+    offset = 3;
+  }
+  // Skip whitespace characters (space, tab, newline, carriage return)
+  while (offset < buffer.length) {
+    const byte = buffer[offset];
+    if (byte === 0x20 || byte === 0x09 || byte === 0x0a || byte === 0x0d) {
+      offset++;
+    } else {
+      break;
+    }
+  }
+
+  if (offset >= buffer.length) {
+    return false;
+  }
+
+  const remaining = buffer.subarray(offset);
+  const prefix = new TextDecoder("utf-8", { fatal: false }).decode(
+    remaining.subarray(0, Math.min(remaining.length, 15)),
+  );
+
+  const upper = prefix.toUpperCase();
+  return upper.startsWith("<!DOCTYPE") || upper.startsWith("<HTML");
+}
+
+const BINARY_MIME_PREFIXES = [
+  "image/",
+  "audio/",
+  "video/",
+  "application/pdf",
+] as const;
+
+/**
+ * Validate that downloaded content actually matches its declared MIME type.
+ *
+ * This catches a common failure mode where CDNs (Slack, WhatsApp, Telegram)
+ * return an HTML error or auth page instead of the actual binary file.
+ * Base64-encoding that HTML and sending it to a provider as e.g. `image/png`
+ * causes the provider to reject the request.
+ */
+export async function validateDownloadedContent(
+  buffer: Uint8Array,
+  declaredMime: string,
+  fileId: string,
+): Promise<void> {
+  const isBinary = BINARY_MIME_PREFIXES.some((prefix) =>
+    declaredMime.startsWith(prefix),
+  );
+
+  if (!isBinary) {
+    return;
+  }
+
+  // Guard: if the buffer looks like HTML, it's almost certainly an error page
+  if (looksLikeHtml(buffer)) {
+    throw new ContentMismatchError(
+      `File ${fileId} declared as ${declaredMime} but content is HTML (likely an auth/error page)`,
+    );
+  }
+
+  // For image types, do a deeper check with file-type detection
+  if (declaredMime.startsWith("image/")) {
+    const detected = await fileTypeFromBuffer(buffer);
+    if (detected && !detected.mime.startsWith("image/")) {
+      throw new ContentMismatchError(
+        `File ${fileId} declared as ${declaredMime} but detected as ${detected.mime}`,
+      );
+    }
+    // If detected is undefined and it doesn't look like HTML, allow it
+    // through — some image formats may not be in file-type's database.
+  }
+}


### PR DESCRIPTION
## Summary
- Add `ContentMismatchError` class and `validateDownloadedContent()` utility to detect when downloaded file content doesn't match the declared MIME type
- Catches HTML error/auth pages being served instead of binary files (common with Slack, WhatsApp, Telegram CDNs)
- Includes comprehensive tests for HTML detection, valid images, edge cases

Part of plan: fix-slack-image-download.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/22999" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
