### PR TITLE
refactor: update Swift generated types for flattened skill response with all origin fields

### DIFF
--- a/clients/ios/Views/Intelligence/SkillDetailView.swift
+++ b/clients/ios/Views/Intelligence/SkillDetailView.swift
@@ -23,15 +23,14 @@ struct SkillDetailView: View {
 
             // Details section
             Section("Details") {
-                if let clawhub = skill.clawhub {
-                    if !clawhub.author.isEmpty {
-                        detailRow(label: "Author", value: clawhub.author)
-                    }
-                    if clawhub.stars > 0 {
-                        detailRow(label: "Stars", value: "\(clawhub.stars)")
-                    }
-                } else if let skillssh = skill.skillssh, !skillssh.sourceRepo.isEmpty {
-                    detailRow(label: "Source Repo", value: skillssh.sourceRepo)
+                if let author = skill.author, !author.isEmpty {
+                    detailRow(label: "Author", value: author)
+                }
+                if let stars = skill.stars, stars > 0 {
+                    detailRow(label: "Stars", value: "\(stars)")
+                }
+                if let sourceRepo = skill.sourceRepo, !sourceRepo.isEmpty {
+                    detailRow(label: "Source Repo", value: sourceRepo)
                 }
                 detailRow(label: "Origin", value: originLabel(skill.origin))
                 detailRow(label: "Status", value: skill.status.capitalized)
@@ -153,7 +152,7 @@ struct SkillDetailView: View {
         .navigationBarTitleDisplayMode(.inline)
         .task {
             // Inspect the skill if it has a clawhub origin
-            if skill.clawhub != nil {
+            if skill.origin == "clawhub" {
                 skillsStore.inspectSkill(slug: skill.id)
             }
             skillsStore.fetchSkillFiles(skillId: skill.id)
@@ -178,7 +177,7 @@ struct SkillDetailView: View {
 
     private var headerSection: some View {
         VStack(spacing: VSpacing.sm) {
-            Text(skill.vellum?.emoji ?? "")
+            Text(skill.emoji ?? "")
                 .font(.system(size: 48))
                 .accessibilityHidden(true)
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -246,7 +246,7 @@ struct SkillItemRow: View {
     var body: some View {
         VCard(action: onSelect) {
             HStack(alignment: .center, spacing: VSpacing.lg) {
-                if let emoji = skill.vellum?.emoji, !emoji.isEmpty {
+                if let emoji = skill.emoji, !emoji.isEmpty {
                     Text(emoji)
                         .font(.system(size: 32))
                 }
@@ -298,7 +298,7 @@ struct AvailableSkillItemRow: View {
 
     var body: some View {
         HStack(alignment: .center, spacing: VSpacing.lg) {
-            if let emoji = skill.vellum?.emoji, !emoji.isEmpty {
+            if let emoji = skill.emoji, !emoji.isEmpty {
                 Text(emoji)
                     .font(.system(size: 32))
                     .opacity(0.5)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
@@ -138,7 +138,7 @@ struct SkillDetailTitleRow: View {
                 .frame(width: 32, height: 32)
 
                 HStack(spacing: VSpacing.sm) {
-                    if let emoji = skill.vellum?.emoji, !emoji.isEmpty {
+                    if let emoji = skill.emoji, !emoji.isEmpty {
                         Text(emoji)
                             .font(.system(size: 20))
                     }

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -3985,65 +3985,40 @@ public struct SkillsListResponse: Codable, Sendable {
     }
 }
 
-public struct VellumSkillMeta: Codable, Sendable {
-    public let emoji: String?
-
-    public init(emoji: String? = nil) {
-        self.emoji = emoji
-    }
-}
-
-public struct ClawhubSkillMeta: Codable, Sendable {
-    public let slug: String
-    public let author: String
-    public let stars: Int
-    public let installs: Int
-    public let reports: Int
-    public let publishedAt: String?
-
-    public init(slug: String, author: String, stars: Int, installs: Int, reports: Int, publishedAt: String? = nil) {
-        self.slug = slug
-        self.author = author
-        self.stars = stars
-        self.installs = installs
-        self.reports = reports
-        self.publishedAt = publishedAt
-    }
-}
-
-public struct SkillsshSkillMeta: Codable, Sendable {
-    public let slug: String
-    public let sourceRepo: String
-    public let installs: Int
-
-    public init(slug: String, sourceRepo: String, installs: Int) {
-        self.slug = slug
-        self.sourceRepo = sourceRepo
-        self.installs = installs
-    }
-}
-
 public struct SkillsListResponseSkill: Codable, Sendable {
     public let id: String
     public let name: String
     public let description: String
+    public let emoji: String?
     public let kind: String
     public let origin: String
     public let status: String
-    public let vellum: VellumSkillMeta?
-    public let clawhub: ClawhubSkillMeta?
-    public let skillssh: SkillsshSkillMeta?
+    // Clawhub + Skillssh shared:
+    public let slug: String?
+    public let installs: Int?
+    // Clawhub-only:
+    public let author: String?
+    public let stars: Int?
+    public let reports: Int?
+    public let publishedAt: String?
+    // Skillssh-only:
+    public let sourceRepo: String?
 
-    public init(id: String, name: String, description: String, kind: String, origin: String, status: String, vellum: VellumSkillMeta? = nil, clawhub: ClawhubSkillMeta? = nil, skillssh: SkillsshSkillMeta? = nil) {
+    public init(id: String, name: String, description: String, emoji: String? = nil, kind: String, origin: String, status: String, slug: String? = nil, installs: Int? = nil, author: String? = nil, stars: Int? = nil, reports: Int? = nil, publishedAt: String? = nil, sourceRepo: String? = nil) {
         self.id = id
         self.name = name
         self.description = description
+        self.emoji = emoji
         self.kind = kind
         self.origin = origin
         self.status = status
-        self.vellum = vellum
-        self.clawhub = clawhub
-        self.skillssh = skillssh
+        self.slug = slug
+        self.installs = installs
+        self.author = author
+        self.stars = stars
+        self.reports = reports
+        self.publishedAt = publishedAt
+        self.sourceRepo = sourceRepo
     }
 }
 
@@ -4085,57 +4060,51 @@ public struct ClawhubDetailVersion: Codable, Sendable {
     }
 }
 
-public struct ClawhubDetailMeta: Codable, Sendable {
-    public let slug: String
-    public let author: String
-    public let stars: Int
-    public let installs: Int
-    public let reports: Int
+public struct SkillDetailHTTPResponse: Codable, Sendable {
+    public let id: String
+    public let name: String
+    public let description: String
+    public let emoji: String?
+    public let kind: String
+    public let origin: String
+    public let status: String
+    // Clawhub + Skillssh shared:
+    public let slug: String?
+    public let installs: Int?
+    // Clawhub-only:
+    public let author: String?
+    public let stars: Int?
+    public let reports: Int?
     public let publishedAt: String?
+    // Skillssh-only:
+    public let sourceRepo: String?
+    // Clawhub detail enrichment fields:
     public let owner: ClawhubDetailOwner?
     public let stats: ClawhubDetailStats?
     public let latestVersion: ClawhubDetailVersion?
     public let createdAt: Int?
     public let updatedAt: Int?
 
-    public init(slug: String, author: String, stars: Int, installs: Int, reports: Int, publishedAt: String? = nil, owner: ClawhubDetailOwner? = nil, stats: ClawhubDetailStats? = nil, latestVersion: ClawhubDetailVersion? = nil, createdAt: Int? = nil, updatedAt: Int? = nil) {
+    public init(id: String, name: String, description: String, emoji: String? = nil, kind: String, origin: String, status: String, slug: String? = nil, installs: Int? = nil, author: String? = nil, stars: Int? = nil, reports: Int? = nil, publishedAt: String? = nil, sourceRepo: String? = nil, owner: ClawhubDetailOwner? = nil, stats: ClawhubDetailStats? = nil, latestVersion: ClawhubDetailVersion? = nil, createdAt: Int? = nil, updatedAt: Int? = nil) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.emoji = emoji
+        self.kind = kind
+        self.origin = origin
+        self.status = status
         self.slug = slug
+        self.installs = installs
         self.author = author
         self.stars = stars
-        self.installs = installs
         self.reports = reports
         self.publishedAt = publishedAt
+        self.sourceRepo = sourceRepo
         self.owner = owner
         self.stats = stats
         self.latestVersion = latestVersion
         self.createdAt = createdAt
         self.updatedAt = updatedAt
-    }
-}
-
-public struct SkillDetailHTTPResponse: Codable, Sendable {
-    public let id: String
-    public let name: String
-    public let description: String
-    public let kind: String
-    public let origin: String
-    public let status: String
-    public let vellum: VellumSkillMeta?
-    public let clawhub: ClawhubDetailMeta?
-    public let skillssh: SkillsshSkillMeta?
-    public let body: String?
-
-    public init(id: String, name: String, description: String, kind: String, origin: String, status: String, vellum: VellumSkillMeta? = nil, clawhub: ClawhubDetailMeta? = nil, skillssh: SkillsshSkillMeta? = nil, body: String? = nil) {
-        self.id = id
-        self.name = name
-        self.description = description
-        self.kind = kind
-        self.origin = origin
-        self.status = status
-        self.vellum = vellum
-        self.clawhub = clawhub
-        self.skillssh = skillssh
-        self.body = body
     }
 }
 

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -914,7 +914,7 @@ extension SkillsListResponseSkill: Identifiable {}
 extension SkillsListResponseSkill {
     /// Returns a copy with a different `status`, preserving all other fields including `id`.
     public func withStatus(_ newStatus: String) -> Self {
-        Self(id: id, name: name, description: description, kind: kind, origin: origin, status: newStatus, vellum: vellum, clawhub: clawhub, skillssh: skillssh)
+        Self(id: id, name: name, description: description, emoji: emoji, kind: kind, origin: origin, status: newStatus, slug: slug, installs: installs, author: author, stars: stars, reports: reports, publishedAt: publishedAt, sourceRepo: sourceRepo)
     }
 
     /// Whether the skill is available from the catalog but not yet installed.
@@ -931,11 +931,6 @@ extension SkillsListResponseSkill {
 
     /// Whether the skill is currently disabled.
     public var isDisabled: Bool { status == "disabled" }
-
-    // MARK: - Convenience accessors
-
-    /// Reads emoji from the `vellum` sub-object for display.
-    public var emoji: String? { vellum?.emoji }
 }
 
 /// Response containing the list of available skills.


### PR DESCRIPTION
## Summary
- Flatten SkillsListResponseSkill and SkillDetailHTTPResponse to flat structs with all origin fields as optionals
- Remove VellumSkillMeta, ClawhubSkillMeta, SkillsshSkillMeta, ClawhubDetailMeta structs
- Add supporting structs for clawhub enrichment (owner, stats, latestVersion)
- Remove body field from detail response
- Update iOS and macOS view consumers to use new flat field access patterns

Part of plan: skills-discrim-union-flatten.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23061" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
