### PR TITLE
fix: enable undo/redo in macOS composer text input

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
@@ -99,6 +99,7 @@ struct ComposerTextEditor: NSViewRepresentable {
         textView.autoresizingMask = [.width]
         textView.font = font
         textView.insertionPointColor = insertionPointColor
+        textView.allowsUndo = true
 
         let defaultColor = NSColor(VColor.contentDefault)
         let paragraphStyle = NSMutableParagraphStyle()


### PR DESCRIPTION
## Summary
- Enable `allowsUndo` on `ComposerTextView` so Cmd+Z / Cmd+Shift+Z work as undo/redo in the chat bar
- `NSTextView.allowsUndo` defaults to `false`; setting it to `true` is all that's needed — the menu bar items and responder chain were already wired correctly

## Original prompt
Enable cmd+z and cmd+shift+z as undo/redo in the macOS app chat bar