### PR TITLE
fix: use UTC methods for date-only event detection in injection

### DIFF
--- a/assistant/src/memory/graph/injection.ts
+++ b/assistant/src/memory/graph/injection.ts
@@ -167,7 +167,9 @@ export function formatEventDate(epochMs: number): string {
   const dayOfMonth = date.getDate();
 
   // Include time only when hours/minutes are non-zero (midnight = date-only event)
-  const hasTime = date.getHours() !== 0 || date.getMinutes() !== 0;
+  // Use UTC methods: date-only events are stored as midnight UTC, so local timezone
+  // methods would show non-zero hours in west-of-UTC timezones, defeating the check.
+  const hasTime = date.getUTCHours() !== 0 || date.getUTCMinutes() !== 0;
   let datePart = `${dayName} ${monthName} ${dayOfMonth}`;
   if (hasTime) {
     const hours = date.getHours();


### PR DESCRIPTION
Address feedback from PR #23018. The hasTime heuristic used local timezone methods, which was self-defeating for the UTC midnight drift scenario. Date-only events stored as midnight UTC would appear as having time in west-of-UTC timezones. Switch to getUTCHours()/getUTCMinutes() to correctly detect midnight-UTC date-only events.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
