### PR TITLE
fix: align userLast text with userLastBlocks for image-only turns

### DIFF
--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -438,14 +438,12 @@ export class ConversationGraphMemory {
       if (msg.role === "user") {
         if (userLastBlocks.length === 0) {
           userLastBlocks = msg.content;
-        }
-        if (!userLast) {
           userLast = text;
         }
       } else if (msg.role === "assistant" && !assistantLast) {
         assistantLast = text;
       }
-      if (userLast && assistantLast) break;
+      if (userLastBlocks.length > 0 && assistantLast) break;
     }
 
     const result = await retrieveForTurn({


### PR DESCRIPTION
Address feedback from PR #23023. When the latest user turn is image-only, userLast was still backfilled from an older text message, causing mismatched inputs to retrieveForTurn. Clear userLast when the current turn has no text to prevent stale text from driving retrieval alongside current images.

Closes JARVIS-23023
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
