### PR TITLE
feat: add procedural/skill banner and heuristic related memories to detail view

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -115,7 +115,10 @@ struct MemoriesPanel: View {
                     MemoryItemDetailSheet(
                         item: item,
                         store: store,
-                        onDismiss: { withAnimation(VAnimation.fast) { selectedItem = nil } }
+                        onDismiss: { withAnimation(VAnimation.fast) { selectedItem = nil } },
+                        onNavigate: { newItem in
+                            withAnimation(VAnimation.fast) { selectedItem = newItem }
+                        }
                     )
                     .id(selectedItem?.id)
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet+Content.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet+Content.swift
@@ -7,6 +7,21 @@ extension MemoryItemDetailSheet {
 
     @ViewBuilder
     var viewModeContent: some View {
+        // Skill/procedural banner
+        if displayItem.kind == MemoryKind.procedural.rawValue {
+            HStack(spacing: VSpacing.sm) {
+                VIconView(.zap, size: 14)
+                    .foregroundStyle(VColor.funRed)
+                Text("Capability — not a personal memory")
+                    .font(VFont.bodySmallEmphasised)
+                    .foregroundStyle(VColor.funRed)
+            }
+            .padding(VSpacing.sm)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(VColor.funRed.opacity(0.08))
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+        }
+
         // Statement — no label, the VModal title already shows the subject
         Text(displayItem.statement)
             .font(VFont.bodyMediumLighter)
@@ -91,6 +106,58 @@ extension MemoryItemDetailSheet {
                 }
             }
         }
+
+        // Possibly Related section
+        let related = relatedItems
+        if !related.isEmpty {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Possibly Related")
+                    .font(VFont.bodySmallEmphasised)
+                    .foregroundStyle(VColor.contentTertiary)
+                ForEach(related) { relatedItem in
+                    Button {
+                        onNavigate?(relatedItem)
+                    } label: {
+                        HStack(spacing: VSpacing.sm) {
+                            Circle()
+                                .fill(MemoryKind(rawValue: relatedItem.kind)?.color ?? VColor.contentTertiary)
+                                .frame(width: 6, height: 6)
+                            Text(relatedItem.subject)
+                                .font(VFont.bodySmallDefault)
+                                .foregroundStyle(VColor.contentSecondary)
+                                .lineLimit(1)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    private var relatedItems: [MemoryItemPayload] {
+        let stopWords: Set<String> = ["the", "and", "that", "this", "with", "from", "have", "been", "was", "were", "are", "for", "not"]
+        let words = Set(
+            displayItem.subject
+                .lowercased()
+                .split(separator: " ")
+                .map(String.init)
+                .filter { $0.count > 3 && !stopWords.contains($0) }
+        )
+        guard !words.isEmpty else { return [] }
+
+        return store.items
+            .filter { $0.id != displayItem.id && $0.kind == displayItem.kind }
+            .filter { candidate in
+                let candidateWords = Set(
+                    candidate.subject.lowercased()
+                        .split(separator: " ")
+                        .map(String.init)
+                        .filter { $0.count > 3 && !stopWords.contains($0) }
+                )
+                return !words.isDisjoint(with: candidateWords)
+            }
+            .prefix(3)
+            .map { $0 }
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet.swift
@@ -5,6 +5,7 @@ struct MemoryItemDetailSheet: View {
     let item: MemoryItemPayload
     let store: MemoryItemsStore
     let onDismiss: () -> Void
+    let onNavigate: ((MemoryItemPayload) -> Void)?
 
     @State var isEditing = false
     @State var editSubject: String
@@ -22,10 +23,11 @@ struct MemoryItemDetailSheet: View {
     /// The item with full detail (supersession subjects resolved), falling back to the list item.
     var displayItem: MemoryItemPayload { detailItem ?? item }
 
-    init(item: MemoryItemPayload, store: MemoryItemsStore, onDismiss: @escaping () -> Void) {
+    init(item: MemoryItemPayload, store: MemoryItemsStore, onDismiss: @escaping () -> Void, onNavigate: ((MemoryItemPayload) -> Void)? = nil) {
         self.item = item
         self.store = store
         self.onDismiss = onDismiss
+        self.onNavigate = onNavigate
         _editSubject = State(initialValue: item.subject)
         _editStatement = State(initialValue: item.statement)
         _editKind = State(initialValue: item.kind)


### PR DESCRIPTION
## Summary
- Show red-tinted banner for procedural/skill memories to distinguish from personal memories
- Add Possibly Related section at bottom of detail view using subject word overlap heuristic
- Related items are clickable and navigate to the selected memory
- Add onNavigate callback to MemoryItemDetailSheet for related item navigation

Part of plan: memories-ui-redesign.md (PR 8 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
