### PR TITLE
Add cursor position tracking and text replacement proxy to ComposerTextEditor

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
@@ -3,6 +3,13 @@ import AppKit
 import SwiftUI
 import VellumAssistantShared
 
+/// Proxy object that allows callers to programmatically replace text
+/// in the composer's underlying NSTextView. Uses `insertText(_:replacementRange:)`
+/// so replacements participate in the undo stack.
+final class TextReplacementProxy {
+    var replaceText: ((NSRange, String) -> Void)?
+}
+
 /// NSScrollView subclass that reports intrinsic content size based on
 /// its document view's text layout height. This lets SwiftUI size the
 /// view correctly without the scroll view expanding to fill all
@@ -55,6 +62,8 @@ struct ComposerTextEditor: NSViewRepresentable {
     var onDownArrow: (() -> Bool)? = nil
     var onEscape: (() -> Bool)? = nil
     var onPasteImage: (() -> Void)? = nil
+    @Binding var cursorPosition: Int
+    var textReplacer: TextReplacementProxy? = nil
 
     func makeCoordinator() -> Coordinator {
         Coordinator(parent: self)
@@ -86,6 +95,7 @@ struct ComposerTextEditor: NSViewRepresentable {
         layoutManager.addTextContainer(textContainer)
 
         let textView = ComposerTextView(frame: .zero, textContainer: textContainer)
+        context.coordinator.textView = textView
         textView.isRichText = false
         textView.importsGraphics = false
         textView.drawsBackground = false
@@ -121,6 +131,12 @@ struct ComposerTextEditor: NSViewRepresentable {
         scrollView.contentHeight = minHeight
         scrollView.documentView = textView
         textView.delegate = context.coordinator
+
+        if let proxy = textReplacer {
+            proxy.replaceText = { [weak textView] range, replacement in
+                textView?.insertText(replacement, replacementRange: range)
+            }
+        }
 
         let coordinator = context.coordinator
 
@@ -207,6 +223,12 @@ struct ComposerTextEditor: NSViewRepresentable {
             coordinator.parent.isFocused = focused
         }
 
+        if let proxy = textReplacer {
+            proxy.replaceText = { [weak textView] range, replacement in
+                textView?.insertText(replacement, replacementRange: range)
+            }
+        }
+
         // Re-strip drag types in case TextKit re-registered them during
         // font or attribute updates above.
         textView.unregisterDraggedTypes()
@@ -245,6 +267,7 @@ struct ComposerTextEditor: NSViewRepresentable {
         var lastAppliedFont: NSFont?
         var lastAppliedLineSpacing: CGFloat?
         var lastAppliedTextColor: NSColor?
+        weak var textView: ComposerTextView?
 
         init(parent: ComposerTextEditor) {
             self.parent = parent
@@ -255,6 +278,10 @@ struct ComposerTextEditor: NSViewRepresentable {
             let newText = textView.string
             if parent.text != newText {
                 parent.text = newText
+            }
+            let pos = textView.selectedRange().location
+            if parent.cursorPosition != pos {
+                parent.cursorPosition = pos
             }
             measureHeight(textView)
         }
@@ -272,6 +299,14 @@ struct ComposerTextEditor: NSViewRepresentable {
         func textDidEndEditing(_ notification: Notification) {
             if parent.isFocused {
                 parent.isFocused = false
+            }
+        }
+
+        func textViewDidChangeSelection(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView else { return }
+            let pos = textView.selectedRange().location
+            if parent.cursorPosition != pos {
+                parent.cursorPosition = pos
             }
         }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -74,6 +74,7 @@ struct ComposerView: View {
     @State private var isComposerFocused = false
     @State private var measuredTextHeight: CGFloat = 32
     @State private var textViewIsFocused: Bool = false
+    @State private var cursorPosition: Int = 0
 
     @State var showSlashMenu = false
     @State var slashFilter = ""
@@ -249,7 +250,8 @@ struct ComposerView: View {
                     if showSlashMenu { handleSlashNavigation(.dismiss); return true }
                     return false
                 },
-                onPasteImage: onPaste
+                onPasteImage: onPaste,
+                cursorPosition: $cursorPosition
             )
             .fixedSize(horizontal: false, vertical: true)
             // Prevent inherited .animation() modifiers from creating animation


### PR DESCRIPTION
## Summary
- Add TextReplacementProxy class for programmatic text replacement preserving undo history
- Add cursorPosition binding to ComposerTextEditor with textViewDidChangeSelection tracking
- Wire cursor position state in ComposerView for emoji picker consumption in PR 3

Part of plan: emoji-picker.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
