### PR TITLE
fix: remove node content from consolidation deletion logs

### DIFF
--- a/assistant/src/memory/graph/consolidation.ts
+++ b/assistant/src/memory/graph/consolidation.ts
@@ -581,8 +581,7 @@ async function consolidateChunk(
   for (const id of input.delete_ids ?? []) {
     if (!nodeIds.has(id)) continue; // safety
     try {
-      const deletedNode = nodeMap.get(id);
-      log.info({ nodeId: id, contentPreview: deletedNode?.content?.slice(0, 80) }, "Consolidation deleting node");
+      log.info({ nodeId: id }, "Consolidation deleting node");
       deleteNode(id);
       result.nodesDeleted++;
       result.deletedIds.push(id);


### PR DESCRIPTION
Address feedback from PR #23045. The consolidation deletion log included the first 80 chars of node content at info level, which could expose PII/secrets in production logs. Remove the content preview from the log message.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23077" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
