### PR TITLE
fix: add lower-bound validation on num_results in recall tool

### DIFF
--- a/assistant/src/memory/graph/tool-handlers.ts
+++ b/assistant/src/memory/graph/tool-handlers.ts
@@ -96,7 +96,7 @@ async function handleMemoryRecall(
   const sparseVector = generateSparseEmbedding(input.query);
 
   // Search graph nodes
-  const limit = Math.min(input.num_results ?? 20, 50);
+  const limit = Math.max(1, Math.min(input.num_results ?? 20, 50));
   const searchResults = await searchGraphNodes(
     queryVector,
     limit,
@@ -156,7 +156,7 @@ async function handleArchiveRecall(
   const { rawAll } = await import("../db.js");
 
   try {
-    const limit = Math.min(input.num_results ?? 20, 50);
+    const limit = Math.max(1, Math.min(input.num_results ?? 20, 50));
     const ftsMatch = buildFtsMatchQuery(input.query.trim());
 
     type ArchiveRow = {


### PR DESCRIPTION
Address review feedback on PR #23007.

- Add Math.max(1, ...) to clamp num_results lower bound in both handleMemoryRecall and handleArchiveRecall
- Prevents zero or negative LIMIT values in SQLite queries

Addresses feedback from #23007.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23022" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
