### PR TITLE
Add emoji picker popup with colon-trigger detection and keyboard navigation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerEmojiPicker.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerEmojiPicker.swift
@@ -1,0 +1,159 @@
+import SwiftUI
+import VellumAssistantShared
+#if os(macOS)
+import AppKit
+
+// MARK: - Emoji Navigation
+
+enum EmojiNavigation {
+    case up, down, select, tab, dismiss
+}
+
+// MARK: - Emoji Picker Logic (ComposerView extension)
+
+extension ComposerView {
+
+    /// Walks backward from `cursorPosition` through `inputText` to find an
+    /// unmatched `:` followed by 2+ alphanumeric/underscore characters.
+    /// Returns nil if no valid trigger is found.
+    func emojiTriggerRange() -> (colonIndex: String.Index, filter: String)? {
+        guard !showSlashMenu else { return nil }
+        guard cursorPosition > 0, cursorPosition <= inputText.count else { return nil }
+
+        let cursorIdx = inputText.index(inputText.startIndex, offsetBy: cursorPosition)
+        var idx = cursorIdx
+
+        // Walk backward looking for the triggering `:`
+        while idx > inputText.startIndex {
+            idx = inputText.index(before: idx)
+            let ch = inputText[idx]
+
+            if ch == ":" {
+                // Found the colon — extract the filter between colon and cursor
+                let afterColon = inputText.index(after: idx)
+                let filter = String(inputText[afterColon..<cursorIdx])
+
+                // Must have at least 2 characters after the colon
+                guard filter.count >= 2 else { return nil }
+
+                return (colonIndex: idx, filter: filter)
+            }
+
+            // Only allow alphanumeric characters and underscores between `:` and cursor
+            if ch.isWhitespace || (!ch.isLetter && !ch.isNumber && ch != "_") {
+                return nil
+            }
+        }
+
+        return nil
+    }
+
+    func updateEmojiState() {
+        if let trigger = emojiTriggerRange() {
+            let results = EmojiCatalog.search(prefix: trigger.filter)
+            if !results.isEmpty {
+                withAnimation(VAnimation.fast) { showEmojiMenu = true }
+                if emojiFilter != trigger.filter {
+                    emojiSelectedIndex = 0
+                }
+                emojiFilter = trigger.filter
+            } else {
+                withAnimation(VAnimation.fast) { showEmojiMenu = false }
+            }
+        } else {
+            withAnimation(VAnimation.fast) { showEmojiMenu = false }
+        }
+    }
+
+    func filteredEmoji(_ filter: String) -> [EmojiEntry] {
+        EmojiCatalog.search(prefix: filter, limit: 8)
+    }
+
+    func selectEmoji(_ entry: EmojiEntry) {
+        guard let trigger = emojiTriggerRange() else { return }
+
+        let colonOffset = inputText.distance(from: inputText.startIndex, to: trigger.colonIndex)
+        let length = cursorPosition - colonOffset
+        let nsRange = NSRange(location: colonOffset, length: length)
+
+        textReplacer.replaceText?(nsRange, entry.emoji)
+
+        withAnimation(VAnimation.fast) { showEmojiMenu = false }
+        emojiSelectedIndex = 0
+    }
+
+    func handleEmojiNavigation(_ action: EmojiNavigation) {
+        if showEmojiMenu {
+            let filtered = filteredEmoji(emojiFilter)
+            guard !filtered.isEmpty else { return }
+            switch action {
+            case .up:
+                emojiSelectedIndex = (emojiSelectedIndex - 1 + filtered.count) % filtered.count
+            case .down:
+                emojiSelectedIndex = (emojiSelectedIndex + 1) % filtered.count
+            case .select:
+                selectEmoji(filtered[emojiSelectedIndex])
+            case .tab:
+                selectEmoji(filtered[emojiSelectedIndex])
+            case .dismiss:
+                withAnimation(VAnimation.fast) { showEmojiMenu = false }
+            }
+        }
+    }
+}
+
+// MARK: - Emoji Picker Popup
+
+struct EmojiPickerPopup: View {
+    let entries: [EmojiEntry]
+    let selectedIndex: Int
+    let onSelect: (EmojiEntry) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(Array(entries.enumerated()), id: \.element.id) { index, entry in
+                EmojiPickerRow(
+                    entry: entry,
+                    isSelected: index == selectedIndex,
+                    onSelect: { onSelect(entry) }
+                )
+            }
+        }
+        .padding(.vertical, VSpacing.xs)
+        .background(VColor.surfaceBase)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .overlay(RoundedRectangle(cornerRadius: VRadius.lg)
+            .stroke(VColor.borderBase, lineWidth: 1))
+        .shadow(color: VColor.auxBlack.opacity(0.3), radius: 12, y: -4)
+    }
+}
+
+// MARK: - Emoji Picker Row
+
+struct EmojiPickerRow: View {
+    let entry: EmojiEntry
+    let isSelected: Bool
+    let onSelect: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(spacing: VSpacing.md) {
+                Text(entry.emoji)
+                    .font(.system(size: 20))
+                Text(":\(entry.shortcode):")
+                    .font(VFont.bodyMediumEmphasised)
+                    .foregroundStyle(VColor.contentDefault)
+                Spacer()
+            }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.sm)
+            .background(isSelected || isHovered ? VColor.contentEmphasized.opacity(0.06) : Color.clear)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in isHovered = hovering }
+        .pointerCursor()
+    }
+}
+#endif

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -80,6 +80,10 @@ struct ComposerView: View {
     @State var slashFilter = ""
     @State var slashSelectedIndex = 0
     @State var suppressSlashReopen = false
+    @State var showEmojiMenu = false
+    @State var emojiFilter = ""
+    @State var emojiSelectedIndex = 0
+    @State private var textReplacer = TextReplacementProxy()
     /// Snapshot of inputText captured when dictation starts, used to restore on cancel.
     @State private var preDictationText: String = ""
     /// Live amplitude from VoiceInputManager, bypassing ChatViewModel's 100ms coalescing.
@@ -110,6 +114,15 @@ struct ComposerView: View {
                 .transition(.opacity.combined(with: .move(edge: .bottom)))
             }
 
+            if showEmojiMenu {
+                EmojiPickerPopup(
+                    entries: filteredEmoji(emojiFilter),
+                    selectedIndex: emojiSelectedIndex,
+                    onSelect: { entry in selectEmoji(entry) }
+                )
+                .transition(.opacity.combined(with: .move(edge: .bottom)))
+            }
+
             // Composer box — switches on the three-mode state machine
             switch currentMode {
             case .voiceConversation:
@@ -129,6 +142,7 @@ struct ComposerView: View {
         #endif
         .fixedSize(horizontal: false, vertical: true)
         .animation(VAnimation.fast, value: showSlashMenu)
+        .animation(VAnimation.fast, value: showEmojiMenu)
         .padding(.horizontal, VSpacing.lg)
         .padding(.top, VSpacing.sm)
         .frame(maxWidth: VSpacing.chatColumnMaxWidth)
@@ -165,6 +179,7 @@ struct ComposerView: View {
             } else if !enabled {
                 composerFocus = false
                 showSlashMenu = false
+                showEmojiMenu = false
                 suppressSlashReopen = false
             }
         }
@@ -235,23 +250,28 @@ struct ComposerView: View {
                 onSubmit: { performSendAction() },
                 onTab: {
                     if showSlashMenu { handleSlashNavigation(.tab); return true }
+                    if showEmojiMenu { handleEmojiNavigation(.tab); return true }
                     if ghostSuffix != nil { onAcceptSuggestion(); return true }
                     return false
                 },
                 onUpArrow: {
                     if showSlashMenu { handleSlashNavigation(.up); return true }
+                    if showEmojiMenu { handleEmojiNavigation(.up); return true }
                     return false
                 },
                 onDownArrow: {
                     if showSlashMenu { handleSlashNavigation(.down); return true }
+                    if showEmojiMenu { handleEmojiNavigation(.down); return true }
                     return false
                 },
                 onEscape: {
                     if showSlashMenu { handleSlashNavigation(.dismiss); return true }
+                    if showEmojiMenu { handleEmojiNavigation(.dismiss); return true }
                     return false
                 },
                 onPasteImage: onPaste,
-                cursorPosition: $cursorPosition
+                cursorPosition: $cursorPosition,
+                textReplacer: textReplacer
             )
             .fixedSize(horizontal: false, vertical: true)
             // Prevent inherited .animation() modifiers from creating animation
@@ -302,9 +322,15 @@ struct ComposerView: View {
         }
         .onChange(of: inputText) {
             if inputText.isEmpty {
-                withAnimation(VAnimation.fast) { showSlashMenu = false }
+                withAnimation(VAnimation.fast) { showSlashMenu = false; showEmojiMenu = false }
             } else {
                 updateSlashState()
+                updateEmojiState()
+            }
+        }
+        .onChange(of: cursorPosition) {
+            if !inputText.isEmpty {
+                updateEmojiState()
             }
         }
     }
@@ -317,6 +343,9 @@ struct ComposerView: View {
         if showSlashMenu {
             sendPath = "slashSelection"
             handleSlashNavigation(.select)
+        } else if showEmojiMenu {
+            sendPath = "emojiSelection"
+            handleEmojiNavigation(.select)
         } else if canSend {
             sendPath = "normalSend"
             onSend()

--- a/clients/macos/vellum-assistantTests/ComposerEmojiPickerTests.swift
+++ b/clients/macos/vellum-assistantTests/ComposerEmojiPickerTests.swift
@@ -1,0 +1,37 @@
+#if os(macOS)
+import XCTest
+@testable import VellumAssistantLib
+import VellumAssistantShared
+
+final class ComposerEmojiPickerTests: XCTestCase {
+
+    func testEmojiCatalogSearchReturnsResultsForCommonPrefixes() {
+        let results = EmojiCatalog.search(prefix: "thu")
+        XCTAssertFalse(results.isEmpty, "Expected results for prefix 'thu'")
+        for entry in results {
+            XCTAssertTrue(
+                entry.shortcode.hasPrefix("thu"),
+                "Expected shortcode '\(entry.shortcode)' to start with 'thu'"
+            )
+        }
+    }
+
+    func testEmojiCatalogSearchCapsAtEightByDefault() {
+        let results = EmojiCatalog.search(prefix: "s")
+        XCTAssertLessThanOrEqual(results.count, 8, "Default limit should cap results at 8")
+    }
+
+    func testEmojiPickerRowRendersEmojiAndShortcode() {
+        let entry = EmojiEntry(shortcode: "thumbsup", emoji: "\u{1F44D}")
+        let row = EmojiPickerRow(
+            entry: entry,
+            isSelected: false,
+            onSelect: {}
+        )
+        // Verify the view can be instantiated without errors
+        XCTAssertNotNil(row)
+        XCTAssertEqual(row.entry.shortcode, "thumbsup")
+        XCTAssertEqual(row.entry.emoji, "\u{1F44D}")
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Add ComposerEmojiPicker with Slack-style colon-trigger detection, keyboard navigation, and popup views
- Integrate emoji picker into ComposerView with state management, keyboard callbacks, and text replacement
- Add tests for emoji catalog search integration and picker row rendering

Part of plan: emoji-picker.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
