### PR TITLE
fix: exclude disabled catalog skills from capability pruning keep-set

### DIFF
--- a/assistant/src/memory/graph/capability-seed.ts
+++ b/assistant/src/memory/graph/capability-seed.ts
@@ -108,9 +108,12 @@ export function seedSkillGraphNodes(): void {
       seenKeys.add(`${SKILL_SOURCE_PREFIX}${summary.id}`);
     }
 
-    // Include catalog skill keys so pruning doesn't remove them
+    // Include enabled catalog skill keys so pruning doesn't remove them
+    const enabledIds = new Set(enabled.map((r) => r.summary.id));
     for (const entry of getCachedCatalogSync()) {
-      seenKeys.add(`${SKILL_SOURCE_PREFIX}${entry.id}`);
+      if (enabledIds.has(entry.id)) {
+        seenKeys.add(`${SKILL_SOURCE_PREFIX}${entry.id}`);
+      }
     }
 
     pruneStaleCapabilities(SKILL_SOURCE_PREFIX, seenKeys);


### PR DESCRIPTION
Address review feedback on PR #22952.

- Filter getCachedCatalogSync() to only include enabled catalog skills in the pruning keep-set
- Disabled catalog skills will now be properly pruned from capability memories

Addresses feedback from #22952.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23025" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
