### PR TITLE
fix: update recall tool archive mode description for AND semantics and FTS5 syntax

### DIFF
--- a/assistant/src/memory/graph/tools.ts
+++ b/assistant/src/memory/graph/tools.ts
@@ -33,7 +33,7 @@ export const graphRecallDefinition: ToolDefinition = {
         type: "string",
         enum: ["memory", "archive"],
         description:
-          '"memory" searches the living memory graph using semantic similarity (default). "archive" searches raw conversation transcripts using keyword matching — any matching keyword will surface results, not just exact phrases.',
+          '"memory" searches the living memory graph using semantic similarity (default). "archive" searches raw conversation transcripts using keyword matching. Supports FTS5 syntax: use "quoted phrases" for exact matching, AND/OR for boolean logic, NEAR(word1 word2, N) for proximity. Without operators, all keywords must appear (implicit AND). Short words like "I" and "a" are ignored. Prefer "memory" for conceptual/emotional queries, "archive" for finding specific wording.',
       },
       filters: {
         type: "object",


### PR DESCRIPTION
## Summary
- Update the recall tool's mode field description to reflect new AND default semantics
- Document FTS5 syntax support (quoted phrases, AND/OR, NEAR)
- Add guidance on when to prefer memory vs archive mode

Part of plan: fix-memory-recall-bugs.md (PR 2 of 5)