### PR TITLE
fix: change FTS default join from OR to AND and support FTS5 syntax pass-through

### DIFF
--- a/assistant/src/memory/conversation-queries.ts
+++ b/assistant/src/memory/conversation-queries.ts
@@ -15,6 +15,12 @@ const log = getLogger("conversation-store");
  * Used for messages_fts full-text search over conversation content.
  */
 export function buildFtsMatchQuery(text: string): string | null {
+  // If the query already contains FTS5 operators, pass it through directly
+  // so users (and callers) can use exact-phrase, AND, OR, NOT, NEAR syntax.
+  if (/\bAND\b|\bOR\b|\bNOT\b|\bNEAR\s*\(|"/i.test(text)) {
+    return text.trim();
+  }
+
   const tokens = text
     .toLowerCase()
     .split(/[^a-z0-9_]+/g)
@@ -22,7 +28,8 @@ export function buildFtsMatchQuery(text: string): string | null {
     .filter((token) => token.length >= 2);
   if (tokens.length === 0) return null;
   const unique = [...new Set(tokens)].slice(0, 24);
-  return unique.map((token) => `"${token.replace(/"/g, '""')}"`).join(" OR ");
+  // Space-separated quoted tokens are implicit AND in FTS5.
+  return unique.map((token) => `"${token.replace(/"/g, '""')}"`).join(" ");
 }
 
 export function listConversations(


### PR DESCRIPTION
## Summary
- Change buildFtsMatchQuery to use implicit AND (space) instead of OR for tokenized queries
- Add FTS5 syntax pass-through: queries containing quotes, AND, OR, NOT, or NEAR are passed directly to FTS5

Part of plan: fix-memory-recall-bugs.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
