### PR TITLE
feat: add color-coded dots and kind-tinted active state to memories sidebar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -188,22 +188,18 @@ struct MemoriesPanel: View {
     }
 
     private func kindFilterRow(icon: String, label: String, kind: MemoryKind?) -> some View {
-        VNavItem(
+        KindFilterRowButton(
             icon: icon,
             label: label,
+            kind: kind,
             isActive: selectedKind == kind,
+            count: kindCount(for: kind),
             action: {
                 withAnimation(VAnimation.fast) { selectedKind = kind }
                 store.kindFilter = kind?.rawValue
                 Task { await store.loadItems() }
             }
-        ) {
-            Text("\(kindCount(for: kind))")
-                .font(VFont.labelDefault)
-                .foregroundStyle(VColor.contentTertiary)
-        }
-        .accessibilityLabel("\(label) filter")
-        .accessibilityAddTraits(selectedKind == kind ? .isSelected : [])
+        )
     }
 
     private func kindCount(for kind: MemoryKind?) -> Int {
@@ -274,5 +270,76 @@ struct MemoriesPanel: View {
             }
             .scrollContentBackground(.hidden)
         }
+    }
+}
+
+// MARK: - Kind Filter Row Button
+
+/// Custom sidebar row that adds a color-coded dot and kind-tinted active background.
+private struct KindFilterRowButton: View {
+    let icon: String
+    let label: String
+    let kind: MemoryKind?
+    let isActive: Bool
+    let count: Int
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    private var dotColor: Color {
+        kind?.color ?? VColor.contentTertiary
+    }
+
+    private var activeBackground: Color {
+        kind?.backgroundTint ?? VColor.surfaceActive
+    }
+
+    private var iconColor: Color {
+        isActive ? VColor.primaryActive : VColor.primaryBase
+    }
+
+    private var textColor: Color {
+        isActive ? VColor.contentEmphasized : VColor.contentSecondary
+    }
+
+    var body: some View {
+        HStack(spacing: VSpacing.xs) {
+            Circle()
+                .fill(dotColor)
+                .frame(width: 8, height: 8)
+
+            VIconView(.resolve(icon), size: VSize.iconDefault)
+                .foregroundStyle(iconColor)
+                .frame(width: VSize.iconSlot, height: VSize.iconSlot)
+
+            Text(label)
+                .font(VFont.bodyMediumDefault)
+                .foregroundStyle(textColor)
+                .lineLimit(1)
+                .truncationMode(.tail)
+
+            Spacer()
+
+            Text("\(count)")
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentTertiary)
+        }
+        .padding(.leading, VSpacing.xs)
+        .padding(.trailing, VSpacing.sm)
+        .padding(.vertical, VSpacing.xs)
+        .frame(minHeight: VSize.rowMinHeight)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            isActive ? activeBackground :
+            isHovered ? VColor.surfaceBase :
+            Color.clear
+        )
+        .animation(VAnimation.fast, value: isHovered)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .contentShape(Rectangle())
+        .onTapGesture { action() }
+        .pointerCursor(onHover: { isHovered = $0 })
+        .accessibilityLabel("\(label) filter")
+        .accessibilityAddTraits(isActive ? .isSelected : [])
     }
 }


### PR DESCRIPTION
## Summary
- Add colored circle dots before each sidebar kind row matching the kind's accent color
- Apply kind-colored background tint on active sidebar rows instead of generic gray
- All row uses neutral tertiary dot color

Part of plan: memories-ui-redesign.md (PR 6 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
