### PR TITLE
feat: add confidence/importance bar views and source type helper to detail sheet

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet+Helpers.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet+Helpers.swift
@@ -33,4 +33,48 @@ extension MemoryItemDetailSheet {
         formatter.timeStyle = .short
         return formatter.string(from: date)
     }
+
+    /// Small horizontal bar showing a 0–1 value. Width is the total track width.
+    func metricBar(value: Double, color: Color, width: CGFloat = 60, height: CGFloat = 6) -> some View {
+        ZStack(alignment: .leading) {
+            RoundedRectangle(cornerRadius: height / 2)
+                .fill(VColor.surfaceActive)
+                .frame(width: width, height: height)
+            RoundedRectangle(cornerRadius: height / 2)
+                .fill(color)
+                .frame(width: max(height, width * CGFloat(min(max(value, 0), 1))), height: height)
+        }
+    }
+
+    /// Graduated color for a confidence value: green above 0.7, amber 0.3–0.7, red below 0.3.
+    func confidenceColor(_ value: Double) -> Color {
+        if value >= 0.7 { return VColor.systemPositiveStrong }
+        if value >= 0.3 { return VColor.systemMidStrong }
+        return VColor.systemNegativeStrong
+    }
+
+    /// Inline source type view with icon and label.
+    @ViewBuilder
+    func sourceTypeIndicator(_ sourceType: String) -> some View {
+        switch sourceType {
+        case "direct":
+            HStack(spacing: VSpacing.xxs) {
+                VIconView(.circleCheck, size: 12)
+                    .foregroundStyle(VColor.systemPositiveStrong)
+                Text("Told directly")
+            }
+        case "observed":
+            HStack(spacing: VSpacing.xxs) {
+                VIconView(.eye, size: 12)
+                    .foregroundStyle(VColor.contentSecondary)
+                Text("Observed")
+            }
+        default:
+            HStack(spacing: VSpacing.xxs) {
+                VIconView(.sparkles, size: 12)
+                    .foregroundStyle(VColor.contentTertiary)
+                Text("Inferred")
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Add `metricBar` helper for rendering horizontal progress bars (0-1 value)
- Add `confidenceColor` helper with green/amber/red graduation by threshold
- Add `sourceTypeIndicator` helper with icon + label for direct/observed/inferred sources

Part of plan: memories-ui-redesign.md (PR 4 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23096" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
