### PR TITLE
fix: refresh nodeMap after updateNode in consolidation merge loop

### DIFF
--- a/assistant/src/memory/graph/consolidation.ts
+++ b/assistant/src/memory/graph/consolidation.ts
@@ -484,6 +484,10 @@ async function consolidateChunk(
     merge_edges?: Array<{ survivor_id: string; deleted_id: string }>;
   };
 
+  // Build nodeMap once upfront; patch entries after each updateNode() so
+  // later iterations always read fresh in-memory state.
+  const nodeMap = new Map(nodes.map((n) => [n.id, n]));
+
   // Apply updates
   for (const update of input.updates ?? []) {
     if (!nodeIds.has(update.id)) continue; // safety: only update nodes in this partition
@@ -504,11 +508,12 @@ async function consolidateChunk(
       // more than just lastConsolidated
       updateNode(update.id, changes);
       result.nodesUpdated++;
+      const node = nodeMap.get(update.id);
+      if (node) Object.assign(node, changes);
     }
   }
 
   // Apply merge edges (before deletion so the edge can reference the node)
-  const nodeMap = new Map(nodes.map((n) => [n.id, n]));
   const { createEdge } = await import("./store.js");
   for (const merge of input.merge_edges ?? []) {
     if (!nodeIds.has(merge.survivor_id) || !nodeIds.has(merge.deleted_id))
@@ -532,6 +537,7 @@ async function consolidateChunk(
         survivor.eventDate == null
       ) {
         updateNode(merge.survivor_id, { eventDate: deleted.eventDate });
+        survivor.eventDate = deleted.eventDate;
 
         // The deleted node's triggers will be cascade-deleted when the node
         // is removed. Ensure the survivor has an event trigger for the
@@ -564,6 +570,7 @@ async function consolidateChunk(
         (survivor.imageRefs == null || survivor.imageRefs.length === 0)
       ) {
         updateNode(merge.survivor_id, { imageRefs: deleted.imageRefs });
+        survivor.imageRefs = deleted.imageRefs;
       }
     } catch (err) {
       log.warn({ err }, "Failed to create merge edge");


### PR DESCRIPTION
Address review feedback on PR #22806.

- Build nodeMap before the updates loop (not after) so updates are reflected
- Patch nodeMap entries after each updateNode() call in both the updates and merge loops
- Prevents stale eventDate/imageRefs reads when a survivor is merged with multiple nodes

Addresses feedback from #22806.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23020" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
