### PR TITLE
fix: pass messageId in iOS ChatViewModel tests to match message_complete guard

### DIFF
--- a/clients/ios/Tests/ChatViewModelIOSTests.swift
+++ b/clients/ios/Tests/ChatViewModelIOSTests.swift
@@ -212,7 +212,7 @@ final class ChatViewModelIOSTests: XCTestCase {
 
         viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response")))
         viewModel.flushStreamingBuffer()
-        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage()))
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage(messageId: "msg-1")))
 
         XCTAssertFalse(viewModel.isSending)
         XCTAssertFalse(viewModel.isThinking)
@@ -223,7 +223,7 @@ final class ChatViewModelIOSTests: XCTestCase {
         viewModel.isSending = true
         viewModel.isThinking = true
 
-        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage()))
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage(messageId: "msg-1")))
 
         XCTAssertFalse(viewModel.isSending)
         XCTAssertFalse(viewModel.isThinking)
@@ -309,7 +309,7 @@ final class ChatViewModelIOSTests: XCTestCase {
         XCTAssertEqual(viewModel.messages[1].text, "iOS is great!")
 
         // 5. Message completes
-        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage()))
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage(messageId: "msg-1")))
         XCTAssertFalse(viewModel.isSending)
         XCTAssertFalse(viewModel.messages[1].isStreaming)
     }


### PR DESCRIPTION
## Summary
- Pass `messageId` in `MessageCompleteMessage()` calls in `ChatViewModelIOSTests` so the `message_complete` guard (which returns early when `messageId == nil && isSending`) doesn't skip state cleanup
- Same fix pattern as #23053 which addressed the identical issue in `ConversationLifecycleIOSTests`

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23878980674/job/69628064850