### PR TITLE
feat: redesign MemoryItemRow with kind accent bar, inline metadata, and hover-only delete

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -6,40 +6,94 @@ struct MemoryItemRow: View {
     let onSelect: () -> Void
     let onDelete: () -> Void
 
+    @State private var isHovered = false
+
     private var memoryKind: MemoryKind? {
         MemoryKind(rawValue: item.kind)
     }
 
+    private var accentColor: Color {
+        memoryKind?.color ?? VColor.contentTertiary
+    }
+
     var body: some View {
         VCard(action: onSelect) {
-            HStack(alignment: .center, spacing: VSpacing.lg) {
+            HStack(spacing: 0) {
+                // Accent bar
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(accentColor)
+                    .frame(width: 4)
+
+                // Content area
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    // Top row: subject + timestamp + delete
                     HStack(alignment: .center, spacing: VSpacing.sm) {
                         Text(item.subject)
-                            .font(VFont.titleSmall)
+                            .font(VFont.brandMini)
                             .foregroundStyle(VColor.contentEmphasized)
                             .lineLimit(1)
                             .truncationMode(.tail)
 
-                        VTag(
-                            memoryKind?.label ?? item.kind.capitalized,
-                            color: memoryKind?.color ?? VColor.contentTertiary
-                        )
+                        Spacer()
+
+                        Text(item.relativeLastSeen)
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+
+                        if isHovered {
+                            VButton(
+                                label: "Delete",
+                                iconOnly: VIcon.trash.rawValue,
+                                style: .dangerGhost,
+                                size: .compact,
+                                action: onDelete
+                            )
+                            .accessibilityLabel("Delete memory")
+                        }
                     }
 
-                    Text(item.statement)
-                        .font(VFont.bodyMediumDefault)
-                        .foregroundStyle(VColor.contentSecondary)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
+                    // Metadata row: kind tag + confidence + source + importance dots
+                    HStack(alignment: .center, spacing: VSpacing.xs) {
+                        VTag(
+                            memoryKind?.label ?? item.kind.capitalized,
+                            color: accentColor
+                        )
+
+                        if let confidence = item.confidence, confidence > 0 {
+                            Text("\u{00B7}")
+                                .font(VFont.bodySmallDefault)
+                                .foregroundStyle(VColor.contentTertiary)
+                            Text("\(Int(confidence * 100))% confident")
+                                .font(VFont.bodySmallDefault)
+                                .foregroundStyle(VColor.contentTertiary)
+                        }
+
+                        if let sourceLabel = item.sourceLabel {
+                            Text("\u{00B7}")
+                                .font(VFont.bodySmallDefault)
+                                .foregroundStyle(VColor.contentTertiary)
+                            Text(sourceLabel)
+                                .font(VFont.bodySmallDefault)
+                                .foregroundStyle(VColor.contentTertiary)
+                        }
+
+                        Spacer()
+
+                        // Importance dots
+                        HStack(spacing: 2) {
+                            ForEach(0..<item.importanceLevel.rawValue, id: \.self) { _ in
+                                Circle()
+                                    .fill(VColor.contentTertiary)
+                                    .frame(width: 8, height: 8)
+                            }
+                        }
+                    }
                 }
-
-                Spacer()
-
-                VButton(label: "Delete", iconOnly: VIcon.trash.rawValue, style: .dangerGhost, size: .compact, action: onDelete)
-                    .accessibilityLabel("Delete memory")
+                .padding(.leading, VSpacing.md)
             }
+            .background(memoryKind?.backgroundTint ?? Color.clear)
         }
+        .onHover { isHovered = $0 }
         .contextMenu {
             Button("Delete", role: .destructive, action: onDelete)
         }


### PR DESCRIPTION
## Summary
- Rewrite memory card rows with colored accent bar indicating memory kind
- Replace redundant statement text with inline metadata (kind tag, confidence, source)
- Show subject in Instrument Serif (brandMini) with relative timestamp
- Hide delete button behind hover state, keep context menu fallback
- Add importance dots (1-3) and kind-colored background tinting

Part of plan: memories-ui-redesign.md (PR 5 of 11)