### PR TITLE
fix: update schema path to match optional trailing slash in feature-flags GET route

### DIFF
--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -2230,7 +2230,7 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
-      "/v1/assistants/{assistantId}/feature-flags/": {
+      "/v1/assistants/{assistantId}/feature-flags": {
         get: {
           summary: "List feature flags (assistant-scoped)",
           description:


### PR DESCRIPTION
## Summary
- Remove trailing slash from the assistant-scoped feature-flags GET schema path to match the updated regex route
- The route regex was changed to make the trailing slash optional (`\/?`), but the schema still had the trailing slash, causing route-schema-guard test failure
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23040" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
