### PR TITLE
Fix Slack image attachments causing provider rejection

### DIFF
--- a/gateway/src/download-validation.test.ts
+++ b/gateway/src/download-validation.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ContentMismatchError,
+  validateDownloadedContent,
+} from "./download-validation.js";
+
+/** Create a minimal valid PNG buffer that file-type can detect. */
+function makePngBuffer(): Uint8Array {
+  return new Uint8Array([
+    // PNG signature
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    // IHDR chunk: length (13)
+    0x00, 0x00, 0x00, 0x0d,
+    // IHDR type
+    0x49, 0x48, 0x44, 0x52,
+    // Width: 1
+    0x00, 0x00, 0x00, 0x01,
+    // Height: 1
+    0x00, 0x00, 0x00, 0x01,
+    // Bit depth, color type, compression, filter, interlace
+    0x08, 0x02, 0x00, 0x00, 0x00,
+    // CRC (placeholder)
+    0x90, 0x77, 0x53, 0xde,
+  ]);
+}
+
+function htmlBuffer(html: string): Uint8Array {
+  return new TextEncoder().encode(html);
+}
+
+describe("validateDownloadedContent", () => {
+  test("throws ContentMismatchError when HTML is received instead of image/png", async () => {
+    const buffer = htmlBuffer(
+      "<!DOCTYPE html><html><body><h1>Access Denied</h1></body></html>",
+    );
+
+    await expect(
+      validateDownloadedContent(buffer, "image/png", "F001"),
+    ).rejects.toThrow(ContentMismatchError);
+
+    await expect(
+      validateDownloadedContent(buffer, "image/png", "F001"),
+    ).rejects.toThrow(
+      "File F001 declared as image/png but content is HTML (likely an auth/error page)",
+    );
+  });
+
+  test("throws ContentMismatchError for HTML with leading whitespace and BOM", async () => {
+    // UTF-8 BOM (EF BB BF) + whitespace + HTML
+    const bom = new Uint8Array([0xef, 0xbb, 0xbf]);
+    const html = new TextEncoder().encode(
+      "  \n  <!DOCTYPE html><html><body>Error</body></html>",
+    );
+    const buffer = new Uint8Array(bom.length + html.length);
+    buffer.set(bom, 0);
+    buffer.set(html, bom.length);
+
+    await expect(
+      validateDownloadedContent(buffer, "image/jpeg", "F002"),
+    ).rejects.toThrow(ContentMismatchError);
+  });
+
+  test("passes for valid PNG buffer with declared image/png", async () => {
+    const buffer = makePngBuffer();
+
+    // Should not throw
+    await validateDownloadedContent(buffer, "image/png", "F003");
+  });
+
+  test("passes for valid PNG buffer with declared image/jpeg (same image family)", async () => {
+    const buffer = makePngBuffer();
+
+    // file-type detects it as image/png, which still starts with "image/"
+    // so it should pass even though declared as image/jpeg
+    await validateDownloadedContent(buffer, "image/jpeg", "F004");
+  });
+
+  test("passes for plain text buffer with declared text/plain (non-binary)", async () => {
+    const buffer = new TextEncoder().encode("hello world");
+
+    // text/plain is not a binary MIME type, so no validation is performed
+    await validateDownloadedContent(
+      new Uint8Array(buffer),
+      "text/plain",
+      "F005",
+    );
+  });
+
+  test("passes for empty buffer with declared image/png", async () => {
+    const buffer = new Uint8Array(0);
+
+    // Empty buffer: looksLikeHtml returns false, fileTypeFromBuffer returns
+    // undefined, so we allow it through and let downstream handle it
+    await validateDownloadedContent(buffer, "image/png", "F006");
+  });
+});

--- a/gateway/src/download-validation.ts
+++ b/gateway/src/download-validation.ts
@@ -1,0 +1,92 @@
+import { fileTypeFromBuffer } from "file-type";
+
+export class ContentMismatchError extends Error {
+  override name = "ContentMismatchError";
+}
+
+/**
+ * Check whether a buffer looks like an HTML page by inspecting the first
+ * non-whitespace / non-BOM bytes for common HTML markers.
+ */
+export function looksLikeHtml(buffer: Uint8Array): boolean {
+  // Skip leading whitespace and UTF-8 BOM (0xEF 0xBB 0xBF)
+  let offset = 0;
+  // Skip UTF-8 BOM if present
+  if (
+    buffer.length >= 3 &&
+    buffer[0] === 0xef &&
+    buffer[1] === 0xbb &&
+    buffer[2] === 0xbf
+  ) {
+    offset = 3;
+  }
+  // Skip whitespace characters (space, tab, newline, carriage return)
+  while (offset < buffer.length) {
+    const byte = buffer[offset];
+    if (byte === 0x20 || byte === 0x09 || byte === 0x0a || byte === 0x0d) {
+      offset++;
+    } else {
+      break;
+    }
+  }
+
+  if (offset >= buffer.length) {
+    return false;
+  }
+
+  const remaining = buffer.subarray(offset);
+  const prefix = new TextDecoder("utf-8", { fatal: false }).decode(
+    remaining.subarray(0, Math.min(remaining.length, 15)),
+  );
+
+  const upper = prefix.toUpperCase();
+  return upper.startsWith("<!DOCTYPE") || upper.startsWith("<HTML");
+}
+
+const BINARY_MIME_PREFIXES = [
+  "image/",
+  "audio/",
+  "video/",
+  "application/pdf",
+] as const;
+
+/**
+ * Validate that downloaded content actually matches its declared MIME type.
+ *
+ * This catches a common failure mode where CDNs (Slack, WhatsApp, Telegram)
+ * return an HTML error or auth page instead of the actual binary file.
+ * Base64-encoding that HTML and sending it to a provider as e.g. `image/png`
+ * causes the provider to reject the request.
+ */
+export async function validateDownloadedContent(
+  buffer: Uint8Array,
+  declaredMime: string,
+  fileId: string,
+): Promise<void> {
+  const isBinary = BINARY_MIME_PREFIXES.some((prefix) =>
+    declaredMime.startsWith(prefix),
+  );
+
+  if (!isBinary) {
+    return;
+  }
+
+  // Guard: if the buffer looks like HTML, it's almost certainly an error page
+  if (looksLikeHtml(buffer)) {
+    throw new ContentMismatchError(
+      `File ${fileId} declared as ${declaredMime} but content is HTML (likely an auth/error page)`,
+    );
+  }
+
+  // For image types, do a deeper check with file-type detection
+  if (declaredMime.startsWith("image/")) {
+    const detected = await fileTypeFromBuffer(buffer);
+    if (detected && !detected.mime.startsWith("image/")) {
+      throw new ContentMismatchError(
+        `File ${fileId} declared as ${declaredMime} but detected as ${detected.mime}`,
+      );
+    }
+    // If detected is undefined and it doesn't look like HTML, allow it
+    // through — some image formats may not be in file-type's database.
+  }
+}

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -4,6 +4,7 @@ import type { GatewayConfig } from "../../config.js";
 import type { CredentialCache } from "../../credential-cache.js";
 import { credentialKey } from "../../credential-key.js";
 import { DedupCache } from "../../dedup-cache.js";
+import { ContentMismatchError } from "../../download-validation.js";
 import { handleInbound } from "../../handlers/handle-inbound.js";
 import { getLogger } from "../../logger.js";
 import { RejectionRateLimiter } from "../../rejection-rate-limiter.js";
@@ -575,6 +576,7 @@ export function createTelegramWebhookHandler(
     // Download and upload attachments if present (skip for edits and callback
     // queries — edits only update text, callbacks have no media to process)
     let attachmentIds: string[] | undefined;
+    const failedAttachmentNames: string[] = [];
     const eventAttachments = normalized.message.attachments;
     if (
       eventAttachments &&
@@ -636,7 +638,8 @@ export function createTelegramWebhookHandler(
               return uploadAttachment(config, downloaded);
             }),
           );
-          for (const result of results) {
+          for (let j = 0; j < results.length; j++) {
+            const result = results[j];
             if (result.status === "fulfilled") {
               attachmentIds.push(result.value.id);
             } else if (result.reason instanceof AttachmentValidationError) {
@@ -644,6 +647,13 @@ export function createTelegramWebhookHandler(
                 { err: result.reason },
                 "Skipping attachment with validation error",
               );
+              failedAttachmentNames.push(batch[j].fileName || batch[j].fileId);
+            } else if (result.reason instanceof ContentMismatchError) {
+              tlog.warn(
+                { err: result.reason },
+                "Skipping attachment with content mismatch",
+              );
+              failedAttachmentNames.push(batch[j].fileName || batch[j].fileId);
             } else {
               // Transient failure — propagate so the webhook returns 500 and
               // Telegram retries the update delivery.
@@ -664,6 +674,16 @@ export function createTelegramWebhookHandler(
           { error: "Attachment processing failed" },
           { status: 500 },
         );
+      }
+    }
+
+    // Inject context about failed attachments into the message
+    if (failedAttachmentNames.length > 0) {
+      const failureNotice = `[The user attached file(s) that could not be retrieved: ${failedAttachmentNames.map((n) => `"${n}"`).join(", ")}. Ask them to re-send if the content is important.]`;
+      if (normalized.message.content.length > 0) {
+        normalized.message.content += `\n\n${failureNotice}`;
+      } else {
+        normalized.message.content = failureNotice;
       }
     }
 

--- a/gateway/src/http/routes/whatsapp-webhook.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.ts
@@ -16,6 +16,7 @@ import {
   AttachmentValidationError,
   uploadAttachment,
 } from "../../runtime/client.js";
+import { ContentMismatchError } from "../../download-validation.js";
 import {
   handleCircuitBreakerError,
   handleNewCommand,
@@ -287,6 +288,7 @@ export function createWhatsAppWebhookHandler(
 
       // Download and upload attachments if present
       let attachmentIds: string[] | undefined;
+      const failedAttachmentNames: string[] = [];
       const eventAttachments = event.message.attachments;
       if (eventAttachments && eventAttachments.length > 0) {
         try {
@@ -343,7 +345,8 @@ export function createWhatsAppWebhookHandler(
                 return uploadAttachment(config, downloaded);
               }),
             );
-            for (const result of results) {
+            for (let j = 0; j < results.length; j++) {
+              const result = results[j];
               if (result.status === "fulfilled") {
                 attachmentIds.push(result.value.id);
               } else if (result.reason instanceof AttachmentValidationError) {
@@ -351,10 +354,24 @@ export function createWhatsAppWebhookHandler(
                   { err: result.reason },
                   "Skipping WhatsApp attachment with validation error",
                 );
+                failedAttachmentNames.push(
+                  batch[j].fileName || batch[j].fileId,
+                );
+              } else if (result.reason instanceof ContentMismatchError) {
+                tlog.warn(
+                  { err: result.reason },
+                  "Skipping WhatsApp attachment with content mismatch",
+                );
+                failedAttachmentNames.push(
+                  batch[j].fileName || batch[j].fileId,
+                );
               } else if (result.reason instanceof WhatsAppNonRetryableError) {
                 tlog.warn(
                   { err: result.reason },
                   "Skipping WhatsApp attachment with non-retryable error",
+                );
+                failedAttachmentNames.push(
+                  batch[j].fileName || batch[j].fileId,
                 );
               } else {
                 // Transient failure — propagate so the webhook returns 500 and
@@ -372,6 +389,16 @@ export function createWhatsAppWebhookHandler(
           dedupCache.unreserve(whatsappMessageId);
           hasFailure = true;
           continue;
+        }
+      }
+
+      // Inject context about failed attachments into the message
+      if (failedAttachmentNames.length > 0) {
+        const failureNotice = `[The user attached file(s) that could not be retrieved: ${failedAttachmentNames.map((n) => `"${n}"`).join(", ")}. Ask them to re-send if the content is important.]`;
+        if (event.message.content.length > 0) {
+          event.message.content += `\n\n${failureNotice}`;
+        } else {
+          event.message.content = failureNotice;
         }
       }
 

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1240,6 +1240,7 @@ async function main() {
               !isCallback
             ) {
               attachmentIds = [];
+              const failedAttachmentNames: string[] = [];
               const maxBytes =
                 config.maxAttachmentBytes.slack ??
                 config.maxAttachmentBytes.default;
@@ -1290,23 +1291,35 @@ async function main() {
                     });
                   }),
                 );
-                for (const result of results) {
+                for (let j = 0; j < results.length; j++) {
+                  const result = results[j];
                   if (result.status === "fulfilled") {
                     attachmentIds.push(result.value.id);
                   } else if (
                     result.reason instanceof AttachmentValidationError
                   ) {
+                    const att = batch[j];
+                    failedAttachmentNames.push(att.fileName || att.fileId);
                     log.warn(
                       { err: result.reason },
                       "Skipping Slack attachment with validation error",
                     );
                   } else {
+                    const att = batch[j];
+                    failedAttachmentNames.push(att.fileName || att.fileId);
                     log.warn(
                       { err: result.reason },
                       "Skipping Slack attachment due to download/upload failure",
                     );
                   }
                 }
+              }
+
+              if (failedAttachmentNames.length > 0) {
+                const nameList = failedAttachmentNames
+                  .map((n) => `"${n}"`)
+                  .join(", ");
+                normalized.event.message.content += `\n\n[The user attached file(s) that could not be retrieved: ${nameList}. Ask them to re-send if the content is important.]`;
               }
             }
 

--- a/gateway/src/slack/download.test.ts
+++ b/gateway/src/slack/download.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import { ContentMismatchError } from "../download-validation.js";
 import type { SlackFile } from "./normalize.js";
 
 type FetchFn = (
@@ -67,9 +68,7 @@ describe("downloadSlackFile", () => {
 
     expect(result.filename).toBe("test-image.png");
     expect(result.mimeType).toBe("image/png");
-    expect(result.data).toBe(
-      Buffer.from(fileBuffer).toString("base64"),
-    );
+    expect(result.data).toBe(Buffer.from(fileBuffer).toString("base64"));
 
     // Verify the correct URL and auth header were used
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -101,21 +100,20 @@ describe("downloadSlackFile", () => {
       url_private: undefined,
     });
 
-    await expect(
-      downloadSlackFile(file, "xoxb-test-token"),
-    ).rejects.toThrow("Slack file F12345 has no download URL");
+    await expect(downloadSlackFile(file, "xoxb-test-token")).rejects.toThrow(
+      "Slack file F12345 has no download URL",
+    );
   });
 
   test("throws on HTTP error response", async () => {
     fetchMock = mock(
-      async () => new Response("Forbidden", { status: 403, statusText: "Forbidden" }),
+      async () =>
+        new Response("Forbidden", { status: 403, statusText: "Forbidden" }),
     );
 
     const file = makeSlackFile();
 
-    await expect(
-      downloadSlackFile(file, "xoxb-test-token"),
-    ).rejects.toThrow(
+    await expect(downloadSlackFile(file, "xoxb-test-token")).rejects.toThrow(
       "Failed to download Slack file F12345: 403 Forbidden",
     );
   });
@@ -179,5 +177,30 @@ describe("downloadSlackFile", () => {
     const result = await downloadSlackFile(file, "xoxb-test-token");
 
     expect(result.filename).toBe("slack_file_F12345");
+  });
+
+  test("throws ContentMismatchError when Slack returns HTML error page", async () => {
+    const htmlBuffer = new TextEncoder().encode(
+      "<!DOCTYPE html><html><body><h1>Error</h1></body></html>",
+    ).buffer;
+    fetchMock = mock(async () => new Response(htmlBuffer));
+
+    const file = makeSlackFile({ mimetype: "image/png" });
+
+    await expect(
+      downloadSlackFile(file, "xoxb-test-token"),
+    ).rejects.toBeInstanceOf(ContentMismatchError);
+  });
+
+  test("succeeds with valid image data when validation is active", async () => {
+    const fileBuffer = makePngBuffer();
+    fetchMock = mock(async () => new Response(fileBuffer));
+
+    const file = makeSlackFile({ mimetype: "image/png" });
+    const result = await downloadSlackFile(file, "xoxb-test-token");
+
+    expect(result.filename).toBe("test-image.png");
+    expect(result.mimeType).toBe("image/png");
+    expect(result.data).toBe(Buffer.from(fileBuffer).toString("base64"));
   });
 });

--- a/gateway/src/slack/download.ts
+++ b/gateway/src/slack/download.ts
@@ -1,4 +1,5 @@
 import { fileTypeFromBuffer } from "file-type";
+import { validateDownloadedContent } from "../download-validation.js";
 import { fetchImpl } from "../fetch.js";
 import type { SlackFile } from "./normalize.js";
 
@@ -42,6 +43,8 @@ export async function downloadSlackFile(
     detected?.mime ||
     response.headers.get("Content-Type")?.split(";")[0].trim() ||
     "application/octet-stream";
+
+  await validateDownloadedContent(new Uint8Array(buffer), mimeType, file.id);
 
   const filename = file.name || `slack_file_${file.id}`;
   const data = Buffer.from(buffer).toString("base64");

--- a/gateway/src/telegram/download.ts
+++ b/gateway/src/telegram/download.ts
@@ -2,6 +2,7 @@ import { fileTypeFromBuffer } from "file-type";
 import type { ConfigFileCache } from "../config-file-cache.js";
 import type { CredentialCache } from "../credential-cache.js";
 import { credentialKey } from "../credential-key.js";
+import { validateDownloadedContent } from "../download-validation.js";
 import { fetchImpl } from "../fetch.js";
 import { callTelegramApi } from "./api.js";
 
@@ -71,6 +72,8 @@ export async function downloadTelegramFile(
     detected?.mime ||
     response.headers.get("Content-Type")?.split(";")[0].trim() ||
     "application/octet-stream";
+
+  await validateDownloadedContent(new Uint8Array(buffer), mimeType, fileId);
 
   const data = Buffer.from(buffer).toString("base64");
 

--- a/gateway/src/whatsapp/download.ts
+++ b/gateway/src/whatsapp/download.ts
@@ -1,5 +1,6 @@
 import { fileTypeFromBuffer } from "file-type";
 import type { GatewayConfig } from "../config.js";
+import { validateDownloadedContent } from "../download-validation.js";
 import {
   getWhatsAppMediaMetadata,
   downloadWhatsAppMediaBytes,
@@ -78,6 +79,8 @@ export async function downloadWhatsAppFile(
     hint?.mimeType ||
     response.headers.get("Content-Type")?.split(";")[0].trim() ||
     "application/octet-stream";
+
+  await validateDownloadedContent(new Uint8Array(buffer), mimeType, mediaId);
 
   const filename = hint?.fileName || inferFilename(mediaId, mimeType);
   const data = Buffer.from(buffer).toString("base64");

--- a/skills/slack-app-setup/SKILL.md
+++ b/skills/slack-app-setup/SKILL.md
@@ -67,6 +67,7 @@ Generate the manifest JSON:
         "channels:history",
         "channels:read",
         "chat:write",
+        "files:read",
         "files:write",
         "groups:history",
         "groups:read",


### PR DESCRIPTION
## Summary
- Add missing `files:read` OAuth scope to the Slack app setup manifest — without this scope, Slack returns an HTML sign-in page instead of the actual image data when the bot tries to download files
- Add `validateDownloadedContent` utility that detects when downloaded file content doesn't match the declared MIME type (catches HTML error pages masquerading as binary files)
- Integrate content validation into all three channel downloaders (Slack, WhatsApp, Telegram)
- When attachment downloads fail, inject context into the message text so the assistant knows an attachment was attempted and can respond helpfully

## PRs merged into feature branch
- #22998: Add `files:read` scope to Slack app setup manifest
- #22999: Add `validateDownloadedContent` utility for channel file downloads
- #23001: Validate Slack file downloads and inject context text for failed attachments
- #23002: Validate WhatsApp and Telegram file download content matches declared MIME type

Part of plan: fix-slack-image-download.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
