### PR TITLE
fix: use newline separator in multimodal-to-text fallback transcript

### DIFF
--- a/assistant/src/memory/graph/extraction.ts
+++ b/assistant/src/memory/graph/extraction.ts
@@ -765,7 +765,7 @@ export async function runGraphExtraction(
             (b): b is { type: "text"; text: string } => b.type === "text",
           )
           .map((b) => b.text)
-          .join("");
+          .join("\n");
       }
       if (!transcript) {
         log.warn(


### PR DESCRIPTION
Address review feedback on PR #22813.

- Change .join('') to .join('\n') in the multimodal-to-text fallback path
- Prevents garbled text when role-prefixed lines and image descriptions are concatenated

Addresses feedback from #22813.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23030" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
