### PR TITLE
fix(macos): handle alreadyResolved confirmation result in AppDelegate

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -125,13 +125,16 @@ extension AppDelegate {
                     requestId: msg.requestId,
                     decision: "allow"
                 )
-                if result == .success {
+                switch result {
+                case .success:
                     self.mainWindow?.conversationManager.updateConfirmationStateAcrossConversations(
                         requestId: msg.requestId,
                         decision: "allow"
                     )
                     log.info("[confirm-flow] CU auto-approved requestId=\(msg.requestId, privacy: .public) tool=\(msg.toolName, privacy: .public)")
-                } else {
+                case .alreadyResolved:
+                    log.info("[confirm-flow] CU auto-approve already resolved (benign 404): requestId=\(msg.requestId, privacy: .public) tool=\(msg.toolName, privacy: .public)")
+                case .failed:
                     log.error("Failed to auto-approve confirmation")
                 }
                 return
@@ -156,12 +159,15 @@ extension AppDelegate {
                 requestId: msg.requestId,
                 decision: decision
             )
-            if result == .success {
+            switch result {
+            case .success:
                 self.mainWindow?.conversationManager.updateConfirmationStateAcrossConversations(
                     requestId: msg.requestId,
                     decision: decision
                 )
-            } else {
+            case .alreadyResolved:
+                log.info("[confirm-flow] Notification-path confirmation already resolved (benign 404): requestId=\(msg.requestId, privacy: .public) decision=\(decision, privacy: .public)")
+            case .failed:
                 log.error("[confirm-flow] Notification-path POST failed: requestId=\(msg.requestId, privacy: .public) decision=\(decision, privacy: .public)")
             }
         }


### PR DESCRIPTION
Address review feedback on PR #22771.

- Replace if/else on ConfirmationSendResult with switch handling all three cases
- Log .alreadyResolved at info level instead of error (benign 404 race)

Addresses feedback from #22771.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23016" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
