### PR TITLE
fix: skip skill memory pruning when catalog cache is empty

### DIFF
--- a/assistant/src/memory/graph/capability-seed.ts
+++ b/assistant/src/memory/graph/capability-seed.ts
@@ -116,7 +116,11 @@ export function seedSkillGraphNodes(): void {
       }
     }
 
-    pruneStaleCapabilities(SKILL_SOURCE_PREFIX, seenKeys);
+    if (getCachedCatalogSync().length > 0) {
+      pruneStaleCapabilities(SKILL_SOURCE_PREFIX, seenKeys);
+    } else {
+      log.debug("Skipping skill capability pruning — catalog cache not yet populated");
+    }
   } catch (err) {
     log.warn({ err }, "Failed to seed skill graph nodes");
   }

--- a/assistant/src/skills/skill-memory.ts
+++ b/assistant/src/skills/skill-memory.ts
@@ -271,19 +271,22 @@ export function seedCatalogSkillMemories(): void {
       )
       .all();
 
-    const cachedCatalogIds = new Set(
-      getCachedCatalogSync().map((s) => s.id),
-    );
+    const cachedCatalog = getCachedCatalogSync();
+    if (cachedCatalog.length === 0) {
+      log.debug("Skipping skill memory pruning — catalog cache not yet populated");
+    } else {
+      const cachedCatalogIds = new Set(cachedCatalog.map((s) => s.id));
 
-    const now = Date.now();
-    for (const item of allCapabilities) {
-      if (!item.content.startsWith("skill:")) continue;
-      const itemSkillId = item.content.split("\n")[0].replace("skill:", "");
-      if (!catalogIds.has(itemSkillId) && !cachedCatalogIds.has(itemSkillId)) {
-        db.update(memoryGraphNodes)
-          .set({ fidelity: "gone", lastAccessed: now })
-          .where(eq(memoryGraphNodes.id, item.id))
-          .run();
+      const now = Date.now();
+      for (const item of allCapabilities) {
+        if (!item.content.startsWith("skill:")) continue;
+        const itemSkillId = item.content.split("\n")[0].replace("skill:", "");
+        if (!catalogIds.has(itemSkillId) && !cachedCatalogIds.has(itemSkillId)) {
+          db.update(memoryGraphNodes)
+            .set({ fidelity: "gone", lastAccessed: now })
+            .where(eq(memoryGraphNodes.id, item.id))
+            .run();
+        }
       }
     }
   } catch (err) {


### PR DESCRIPTION
## Summary
- Guard pruning in seedCatalogSkillMemories() to skip when getCachedCatalogSync() returns empty — prevents race condition on daemon restart where uninstalled catalog skill nodes are deleted before the async catalog fetch completes
- Guard pruning in seedSkillGraphNodes() with the same cache-populated check

Part of plan: skill-memory-recall.md (PR 2 of 5)