### PR TITLE
feat: add debug logging for skill memory seeding, pruning, and deletion

### DIFF
--- a/assistant/src/memory/graph/capability-seed.ts
+++ b/assistant/src/memory/graph/capability-seed.ts
@@ -241,6 +241,7 @@ function upsertCapabilityNode(sourceKey: string, content: string): void {
   });
 
   enqueueMemoryJob("embed_graph_node", { nodeId: node.id });
+  log.info({ sourceKey, nodeId: node.id }, "Created capability graph node");
 }
 
 /**
@@ -292,6 +293,7 @@ function pruneStaleCapabilities(prefix: string, activeKeys: Set<string>): void {
       const sources = JSON.parse(row.sourceConversations as string);
       const key = Array.isArray(sources) ? sources[0] : null;
       if (key && typeof key === "string" && !activeKeys.has(key)) {
+        log.info({ sourceKey: key, nodeId: row.id }, "Pruning stale capability graph node");
         db.update(memoryGraphNodes)
           .set({ fidelity: "gone", lastAccessed: now })
           .where(eq(memoryGraphNodes.id, row.id))

--- a/assistant/src/memory/graph/consolidation.ts
+++ b/assistant/src/memory/graph/consolidation.ts
@@ -581,6 +581,8 @@ async function consolidateChunk(
   for (const id of input.delete_ids ?? []) {
     if (!nodeIds.has(id)) continue; // safety
     try {
+      const deletedNode = nodeMap.get(id);
+      log.info({ nodeId: id, contentPreview: deletedNode?.content?.slice(0, 80) }, "Consolidation deleting node");
       deleteNode(id);
       result.nodesDeleted++;
       result.deletedIds.push(id);

--- a/assistant/src/skills/skill-memory.ts
+++ b/assistant/src/skills/skill-memory.ts
@@ -157,6 +157,7 @@ export function upsertSkillCapabilityMemory(
         .where(eq(memoryGraphNodes.id, existing.id))
         .run();
       enqueueMemoryJob("embed_graph_node", { nodeId: existing.id });
+      log.info({ skillId, nodeId: existing.id }, "Reactivated skill capability memory");
       return;
     }
 
@@ -185,6 +186,7 @@ export function upsertSkillCapabilityMemory(
       })
       .run();
     enqueueMemoryJob("embed_graph_node", { nodeId: id });
+    log.info({ skillId, nodeId: id }, "Created skill capability memory");
   } catch (err) {
     log.warn({ err, skillId }, "Failed to upsert skill capability memory");
   }
@@ -282,6 +284,7 @@ export function seedCatalogSkillMemories(): void {
         if (!item.content.startsWith("skill:")) continue;
         const itemSkillId = item.content.split("\n")[0].replace("skill:", "");
         if (!catalogIds.has(itemSkillId) && !cachedCatalogIds.has(itemSkillId)) {
+          log.info({ skillId: itemSkillId, nodeId: item.id, catalogSize: catalogIds.size, cacheSize: cachedCatalogIds.size }, "Pruning stale skill capability memory");
           db.update(memoryGraphNodes)
             .set({ fidelity: "gone", lastAccessed: now })
             .where(eq(memoryGraphNodes.id, item.id))


### PR DESCRIPTION
## Summary
- Add info-level logging to skill memory creation, reactivation, and pruning in both seeding systems
- Add logging to consolidation node deletion with content preview
- Enables debugging of skill memory disappearance issues

Part of plan: skill-memory-recall.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
