### PR TITLE
refactor: remove min_confidence filter from recall tool

### DIFF
--- a/assistant/src/memory/graph/tool-handlers.ts
+++ b/assistant/src/memory/graph/tool-handlers.ts
@@ -9,7 +9,7 @@
 import type { AssistantConfig } from "../../config/types.js";
 import { getLogger } from "../../util/logger.js";
 import { embedWithRetry } from "../embed.js";
-import { enqueueGraphNodeEmbed,searchGraphNodes } from "./graph-search.js";
+import { enqueueGraphNodeEmbed, searchGraphNodes } from "./graph-search.js";
 import {
   createNode,
   deleteNode,
@@ -39,7 +39,6 @@ export interface RecallInput {
     types?: string[];
     after?: string;
     before?: string;
-    min_confidence?: number;
   };
 }
 
@@ -118,14 +117,6 @@ async function handleMemoryRecall(
     if (input.filters?.before) {
       const beforeMs = new Date(input.filters.before).getTime();
       if (!isNaN(beforeMs) && node.created > beforeMs) return [];
-    }
-
-    // Confidence filter
-    if (
-      input.filters?.min_confidence != null &&
-      node.confidence < input.filters.min_confidence
-    ) {
-      return [];
     }
 
     return [

--- a/assistant/src/memory/graph/tools.ts
+++ b/assistant/src/memory/graph/tools.ts
@@ -61,10 +61,6 @@ export const graphRecallDefinition: ToolDefinition = {
             description:
               "Only return memories created before this date (ISO 8601)",
           },
-          min_confidence: {
-            type: "number",
-            description: "Minimum confidence threshold (0-1)",
-          },
         },
       },
     },


### PR DESCRIPTION
## Summary
- Remove `min_confidence` from the recall tool definition and handler
- Simplifies the tool interface by removing a rarely-used filter

Part of plan: recall-tool-improvements.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
