### PR TITLE
feat: pass active context node IDs from conversation tracker to extraction job

### DIFF
--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -151,6 +151,8 @@ export interface DisposeContext extends AbortContext {
   lastSurfaceAction: Map<string, unknown>;
   workspaceTopLevelContext: string | null;
   trustContext?: { trustClass: TrustClass };
+  /** Active memory node IDs snapshotted from the conversation's InContextTracker before disposal. */
+  activeContextNodeIds?: string[];
   abort(): void;
 }
 
@@ -309,6 +311,9 @@ export function disposeConversation(ctx: DisposeContext): void {
     try {
       enqueueMemoryJob("graph_extract", {
         conversationId: ctx.conversationId,
+        ...(ctx.activeContextNodeIds?.length
+          ? { activeContextNodeIds: ctx.activeContextNodeIds }
+          : {}),
       });
     } catch {
       // Best-effort — don't block conversation disposal

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -248,6 +248,7 @@ export class Conversation {
   public readonly hasSystemPromptOverride: boolean;
   public memoryPolicy: ConversationMemoryPolicy;
   /** @internal */ readonly graphMemory: ConversationGraphMemory;
+  /** @internal */ activeContextNodeIds?: string[];
   /** @internal */ streamThinking: boolean;
   /** @internal */ turnCount = 0;
   public lastAssistantAttachments: AssistantAttachmentDraft[] = [];
@@ -564,6 +565,7 @@ export class Conversation {
     // CES client is owned by DaemonServer — just drop the reference.
     // Do NOT close it here; the server manages the CES lifecycle.
     this.cesClient = undefined;
+    this.activeContextNodeIds = this.graphMemory.tracker.getActiveNodeIds();
     disposeConversation(this);
   }
 

--- a/assistant/src/memory/graph/extraction-job.ts
+++ b/assistant/src/memory/graph/extraction-job.ts
@@ -40,9 +40,14 @@ export async function graphExtractJob(
   const lastTs = getMemoryCheckpoint(checkpointKey);
   const afterTimestamp = lastTs ? parseInt(lastTs, 10) : undefined;
 
+  const activeContextNodeIds = Array.isArray(job.payload.activeContextNodeIds)
+    ? (job.payload.activeContextNodeIds as string[])
+    : undefined;
+
   try {
     const result = await runGraphExtraction(conversationId, scopeId, config, {
       afterTimestamp,
+      activeContextNodeIds,
     });
 
     // Update checkpoint to the newest message actually processed — using


### PR DESCRIPTION
## Summary
- Snapshot InContextTracker active node IDs in Conversation.dispose() before state is cleared
- Include activeContextNodeIds in graph_extract job payload
- Wire IDs through extraction-job.ts to runGraphExtraction opts

Part of plan: memory-reconsolidation.md (PR 1 of 5)