### PR TITLE
fix: enable text selection in markdown table cells

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
@@ -357,6 +357,7 @@ struct MarkdownTableView: View {
                     Text(header)
                         .font(VFont.labelDefault)
                         .foregroundStyle(VColor.contentSecondary)
+                        .textSelection(.enabled)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.horizontal, VSpacing.sm)
                         .padding(.vertical, VSpacing.sm)
@@ -394,6 +395,7 @@ struct MarkdownTableView: View {
         return Text(attributed)
             .font(VFont.bodyMediumLighter)
             .foregroundStyle(VColor.contentDefault)
+            .textSelection(.enabled)
             .lineLimit(nil)
             .fixedSize(horizontal: false, vertical: true)
     }


### PR DESCRIPTION
## Summary
- Add `.textSelection(.enabled)` to header and data cell `Text` views in `MarkdownTableView`
- Matches the pattern used by all other markdown content (paragraphs, lists, `InlineTableWidget`)

## Original prompt
Enable click-and-drag text selection inside markdown tables in the assistant chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
