### PR TITLE
Validate Slack file downloads and inject context text for failed attachments

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1319,7 +1319,7 @@ async function main() {
                 const nameList = failedAttachmentNames
                   .map((n) => `"${n}"`)
                   .join(", ");
-                normalized.event.message.text += `\n\n[The user attached file(s) that could not be retrieved: ${nameList}. Ask them to re-send if the content is important.]`;
+                normalized.event.message.content += `\n\n[The user attached file(s) that could not be retrieved: ${nameList}. Ask them to re-send if the content is important.]`;
               }
             }
 

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1240,6 +1240,7 @@ async function main() {
               !isCallback
             ) {
               attachmentIds = [];
+              const failedAttachmentNames: string[] = [];
               const maxBytes =
                 config.maxAttachmentBytes.slack ??
                 config.maxAttachmentBytes.default;
@@ -1290,23 +1291,35 @@ async function main() {
                     });
                   }),
                 );
-                for (const result of results) {
+                for (let j = 0; j < results.length; j++) {
+                  const result = results[j];
                   if (result.status === "fulfilled") {
                     attachmentIds.push(result.value.id);
                   } else if (
                     result.reason instanceof AttachmentValidationError
                   ) {
+                    const att = batch[j];
+                    failedAttachmentNames.push(att.fileName || att.fileId);
                     log.warn(
                       { err: result.reason },
                       "Skipping Slack attachment with validation error",
                     );
                   } else {
+                    const att = batch[j];
+                    failedAttachmentNames.push(att.fileName || att.fileId);
                     log.warn(
                       { err: result.reason },
                       "Skipping Slack attachment due to download/upload failure",
                     );
                   }
                 }
+              }
+
+              if (failedAttachmentNames.length > 0) {
+                const nameList = failedAttachmentNames
+                  .map((n) => `"${n}"`)
+                  .join(", ");
+                normalized.event.message.text += `\n\n[The user attached file(s) that could not be retrieved: ${nameList}. Ask them to re-send if the content is important.]`;
               }
             }
 

--- a/gateway/src/slack/download.test.ts
+++ b/gateway/src/slack/download.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import { ContentMismatchError } from "../download-validation.js";
 import type { SlackFile } from "./normalize.js";
 
 type FetchFn = (
@@ -67,9 +68,7 @@ describe("downloadSlackFile", () => {
 
     expect(result.filename).toBe("test-image.png");
     expect(result.mimeType).toBe("image/png");
-    expect(result.data).toBe(
-      Buffer.from(fileBuffer).toString("base64"),
-    );
+    expect(result.data).toBe(Buffer.from(fileBuffer).toString("base64"));
 
     // Verify the correct URL and auth header were used
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -101,21 +100,20 @@ describe("downloadSlackFile", () => {
       url_private: undefined,
     });
 
-    await expect(
-      downloadSlackFile(file, "xoxb-test-token"),
-    ).rejects.toThrow("Slack file F12345 has no download URL");
+    await expect(downloadSlackFile(file, "xoxb-test-token")).rejects.toThrow(
+      "Slack file F12345 has no download URL",
+    );
   });
 
   test("throws on HTTP error response", async () => {
     fetchMock = mock(
-      async () => new Response("Forbidden", { status: 403, statusText: "Forbidden" }),
+      async () =>
+        new Response("Forbidden", { status: 403, statusText: "Forbidden" }),
     );
 
     const file = makeSlackFile();
 
-    await expect(
-      downloadSlackFile(file, "xoxb-test-token"),
-    ).rejects.toThrow(
+    await expect(downloadSlackFile(file, "xoxb-test-token")).rejects.toThrow(
       "Failed to download Slack file F12345: 403 Forbidden",
     );
   });
@@ -179,5 +177,30 @@ describe("downloadSlackFile", () => {
     const result = await downloadSlackFile(file, "xoxb-test-token");
 
     expect(result.filename).toBe("slack_file_F12345");
+  });
+
+  test("throws ContentMismatchError when Slack returns HTML error page", async () => {
+    const htmlBuffer = new TextEncoder().encode(
+      "<!DOCTYPE html><html><body><h1>Error</h1></body></html>",
+    ).buffer;
+    fetchMock = mock(async () => new Response(htmlBuffer));
+
+    const file = makeSlackFile({ mimetype: "image/png" });
+
+    await expect(
+      downloadSlackFile(file, "xoxb-test-token"),
+    ).rejects.toBeInstanceOf(ContentMismatchError);
+  });
+
+  test("succeeds with valid image data when validation is active", async () => {
+    const fileBuffer = makePngBuffer();
+    fetchMock = mock(async () => new Response(fileBuffer));
+
+    const file = makeSlackFile({ mimetype: "image/png" });
+    const result = await downloadSlackFile(file, "xoxb-test-token");
+
+    expect(result.filename).toBe("test-image.png");
+    expect(result.mimeType).toBe("image/png");
+    expect(result.data).toBe(Buffer.from(fileBuffer).toString("base64"));
   });
 });

--- a/gateway/src/slack/download.ts
+++ b/gateway/src/slack/download.ts
@@ -1,4 +1,5 @@
 import { fileTypeFromBuffer } from "file-type";
+import { validateDownloadedContent } from "../download-validation.js";
 import { fetchImpl } from "../fetch.js";
 import type { SlackFile } from "./normalize.js";
 
@@ -42,6 +43,8 @@ export async function downloadSlackFile(
     detected?.mime ||
     response.headers.get("Content-Type")?.split(";")[0].trim() ||
     "application/octet-stream";
+
+  await validateDownloadedContent(new Uint8Array(buffer), mimeType, file.id);
 
   const filename = file.name || `slack_file_${file.id}`;
   const data = Buffer.from(buffer).toString("base64");


### PR DESCRIPTION
## Summary
- Integrate `validateDownloadedContent` into Slack file downloader to catch HTML error pages masquerading as images
- Track failed attachment filenames and inject context into the message text so the assistant knows an attachment was attempted
- Add tests for HTML error page detection in Slack downloads

Part of plan: fix-slack-image-download.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23001" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
