### PR TITLE
fix: narrow procedural node filtering to capability nodes only

### DIFF
--- a/assistant/src/memory/graph/consolidation.ts
+++ b/assistant/src/memory/graph/consolidation.ts
@@ -28,6 +28,7 @@ import {
   queryNodes,
   updateNode,
 } from "./store.js";
+import { isCapabilityNode } from "./types.js";
 import type { MemoryNode } from "./types.js";
 
 const log = getLogger("graph-consolidation");
@@ -182,7 +183,7 @@ function getRecentNodes(scopeId: string, days: number = 7): MemoryNode[] {
     fidelityNot: ["gone"],
     createdAfter: cutoff,
     limit: 10000,
-  }).filter((n) => n.type !== "procedural");
+  }).filter((n) => !isCapabilityNode(n));
 }
 
 function getTopSignificanceNodes(
@@ -194,7 +195,7 @@ function getTopSignificanceNodes(
     fidelityNot: ["gone"],
     minSignificance: 0.6,
     limit: n,
-  }).filter((n) => n.type !== "procedural");
+  }).filter((n) => !isCapabilityNode(n));
 }
 
 function getDecayedNodes(scopeId: string): MemoryNode[] {
@@ -202,7 +203,7 @@ function getDecayedNodes(scopeId: string): MemoryNode[] {
     scopeId,
     limit: 10000,
   });
-  return all.filter((n) => (n.fidelity === "faded" || n.fidelity === "gist") && n.type !== "procedural");
+  return all.filter((n) => (n.fidelity === "faded" || n.fidelity === "gist") && !isCapabilityNode(n));
 }
 
 function getRandomSample(scopeId: string, n: number = 30): MemoryNode[] {
@@ -210,7 +211,7 @@ function getRandomSample(scopeId: string, n: number = 30): MemoryNode[] {
     scopeId,
     fidelityNot: ["gone"],
     limit: 10000,
-  }).filter((n) => n.type !== "procedural");
+  }).filter((n) => !isCapabilityNode(n));
   // Fisher-Yates shuffle, take first n
   for (let i = all.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));

--- a/assistant/src/memory/graph/injection.ts
+++ b/assistant/src/memory/graph/injection.ts
@@ -5,6 +5,7 @@
 import { optimizeImageForTransport } from "../../agent/image-optimize.js";
 import { getLogger } from "../../util/logger.js";
 import { loadImageRefData } from "./image-ref-utils.js";
+import { isCapabilityNode } from "./types.js";
 import type { MemoryNode, ScoredNode } from "./types.js";
 
 // ---------------------------------------------------------------------------
@@ -274,7 +275,7 @@ export function assembleContextBlock(
       upcoming.push(scored);
     } else if (node.type === "prospective") {
       threads.push(scored);
-    } else if (node.type === "procedural") {
+    } else if (isCapabilityNode(node)) {
       capabilities.push(scored);
     } else if (node.type === "emotional" && isRecent(node)) {
       // Recent emotional nodes go in "Right Now" — present-tense state
@@ -366,7 +367,7 @@ export function assembleInjectionBlock(nodes: ScoredNode[]): string {
   if (nodes.length === 0) return "";
   return nodes
     .map((scored) => {
-      if (scored.node.type === "procedural") {
+      if (isCapabilityNode(scored.node)) {
         const content = scored.node.content.replace(/^skill:\S+\n/, "");
         return `- [skill] ${content} → use skill_load to activate`;
       }

--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -35,6 +35,7 @@ import {
   evaluateTemporalTriggers,
   type TriggeredResult,
 } from "./triggers.js";
+import { isCapabilityNode } from "./types.js";
 import type { MemoryEdge, MemoryNode, ScoredNode } from "./types.js";
 
 const log = getLogger("graph-retriever");
@@ -337,7 +338,7 @@ export async function loadContextMemory(
     limit: maxNodes,
   });
   for (const node of recentNodes) {
-    if (node.type === "procedural") continue;
+    if (isCapabilityNode(node)) continue;
     if (!semanticCandidateIds.has(node.id)) {
       semanticCandidateIds.set(node.id, 0);
     }
@@ -455,7 +456,7 @@ export async function loadContextMemory(
   // Dedup: both seeding systems may create nodes for the same skill.
   // Extract skill ID from content and keep only the first node per skill.
   const seenSkillIds = new Set<string>();
-  const capabilityNodes = rawCapabilityNodes.filter((node) => {
+  const capabilityNodes = rawCapabilityNodes.filter(isCapabilityNode).filter((node) => {
     const skillMatch = node.content.match(
       /^skill:(\S+)\n|^\s*The ".*?" skill \(([^)]+)\)/,
     );
@@ -583,7 +584,7 @@ export async function loadContextMemory(
   // the cut shouldn't compete with organic memories for general slots.
   const mainPool = scored.filter(
     (s) =>
-      s.node.type !== "procedural" &&
+      !isCapabilityNode(s.node) &&
       !prospectiveIds.has(s.node.id) &&
       !upcomingIds.has(s.node.id),
   );
@@ -613,7 +614,7 @@ export async function loadContextMemory(
   // Exclude procedural nodes from serendipity — they have reserved slots
   // and shouldn't appear as random wildcard picks.
   const serendipityPool = scored.filter(
-    (s) => s.node.type !== "procedural",
+    (s) => !isCapabilityNode(s.node),
   );
   const serendipityPicks = sampleSerendipity(serendipityPool, serendipitySlots);
 
@@ -823,7 +824,7 @@ export async function retrieveForTurn(
     if (node.fidelity === "gone") continue;
     // Procedural nodes (capabilities) have reserved slots at context-load
     // and shouldn't compete with organic memories in per-turn injection.
-    if (node.type === "procedural") continue;
+    if (isCapabilityNode(node)) continue;
 
     const semanticSim = allCandidateIds.get(node.id) ?? 0;
     const effectiveSig = computeEffectiveSignificance(node, nowMs);
@@ -967,7 +968,7 @@ export async function refreshContextMemory(
   const scored: ScoredNode[] = [];
   for (const node of nodes) {
     if (node.fidelity === "gone") continue;
-    if (node.type === "procedural") continue;
+    if (isCapabilityNode(node)) continue;
 
     const semanticSim = candidateScoreMap.get(node.id) ?? 0;
     const effectiveSig = computeEffectiveSignificance(node, nowMs);

--- a/assistant/src/memory/graph/types.ts
+++ b/assistant/src/memory/graph/types.ts
@@ -111,6 +111,31 @@ export interface MemoryNode {
   scopeId: string;
 }
 
+/**
+ * Whether a node is an auto-seeded capability (skill or CLI command) rather
+ * than an organically-extracted procedural memory. Capability nodes are
+ * created by the seeding systems at startup; organic procedural nodes are
+ * extracted from conversations (e.g. "FFmpeg needs -ac 2 for stereo").
+ *
+ * Only capability nodes should be reserved/excluded from normal retrieval
+ * and consolidation — organic procedural nodes participate normally.
+ */
+export function isCapabilityNode(node: MemoryNode): boolean {
+  if (node.type !== "procedural") return false;
+  // Old seeding system (skill-memory.ts): content starts with "skill:{id}\n"
+  if (node.content.startsWith("skill:")) return true;
+  // New seeding system (capability-seed.ts): content matches
+  // 'The "{name}" skill ({id}) is available.' or
+  // 'The "assistant {name}" CLI command is available.'
+  if (
+    node.content.startsWith('The "') &&
+    node.content.includes(") is available.")
+  ) {
+    return true;
+  }
+  return false;
+}
+
 /** Relationship type between two memory nodes. */
 export type EdgeRelationship =
   | "caused-by"


### PR DESCRIPTION
## Summary
- Add `isCapabilityNode()` predicate to `types.ts` that distinguishes auto-seeded capability nodes (skill/CLI) from organically-extracted procedural memories (how-to knowledge from conversations)
- Replace all `node.type === 'procedural'` checks in retriever, injection, and consolidation with `isCapabilityNode()`
- Organic procedural memories now correctly participate in normal retrieval, consolidation, and injection

The previous implementation used `type === 'procedural'` as a blanket filter, but the memory extraction system teaches the LLM to classify how-to knowledge as `procedural` (e.g. 'FFmpeg needs -ac 2 for stereo'). These organic memories were inadvertently excluded from all retrieval paths.

Part of plan: skill-memory-recall.md (review fix round 4)