### PR TITLE
feat: add memory_graph_node_edits table and store functions for edit chain tracking

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -94,6 +94,7 @@ import {
   migrateInviteContactId,
   migrateLlmRequestLogMessageId,
   migrateLlmRequestLogProvider,
+  migrateCreateMemoryGraphNodeEdits,
   migrateMemoryGraphImageRefs,
   migrateMemoryItemSupersession,
   migrateMessagesConversationCreatedAtIndex,
@@ -575,6 +576,9 @@ export function initializeDb(): void {
 
   // 104. Add nullable image_refs TEXT column to memory_graph_nodes
   migrateMemoryGraphImageRefs(database);
+
+  // 105. Memory graph node edit history
+  migrateCreateMemoryGraphNodeEdits(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/graph/store.ts
+++ b/assistant/src/memory/graph/store.ts
@@ -2,12 +2,13 @@
 // Memory Graph — Data access layer
 // ---------------------------------------------------------------------------
 
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "../db.js";
 import {
   memoryGraphEdges,
+  memoryGraphNodeEdits,
   memoryGraphNodes,
   memoryGraphTriggers,
 } from "../schema.js";
@@ -758,4 +759,52 @@ export function applyDiff(diff: MemoryDiff): ApplyDiffResult {
   });
 
   return result;
+}
+
+// ---------------------------------------------------------------------------
+// Node edit history
+// ---------------------------------------------------------------------------
+
+/** Record a content change to a memory node for edit chain tracking. */
+export function recordNodeEdit(opts: {
+  nodeId: string;
+  previousContent: string;
+  newContent: string;
+  source: "extraction" | "consolidation" | "manual";
+  conversationId?: string;
+}): void {
+  const db = getDb();
+  db.insert(memoryGraphNodeEdits)
+    .values({
+      id: uuid(),
+      nodeId: opts.nodeId,
+      previousContent: opts.previousContent,
+      newContent: opts.newContent,
+      source: opts.source,
+      conversationId: opts.conversationId ?? null,
+      created: Date.now(),
+    })
+    .run();
+}
+
+/** Retrieve the edit history for a memory node, newest first. */
+export function getNodeEditHistory(
+  nodeId: string,
+  limit = 20,
+): Array<{
+  id: string;
+  previousContent: string;
+  newContent: string;
+  source: string;
+  conversationId: string | null;
+  created: number;
+}> {
+  const db = getDb();
+  return db
+    .select()
+    .from(memoryGraphNodeEdits)
+    .where(eq(memoryGraphNodeEdits.nodeId, nodeId))
+    .orderBy(desc(memoryGraphNodeEdits.created))
+    .limit(limit)
+    .all();
 }

--- a/assistant/src/memory/migrations/206-memory-graph-node-edits.ts
+++ b/assistant/src/memory/migrations/206-memory-graph-node-edits.ts
@@ -1,0 +1,19 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+export function migrateCreateMemoryGraphNodeEdits(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  raw.exec(`
+    CREATE TABLE IF NOT EXISTS memory_graph_node_edits (
+      id                TEXT PRIMARY KEY,
+      node_id           TEXT NOT NULL REFERENCES memory_graph_nodes(id) ON DELETE CASCADE,
+      previous_content  TEXT NOT NULL,
+      new_content       TEXT NOT NULL,
+      source            TEXT NOT NULL,
+      conversation_id   TEXT,
+      created           INTEGER NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_graph_node_edits_node_id ON memory_graph_node_edits(node_id);
+    CREATE INDEX IF NOT EXISTS idx_graph_node_edits_created ON memory_graph_node_edits(created);
+  `);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -146,6 +146,7 @@ export { migrateCreateMemoryGraphTables } from "./202-memory-graph-tables.js";
 export { migrateDropMemoryItemsTables } from "./203-drop-memory-items-tables.js";
 export { migrateRenameMemoryGraphTypeValues } from "./204-rename-memory-graph-type-values.js";
 export { migrateMemoryGraphImageRefs } from "./205-memory-graph-image-refs.js";
+export { migrateCreateMemoryGraphNodeEdits } from "./206-memory-graph-node-edits.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/memory-graph.ts
+++ b/assistant/src/memory/schema/memory-graph.ts
@@ -137,3 +137,18 @@ export const memoryGraphTriggers = sqliteTable(
     index("idx_graph_triggers_type").on(table.type),
   ],
 );
+
+export const memoryGraphNodeEdits = sqliteTable(
+  "memory_graph_node_edits",
+  {
+    id: text("id").primaryKey(),
+    nodeId: text("node_id")
+      .notNull()
+      .references(() => memoryGraphNodes.id, { onDelete: "cascade" }),
+    previousContent: text("previous_content").notNull(),
+    newContent: text("new_content").notNull(),
+    source: text("source").notNull(),
+    conversationId: text("conversation_id"),
+    created: integer("created").notNull(),
+  },
+);


### PR DESCRIPTION
## Summary
- Add migration 206 creating memory_graph_node_edits table with CASCADE delete
- Add Drizzle schema definition for memoryGraphNodeEdits
- Add recordNodeEdit() and getNodeEditHistory() store functions

Part of plan: memory-reconsolidation.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
