### PR TITLE
refactor: flatten SkillDetailResponse as discriminated union, remove body field

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5934,6 +5934,229 @@ paths:
       responses:
         "200":
           description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  skill:
+                    oneOf:
+                      - type: object
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          description:
+                            type: string
+                          emoji:
+                            type: string
+                          kind:
+                            type: string
+                            enum:
+                              - bundled
+                              - installed
+                              - catalog
+                          status:
+                            type: string
+                            enum:
+                              - enabled
+                              - disabled
+                              - available
+                          origin:
+                            type: string
+                            const: vellum
+                        required:
+                          - id
+                          - name
+                          - description
+                          - kind
+                          - status
+                          - origin
+                        additionalProperties: false
+                      - type: object
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          description:
+                            type: string
+                          emoji:
+                            type: string
+                          kind:
+                            type: string
+                            enum:
+                              - bundled
+                              - installed
+                              - catalog
+                          status:
+                            type: string
+                            enum:
+                              - enabled
+                              - disabled
+                              - available
+                          origin:
+                            type: string
+                            const: clawhub
+                          slug:
+                            type: string
+                          author:
+                            type: string
+                          stars:
+                            type: number
+                          installs:
+                            type: number
+                          reports:
+                            type: number
+                          publishedAt:
+                            type: string
+                          owner:
+                            anyOf:
+                              - type: object
+                                properties:
+                                  handle:
+                                    type: string
+                                  displayName:
+                                    type: string
+                                  image:
+                                    type: string
+                                required:
+                                  - handle
+                                  - displayName
+                                additionalProperties: false
+                              - type: "null"
+                          stats:
+                            anyOf:
+                              - type: object
+                                properties:
+                                  stars:
+                                    type: number
+                                  installs:
+                                    type: number
+                                  downloads:
+                                    type: number
+                                  versions:
+                                    type: number
+                                required:
+                                  - stars
+                                  - installs
+                                  - downloads
+                                  - versions
+                                additionalProperties: false
+                              - type: "null"
+                          latestVersion:
+                            anyOf:
+                              - type: object
+                                properties:
+                                  version:
+                                    type: string
+                                  changelog:
+                                    type: string
+                                required:
+                                  - version
+                                additionalProperties: false
+                              - type: "null"
+                          createdAt:
+                            anyOf:
+                              - type: number
+                              - type: "null"
+                          updatedAt:
+                            anyOf:
+                              - type: number
+                              - type: "null"
+                        required:
+                          - id
+                          - name
+                          - description
+                          - kind
+                          - status
+                          - origin
+                          - slug
+                          - author
+                          - stars
+                          - installs
+                          - reports
+                        additionalProperties: false
+                      - type: object
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          description:
+                            type: string
+                          emoji:
+                            type: string
+                          kind:
+                            type: string
+                            enum:
+                              - bundled
+                              - installed
+                              - catalog
+                          status:
+                            type: string
+                            enum:
+                              - enabled
+                              - disabled
+                              - available
+                          origin:
+                            type: string
+                            const: skillssh
+                          slug:
+                            type: string
+                          sourceRepo:
+                            type: string
+                          installs:
+                            type: number
+                        required:
+                          - id
+                          - name
+                          - description
+                          - kind
+                          - status
+                          - origin
+                          - slug
+                          - sourceRepo
+                          - installs
+                        additionalProperties: false
+                      - type: object
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          description:
+                            type: string
+                          emoji:
+                            type: string
+                          kind:
+                            type: string
+                            enum:
+                              - bundled
+                              - installed
+                              - catalog
+                          status:
+                            type: string
+                            enum:
+                              - enabled
+                              - disabled
+                              - available
+                          origin:
+                            type: string
+                            const: custom
+                        required:
+                          - id
+                          - name
+                          - description
+                          - kind
+                          - status
+                          - origin
+                        additionalProperties: false
+                    description: Skill detail object
+                required:
+                  - skill
+                additionalProperties: false
       parameters:
         - name: id
           in: path

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -63,7 +63,6 @@ import {
 } from "../../skills/skillssh-registry.js";
 import { getWorkspaceSkillsDir } from "../../util/platform.js";
 import type {
-  ClawhubDetailMeta,
   SkillDetailResponse,
   SlimSkillResponse,
 } from "../message-types/skills.js";
@@ -429,43 +428,18 @@ export async function getSkill(
 
   const slim = found.item;
 
-  // Read SKILL.md body from disk
-  let body: string | undefined;
-  const skillMdPath = join(found.summary.directoryPath, "SKILL.md");
-  try {
-    if (existsSync(skillMdPath)) {
-      body = readFileSync(skillMdPath, "utf-8");
-    }
-  } catch {
-    // Best-effort: body is optional
-  }
-
-  // Build the detail response, starting from the slim shape.
-  // SkillDetailResponse still uses the old nested sub-object shape (PR 2
-  // will flatten it); reconstruct nested objects from the flat union here.
-  const detail: SkillDetailResponse = {
-    id: slim.id,
-    name: slim.name,
-    description: slim.description,
-    emoji: slim.emoji,
-    kind: slim.kind,
-    origin: slim.origin,
-    status: slim.status,
-    ...(slim.origin === "skillssh"
-      ? {
-          skillssh: {
-            slug: slim.slug,
-            sourceRepo: slim.sourceRepo,
-            installs: slim.installs,
-          },
-        }
-      : {}),
-    ...(body !== undefined ? { body } : {}),
-  };
-
-  // For clawhub-origin skills, enrich with inspect data
+  // Build the detail response as a flat discriminated union on origin.
+  // Origin-specific fields are spread directly at the top level.
   if (slim.origin === "clawhub") {
-    const enriched: ClawhubDetailMeta = {
+    // Start with slim clawhub fields, then enrich with inspect data.
+    const detail: SkillDetailResponse = {
+      id: slim.id,
+      name: slim.name,
+      description: slim.description,
+      emoji: slim.emoji,
+      kind: slim.kind,
+      origin: slim.origin,
+      status: slim.status,
       slug: slim.slug,
       author: slim.author,
       stars: slim.stars,
@@ -477,18 +451,48 @@ export async function getSkill(
       const inspectResult = await clawhubInspect(slim.slug);
       if (inspectResult.data) {
         const data = inspectResult.data;
-        enriched.owner = data.owner;
-        enriched.stats = data.stats;
-        enriched.latestVersion = data.latestVersion;
-        enriched.createdAt = data.createdAt;
-        enriched.updatedAt = data.updatedAt;
+        (detail as { owner?: typeof data.owner }).owner = data.owner;
+        (detail as { stats?: typeof data.stats }).stats = data.stats;
+        (
+          detail as { latestVersion?: typeof data.latestVersion }
+        ).latestVersion = data.latestVersion;
+        (detail as { createdAt?: typeof data.createdAt }).createdAt =
+          data.createdAt;
+        (detail as { updatedAt?: typeof data.updatedAt }).updatedAt =
+          data.updatedAt;
       }
     } catch (err) {
       log.warn({ err, skillId }, "Failed to enrich clawhub skill detail");
     }
-    detail.clawhub = enriched;
+    return { skill: detail };
   }
 
+  if (slim.origin === "skillssh") {
+    const detail: SkillDetailResponse = {
+      id: slim.id,
+      name: slim.name,
+      description: slim.description,
+      emoji: slim.emoji,
+      kind: slim.kind,
+      origin: slim.origin,
+      status: slim.status,
+      slug: slim.slug,
+      sourceRepo: slim.sourceRepo,
+      installs: slim.installs,
+    };
+    return { skill: detail };
+  }
+
+  // vellum or custom origin — base fields only
+  const detail: SkillDetailResponse = {
+    id: slim.id,
+    name: slim.name,
+    description: slim.description,
+    emoji: slim.emoji,
+    kind: slim.kind,
+    origin: slim.origin,
+    status: slim.status,
+  };
   return { skill: detail };
 }
 

--- a/assistant/src/daemon/message-types/skills.ts
+++ b/assistant/src/daemon/message-types/skills.ts
@@ -138,13 +138,28 @@ export interface SkillBodyResponse {
 
 // ─── Detail endpoint response (HTTP API) ──────────────────────────────────
 
-export interface ClawhubDetailMeta {
+interface SkillDetailBase {
+  id: string;
+  name: string;
+  description: string;
+  emoji?: string;
+  kind: "bundled" | "installed" | "catalog";
+  status: "enabled" | "disabled" | "available";
+}
+
+interface VellumSkillDetail extends SkillDetailBase {
+  origin: "vellum";
+}
+
+interface ClawhubSkillDetail extends SkillDetailBase {
+  origin: "clawhub";
   slug: string;
   author: string;
   stars: number;
   installs: number;
   reports: number;
   publishedAt?: string;
+  // Enrichment fields (from clawhubInspect):
   owner?: { handle: string; displayName: string; image?: string } | null;
   stats?: {
     stars: number;
@@ -157,19 +172,22 @@ export interface ClawhubDetailMeta {
   updatedAt?: number | null;
 }
 
-export interface SkillDetailResponse {
-  id: string;
-  name: string;
-  description: string;
-  kind: "bundled" | "installed" | "catalog";
-  origin: "vellum" | "clawhub" | "skillssh" | "custom";
-  status: "enabled" | "disabled" | "available";
-  emoji?: string;
-  vellum?: { emoji?: string };
-  clawhub?: ClawhubDetailMeta;
-  skillssh?: { slug: string; sourceRepo: string; installs: number };
-  body?: string;
+interface SkillsshSkillDetail extends SkillDetailBase {
+  origin: "skillssh";
+  slug: string;
+  sourceRepo: string;
+  installs: number;
 }
+
+interface CustomSkillDetail extends SkillDetailBase {
+  origin: "custom";
+}
+
+export type SkillDetailResponse =
+  | VellumSkillDetail
+  | ClawhubSkillDetail
+  | SkillsshSkillDetail
+  | CustomSkillDetail;
 
 export interface SkillsDraftResponse {
   type: "skills_draft_response";

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -70,6 +70,54 @@ const slimSkillSchema = z.discriminatedUnion("origin", [
   z.object({ ...slimSkillBase, origin: z.literal("custom") }),
 ]);
 
+const skillDetailSchema = z.discriminatedUnion("origin", [
+  z.object({ ...slimSkillBase, origin: z.literal("vellum") }),
+  z.object({
+    ...slimSkillBase,
+    origin: z.literal("clawhub"),
+    slug: z.string(),
+    author: z.string(),
+    stars: z.number(),
+    installs: z.number(),
+    reports: z.number(),
+    publishedAt: z.string().optional(),
+    owner: z
+      .object({
+        handle: z.string(),
+        displayName: z.string(),
+        image: z.string().optional(),
+      })
+      .nullable()
+      .optional(),
+    stats: z
+      .object({
+        stars: z.number(),
+        installs: z.number(),
+        downloads: z.number(),
+        versions: z.number(),
+      })
+      .nullable()
+      .optional(),
+    latestVersion: z
+      .object({
+        version: z.string(),
+        changelog: z.string().optional(),
+      })
+      .nullable()
+      .optional(),
+    createdAt: z.number().nullable().optional(),
+    updatedAt: z.number().nullable().optional(),
+  }),
+  z.object({
+    ...slimSkillBase,
+    origin: z.literal("skillssh"),
+    slug: z.string(),
+    sourceRepo: z.string(),
+    installs: z.number(),
+  }),
+  z.object({ ...slimSkillBase, origin: z.literal("custom") }),
+]);
+
 export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
   const ctx = () => deps.getSkillContext();
 
@@ -412,6 +460,9 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
       summary: "Get skill",
       description: "Return a single skill by ID with enriched detail fields.",
       tags: ["skills"],
+      responseBody: z.object({
+        skill: skillDetailSchema.describe("Skill detail object"),
+      }),
       handler: async ({ params }) => {
         const result = await getSkill(params.id, ctx());
         if ("error" in result) {


### PR DESCRIPTION
## Summary
- Flatten SkillDetailResponse into discriminated union on origin with enrichment fields at top level
- Remove unused body field from detail response
- Remove ClawhubDetailMeta interface
- Regenerate OpenAPI spec

Part of plan: skills-discrim-union-flatten.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23057" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
