### PR TITLE
fix: exclude procedural nodes from serendipity sampling

### DIFF
--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -610,7 +610,12 @@ export async function loadContextMemory(
     ...reservedCapabilities,
     ...reranked,
   ].slice(0, maxNodes - serendipitySlots);
-  const serendipityPicks = sampleSerendipity(scored, serendipitySlots);
+  // Exclude procedural nodes from serendipity — they have reserved slots
+  // and shouldn't appear as random wildcard picks.
+  const serendipityPool = scored.filter(
+    (s) => s.node.type !== "procedural",
+  );
+  const serendipityPicks = sampleSerendipity(serendipityPool, serendipitySlots);
 
   // Deduplicate serendipity against deterministic
   const deterministicIds = new Set(deterministic.map((s) => s.node.id));


### PR DESCRIPTION
## Summary
- Filter procedural nodes out of the serendipity pool so capabilities only surface through their reserved slots, not as random wildcard picks

Part of plan: skill-memory-recall.md (review fix round 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23056" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
