### PR TITLE
fix: align test assertions with undefined trust class change

### DIFF
--- a/assistant/src/__tests__/conversation-load-history-repair.test.ts
+++ b/assistant/src/__tests__/conversation-load-history-repair.test.ts
@@ -106,7 +106,7 @@ function makeConversation(): Conversation {
       stopReason: "end_turn",
     }),
   };
-  return new Conversation(
+  const conv = new Conversation(
     "conv-1",
     provider,
     "system prompt",
@@ -114,6 +114,10 @@ function makeConversation(): Conversation {
     () => {},
     "/tmp",
   );
+  // Default to guardian trust so history repair tests load all messages.
+  // Tests that exercise untrusted-actor filtering override this explicitly.
+  conv.setTrustContext({ trustClass: "guardian", sourceChannel: "cli" });
+  return conv;
 }
 
 describe("loadFromDb history repair", () => {

--- a/assistant/src/__tests__/credential-execution-shell-lockdown.test.ts
+++ b/assistant/src/__tests__/credential-execution-shell-lockdown.test.ts
@@ -33,8 +33,8 @@ describe("trust class categorization for CES lockdown", () => {
     expect(isUntrustedTrustClass("unknown")).toBe(true);
   });
 
-  test("undefined is not untrusted", () => {
-    expect(isUntrustedTrustClass(undefined)).toBe(false);
+  test("undefined is untrusted", () => {
+    expect(isUntrustedTrustClass(undefined)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- Update `credential-execution-shell-lockdown` test to expect `true` for `isUntrustedTrustClass(undefined)`, matching the behavior change in #23014
- Default `makeConversation()` in `conversation-load-history-repair` to guardian trust context so history repair tests aren't affected by the untrusted-actor message filter

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23876697012/job/69621036611
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23028" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
