### PR TITLE
fix: remove dead Decodable conformance from SkillOriginMeta

### DIFF
--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1045,42 +1045,12 @@ public struct SkillsshOriginMeta: Codable, Sendable, Equatable {
 }
 
 /// Discriminated union over the `origin` field of a skill.
-/// Dispatches on the origin string to decode origin-specific metadata.
-public enum SkillOriginMeta: Decodable, Sendable, Equatable {
+/// Constructed via the `originMeta` computed property, which dispatches on origin.
+public enum SkillOriginMeta: Sendable, Equatable {
     case vellum
     case clawhub(ClawhubOriginMeta)
     case skillssh(SkillsshOriginMeta)
     case custom
-
-    private enum CodingKeys: String, CodingKey {
-        case origin, slug, author, stars, installs, reports, publishedAt, sourceRepo
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let origin = try container.decode(String.self, forKey: .origin)
-        switch origin {
-        case "clawhub":
-            self = .clawhub(ClawhubOriginMeta(
-                slug: try container.decode(String.self, forKey: .slug),
-                author: try container.decode(String.self, forKey: .author),
-                stars: try container.decode(Int.self, forKey: .stars),
-                installs: try container.decode(Int.self, forKey: .installs),
-                reports: try container.decode(Int.self, forKey: .reports),
-                publishedAt: try container.decodeIfPresent(String.self, forKey: .publishedAt)
-            ))
-        case "skillssh":
-            self = .skillssh(SkillsshOriginMeta(
-                slug: try container.decode(String.self, forKey: .slug),
-                sourceRepo: try container.decode(String.self, forKey: .sourceRepo),
-                installs: try container.decode(Int.self, forKey: .installs)
-            ))
-        case "vellum":
-            self = .vellum
-        default:
-            self = .custom
-        }
-    }
 }
 
 extension SkillsListResponseSkill {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skills-discrim-union-flatten.md.

**Gap:** SkillOriginMeta Decodable conformance is dead code
**What was expected:** No unused Decodable machinery
**What was found:** Decodable + init(from:) + CodingKeys never invoked
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
