### PR TITLE
fix: pass full memory content to dedup LLM instead of truncated previews

### DIFF
--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -78,7 +78,7 @@ async function rerankAndDedup(
     const provider = await getConfiguredProvider();
     if (!provider) return candidates.slice(0, maxNodes);
 
-    // Compact listing for the LLM: numbered index + age + first 100 chars
+    // Numbered listing for the LLM: index + age + full content
     const now = Date.now();
     const listing = candidates
       .map((s, i) => {
@@ -87,11 +87,7 @@ async function rerankAndDedup(
           ageDays < 1
             ? `${Math.floor(ageDays * 24)}h`
             : `${Math.floor(ageDays)}d`;
-        const preview =
-          s.node.content.length > 100
-            ? s.node.content.slice(0, 100) + "…"
-            : s.node.content;
-        return `${i + 1}. (${age}) ${preview}`;
+        return `${i + 1}. (${age}) ${s.node.content}`;
       })
       .join("\n");
 
@@ -189,11 +185,7 @@ async function dedupForTurn(
           ageDays < 1
             ? `${Math.floor(ageDays * 24)}h`
             : `${Math.floor(ageDays)}d`;
-        const preview =
-          s.node.content.length > 150
-            ? s.node.content.slice(0, 150) + "…"
-            : s.node.content;
-        return `${i + 1}. (${age}) ${preview}`;
+        return `${i + 1}. (${age}) ${s.node.content}`;
       })
       .join("\n");
 


### PR DESCRIPTION
## Summary
- Remove 100-char and 150-char content truncation in rerankAndDedup and dedupForTurn
- Dedup LLM now sees full memory content, enabling accurate duplicate detection
- Rename misleading 'preview' variable to 'content'

Part of plan: memory-injection-quality.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23086" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
