### PR TITLE
fix: exclude procedural nodes from memory consolidation

### DIFF
--- a/assistant/src/memory/graph/consolidation.ts
+++ b/assistant/src/memory/graph/consolidation.ts
@@ -182,7 +182,7 @@ function getRecentNodes(scopeId: string, days: number = 7): MemoryNode[] {
     fidelityNot: ["gone"],
     createdAfter: cutoff,
     limit: 10000,
-  });
+  }).filter((n) => n.type !== "procedural");
 }
 
 function getTopSignificanceNodes(
@@ -194,7 +194,7 @@ function getTopSignificanceNodes(
     fidelityNot: ["gone"],
     minSignificance: 0.6,
     limit: n,
-  });
+  }).filter((n) => n.type !== "procedural");
 }
 
 function getDecayedNodes(scopeId: string): MemoryNode[] {
@@ -202,7 +202,7 @@ function getDecayedNodes(scopeId: string): MemoryNode[] {
     scopeId,
     limit: 10000,
   });
-  return all.filter((n) => n.fidelity === "faded" || n.fidelity === "gist");
+  return all.filter((n) => (n.fidelity === "faded" || n.fidelity === "gist") && n.type !== "procedural");
 }
 
 function getRandomSample(scopeId: string, n: number = 30): MemoryNode[] {
@@ -210,7 +210,7 @@ function getRandomSample(scopeId: string, n: number = 30): MemoryNode[] {
     scopeId,
     fidelityNot: ["gone"],
     limit: 10000,
-  });
+  }).filter((n) => n.type !== "procedural");
   // Fisher-Yates shuffle, take first n
   for (let i = all.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));


### PR DESCRIPTION
## Summary
- Exclude type=procedural nodes from all four consolidation partition builders (recent, top-significance, decayed, random)
- Prevents consolidation from merging, rewriting, or deleting auto-seeded skill/CLI capability memories

Part of plan: skill-memory-recall.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23043" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
