### PR TITLE
fix: persist assistant flag toggles locally and treat gateway PATCH as best-effort

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftUI
 @preconcurrency import Sentry
 import VellumAssistantShared
+import os
 
 /// Wraps both `AssistantFeatureFlag` and `MacOSFeatureFlagState` into a single
 /// type so the Developer tab can render all flags in one card.
@@ -1066,25 +1067,16 @@ struct SettingsDeveloperTab: View {
                         userInfo: ["key": flag.key, "enabled": newValue]
                     )
                     AssistantFeatureFlagResolver.mergeCachedFlag(key: flag.key, enabled: newValue)
+                    try? AssistantFeatureFlagResolver.mergePersistedFlag(key: flag.key, enabled: newValue)
                     Task {
                         do {
                             try await featureFlagClient.setFeatureFlag(key: flag.key, enabled: newValue)
                         } catch {
-                            if let index = assistantFlags.firstIndex(where: { $0.key == flag.key }) {
-                                assistantFlags[index] = AssistantFeatureFlag(
-                                    key: flag.key,
-                                    enabled: !newValue,
-                                    defaultEnabled: flag.defaultEnabled,
-                                    description: flag.description.isEmpty ? nil : flag.description,
-                                    label: flag.label
-                                )
-                            }
-                            AssistantFeatureFlagResolver.mergeCachedFlag(key: flag.key, enabled: !newValue)
-                            NotificationCenter.default.post(
-                                name: .assistantFeatureFlagDidChange,
-                                object: nil,
-                                userInfo: ["key": flag.key, "enabled": !newValue]
-                            )
+                            // Best-effort: local persistence (file + cache) already saved the override.
+                            // The gateway PATCH may fail for managed assistants where the platform
+                            // doesn't support the write endpoint. Log but don't revert.
+                            os.Logger(subsystem: Bundle.appBundleIdentifier, category: "FeatureFlags")
+                                .warning("Failed to sync feature flag '\(flag.key)' to gateway: \(error.localizedDescription)")
                         }
                     }
                 case .macos:


### PR DESCRIPTION
## Summary
- Write flag overrides to both UserDefaults cache and persisted file (feature-flags.json) on toggle
- Make the gateway PATCH call best-effort: log warning on failure instead of reverting the toggle
- Fixes managed assistant flag toggling where the platform doesn't support the PATCH endpoint

Part of plan: ff-toggle-managed.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23033" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
