### PR TITLE
refactor: flatten SlimSkillResponse into discriminated union on origin, promote emoji to base

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5697,42 +5697,65 @@ paths:
                   skills:
                     type: array
                     items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        name:
-                          type: string
-                        description:
-                          type: string
-                        kind:
-                          type: string
-                          enum:
-                            - bundled
-                            - installed
-                            - catalog
-                        origin:
-                          type: string
-                          enum:
-                            - vellum
-                            - clawhub
-                            - skillssh
-                            - custom
-                        status:
-                          type: string
-                          enum:
-                            - enabled
-                            - disabled
-                            - available
-                        vellum:
-                          type: object
+                      oneOf:
+                        - type: object
                           properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
                             emoji:
                               type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: vellum
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
                           additionalProperties: false
-                        clawhub:
-                          type: object
+                        - type: object
                           properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: clawhub
                             slug:
                               type: string
                             author:
@@ -5746,15 +5769,43 @@ paths:
                             publishedAt:
                               type: string
                           required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
                             - slug
                             - author
                             - stars
                             - installs
                             - reports
                           additionalProperties: false
-                        skillssh:
-                          type: object
+                        - type: object
                           properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: skillssh
                             slug:
                               type: string
                             sourceRepo:
@@ -5762,18 +5813,49 @@ paths:
                             installs:
                               type: number
                           required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
                             - slug
                             - sourceRepo
                             - installs
                           additionalProperties: false
-                      required:
-                        - id
-                        - name
-                        - description
-                        - kind
-                        - origin
-                        - status
-                      additionalProperties: false
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: custom
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
+                          additionalProperties: false
                     description: Skill objects
                 required:
                   - skills
@@ -6132,42 +6214,65 @@ paths:
                   skills:
                     type: array
                     items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        name:
-                          type: string
-                        description:
-                          type: string
-                        kind:
-                          type: string
-                          enum:
-                            - bundled
-                            - installed
-                            - catalog
-                        origin:
-                          type: string
-                          enum:
-                            - vellum
-                            - clawhub
-                            - skillssh
-                            - custom
-                        status:
-                          type: string
-                          enum:
-                            - enabled
-                            - disabled
-                            - available
-                        vellum:
-                          type: object
+                      oneOf:
+                        - type: object
                           properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
                             emoji:
                               type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: vellum
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
                           additionalProperties: false
-                        clawhub:
-                          type: object
+                        - type: object
                           properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: clawhub
                             slug:
                               type: string
                             author:
@@ -6181,15 +6286,43 @@ paths:
                             publishedAt:
                               type: string
                           required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
                             - slug
                             - author
                             - stars
                             - installs
                             - reports
                           additionalProperties: false
-                        skillssh:
-                          type: object
+                        - type: object
                           properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: skillssh
                             slug:
                               type: string
                             sourceRepo:
@@ -6197,18 +6330,49 @@ paths:
                             installs:
                               type: number
                           required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
                             - slug
                             - sourceRepo
                             - installs
                           additionalProperties: false
-                      required:
-                        - id
-                        - name
-                        - description
-                        - kind
-                        - origin
-                        - status
-                      additionalProperties: false
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: custom
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
+                          additionalProperties: false
                     description: Skill objects matching the search query
                 required:
                   - skills

--- a/assistant/src/__tests__/search-skills-unified.test.ts
+++ b/assistant/src/__tests__/search-skills-unified.test.ts
@@ -412,10 +412,10 @@ describe("searchSkills (unified)", () => {
     expect(skill.kind).toBe("catalog");
     expect(skill.origin).toBe("skillssh");
     expect(skill.status).toBe("available");
-    expect(skill.skillssh).toEqual({
-      slug: "org/repo/test-skill",
-      sourceRepo: "org/repo",
-      installs: 99,
-    });
+    if (skill.origin === "skillssh") {
+      expect(skill.slug).toBe("org/repo/test-skill");
+      expect(skill.sourceRepo).toBe("org/repo");
+      expect(skill.installs).toBe(99);
+    }
   });
 });

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -64,11 +64,8 @@ import {
 import { getWorkspaceSkillsDir } from "../../util/platform.js";
 import type {
   ClawhubDetailMeta,
-  ClawhubSkillMeta,
   SkillDetailResponse,
-  SkillsshSkillMeta,
   SlimSkillResponse,
-  VellumSkillMeta,
 } from "../message-types/skills.js";
 import {
   CONFIG_RELOAD_DEBOUNCE_MS,
@@ -276,38 +273,26 @@ function deriveOrigin(
   return meta?.origin ?? "custom";
 }
 
-/** Build the correct polymorphic sub-object for a given origin. */
+/** Build the origin-specific fields for a given origin (flattened at top level). */
 function buildOriginMeta(
   origin: SlimSkillResponse["origin"],
   summary: SkillSummary,
   installMeta?: SkillInstallMeta | null,
-): Pick<SlimSkillResponse, "vellum" | "clawhub" | "skillssh"> {
+): Record<string, unknown> {
   switch (origin) {
-    case "vellum": {
-      const vellumMeta: VellumSkillMeta | undefined = summary.emoji
-        ? { emoji: summary.emoji }
-        : undefined;
-      return vellumMeta ? { vellum: vellumMeta } : {};
-    }
+    case "vellum":
+      return {};
     case "clawhub": {
       const meta =
         installMeta !== undefined
           ? installMeta
           : readInstallMeta(summary.directoryPath);
-      const clawhubMeta: ClawhubSkillMeta = {
+      return {
         slug: meta?.slug ?? summary.id,
         author: "",
         stars: 0,
         installs: 0,
         reports: 0,
-      };
-      // Preserve emoji for the Swift client which reads skill.vellum?.emoji
-      const emojiMeta: VellumSkillMeta | undefined = summary.emoji
-        ? { emoji: summary.emoji }
-        : undefined;
-      return {
-        clawhub: clawhubMeta,
-        ...(emojiMeta ? { vellum: emojiMeta } : {}),
       };
     }
     case "skillssh": {
@@ -315,27 +300,14 @@ function buildOriginMeta(
         installMeta !== undefined
           ? installMeta
           : readInstallMeta(summary.directoryPath);
-      const skillsshMeta: SkillsshSkillMeta = {
+      return {
         slug: meta?.slug ?? summary.id,
         sourceRepo: meta?.sourceRepo ?? "",
         installs: 0,
       };
-      // Preserve emoji for the Swift client which reads skill.vellum?.emoji
-      const emojiMeta: VellumSkillMeta | undefined = summary.emoji
-        ? { emoji: summary.emoji }
-        : undefined;
-      return {
-        skillssh: skillsshMeta,
-        ...(emojiMeta ? { vellum: emojiMeta } : {}),
-      };
     }
-    default: {
-      // Custom origin: still preserve emoji if present
-      const emojiMeta: VellumSkillMeta | undefined = summary.emoji
-        ? { emoji: summary.emoji }
-        : undefined;
-      return emojiMeta ? { vellum: emojiMeta } : {};
-    }
+    default:
+      return {};
   }
 }
 
@@ -362,11 +334,12 @@ function toSlimSkillResponse(
     id: summary.id,
     name: summary.displayName,
     description: summary.description,
+    emoji: summary.emoji,
     kind,
     origin,
     status,
     ...buildOriginMeta(origin, summary, installMeta),
-  };
+  } as SlimSkillResponse;
 }
 
 export function listSkills(_ctx: SkillOperationContext): SlimSkillResponse[] {
@@ -408,21 +381,15 @@ export async function listSkillsWithCatalog(
   // Create SlimSkillResponses for catalog skills not already installed.
   const available: SlimSkillResponse[] = catalogSkills
     .filter((cs) => !installedIds.has(cs.id))
-    .map((cs) => {
-      const emoji = cs.emoji;
-      const result: SlimSkillResponse = {
-        id: cs.id,
-        name: cs.metadata?.vellum?.["display-name"] ?? cs.name,
-        description: cs.description,
-        kind: "catalog",
-        origin: "vellum",
-        status: "available",
-      };
-      if (emoji) {
-        result.vellum = { emoji };
-      }
-      return result;
-    });
+    .map((cs) => ({
+      id: cs.id,
+      name: cs.metadata?.vellum?.["display-name"] ?? cs.name,
+      description: cs.description,
+      emoji: cs.emoji,
+      kind: "catalog" as const,
+      origin: "vellum" as const,
+      status: "available" as const,
+    }));
 
   const merged = [...installed, ...available];
 
@@ -473,24 +440,41 @@ export async function getSkill(
     // Best-effort: body is optional
   }
 
-  // Build the detail response, starting from the slim shape
+  // Build the detail response, starting from the slim shape.
+  // SkillDetailResponse still uses the old nested sub-object shape (PR 2
+  // will flatten it); reconstruct nested objects from the flat union here.
   const detail: SkillDetailResponse = {
     id: slim.id,
     name: slim.name,
     description: slim.description,
+    emoji: slim.emoji,
     kind: slim.kind,
     origin: slim.origin,
     status: slim.status,
-    ...(slim.vellum ? { vellum: slim.vellum } : {}),
-    ...(slim.skillssh ? { skillssh: slim.skillssh } : {}),
+    ...(slim.origin === "skillssh"
+      ? {
+          skillssh: {
+            slug: slim.slug,
+            sourceRepo: slim.sourceRepo,
+            installs: slim.installs,
+          },
+        }
+      : {}),
     ...(body !== undefined ? { body } : {}),
   };
 
   // For clawhub-origin skills, enrich with inspect data
-  if (slim.origin === "clawhub" && slim.clawhub) {
-    const enriched: ClawhubDetailMeta = { ...slim.clawhub };
+  if (slim.origin === "clawhub") {
+    const enriched: ClawhubDetailMeta = {
+      slug: slim.slug,
+      author: slim.author,
+      stars: slim.stars,
+      installs: slim.installs,
+      reports: slim.reports,
+      publishedAt: slim.publishedAt,
+    };
     try {
-      const inspectResult = await clawhubInspect(slim.clawhub.slug);
+      const inspectResult = await clawhubInspect(slim.slug);
       if (inspectResult.data) {
         const data = inspectResult.data;
         enriched.owner = data.owner;
@@ -503,8 +487,6 @@ export async function getSkill(
       log.warn({ err, skillId }, "Failed to enrich clawhub skill detail");
     }
     detail.clawhub = enriched;
-  } else if (slim.clawhub) {
-    detail.clawhub = slim.clawhub;
   }
 
   return { skill: detail };
@@ -962,18 +944,15 @@ export async function searchSkills(
       }
       // Fallback for catalog entries not in resolvedSkillStates (shouldn't
       // normally happen, but defensive)
-      const result: SlimSkillResponse = {
+      return {
         id: s.id,
         name: s.displayName,
         description: s.description,
-        kind: "catalog",
-        origin: "vellum",
-        status: "available",
+        emoji: s.emoji,
+        kind: "catalog" as const,
+        origin: "vellum" as const,
+        status: "available" as const,
       };
-      if (s.emoji) {
-        result.vellum = { emoji: s.emoji };
-      }
-      return result;
     });
 
     // Search both community registries in parallel (non-fatal on failure)
@@ -991,16 +970,14 @@ export async function searchSkills(
         kind: "catalog" as const,
         origin: "clawhub" as const,
         status: "available" as const,
-        clawhub: {
-          slug: s.slug,
-          author: s.author,
-          stars: s.stars,
-          installs: s.installs,
-          reports: 0,
-          publishedAt: s.createdAt
-            ? new Date(s.createdAt * 1000).toISOString()
-            : undefined,
-        },
+        slug: s.slug,
+        author: s.author,
+        stars: s.stars,
+        installs: s.installs,
+        reports: 0,
+        publishedAt: s.createdAt
+          ? new Date(s.createdAt * 1000).toISOString()
+          : undefined,
       }));
     } else {
       log.warn(
@@ -1018,11 +995,9 @@ export async function searchSkills(
         kind: "catalog" as const,
         origin: "skillssh" as const,
         status: "available" as const,
-        skillssh: {
-          slug: r.id,
-          sourceRepo: r.source,
-          installs: r.installs,
-        },
+        slug: r.id,
+        sourceRepo: r.source,
+        installs: r.installs,
       }));
     } else {
       log.warn(

--- a/assistant/src/daemon/message-types/skills.ts
+++ b/assistant/src/daemon/message-types/skills.ts
@@ -76,11 +76,22 @@ export interface SkillsCreateRequest {
 
 // === Server → Client ===
 
-export interface VellumSkillMeta {
+/** Fields shared by all skill origins. */
+interface SlimSkillBase {
+  id: string;
+  name: string;
+  description: string;
   emoji?: string;
+  kind: "bundled" | "installed" | "catalog";
+  status: "enabled" | "disabled" | "available";
 }
 
-export interface ClawhubSkillMeta {
+interface VellumSlimSkill extends SlimSkillBase {
+  origin: "vellum";
+}
+
+interface ClawhubSlimSkill extends SlimSkillBase {
+  origin: "clawhub";
   slug: string;
   author: string;
   stars: number;
@@ -89,23 +100,22 @@ export interface ClawhubSkillMeta {
   publishedAt?: string;
 }
 
-export interface SkillsshSkillMeta {
+interface SkillsshSlimSkill extends SlimSkillBase {
+  origin: "skillssh";
   slug: string;
   sourceRepo: string;
   installs: number;
 }
 
-export interface SlimSkillResponse {
-  id: string;
-  name: string;
-  description: string;
-  kind: "bundled" | "installed" | "catalog";
-  origin: "vellum" | "clawhub" | "skillssh" | "custom";
-  status: "enabled" | "disabled" | "available";
-  vellum?: VellumSkillMeta;
-  clawhub?: ClawhubSkillMeta;
-  skillssh?: SkillsshSkillMeta;
+interface CustomSlimSkill extends SlimSkillBase {
+  origin: "custom";
 }
+
+export type SlimSkillResponse =
+  | VellumSlimSkill
+  | ClawhubSlimSkill
+  | SkillsshSlimSkill
+  | CustomSlimSkill;
 
 export interface SkillsListResponse {
   type: "skills_list_response";
@@ -128,7 +138,13 @@ export interface SkillBodyResponse {
 
 // ─── Detail endpoint response (HTTP API) ──────────────────────────────────
 
-export interface ClawhubDetailMeta extends ClawhubSkillMeta {
+export interface ClawhubDetailMeta {
+  slug: string;
+  author: string;
+  stars: number;
+  installs: number;
+  reports: number;
+  publishedAt?: string;
   owner?: { handle: string; displayName: string; image?: string } | null;
   stats?: {
     stars: number;
@@ -148,9 +164,10 @@ export interface SkillDetailResponse {
   kind: "bundled" | "installed" | "catalog";
   origin: "vellum" | "clawhub" | "skillssh" | "custom";
   status: "enabled" | "disabled" | "available";
-  vellum?: VellumSkillMeta;
+  emoji?: string;
+  vellum?: { emoji?: string };
   clawhub?: ClawhubDetailMeta;
-  skillssh?: SkillsshSkillMeta;
+  skillssh?: { slug: string; sourceRepo: string; installs: number };
   body?: string;
 }
 

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -39,6 +39,37 @@ export interface SkillRouteDeps {
   getSkillContext: () => SkillOperationContext;
 }
 
+const slimSkillBase = {
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  emoji: z.string().optional(),
+  kind: z.enum(["bundled", "installed", "catalog"]),
+  status: z.enum(["enabled", "disabled", "available"]),
+};
+
+const slimSkillSchema = z.discriminatedUnion("origin", [
+  z.object({ ...slimSkillBase, origin: z.literal("vellum") }),
+  z.object({
+    ...slimSkillBase,
+    origin: z.literal("clawhub"),
+    slug: z.string(),
+    author: z.string(),
+    stars: z.number(),
+    installs: z.number(),
+    reports: z.number(),
+    publishedAt: z.string().optional(),
+  }),
+  z.object({
+    ...slimSkillBase,
+    origin: z.literal("skillssh"),
+    slug: z.string(),
+    sourceRepo: z.string(),
+    installs: z.number(),
+  }),
+  z.object({ ...slimSkillBase, origin: z.literal("custom") }),
+]);
+
 export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
   const ctx = () => deps.getSkillContext();
 
@@ -60,40 +91,7 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
         },
       ],
       responseBody: z.object({
-        skills: z
-          .array(
-            z.object({
-              id: z.string(),
-              name: z.string(),
-              description: z.string(),
-              kind: z.enum(["bundled", "installed", "catalog"]),
-              origin: z.enum(["vellum", "clawhub", "skillssh", "custom"]),
-              status: z.enum(["enabled", "disabled", "available"]),
-              vellum: z
-                .object({
-                  emoji: z.string().optional(),
-                })
-                .optional(),
-              clawhub: z
-                .object({
-                  slug: z.string(),
-                  author: z.string(),
-                  stars: z.number(),
-                  installs: z.number(),
-                  reports: z.number(),
-                  publishedAt: z.string().optional(),
-                })
-                .optional(),
-              skillssh: z
-                .object({
-                  slug: z.string(),
-                  sourceRepo: z.string(),
-                  installs: z.number(),
-                })
-                .optional(),
-            }),
-          )
-          .describe("Skill objects"),
+        skills: z.array(slimSkillSchema).describe("Skill objects"),
       }),
       handler: async ({ url }) => {
         const include = url.searchParams.get("include");
@@ -280,38 +278,7 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
       ],
       responseBody: z.object({
         skills: z
-          .array(
-            z.object({
-              id: z.string(),
-              name: z.string(),
-              description: z.string(),
-              kind: z.enum(["bundled", "installed", "catalog"]),
-              origin: z.enum(["vellum", "clawhub", "skillssh", "custom"]),
-              status: z.enum(["enabled", "disabled", "available"]),
-              vellum: z
-                .object({
-                  emoji: z.string().optional(),
-                })
-                .optional(),
-              clawhub: z
-                .object({
-                  slug: z.string(),
-                  author: z.string(),
-                  stars: z.number(),
-                  installs: z.number(),
-                  reports: z.number(),
-                  publishedAt: z.string().optional(),
-                })
-                .optional(),
-              skillssh: z
-                .object({
-                  slug: z.string(),
-                  sourceRepo: z.string(),
-                  installs: z.number(),
-                })
-                .optional(),
-            }),
-          )
+          .array(slimSkillSchema)
           .describe("Skill objects matching the search query"),
       }),
       handler: async ({ url }) => {


### PR DESCRIPTION
## Summary
- Replace optional sub-objects (vellum/clawhub/skillssh) with a discriminated union on origin
- Promote emoji to a shared base field
- Update Zod schemas to use z.discriminatedUnion

Part of plan: skills-discrim-union-flatten.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23050" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
