### PR TITLE
fix: guard against empty query in archive recall LIKE fallback

### DIFF
--- a/assistant/src/memory/graph/tool-handlers.ts
+++ b/assistant/src/memory/graph/tool-handlers.ts
@@ -184,6 +184,10 @@ async function handleArchiveRecall(
         scopeId,
         limit,
       );
+    } else if (!input.query.trim()) {
+      // Empty or whitespace-only query — return nothing rather than matching
+      // every message via a `%%` LIKE pattern.
+      rows = [];
     } else {
       // All FTS tokens dropped (non-ASCII, single-char, etc.) — fall back to
       // LIKE-based search so queries like CJK characters still match.


### PR DESCRIPTION
Address review feedback on PR #23011.

- Add empty/whitespace query guard before LIKE fallback in handleArchiveRecall
- Prevents %% pattern from matching all messages in scope

Addresses feedback from #23011.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23026" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
