### PR TITLE
feat: add compact list view mode with dense single-line memory rows

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -77,6 +77,19 @@ struct MemoriesPanel: View {
     @State private var statusFilter: MemoryStatusFilter = .active
     @State private var sortOption: MemorySortOption = .newest
     @State private var searchDebounceTask: Task<Void, Never>?
+    @State private var viewMode: MemoryViewMode = .cards
+
+    private enum MemoryViewMode: String, CaseIterable {
+        case cards = "Cards"
+        case compact = "Compact"
+
+        var icon: String {
+            switch self {
+            case .cards: return VIcon.layoutGrid.rawValue
+            case .compact: return VIcon.list.rawValue
+            }
+        }
+    }
 
     init(connectionManager: GatewayConnectionManager, focusedMemoryId: Binding<String?> = .constant(nil)) {
         self.connectionManager = connectionManager
@@ -224,6 +237,13 @@ struct MemoriesPanel: View {
                 }
             )
 
+            VTabs(
+                items: MemoryViewMode.allCases.map { (label: $0.rawValue, icon: $0.icon, tag: $0) },
+                selection: $viewMode,
+                style: .pill,
+                size: .compact
+            )
+
             VButton(label: "New", icon: VIcon.plus.rawValue, style: .primary) {
                 showCreateSheet = true
             }
@@ -306,14 +326,25 @@ struct MemoriesPanel: View {
         } else {
             ScrollView {
                 LazyVStack(spacing: VSpacing.sm) {
-                    ForEach(store.items) { item in
-                        MemoryItemRow(
-                            item: item,
-                            onSelect: { withAnimation(VAnimation.panel) { selectedItem = item } },
-                            onDelete: {
-                                Task { _ = await store.deleteItem(id: item.id) }
-                            }
-                        )
+                    switch viewMode {
+                    case .cards:
+                        ForEach(store.items) { item in
+                            MemoryItemRow(
+                                item: item,
+                                onSelect: { withAnimation(VAnimation.panel) { selectedItem = item } },
+                                onDelete: {
+                                    Task { _ = await store.deleteItem(id: item.id) }
+                                }
+                            )
+                        }
+                    case .compact:
+                        ForEach(store.items) { item in
+                            MemoryItemCompactRow(
+                                item: item,
+                                isSelected: selectedItem?.id == item.id,
+                                onSelect: { withAnimation(VAnimation.panel) { selectedItem = item } }
+                            )
+                        }
                     }
                     if store.hasMore {
                         VLoadingIndicator()

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemCompactRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemCompactRow.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Dense single-line memory row for compact browse mode.
+struct MemoryItemCompactRow: View {
+    let item: MemoryItemPayload
+    let isSelected: Bool
+    let onSelect: () -> Void
+
+    @State private var isHovered = false
+
+    private var memoryKind: MemoryKind? {
+        MemoryKind(rawValue: item.kind)
+    }
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(spacing: VSpacing.sm) {
+                Circle()
+                    .fill(memoryKind?.color ?? VColor.contentTertiary)
+                    .frame(width: 8, height: 8)
+
+                Text(item.subject)
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(isSelected ? VColor.contentEmphasized : VColor.contentDefault)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                Spacer()
+
+                Text(item.relativeLastSeen)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.xs)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.sm)
+                    .fill(isSelected
+                        ? (memoryKind?.backgroundTint ?? VColor.surfaceActive)
+                        : (isHovered ? VColor.surfaceBase : Color.clear))
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+        .contextMenu {
+            Button("Delete", role: .destructive) {
+                // Deletion handled by parent
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add Cards/Compact view mode toggle (pill tabs) in the filter bar
- Create MemoryItemCompactRow: dense single-line rows with kind dot, subject, and timestamp
- Selected compact row highlights with kind-colored background tint
- Both modes use the same side detail panel and pagination

Part of plan: memories-ui-redesign.md (PR 11 of 11)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
