### PR TITLE
fix: apply deduplicateParagraphs to consolidation in-memory nodeMap

### DIFF
--- a/assistant/src/memory/graph/consolidation.ts
+++ b/assistant/src/memory/graph/consolidation.ts
@@ -22,6 +22,7 @@ import { getLogger } from "../../util/logger.js";
 import { parseEpochMs } from "./extraction.js";
 import {
   createTrigger,
+  deduplicateParagraphs,
   deleteNode,
   getEdgesForNode,
   getTriggersForNode,
@@ -508,6 +509,10 @@ async function consolidateChunk(
       // more than just lastConsolidated
       updateNode(update.id, changes);
       result.nodesUpdated++;
+      // Sync in-memory state with what updateNode actually wrote to the DB
+      // (updateNode deduplicates content before persisting)
+      if (changes.content)
+        changes.content = deduplicateParagraphs(changes.content);
       const node = nodeMap.get(update.id);
       if (node) Object.assign(node, changes);
     }


### PR DESCRIPTION
## Summary
Fixes stale in-memory content in consolidation nodeMap after updateNode.

**Gap:** consolidation.ts Object.assign writes raw content while updateNode now deduplicates it
**Fix:** Apply deduplicateParagraphs to changes.content before Object.assign so in-memory state matches DB
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23089" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
