### PR TITLE
fix: remove unused assistantId from feature flag sync guard

### DIFF
--- a/gateway/src/__tests__/remote-feature-flag-sync.test.ts
+++ b/gateway/src/__tests__/remote-feature-flag-sync.test.ts
@@ -76,7 +76,6 @@ function fakeCredentialCache(
 function defaultCredentials(): Record<string, string> {
   return {
     "credential/vellum/platform_base_url": "https://platform.vellum.ai",
-    "credential/vellum/platform_assistant_id": "asst-123",
     "credential/vellum/assistant_api_key": "test-api-key",
   };
 }
@@ -85,14 +84,12 @@ function defaultCredentials(): Record<string, string> {
 // Setup / teardown
 // ---------------------------------------------------------------------------
 const savedVellumPlatformUrl = process.env.VELLUM_PLATFORM_URL;
-const savedPlatformAssistantId = process.env.PLATFORM_ASSISTANT_ID;
 const savedPlatformInternalApiKey = process.env.PLATFORM_INTERNAL_API_KEY;
 
 beforeEach(() => {
   // Clear env vars that the production code falls back to, so tests remain
   // deterministic unless they explicitly set them.
   delete process.env.VELLUM_PLATFORM_URL;
-  delete process.env.PLATFORM_ASSISTANT_ID;
   delete process.env.PLATFORM_INTERNAL_API_KEY;
   mkdirSync(protectedDir, { recursive: true });
   clearRemoteFeatureFlagStoreCache();
@@ -109,7 +106,6 @@ afterEach(() => {
     }
   };
   restoreEnv("VELLUM_PLATFORM_URL", savedVellumPlatformUrl);
-  restoreEnv("PLATFORM_ASSISTANT_ID", savedPlatformAssistantId);
   restoreEnv("PLATFORM_INTERNAL_API_KEY", savedPlatformInternalApiKey);
   try {
     rmSync(protectedDir, { recursive: true, force: true });
@@ -192,25 +188,13 @@ describe("RemoteFeatureFlagSync", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  test("skips sync when platform_assistant_id is missing and no PLATFORM_ASSISTANT_ID", async () => {
-    const creds = defaultCredentials();
-    delete creds["credential/vellum/platform_assistant_id"];
+  test("syncs when only platformUrl and assistantApiKey are present", async () => {
+    fetchMock = mock(async () => Response.json({ flags: { ff1: true } }));
 
-    const sync = new RemoteFeatureFlagSync({
-      credentials: fakeCredentialCache(creds),
-    });
-    await sync.start();
-    sync.stop();
-
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  test("falls back to PLATFORM_ASSISTANT_ID env var when credential cache is empty", async () => {
-    fetchMock = mock(async () => Response.json({ flags: {} }));
-    process.env.PLATFORM_ASSISTANT_ID = "env-asst-456";
-
-    const creds = defaultCredentials();
-    delete creds["credential/vellum/platform_assistant_id"];
+    const creds = {
+      "credential/vellum/platform_base_url": "https://platform.example.com",
+      "credential/vellum/assistant_api_key": "test-api-key",
+    };
 
     const sync = new RemoteFeatureFlagSync({
       credentials: fakeCredentialCache(creds),
@@ -219,8 +203,6 @@ describe("RemoteFeatureFlagSync", () => {
     sync.stop();
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url] = fetchMock.mock.calls[0];
-    expect(url).toContain("/v1/feature-flags/assistant-flag-values/");
   });
 
   test("fetches and caches flags on successful response", async () => {
@@ -338,13 +320,12 @@ describe("RemoteFeatureFlagSync", () => {
     expect(headers.Authorization).toBe(`Api-Key ${apiKey}`);
   });
 
-  test("constructs correct URL with assistant ID", async () => {
+  test("constructs correct URL from platform base URL", async () => {
     fetchMock = mock(async () => Response.json({ flags: {} }));
 
     const creds = {
       ...defaultCredentials(),
       "credential/vellum/platform_base_url": "https://platform.example.com",
-      "credential/vellum/platform_assistant_id": "asst-abc-999",
     };
     const sync = new RemoteFeatureFlagSync({
       credentials: fakeCredentialCache(creds),
@@ -480,7 +461,6 @@ describe("RemoteFeatureFlagSync", () => {
 
     const creds = {
       "credential/vellum/platform_base_url": "  https://platform.example.com  ",
-      "credential/vellum/platform_assistant_id": "  asst-trimmed  ",
       "credential/vellum/assistant_api_key": "  trimmed-key  ",
     };
     const sync = new RemoteFeatureFlagSync({

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -38,7 +38,7 @@ type RemoteFetchResult =
   | { status: "error" };
 
 export type RemoteFeatureFlagSyncConfig = {
-  /** Credential cache for resolving platform URL, API key, and assistant ID dynamically. */
+  /** Credential cache for resolving platform URL and API key dynamically. */
   credentials: CredentialCache;
   /** Override the initial poll interval (ms) — useful for testing. Defaults to 10 000. */
   initialPollIntervalMs?: number;
@@ -297,12 +297,10 @@ export class RemoteFeatureFlagSync {
     // errors) are treated as retriable errors with backoff, not as "missing
     // credentials" which would pause polling indefinitely.
     let platformUrlRaw: string | undefined;
-    let assistantIdRaw: string | undefined;
     let assistantApiKeyRaw: string | undefined;
     try {
-      [platformUrlRaw, assistantIdRaw, assistantApiKeyRaw] = await Promise.all([
+      [platformUrlRaw, assistantApiKeyRaw] = await Promise.all([
         this.credentials.get(credentialKey("vellum", "platform_base_url")),
-        this.credentials.get(credentialKey("vellum", "platform_assistant_id")),
         this.credentials.get(credentialKey("vellum", "assistant_api_key")),
       ]);
     } catch (err) {
@@ -322,17 +320,11 @@ export class RemoteFeatureFlagSync {
     // for internal gateway endpoints and would produce 401s here.
     const assistantApiKey = assistantApiKeyRaw?.trim() || undefined;
 
-    const assistantId =
-      process.env.PLATFORM_ASSISTANT_ID?.trim() ||
-      assistantIdRaw?.trim() ||
-      undefined;
-
-    if (!platformUrl || !assistantApiKey || !assistantId) {
+    if (!platformUrl || !assistantApiKey) {
       log.debug(
         {
           hasPlatformUrl: !!platformUrl,
           hasApiKey: !!assistantApiKey,
-          hasAssistantId: !!assistantId,
         },
         "Remote feature flag sync skipped: missing credentials",
       );


### PR DESCRIPTION
## Summary
- Remove `assistantId` fetch, resolution, and guard check from `RemoteFeatureFlagSync` — the new `/v1/feature-flags/assistant-flag-values/` endpoint uses Api-Key auth and doesn't need the assistant ID in the URL
- Remove tests for assistant ID fallback/missing behavior, add a test verifying sync works with only `platformUrl` and `assistantApiKey`
- Rename misleading test "constructs correct URL with assistant ID" to "constructs correct URL from platform base URL"

## Original prompt
this clean up
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23084" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
