### PR TITLE
fix: filter procedural nodes before applying limit in getTopSignificanceNodes

### DIFF
--- a/assistant/src/memory/graph/consolidation.ts
+++ b/assistant/src/memory/graph/consolidation.ts
@@ -194,8 +194,7 @@ function getTopSignificanceNodes(
     scopeId,
     fidelityNot: ["gone"],
     minSignificance: 0.6,
-    limit: n,
-  }).filter((n) => !isCapabilityNode(n));
+  }).filter((n) => !isCapabilityNode(n)).slice(0, n);
 }
 
 function getDecayedNodes(scopeId: string): MemoryNode[] {


### PR DESCRIPTION
Address feedback from PR #23043. The limit was applied before filtering out capability nodes, causing fewer than n items to be returned when capability nodes ranked highly. Remove the DB-level limit so the filter applies first, then slice to n.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23074" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
