### PR TITLE
fix: restrict image_refs validation to current conversation

### DIFF
--- a/assistant/src/memory/graph/extraction.ts
+++ b/assistant/src/memory/graph/extraction.ts
@@ -634,6 +634,7 @@ export function parseExtractionResponse(
         const mimeType = resolveImageRefMimeType(
           ref.message_id,
           ref.block_index,
+          conversationId,
         );
         if (!mimeType) continue;
         validRefs.push({
@@ -1003,12 +1004,18 @@ function resolveConversationTimestamp(conversationId: string): number | null {
 function resolveImageRefMimeType(
   messageId: string,
   blockIndex: number,
+  conversationId: string,
 ): string | null {
   const db = getDb();
   const msg = db
     .select({ content: messages.content })
     .from(messages)
-    .where(eq(messages.id, messageId))
+    .where(
+      and(
+        eq(messages.id, messageId),
+        eq(messages.conversationId, conversationId),
+      ),
+    )
     .get();
   if (!msg) return null;
 


### PR DESCRIPTION
Address review feedback on PR #22809.

- Validate image_refs message_id against the current extraction conversation, not global message existence

Addresses feedback from #22809.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23029" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
