### PR TITLE
fix: strip cli: prefix in injection and dedup CLI capability nodes

### DIFF
--- a/assistant/src/memory/graph/injection.ts
+++ b/assistant/src/memory/graph/injection.ts
@@ -312,7 +312,7 @@ export function assembleContextBlock(
   // --- Skills You Can Use ---
   if (capabilities.length > 0) {
     const entries = capabilities.slice(0, 5).map((scored) => {
-      const content = scored.node.content.replace(/^skill:\S+\n/, "");
+      const content = scored.node.content.replace(/^(?:skill|cli):\S+\n/, "");
       return `- ${content} → use skill_load to activate`;
     });
     parts.push(`### Skills You Can Use\n${entries.join("\n")}`);
@@ -368,7 +368,7 @@ export function assembleInjectionBlock(nodes: ScoredNode[]): string {
   return nodes
     .map((scored) => {
       if (isCapabilityNode(scored.node)) {
-        const content = scored.node.content.replace(/^skill:\S+\n/, "");
+        const content = scored.node.content.replace(/^(?:skill|cli):\S+\n/, "");
         return `- [skill] ${content} → use skill_load to activate`;
       }
       if (scored.node.eventDate != null) {

--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -453,20 +453,22 @@ export async function loadContextMemory(
     limit: CAPABILITY_RESERVE * 4,
   });
 
-  // Dedup: both seeding systems may create nodes for the same skill.
-  // Extract skill ID from content and keep only the first node per skill.
-  const seenSkillIds = new Set<string>();
-  const capabilityNodes = rawCapabilityNodes.filter(isCapabilityNode).filter((node) => {
-    const skillMatch = node.content.match(
-      /^skill:(\S+)\n|^\s*The ".*?" skill \(([^)]+)\)/,
-    );
-    const skillId = skillMatch?.[1] ?? skillMatch?.[2];
-    if (skillId) {
-      if (seenSkillIds.has(skillId)) return false;
-      seenSkillIds.add(skillId);
-    }
-    return true;
-  });
+  // Dedup: both seeding systems may create nodes for the same capability.
+  // Extract capability ID from content and keep only the first node per ID.
+  const seenCapabilityIds = new Set<string>();
+  const capabilityNodes = rawCapabilityNodes
+    .filter(isCapabilityNode)
+    .filter((node) => {
+      const match = node.content.match(
+        /^skill:(\S+)\n|^cli:(\S+)\n|^\s*The ".*?" skill \(([^)]+)\)|^\s*The "assistant (\S+)" CLI command/,
+      );
+      const capId = match?.[1] ?? match?.[2] ?? match?.[3] ?? match?.[4];
+      if (capId) {
+        if (seenCapabilityIds.has(capId)) return false;
+        seenCapabilityIds.add(capId);
+      }
+      return true;
+    });
 
   // Rank by semantic similarity when a query vector exists
   let selectedCapabilities: MemoryNode[];


### PR DESCRIPTION
## Summary
- Broaden prefix stripping regex from `/^skill:\S+\n/` to `/^(?:skill|cli):\S+\n/` so old-format CLI nodes don't leak raw prefixes into rendered output
- Extend dedup regex to also extract CLI command names, preventing duplicate CLI nodes from both seeding systems from wasting reserved capability slots

Part of plan: skill-memory-recall.md (review fix round 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
