### PR TITLE
fix: narrow message_complete guard to only filter mid-stream auxiliary events

### DIFF
--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -348,11 +348,11 @@ final class ChatActionHandler {
         guard belongsToConversation(complete.conversationId) else { return }
         // Auxiliary message_complete events (watch notifiers, call notifications)
         // that lack a messageId should not reset the main agent turn state.
-        // Without this guard, a watch commentary/summary message_complete arriving
-        // mid-stream clears currentAssistantMessageId, causing the main agent
-        // loop's subsequent message_complete to set daemonMessageId on the wrong
-        // (newly created) message — breaking the LLM Context Inspector until restart.
-        if complete.messageId == nil && vm.isSending {
+        // Only filter when a main agent turn is actively streaming
+        // (currentAssistantMessageId is set). This allows slash commands and other
+        // non-auxiliary completions (which don't set currentAssistantMessageId)
+        // to process normally.
+        if complete.messageId == nil && vm.currentAssistantMessageId != nil {
             return
         }
         // Flush any buffered streaming text before finalizing the message.


### PR DESCRIPTION
Address feedback from PR #23049. The guard blocked ALL nil-messageId message_complete events during sending, including slash commands. Narrow it to only filter when a main agent turn is actively streaming (currentAssistantMessageId != nil), allowing slash command completions to process normally.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
