### PR TITLE
fix: include messageId in notifier message_complete events

### DIFF
--- a/assistant/src/daemon/conversation-notifiers.ts
+++ b/assistant/src/daemon/conversation-notifiers.ts
@@ -99,6 +99,7 @@ export function registerConversationNotifiers(
         ctx.sendToClient({
           type: "message_complete",
           conversationId: conversationId,
+          messageId: msg.id,
         });
       }
     },
@@ -133,6 +134,7 @@ export function registerConversationNotifiers(
         ctx.sendToClient({
           type: "message_complete",
           conversationId: conversationId,
+          messageId: msg.id,
         });
       }
     },
@@ -145,7 +147,7 @@ export function registerConversationNotifiers(
       const callee = callSession?.toNumber ?? "the caller";
       const questionText = `**Live call question** (to ${callee}):\n\n${question}\n\n_Use the call answer API to respond._`;
 
-      await addMessage(
+      const msg = await addMessage(
         conversationId,
         "assistant",
         JSON.stringify([{ type: "text", text: questionText }]),
@@ -168,6 +170,7 @@ export function registerConversationNotifiers(
       ctx.sendToClient({
         type: "message_complete",
         conversationId: conversationId,
+        messageId: msg.id,
       });
     },
   );


### PR DESCRIPTION
## Summary
- Watch commentary, watch completion, and call question notifiers now include `messageId` in their `message_complete` SSE events
- Fixes a race condition where the LLM Context Inspector shows "No LLM calls yet" during a live session but works after app restart
- The `msg.id` from `addMessage()` was already available in all three paths — just not threaded through to the event

## Original prompt
these 2 PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23048" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
