### PR TITLE
fix: remove unused capabilityIds variable to fix lint

### DIFF
--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -479,7 +479,6 @@ export async function loadContextMemory(
     selectedCapabilities = capabilityNodes.slice(0, CAPABILITY_RESERVE);
   }
 
-  const capabilityIds = new Set(selectedCapabilities.map((n) => n.id));
   const reservedCapabilities: ScoredNode[] = selectedCapabilities.map(
     (node) => {
       const existing = scored.find((s) => s.node.id === node.id);


### PR DESCRIPTION
## Summary
- Remove unused `capabilityIds` variable in `assistant/src/memory/graph/retriever.ts` that was causing an eslint `no-unused-vars` lint failure in CI.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23878925395/job/69627896977
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23055" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
