### PR TITLE
fix: remove Velissa reference from retriever comment

### DIFF
--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -564,7 +564,7 @@ export async function loadContextMemory(
 
   // 6. Reserve slots for recent prospective nodes (commitments, tasks, plans).
   //    These MUST surface at conversation start regardless of score — if the user
-  //    said "I have a doctor appointment tomorrow," Velissa must remember it.
+  //    said "I have a doctor appointment tomorrow," the assistant must remember it.
   const PROSPECTIVE_RESERVE = 10;
   const recentProspective = queryNodes({
     scopeId: opts.scopeId,


### PR DESCRIPTION
## Summary
- Replaced hardcoded "Velissa" with generic "the assistant" in a code comment in the memory graph retriever

## Original prompt
Remove this reference to Velissa from the codebase:
```
src/memory/graph/retriever.ts
567:  //    said "I have a doctor appointment tomorrow," Velissa must remember it.
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
