### PR TITLE
fix: set lastConsolidated to current time instead of 0 for capability nodes

### DIFF
--- a/assistant/src/memory/graph/capability-seed.ts
+++ b/assistant/src/memory/graph/capability-seed.ts
@@ -208,7 +208,7 @@ function upsertCapabilityNode(sourceKey: string, content: string): void {
     type: "procedural" as const,
     created: now,
     lastAccessed: now,
-    lastConsolidated: 0,
+    lastConsolidated: now,
     eventDate: null,
     emotionalCharge: {
       valence: 0,


### PR DESCRIPTION
## Summary
- Change lastConsolidated from hardcoded 0 to Date.now() in capability node creation
- Prevents immediate fidelity decay from vivid to gist on capability nodes

Part of plan: fix-memory-recall-bugs.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
