### PR TITLE
fix: sort imports in workspace migration 027

### DIFF
--- a/assistant/src/workspace/migrations/027-remove-orphaned-optimized-images-cache.ts
+++ b/assistant/src/workspace/migrations/027-remove-orphaned-optimized-images-cache.ts
@@ -8,7 +8,7 @@
  * Idempotent: safe to re-run after interruption at any point.
  */
 
-import { existsSync, readdirSync, rmSync, rmdirSync } from "node:fs";
+import { existsSync, readdirSync, rmdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 
 import type { WorkspaceMigration } from "./types.js";


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error in `027-remove-orphaned-optimized-images-cache.ts` by reordering named imports alphabetically (`rmdirSync` before `rmSync`)

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23880123882/job/69631449239
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23081" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
