### PR TITLE
fix: include CLI command nodes in isCapabilityNode predicate

### DIFF
--- a/assistant/src/memory/graph/types.ts
+++ b/assistant/src/memory/graph/types.ts
@@ -122,14 +122,15 @@ export interface MemoryNode {
  */
 export function isCapabilityNode(node: MemoryNode): boolean {
   if (node.type !== "procedural") return false;
-  // Old seeding system (skill-memory.ts): content starts with "skill:{id}\n"
-  if (node.content.startsWith("skill:")) return true;
+  // Old seeding systems: content starts with "skill:{id}\n" or "cli:{name}\n"
+  if (node.content.startsWith("skill:") || node.content.startsWith("cli:"))
+    return true;
   // New seeding system (capability-seed.ts): content matches
   // 'The "{name}" skill ({id}) is available.' or
   // 'The "assistant {name}" CLI command is available.'
   if (
     node.content.startsWith('The "') &&
-    node.content.includes(") is available.")
+    node.content.includes(" is available.")
   ) {
     return true;
   }


### PR DESCRIPTION
## Summary
- Add `cli:` prefix check for old-format CLI capability nodes
- Broaden new-format check from `) is available.` to ` is available.` to match CLI commands (which have no parenthesized ID)

Part of plan: skill-memory-recall.md (review fix round 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23064" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
