### PR TITLE
test: add tests for skill capability reservation and injection formatting

### DIFF
--- a/assistant/src/__tests__/injection-block.test.ts
+++ b/assistant/src/__tests__/injection-block.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { assembleInjectionBlock } from "../memory/graph/injection.js";
+import {
+  assembleContextBlock,
+  assembleInjectionBlock,
+} from "../memory/graph/injection.js";
 import type { MemoryNode, ScoredNode } from "../memory/graph/types.js";
 
 function makeScoredNode(
@@ -110,5 +113,42 @@ describe("assembleInjectionBlock", () => {
     expect(result).toMatch(/\(\d+d ago\)/);
     // The line should use the event date format (date — content) not age format ((age) content)
     expect(result).toContain(" — Team standup");
+  });
+
+  test("assembleInjectionBlock formats procedural nodes with [skill] prefix", () => {
+    const node = makeScoredNode({
+      type: "procedural",
+      content:
+        'skill:telegram-setup\nThe "Telegram Setup" skill (telegram-setup) is available.',
+    });
+    const result = assembleInjectionBlock([node]);
+    expect(result).toContain("[skill]");
+    expect(result).toContain("→ use skill_load to activate");
+  });
+});
+
+describe("assembleContextBlock — procedural nodes", () => {
+  test("puts procedural nodes under Skills You Can Use", () => {
+    const node = makeScoredNode({
+      type: "procedural",
+      content:
+        'skill:telegram-setup\nThe "Telegram Setup" skill (telegram-setup) is available.',
+    });
+    const result = assembleContextBlock([node]);
+    expect(result).toContain("### Skills You Can Use");
+    expect(result).toContain("use skill_load to activate");
+  });
+
+  test("strips skill: prefix from old-format content", () => {
+    const node = makeScoredNode({
+      type: "procedural",
+      content:
+        'skill:telegram-setup\nThe "Telegram Setup" skill (telegram-setup) is available.',
+    });
+    const result = assembleContextBlock([node]);
+    // The "skill:telegram-setup" prefix line should be stripped from the rendered output
+    expect(result).not.toContain("skill:telegram-setup\n");
+    // But the skill name in the description should remain
+    expect(result).toContain('The "Telegram Setup" skill');
   });
 });

--- a/assistant/src/__tests__/skill-memory.test.ts
+++ b/assistant/src/__tests__/skill-memory.test.ts
@@ -28,6 +28,16 @@ mock.module("../config/skills.js", () => ({
   loadSkillCatalog: (..._args: unknown[]) => mockLoadSkillCatalog(),
 }));
 
+// Controllable mock for getCachedCatalogSync used by seedCatalogSkillMemories
+let mockGetCachedCatalogSync: () => import("../skills/catalog-install.js").CatalogSkill[] =
+  () => [];
+
+mock.module("../skills/catalog-cache.js", () => ({
+  getCachedCatalogSync: (..._args: unknown[]) => mockGetCachedCatalogSync(),
+  getCatalog: async () => mockGetCachedCatalogSync(),
+  invalidateCatalogCache: () => {},
+}));
+
 // Controllable mock for isAssistantFeatureFlagEnabled used by resolveSkillStates
 let mockIsFeatureFlagEnabled: (key: string) => boolean = () => true;
 
@@ -422,6 +432,10 @@ describe("seedCatalogSkillMemories", () => {
     // Reset mocks to defaults
     mockLoadSkillCatalog = () => [];
     mockIsFeatureFlagEnabled = () => true;
+    // Default: non-empty cache so pruning is allowed
+    mockGetCachedCatalogSync = () => [
+      { id: "_sentinel", name: "_sentinel", description: "" },
+    ];
   });
 
   test("upserts capability memories for all enabled skills", () => {
@@ -647,6 +661,29 @@ describe("seedCatalogSkillMemories", () => {
     const afterItems = db.select().from(memoryGraphNodes).all();
     expect(afterItems).toHaveLength(1);
     expect(afterItems[0].fidelity).toBe("gone");
+  });
+
+  test("does not prune when catalog cache is empty", () => {
+    // Pre-populate a skill
+    upsertSkillCapabilityMemory(
+      "existing-skill",
+      fromSkillSummary(makeSkillSummary({ id: "existing-skill" })),
+    );
+
+    const db = getDb();
+    const beforeItems = db.select().from(memoryGraphNodes).all();
+    expect(beforeItems).toHaveLength(1);
+    expect(beforeItems[0].fidelity).toBe("vivid");
+
+    // Seed with empty catalog AND empty cache — pruning guard should skip
+    mockLoadSkillCatalog = () => [];
+    mockGetCachedCatalogSync = () => [];
+    seedCatalogSkillMemories();
+
+    // The existing skill should NOT be pruned because the cache is empty
+    const afterItems = db.select().from(memoryGraphNodes).all();
+    expect(afterItems).toHaveLength(1);
+    expect(afterItems[0].fidelity).toBe("vivid");
   });
 
   test("does not prune non-skill capability memories", () => {


### PR DESCRIPTION
## Summary
- Add tests for Skills You Can Use section in assembleContextBlock
- Add tests for procedural node formatting in assembleInjectionBlock
- Add test for pruning guard when catalog cache is empty
- Fix existing pruning tests by adding mock for getCachedCatalogSync

Part of plan: skill-memory-recall.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
