### PR TITLE
fix: deduplicate repeated paragraphs in memory node content on write

### DIFF
--- a/assistant/src/memory/graph/store.test.ts
+++ b/assistant/src/memory/graph/store.test.ts
@@ -7,6 +7,7 @@ import {
   createEdge,
   createNode,
   createTrigger,
+  deduplicateParagraphs,
   deleteEdge,
   deleteNode,
   deleteTrigger,
@@ -1046,5 +1047,52 @@ describe("updateNode event trigger sync", () => {
     const triggers = getTriggersForNode(node.id);
     expect(triggers).toHaveLength(1);
     expect(triggers[0].eventDate).toBe(eventDate);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Paragraph deduplication
+// ---------------------------------------------------------------------------
+
+describe("deduplicateParagraphs", () => {
+  test("content with no duplicates passes through unchanged", () => {
+    const input = "First paragraph.\n\nSecond paragraph.\n\nThird paragraph.";
+    expect(deduplicateParagraphs(input)).toBe(input);
+  });
+
+  test("two identical paragraphs separated by \\n\\n collapses to one", () => {
+    const input = "Hello world.\n\nHello world.";
+    expect(deduplicateParagraphs(input)).toBe("Hello world.");
+  });
+
+  test("paragraphs that differ only in trailing whitespace are treated as duplicates", () => {
+    const input = "Hello world.  \n\nHello world.";
+    expect(deduplicateParagraphs(input)).toBe("Hello world.  ");
+  });
+
+  test("bullet lists with repeated items are deduped", () => {
+    const input = "- item one\n- item two\n- item one\n- item three";
+    expect(deduplicateParagraphs(input)).toBe(
+      "- item one\n- item two\n- item three",
+    );
+  });
+
+  test("empty content returns empty string", () => {
+    expect(deduplicateParagraphs("")).toBe("");
+  });
+
+  test("multiple duplicate paragraphs with different content", () => {
+    const input = "Alpha.\n\nBeta.\n\nAlpha.\n\nGamma.\n\nBeta.";
+    expect(deduplicateParagraphs(input)).toBe("Alpha.\n\nBeta.\n\nGamma.");
+  });
+
+  test("bullet dedup within a paragraph preserves non-bullet lines", () => {
+    const input = "Header:\n- item A\n- item B\n- item A";
+    expect(deduplicateParagraphs(input)).toBe("Header:\n- item A\n- item B");
+  });
+
+  test("paragraphs differing only in internal whitespace are treated as duplicates", () => {
+    const input = "hello   world\n\nhello world";
+    expect(deduplicateParagraphs(input)).toBe("hello   world");
   });
 });

--- a/assistant/src/memory/graph/store.ts
+++ b/assistant/src/memory/graph/store.ts
@@ -116,14 +116,71 @@ function rowToTrigger(
 }
 
 // ---------------------------------------------------------------------------
+// Paragraph deduplication
+// ---------------------------------------------------------------------------
+
+/**
+ * Remove repeated paragraphs and bullet items from memory node content.
+ * Paragraphs are separated by `\n\n`. Within each paragraph, lines starting
+ * with `- ` are treated as bullet items and individually deduplicated.
+ */
+export function deduplicateParagraphs(content: string): string {
+  if (!content) return content;
+
+  const paragraphs = content.split("\n\n");
+  const seen = new Set<string>();
+  const unique: string[] = [];
+
+  for (const paragraph of paragraphs) {
+    // Deduplicate bullet items within the paragraph
+    const lines = paragraph.split("\n");
+    const isBulletList = lines.some((l) => l.trimStart().startsWith("- "));
+
+    let processed: string;
+    if (isBulletList) {
+      const seenBullets = new Set<string>();
+      const uniqueLines: string[] = [];
+      for (const line of lines) {
+        if (line.trimStart().startsWith("- ")) {
+          const normalized = line.trim().replace(/\s+/g, " ");
+          if (!seenBullets.has(normalized)) {
+            seenBullets.add(normalized);
+            uniqueLines.push(line);
+          }
+        } else {
+          uniqueLines.push(line);
+        }
+      }
+      processed = uniqueLines.join("\n");
+    } else {
+      processed = paragraph;
+    }
+
+    const normalized = processed.trim().replace(/\s+/g, " ");
+    if (normalized === "") {
+      // Preserve empty paragraphs (whitespace-only) as separators
+      unique.push(processed);
+    } else if (!seen.has(normalized)) {
+      seen.add(normalized);
+      unique.push(processed);
+    }
+  }
+
+  return unique.join("\n\n");
+}
+
+// ---------------------------------------------------------------------------
 // Node CRUD
 // ---------------------------------------------------------------------------
 
 export function createNode(node: NewNode): MemoryNode {
   const db = getDb();
   const id = uuid();
-  db.insert(memoryGraphNodes).values(nodeToInsertValues(node, id)).run();
-  return { ...node, id };
+  const cleanContent = deduplicateParagraphs(node.content);
+  db.insert(memoryGraphNodes)
+    .values(nodeToInsertValues({ ...node, content: cleanContent }, id))
+    .run();
+  return { ...node, content: cleanContent, id };
 }
 
 export function getNode(id: string): MemoryNode | null {
@@ -154,7 +211,8 @@ export function updateNode(
   const db = getDb();
   const updates: Record<string, unknown> = {};
 
-  if (changes.content !== undefined) updates.content = changes.content;
+  if (changes.content !== undefined)
+    updates.content = deduplicateParagraphs(changes.content);
   if (changes.type !== undefined) updates.type = changes.type;
   if (changes.created !== undefined) updates.created = changes.created;
   if (changes.lastAccessed !== undefined)
@@ -558,7 +616,10 @@ export function applyDiff(diff: MemoryDiff): ApplyDiffResult {
     // Create nodes
     for (const node of diff.createNodes) {
       const id = uuid();
-      tx.insert(memoryGraphNodes).values(nodeToInsertValues(node, id)).run();
+      const cleanContent = deduplicateParagraphs(node.content);
+      tx.insert(memoryGraphNodes)
+        .values(nodeToInsertValues({ ...node, content: cleanContent }, id))
+        .run();
       result.nodesCreated++;
       result.createdNodeIds.push(id);
     }
@@ -567,7 +628,8 @@ export function applyDiff(diff: MemoryDiff): ApplyDiffResult {
     for (const update of diff.updateNodes) {
       const updates: Record<string, unknown> = {};
       const c = update.changes;
-      if (c.content !== undefined) updates.content = c.content;
+      if (c.content !== undefined)
+        updates.content = deduplicateParagraphs(c.content as string);
       if (c.type !== undefined) updates.type = c.type;
       if (c.emotionalCharge !== undefined)
         updates.emotionalCharge = JSON.stringify(c.emotionalCharge);


### PR DESCRIPTION
## Summary
- Add deduplicateParagraphs() helper that removes repeated paragraphs and bullet items from memory node content
- Apply dedup at all three write points: createNode, updateNode, applyDiff
- Add tests covering paragraph and bullet dedup edge cases

Part of plan: memory-injection-quality.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23087" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
