### PR TITLE
fix: capability injection ordering, mainPool leak, and dedup by skill ID

### DIFF
--- a/assistant/src/memory/graph/injection.ts
+++ b/assistant/src/memory/graph/injection.ts
@@ -274,14 +274,14 @@ export function assembleContextBlock(
       upcoming.push(scored);
     } else if (node.type === "prospective") {
       threads.push(scored);
+    } else if (node.type === "procedural") {
+      capabilities.push(scored);
     } else if (node.type === "emotional" && isRecent(node)) {
       // Recent emotional nodes go in "Right Now" — present-tense state
       rightNow.push(scored);
     } else if (isVeryRecent(node)) {
       // Very recent nodes (last few hours) are "right now" context
       rightNow.push(scored);
-    } else if (node.type === "procedural") {
-      capabilities.push(scored);
     } else {
       onMyMind.push(scored);
     }

--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -445,11 +445,26 @@ export async function loadContextMemory(
   // SQLite — no Qdrant vectors needed — so capabilities surface even on
   // fresh assistants whose embedding jobs haven't completed yet.
   const CAPABILITY_RESERVE = 5;
-  const capabilityNodes = queryNodes({
+  const rawCapabilityNodes = queryNodes({
     scopeId: opts.scopeId,
     types: ["procedural"],
     fidelityNot: ["gone"],
-    limit: CAPABILITY_RESERVE * 2,
+    limit: CAPABILITY_RESERVE * 4,
+  });
+
+  // Dedup: both seeding systems may create nodes for the same skill.
+  // Extract skill ID from content and keep only the first node per skill.
+  const seenSkillIds = new Set<string>();
+  const capabilityNodes = rawCapabilityNodes.filter((node) => {
+    const skillMatch = node.content.match(
+      /^skill:(\S+)\n|^\s*The ".*?" skill \(([^)]+)\)/,
+    );
+    const skillId = skillMatch?.[1] ?? skillMatch?.[2];
+    if (skillId) {
+      if (seenSkillIds.has(skillId)) return false;
+      seenSkillIds.add(skillId);
+    }
+    return true;
   });
 
   // Rank by semantic similarity when a query vector exists
@@ -564,12 +579,14 @@ export async function loadContextMemory(
     });
   });
 
-  // Remove reserved nodes from the main pool (they have guaranteed slots)
+  // Remove reserved nodes and all procedural nodes from the main pool.
+  // Procedural nodes have dedicated reserved slots — any that didn't make
+  // the cut shouldn't compete with organic memories for general slots.
   const mainPool = scored.filter(
     (s) =>
+      s.node.type !== "procedural" &&
       !prospectiveIds.has(s.node.id) &&
-      !upcomingIds.has(s.node.id) &&
-      !capabilityIds.has(s.node.id),
+      !upcomingIds.has(s.node.id),
   );
   const mainSlots = Math.max(
     0,


### PR DESCRIPTION
## Summary
Fixes three integration issues found during self-review:
- Move procedural node check before isVeryRecent in assembleContextBlock so freshly-seeded capabilities go to 'Skills You Can Use' instead of 'Right Now'
- Filter ALL procedural nodes from mainPool (not just reserved ones) so extras don't leak into general slots
- Dedup capability nodes by skill ID before reservation to handle dual seeding systems creating overlapping entries

Part of plan: skill-memory-recall.md (review fix round 1)