### PR TITLE
fix: align hybrid search scope filter and increase RRF prefetch limit

### DIFF
--- a/assistant/src/memory/graph/graph-search.ts
+++ b/assistant/src/memory/graph/graph-search.ts
@@ -58,14 +58,7 @@ export async function searchGraphNodes(
       must: [
         { key: "target_type", match: { value: "graph_node" } },
         ...(scopeIds && scopeIds.length > 0
-          ? [
-              {
-                should: [
-                  { key: "memory_scope_id", match: { any: scopeIds } },
-                  { is_empty: { key: "memory_scope_id" } },
-                ],
-              },
-            ]
+          ? [{ key: "memory_scope_id", match: { any: scopeIds } }]
           : []),
       ],
       must_not: [{ key: "_meta", match: { value: true } }],
@@ -77,7 +70,7 @@ export async function searchGraphNodes(
         sparseVector,
         filter,
         limit,
-        prefetchLimit: limit,
+        prefetchLimit: limit * 3,
       }),
     );
 


### PR DESCRIPTION
Address review feedback on PR #23010.

- Remove is_empty(memory_scope_id) from hybrid search to prevent cross-scope leakage
- Increase prefetchLimit to 3x limit for better RRF fusion quality

Addresses feedback from #23010.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23027" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
