### PR TITLE
refactor: update Swift UI views to use flat fields and SkillOriginMeta enum

### DIFF
--- a/clients/ios/Views/Intelligence/SkillDetailView.swift
+++ b/clients/ios/Views/Intelligence/SkillDetailView.swift
@@ -21,54 +21,17 @@ struct SkillDetailView: View {
                 headerSection
             }
 
-            // Details section
+            // Details section with origin-specific metadata via originMeta
             Section("Details") {
-                if let author = skill.author, !author.isEmpty {
-                    detailRow(label: "Author", value: author)
-                }
-                if let stars = skill.stars, stars > 0 {
-                    detailRow(label: "Stars", value: "\(stars)")
-                }
-                if let sourceRepo = skill.sourceRepo, !sourceRepo.isEmpty {
-                    detailRow(label: "Source Repo", value: sourceRepo)
-                }
+                detailsSection
                 detailRow(label: "Origin", value: originLabel(skill.origin))
                 detailRow(label: "Status", value: skill.status.capitalized)
             }
 
-            // Inspect data section (loaded from ClaWHub)
-            if let inspected = skillsStore.inspectedSkill {
-                Section("About") {
-                    if !inspected.skill.summary.isEmpty {
-                        Text(inspected.skill.summary)
-                            .font(VFont.bodyMediumLighter)
-                            .foregroundStyle(VColor.contentSecondary)
-                    }
-
-                    if let owner = inspected.owner {
-                        detailRow(label: "Owner", value: owner.displayName)
-                    }
-
-                    if let stats = inspected.stats {
-                        detailRow(label: "Stars", value: "\(stats.stars)")
-                        detailRow(label: "Installs", value: "\(stats.installs)")
-                    }
-
-                    if let latestVersion = inspected.latestVersion {
-                        detailRow(label: "Latest Version", value: latestVersion.version)
-                        if let changelog = latestVersion.changelog, !changelog.isEmpty {
-                            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                                Text("Changelog")
-                                    .font(VFont.labelDefault)
-                                    .foregroundStyle(VColor.contentTertiary)
-                                Text(changelog)
-                                    .font(VFont.bodyMediumLighter)
-                                    .foregroundStyle(VColor.contentSecondary)
-                            }
-                        }
-                    }
-                }
-            } else if skillsStore.isInspecting {
+            // Enrichment data from skill detail endpoint
+            if let detail = skillsStore.selectedSkillDetail {
+                enrichmentSection(detail)
+            } else if skillsStore.isLoadingSkillDetail {
                 Section("About") {
                     HStack {
                         Spacer()
@@ -77,7 +40,7 @@ struct SkillDetailView: View {
                         Spacer()
                     }
                 }
-            } else if let error = skillsStore.inspectError {
+            } else if let error = skillsStore.skillDetailError {
                 Section("About") {
                     Text(error)
                         .font(VFont.bodyMediumLighter)
@@ -151,14 +114,10 @@ struct SkillDetailView: View {
         .navigationTitle(skill.name)
         .navigationBarTitleDisplayMode(.inline)
         .task {
-            // Inspect the skill if it has a clawhub origin
-            if skill.origin == "clawhub" {
-                skillsStore.inspectSkill(slug: skill.id)
-            }
+            skillsStore.fetchSkillDetail(skillId: skill.id)
             skillsStore.fetchSkillFiles(skillId: skill.id)
         }
         .onDisappear {
-            skillsStore.clearInspection()
             skillsStore.clearSkillDetail()
             expandedFilePath = nil
         }
@@ -270,6 +229,59 @@ struct SkillDetailView: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(file.path), \(formatFileSize(file.size))\(file.isBinary ? ", binary" : "")")
+    }
+
+    // MARK: - Details Section (origin-specific metadata via originMeta)
+
+    @ViewBuilder
+    private var detailsSection: some View {
+        switch skill.originMeta {
+        case .clawhub(let meta):
+            if !meta.author.isEmpty {
+                detailRow(label: "Author", value: meta.author)
+            }
+            if meta.stars > 0 {
+                detailRow(label: "Stars", value: "\(meta.stars)")
+            }
+        case .skillssh(let meta):
+            if !meta.sourceRepo.isEmpty {
+                detailRow(label: "Source Repo", value: meta.sourceRepo)
+            }
+        case .vellum, .custom:
+            EmptyView()
+        }
+    }
+
+    // MARK: - Enrichment Section (from skill detail endpoint)
+
+    @ViewBuilder
+    private func enrichmentSection(_ detail: SkillDetailHTTPResponse) -> some View {
+        if detail.owner != nil || detail.stats != nil || detail.latestVersion != nil {
+            Section("About") {
+                if let owner = detail.owner {
+                    detailRow(label: "Owner", value: owner.displayName)
+                }
+
+                if let stats = detail.stats {
+                    detailRow(label: "Stars", value: "\(stats.stars)")
+                    detailRow(label: "Installs", value: "\(stats.installs)")
+                }
+
+                if let latestVersion = detail.latestVersion {
+                    detailRow(label: "Latest Version", value: latestVersion.version)
+                    if let changelog = latestVersion.changelog, !changelog.isEmpty {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            Text("Changelog")
+                                .font(VFont.labelDefault)
+                                .foregroundStyle(VColor.contentTertiary)
+                            Text(changelog)
+                                .font(VFont.bodyMediumLighter)
+                                .foregroundStyle(VColor.contentSecondary)
+                        }
+                    }
+                }
+            }
+        }
     }
 
     // MARK: - Origin Label

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
@@ -32,6 +32,7 @@ struct SkillDetailView: View {
                     .lineSpacing(8)
                     .frame(maxWidth: 800, alignment: .leading)
             }
+            originMetaRow
             skillDetailFileBrowser
         }
         .onAppear {
@@ -59,6 +60,62 @@ struct SkillDetailView: View {
         .onDisappear {
             expandedFilePath = nil
             skillsManager.clearSkillDetail()
+        }
+    }
+
+    // MARK: - Origin-Specific Metadata
+
+    @ViewBuilder
+    private var originMetaRow: some View {
+        switch skill.originMeta {
+        case .clawhub(let meta):
+            HStack(spacing: VSpacing.lg) {
+                if !meta.author.isEmpty {
+                    HStack(spacing: VSpacing.xs) {
+                        VIconView(.user, size: 12)
+                        Text(meta.author)
+                            .font(VFont.labelDefault)
+                    }
+                    .foregroundStyle(VColor.contentTertiary)
+                }
+                if meta.stars > 0 {
+                    HStack(spacing: VSpacing.xs) {
+                        VIconView(.star, size: 12)
+                        Text("\(meta.stars)")
+                            .font(VFont.labelDefault)
+                    }
+                    .foregroundStyle(VColor.contentTertiary)
+                }
+                if meta.installs > 0 {
+                    HStack(spacing: VSpacing.xs) {
+                        VIconView(.arrowDownToLine, size: 12)
+                        Text("\(meta.installs)")
+                            .font(VFont.labelDefault)
+                    }
+                    .foregroundStyle(VColor.contentTertiary)
+                }
+            }
+        case .skillssh(let meta):
+            HStack(spacing: VSpacing.lg) {
+                if !meta.sourceRepo.isEmpty {
+                    HStack(spacing: VSpacing.xs) {
+                        VIconView(.gitBranch, size: 12)
+                        Text(meta.sourceRepo)
+                            .font(VFont.labelDefault)
+                    }
+                    .foregroundStyle(VColor.contentTertiary)
+                }
+                if meta.installs > 0 {
+                    HStack(spacing: VSpacing.xs) {
+                        VIconView(.arrowDownToLine, size: 12)
+                        Text("\(meta.installs)")
+                            .font(VFont.labelDefault)
+                    }
+                    .foregroundStyle(VColor.contentTertiary)
+                }
+            }
+        case .vellum, .custom:
+            EmptyView()
         }
     }
 

--- a/clients/shared/Features/Skills/SkillsStore.swift
+++ b/clients/shared/Features/Skills/SkillsStore.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Cross-platform store for skills data operations.
 ///
-/// Encapsulates all daemon communication for listing, searching, inspecting,
+/// Encapsulates all daemon communication for listing, searching,
 /// installing, uninstalling, enabling, disabling, configuring, drafting, and
 /// creating skills. Platform-specific UI state (panel presentation, tab
 /// selection, etc.) remains in the platform view model that delegates here.
@@ -17,10 +17,6 @@ public final class SkillsStore: ObservableObject {
 
     @Published public var searchResults: [SkillInfo] = []
     @Published public var isSearching = false
-
-    @Published public var inspectedSkill: SkillsInspectResponseData?
-    @Published public var isInspecting = false
-    @Published public var inspectError: String?
 
     @Published public var installResult: InstallResult?
 
@@ -88,8 +84,6 @@ public final class SkillsStore: ObservableObject {
     // MARK: - Private State
 
     private let skillsClient: SkillsClientProtocol
-    private var inspectCache: [String: SkillsInspectResponseData] = [:]
-    private var currentInspectSlug: String?
     private var lastSearchQuery: String?
     private var draftTask: Task<Void, Never>?
     private var createTask: Task<Void, Never>?
@@ -174,7 +168,6 @@ public final class SkillsStore: ObservableObject {
             }
             installResult = result
             if result.success {
-                inspectCache.removeValue(forKey: slug)
                 fetchSkills(force: true)
             }
             Task { @MainActor in
@@ -183,34 +176,6 @@ public final class SkillsStore: ObservableObject {
                     self.installResult = nil
                 }
             }
-        }
-    }
-
-    // MARK: - Inspect Skill
-
-    public func inspectSkill(slug: String) {
-        currentInspectSlug = slug
-        inspectError = nil
-
-        if let cached = inspectCache[slug] {
-            inspectedSkill = cached
-            isInspecting = false
-            return
-        }
-
-        isInspecting = true
-        inspectedSkill = nil
-
-        Task {
-            let response = await skillsClient.inspectSkill(slug: slug)
-            guard currentInspectSlug == slug else { return }
-            if let data = response?.data {
-                inspectedSkill = data
-                inspectCache[slug] = data
-            } else {
-                inspectError = response?.error ?? "Inspection timed out"
-            }
-            isInspecting = false
         }
     }
 
@@ -231,7 +196,6 @@ public final class SkillsStore: ObservableObject {
             }
             uninstallResult = result
             if result.success {
-                inspectCache.removeAll()
                 fetchSkills(force: true)
             }
             Task { @MainActor in
@@ -264,15 +228,6 @@ public final class SkillsStore: ObservableObject {
 
     public func configureSkill(name: String, env: [String: String]? = nil, apiKey: String? = nil, config: [String: AnyCodable]? = nil) {
         Task { _ = await skillsClient.configureSkill(name: name, env: env, apiKey: apiKey, config: config) }
-    }
-
-    // MARK: - Clear Inspection
-
-    public func clearInspection() {
-        currentInspectSlug = nil
-        inspectedSkill = nil
-        isInspecting = false
-        inspectError = nil
     }
 
     // MARK: - Skill Drafting

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1110,6 +1110,33 @@ extension SkillsListResponseSkill {
     }
 }
 
+extension SkillDetailHTTPResponse {
+    /// Decoded origin-specific metadata. Lazily parses from the flat fields.
+    public var originMeta: SkillOriginMeta {
+        switch origin {
+        case "clawhub":
+            return .clawhub(ClawhubOriginMeta(
+                slug: slug ?? id,
+                author: author ?? "",
+                stars: stars ?? 0,
+                installs: installs ?? 0,
+                reports: reports ?? 0,
+                publishedAt: publishedAt
+            ))
+        case "skillssh":
+            return .skillssh(SkillsshOriginMeta(
+                slug: slug ?? id,
+                sourceRepo: sourceRepo ?? "",
+                installs: installs ?? 0
+            ))
+        case "vellum":
+            return .vellum
+        default:
+            return .custom
+        }
+    }
+}
+
 /// Skill info from a ClaWHub inspect response.
 /// Backed by generated `SkillsInspectResponseDataSkill`.
 public typealias ClawhubInspectSkill = SkillsInspectResponseDataSkill

--- a/clients/shared/Network/SkillsClient.swift
+++ b/clients/shared/Network/SkillsClient.swift
@@ -6,7 +6,7 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "Skill
 /// Focused client for skills-related operations routed through the gateway.
 ///
 /// Covers listing, enabling, disabling, configuring, installing, uninstalling,
-/// updating, searching, inspecting, drafting, and creating skills.
+/// updating, searching, drafting, and creating skills.
 public protocol SkillsClientProtocol {
     func fetchSkillsList(includeCatalog: Bool) async -> SkillsListResponseMessage?
     func enableSkill(name: String) async -> SkillOperationResult?
@@ -17,7 +17,6 @@ public protocol SkillsClientProtocol {
     func updateSkill(name: String) async -> SkillOperationResult?
     func checkSkillUpdates() async -> SkillOperationResult?
     func searchSkills(query: String) async -> SkillSearchResult?
-    func inspectSkill(slug: String) async -> SkillsInspectResponseMessage?
     func draftSkill(sourceText: String) async -> SkillsDraftResponseMessage?
     func createSkill(skillId: String, name: String, description: String, emoji: String?, bodyMarkdown: String, overwrite: Bool?) async -> SkillOperationResult?
     func fetchSkillDetail(skillId: String) async -> SkillDetailHTTPResponse?
@@ -225,28 +224,6 @@ public struct SkillsClient: SkillsClientProtocol {
         } catch {
             log.error("searchSkills error: \(error.localizedDescription)")
             return SkillSearchResult(success: false, error: error.localizedDescription)
-        }
-    }
-
-    public func inspectSkill(slug: String) async -> SkillsInspectResponseMessage? {
-        do {
-            let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/skills/\(Self.encodePath(slug))/inspect", timeout: 10
-            )
-            guard response.isSuccess else {
-                log.error("inspectSkill failed (HTTP \(response.statusCode))")
-                return nil
-            }
-            // REST returns { slug, data?: ClawhubInspectData, error? } — inject the
-            // type discriminator so the generated SkillsInspectResponse can decode it.
-            var json = (try? JSONSerialization.jsonObject(with: response.data) as? [String: Any]) ?? [:]
-            json["type"] = "skills_inspect_response"
-            if json["slug"] == nil { json["slug"] = slug }
-            let enriched = (try? JSONSerialization.data(withJSONObject: json)) ?? response.data
-            return try JSONDecoder().decode(SkillsInspectResponseMessage.self, from: enriched)
-        } catch {
-            log.error("inspectSkill error: \(error.localizedDescription)")
-            return nil
         }
     }
 


### PR DESCRIPTION
## Summary
- Migrate remaining UI consumers from old nested sub-object access to flat fields and originMeta enum
- Clean up SkillsClient and SkillsStore references to old patterns
- Use SkillOriginMeta for type-safe origin-specific metadata display

Part of plan: skills-discrim-union-flatten.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23065" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
