### PR TITLE
fix: update feature flag sync endpoint

### DIFF
--- a/gateway/src/__tests__/remote-feature-flag-sync.test.ts
+++ b/gateway/src/__tests__/remote-feature-flag-sync.test.ts
@@ -147,7 +147,7 @@ describe("RemoteFeatureFlagSync", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url] = fetchMock.mock.calls[0];
     expect(url).toBe(
-      "https://env-platform.example.com/v1/assistants/asst-123/feature-flags/",
+      "https://env-platform.example.com/v1/feature-flags/assistant-flag-values/",
     );
   });
 
@@ -210,7 +210,7 @@ describe("RemoteFeatureFlagSync", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url] = fetchMock.mock.calls[0];
-    expect(url).toContain("/v1/assistants/env-asst-456/feature-flags/");
+    expect(url).toContain("/v1/feature-flags/assistant-flag-values/");
   });
 
   test("fetches and caches flags on successful response", async () => {
@@ -345,7 +345,7 @@ describe("RemoteFeatureFlagSync", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url] = fetchMock.mock.calls[0];
     expect(url).toBe(
-      "https://platform.example.com/v1/assistants/asst-abc-999/feature-flags/",
+      "https://platform.example.com/v1/feature-flags/assistant-flag-values/",
     );
   });
 
@@ -424,7 +424,7 @@ describe("RemoteFeatureFlagSync", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url] = fetchMock.mock.calls[0];
     expect(url).toBe(
-      "https://platform.example.com/v1/assistants/asst-123/feature-flags/",
+      "https://platform.example.com/v1/feature-flags/assistant-flag-values/",
     );
   });
 
@@ -445,7 +445,7 @@ describe("RemoteFeatureFlagSync", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe(
-      "https://platform.example.com/v1/assistants/asst-trimmed/feature-flags/",
+      "https://platform.example.com/v1/feature-flags/assistant-flag-values/",
     );
     const headers = init?.headers as Record<string, string>;
     expect(headers.Authorization).toBe("Api-Key trimmed-key");

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -103,7 +103,7 @@ export class RemoteFeatureFlagSync {
       ""
     ).replace(/\/+$/, "");
 
-    // Feature flag sync hits the public platform API (/v1/assistants/…),
+    // Feature flag sync hits the public platform API (/v1/feature-flags/assistant-flag-values/),
     // which requires Api-Key auth. PLATFORM_INTERNAL_API_KEY is only valid
     // for internal gateway endpoints and would produce 401s here.
     const assistantApiKey = assistantApiKeyRaw?.trim() || undefined;
@@ -125,7 +125,7 @@ export class RemoteFeatureFlagSync {
       return null;
     }
 
-    const url = `${platformUrl}/v1/assistants/${assistantId}/feature-flags/`;
+    const url = `${platformUrl}/v1/feature-flags/assistant-flag-values/`;
     log.debug({ url }, "Fetching remote feature flags from platform");
 
     const response = await fetchImpl(url, {


### PR DESCRIPTION
## Summary
- Update remote feature flag sync URL from `/v1/assistants/{id}/feature-flags/` to `/v1/feature-flags/assistant-flag-values/`, removing the assistant ID from the URL path
- Update all corresponding test assertions to match the new endpoint
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23083" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
