### PR TITLE
Validate WhatsApp and Telegram file download content matches declared MIME type

### DIFF
--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -4,6 +4,7 @@ import type { GatewayConfig } from "../../config.js";
 import type { CredentialCache } from "../../credential-cache.js";
 import { credentialKey } from "../../credential-key.js";
 import { DedupCache } from "../../dedup-cache.js";
+import { ContentMismatchError } from "../../download-validation.js";
 import { handleInbound } from "../../handlers/handle-inbound.js";
 import { getLogger } from "../../logger.js";
 import { RejectionRateLimiter } from "../../rejection-rate-limiter.js";
@@ -575,6 +576,7 @@ export function createTelegramWebhookHandler(
     // Download and upload attachments if present (skip for edits and callback
     // queries — edits only update text, callbacks have no media to process)
     let attachmentIds: string[] | undefined;
+    const failedAttachmentNames: string[] = [];
     const eventAttachments = normalized.message.attachments;
     if (
       eventAttachments &&
@@ -636,7 +638,8 @@ export function createTelegramWebhookHandler(
               return uploadAttachment(config, downloaded);
             }),
           );
-          for (const result of results) {
+          for (let j = 0; j < results.length; j++) {
+            const result = results[j];
             if (result.status === "fulfilled") {
               attachmentIds.push(result.value.id);
             } else if (result.reason instanceof AttachmentValidationError) {
@@ -644,6 +647,13 @@ export function createTelegramWebhookHandler(
                 { err: result.reason },
                 "Skipping attachment with validation error",
               );
+              failedAttachmentNames.push(batch[j].fileName || batch[j].fileId);
+            } else if (result.reason instanceof ContentMismatchError) {
+              tlog.warn(
+                { err: result.reason },
+                "Skipping attachment with content mismatch",
+              );
+              failedAttachmentNames.push(batch[j].fileName || batch[j].fileId);
             } else {
               // Transient failure — propagate so the webhook returns 500 and
               // Telegram retries the update delivery.
@@ -664,6 +674,16 @@ export function createTelegramWebhookHandler(
           { error: "Attachment processing failed" },
           { status: 500 },
         );
+      }
+    }
+
+    // Inject context about failed attachments into the message
+    if (failedAttachmentNames.length > 0) {
+      const failureNotice = `[The user attached file(s) that could not be retrieved: ${failedAttachmentNames.map((n) => `"${n}"`).join(", ")}. Ask them to re-send if the content is important.]`;
+      if (normalized.message.content.length > 0) {
+        normalized.message.content += `\n\n${failureNotice}`;
+      } else {
+        normalized.message.content = failureNotice;
       }
     }
 

--- a/gateway/src/http/routes/whatsapp-webhook.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.ts
@@ -16,6 +16,7 @@ import {
   AttachmentValidationError,
   uploadAttachment,
 } from "../../runtime/client.js";
+import { ContentMismatchError } from "../../download-validation.js";
 import {
   handleCircuitBreakerError,
   handleNewCommand,
@@ -287,6 +288,7 @@ export function createWhatsAppWebhookHandler(
 
       // Download and upload attachments if present
       let attachmentIds: string[] | undefined;
+      const failedAttachmentNames: string[] = [];
       const eventAttachments = event.message.attachments;
       if (eventAttachments && eventAttachments.length > 0) {
         try {
@@ -343,7 +345,8 @@ export function createWhatsAppWebhookHandler(
                 return uploadAttachment(config, downloaded);
               }),
             );
-            for (const result of results) {
+            for (let j = 0; j < results.length; j++) {
+              const result = results[j];
               if (result.status === "fulfilled") {
                 attachmentIds.push(result.value.id);
               } else if (result.reason instanceof AttachmentValidationError) {
@@ -351,10 +354,24 @@ export function createWhatsAppWebhookHandler(
                   { err: result.reason },
                   "Skipping WhatsApp attachment with validation error",
                 );
+                failedAttachmentNames.push(
+                  batch[j].fileName || batch[j].fileId,
+                );
+              } else if (result.reason instanceof ContentMismatchError) {
+                tlog.warn(
+                  { err: result.reason },
+                  "Skipping WhatsApp attachment with content mismatch",
+                );
+                failedAttachmentNames.push(
+                  batch[j].fileName || batch[j].fileId,
+                );
               } else if (result.reason instanceof WhatsAppNonRetryableError) {
                 tlog.warn(
                   { err: result.reason },
                   "Skipping WhatsApp attachment with non-retryable error",
+                );
+                failedAttachmentNames.push(
+                  batch[j].fileName || batch[j].fileId,
                 );
               } else {
                 // Transient failure — propagate so the webhook returns 500 and
@@ -372,6 +389,16 @@ export function createWhatsAppWebhookHandler(
           dedupCache.unreserve(whatsappMessageId);
           hasFailure = true;
           continue;
+        }
+      }
+
+      // Inject context about failed attachments into the message
+      if (failedAttachmentNames.length > 0) {
+        const failureNotice = `[The user attached file(s) that could not be retrieved: ${failedAttachmentNames.map((n) => `"${n}"`).join(", ")}. Ask them to re-send if the content is important.]`;
+        if (event.message.content.length > 0) {
+          event.message.content += `\n\n${failureNotice}`;
+        } else {
+          event.message.content = failureNotice;
         }
       }
 

--- a/gateway/src/telegram/download.ts
+++ b/gateway/src/telegram/download.ts
@@ -2,6 +2,7 @@ import { fileTypeFromBuffer } from "file-type";
 import type { ConfigFileCache } from "../config-file-cache.js";
 import type { CredentialCache } from "../credential-cache.js";
 import { credentialKey } from "../credential-key.js";
+import { validateDownloadedContent } from "../download-validation.js";
 import { fetchImpl } from "../fetch.js";
 import { callTelegramApi } from "./api.js";
 
@@ -71,6 +72,8 @@ export async function downloadTelegramFile(
     detected?.mime ||
     response.headers.get("Content-Type")?.split(";")[0].trim() ||
     "application/octet-stream";
+
+  await validateDownloadedContent(new Uint8Array(buffer), mimeType, fileId);
 
   const data = Buffer.from(buffer).toString("base64");
 

--- a/gateway/src/whatsapp/download.ts
+++ b/gateway/src/whatsapp/download.ts
@@ -1,5 +1,6 @@
 import { fileTypeFromBuffer } from "file-type";
 import type { GatewayConfig } from "../config.js";
+import { validateDownloadedContent } from "../download-validation.js";
 import {
   getWhatsAppMediaMetadata,
   downloadWhatsAppMediaBytes,
@@ -78,6 +79,8 @@ export async function downloadWhatsAppFile(
     hint?.mimeType ||
     response.headers.get("Content-Type")?.split(";")[0].trim() ||
     "application/octet-stream";
+
+  await validateDownloadedContent(new Uint8Array(buffer), mimeType, mediaId);
 
   const filename = hint?.fileName || inferFilename(mediaId, mimeType);
   const data = Buffer.from(buffer).toString("base64");


### PR DESCRIPTION
## Summary
- Integrate `validateDownloadedContent` into WhatsApp and Telegram file downloaders
- Track failed attachment filenames and inject context into messages for both channels
- Ensures HTML error pages from CDNs are caught before reaching the LLM provider

Part of plan: fix-slack-image-download.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23002" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
