### PR TITLE
fix: update stale vbundle importer comments to mention data/db/

### DIFF
--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -171,7 +171,7 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
   // Step 1b: Clear the workspace directory before restore if the bundle
   // contains new-format workspace/ entries. This ensures an exact-match
   // restore with no stale files left behind. Skips embedding-models/ and
-  // data/qdrant/ (large, regenerable).
+  // data/qdrant/ & data/db/ (large, regenerable).
   //
   // Only new-format bundles (workspace/ prefix) trigger clearing. Old-format
   // bundles (skills/, hooks/, data/db/*, config/*) wrote specific files
@@ -195,7 +195,7 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
 
         const entryPath = join(workspaceDir, entry.name);
         if (entry.name === "data" && entry.isDirectory()) {
-          // Inside data/, preserve qdrant/ but clear everything else
+          // Inside data/, preserve qdrant/ and db/ but clear everything else
           const dataEntries = readdirSync(entryPath, { withFileTypes: true });
           for (const dataEntry of dataEntries) {
             if (DATA_SKIP_DIRS.has(dataEntry.name)) continue;


### PR DESCRIPTION
## Summary
- Update two comments in vbundle-importer.ts that still only mentioned qdrant/ after db/ was added to DATA_SKIP_DIRS

Fixes gap from plan review for recover-db-from-disk-view.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
