### PR TITLE
fix: treat missing trust context as untrusted and fix FTS rowid join

### DIFF
--- a/assistant/src/memory/graph/tool-handlers.ts
+++ b/assistant/src/memory/graph/tool-handlers.ts
@@ -174,7 +174,7 @@ async function handleArchiveRecall(
       rows = rawAll<ArchiveRow>(
         `SELECT m.id, m.content, m.role, m.created_at, c.id as conversation_id
          FROM messages_fts fts
-         JOIN messages m ON m.rowid = fts.rowid
+         JOIN messages m ON m.id = fts.message_id
          JOIN conversations c ON c.id = m.conversation_id
          WHERE messages_fts MATCH ?
            AND c.memory_scope_id = ?

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -48,7 +48,11 @@ export type TrustClass = "guardian" | "trusted_contact" | "unknown";
 export function isUntrustedTrustClass(
   trustClass: TrustClass | undefined,
 ): boolean {
-  return trustClass === "trusted_contact" || trustClass === "unknown";
+  return (
+    trustClass === "trusted_contact" ||
+    trustClass === "unknown" ||
+    trustClass === undefined
+  );
 }
 
 /**


### PR DESCRIPTION
Address review feedback on PR #22769.

- Add undefined to untrusted trust class check (fail closed instead of fail open)
- Fix archive recall FTS join from fragile rowid-based to stable message_id-based

Addresses feedback from #22769.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
