### PR TITLE
fix: merge local flag overrides into platform-fetched flags on load

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -911,9 +911,27 @@ struct SettingsDeveloperTab: View {
         isLoadingAssistantFlags = true
         assistantFlagsError = nil
         do {
-            assistantFlags = try await featureFlagClient.getFeatureFlags()
-            // Cache the fetched flag state for persistence across restarts
-            let cacheValues = Dictionary(uniqueKeysWithValues: assistantFlags.map { ($0.key, $0.enabled) })
+            var flags = try await featureFlagClient.getFeatureFlags()
+            // Merge persisted local overrides so user toggles survive app restarts
+            // even when the platform doesn't support the PATCH write endpoint.
+            let persistedOverrides = AssistantFeatureFlagResolver.readPersistedFlags()
+            if !persistedOverrides.isEmpty {
+                flags = flags.map { flag in
+                    if let override = persistedOverrides[flag.key] {
+                        return AssistantFeatureFlag(
+                            key: flag.key,
+                            enabled: override,
+                            defaultEnabled: flag.defaultEnabled,
+                            description: flag.description,
+                            label: flag.label
+                        )
+                    }
+                    return flag
+                }
+            }
+            assistantFlags = flags
+            // Cache the MERGED state (including local overrides) for persistence across restarts
+            let cacheValues = Dictionary(uniqueKeysWithValues: flags.map { ($0.key, $0.enabled) })
             AssistantFeatureFlagResolver.writeCachedFlags(cacheValues)
         } catch {
             // Fall back to the bundled registry + local persisted overrides


### PR DESCRIPTION
## Summary
- Merge locally persisted flag overrides on top of platform-fetched flags in loadAssistantFlags()
- Ensures user toggle overrides survive app restarts even when the platform doesn't support PATCH
- Cache the merged state to UserDefaults so AssistantFeatureFlagStore also sees overrides

Part of plan: ff-toggle-managed.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23034" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
