### PR TITLE
fix: validate event triggers and allow null in event_date schema

### DIFF
--- a/assistant/src/memory/graph/extraction.ts
+++ b/assistant/src/memory/graph/extraction.ts
@@ -231,7 +231,7 @@ const EXTRACT_TOOL_SCHEMA = {
               enum: ["direct", "inferred", "observed", "told-by-other"],
             },
             event_date: {
-              type: "number",
+              type: ["number", "null"],
               description:
                 "Epoch ms of the event date for calendar-anchored events (flights, appointments, birthdays, deadlines). Null for non-event memories.",
             },
@@ -601,7 +601,9 @@ export function parseExtractionResponse(
     if (
       node.eventDate != null &&
       (!Array.isArray(raw.triggers) ||
-        !raw.triggers.some((t) => t.type === "event"))
+        !raw.triggers.some(
+          (t) => t.type === "event" && t.event_date != null,
+        ))
     ) {
       deferredTriggers.push({
         newNodeIndex: nodeIndex,


### PR DESCRIPTION
Address review feedback on PR #22786.

- Validate event trigger fields before suppressing auto-creation
- Allow null in event_date JSON schema to match prompt instructions

Addresses feedback from #22786.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23017" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
