### PR TITLE
fix: pass messageId in iOS lifecycle tests to match message_complete guard

### DIFF
--- a/clients/ios/Tests/ConversationLifecycleIOSTests.swift
+++ b/clients/ios/Tests/ConversationLifecycleIOSTests.swift
@@ -148,8 +148,9 @@ final class ConversationLifecycleIOSTests: XCTestCase {
         XCTAssertEqual(vm.messages.count, 2)
         XCTAssertEqual(vm.messages[1].role, .assistant)
 
-        // Step 3: Message completes
-        vm.handleServerMessage(.messageComplete(MessageCompleteMessage()))
+        // Step 3: Message completes (messageId must be non-nil; the guard in
+        // ChatActionHandler skips message_complete without messageId while isSending)
+        vm.handleServerMessage(.messageComplete(MessageCompleteMessage(messageId: "msg-1")))
         XCTAssertFalse(vm.isSending)
         XCTAssertFalse(vm.messages[1].isStreaming)
     }
@@ -163,14 +164,14 @@ final class ConversationLifecycleIOSTests: XCTestCase {
         vm.sendMessage()
         vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "First answer")))
         vm.flushStreamingBuffer()
-        vm.handleServerMessage(.messageComplete(MessageCompleteMessage()))
+        vm.handleServerMessage(.messageComplete(MessageCompleteMessage(messageId: "msg-1")))
 
         // Second exchange
         vm.inputText = "Second question"
         vm.sendMessage()
         vm.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Second answer")))
         vm.flushStreamingBuffer()
-        vm.handleServerMessage(.messageComplete(MessageCompleteMessage()))
+        vm.handleServerMessage(.messageComplete(MessageCompleteMessage(messageId: "msg-2")))
 
         XCTAssertEqual(vm.messages.count, 4)
         XCTAssertEqual(vm.messages[0].role, .user)


### PR DESCRIPTION
## Summary
- Two iOS tests (`testNewConversationReceivesAndCompletesMessages`, `testMultipleMessagesInSameConversation`) were failing because the guard added in #23049 skips `message_complete` events without `messageId` while `isSending` is true
- Pass a `messageId` in test `MessageCompleteMessage()` calls to match real backend behavior (which now includes `messageId` per #23048)

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23878739463/job/69627346840