### PR TITLE
fix: preserve data/db/ during vbundle workspace import

### DIFF
--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -165,8 +165,8 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
 
   // Directories to preserve when clearing the workspace (large/regenerable).
   const WORKSPACE_SKIP_DIRS = new Set(["embedding-models", "deprecated"]);
-  // data/qdrant is nested — we skip "qdrant" inside "data/"
-  const DATA_SKIP_DIRS = new Set(["qdrant"]);
+  // data/qdrant and data/db are nested — we skip them inside "data/"
+  const DATA_SKIP_DIRS = new Set(["qdrant", "db"]);
 
   // Step 1b: Clear the workspace directory before restore if the bundle
   // contains new-format workspace/ entries. This ensures an exact-match


### PR DESCRIPTION
## Summary
- Add "db" to DATA_SKIP_DIRS in vbundle importer so the SQLite database directory is preserved during workspace import
- Prevents data loss if a vbundle import runs without a DB in the archive

Part of plan: recover-db-from-disk-view.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23091" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
