### PR TITLE
fix: replace malformed event triggers and allow null in update_nodes schema

### DIFF
--- a/assistant/src/memory/graph/extraction.ts
+++ b/assistant/src/memory/graph/extraction.ts
@@ -324,9 +324,9 @@ const EXTRACT_TOOL_SCHEMA = {
                 "Downgrade fidelity when a transient event has resolved",
             },
             event_date: {
-              type: "number",
+              type: ["number", "null"],
               description:
-                "Epoch ms of the event date. Use to update when an event is rescheduled.",
+                "Epoch ms of the event date. Use to update when an event is rescheduled. Set to null to clear.",
             },
           },
           required: ["id"],
@@ -596,7 +596,8 @@ export function parseExtractionResponse(
       }
     }
 
-    // Auto-create event trigger when event_date is set but LLM didn't include one
+    // Auto-create event trigger when event_date is set but LLM didn't include one,
+    // or replace a malformed event trigger (event_date unset) with a valid one.
     if (
       node.eventDate != null &&
       (!Array.isArray(raw.triggers) ||
@@ -604,6 +605,17 @@ export function parseExtractionResponse(
           (t) => t.type === "event" && t.event_date != null,
         ))
     ) {
+      // Remove any malformed event triggers (type=event but missing event_date)
+      const malformedIdx = deferredTriggers.findIndex(
+        (dt) =>
+          dt.newNodeIndex === nodeIndex &&
+          dt.trigger.type === "event" &&
+          dt.trigger.eventDate == null,
+      );
+      if (malformedIdx !== -1) {
+        deferredTriggers.splice(malformedIdx, 1);
+      }
+
       deferredTriggers.push({
         newNodeIndex: nodeIndex,
         trigger: {


### PR DESCRIPTION
Address feedback from PR #23017. (1) Replace malformed event triggers instead of appending a fallback, preventing duplicate trigger records. (2) Update update_nodes.event_date schema to allow null, matching create_nodes for consistent event date clearing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
