### PR TITLE
fix: sort imports in workspace migration 028

### DIFF
--- a/assistant/src/workspace/migrations/028-recover-conversations-from-disk-view.ts
+++ b/assistant/src/workspace/migrations/028-recover-conversations-from-disk-view.ts
@@ -10,9 +10,9 @@
  * Malformed files are skipped with warnings — they do not crash the migration.
  */
 
+import { randomUUID } from "node:crypto";
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
-import { randomUUID } from "node:crypto";
 
 import { eq } from "drizzle-orm";
 


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error in `028-recover-conversations-from-disk-view.ts` by sorting `node:crypto` before `node:fs` and `node:path`

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23881839420/job/69636460425
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
