### PR TITLE
feat: display names in trusted contact notification messages

### DIFF
--- a/assistant/src/__tests__/copy-composer-tc-templates.test.ts
+++ b/assistant/src/__tests__/copy-composer-tc-templates.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Tests for the trusted contact lifecycle fallback copy templates.
+ *
+ * Verifies that `ingress.trusted_contact.guardian_decision` and
+ * `ingress.trusted_contact.denied` templates in copy-composer.ts render
+ * display names when available and fall back to Slack <@ID> mention format
+ * for raw user IDs on the Slack source channel.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { composeFallbackCopy } from "../notifications/copy-composer.js";
+import type { NotificationSignal } from "../notifications/signal.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function buildGuardianDecisionSignal(
+  payloadOverrides: Record<string, unknown> = {},
+  sourceChannel: "slack" | "telegram" | "vellum" = "slack",
+): NotificationSignal {
+  return {
+    signalId: "test-signal-gd",
+    createdAt: Date.now(),
+    sourceChannel,
+    sourceContextId: "test-ctx-1",
+    sourceEventName: "ingress.trusted_contact.guardian_decision",
+    contextPayload: {
+      sourceChannel,
+      requesterExternalUserId: "U07CLDQ4TB3",
+      requesterChatId: "D0AQ9C5PPPF",
+      decidedByExternalUserId: "U099H19C0KA",
+      requesterDisplayName: null,
+      decidedByDisplayName: null,
+      decision: "denied",
+      ...payloadOverrides,
+    },
+    attentionHints: {
+      requiresAction: false,
+      urgency: "medium",
+      isAsyncBackground: false,
+      visibleInSourceNow: false,
+    },
+  };
+}
+
+function buildDeniedSignal(
+  payloadOverrides: Record<string, unknown> = {},
+  sourceChannel: "slack" | "telegram" | "vellum" = "slack",
+): NotificationSignal {
+  return {
+    signalId: "test-signal-denied",
+    createdAt: Date.now(),
+    sourceChannel,
+    sourceContextId: "test-ctx-2",
+    sourceEventName: "ingress.trusted_contact.denied",
+    contextPayload: {
+      sourceChannel,
+      requesterExternalUserId: "U07CLDQ4TB3",
+      requesterChatId: "D0AQ9C5PPPF",
+      decidedByExternalUserId: "U099H19C0KA",
+      requesterDisplayName: null,
+      decidedByDisplayName: null,
+      decision: "denied",
+      ...payloadOverrides,
+    },
+    attentionHints: {
+      requiresAction: false,
+      urgency: "low",
+      isAsyncBackground: false,
+      visibleInSourceNow: false,
+    },
+  };
+}
+
+// ── guardian_decision template ────────────────────────────────────────────────
+
+describe("guardian_decision fallback copy", () => {
+  test("uses display names when both are present", () => {
+    const signal = buildGuardianDecisionSignal({
+      requesterDisplayName: "Alice",
+      decidedByDisplayName: "Bob",
+      decision: "denied",
+    });
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    expect(copy.title).toBe("Trusted Contact Decision");
+    expect(copy.body).toBe("Alice's access request has been denied by Bob.");
+  });
+
+  test("falls back to Slack <@ID> mention format when display names are absent on Slack", () => {
+    const signal = buildGuardianDecisionSignal({
+      requesterDisplayName: null,
+      decidedByDisplayName: null,
+      requesterExternalUserId: "U07CLDQ4TB3",
+      decidedByExternalUserId: "U099H19C0KA",
+      sourceChannel: "slack",
+      decision: "denied",
+    });
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    expect(copy.body).toBe(
+      "<@U07CLDQ4TB3>'s access request has been denied by <@U099H19C0KA>.",
+    );
+  });
+
+  test("uses raw user IDs without Slack formatting on non-Slack channels", () => {
+    const signal = buildGuardianDecisionSignal(
+      {
+        requesterDisplayName: null,
+        decidedByDisplayName: null,
+        requesterExternalUserId: "U07CLDQ4TB3",
+        decidedByExternalUserId: "U099H19C0KA",
+        sourceChannel: "telegram",
+        decision: "denied",
+      },
+      "telegram",
+    );
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    expect(copy.body).toBe(
+      "U07CLDQ4TB3's access request has been denied by U099H19C0KA.",
+    );
+    expect(copy.body).not.toContain("<@");
+  });
+
+  test("produces distinct copy for approved vs denied decisions", () => {
+    const deniedSignal = buildGuardianDecisionSignal({
+      requesterDisplayName: "Alice",
+      decidedByDisplayName: "Bob",
+      decision: "denied",
+    });
+    const approvedSignal = buildGuardianDecisionSignal({
+      requesterDisplayName: "Alice",
+      decidedByDisplayName: "Bob",
+      decision: "approved",
+    });
+
+    const deniedCopy = composeFallbackCopy(deniedSignal, ["vellum"]).vellum!;
+    const approvedCopy = composeFallbackCopy(approvedSignal, [
+      "vellum",
+    ]).vellum!;
+
+    expect(deniedCopy.body).toContain("denied");
+    expect(deniedCopy.body).not.toContain("approved");
+    expect(approvedCopy.body).toContain("approved");
+    expect(approvedCopy.body).not.toContain("denied");
+  });
+
+  test("does not expose raw conversation IDs (requesterChatId) in output", () => {
+    const signal = buildGuardianDecisionSignal({
+      requesterDisplayName: null,
+      decidedByDisplayName: null,
+      requesterChatId: "D0AQ9C5PPPF",
+      requesterExternalUserId: "U07CLDQ4TB3",
+      decidedByExternalUserId: "U099H19C0KA",
+    });
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    expect(copy.body).not.toContain("D0AQ9C5PPPF");
+  });
+
+  test("falls back to 'Someone' when requester identity is entirely absent", () => {
+    const signal = buildGuardianDecisionSignal({
+      requesterDisplayName: null,
+      requesterExternalUserId: null,
+      decidedByDisplayName: "Bob",
+      decision: "denied",
+    });
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    expect(copy.body).toBe("Someone's access request has been denied by Bob.");
+  });
+
+  test("falls back to 'a guardian' when decider identity is entirely absent", () => {
+    const signal = buildGuardianDecisionSignal({
+      requesterDisplayName: "Alice",
+      decidedByDisplayName: null,
+      decidedByExternalUserId: null,
+      decision: "approved",
+    });
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    expect(copy.body).toBe(
+      "Alice's access request has been approved by a guardian.",
+    );
+  });
+
+  test("prefers display name over Slack user ID when both are present", () => {
+    const signal = buildGuardianDecisionSignal({
+      requesterDisplayName: "Alice",
+      requesterExternalUserId: "U07CLDQ4TB3",
+      decidedByDisplayName: "Bob",
+      decidedByExternalUserId: "U099H19C0KA",
+      sourceChannel: "slack",
+      decision: "denied",
+    });
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    expect(copy.body).toBe("Alice's access request has been denied by Bob.");
+    expect(copy.body).not.toContain("<@");
+  });
+});
+
+// ── denied template ──────────────────────────────────────────────────────────
+
+describe("trusted_contact.denied fallback copy", () => {
+  test("uses display name when present", () => {
+    const signal = buildDeniedSignal({
+      requesterDisplayName: "Alice",
+    });
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    expect(copy.title).toBe("Trusted Contact Denied");
+    expect(copy.body).toBe(
+      "A trusted contact request from Alice has been denied.",
+    );
+  });
+
+  test("falls back to Slack <@ID> mention format on Slack when display name absent", () => {
+    const signal = buildDeniedSignal({
+      requesterDisplayName: null,
+      requesterExternalUserId: "U07CLDQ4TB3",
+      sourceChannel: "slack",
+    });
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    expect(copy.body).toBe(
+      "A trusted contact request from <@U07CLDQ4TB3> has been denied.",
+    );
+  });
+
+  test("uses raw user ID without Slack formatting on non-Slack channels", () => {
+    const signal = buildDeniedSignal(
+      {
+        requesterDisplayName: null,
+        requesterExternalUserId: "U07CLDQ4TB3",
+        sourceChannel: "telegram",
+      },
+      "telegram",
+    );
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    expect(copy.body).toBe(
+      "A trusted contact request from U07CLDQ4TB3 has been denied.",
+    );
+    expect(copy.body).not.toContain("<@");
+  });
+
+  test("falls back to 'Someone' when requester identity is absent", () => {
+    const signal = buildDeniedSignal({
+      requesterDisplayName: null,
+      requesterExternalUserId: null,
+    });
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    expect(copy.body).toBe(
+      "A trusted contact request from Someone has been denied.",
+    );
+  });
+
+  test("does not expose raw conversation IDs (requesterChatId) in output", () => {
+    const signal = buildDeniedSignal({
+      requesterDisplayName: null,
+      requesterExternalUserId: "U07CLDQ4TB3",
+      requesterChatId: "D0AQ9C5PPPF",
+    });
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    expect(copy.body).not.toContain("D0AQ9C5PPPF");
+  });
+});

--- a/assistant/src/__tests__/copy-composer-tc-templates.test.ts
+++ b/assistant/src/__tests__/copy-composer-tc-templates.test.ts
@@ -205,6 +205,35 @@ describe("guardian_decision fallback copy", () => {
     expect(copy.body).toBe("Alice's access request has been denied by Bob.");
     expect(copy.body).not.toContain("<@");
   });
+
+  test("sanitizes control characters from display names", () => {
+    const signal = buildGuardianDecisionSignal({
+      requesterDisplayName: "Alice\x00\x07\nEvil",
+      decidedByDisplayName: "Bob\r\nMalicious",
+      decision: "approved",
+    });
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    expect(copy.body).not.toMatch(/[\x00-\x1f\x7f-\x9f]/);
+    expect(copy.body).toContain("Alice");
+    expect(copy.body).toContain("Bob");
+  });
+
+  test("clamps excessively long display names", () => {
+    const longName = "A".repeat(200);
+    const signal = buildGuardianDecisionSignal({
+      requesterDisplayName: longName,
+      decidedByDisplayName: "Bob",
+      decision: "denied",
+    });
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    // sanitizeIdentityField clamps to 120 chars + ellipsis
+    expect(copy.body.length).toBeLessThan(longName.length);
+    expect(copy.body).toContain("…");
+  });
 });
 
 // ── denied template ──────────────────────────────────────────────────────────
@@ -278,5 +307,29 @@ describe("trusted_contact.denied fallback copy", () => {
     const copy = result.vellum!;
 
     expect(copy.body).not.toContain("D0AQ9C5PPPF");
+  });
+
+  test("sanitizes control characters from display names", () => {
+    const signal = buildDeniedSignal({
+      requesterDisplayName: "Alice\x00\x07\nEvil",
+    });
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    expect(copy.body).not.toMatch(/[\x00-\x1f\x7f-\x9f]/);
+    expect(copy.body).toContain("Alice");
+  });
+
+  test("clamps excessively long display names", () => {
+    const longName = "A".repeat(200);
+    const signal = buildDeniedSignal({
+      requesterDisplayName: longName,
+    });
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    // sanitizeIdentityField clamps to 120 chars + ellipsis
+    expect(copy.body.length).toBeLessThan(longName.length);
+    expect(copy.body).toContain("…");
   });
 });

--- a/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
+++ b/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
@@ -133,7 +133,7 @@ describe("trusted contact lifecycle notification signals", () => {
     resetState();
   });
 
-  test("guardian deny emits guardian_decision and denied signals", async () => {
+  test("guardian deny emits guardian_decision and denied signals with display names", async () => {
     // Set up guardian binding and member record (guardians must pass ACL)
     createGuardianBinding({
       channel: "telegram",
@@ -148,6 +148,17 @@ describe("trusted contact lifecycle notification signals", () => {
       externalChatId: "guardian-chat-789",
       status: "active",
       policy: "allow",
+      displayName: "Guardian Bob",
+    });
+
+    // Set up requester contact with a display name so payloads are enriched
+    upsertContactChannel({
+      sourceChannel: "telegram",
+      externalUserId: "requester-user-456",
+      externalChatId: "requester-chat-456",
+      status: "pending",
+      policy: "ask",
+      displayName: "Alice Requester",
     });
 
     const testRequestId = `req-deny-${Date.now()}`;
@@ -199,11 +210,15 @@ describe("trusted contact lifecycle notification signals", () => {
     expect(gdPayload.decision).toBe("denied");
     expect(gdPayload.requesterExternalUserId).toBe("requester-user-456");
     expect(gdPayload.decidedByExternalUserId).toBe("guardian-user-789");
+    expect(gdPayload.requesterDisplayName).toBe("Alice Requester");
+    expect(gdPayload.decidedByDisplayName).toBe("Guardian Bob");
 
     // Verify denied payload
     const dPayload = deniedSignals[0].contextPayload as Record<string, unknown>;
     expect(dPayload.decision).toBe("denied");
     expect(dPayload.requesterExternalUserId).toBe("requester-user-456");
+    expect(dPayload.requesterDisplayName).toBe("Alice Requester");
+    expect(dPayload.decidedByDisplayName).toBe("Guardian Bob");
 
     // Verify deduplication keys are distinct
     expect(guardianDecisionSignals[0].dedupeKey).toContain(
@@ -212,7 +227,7 @@ describe("trusted contact lifecycle notification signals", () => {
     expect(deniedSignals[0].dedupeKey).toContain("trusted-contact:denied:");
   });
 
-  test("guardian approve emits guardian_decision and verification_sent signals", async () => {
+  test("guardian approve emits guardian_decision and verification_sent signals with display names", async () => {
     // Set up guardian binding and member record (guardians must pass ACL)
     createGuardianBinding({
       channel: "telegram",
@@ -227,6 +242,17 @@ describe("trusted contact lifecycle notification signals", () => {
       externalChatId: "guardian-chat-789",
       status: "active",
       policy: "allow",
+      displayName: "Guardian Bob",
+    });
+
+    // Set up requester contact with a display name
+    upsertContactChannel({
+      sourceChannel: "telegram",
+      externalUserId: "requester-user-456",
+      externalChatId: "requester-chat-456",
+      status: "pending",
+      policy: "ask",
+      displayName: "Alice Requester",
     });
 
     const testRequestId = `req-approve-${Date.now()}`;
@@ -276,6 +302,8 @@ describe("trusted contact lifecycle notification signals", () => {
     const vsPayload = vsSignal.contextPayload as Record<string, unknown>;
     expect(vsPayload.requesterExternalUserId).toBe("requester-user-456");
     expect(vsPayload.verificationSessionId).toBeDefined();
+    expect(vsPayload.requesterDisplayName).toBe("Alice Requester");
+    expect(vsPayload.decidedByDisplayName).toBe("Guardian Bob");
     expect(
       (vsSignal.attentionHints as Record<string, unknown>).visibleInSourceNow,
     ).toBe(true);
@@ -339,6 +367,88 @@ describe("trusted contact lifecycle notification signals", () => {
     );
     // guardian_decision and denied — both keyed on approval.id
     expect(signals.length).toBe(2);
+  });
+
+  test("display name fields fall back to null when contacts have no display name", async () => {
+    // Set up guardian binding and member record WITHOUT display names
+    createGuardianBinding({
+      channel: "telegram",
+      guardianExternalUserId: "guardian-noname-111",
+      guardianDeliveryChatId: "guardian-chat-111",
+      guardianPrincipalId: "guardian-noname-111",
+      verifiedVia: "test",
+    });
+    upsertContactChannel({
+      sourceChannel: "telegram",
+      externalUserId: "guardian-noname-111",
+      externalChatId: "guardian-chat-111",
+      status: "active",
+      policy: "allow",
+      // No displayName set
+    });
+
+    // Do NOT create a requester contact — display name should resolve to null
+
+    const testRequestId = `req-noname-${Date.now()}`;
+
+    createApprovalRequest({
+      runId: `ingress-access-request-${Date.now()}`,
+      requestId: testRequestId,
+      conversationId: "access-req-telegram-requester-noname-222",
+      channel: "telegram",
+      requesterExternalUserId: "requester-noname-222",
+      requesterChatId: "requester-chat-222",
+      guardianExternalUserId: "guardian-noname-111",
+      guardianChatId: "guardian-chat-111",
+      toolName: "ingress_access_request",
+      riskLevel: "access_request",
+      reason: "Unknown user requesting access",
+      expiresAt: Date.now() + GUARDIAN_APPROVAL_TTL_MS,
+    });
+
+    // Guardian denies via callback button
+    const guardianReq = buildInboundRequest({
+      conversationExternalId: "guardian-chat-111",
+      actorExternalId: "guardian-noname-111",
+      actorDisplayName: "Guardian",
+      content: "",
+      callbackData: `apr:${testRequestId}:reject`,
+    });
+
+    await handleChannelInbound(guardianReq, undefined, TEST_BEARER_TOKEN);
+
+    const guardianDecisionSignals = emitSignalCalls.filter(
+      (c) => c.sourceEventName === "ingress.trusted_contact.guardian_decision",
+    );
+    const deniedSignals = emitSignalCalls.filter(
+      (c) => c.sourceEventName === "ingress.trusted_contact.denied",
+    );
+
+    expect(guardianDecisionSignals.length).toBe(1);
+    expect(deniedSignals.length).toBe(1);
+
+    // Verify display names fall back to null when contacts have no display name
+    const gdPayload = guardianDecisionSignals[0].contextPayload as Record<
+      string,
+      unknown
+    >;
+    expect(gdPayload.requesterDisplayName).toBeNull();
+    // Guardian contact exists but was created without a displayName —
+    // upsertContactChannel defaults displayName to the empty string, and
+    // the contacts DB stores that as an empty string. findContactChannel
+    // returns the raw value so decidedByDisplayName may be "" rather than
+    // null. Accept either falsy value.
+    expect(
+      gdPayload.decidedByDisplayName === null ||
+        gdPayload.decidedByDisplayName === "",
+    ).toBe(true);
+
+    const dPayload = deniedSignals[0].contextPayload as Record<string, unknown>;
+    expect(dPayload.requesterDisplayName).toBeNull();
+    expect(
+      dPayload.decidedByDisplayName === null ||
+        dPayload.decidedByDisplayName === "",
+    ).toBe(true);
   });
 });
 

--- a/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
+++ b/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
@@ -370,7 +370,19 @@ describe("trusted contact lifecycle notification signals", () => {
   });
 
   test("display name fields fall back to null when contacts have no display name", async () => {
-    // Set up guardian binding and member record WITHOUT display names
+    // Set up guardian binding — createGuardianBinding creates a contact with
+    // displayName defaulting to the externalUserId. We need to verify the
+    // null-fallback path for display name resolution, so we use a guardian
+    // whose external user ID does NOT have a matching contact_channels row.
+    //
+    // Strategy: create the guardian binding normally (so the sender is
+    // classified as trustClass="guardian"), then use a DIFFERENT external
+    // user ID in the approval request's guardianExternalUserId field. The
+    // decidedByExternalUserId comes from actorExternalId (the real guardian),
+    // which DOES have a contact. To truly get null, we clear the guardian
+    // contact's displayName to empty string after creation — the signal
+    // enrichment code treats empty string the same as null for display
+    // purposes.
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "guardian-noname-111",
@@ -378,14 +390,13 @@ describe("trusted contact lifecycle notification signals", () => {
       guardianPrincipalId: "guardian-noname-111",
       verifiedVia: "test",
     });
-    upsertContactChannel({
-      sourceChannel: "telegram",
-      externalUserId: "guardian-noname-111",
-      externalChatId: "guardian-chat-111",
-      status: "active",
-      policy: "allow",
-      // No displayName set
-    });
+
+    // Clear the guardian contact's displayName to empty string so the
+    // display name resolution returns a falsy value. createGuardianBinding
+    // defaults displayName to the externalUserId, which would be a non-empty
+    // string and defeat the purpose of this test.
+    const db = getDb();
+    db.run("UPDATE contacts SET display_name = '' WHERE role = 'guardian'");
 
     // Do NOT create a requester contact — display name should resolve to null
 
@@ -427,28 +438,21 @@ describe("trusted contact lifecycle notification signals", () => {
     expect(guardianDecisionSignals.length).toBe(1);
     expect(deniedSignals.length).toBe(1);
 
-    // Verify display names fall back to null when contacts have no display name
+    // Verify display names fall back to null/empty when contacts have no
+    // display name set.
     const gdPayload = guardianDecisionSignals[0].contextPayload as Record<
       string,
       unknown
     >;
     expect(gdPayload.requesterDisplayName).toBeNull();
-    // Guardian contact exists but was created without a displayName —
-    // upsertContactChannel defaults displayName to the empty string, and
-    // the contacts DB stores that as an empty string. findContactChannel
-    // returns the raw value so decidedByDisplayName may be "" rather than
-    // null. Accept either falsy value.
-    expect(
-      gdPayload.decidedByDisplayName === null ||
-        gdPayload.decidedByDisplayName === "",
-    ).toBe(true);
+    // Guardian contact exists but displayName was cleared to empty string.
+    // The signal enrichment resolves displayName from the contact record,
+    // so decidedByDisplayName will be "" (empty string) rather than null.
+    expect(gdPayload.decidedByDisplayName).toBe("");
 
     const dPayload = deniedSignals[0].contextPayload as Record<string, unknown>;
     expect(dPayload.requesterDisplayName).toBeNull();
-    expect(
-      dPayload.decidedByDisplayName === null ||
-        dPayload.decidedByDisplayName === "",
-    ).toBe(true);
+    expect(dPayload.decidedByDisplayName).toBe("");
   });
 });
 

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -13,6 +13,7 @@
 
 import { answerCall } from "../calls/call-domain.js";
 import { getGatewayInternalBaseUrl } from "../config/env.js";
+import { findContactChannel } from "../contacts/contact-store.js";
 import { upsertContactChannel } from "../contacts/contacts-write.js";
 import {
   type CanonicalGuardianRequest,
@@ -396,6 +397,25 @@ const accessRequestResolver: GuardianRequestResolver = {
     const desktopDeliverUrl = resolveDeliverCallbackUrlForChannel(channel);
     const desktopBearerToken = mintDaemonDeliveryToken();
 
+    // Resolve display names from the contacts database for enriched payloads
+    const requesterContactResult = requesterExternalUserId
+      ? findContactChannel({
+          channelType: channel,
+          externalUserId: requesterExternalUserId,
+        })
+      : null;
+    const requesterDisplayName =
+      requesterContactResult?.contact.displayName ?? null;
+
+    const decidedByContactResult = decidedByExternalUserId
+      ? findContactChannel({
+          channelType: channel,
+          externalUserId: decidedByExternalUserId,
+        })
+      : null;
+    const decidedByDisplayName =
+      decidedByContactResult?.contact.displayName ?? null;
+
     if (decision.action === "reject") {
       log.info(
         { event: "resolver_access_request_denied", requestId: request.id },
@@ -435,6 +455,8 @@ const accessRequestResolver: GuardianRequestResolver = {
           requesterExternalUserId,
           requesterChatId,
           decidedByExternalUserId,
+          requesterDisplayName,
+          decidedByDisplayName,
           decision: "denied" as const,
         };
 
@@ -726,6 +748,8 @@ const accessRequestResolver: GuardianRequestResolver = {
             sourceChannel: channel,
             requesterExternalUserId,
             requesterChatId,
+            requesterDisplayName,
+            decidedByDisplayName,
             verificationSessionId: session.sessionId,
           },
           dedupeKey: `trusted-contact:verification-sent:${session.sessionId}`,

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -416,14 +416,15 @@ const TEMPLATES: Partial<Record<NotificationSourceEventName, CopyTemplate>> = {
       payload.requesterExternalUserId.length > 0
         ? payload.requesterExternalUserId
         : undefined;
-    const requesterLabel =
+    const requesterLabel = sanitizeIdentityField(
       requesterDisplayName ??
-      (sourceChannel === "slack" &&
-      requesterExternalUserId &&
-      /^U[A-Z0-9]+$/i.test(requesterExternalUserId)
-        ? `<@${requesterExternalUserId}>`
-        : requesterExternalUserId) ??
-      "Someone";
+        (sourceChannel === "slack" &&
+        requesterExternalUserId &&
+        /^U[A-Z0-9]+$/i.test(requesterExternalUserId)
+          ? `<@${requesterExternalUserId}>`
+          : requesterExternalUserId) ??
+        "Someone",
+    );
 
     const decidedByDisplayName =
       typeof payload.decidedByDisplayName === "string" &&
@@ -435,14 +436,15 @@ const TEMPLATES: Partial<Record<NotificationSourceEventName, CopyTemplate>> = {
       payload.decidedByExternalUserId.length > 0
         ? payload.decidedByExternalUserId
         : undefined;
-    const decidedByLabel =
+    const decidedByLabel = sanitizeIdentityField(
       decidedByDisplayName ??
-      (sourceChannel === "slack" &&
-      decidedByExternalUserId &&
-      /^U[A-Z0-9]+$/i.test(decidedByExternalUserId)
-        ? `<@${decidedByExternalUserId}>`
-        : decidedByExternalUserId) ??
-      "a guardian";
+        (sourceChannel === "slack" &&
+        decidedByExternalUserId &&
+        /^U[A-Z0-9]+$/i.test(decidedByExternalUserId)
+          ? `<@${decidedByExternalUserId}>`
+          : decidedByExternalUserId) ??
+        "a guardian",
+    );
 
     const verb = decision === "approved" ? "approved" : "denied";
     return {
@@ -467,14 +469,15 @@ const TEMPLATES: Partial<Record<NotificationSourceEventName, CopyTemplate>> = {
       payload.requesterExternalUserId.length > 0
         ? payload.requesterExternalUserId
         : undefined;
-    const requesterLabel =
+    const requesterLabel = sanitizeIdentityField(
       requesterDisplayName ??
-      (sourceChannel === "slack" &&
-      requesterExternalUserId &&
-      /^U[A-Z0-9]+$/i.test(requesterExternalUserId)
-        ? `<@${requesterExternalUserId}>`
-        : requesterExternalUserId) ??
-      "Someone";
+        (sourceChannel === "slack" &&
+        requesterExternalUserId &&
+        /^U[A-Z0-9]+$/i.test(requesterExternalUserId)
+          ? `<@${requesterExternalUserId}>`
+          : requesterExternalUserId) ??
+        "Someone",
+    );
 
     return {
       title: "Trusted Contact Denied",

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -399,6 +399,89 @@ const TEMPLATES: Partial<Record<NotificationSourceEventName, CopyTemplate>> = {
     };
   },
 
+  "ingress.trusted_contact.guardian_decision": (payload) => {
+    const decision = str(payload.decision, "decided on");
+    const sourceChannel =
+      typeof payload.sourceChannel === "string"
+        ? payload.sourceChannel
+        : undefined;
+
+    const requesterDisplayName =
+      typeof payload.requesterDisplayName === "string" &&
+      payload.requesterDisplayName.length > 0
+        ? payload.requesterDisplayName
+        : undefined;
+    const requesterExternalUserId =
+      typeof payload.requesterExternalUserId === "string" &&
+      payload.requesterExternalUserId.length > 0
+        ? payload.requesterExternalUserId
+        : undefined;
+    const requesterLabel =
+      requesterDisplayName ??
+      (sourceChannel === "slack" &&
+      requesterExternalUserId &&
+      /^U[A-Z0-9]+$/i.test(requesterExternalUserId)
+        ? `<@${requesterExternalUserId}>`
+        : requesterExternalUserId) ??
+      "Someone";
+
+    const decidedByDisplayName =
+      typeof payload.decidedByDisplayName === "string" &&
+      payload.decidedByDisplayName.length > 0
+        ? payload.decidedByDisplayName
+        : undefined;
+    const decidedByExternalUserId =
+      typeof payload.decidedByExternalUserId === "string" &&
+      payload.decidedByExternalUserId.length > 0
+        ? payload.decidedByExternalUserId
+        : undefined;
+    const decidedByLabel =
+      decidedByDisplayName ??
+      (sourceChannel === "slack" &&
+      decidedByExternalUserId &&
+      /^U[A-Z0-9]+$/i.test(decidedByExternalUserId)
+        ? `<@${decidedByExternalUserId}>`
+        : decidedByExternalUserId) ??
+      "a guardian";
+
+    const verb = decision === "approved" ? "approved" : "denied";
+    return {
+      title: "Trusted Contact Decision",
+      body: `${requesterLabel}'s access request has been ${verb} by ${decidedByLabel}.`,
+    };
+  },
+
+  "ingress.trusted_contact.denied": (payload) => {
+    const sourceChannel =
+      typeof payload.sourceChannel === "string"
+        ? payload.sourceChannel
+        : undefined;
+
+    const requesterDisplayName =
+      typeof payload.requesterDisplayName === "string" &&
+      payload.requesterDisplayName.length > 0
+        ? payload.requesterDisplayName
+        : undefined;
+    const requesterExternalUserId =
+      typeof payload.requesterExternalUserId === "string" &&
+      payload.requesterExternalUserId.length > 0
+        ? payload.requesterExternalUserId
+        : undefined;
+    const requesterLabel =
+      requesterDisplayName ??
+      (sourceChannel === "slack" &&
+      requesterExternalUserId &&
+      /^U[A-Z0-9]+$/i.test(requesterExternalUserId)
+        ? `<@${requesterExternalUserId}>`
+        : requesterExternalUserId) ??
+      "Someone";
+
+    return {
+      title: "Trusted Contact Denied",
+      body: `A trusted contact request from ${requesterLabel} has been denied.`,
+    };
+  },
+
   "ingress.escalation": (payload) => ({
     title: "Escalation",
     body:

--- a/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
+++ b/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
@@ -5,6 +5,7 @@
  */
 import { applyGuardianDecision } from "../../../approvals/guardian-decision-primitive.js";
 import type { ChannelId } from "../../../channels/types.js";
+import { findContactChannel } from "../../../contacts/contact-store.js";
 import {
   getAllPendingApprovalsByGuardianChat,
   getApprovalRequestById,
@@ -804,6 +805,25 @@ async function handleAccessRequestApproval(
     return { handled: true, type: "stale_ignored" };
   }
 
+  // Resolve display names from the contacts database for enriched payloads
+  const requesterContactResult = approval.requesterExternalUserId
+    ? findContactChannel({
+        channelType: approval.channel,
+        externalUserId: approval.requesterExternalUserId,
+      })
+    : null;
+  const requesterDisplayName =
+    requesterContactResult?.contact.displayName ?? null;
+
+  const decidedByContactResult = decidedByExternalUserId
+    ? findContactChannel({
+        channelType: approval.channel,
+        externalUserId: decidedByExternalUserId,
+      })
+    : null;
+  const decidedByDisplayName =
+    decidedByContactResult?.contact.displayName ?? null;
+
   if (decisionResult.type === "denied") {
     await notifyRequesterOfDenial({
       replyCallbackUrl,
@@ -821,6 +841,8 @@ async function handleAccessRequestApproval(
       requesterExternalUserId: approval.requesterExternalUserId,
       requesterChatId: approval.requesterChatId,
       decidedByExternalUserId,
+      requesterDisplayName,
+      decidedByDisplayName,
       decision: "denied" as const,
     };
 
@@ -952,6 +974,8 @@ async function handleAccessRequestApproval(
         requesterExternalUserId: approval.requesterExternalUserId,
         requesterChatId: approval.requesterChatId,
         decidedByExternalUserId,
+        requesterDisplayName,
+        decidedByDisplayName,
         decision: "approved",
       },
       dedupeKey: `trusted-contact:guardian-decision:${approval.id}`,
@@ -977,6 +1001,8 @@ async function handleAccessRequestApproval(
         sourceChannel: approval.channel as NotificationSourceChannel,
         requesterExternalUserId: approval.requesterExternalUserId,
         requesterChatId: approval.requesterChatId,
+        requesterDisplayName,
+        decidedByDisplayName,
         verificationSessionId: decisionResult.verificationSessionId,
       },
       dedupeKey: `trusted-contact:verification-sent:${decisionResult.verificationSessionId}`,


### PR DESCRIPTION
## Summary
Trusted contact lifecycle notification messages (guardian decision, denial, verification sent) were showing raw Slack user IDs (e.g. `U07CLDQ4TB3`) and conversation IDs (e.g. `D0AQ9C5PPPF`) instead of human-readable names. This PR enriches notification payloads with display names from the contacts database and adds deterministic fallback templates for user-friendly notification copy.

## PRs merged into feature branch
- #23000: feat: add display names to trusted contact notification payloads
- #23003: feat: add fallback copy templates for trusted contact lifecycle notifications
- #23251: fix: sanitize identity fields in trusted contact notification templates
- #23253: fix: correct null display name fallback test

Part of plan: tc-notif-display-names.md