### PR TITLE
fix: make gateway feature-flags GET route accept paths without trailing slash

### DIFF
--- a/gateway/src/__tests__/feature-flags-route.test.ts
+++ b/gateway/src/__tests__/feature-flags-route.test.ts
@@ -374,6 +374,34 @@ describe("GET /v1/feature-flags handler", () => {
     expect(browserFlag.enabled).toBe(true);
     expect(browserFlag.defaultEnabled).toBe(true);
   });
+
+  test("returns flags when invoked via assistants path without trailing slash", async () => {
+    // The macOS client sends GET /v1/assistants/<id>/feature-flags (no trailing slash).
+    // The gateway route regex must accept this path.
+    const handler = createFeatureFlagsGetHandler();
+    const res = await handler(
+      new Request(
+        "http://gateway.test/v1/assistants/some-assistant-id/feature-flags",
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // Should return all assistant-scope flags with expected shape
+    expect(body.flags.length).toBeGreaterThan(0);
+    for (const flag of body.flags) {
+      expect(typeof flag.key).toBe("string");
+      expect(typeof flag.enabled).toBe("boolean");
+    }
+
+    // Verify a known flag is present
+    const browserFlag = body.flags.find(
+      (f: { key: string }) => f.key === "browser",
+    );
+    expect(browserFlag).toBeDefined();
+    expect(browserFlag.enabled).toBe(true);
+  });
 });
 
 describe("PATCH /v1/feature-flags/:flagKey handler", () => {

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -864,7 +864,7 @@ async function main() {
       handler: (req) => handleFeatureFlagsGet(req),
     },
     {
-      path: /^\/v1\/assistants\/([^/]+)\/feature-flags\/$/,
+      path: /^\/v1\/assistants\/([^/]+)\/feature-flags\/?$/,
       method: "GET",
       auth: "edge-scoped",
       scope: "feature_flags.read",


### PR DESCRIPTION
## Summary
- Fix GET route regex for `/v1/assistants/{id}/feature-flags` to accept paths without trailing slash
- The regex previously required a trailing slash which the macOS client never sends
- Add test verifying the no-trailing-slash path works

Part of plan: ff-toggle-managed.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23032" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
