### PR TITLE
fix: optimize images before size check and use temp dir for cache

### DIFF
--- a/assistant/src/agent/image-optimize.ts
+++ b/assistant/src/agent/image-optimize.ts
@@ -13,7 +13,6 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { parseImageDimensions } from "../context/image-dimensions.js";
-import { getWorkspaceDir } from "../util/platform.js";
 
 // Anthropic's documented max dimension — images larger than this are scaled
 // down server-side anyway, so pre-scaling is zero quality loss.
@@ -25,11 +24,10 @@ const OPTIMIZE_THRESHOLD_BYTES = 300 * 1024; // 300 KB
 const JPEG_QUALITY = 80;
 
 // Content-addressed disk cache to avoid re-running sips on the same image.
-const CACHE_SUBDIR = "cache/optimized-images";
 const CACHE_MAX_ENTRIES = 500;
 
 function getCacheDir(): string {
-  return join(getWorkspaceDir(), CACHE_SUBDIR);
+  return join(tmpdir(), "vellum-optimized-images");
 }
 
 function readFromCache(

--- a/assistant/src/tools/shared/filesystem/image-read.ts
+++ b/assistant/src/tools/shared/filesystem/image-read.ts
@@ -99,14 +99,6 @@ export function readImageFile(resolvedPath: string): ToolExecutionResult {
     return { content: `Error reading file: ${msg}`, isError: true };
   }
 
-  if (buffer.length > MAX_SIZE_BYTES) {
-    const sizeMB = (buffer.length / (1024 * 1024)).toFixed(1);
-    return {
-      content: `Error: image too large (${sizeMB} MB). Maximum is 20 MB.`,
-      isError: true,
-    };
-  }
-
   // Detect actual format from magic bytes - never trust the file extension
   // alone, since sips converts to JPEG and files can be misnamed.
   const detectedType = detectMediaType(buffer);
@@ -117,10 +109,22 @@ export function readImageFile(resolvedPath: string): ToolExecutionResult {
     };
   }
 
+  // Optimize before size-checking — oversized images may compress under the limit.
   const rawBase64 = buffer.toString("base64");
   const { data: base64Data, mediaType: finalType } =
     optimizeImageForTransport(rawBase64, detectedType);
   const optimized = base64Data !== rawBase64;
+
+  const optimizedBytes = optimized
+    ? Math.ceil((base64Data.length * 3) / 4)
+    : buffer.length;
+  if (optimizedBytes > MAX_SIZE_BYTES) {
+    const sizeMB = (optimizedBytes / (1024 * 1024)).toFixed(1);
+    return {
+      content: `Error: image too large (${sizeMB} MB). Maximum is 20 MB even after optimization.`,
+      isError: true,
+    };
+  }
 
   const imageBlock: ImageContent = {
     type: "image" as const,
@@ -131,9 +135,6 @@ export function readImageFile(resolvedPath: string): ToolExecutionResult {
     },
   };
 
-  const optimizedBytes = optimized
-    ? Math.ceil((base64Data.length * 3) / 4)
-    : buffer.length;
   const sizeSuffix = optimized
     ? ` (optimized from ${(stat.size / 1024).toFixed(0)} KB to ${(
         optimizedBytes / 1024


### PR DESCRIPTION
Address review feedback on PR #22781.

- Move image optimization before the 20 MB size cap so oversized images get optimized first
- Use os.tmpdir() instead of workspace dir for optimized image cache (excluded from diagnostic exports)

Addresses feedback from #22781.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
