### PR TITLE
fix: eagerly apply avatar traits during managed onboarding to prevent green V flash

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -820,6 +820,15 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             onboardingState = nil
             return
         }
+        // Eagerly apply onboarding avatar traits so the ComingAliveOverlay
+        // (and any other UI) can render the character avatar immediately
+        // instead of falling back to the bundled green V logo while the
+        // async daemon sync completes.
+        if AvatarAppearanceManager.shared.customAvatarImage == nil,
+           AvatarAppearanceManager.shared.characterBodyShape == nil {
+            let image = AvatarCompositor.render(bodyShape: body, eyeStyle: eyes, color: color)
+            AvatarAppearanceManager.shared.saveAvatar(image, bodyShape: body, eyeStyle: eyes, color: color)
+        }
         Task {
             await AvatarAppearanceManager.shared.syncTraitsToDaemon(
                 bodyShape: body, eyeStyle: eyes, color: color


### PR DESCRIPTION
## Summary
- During Vellum Cloud onboarding, the `ComingAliveOverlay` briefly showed the green V logo before the generated character avatar because `AvatarAppearanceManager` had no traits yet — they were only populated asynchronously via an HTTP round-trip to the daemon
- Added an eager, synchronous `saveAvatar()` call in `syncOnboardingAvatarIfNeeded()` that immediately applies the onboarding avatar traits to `AvatarAppearanceManager` before the async daemon sync, eliminating the flash

## Original prompt
Fix the brief flash of the green V logo during the Vellum Cloud onboarding loading state, where the bundled fallback avatar shows before the generated character avatar.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23097" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
