### PR TITLE
feat: add fallback copy templates for trusted contact lifecycle notifications

### DIFF
--- a/assistant/src/__tests__/copy-composer-tc-templates.test.ts
+++ b/assistant/src/__tests__/copy-composer-tc-templates.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Tests for the trusted contact lifecycle fallback copy templates.
+ *
+ * Verifies that `ingress.trusted_contact.guardian_decision` and
+ * `ingress.trusted_contact.denied` templates in copy-composer.ts render
+ * display names when available and fall back to Slack <@ID> mention format
+ * for raw user IDs on the Slack source channel.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { composeFallbackCopy } from "../notifications/copy-composer.js";
+import type { NotificationSignal } from "../notifications/signal.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function buildGuardianDecisionSignal(
+  payloadOverrides: Record<string, unknown> = {},
+  sourceChannel: "slack" | "telegram" | "vellum" = "slack",
+): NotificationSignal {
+  return {
+    signalId: "test-signal-gd",
+    createdAt: Date.now(),
+    sourceChannel,
+    sourceContextId: "test-ctx-1",
+    sourceEventName: "ingress.trusted_contact.guardian_decision",
+    contextPayload: {
+      sourceChannel,
+      requesterExternalUserId: "U07CLDQ4TB3",
+      requesterChatId: "D0AQ9C5PPPF",
+      decidedByExternalUserId: "U099H19C0KA",
+      requesterDisplayName: null,
+      decidedByDisplayName: null,
+      decision: "denied",
+      ...payloadOverrides,
+    },
+    attentionHints: {
+      requiresAction: false,
+      urgency: "medium",
+      isAsyncBackground: false,
+      visibleInSourceNow: false,
+    },
+  };
+}
+
+function buildDeniedSignal(
+  payloadOverrides: Record<string, unknown> = {},
+  sourceChannel: "slack" | "telegram" | "vellum" = "slack",
+): NotificationSignal {
+  return {
+    signalId: "test-signal-denied",
+    createdAt: Date.now(),
+    sourceChannel,
+    sourceContextId: "test-ctx-2",
+    sourceEventName: "ingress.trusted_contact.denied",
+    contextPayload: {
+      sourceChannel,
+      requesterExternalUserId: "U07CLDQ4TB3",
+      requesterChatId: "D0AQ9C5PPPF",
+      decidedByExternalUserId: "U099H19C0KA",
+      requesterDisplayName: null,
+      decidedByDisplayName: null,
+      decision: "denied",
+      ...payloadOverrides,
+    },
+    attentionHints: {
+      requiresAction: false,
+      urgency: "low",
+      isAsyncBackground: false,
+      visibleInSourceNow: false,
+    },
+  };
+}
+
+// ── guardian_decision template ────────────────────────────────────────────────
+
+describe("guardian_decision fallback copy", () => {
+  test("uses display names when both are present", () => {
+    const signal = buildGuardianDecisionSignal({
+      requesterDisplayName: "Alice",
+      decidedByDisplayName: "Bob",
+      decision: "denied",
+    });
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    expect(copy.title).toBe("Trusted Contact Decision");
+    expect(copy.body).toBe("Alice's access request has been denied by Bob.");
+  });
+
+  test("falls back to Slack <@ID> mention format when display names are absent on Slack", () => {
+    const signal = buildGuardianDecisionSignal({
+      requesterDisplayName: null,
+      decidedByDisplayName: null,
+      requesterExternalUserId: "U07CLDQ4TB3",
+      decidedByExternalUserId: "U099H19C0KA",
+      sourceChannel: "slack",
+      decision: "denied",
+    });
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    expect(copy.body).toBe(
+      "<@U07CLDQ4TB3>'s access request has been denied by <@U099H19C0KA>.",
+    );
+  });
+
+  test("uses raw user IDs without Slack formatting on non-Slack channels", () => {
+    const signal = buildGuardianDecisionSignal(
+      {
+        requesterDisplayName: null,
+        decidedByDisplayName: null,
+        requesterExternalUserId: "U07CLDQ4TB3",
+        decidedByExternalUserId: "U099H19C0KA",
+        sourceChannel: "telegram",
+        decision: "denied",
+      },
+      "telegram",
+    );
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    expect(copy.body).toBe(
+      "U07CLDQ4TB3's access request has been denied by U099H19C0KA.",
+    );
+    expect(copy.body).not.toContain("<@");
+  });
+
+  test("produces distinct copy for approved vs denied decisions", () => {
+    const deniedSignal = buildGuardianDecisionSignal({
+      requesterDisplayName: "Alice",
+      decidedByDisplayName: "Bob",
+      decision: "denied",
+    });
+    const approvedSignal = buildGuardianDecisionSignal({
+      requesterDisplayName: "Alice",
+      decidedByDisplayName: "Bob",
+      decision: "approved",
+    });
+
+    const deniedCopy = composeFallbackCopy(deniedSignal, ["vellum"]).vellum!;
+    const approvedCopy = composeFallbackCopy(approvedSignal, [
+      "vellum",
+    ]).vellum!;
+
+    expect(deniedCopy.body).toContain("denied");
+    expect(deniedCopy.body).not.toContain("approved");
+    expect(approvedCopy.body).toContain("approved");
+    expect(approvedCopy.body).not.toContain("denied");
+  });
+
+  test("does not expose raw conversation IDs (requesterChatId) in output", () => {
+    const signal = buildGuardianDecisionSignal({
+      requesterDisplayName: null,
+      decidedByDisplayName: null,
+      requesterChatId: "D0AQ9C5PPPF",
+      requesterExternalUserId: "U07CLDQ4TB3",
+      decidedByExternalUserId: "U099H19C0KA",
+    });
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    expect(copy.body).not.toContain("D0AQ9C5PPPF");
+  });
+
+  test("falls back to 'Someone' when requester identity is entirely absent", () => {
+    const signal = buildGuardianDecisionSignal({
+      requesterDisplayName: null,
+      requesterExternalUserId: null,
+      decidedByDisplayName: "Bob",
+      decision: "denied",
+    });
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    expect(copy.body).toBe("Someone's access request has been denied by Bob.");
+  });
+
+  test("falls back to 'a guardian' when decider identity is entirely absent", () => {
+    const signal = buildGuardianDecisionSignal({
+      requesterDisplayName: "Alice",
+      decidedByDisplayName: null,
+      decidedByExternalUserId: null,
+      decision: "approved",
+    });
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    expect(copy.body).toBe(
+      "Alice's access request has been approved by a guardian.",
+    );
+  });
+
+  test("prefers display name over Slack user ID when both are present", () => {
+    const signal = buildGuardianDecisionSignal({
+      requesterDisplayName: "Alice",
+      requesterExternalUserId: "U07CLDQ4TB3",
+      decidedByDisplayName: "Bob",
+      decidedByExternalUserId: "U099H19C0KA",
+      sourceChannel: "slack",
+      decision: "denied",
+    });
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    expect(copy.body).toBe("Alice's access request has been denied by Bob.");
+    expect(copy.body).not.toContain("<@");
+  });
+});
+
+// ── denied template ──────────────────────────────────────────────────────────
+
+describe("trusted_contact.denied fallback copy", () => {
+  test("uses display name when present", () => {
+    const signal = buildDeniedSignal({
+      requesterDisplayName: "Alice",
+    });
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    expect(copy.title).toBe("Trusted Contact Denied");
+    expect(copy.body).toBe(
+      "A trusted contact request from Alice has been denied.",
+    );
+  });
+
+  test("falls back to Slack <@ID> mention format on Slack when display name absent", () => {
+    const signal = buildDeniedSignal({
+      requesterDisplayName: null,
+      requesterExternalUserId: "U07CLDQ4TB3",
+      sourceChannel: "slack",
+    });
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    expect(copy.body).toBe(
+      "A trusted contact request from <@U07CLDQ4TB3> has been denied.",
+    );
+  });
+
+  test("uses raw user ID without Slack formatting on non-Slack channels", () => {
+    const signal = buildDeniedSignal(
+      {
+        requesterDisplayName: null,
+        requesterExternalUserId: "U07CLDQ4TB3",
+        sourceChannel: "telegram",
+      },
+      "telegram",
+    );
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    expect(copy.body).toBe(
+      "A trusted contact request from U07CLDQ4TB3 has been denied.",
+    );
+    expect(copy.body).not.toContain("<@");
+  });
+
+  test("falls back to 'Someone' when requester identity is absent", () => {
+    const signal = buildDeniedSignal({
+      requesterDisplayName: null,
+      requesterExternalUserId: null,
+    });
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    expect(copy.body).toBe(
+      "A trusted contact request from Someone has been denied.",
+    );
+  });
+
+  test("does not expose raw conversation IDs (requesterChatId) in output", () => {
+    const signal = buildDeniedSignal({
+      requesterDisplayName: null,
+      requesterExternalUserId: "U07CLDQ4TB3",
+      requesterChatId: "D0AQ9C5PPPF",
+    });
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    expect(copy.body).not.toContain("D0AQ9C5PPPF");
+  });
+});

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -399,6 +399,89 @@ const TEMPLATES: Partial<Record<NotificationSourceEventName, CopyTemplate>> = {
     };
   },
 
+  "ingress.trusted_contact.guardian_decision": (payload) => {
+    const decision = str(payload.decision, "decided on");
+    const sourceChannel =
+      typeof payload.sourceChannel === "string"
+        ? payload.sourceChannel
+        : undefined;
+
+    const requesterDisplayName =
+      typeof payload.requesterDisplayName === "string" &&
+      payload.requesterDisplayName.length > 0
+        ? payload.requesterDisplayName
+        : undefined;
+    const requesterExternalUserId =
+      typeof payload.requesterExternalUserId === "string" &&
+      payload.requesterExternalUserId.length > 0
+        ? payload.requesterExternalUserId
+        : undefined;
+    const requesterLabel =
+      requesterDisplayName ??
+      (sourceChannel === "slack" &&
+      requesterExternalUserId &&
+      /^U[A-Z0-9]+$/i.test(requesterExternalUserId)
+        ? `<@${requesterExternalUserId}>`
+        : requesterExternalUserId) ??
+      "Someone";
+
+    const decidedByDisplayName =
+      typeof payload.decidedByDisplayName === "string" &&
+      payload.decidedByDisplayName.length > 0
+        ? payload.decidedByDisplayName
+        : undefined;
+    const decidedByExternalUserId =
+      typeof payload.decidedByExternalUserId === "string" &&
+      payload.decidedByExternalUserId.length > 0
+        ? payload.decidedByExternalUserId
+        : undefined;
+    const decidedByLabel =
+      decidedByDisplayName ??
+      (sourceChannel === "slack" &&
+      decidedByExternalUserId &&
+      /^U[A-Z0-9]+$/i.test(decidedByExternalUserId)
+        ? `<@${decidedByExternalUserId}>`
+        : decidedByExternalUserId) ??
+      "a guardian";
+
+    const verb = decision === "approved" ? "approved" : "denied";
+    return {
+      title: "Trusted Contact Decision",
+      body: `${requesterLabel}'s access request has been ${verb} by ${decidedByLabel}.`,
+    };
+  },
+
+  "ingress.trusted_contact.denied": (payload) => {
+    const sourceChannel =
+      typeof payload.sourceChannel === "string"
+        ? payload.sourceChannel
+        : undefined;
+
+    const requesterDisplayName =
+      typeof payload.requesterDisplayName === "string" &&
+      payload.requesterDisplayName.length > 0
+        ? payload.requesterDisplayName
+        : undefined;
+    const requesterExternalUserId =
+      typeof payload.requesterExternalUserId === "string" &&
+      payload.requesterExternalUserId.length > 0
+        ? payload.requesterExternalUserId
+        : undefined;
+    const requesterLabel =
+      requesterDisplayName ??
+      (sourceChannel === "slack" &&
+      requesterExternalUserId &&
+      /^U[A-Z0-9]+$/i.test(requesterExternalUserId)
+        ? `<@${requesterExternalUserId}>`
+        : requesterExternalUserId) ??
+      "Someone";
+
+    return {
+      title: "Trusted Contact Denied",
+      body: `A trusted contact request from ${requesterLabel} has been denied.`,
+    };
+  },
+
   "ingress.escalation": (payload) => ({
     title: "Escalation",
     body:


### PR DESCRIPTION
## Summary
- Add deterministic fallback templates for guardian_decision and denied trusted contact events
- Templates use display names when available, fall back to Slack <@ID> mention format for user IDs
- Conversation IDs are not exposed as raw IDs in notification copy
- Add comprehensive unit tests for the new templates

Part of plan: tc-notif-display-names.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23003" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
