### PR TITLE
feat: make version mismatch banner dismissible

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowVersionMismatchBanner.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowVersionMismatchBanner.swift
@@ -25,7 +25,9 @@ struct MainWindowVersionMismatchBanner: View {
                             windowState.selection = .panel(.settings)
                         },
                         onDismiss: {
-                            connectionManager.dismissVersionMismatch()
+                            withAnimation(VAnimation.fast) {
+                                connectionManager.dismissVersionMismatch()
+                            }
                         }
                     )
                     .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
@@ -41,7 +43,9 @@ struct MainWindowVersionMismatchBanner: View {
                             AppDelegate.shared?.updateManager.checkForUpdates()
                         },
                         onDismiss: {
-                            connectionManager.dismissVersionMismatch()
+                            withAnimation(VAnimation.fast) {
+                                connectionManager.dismissVersionMismatch()
+                            }
                         }
                     )
                     .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowVersionMismatchBanner.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowVersionMismatchBanner.swift
@@ -11,7 +11,7 @@ struct MainWindowVersionMismatchBanner: View {
     let windowState: MainWindowState
 
     var body: some View {
-        if connectionManager.versionMismatch && !connectionManager.isUpdateInProgress {
+        if connectionManager.versionMismatch && !connectionManager.isUpdateInProgress && !isDismissed {
             // Suppress when the "Update" pill already covers it (daemon behind + update available)
             if !(updateManager.isServiceGroupUpdateAvailable && isDaemonBehind) {
                 if isDaemonBehind {
@@ -23,6 +23,9 @@ struct MainWindowVersionMismatchBanner: View {
                         onAction: {
                             settingsStore.pendingSettingsTab = .general
                             windowState.selection = .panel(.settings)
+                        },
+                        onDismiss: {
+                            connectionManager.dismissVersionMismatch()
                         }
                     )
                     .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
@@ -36,6 +39,9 @@ struct MainWindowVersionMismatchBanner: View {
                         actionLabel: "Check for App Update",
                         onAction: {
                             AppDelegate.shared?.updateManager.checkForUpdates()
+                        },
+                        onDismiss: {
+                            connectionManager.dismissVersionMismatch()
                         }
                     )
                     .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
@@ -47,6 +53,14 @@ struct MainWindowVersionMismatchBanner: View {
     }
 
     // MARK: - Helpers
+
+    /// Whether the user dismissed this specific version mismatch.
+    private var isDismissed: Bool {
+        guard let key = connectionManager.dismissedMismatchKey,
+              let clientVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
+              let assistantVersion = connectionManager.assistantVersion else { return false }
+        return key == "\(clientVersion)|\(assistantVersion)"
+    }
 
     /// Whether the daemon version is behind the client version.
     private var isDaemonBehind: Bool {

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -46,6 +46,9 @@ public final class GatewayConnectionManager {
     public var isConnecting: Bool = false
     public internal(set) var assistantVersion: String?
     public internal(set) var versionMismatch: Bool = false
+    /// Composite key ("clientVersion|assistantVersion") of the version mismatch the user dismissed.
+    /// When non-nil and matching the current pair, the banner stays hidden until versions change.
+    public internal(set) var dismissedMismatchKey: String?
     public internal(set) var isUpdateInProgress: Bool = false
     public internal(set) var updateTargetVersion: String?
     public internal(set) var updateStatusMessage: String?
@@ -323,6 +326,7 @@ public final class GatewayConnectionManager {
         isConnected = false
         assistantVersion = nil
         versionMismatch = false
+        dismissedMismatchKey = nil
         isUpdateInProgress = false
         updateTargetVersion = nil
         updateStatusMessage = nil
@@ -574,9 +578,24 @@ public final class GatewayConnectionManager {
         if mismatch != versionMismatch {
             versionMismatch = mismatch
         }
+        // Reset dismissal when the version pair changes (new mismatch should re-show the banner)
         if mismatch {
+            let currentKey = "\(clientVersion)|\(assistantVersion)"
+            if dismissedMismatchKey != nil && dismissedMismatchKey != currentKey {
+                dismissedMismatchKey = nil
+            }
             log.warning("Version mismatch: client \(clientVersion, privacy: .public) vs assistant \(assistantVersion, privacy: .public)")
+        } else {
+            dismissedMismatchKey = nil
         }
+    }
+
+    /// Dismiss the version mismatch banner for the current version pair.
+    /// The banner will re-appear if either version changes.
+    public func dismissVersionMismatch() {
+        guard let clientVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
+              let assistantVersion = assistantVersion else { return }
+        dismissedMismatchKey = "\(clientVersion)|\(assistantVersion)"
     }
 
     // MARK: - SSE Message Pre-Processing


### PR DESCRIPTION
## Summary
- Added a dismiss button (X) to the yellow version mismatch warning banner so users can hide it
- Dismissal is tracked per version pair — if either version changes, the banner re-appears
- Leverages the existing `onDismiss` support in `ChatConversationErrorToast`

## Original prompt
this yellow warning banner should be dismissible and go away until theres another new version mismatch
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23041" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
