### PR TITLE
fix: restrict multimodal embeddings to active provider

### DIFF
--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -650,27 +650,21 @@ async function selectFallbackBackends(
 }
 
 /**
- * Returns true when the embedding pipeline can handle multimodal inputs
- * (images, audio, video). Today only Gemini supports multimodal.
+ * Returns true when the active (primary) embedding backend can handle
+ * multimodal inputs (images, audio, video). Today only Gemini supports
+ * multimodal.
  *
- * In auto mode, the primary backend is usually local or OpenAI, but
- * embedWithBackend builds a fallback chain that includes Gemini when
- * available. We check both the primary and fallback backends so that
- * multimodal jobs are still enqueued when Gemini is reachable via fallback.
+ * Only returns true when Gemini is the primary selected backend — not when
+ * it's merely available as a fallback. Writing multimodal embeddings via a
+ * fallback provider while queries go through the primary text backend would
+ * mix incompatible vector spaces, making retrieval unreliable.
  */
 export async function selectedBackendSupportsMultimodal(
   config: AssistantConfig,
 ): Promise<boolean> {
   const { backend } = await selectEmbeddingBackend(config);
   if (!backend) return false;
-  if (backend.provider === "gemini") return true;
-
-  // In auto mode, check if Gemini is available as a fallback backend.
-  if (config.memory.embeddings.provider === "auto") {
-    const fallbacks = await selectFallbackBackends(config, backend.provider);
-    return fallbacks.some((fb) => fb.provider === "gemini");
-  }
-  return false;
+  return backend.provider === "gemini";
 }
 
 async function isOllamaConfigured(config: AssistantConfig): Promise<boolean> {


### PR DESCRIPTION
Address review feedback on PR #22804.

- Ensure multimodal image embedding path only activates when Gemini is the active embedding backend, not just a fallback

Addresses feedback from #22804.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
