### PR TITLE
feat: add `backgroundTint` computed property to `MemoryKind`

### DIFF
--- a/clients/shared/Features/Memory/MemoryKindStyle.swift
+++ b/clients/shared/Features/Memory/MemoryKindStyle.swift
@@ -57,6 +57,12 @@ public enum MemoryKind: String, CaseIterable, Identifiable, Sendable {
         }
     }
 
+    /// Subtle background tint derived from the kind's accent color.
+    /// Use for card backgrounds and sidebar active states.
+    public var backgroundTint: Color {
+        color.opacity(0.06)
+    }
+
     /// Lucide icon raw value matching `VIcon` cases.
     public var icon: String {
         switch self {


### PR DESCRIPTION
## Summary
- Add `backgroundTint` computed property returning kind color at 6% opacity
- Used for card backgrounds and sidebar active states

Part of plan: memories-ui-redesign.md (PR 2 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23093" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
