### PR TITLE
fix: wire onDelete callback in MemoryItemCompactRow context menu

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -342,7 +342,10 @@ struct MemoriesPanel: View {
                             MemoryItemCompactRow(
                                 item: item,
                                 isSelected: selectedItem?.id == item.id,
-                                onSelect: { withAnimation(VAnimation.panel) { selectedItem = item } }
+                                onSelect: { withAnimation(VAnimation.panel) { selectedItem = item } },
+                                onDelete: {
+                                    Task { _ = await store.deleteItem(id: item.id) }
+                                }
                             )
                         }
                     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemCompactRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemCompactRow.swift
@@ -6,6 +6,7 @@ struct MemoryItemCompactRow: View {
     let item: MemoryItemPayload
     let isSelected: Bool
     let onSelect: () -> Void
+    let onDelete: () -> Void
 
     @State private var isHovered = false
 
@@ -46,7 +47,7 @@ struct MemoryItemCompactRow: View {
         .onHover { isHovered = $0 }
         .contextMenu {
             Button("Delete", role: .destructive) {
-                // Deletion handled by parent
+                onDelete()
             }
         }
     }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for memories-ui-redesign.md.

**Gap:** Compact row delete context menu is non-functional
**What was expected:** Working delete action in compact mode context menu
**What was found:** Empty action body with no onDelete callback parameter