### PR TITLE
fix: restrict -1 day today label to date-only event dates

### DIFF
--- a/assistant/src/memory/graph/injection.ts
+++ b/assistant/src/memory/graph/injection.ts
@@ -192,9 +192,12 @@ export function formatEventDate(epochMs: number): string {
   );
 
   let relative: string;
-  if (diffDays === 0 || diffDays === -1) {
-    // Same calendar day, or just crossed midnight — treat as "today"
+  if (diffDays === 0) {
     relative = "today";
+  } else if (diffDays === -1) {
+    // For date-only inputs (no time component), -1 day can be UTC midnight drift — treat as "today".
+    // For timed events, -1 day is genuinely yesterday.
+    relative = hasTime ? "yesterday" : "today";
   } else if (diffDays < -1) {
     // Past dates
     const absDays = -diffDays;


### PR DESCRIPTION
Address review feedback on PR #22807.

- Only label diffDays === -1 as '(today)' for date-only inputs (no time component)
- Timed events from yesterday now show '(yesterday)' instead of the contradictory '(today)'

Addresses feedback from #22807.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
