### PR TITLE
fix: prune stale uninstalled skill capability nodes on startup

### DIFF
--- a/assistant/src/memory/graph/capability-seed.ts
+++ b/assistant/src/memory/graph/capability-seed.ts
@@ -12,7 +12,6 @@ import { buildCliProgram } from "../../cli/program.js";
 import { getConfig } from "../../config/loader.js";
 import { resolveSkillStates } from "../../config/skill-state.js";
 import { loadSkillCatalog } from "../../config/skills.js";
-import { getCachedCatalogSync } from "../../skills/catalog-cache.js";
 import {
   fromSkillSummary,
   type SkillCapabilityInput,
@@ -108,19 +107,11 @@ export function seedSkillGraphNodes(): void {
       seenKeys.add(`${SKILL_SOURCE_PREFIX}${summary.id}`);
     }
 
-    // Include enabled catalog skill keys so pruning doesn't remove them
-    const enabledIds = new Set(enabled.map((r) => r.summary.id));
-    for (const entry of getCachedCatalogSync()) {
-      if (enabledIds.has(entry.id)) {
-        seenKeys.add(`${SKILL_SOURCE_PREFIX}${entry.id}`);
-      }
-    }
-
-    if (getCachedCatalogSync().length > 0) {
-      pruneStaleCapabilities(SKILL_SOURCE_PREFIX, seenKeys);
-    } else {
-      log.debug("Skipping skill capability pruning — catalog cache not yet populated");
-    }
+    // Always prune stale capability nodes — this cleans up nodes from
+    // previously-seeded uninstalled skills that are no longer refreshed.
+    // seenKeys already contains all locally-installed-and-enabled skills
+    // which is sufficient to identify what should be kept.
+    pruneStaleCapabilities(SKILL_SOURCE_PREFIX, seenKeys);
   } catch (err) {
     log.warn({ err }, "Failed to seed skill graph nodes");
   }


### PR DESCRIPTION
Address feedback from PR #22954. Removes the catalog cache guard that could prevent pruning on startup, ensuring capability:skill:* graph nodes for skills that are no longer installed or enabled get cleaned up immediately. The seenKeys set from resolveSkillStates() already contains all enabled skills, making the catalog cache check unnecessary.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23076" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
