### PR TITLE
fix: add workspace migration to clean up orphaned optimized-images cache

### DIFF
--- a/assistant/src/workspace/migrations/027-remove-orphaned-optimized-images-cache.ts
+++ b/assistant/src/workspace/migrations/027-remove-orphaned-optimized-images-cache.ts
@@ -1,0 +1,42 @@
+/**
+ * Workspace migration 027: Remove orphaned optimized-images cache directory.
+ *
+ * The optimized image cache was moved from `workspace/cache/optimized-images/`
+ * to `os.tmpdir()/vellum-optimized-images/`. This migration cleans up the old
+ * directory and removes the parent `cache/` directory if it is now empty.
+ *
+ * Idempotent: safe to re-run after interruption at any point.
+ */
+
+import { existsSync, readdirSync, rmSync, rmdirSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+export const removeOrphanedOptimizedImagesCacheMigration: WorkspaceMigration = {
+  id: "027-remove-orphaned-optimized-images-cache",
+  description:
+    "Remove orphaned cache/optimized-images/ directory after cache moved to tmpdir",
+
+  run(workspaceDir: string): void {
+    const cacheDir = join(workspaceDir, "cache");
+    const optimizedImagesDir = join(cacheDir, "optimized-images");
+
+    if (existsSync(optimizedImagesDir)) {
+      rmSync(optimizedImagesDir, { recursive: true, force: true });
+    }
+
+    // Remove the parent cache/ directory if it is now empty
+    if (existsSync(cacheDir)) {
+      const remaining = readdirSync(cacheDir);
+      if (remaining.length === 0) {
+        rmdirSync(cacheDir);
+      }
+    }
+  },
+
+  down(_workspaceDir: string): void {
+    // The old cache directory contained ephemeral cached data that does not
+    // need to be restored. The cache will be rebuilt in tmpdir on next use.
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -23,6 +23,7 @@ import { moveConfigFilesToWorkspaceMigration } from "./023-move-config-files-to-
 import { moveRuntimeFilesToWorkspaceMigration } from "./024-move-runtime-files-to-workspace.js";
 import { removeOauthAppSetupSkillsMigration } from "./025-remove-oauth-app-setup-skills.js";
 import { backfillInstallMetaMigration } from "./026-backfill-install-meta.js";
+import { removeOrphanedOptimizedImagesCacheMigration } from "./027-remove-orphaned-optimized-images-cache.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -57,4 +58,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   moveRuntimeFilesToWorkspaceMigration,
   removeOauthAppSetupSkillsMigration,
   backfillInstallMetaMigration,
+  removeOrphanedOptimizedImagesCacheMigration,
 ];


### PR DESCRIPTION
Address feedback from PR #23019. The optimized image cache was moved from the workspace to tmpdir, but no migration was added to clean up the old directory. Adds a workspace migration that removes the orphaned cache/optimized-images/ directory and the empty parent cache/ directory.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23072" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
