### PR TITLE
refactor: export buildFtsMatchQuery and buildExcerpt from conversation-queries

### DIFF
--- a/assistant/src/memory/conversation-queries.ts
+++ b/assistant/src/memory/conversation-queries.ts
@@ -14,7 +14,7 @@ const log = getLogger("conversation-store");
  * Build an FTS5 MATCH query string from natural text by extracting tokens.
  * Used for messages_fts full-text search over conversation content.
  */
-function buildFtsMatchQuery(text: string): string | null {
+export function buildFtsMatchQuery(text: string): string | null {
   const tokens = text
     .toLowerCase()
     .split(/[^a-z0-9_]+/g)
@@ -311,7 +311,7 @@ export function searchConversations(
  * occurrence of `query`. The content may be JSON (content blocks) or plain
  * text; we extract a readable snippet in either case.
  */
-function buildExcerpt(rawContent: string, query: string): string {
+export function buildExcerpt(rawContent: string, query: string): string {
   // Try to extract plain text from JSON content blocks first.
   let text = rawContent;
   try {


### PR DESCRIPTION
## Summary
- Export `buildFtsMatchQuery` and `buildExcerpt` so they can be reused by the recall tool's archive mode

Part of plan: recall-tool-improvements.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
