### PR TITLE
feat: replace centered overlay modal with inline side detail panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -1,4 +1,3 @@
-import AppKit
 import SwiftUI
 import VellumAssistantShared
 
@@ -78,7 +77,6 @@ struct MemoriesPanel: View {
     @State private var statusFilter: MemoryStatusFilter = .active
     @State private var sortOption: MemorySortOption = .newest
     @State private var searchDebounceTask: Task<Void, Never>?
-    @State private var escapeMonitor: Any?
 
     init(connectionManager: GatewayConnectionManager, focusedMemoryId: Binding<String?> = .constant(nil)) {
         self.connectionManager = connectionManager
@@ -136,7 +134,36 @@ struct MemoriesPanel: View {
             HStack(alignment: .top, spacing: VSpacing.xxl) {
                 kindSidebar
                     .frame(width: 220)
-                contentView
+
+                HStack(spacing: 0) {
+                    // Memory list — takes remaining width
+                    listContent
+                        .frame(maxWidth: .infinity)
+
+                    // Side detail panel — slides in from right
+                    if let item = selectedItem {
+                        Divider()
+                        ScrollView {
+                            MemoryItemDetailSheet(
+                                item: item,
+                                store: store,
+                                onDismiss: { withAnimation(VAnimation.panel) { selectedItem = nil } },
+                                onNavigate: { newItem in
+                                    withAnimation(VAnimation.fast) { selectedItem = newItem }
+                                }
+                            )
+                            .id(item.id)
+                        }
+                        .frame(width: 400)
+                        .scrollContentBackground(.hidden)
+                        .transition(.move(edge: .trailing).combined(with: .opacity))
+                        .onKeyPress(.escape) {
+                            withAnimation(VAnimation.panel) { selectedItem = nil }
+                            return .handled
+                        }
+                    }
+                }
+                .animation(VAnimation.panel, value: selectedItem?.id)
             }
             .padding(.top, VSpacing.lg)
         }
@@ -144,37 +171,13 @@ struct MemoriesPanel: View {
         .task(id: focusedMemoryId) {
             guard let memoryId = focusedMemoryId else { return }
             if let item = await store.fetchDetail(id: memoryId) {
-                withAnimation(VAnimation.fast) { selectedItem = item }
+                withAnimation(VAnimation.panel) { selectedItem = item }
             }
             focusedMemoryId = nil
         }
         .onDisappear {
             searchDebounceTask?.cancel()
             searchDebounceTask = nil
-        }
-        .overlay {
-            if let item = selectedItem {
-                ZStack {
-                    VColor.auxBlack.opacity(0.4)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .contentShape(Rectangle())
-                        .onTapGesture {
-                            withAnimation(VAnimation.fast) { selectedItem = nil }
-                        }
-                    MemoryItemDetailSheet(
-                        item: item,
-                        store: store,
-                        onDismiss: { withAnimation(VAnimation.fast) { selectedItem = nil } },
-                        onNavigate: { newItem in
-                            withAnimation(VAnimation.fast) { selectedItem = newItem }
-                        }
-                    )
-                    .id(selectedItem?.id)
-                }
-                .transition(.opacity)
-                .onAppear { installEscapeMonitor() }
-                .onDisappear { removeEscapeMonitor() }
-            }
         }
         .sheet(isPresented: $showCreateSheet) {
             MemoryItemCreateSheet(
@@ -281,27 +284,10 @@ struct MemoriesPanel: View {
         .clipShape(Capsule())
     }
 
-    // MARK: - Escape Key
-
-    private func installEscapeMonitor() {
-        escapeMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-            guard event.keyCode == 53 else { return event } // 53 = Escape
-            withAnimation(VAnimation.fast) { selectedItem = nil }
-            return nil
-        }
-    }
-
-    private func removeEscapeMonitor() {
-        if let monitor = escapeMonitor {
-            NSEvent.removeMonitor(monitor)
-            escapeMonitor = nil
-        }
-    }
-
-    // MARK: - Content View
+    // MARK: - List Content
 
     @ViewBuilder
-    private var contentView: some View {
+    private var listContent: some View {
         if store.isLoading && store.items.isEmpty {
             VStack {
                 Spacer()
@@ -323,7 +309,7 @@ struct MemoriesPanel: View {
                     ForEach(store.items) { item in
                         MemoryItemRow(
                             item: item,
-                            onSelect: { withAnimation(VAnimation.fast) { selectedItem = item } },
+                            onSelect: { withAnimation(VAnimation.panel) { selectedItem = item } },
                             onDelete: {
                                 Task { _ = await store.deleteItem(id: item.id) }
                             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet.swift
@@ -77,13 +77,6 @@ struct MemoryItemDetailSheet: View {
                             save()
                         }
                     } else {
-                        VButton(
-                            label: "Delete",
-                            leftIcon: VIcon.trash.rawValue,
-                            style: .dangerOutline
-                        ) {
-                            showDeleteConfirm = true
-                        }
                         Spacer()
                         VButton(label: "Close", style: .outlined) {
                             onDismiss()
@@ -105,7 +98,20 @@ struct MemoryItemDetailSheet: View {
                 }
             }
         }
-        .frame(width: 480, height: 520)
+        .overlay(alignment: .topTrailing) {
+            if !isEditing {
+                Menu {
+                    Button("Delete", role: .destructive) { showDeleteConfirm = true }
+                } label: {
+                    VIconView(.ellipsis, size: 14)
+                        .foregroundStyle(VColor.contentTertiary)
+                        .padding(VSpacing.sm)
+                }
+                .buttonStyle(.plain)
+                .padding(.top, VSpacing.md)
+                .padding(.trailing, VSpacing.md)
+            }
+        }
         .alert("Delete this memory?", isPresented: $showDeleteConfirm) {
             Button("Cancel", role: .cancel) {}
             Button("Delete", role: .destructive) {


### PR DESCRIPTION
## Summary
- Replace centered overlay modal with inline side panel (400pt) that slides in from the right
- Memory list remains visible and scrollable alongside the detail panel
- Move delete action to a ... menu in the panel header for safer placement
- Remove escape key monitor in favor of Close button / keyboard handling

Part of plan: memories-ui-redesign.md (PR 10 of 11)