### PR TITLE
fix: remove redundant outer ScrollView wrapper around detail panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -156,19 +156,16 @@ struct MemoriesPanel: View {
                     // Side detail panel — slides in from right
                     if let item = selectedItem {
                         Divider()
-                        ScrollView {
-                            MemoryItemDetailSheet(
-                                item: item,
-                                store: store,
-                                onDismiss: { withAnimation(VAnimation.panel) { selectedItem = nil } },
-                                onNavigate: { newItem in
-                                    withAnimation(VAnimation.fast) { selectedItem = newItem }
-                                }
-                            )
-                            .id(item.id)
-                        }
-                        .frame(width: 400)
-                        .scrollContentBackground(.hidden)
+                        MemoryItemDetailSheet(
+                            item: item,
+                            store: store,
+                            onDismiss: { withAnimation(VAnimation.panel) { selectedItem = nil } },
+                            onNavigate: { newItem in
+                                withAnimation(VAnimation.fast) { selectedItem = newItem }
+                            }
+                        )
+                        .id(item.id)
+                        .frame(width: 400, maxHeight: .infinity)
                         .transition(.move(edge: .trailing).combined(with: .opacity))
                         .onKeyPress(.escape) {
                             withAnimation(VAnimation.panel) { selectedItem = nil }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for memories-ui-redesign.md.

**Gap:** Nested ScrollView in side detail panel
**What was expected:** Single scroll container for detail panel content
**What was found:** Outer ScrollView wrapping MemoryItemDetailSheet which already uses VModal with its own internal ScrollView
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
