### PR TITLE
fix: split .frame() call to fix macOS CI build

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -165,7 +165,8 @@ struct MemoriesPanel: View {
                             }
                         )
                         .id(item.id)
-                        .frame(width: 400, maxHeight: .infinity)
+                        .frame(width: 400)
+                        .frame(maxHeight: .infinity)
                         .transition(.move(edge: .trailing).combined(with: .opacity))
                         .onKeyPress(.escape) {
                             withAnimation(VAnimation.panel) { selectedItem = nil }


### PR DESCRIPTION
## Summary
- Split `.frame(width: 400, maxHeight: .infinity)` into `.frame(width: 400).frame(maxHeight: .infinity)` in MemoriesPanel.swift
- The combined call mixed parameters from two different SwiftUI `.frame()` overloads, causing "extra argument 'width' in call" on CI

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23882400300/job/69638182123
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
