### PR TITLE
fix: guard against auxiliary message_complete clearing turn state

### DIFF
--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -346,6 +346,15 @@ final class ChatActionHandler {
 
     private func handleMessageComplete(_ complete: MessageCompleteMessage, vm: ChatViewModel) {
         guard belongsToConversation(complete.conversationId) else { return }
+        // Auxiliary message_complete events (watch notifiers, call notifications)
+        // that lack a messageId should not reset the main agent turn state.
+        // Without this guard, a watch commentary/summary message_complete arriving
+        // mid-stream clears currentAssistantMessageId, causing the main agent
+        // loop's subsequent message_complete to set daemonMessageId on the wrong
+        // (newly created) message — breaking the LLM Context Inspector until restart.
+        if complete.messageId == nil && vm.isSending {
+            return
+        }
         // Flush any buffered streaming text before finalizing the message.
         vm.flushStreamingBuffer()
         vm.flushPartialOutputBuffer()


### PR DESCRIPTION
## Summary
- Add early return in `handleMessageComplete` when `messageId` is nil and `isSending` is true
- Prevents auxiliary `message_complete` events (watch notifiers, call notifications) from prematurely clearing `currentAssistantMessageId` mid-stream
- Fixes the LLM Context Inspector showing 0 calls until app restart when watch handlers fire during active streaming

## Original prompt
these 2 PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
