### PR TITLE
fix: run topic-level dedup across reserved categories and serendipity

### DIFF
--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -618,9 +618,33 @@ export async function loadContextMemory(
     (s) => !deterministicIds.has(s.node.id),
   );
 
+  // 9. Cross-category dedup: catch topic-level duplicates across reserved
+  //    categories (prospective, upcoming, capabilities) and serendipity.
+  //    Only runs when the combined set is large enough to warrant an LLM call.
+  const CROSS_DEDUP_THRESHOLD = 15;
+  const combined = [...deterministic, ...uniqueSerendipity];
+  let dedupedDeterministic = deterministic;
+  let dedupedSerendipity = uniqueSerendipity;
+
+  if (combined.length > CROSS_DEDUP_THRESHOLD) {
+    const deduped = await dedupForTurn(
+      combined,
+      combined.length, // preserve all non-duplicate nodes
+      "context load — deduplicate across all categories",
+    );
+
+    // Re-split into deterministic vs serendipity by checking original membership
+    dedupedDeterministic = deduped.filter((s) =>
+      deterministicIds.has(s.node.id),
+    );
+    dedupedSerendipity = deduped.filter(
+      (s) => !deterministicIds.has(s.node.id),
+    );
+  }
+
   return {
-    nodes: deterministic,
-    serendipityNodes: uniqueSerendipity,
+    nodes: dedupedDeterministic,
+    serendipityNodes: dedupedSerendipity,
     triggeredNodes: allTriggered,
     latencyMs: Date.now() - start,
   };


### PR DESCRIPTION
## Summary
- Add cross-category dedup pass after combining reserved nodes (prospective, upcoming, capabilities) with the main pool and serendipity
- Reuses the fast-model dedup to catch topic-level duplicates across sections
- Falls back gracefully to un-deduped list on LLM failure
- Only runs when combined set exceeds 15 nodes to avoid unnecessary LLM calls

Part of plan: memory-injection-quality.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23088" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
