### PR TITLE
fix: remove private access level from emoji picker dependencies

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -74,7 +74,7 @@ struct ComposerView: View {
     @State private var isComposerFocused = false
     @State private var measuredTextHeight: CGFloat = 32
     @State private var textViewIsFocused: Bool = false
-    @State private var cursorPosition: Int = 0
+    @State var cursorPosition: Int = 0
 
     @State var showSlashMenu = false
     @State var slashFilter = ""
@@ -83,7 +83,7 @@ struct ComposerView: View {
     @State var showEmojiMenu = false
     @State var emojiFilter = ""
     @State var emojiSelectedIndex = 0
-    @State private var textReplacer = TextReplacementProxy()
+    @State var textReplacer = TextReplacementProxy()
     /// Snapshot of inputText captured when dictation starts, used to restore on cancel.
     @State private var preDictationText: String = ""
     /// Live amplitude from VoiceInputManager, bypassing ChatViewModel's 100ms coalescing.


### PR DESCRIPTION
## Summary
- Remove `private` from `cursorPosition` and `textReplacer` in `ComposerView.swift` so the `ComposerEmojiPicker.swift` extension can access them
- These properties were made private in recent changes but are accessed from a file-external extension, causing Swift compilation errors in CI

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23882712762/job/69639075488