### PR TITLE
fix: use valid ChannelId in history repair test

### DIFF
--- a/assistant/src/__tests__/conversation-load-history-repair.test.ts
+++ b/assistant/src/__tests__/conversation-load-history-repair.test.ts
@@ -116,7 +116,7 @@ function makeConversation(): Conversation {
   );
   // Default to guardian trust so history repair tests load all messages.
   // Tests that exercise untrusted-actor filtering override this explicitly.
-  conv.setTrustContext({ trustClass: "guardian", sourceChannel: "cli" });
+  conv.setTrustContext({ trustClass: "guardian", sourceChannel: "vellum" });
   return conv;
 }
 


### PR DESCRIPTION
## Summary
- Replace invalid `sourceChannel: "cli"` with `sourceChannel: "vellum"` in `conversation-load-history-repair.test.ts`
- `"cli"` is not a valid `ChannelId` — the type only allows `"telegram" | "phone" | "vellum" | "whatsapp" | "slack" | "email"`
- Fixes the `tsc --noEmit` type check failure on main

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23876943599/job/69621802964
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23031" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
