### PR TITLE
fix: sort imports in memory graph modules

### DIFF
--- a/assistant/src/memory/graph/consolidation.ts
+++ b/assistant/src/memory/graph/consolidation.ts
@@ -28,8 +28,8 @@ import {
   queryNodes,
   updateNode,
 } from "./store.js";
-import { isCapabilityNode } from "./types.js";
 import type { MemoryNode } from "./types.js";
+import { isCapabilityNode } from "./types.js";
 
 const log = getLogger("graph-consolidation");
 

--- a/assistant/src/memory/graph/injection.ts
+++ b/assistant/src/memory/graph/injection.ts
@@ -5,8 +5,8 @@
 import { optimizeImageForTransport } from "../../agent/image-optimize.js";
 import { getLogger } from "../../util/logger.js";
 import { loadImageRefData } from "./image-ref-utils.js";
-import { isCapabilityNode } from "./types.js";
 import type { MemoryNode, ScoredNode } from "./types.js";
+import { isCapabilityNode } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Image injection budgets

--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -35,8 +35,8 @@ import {
   evaluateTemporalTriggers,
   type TriggeredResult,
 } from "./triggers.js";
-import { isCapabilityNode } from "./types.js";
 import type { MemoryEdge, MemoryNode, ScoredNode } from "./types.js";
+import { isCapabilityNode } from "./types.js";
 
 const log = getLogger("graph-retriever");
 


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint errors in `consolidation.ts`, `injection.ts`, and `retriever.ts` by reordering type imports before value imports from the same module

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23879565668/job/69629795475