### PR TITLE
refactor: flatten skill response types into discriminated union on origin

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5697,42 +5697,65 @@ paths:
                   skills:
                     type: array
                     items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        name:
-                          type: string
-                        description:
-                          type: string
-                        kind:
-                          type: string
-                          enum:
-                            - bundled
-                            - installed
-                            - catalog
-                        origin:
-                          type: string
-                          enum:
-                            - vellum
-                            - clawhub
-                            - skillssh
-                            - custom
-                        status:
-                          type: string
-                          enum:
-                            - enabled
-                            - disabled
-                            - available
-                        vellum:
-                          type: object
+                      oneOf:
+                        - type: object
                           properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
                             emoji:
                               type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: vellum
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
                           additionalProperties: false
-                        clawhub:
-                          type: object
+                        - type: object
                           properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: clawhub
                             slug:
                               type: string
                             author:
@@ -5746,15 +5769,43 @@ paths:
                             publishedAt:
                               type: string
                           required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
                             - slug
                             - author
                             - stars
                             - installs
                             - reports
                           additionalProperties: false
-                        skillssh:
-                          type: object
+                        - type: object
                           properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: skillssh
                             slug:
                               type: string
                             sourceRepo:
@@ -5762,18 +5813,49 @@ paths:
                             installs:
                               type: number
                           required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
                             - slug
                             - sourceRepo
                             - installs
                           additionalProperties: false
-                      required:
-                        - id
-                        - name
-                        - description
-                        - kind
-                        - origin
-                        - status
-                      additionalProperties: false
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: custom
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
+                          additionalProperties: false
                     description: Skill objects
                 required:
                   - skills
@@ -6132,42 +6214,65 @@ paths:
                   skills:
                     type: array
                     items:
-                      type: object
-                      properties:
-                        id:
-                          type: string
-                        name:
-                          type: string
-                        description:
-                          type: string
-                        kind:
-                          type: string
-                          enum:
-                            - bundled
-                            - installed
-                            - catalog
-                        origin:
-                          type: string
-                          enum:
-                            - vellum
-                            - clawhub
-                            - skillssh
-                            - custom
-                        status:
-                          type: string
-                          enum:
-                            - enabled
-                            - disabled
-                            - available
-                        vellum:
-                          type: object
+                      oneOf:
+                        - type: object
                           properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
                             emoji:
                               type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: vellum
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
                           additionalProperties: false
-                        clawhub:
-                          type: object
+                        - type: object
                           properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: clawhub
                             slug:
                               type: string
                             author:
@@ -6181,15 +6286,43 @@ paths:
                             publishedAt:
                               type: string
                           required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
                             - slug
                             - author
                             - stars
                             - installs
                             - reports
                           additionalProperties: false
-                        skillssh:
-                          type: object
+                        - type: object
                           properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: skillssh
                             slug:
                               type: string
                             sourceRepo:
@@ -6197,18 +6330,49 @@ paths:
                             installs:
                               type: number
                           required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
                             - slug
                             - sourceRepo
                             - installs
                           additionalProperties: false
-                      required:
-                        - id
-                        - name
-                        - description
-                        - kind
-                        - origin
-                        - status
-                      additionalProperties: false
+                        - type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            description:
+                              type: string
+                            emoji:
+                              type: string
+                            kind:
+                              type: string
+                              enum:
+                                - bundled
+                                - installed
+                                - catalog
+                            status:
+                              type: string
+                              enum:
+                                - enabled
+                                - disabled
+                                - available
+                            origin:
+                              type: string
+                              const: custom
+                          required:
+                            - id
+                            - name
+                            - description
+                            - kind
+                            - status
+                            - origin
+                          additionalProperties: false
                     description: Skill objects matching the search query
                 required:
                   - skills

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5934,6 +5934,229 @@ paths:
       responses:
         "200":
           description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  skill:
+                    oneOf:
+                      - type: object
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          description:
+                            type: string
+                          emoji:
+                            type: string
+                          kind:
+                            type: string
+                            enum:
+                              - bundled
+                              - installed
+                              - catalog
+                          status:
+                            type: string
+                            enum:
+                              - enabled
+                              - disabled
+                              - available
+                          origin:
+                            type: string
+                            const: vellum
+                        required:
+                          - id
+                          - name
+                          - description
+                          - kind
+                          - status
+                          - origin
+                        additionalProperties: false
+                      - type: object
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          description:
+                            type: string
+                          emoji:
+                            type: string
+                          kind:
+                            type: string
+                            enum:
+                              - bundled
+                              - installed
+                              - catalog
+                          status:
+                            type: string
+                            enum:
+                              - enabled
+                              - disabled
+                              - available
+                          origin:
+                            type: string
+                            const: clawhub
+                          slug:
+                            type: string
+                          author:
+                            type: string
+                          stars:
+                            type: number
+                          installs:
+                            type: number
+                          reports:
+                            type: number
+                          publishedAt:
+                            type: string
+                          owner:
+                            anyOf:
+                              - type: object
+                                properties:
+                                  handle:
+                                    type: string
+                                  displayName:
+                                    type: string
+                                  image:
+                                    type: string
+                                required:
+                                  - handle
+                                  - displayName
+                                additionalProperties: false
+                              - type: "null"
+                          stats:
+                            anyOf:
+                              - type: object
+                                properties:
+                                  stars:
+                                    type: number
+                                  installs:
+                                    type: number
+                                  downloads:
+                                    type: number
+                                  versions:
+                                    type: number
+                                required:
+                                  - stars
+                                  - installs
+                                  - downloads
+                                  - versions
+                                additionalProperties: false
+                              - type: "null"
+                          latestVersion:
+                            anyOf:
+                              - type: object
+                                properties:
+                                  version:
+                                    type: string
+                                  changelog:
+                                    type: string
+                                required:
+                                  - version
+                                additionalProperties: false
+                              - type: "null"
+                          createdAt:
+                            anyOf:
+                              - type: number
+                              - type: "null"
+                          updatedAt:
+                            anyOf:
+                              - type: number
+                              - type: "null"
+                        required:
+                          - id
+                          - name
+                          - description
+                          - kind
+                          - status
+                          - origin
+                          - slug
+                          - author
+                          - stars
+                          - installs
+                          - reports
+                        additionalProperties: false
+                      - type: object
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          description:
+                            type: string
+                          emoji:
+                            type: string
+                          kind:
+                            type: string
+                            enum:
+                              - bundled
+                              - installed
+                              - catalog
+                          status:
+                            type: string
+                            enum:
+                              - enabled
+                              - disabled
+                              - available
+                          origin:
+                            type: string
+                            const: skillssh
+                          slug:
+                            type: string
+                          sourceRepo:
+                            type: string
+                          installs:
+                            type: number
+                        required:
+                          - id
+                          - name
+                          - description
+                          - kind
+                          - status
+                          - origin
+                          - slug
+                          - sourceRepo
+                          - installs
+                        additionalProperties: false
+                      - type: object
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          description:
+                            type: string
+                          emoji:
+                            type: string
+                          kind:
+                            type: string
+                            enum:
+                              - bundled
+                              - installed
+                              - catalog
+                          status:
+                            type: string
+                            enum:
+                              - enabled
+                              - disabled
+                              - available
+                          origin:
+                            type: string
+                            const: custom
+                        required:
+                          - id
+                          - name
+                          - description
+                          - kind
+                          - status
+                          - origin
+                        additionalProperties: false
+                    description: Skill detail object
+                required:
+                  - skill
+                additionalProperties: false
       parameters:
         - name: id
           in: path

--- a/assistant/src/__tests__/search-skills-unified.test.ts
+++ b/assistant/src/__tests__/search-skills-unified.test.ts
@@ -412,10 +412,10 @@ describe("searchSkills (unified)", () => {
     expect(skill.kind).toBe("catalog");
     expect(skill.origin).toBe("skillssh");
     expect(skill.status).toBe("available");
-    expect(skill.skillssh).toEqual({
-      slug: "org/repo/test-skill",
-      sourceRepo: "org/repo",
-      installs: 99,
-    });
+    if (skill.origin === "skillssh") {
+      expect(skill.slug).toBe("org/repo/test-skill");
+      expect(skill.sourceRepo).toBe("org/repo");
+      expect(skill.installs).toBe(99);
+    }
   });
 });

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -63,7 +63,6 @@ import {
 } from "../../skills/skillssh-registry.js";
 import { getWorkspaceSkillsDir } from "../../util/platform.js";
 import type {
-  ClawhubDetailMeta,
   SkillDetailResponse,
   SlimSkillResponse,
 } from "../message-types/skills.js";
@@ -429,43 +428,18 @@ export async function getSkill(
 
   const slim = found.item;
 
-  // Read SKILL.md body from disk
-  let body: string | undefined;
-  const skillMdPath = join(found.summary.directoryPath, "SKILL.md");
-  try {
-    if (existsSync(skillMdPath)) {
-      body = readFileSync(skillMdPath, "utf-8");
-    }
-  } catch {
-    // Best-effort: body is optional
-  }
-
-  // Build the detail response, starting from the slim shape.
-  // SkillDetailResponse still uses the old nested sub-object shape (PR 2
-  // will flatten it); reconstruct nested objects from the flat union here.
-  const detail: SkillDetailResponse = {
-    id: slim.id,
-    name: slim.name,
-    description: slim.description,
-    emoji: slim.emoji,
-    kind: slim.kind,
-    origin: slim.origin,
-    status: slim.status,
-    ...(slim.origin === "skillssh"
-      ? {
-          skillssh: {
-            slug: slim.slug,
-            sourceRepo: slim.sourceRepo,
-            installs: slim.installs,
-          },
-        }
-      : {}),
-    ...(body !== undefined ? { body } : {}),
-  };
-
-  // For clawhub-origin skills, enrich with inspect data
+  // Build the detail response as a flat discriminated union on origin.
+  // Origin-specific fields are spread directly at the top level.
   if (slim.origin === "clawhub") {
-    const enriched: ClawhubDetailMeta = {
+    // Start with slim clawhub fields, then enrich with inspect data.
+    const detail: SkillDetailResponse = {
+      id: slim.id,
+      name: slim.name,
+      description: slim.description,
+      emoji: slim.emoji,
+      kind: slim.kind,
+      origin: slim.origin,
+      status: slim.status,
       slug: slim.slug,
       author: slim.author,
       stars: slim.stars,
@@ -477,18 +451,48 @@ export async function getSkill(
       const inspectResult = await clawhubInspect(slim.slug);
       if (inspectResult.data) {
         const data = inspectResult.data;
-        enriched.owner = data.owner;
-        enriched.stats = data.stats;
-        enriched.latestVersion = data.latestVersion;
-        enriched.createdAt = data.createdAt;
-        enriched.updatedAt = data.updatedAt;
+        (detail as { owner?: typeof data.owner }).owner = data.owner;
+        (detail as { stats?: typeof data.stats }).stats = data.stats;
+        (
+          detail as { latestVersion?: typeof data.latestVersion }
+        ).latestVersion = data.latestVersion;
+        (detail as { createdAt?: typeof data.createdAt }).createdAt =
+          data.createdAt;
+        (detail as { updatedAt?: typeof data.updatedAt }).updatedAt =
+          data.updatedAt;
       }
     } catch (err) {
       log.warn({ err, skillId }, "Failed to enrich clawhub skill detail");
     }
-    detail.clawhub = enriched;
+    return { skill: detail };
   }
 
+  if (slim.origin === "skillssh") {
+    const detail: SkillDetailResponse = {
+      id: slim.id,
+      name: slim.name,
+      description: slim.description,
+      emoji: slim.emoji,
+      kind: slim.kind,
+      origin: slim.origin,
+      status: slim.status,
+      slug: slim.slug,
+      sourceRepo: slim.sourceRepo,
+      installs: slim.installs,
+    };
+    return { skill: detail };
+  }
+
+  // vellum or custom origin — base fields only
+  const detail: SkillDetailResponse = {
+    id: slim.id,
+    name: slim.name,
+    description: slim.description,
+    emoji: slim.emoji,
+    kind: slim.kind,
+    origin: slim.origin,
+    status: slim.status,
+  };
   return { skill: detail };
 }
 

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -64,11 +64,8 @@ import {
 import { getWorkspaceSkillsDir } from "../../util/platform.js";
 import type {
   ClawhubDetailMeta,
-  ClawhubSkillMeta,
   SkillDetailResponse,
-  SkillsshSkillMeta,
   SlimSkillResponse,
-  VellumSkillMeta,
 } from "../message-types/skills.js";
 import {
   CONFIG_RELOAD_DEBOUNCE_MS,
@@ -276,38 +273,26 @@ function deriveOrigin(
   return meta?.origin ?? "custom";
 }
 
-/** Build the correct polymorphic sub-object for a given origin. */
+/** Build the origin-specific fields for a given origin (flattened at top level). */
 function buildOriginMeta(
   origin: SlimSkillResponse["origin"],
   summary: SkillSummary,
   installMeta?: SkillInstallMeta | null,
-): Pick<SlimSkillResponse, "vellum" | "clawhub" | "skillssh"> {
+): Record<string, unknown> {
   switch (origin) {
-    case "vellum": {
-      const vellumMeta: VellumSkillMeta | undefined = summary.emoji
-        ? { emoji: summary.emoji }
-        : undefined;
-      return vellumMeta ? { vellum: vellumMeta } : {};
-    }
+    case "vellum":
+      return {};
     case "clawhub": {
       const meta =
         installMeta !== undefined
           ? installMeta
           : readInstallMeta(summary.directoryPath);
-      const clawhubMeta: ClawhubSkillMeta = {
+      return {
         slug: meta?.slug ?? summary.id,
         author: "",
         stars: 0,
         installs: 0,
         reports: 0,
-      };
-      // Preserve emoji for the Swift client which reads skill.vellum?.emoji
-      const emojiMeta: VellumSkillMeta | undefined = summary.emoji
-        ? { emoji: summary.emoji }
-        : undefined;
-      return {
-        clawhub: clawhubMeta,
-        ...(emojiMeta ? { vellum: emojiMeta } : {}),
       };
     }
     case "skillssh": {
@@ -315,27 +300,14 @@ function buildOriginMeta(
         installMeta !== undefined
           ? installMeta
           : readInstallMeta(summary.directoryPath);
-      const skillsshMeta: SkillsshSkillMeta = {
+      return {
         slug: meta?.slug ?? summary.id,
         sourceRepo: meta?.sourceRepo ?? "",
         installs: 0,
       };
-      // Preserve emoji for the Swift client which reads skill.vellum?.emoji
-      const emojiMeta: VellumSkillMeta | undefined = summary.emoji
-        ? { emoji: summary.emoji }
-        : undefined;
-      return {
-        skillssh: skillsshMeta,
-        ...(emojiMeta ? { vellum: emojiMeta } : {}),
-      };
     }
-    default: {
-      // Custom origin: still preserve emoji if present
-      const emojiMeta: VellumSkillMeta | undefined = summary.emoji
-        ? { emoji: summary.emoji }
-        : undefined;
-      return emojiMeta ? { vellum: emojiMeta } : {};
-    }
+    default:
+      return {};
   }
 }
 
@@ -362,11 +334,12 @@ function toSlimSkillResponse(
     id: summary.id,
     name: summary.displayName,
     description: summary.description,
+    emoji: summary.emoji,
     kind,
     origin,
     status,
     ...buildOriginMeta(origin, summary, installMeta),
-  };
+  } as SlimSkillResponse;
 }
 
 export function listSkills(_ctx: SkillOperationContext): SlimSkillResponse[] {
@@ -408,21 +381,15 @@ export async function listSkillsWithCatalog(
   // Create SlimSkillResponses for catalog skills not already installed.
   const available: SlimSkillResponse[] = catalogSkills
     .filter((cs) => !installedIds.has(cs.id))
-    .map((cs) => {
-      const emoji = cs.emoji;
-      const result: SlimSkillResponse = {
-        id: cs.id,
-        name: cs.metadata?.vellum?.["display-name"] ?? cs.name,
-        description: cs.description,
-        kind: "catalog",
-        origin: "vellum",
-        status: "available",
-      };
-      if (emoji) {
-        result.vellum = { emoji };
-      }
-      return result;
-    });
+    .map((cs) => ({
+      id: cs.id,
+      name: cs.metadata?.vellum?.["display-name"] ?? cs.name,
+      description: cs.description,
+      emoji: cs.emoji,
+      kind: "catalog" as const,
+      origin: "vellum" as const,
+      status: "available" as const,
+    }));
 
   const merged = [...installed, ...available];
 
@@ -473,24 +440,41 @@ export async function getSkill(
     // Best-effort: body is optional
   }
 
-  // Build the detail response, starting from the slim shape
+  // Build the detail response, starting from the slim shape.
+  // SkillDetailResponse still uses the old nested sub-object shape (PR 2
+  // will flatten it); reconstruct nested objects from the flat union here.
   const detail: SkillDetailResponse = {
     id: slim.id,
     name: slim.name,
     description: slim.description,
+    emoji: slim.emoji,
     kind: slim.kind,
     origin: slim.origin,
     status: slim.status,
-    ...(slim.vellum ? { vellum: slim.vellum } : {}),
-    ...(slim.skillssh ? { skillssh: slim.skillssh } : {}),
+    ...(slim.origin === "skillssh"
+      ? {
+          skillssh: {
+            slug: slim.slug,
+            sourceRepo: slim.sourceRepo,
+            installs: slim.installs,
+          },
+        }
+      : {}),
     ...(body !== undefined ? { body } : {}),
   };
 
   // For clawhub-origin skills, enrich with inspect data
-  if (slim.origin === "clawhub" && slim.clawhub) {
-    const enriched: ClawhubDetailMeta = { ...slim.clawhub };
+  if (slim.origin === "clawhub") {
+    const enriched: ClawhubDetailMeta = {
+      slug: slim.slug,
+      author: slim.author,
+      stars: slim.stars,
+      installs: slim.installs,
+      reports: slim.reports,
+      publishedAt: slim.publishedAt,
+    };
     try {
-      const inspectResult = await clawhubInspect(slim.clawhub.slug);
+      const inspectResult = await clawhubInspect(slim.slug);
       if (inspectResult.data) {
         const data = inspectResult.data;
         enriched.owner = data.owner;
@@ -503,8 +487,6 @@ export async function getSkill(
       log.warn({ err, skillId }, "Failed to enrich clawhub skill detail");
     }
     detail.clawhub = enriched;
-  } else if (slim.clawhub) {
-    detail.clawhub = slim.clawhub;
   }
 
   return { skill: detail };
@@ -962,18 +944,15 @@ export async function searchSkills(
       }
       // Fallback for catalog entries not in resolvedSkillStates (shouldn't
       // normally happen, but defensive)
-      const result: SlimSkillResponse = {
+      return {
         id: s.id,
         name: s.displayName,
         description: s.description,
-        kind: "catalog",
-        origin: "vellum",
-        status: "available",
+        emoji: s.emoji,
+        kind: "catalog" as const,
+        origin: "vellum" as const,
+        status: "available" as const,
       };
-      if (s.emoji) {
-        result.vellum = { emoji: s.emoji };
-      }
-      return result;
     });
 
     // Search both community registries in parallel (non-fatal on failure)
@@ -991,16 +970,14 @@ export async function searchSkills(
         kind: "catalog" as const,
         origin: "clawhub" as const,
         status: "available" as const,
-        clawhub: {
-          slug: s.slug,
-          author: s.author,
-          stars: s.stars,
-          installs: s.installs,
-          reports: 0,
-          publishedAt: s.createdAt
-            ? new Date(s.createdAt * 1000).toISOString()
-            : undefined,
-        },
+        slug: s.slug,
+        author: s.author,
+        stars: s.stars,
+        installs: s.installs,
+        reports: 0,
+        publishedAt: s.createdAt
+          ? new Date(s.createdAt * 1000).toISOString()
+          : undefined,
       }));
     } else {
       log.warn(
@@ -1018,11 +995,9 @@ export async function searchSkills(
         kind: "catalog" as const,
         origin: "skillssh" as const,
         status: "available" as const,
-        skillssh: {
-          slug: r.id,
-          sourceRepo: r.source,
-          installs: r.installs,
-        },
+        slug: r.id,
+        sourceRepo: r.source,
+        installs: r.installs,
       }));
     } else {
       log.warn(

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -272,44 +272,6 @@ function deriveOrigin(
   return meta?.origin ?? "custom";
 }
 
-/** Build the origin-specific fields for a given origin (flattened at top level). */
-function buildOriginMeta(
-  origin: SlimSkillResponse["origin"],
-  summary: SkillSummary,
-  installMeta?: SkillInstallMeta | null,
-): Record<string, unknown> {
-  switch (origin) {
-    case "vellum":
-      return {};
-    case "clawhub": {
-      const meta =
-        installMeta !== undefined
-          ? installMeta
-          : readInstallMeta(summary.directoryPath);
-      return {
-        slug: meta?.slug ?? summary.id,
-        author: "",
-        stars: 0,
-        installs: 0,
-        reports: 0,
-      };
-    }
-    case "skillssh": {
-      const meta =
-        installMeta !== undefined
-          ? installMeta
-          : readInstallMeta(summary.directoryPath);
-      return {
-        slug: meta?.slug ?? summary.id,
-        sourceRepo: meta?.sourceRepo ?? "",
-        installs: 0,
-      };
-    }
-    default:
-      return {};
-  }
-}
-
 /** Sort rank by kind: bundled first, then catalog, then installed. */
 function kindSortRank(kind: SlimSkillResponse["kind"]): number {
   if (kind === "bundled") return 0;
@@ -329,16 +291,50 @@ function toSlimSkillResponse(
     kind === "installed" ? readInstallMeta(summary.directoryPath) : undefined;
   const origin = deriveOrigin(kind, summary.directoryPath, installMeta);
   const status: SlimSkillResponse["status"] = state;
-  return {
+
+  const base = {
     id: summary.id,
     name: summary.displayName,
     description: summary.description,
     emoji: summary.emoji,
     kind,
-    origin,
     status,
-    ...buildOriginMeta(origin, summary, installMeta),
-  } as SlimSkillResponse;
+  } as const;
+
+  switch (origin) {
+    case "vellum":
+      return { ...base, origin };
+    case "clawhub": {
+      const meta =
+        installMeta !== undefined
+          ? installMeta
+          : readInstallMeta(summary.directoryPath);
+      return {
+        ...base,
+        origin,
+        slug: meta?.slug ?? summary.id,
+        author: "",
+        stars: 0,
+        installs: 0,
+        reports: 0,
+      };
+    }
+    case "skillssh": {
+      const meta =
+        installMeta !== undefined
+          ? installMeta
+          : readInstallMeta(summary.directoryPath);
+      return {
+        ...base,
+        origin,
+        slug: meta?.slug ?? summary.id,
+        sourceRepo: meta?.sourceRepo ?? "",
+        installs: 0,
+      };
+    }
+    case "custom":
+      return { ...base, origin };
+  }
 }
 
 export function listSkills(_ctx: SkillOperationContext): SlimSkillResponse[] {

--- a/assistant/src/daemon/message-types/skills.ts
+++ b/assistant/src/daemon/message-types/skills.ts
@@ -138,13 +138,28 @@ export interface SkillBodyResponse {
 
 // ─── Detail endpoint response (HTTP API) ──────────────────────────────────
 
-export interface ClawhubDetailMeta {
+interface SkillDetailBase {
+  id: string;
+  name: string;
+  description: string;
+  emoji?: string;
+  kind: "bundled" | "installed" | "catalog";
+  status: "enabled" | "disabled" | "available";
+}
+
+interface VellumSkillDetail extends SkillDetailBase {
+  origin: "vellum";
+}
+
+interface ClawhubSkillDetail extends SkillDetailBase {
+  origin: "clawhub";
   slug: string;
   author: string;
   stars: number;
   installs: number;
   reports: number;
   publishedAt?: string;
+  // Enrichment fields (from clawhubInspect):
   owner?: { handle: string; displayName: string; image?: string } | null;
   stats?: {
     stars: number;
@@ -157,19 +172,22 @@ export interface ClawhubDetailMeta {
   updatedAt?: number | null;
 }
 
-export interface SkillDetailResponse {
-  id: string;
-  name: string;
-  description: string;
-  kind: "bundled" | "installed" | "catalog";
-  origin: "vellum" | "clawhub" | "skillssh" | "custom";
-  status: "enabled" | "disabled" | "available";
-  emoji?: string;
-  vellum?: { emoji?: string };
-  clawhub?: ClawhubDetailMeta;
-  skillssh?: { slug: string; sourceRepo: string; installs: number };
-  body?: string;
+interface SkillsshSkillDetail extends SkillDetailBase {
+  origin: "skillssh";
+  slug: string;
+  sourceRepo: string;
+  installs: number;
 }
+
+interface CustomSkillDetail extends SkillDetailBase {
+  origin: "custom";
+}
+
+export type SkillDetailResponse =
+  | VellumSkillDetail
+  | ClawhubSkillDetail
+  | SkillsshSkillDetail
+  | CustomSkillDetail;
 
 export interface SkillsDraftResponse {
   type: "skills_draft_response";

--- a/assistant/src/daemon/message-types/skills.ts
+++ b/assistant/src/daemon/message-types/skills.ts
@@ -76,11 +76,22 @@ export interface SkillsCreateRequest {
 
 // === Server → Client ===
 
-export interface VellumSkillMeta {
+/** Fields shared by all skill origins. */
+interface SlimSkillBase {
+  id: string;
+  name: string;
+  description: string;
   emoji?: string;
+  kind: "bundled" | "installed" | "catalog";
+  status: "enabled" | "disabled" | "available";
 }
 
-export interface ClawhubSkillMeta {
+interface VellumSlimSkill extends SlimSkillBase {
+  origin: "vellum";
+}
+
+interface ClawhubSlimSkill extends SlimSkillBase {
+  origin: "clawhub";
   slug: string;
   author: string;
   stars: number;
@@ -89,23 +100,22 @@ export interface ClawhubSkillMeta {
   publishedAt?: string;
 }
 
-export interface SkillsshSkillMeta {
+interface SkillsshSlimSkill extends SlimSkillBase {
+  origin: "skillssh";
   slug: string;
   sourceRepo: string;
   installs: number;
 }
 
-export interface SlimSkillResponse {
-  id: string;
-  name: string;
-  description: string;
-  kind: "bundled" | "installed" | "catalog";
-  origin: "vellum" | "clawhub" | "skillssh" | "custom";
-  status: "enabled" | "disabled" | "available";
-  vellum?: VellumSkillMeta;
-  clawhub?: ClawhubSkillMeta;
-  skillssh?: SkillsshSkillMeta;
+interface CustomSlimSkill extends SlimSkillBase {
+  origin: "custom";
 }
+
+export type SlimSkillResponse =
+  | VellumSlimSkill
+  | ClawhubSlimSkill
+  | SkillsshSlimSkill
+  | CustomSlimSkill;
 
 export interface SkillsListResponse {
   type: "skills_list_response";
@@ -128,7 +138,13 @@ export interface SkillBodyResponse {
 
 // ─── Detail endpoint response (HTTP API) ──────────────────────────────────
 
-export interface ClawhubDetailMeta extends ClawhubSkillMeta {
+export interface ClawhubDetailMeta {
+  slug: string;
+  author: string;
+  stars: number;
+  installs: number;
+  reports: number;
+  publishedAt?: string;
   owner?: { handle: string; displayName: string; image?: string } | null;
   stats?: {
     stars: number;
@@ -148,9 +164,10 @@ export interface SkillDetailResponse {
   kind: "bundled" | "installed" | "catalog";
   origin: "vellum" | "clawhub" | "skillssh" | "custom";
   status: "enabled" | "disabled" | "available";
-  vellum?: VellumSkillMeta;
+  emoji?: string;
+  vellum?: { emoji?: string };
   clawhub?: ClawhubDetailMeta;
-  skillssh?: SkillsshSkillMeta;
+  skillssh?: { slug: string; sourceRepo: string; installs: number };
   body?: string;
 }
 

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -70,6 +70,54 @@ const slimSkillSchema = z.discriminatedUnion("origin", [
   z.object({ ...slimSkillBase, origin: z.literal("custom") }),
 ]);
 
+const skillDetailSchema = z.discriminatedUnion("origin", [
+  z.object({ ...slimSkillBase, origin: z.literal("vellum") }),
+  z.object({
+    ...slimSkillBase,
+    origin: z.literal("clawhub"),
+    slug: z.string(),
+    author: z.string(),
+    stars: z.number(),
+    installs: z.number(),
+    reports: z.number(),
+    publishedAt: z.string().optional(),
+    owner: z
+      .object({
+        handle: z.string(),
+        displayName: z.string(),
+        image: z.string().optional(),
+      })
+      .nullable()
+      .optional(),
+    stats: z
+      .object({
+        stars: z.number(),
+        installs: z.number(),
+        downloads: z.number(),
+        versions: z.number(),
+      })
+      .nullable()
+      .optional(),
+    latestVersion: z
+      .object({
+        version: z.string(),
+        changelog: z.string().optional(),
+      })
+      .nullable()
+      .optional(),
+    createdAt: z.number().nullable().optional(),
+    updatedAt: z.number().nullable().optional(),
+  }),
+  z.object({
+    ...slimSkillBase,
+    origin: z.literal("skillssh"),
+    slug: z.string(),
+    sourceRepo: z.string(),
+    installs: z.number(),
+  }),
+  z.object({ ...slimSkillBase, origin: z.literal("custom") }),
+]);
+
 export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
   const ctx = () => deps.getSkillContext();
 
@@ -412,6 +460,9 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
       summary: "Get skill",
       description: "Return a single skill by ID with enriched detail fields.",
       tags: ["skills"],
+      responseBody: z.object({
+        skill: skillDetailSchema.describe("Skill detail object"),
+      }),
       handler: async ({ params }) => {
         const result = await getSkill(params.id, ctx());
         if ("error" in result) {

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -39,6 +39,37 @@ export interface SkillRouteDeps {
   getSkillContext: () => SkillOperationContext;
 }
 
+const slimSkillBase = {
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  emoji: z.string().optional(),
+  kind: z.enum(["bundled", "installed", "catalog"]),
+  status: z.enum(["enabled", "disabled", "available"]),
+};
+
+const slimSkillSchema = z.discriminatedUnion("origin", [
+  z.object({ ...slimSkillBase, origin: z.literal("vellum") }),
+  z.object({
+    ...slimSkillBase,
+    origin: z.literal("clawhub"),
+    slug: z.string(),
+    author: z.string(),
+    stars: z.number(),
+    installs: z.number(),
+    reports: z.number(),
+    publishedAt: z.string().optional(),
+  }),
+  z.object({
+    ...slimSkillBase,
+    origin: z.literal("skillssh"),
+    slug: z.string(),
+    sourceRepo: z.string(),
+    installs: z.number(),
+  }),
+  z.object({ ...slimSkillBase, origin: z.literal("custom") }),
+]);
+
 export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
   const ctx = () => deps.getSkillContext();
 
@@ -60,40 +91,7 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
         },
       ],
       responseBody: z.object({
-        skills: z
-          .array(
-            z.object({
-              id: z.string(),
-              name: z.string(),
-              description: z.string(),
-              kind: z.enum(["bundled", "installed", "catalog"]),
-              origin: z.enum(["vellum", "clawhub", "skillssh", "custom"]),
-              status: z.enum(["enabled", "disabled", "available"]),
-              vellum: z
-                .object({
-                  emoji: z.string().optional(),
-                })
-                .optional(),
-              clawhub: z
-                .object({
-                  slug: z.string(),
-                  author: z.string(),
-                  stars: z.number(),
-                  installs: z.number(),
-                  reports: z.number(),
-                  publishedAt: z.string().optional(),
-                })
-                .optional(),
-              skillssh: z
-                .object({
-                  slug: z.string(),
-                  sourceRepo: z.string(),
-                  installs: z.number(),
-                })
-                .optional(),
-            }),
-          )
-          .describe("Skill objects"),
+        skills: z.array(slimSkillSchema).describe("Skill objects"),
       }),
       handler: async ({ url }) => {
         const include = url.searchParams.get("include");
@@ -280,38 +278,7 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
       ],
       responseBody: z.object({
         skills: z
-          .array(
-            z.object({
-              id: z.string(),
-              name: z.string(),
-              description: z.string(),
-              kind: z.enum(["bundled", "installed", "catalog"]),
-              origin: z.enum(["vellum", "clawhub", "skillssh", "custom"]),
-              status: z.enum(["enabled", "disabled", "available"]),
-              vellum: z
-                .object({
-                  emoji: z.string().optional(),
-                })
-                .optional(),
-              clawhub: z
-                .object({
-                  slug: z.string(),
-                  author: z.string(),
-                  stars: z.number(),
-                  installs: z.number(),
-                  reports: z.number(),
-                  publishedAt: z.string().optional(),
-                })
-                .optional(),
-              skillssh: z
-                .object({
-                  slug: z.string(),
-                  sourceRepo: z.string(),
-                  installs: z.number(),
-                })
-                .optional(),
-            }),
-          )
+          .array(slimSkillSchema)
           .describe("Skill objects matching the search query"),
       }),
       handler: async ({ url }) => {

--- a/clients/ios/Views/Intelligence/SkillDetailView.swift
+++ b/clients/ios/Views/Intelligence/SkillDetailView.swift
@@ -114,8 +114,13 @@ struct SkillDetailView: View {
         .navigationTitle(skill.name)
         .navigationBarTitleDisplayMode(.inline)
         .task {
-            skillsStore.fetchSkillDetail(skillId: skill.id)
-            skillsStore.fetchSkillFiles(skillId: skill.id)
+            // Only fetch detail and files for locally available skills (bundled or installed).
+            // Remote catalog search results are not in the local resolved catalog, so
+            // GET /skills/:id and GET /skills/:id/files would 404 for them.
+            if skill.isInstalled {
+                skillsStore.fetchSkillDetail(skillId: skill.id)
+                skillsStore.fetchSkillFiles(skillId: skill.id)
+            }
         }
         .onDisappear {
             skillsStore.clearSkillDetail()

--- a/clients/ios/Views/Intelligence/SkillDetailView.swift
+++ b/clients/ios/Views/Intelligence/SkillDetailView.swift
@@ -21,54 +21,17 @@ struct SkillDetailView: View {
                 headerSection
             }
 
-            // Details section
+            // Details section with origin-specific metadata via originMeta
             Section("Details") {
-                if let author = skill.author, !author.isEmpty {
-                    detailRow(label: "Author", value: author)
-                }
-                if let stars = skill.stars, stars > 0 {
-                    detailRow(label: "Stars", value: "\(stars)")
-                }
-                if let sourceRepo = skill.sourceRepo, !sourceRepo.isEmpty {
-                    detailRow(label: "Source Repo", value: sourceRepo)
-                }
+                detailsSection
                 detailRow(label: "Origin", value: originLabel(skill.origin))
                 detailRow(label: "Status", value: skill.status.capitalized)
             }
 
-            // Inspect data section (loaded from ClaWHub)
-            if let inspected = skillsStore.inspectedSkill {
-                Section("About") {
-                    if !inspected.skill.summary.isEmpty {
-                        Text(inspected.skill.summary)
-                            .font(VFont.bodyMediumLighter)
-                            .foregroundStyle(VColor.contentSecondary)
-                    }
-
-                    if let owner = inspected.owner {
-                        detailRow(label: "Owner", value: owner.displayName)
-                    }
-
-                    if let stats = inspected.stats {
-                        detailRow(label: "Stars", value: "\(stats.stars)")
-                        detailRow(label: "Installs", value: "\(stats.installs)")
-                    }
-
-                    if let latestVersion = inspected.latestVersion {
-                        detailRow(label: "Latest Version", value: latestVersion.version)
-                        if let changelog = latestVersion.changelog, !changelog.isEmpty {
-                            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                                Text("Changelog")
-                                    .font(VFont.labelDefault)
-                                    .foregroundStyle(VColor.contentTertiary)
-                                Text(changelog)
-                                    .font(VFont.bodyMediumLighter)
-                                    .foregroundStyle(VColor.contentSecondary)
-                            }
-                        }
-                    }
-                }
-            } else if skillsStore.isInspecting {
+            // Enrichment data from skill detail endpoint
+            if let detail = skillsStore.selectedSkillDetail {
+                enrichmentSection(detail)
+            } else if skillsStore.isLoadingSkillDetail {
                 Section("About") {
                     HStack {
                         Spacer()
@@ -77,7 +40,7 @@ struct SkillDetailView: View {
                         Spacer()
                     }
                 }
-            } else if let error = skillsStore.inspectError {
+            } else if let error = skillsStore.skillDetailError {
                 Section("About") {
                     Text(error)
                         .font(VFont.bodyMediumLighter)
@@ -151,14 +114,10 @@ struct SkillDetailView: View {
         .navigationTitle(skill.name)
         .navigationBarTitleDisplayMode(.inline)
         .task {
-            // Inspect the skill if it has a clawhub origin
-            if skill.origin == "clawhub" {
-                skillsStore.inspectSkill(slug: skill.id)
-            }
+            skillsStore.fetchSkillDetail(skillId: skill.id)
             skillsStore.fetchSkillFiles(skillId: skill.id)
         }
         .onDisappear {
-            skillsStore.clearInspection()
             skillsStore.clearSkillDetail()
             expandedFilePath = nil
         }
@@ -270,6 +229,59 @@ struct SkillDetailView: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(file.path), \(formatFileSize(file.size))\(file.isBinary ? ", binary" : "")")
+    }
+
+    // MARK: - Details Section (origin-specific metadata via originMeta)
+
+    @ViewBuilder
+    private var detailsSection: some View {
+        switch skill.originMeta {
+        case .clawhub(let meta):
+            if !meta.author.isEmpty {
+                detailRow(label: "Author", value: meta.author)
+            }
+            if meta.stars > 0 {
+                detailRow(label: "Stars", value: "\(meta.stars)")
+            }
+        case .skillssh(let meta):
+            if !meta.sourceRepo.isEmpty {
+                detailRow(label: "Source Repo", value: meta.sourceRepo)
+            }
+        case .vellum, .custom:
+            EmptyView()
+        }
+    }
+
+    // MARK: - Enrichment Section (from skill detail endpoint)
+
+    @ViewBuilder
+    private func enrichmentSection(_ detail: SkillDetailHTTPResponse) -> some View {
+        if detail.owner != nil || detail.stats != nil || detail.latestVersion != nil {
+            Section("About") {
+                if let owner = detail.owner {
+                    detailRow(label: "Owner", value: owner.displayName)
+                }
+
+                if let stats = detail.stats {
+                    detailRow(label: "Stars", value: "\(stats.stars)")
+                    detailRow(label: "Installs", value: "\(stats.installs)")
+                }
+
+                if let latestVersion = detail.latestVersion {
+                    detailRow(label: "Latest Version", value: latestVersion.version)
+                    if let changelog = latestVersion.changelog, !changelog.isEmpty {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            Text("Changelog")
+                                .font(VFont.labelDefault)
+                                .foregroundStyle(VColor.contentTertiary)
+                            Text(changelog)
+                                .font(VFont.bodyMediumLighter)
+                                .foregroundStyle(VColor.contentSecondary)
+                        }
+                    }
+                }
+            }
+        }
     }
 
     // MARK: - Origin Label

--- a/clients/ios/Views/Intelligence/SkillDetailView.swift
+++ b/clients/ios/Views/Intelligence/SkillDetailView.swift
@@ -23,15 +23,14 @@ struct SkillDetailView: View {
 
             // Details section
             Section("Details") {
-                if let clawhub = skill.clawhub {
-                    if !clawhub.author.isEmpty {
-                        detailRow(label: "Author", value: clawhub.author)
-                    }
-                    if clawhub.stars > 0 {
-                        detailRow(label: "Stars", value: "\(clawhub.stars)")
-                    }
-                } else if let skillssh = skill.skillssh, !skillssh.sourceRepo.isEmpty {
-                    detailRow(label: "Source Repo", value: skillssh.sourceRepo)
+                if let author = skill.author, !author.isEmpty {
+                    detailRow(label: "Author", value: author)
+                }
+                if let stars = skill.stars, stars > 0 {
+                    detailRow(label: "Stars", value: "\(stars)")
+                }
+                if let sourceRepo = skill.sourceRepo, !sourceRepo.isEmpty {
+                    detailRow(label: "Source Repo", value: sourceRepo)
                 }
                 detailRow(label: "Origin", value: originLabel(skill.origin))
                 detailRow(label: "Status", value: skill.status.capitalized)
@@ -153,7 +152,7 @@ struct SkillDetailView: View {
         .navigationBarTitleDisplayMode(.inline)
         .task {
             // Inspect the skill if it has a clawhub origin
-            if skill.clawhub != nil {
+            if skill.origin == "clawhub" {
                 skillsStore.inspectSkill(slug: skill.id)
             }
             skillsStore.fetchSkillFiles(skillId: skill.id)
@@ -178,7 +177,7 @@ struct SkillDetailView: View {
 
     private var headerSection: some View {
         VStack(spacing: VSpacing.sm) {
-            Text(skill.vellum?.emoji ?? "")
+            Text(skill.emoji ?? "")
                 .font(.system(size: 48))
                 .accessibilityHidden(true)
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -246,7 +246,7 @@ struct SkillItemRow: View {
     var body: some View {
         VCard(action: onSelect) {
             HStack(alignment: .center, spacing: VSpacing.lg) {
-                if let emoji = skill.vellum?.emoji, !emoji.isEmpty {
+                if let emoji = skill.emoji, !emoji.isEmpty {
                     Text(emoji)
                         .font(.system(size: 32))
                 }
@@ -298,7 +298,7 @@ struct AvailableSkillItemRow: View {
 
     var body: some View {
         HStack(alignment: .center, spacing: VSpacing.lg) {
-            if let emoji = skill.vellum?.emoji, !emoji.isEmpty {
+            if let emoji = skill.emoji, !emoji.isEmpty {
                 Text(emoji)
                     .font(.system(size: 32))
                     .opacity(0.5)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
@@ -32,6 +32,7 @@ struct SkillDetailView: View {
                     .lineSpacing(8)
                     .frame(maxWidth: 800, alignment: .leading)
             }
+            originMetaRow
             skillDetailFileBrowser
         }
         .onAppear {
@@ -59,6 +60,62 @@ struct SkillDetailView: View {
         .onDisappear {
             expandedFilePath = nil
             skillsManager.clearSkillDetail()
+        }
+    }
+
+    // MARK: - Origin-Specific Metadata
+
+    @ViewBuilder
+    private var originMetaRow: some View {
+        switch skill.originMeta {
+        case .clawhub(let meta):
+            HStack(spacing: VSpacing.lg) {
+                if !meta.author.isEmpty {
+                    HStack(spacing: VSpacing.xs) {
+                        VIconView(.user, size: 12)
+                        Text(meta.author)
+                            .font(VFont.labelDefault)
+                    }
+                    .foregroundStyle(VColor.contentTertiary)
+                }
+                if meta.stars > 0 {
+                    HStack(spacing: VSpacing.xs) {
+                        VIconView(.star, size: 12)
+                        Text("\(meta.stars)")
+                            .font(VFont.labelDefault)
+                    }
+                    .foregroundStyle(VColor.contentTertiary)
+                }
+                if meta.installs > 0 {
+                    HStack(spacing: VSpacing.xs) {
+                        VIconView(.arrowDownToLine, size: 12)
+                        Text("\(meta.installs)")
+                            .font(VFont.labelDefault)
+                    }
+                    .foregroundStyle(VColor.contentTertiary)
+                }
+            }
+        case .skillssh(let meta):
+            HStack(spacing: VSpacing.lg) {
+                if !meta.sourceRepo.isEmpty {
+                    HStack(spacing: VSpacing.xs) {
+                        VIconView(.gitBranch, size: 12)
+                        Text(meta.sourceRepo)
+                            .font(VFont.labelDefault)
+                    }
+                    .foregroundStyle(VColor.contentTertiary)
+                }
+                if meta.installs > 0 {
+                    HStack(spacing: VSpacing.xs) {
+                        VIconView(.arrowDownToLine, size: 12)
+                        Text("\(meta.installs)")
+                            .font(VFont.labelDefault)
+                    }
+                    .foregroundStyle(VColor.contentTertiary)
+                }
+            }
+        case .vellum, .custom:
+            EmptyView()
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
@@ -36,7 +36,12 @@ struct SkillDetailView: View {
             skillDetailFileBrowser
         }
         .onAppear {
-            skillsManager.fetchSkillFiles(skillId: skill.id)
+            // Only fetch files for locally available skills (bundled or installed).
+            // Remote catalog search results are not in the local resolved catalog, so
+            // GET /skills/:id/files would 404 for them.
+            if skill.isInstalled {
+                skillsManager.fetchSkillFiles(skillId: skill.id)
+            }
         }
         .onChange(of: skillsManager.selectedSkillFiles?.files.map(\.path)) {
             if expandedFilePath == nil, let files = skillsManager.selectedSkillFiles?.files {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
@@ -138,7 +138,7 @@ struct SkillDetailTitleRow: View {
                 .frame(width: 32, height: 32)
 
                 HStack(spacing: VSpacing.sm) {
-                    if let emoji = skill.vellum?.emoji, !emoji.isEmpty {
+                    if let emoji = skill.emoji, !emoji.isEmpty {
                         Text(emoji)
                             .font(.system(size: 20))
                     }

--- a/clients/shared/Features/Skills/SkillsStore.swift
+++ b/clients/shared/Features/Skills/SkillsStore.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Cross-platform store for skills data operations.
 ///
-/// Encapsulates all daemon communication for listing, searching, inspecting,
+/// Encapsulates all daemon communication for listing, searching,
 /// installing, uninstalling, enabling, disabling, configuring, drafting, and
 /// creating skills. Platform-specific UI state (panel presentation, tab
 /// selection, etc.) remains in the platform view model that delegates here.
@@ -17,10 +17,6 @@ public final class SkillsStore: ObservableObject {
 
     @Published public var searchResults: [SkillInfo] = []
     @Published public var isSearching = false
-
-    @Published public var inspectedSkill: SkillsInspectResponseData?
-    @Published public var isInspecting = false
-    @Published public var inspectError: String?
 
     @Published public var installResult: InstallResult?
 
@@ -88,8 +84,6 @@ public final class SkillsStore: ObservableObject {
     // MARK: - Private State
 
     private let skillsClient: SkillsClientProtocol
-    private var inspectCache: [String: SkillsInspectResponseData] = [:]
-    private var currentInspectSlug: String?
     private var lastSearchQuery: String?
     private var draftTask: Task<Void, Never>?
     private var createTask: Task<Void, Never>?
@@ -174,7 +168,6 @@ public final class SkillsStore: ObservableObject {
             }
             installResult = result
             if result.success {
-                inspectCache.removeValue(forKey: slug)
                 fetchSkills(force: true)
             }
             Task { @MainActor in
@@ -183,34 +176,6 @@ public final class SkillsStore: ObservableObject {
                     self.installResult = nil
                 }
             }
-        }
-    }
-
-    // MARK: - Inspect Skill
-
-    public func inspectSkill(slug: String) {
-        currentInspectSlug = slug
-        inspectError = nil
-
-        if let cached = inspectCache[slug] {
-            inspectedSkill = cached
-            isInspecting = false
-            return
-        }
-
-        isInspecting = true
-        inspectedSkill = nil
-
-        Task {
-            let response = await skillsClient.inspectSkill(slug: slug)
-            guard currentInspectSlug == slug else { return }
-            if let data = response?.data {
-                inspectedSkill = data
-                inspectCache[slug] = data
-            } else {
-                inspectError = response?.error ?? "Inspection timed out"
-            }
-            isInspecting = false
         }
     }
 
@@ -231,7 +196,6 @@ public final class SkillsStore: ObservableObject {
             }
             uninstallResult = result
             if result.success {
-                inspectCache.removeAll()
                 fetchSkills(force: true)
             }
             Task { @MainActor in
@@ -264,15 +228,6 @@ public final class SkillsStore: ObservableObject {
 
     public func configureSkill(name: String, env: [String: String]? = nil, apiKey: String? = nil, config: [String: AnyCodable]? = nil) {
         Task { _ = await skillsClient.configureSkill(name: name, env: env, apiKey: apiKey, config: config) }
-    }
-
-    // MARK: - Clear Inspection
-
-    public func clearInspection() {
-        currentInspectSlug = nil
-        inspectedSkill = nil
-        isInspecting = false
-        inspectError = nil
     }
 
     // MARK: - Skill Drafting

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -3985,65 +3985,40 @@ public struct SkillsListResponse: Codable, Sendable {
     }
 }
 
-public struct VellumSkillMeta: Codable, Sendable {
-    public let emoji: String?
-
-    public init(emoji: String? = nil) {
-        self.emoji = emoji
-    }
-}
-
-public struct ClawhubSkillMeta: Codable, Sendable {
-    public let slug: String
-    public let author: String
-    public let stars: Int
-    public let installs: Int
-    public let reports: Int
-    public let publishedAt: String?
-
-    public init(slug: String, author: String, stars: Int, installs: Int, reports: Int, publishedAt: String? = nil) {
-        self.slug = slug
-        self.author = author
-        self.stars = stars
-        self.installs = installs
-        self.reports = reports
-        self.publishedAt = publishedAt
-    }
-}
-
-public struct SkillsshSkillMeta: Codable, Sendable {
-    public let slug: String
-    public let sourceRepo: String
-    public let installs: Int
-
-    public init(slug: String, sourceRepo: String, installs: Int) {
-        self.slug = slug
-        self.sourceRepo = sourceRepo
-        self.installs = installs
-    }
-}
-
 public struct SkillsListResponseSkill: Codable, Sendable {
     public let id: String
     public let name: String
     public let description: String
+    public let emoji: String?
     public let kind: String
     public let origin: String
     public let status: String
-    public let vellum: VellumSkillMeta?
-    public let clawhub: ClawhubSkillMeta?
-    public let skillssh: SkillsshSkillMeta?
+    // Clawhub + Skillssh shared:
+    public let slug: String?
+    public let installs: Int?
+    // Clawhub-only:
+    public let author: String?
+    public let stars: Int?
+    public let reports: Int?
+    public let publishedAt: String?
+    // Skillssh-only:
+    public let sourceRepo: String?
 
-    public init(id: String, name: String, description: String, kind: String, origin: String, status: String, vellum: VellumSkillMeta? = nil, clawhub: ClawhubSkillMeta? = nil, skillssh: SkillsshSkillMeta? = nil) {
+    public init(id: String, name: String, description: String, emoji: String? = nil, kind: String, origin: String, status: String, slug: String? = nil, installs: Int? = nil, author: String? = nil, stars: Int? = nil, reports: Int? = nil, publishedAt: String? = nil, sourceRepo: String? = nil) {
         self.id = id
         self.name = name
         self.description = description
+        self.emoji = emoji
         self.kind = kind
         self.origin = origin
         self.status = status
-        self.vellum = vellum
-        self.clawhub = clawhub
-        self.skillssh = skillssh
+        self.slug = slug
+        self.installs = installs
+        self.author = author
+        self.stars = stars
+        self.reports = reports
+        self.publishedAt = publishedAt
+        self.sourceRepo = sourceRepo
     }
 }
 
@@ -4085,57 +4060,51 @@ public struct ClawhubDetailVersion: Codable, Sendable {
     }
 }
 
-public struct ClawhubDetailMeta: Codable, Sendable {
-    public let slug: String
-    public let author: String
-    public let stars: Int
-    public let installs: Int
-    public let reports: Int
+public struct SkillDetailHTTPResponse: Codable, Sendable {
+    public let id: String
+    public let name: String
+    public let description: String
+    public let emoji: String?
+    public let kind: String
+    public let origin: String
+    public let status: String
+    // Clawhub + Skillssh shared:
+    public let slug: String?
+    public let installs: Int?
+    // Clawhub-only:
+    public let author: String?
+    public let stars: Int?
+    public let reports: Int?
     public let publishedAt: String?
+    // Skillssh-only:
+    public let sourceRepo: String?
+    // Clawhub detail enrichment fields:
     public let owner: ClawhubDetailOwner?
     public let stats: ClawhubDetailStats?
     public let latestVersion: ClawhubDetailVersion?
     public let createdAt: Int?
     public let updatedAt: Int?
 
-    public init(slug: String, author: String, stars: Int, installs: Int, reports: Int, publishedAt: String? = nil, owner: ClawhubDetailOwner? = nil, stats: ClawhubDetailStats? = nil, latestVersion: ClawhubDetailVersion? = nil, createdAt: Int? = nil, updatedAt: Int? = nil) {
+    public init(id: String, name: String, description: String, emoji: String? = nil, kind: String, origin: String, status: String, slug: String? = nil, installs: Int? = nil, author: String? = nil, stars: Int? = nil, reports: Int? = nil, publishedAt: String? = nil, sourceRepo: String? = nil, owner: ClawhubDetailOwner? = nil, stats: ClawhubDetailStats? = nil, latestVersion: ClawhubDetailVersion? = nil, createdAt: Int? = nil, updatedAt: Int? = nil) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.emoji = emoji
+        self.kind = kind
+        self.origin = origin
+        self.status = status
         self.slug = slug
+        self.installs = installs
         self.author = author
         self.stars = stars
-        self.installs = installs
         self.reports = reports
         self.publishedAt = publishedAt
+        self.sourceRepo = sourceRepo
         self.owner = owner
         self.stats = stats
         self.latestVersion = latestVersion
         self.createdAt = createdAt
         self.updatedAt = updatedAt
-    }
-}
-
-public struct SkillDetailHTTPResponse: Codable, Sendable {
-    public let id: String
-    public let name: String
-    public let description: String
-    public let kind: String
-    public let origin: String
-    public let status: String
-    public let vellum: VellumSkillMeta?
-    public let clawhub: ClawhubDetailMeta?
-    public let skillssh: SkillsshSkillMeta?
-    public let body: String?
-
-    public init(id: String, name: String, description: String, kind: String, origin: String, status: String, vellum: VellumSkillMeta? = nil, clawhub: ClawhubDetailMeta? = nil, skillssh: SkillsshSkillMeta? = nil, body: String? = nil) {
-        self.id = id
-        self.name = name
-        self.description = description
-        self.kind = kind
-        self.origin = origin
-        self.status = status
-        self.vellum = vellum
-        self.clawhub = clawhub
-        self.skillssh = skillssh
-        self.body = body
     }
 }
 

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1045,42 +1045,12 @@ public struct SkillsshOriginMeta: Codable, Sendable, Equatable {
 }
 
 /// Discriminated union over the `origin` field of a skill.
-/// Dispatches on the origin string to decode origin-specific metadata.
-public enum SkillOriginMeta: Decodable, Sendable, Equatable {
+/// Constructed via the `originMeta` computed property, which dispatches on origin.
+public enum SkillOriginMeta: Sendable, Equatable {
     case vellum
     case clawhub(ClawhubOriginMeta)
     case skillssh(SkillsshOriginMeta)
     case custom
-
-    private enum CodingKeys: String, CodingKey {
-        case origin, slug, author, stars, installs, reports, publishedAt, sourceRepo
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let origin = try container.decode(String.self, forKey: .origin)
-        switch origin {
-        case "clawhub":
-            self = .clawhub(ClawhubOriginMeta(
-                slug: try container.decode(String.self, forKey: .slug),
-                author: try container.decode(String.self, forKey: .author),
-                stars: try container.decode(Int.self, forKey: .stars),
-                installs: try container.decode(Int.self, forKey: .installs),
-                reports: try container.decode(Int.self, forKey: .reports),
-                publishedAt: try container.decodeIfPresent(String.self, forKey: .publishedAt)
-            ))
-        case "skillssh":
-            self = .skillssh(SkillsshOriginMeta(
-                slug: try container.decode(String.self, forKey: .slug),
-                sourceRepo: try container.decode(String.self, forKey: .sourceRepo),
-                installs: try container.decode(Int.self, forKey: .installs)
-            ))
-        case "vellum":
-            self = .vellum
-        default:
-            self = .custom
-        }
-    }
 }
 
 extension SkillsListResponseSkill {

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -914,7 +914,7 @@ extension SkillsListResponseSkill: Identifiable {}
 extension SkillsListResponseSkill {
     /// Returns a copy with a different `status`, preserving all other fields including `id`.
     public func withStatus(_ newStatus: String) -> Self {
-        Self(id: id, name: name, description: description, kind: kind, origin: origin, status: newStatus, vellum: vellum, clawhub: clawhub, skillssh: skillssh)
+        Self(id: id, name: name, description: description, emoji: emoji, kind: kind, origin: origin, status: newStatus, slug: slug, installs: installs, author: author, stars: stars, reports: reports, publishedAt: publishedAt, sourceRepo: sourceRepo)
     }
 
     /// Whether the skill is available from the catalog but not yet installed.
@@ -931,11 +931,6 @@ extension SkillsListResponseSkill {
 
     /// Whether the skill is currently disabled.
     public var isDisabled: Bool { status == "disabled" }
-
-    // MARK: - Convenience accessors
-
-    /// Reads emoji from the `vellum` sub-object for display.
-    public var emoji: String? { vellum?.emoji }
 }
 
 /// Response containing the list of available skills.

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1110,6 +1110,33 @@ extension SkillsListResponseSkill {
     }
 }
 
+extension SkillDetailHTTPResponse {
+    /// Decoded origin-specific metadata. Lazily parses from the flat fields.
+    public var originMeta: SkillOriginMeta {
+        switch origin {
+        case "clawhub":
+            return .clawhub(ClawhubOriginMeta(
+                slug: slug ?? id,
+                author: author ?? "",
+                stars: stars ?? 0,
+                installs: installs ?? 0,
+                reports: reports ?? 0,
+                publishedAt: publishedAt
+            ))
+        case "skillssh":
+            return .skillssh(SkillsshOriginMeta(
+                slug: slug ?? id,
+                sourceRepo: sourceRepo ?? "",
+                installs: installs ?? 0
+            ))
+        case "vellum":
+            return .vellum
+        default:
+            return .custom
+        }
+    }
+}
+
 /// Skill info from a ClaWHub inspect response.
 /// Backed by generated `SkillsInspectResponseDataSkill`.
 public typealias ClawhubInspectSkill = SkillsInspectResponseDataSkill

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -46,6 +46,13 @@ import Foundation
 // │                                 │ not a wire type                         │
 // │ SkillOperationResult            │ Client-only result wrapper for skill    │
 // │                                 │ operations; not a wire type             │
+// │ SkillOriginMeta (enum)         │ Discriminated union over `origin`;     │
+// │                                 │ custom Decodable init dispatches on    │
+// │                                 │ origin string                          │
+// │ ClawhubOriginMeta              │ Payload struct for clawhub origin;     │
+// │                                 │ decoded from flat fields               │
+// │ SkillsshOriginMeta             │ Payload struct for skillssh origin;    │
+// │                                 │ decoded from flat fields               │
 // └─────────────────────────────────┴──────────────────────────────────────────┘
 //
 // **Do not add new manual structs** without documenting the reason here.
@@ -1015,6 +1022,91 @@ public struct SkillOperationResult: Sendable {
     public init(success: Bool, error: String? = nil) {
         self.success = success
         self.error = error
+    }
+}
+
+// MARK: - Skill Origin Meta
+
+/// Origin-specific metadata for a skill sourced from ClaWHub.
+public struct ClawhubOriginMeta: Codable, Sendable, Equatable {
+    public let slug: String
+    public let author: String
+    public let stars: Int
+    public let installs: Int
+    public let reports: Int
+    public let publishedAt: String?
+}
+
+/// Origin-specific metadata for a skill sourced from Skills.sh.
+public struct SkillsshOriginMeta: Codable, Sendable, Equatable {
+    public let slug: String
+    public let sourceRepo: String
+    public let installs: Int
+}
+
+/// Discriminated union over the `origin` field of a skill.
+/// Dispatches on the origin string to decode origin-specific metadata.
+public enum SkillOriginMeta: Decodable, Sendable, Equatable {
+    case vellum
+    case clawhub(ClawhubOriginMeta)
+    case skillssh(SkillsshOriginMeta)
+    case custom
+
+    private enum CodingKeys: String, CodingKey {
+        case origin, slug, author, stars, installs, reports, publishedAt, sourceRepo
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let origin = try container.decode(String.self, forKey: .origin)
+        switch origin {
+        case "clawhub":
+            self = .clawhub(ClawhubOriginMeta(
+                slug: try container.decode(String.self, forKey: .slug),
+                author: try container.decode(String.self, forKey: .author),
+                stars: try container.decode(Int.self, forKey: .stars),
+                installs: try container.decode(Int.self, forKey: .installs),
+                reports: try container.decode(Int.self, forKey: .reports),
+                publishedAt: try container.decodeIfPresent(String.self, forKey: .publishedAt)
+            ))
+        case "skillssh":
+            self = .skillssh(SkillsshOriginMeta(
+                slug: try container.decode(String.self, forKey: .slug),
+                sourceRepo: try container.decode(String.self, forKey: .sourceRepo),
+                installs: try container.decode(Int.self, forKey: .installs)
+            ))
+        case "vellum":
+            self = .vellum
+        default:
+            self = .custom
+        }
+    }
+}
+
+extension SkillsListResponseSkill {
+    /// Decoded origin-specific metadata. Lazily parses from the flat fields.
+    public var originMeta: SkillOriginMeta {
+        switch origin {
+        case "clawhub":
+            return .clawhub(ClawhubOriginMeta(
+                slug: slug ?? id,
+                author: author ?? "",
+                stars: stars ?? 0,
+                installs: installs ?? 0,
+                reports: reports ?? 0,
+                publishedAt: publishedAt
+            ))
+        case "skillssh":
+            return .skillssh(SkillsshOriginMeta(
+                slug: slug ?? id,
+                sourceRepo: sourceRepo ?? "",
+                installs: installs ?? 0
+            ))
+        case "vellum":
+            return .vellum
+        default:
+            return .custom
+        }
     }
 }
 

--- a/clients/shared/Network/SkillsClient.swift
+++ b/clients/shared/Network/SkillsClient.swift
@@ -6,7 +6,7 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "Skill
 /// Focused client for skills-related operations routed through the gateway.
 ///
 /// Covers listing, enabling, disabling, configuring, installing, uninstalling,
-/// updating, searching, inspecting, drafting, and creating skills.
+/// updating, searching, drafting, and creating skills.
 public protocol SkillsClientProtocol {
     func fetchSkillsList(includeCatalog: Bool) async -> SkillsListResponseMessage?
     func enableSkill(name: String) async -> SkillOperationResult?
@@ -17,7 +17,6 @@ public protocol SkillsClientProtocol {
     func updateSkill(name: String) async -> SkillOperationResult?
     func checkSkillUpdates() async -> SkillOperationResult?
     func searchSkills(query: String) async -> SkillSearchResult?
-    func inspectSkill(slug: String) async -> SkillsInspectResponseMessage?
     func draftSkill(sourceText: String) async -> SkillsDraftResponseMessage?
     func createSkill(skillId: String, name: String, description: String, emoji: String?, bodyMarkdown: String, overwrite: Bool?) async -> SkillOperationResult?
     func fetchSkillDetail(skillId: String) async -> SkillDetailHTTPResponse?
@@ -225,28 +224,6 @@ public struct SkillsClient: SkillsClientProtocol {
         } catch {
             log.error("searchSkills error: \(error.localizedDescription)")
             return SkillSearchResult(success: false, error: error.localizedDescription)
-        }
-    }
-
-    public func inspectSkill(slug: String) async -> SkillsInspectResponseMessage? {
-        do {
-            let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/skills/\(Self.encodePath(slug))/inspect", timeout: 10
-            )
-            guard response.isSuccess else {
-                log.error("inspectSkill failed (HTTP \(response.statusCode))")
-                return nil
-            }
-            // REST returns { slug, data?: ClawhubInspectData, error? } — inject the
-            // type discriminator so the generated SkillsInspectResponse can decode it.
-            var json = (try? JSONSerialization.jsonObject(with: response.data) as? [String: Any]) ?? [:]
-            json["type"] = "skills_inspect_response"
-            if json["slug"] == nil { json["slug"] = slug }
-            let enriched = (try? JSONSerialization.data(withJSONObject: json)) ?? response.data
-            return try JSONDecoder().decode(SkillsInspectResponseMessage.self, from: enriched)
-        } catch {
-            log.error("inspectSkill error: \(error.localizedDescription)")
-            return nil
         }
     }
 


### PR DESCRIPTION
## Summary
Refactor `SlimSkillResponse` and `SkillDetailResponse` from optional sub-objects (`vellum?`, `clawhub?`, `skillssh?`) to a proper discriminated union on `origin`. Flatten origin-specific fields to the top level, promote `emoji` to a shared base field, remove the unused `body` field from `SkillDetailResponse`, and add a Swift `SkillOriginMeta` enum with custom `Decodable` for type-safe origin-dispatched decoding.

## PRs merged into feature branch
- #23050: refactor: flatten SlimSkillResponse into discriminated union on origin, promote emoji to base
- #23057: refactor: flatten SkillDetailResponse as discriminated union, remove body field
- #23061: refactor: update Swift generated types for flattened skill response with all origin fields
- #23063: feat: add SkillOriginMeta Swift enum with custom Decodable for origin-dispatched decoding
- #23065: refactor: update Swift UI views to use flat fields and SkillOriginMeta enum
- #23068: chore: regenerate OpenAPI spec, remove stale type references

Part of plan: skills-discrim-union-flatten.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23069" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
