### PR TITLE
fix: guard text block payloads and remove unused hasImageBlocks

### DIFF
--- a/assistant/src/memory/graph/extraction.ts
+++ b/assistant/src/memory/graph/extraction.ts
@@ -1164,9 +1164,11 @@ export function loadTranscriptWithImages(
     for (let i = 0; i < parsed.length; i++) {
       const block = parsed[i];
       if (block?.type === "text") {
+        const rawText =
+          typeof block.text === "string" ? block.text : "";
         const text = prefixAdded
-          ? block.text
-          : `[${row.role}]: ${block.text}`;
+          ? rawText
+          : `[${row.role}]: ${rawText}`;
         prefixAdded = true;
         totalTextLength += text.length;
         contentBlocks.push({ type: "text", text });

--- a/assistant/src/memory/message-content.ts
+++ b/assistant/src/memory/message-content.ts
@@ -121,21 +121,6 @@ export function extractMediaBlockMeta(
   }
 }
 
-/**
- * Lightweight check for whether stored message content contains image blocks.
- * Does NOT decode base64 data — only checks for `"type":"image"` in the JSON.
- */
-export function hasImageBlocks(raw: string): boolean {
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (!Array.isArray(parsed)) return false;
-    return parsed.some(
-      (block: { type?: string }) => block.type === "image",
-    );
-  } catch {
-    return false;
-  }
-}
 
 function stableJson(value: unknown): string {
   try {


### PR DESCRIPTION
Address feedback from PR #23024. (1) Add typeof guard for block.text in loadTranscriptWithImages to handle legacy/malformed rows gracefully. (2) Remove the now-unused hasImageBlocks function from message-content.ts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23078" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
