### PR TITLE
fix: type-safe buildOriginMeta — remove Record<string, unknown> and as cast

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -272,44 +272,6 @@ function deriveOrigin(
   return meta?.origin ?? "custom";
 }
 
-/** Build the origin-specific fields for a given origin (flattened at top level). */
-function buildOriginMeta(
-  origin: SlimSkillResponse["origin"],
-  summary: SkillSummary,
-  installMeta?: SkillInstallMeta | null,
-): Record<string, unknown> {
-  switch (origin) {
-    case "vellum":
-      return {};
-    case "clawhub": {
-      const meta =
-        installMeta !== undefined
-          ? installMeta
-          : readInstallMeta(summary.directoryPath);
-      return {
-        slug: meta?.slug ?? summary.id,
-        author: "",
-        stars: 0,
-        installs: 0,
-        reports: 0,
-      };
-    }
-    case "skillssh": {
-      const meta =
-        installMeta !== undefined
-          ? installMeta
-          : readInstallMeta(summary.directoryPath);
-      return {
-        slug: meta?.slug ?? summary.id,
-        sourceRepo: meta?.sourceRepo ?? "",
-        installs: 0,
-      };
-    }
-    default:
-      return {};
-  }
-}
-
 /** Sort rank by kind: bundled first, then catalog, then installed. */
 function kindSortRank(kind: SlimSkillResponse["kind"]): number {
   if (kind === "bundled") return 0;
@@ -329,16 +291,50 @@ function toSlimSkillResponse(
     kind === "installed" ? readInstallMeta(summary.directoryPath) : undefined;
   const origin = deriveOrigin(kind, summary.directoryPath, installMeta);
   const status: SlimSkillResponse["status"] = state;
-  return {
+
+  const base = {
     id: summary.id,
     name: summary.displayName,
     description: summary.description,
     emoji: summary.emoji,
     kind,
-    origin,
     status,
-    ...buildOriginMeta(origin, summary, installMeta),
-  } as SlimSkillResponse;
+  } as const;
+
+  switch (origin) {
+    case "vellum":
+      return { ...base, origin };
+    case "clawhub": {
+      const meta =
+        installMeta !== undefined
+          ? installMeta
+          : readInstallMeta(summary.directoryPath);
+      return {
+        ...base,
+        origin,
+        slug: meta?.slug ?? summary.id,
+        author: "",
+        stars: 0,
+        installs: 0,
+        reports: 0,
+      };
+    }
+    case "skillssh": {
+      const meta =
+        installMeta !== undefined
+          ? installMeta
+          : readInstallMeta(summary.directoryPath);
+      return {
+        ...base,
+        origin,
+        slug: meta?.slug ?? summary.id,
+        sourceRepo: meta?.sourceRepo ?? "",
+        installs: 0,
+      };
+    }
+    case "custom":
+      return { ...base, origin };
+  }
 }
 
 export function listSkills(_ctx: SkillOperationContext): SlimSkillResponse[] {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skills-discrim-union-flatten.md.

**Gap:** buildOriginMeta returns Record<string, unknown> bypassing type safety
**What was expected:** Each variant should be typed correctly at construction time
**What was found:** Record<string, unknown> spread + as SlimSkillResponse cast
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23079" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
