### PR TITLE
feat: add `brandMini` Instrument Serif typography token at 16pt

### DIFF
--- a/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
@@ -90,6 +90,7 @@ public enum VFont {
 
     public static let brandMedium = instrumentSerif(weight: 400, size: adaptiveSize(32))
     public static let brandSmall  = instrumentSerif(weight: 400, size: adaptiveSize(22))
+    public static let brandMini   = instrumentSerif(weight: 400, size: adaptiveSize(16))
 
     // MARK: - Display
 
@@ -192,6 +193,7 @@ public enum VFont {
         // SwiftUI Font tokens
         _ = brandMedium
         _ = brandSmall
+        _ = brandMini
         _ = displayLarge
         _ = titleLarge
         _ = titleMedium


### PR DESCRIPTION
## Summary
- Add `VFont.brandMini` token (16pt Instrument Serif) for memory card subjects
- Provides typographic warmth distinct from DM Sans used elsewhere

Part of plan: memories-ui-redesign.md (PR 1 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23094" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
