### PR TITLE
fix: apply date filters to archive recall SQL queries

### DIFF
--- a/assistant/src/memory/graph/tool-handlers.ts
+++ b/assistant/src/memory/graph/tool-handlers.ts
@@ -159,6 +159,27 @@ async function handleArchiveRecall(
     const limit = Math.max(1, Math.min(input.num_results ?? 20, 50));
     const ftsMatch = buildFtsMatchQuery(input.query.trim());
 
+    const afterMs = input.filters?.after
+      ? new Date(input.filters.after).getTime()
+      : NaN;
+    const beforeMs = input.filters?.before
+      ? new Date(input.filters.before).getTime()
+      : NaN;
+    const dateConditions: string[] = [];
+    const dateParams: number[] = [];
+    if (!isNaN(afterMs)) {
+      dateConditions.push("m.created_at >= ?");
+      dateParams.push(afterMs);
+    }
+    if (!isNaN(beforeMs)) {
+      dateConditions.push("m.created_at <= ?");
+      dateParams.push(beforeMs);
+    }
+    const dateClause =
+      dateConditions.length > 0
+        ? " AND " + dateConditions.join(" AND ")
+        : "";
+
     type ArchiveRow = {
       id: string;
       content: string;
@@ -177,11 +198,12 @@ async function handleArchiveRecall(
          JOIN messages m ON m.id = fts.message_id
          JOIN conversations c ON c.id = m.conversation_id
          WHERE messages_fts MATCH ?
-           AND c.memory_scope_id = ?
+           AND c.memory_scope_id = ?${dateClause}
          ORDER BY rank
          LIMIT ?`,
         ftsMatch,
         scopeId,
+        ...dateParams,
         limit,
       );
     } else if (!input.query.trim()) {
@@ -199,11 +221,12 @@ async function handleArchiveRecall(
         `SELECT m.id, m.content, m.role, m.created_at, c.id as conversation_id
          FROM messages m
          JOIN conversations c ON c.id = m.conversation_id
-         WHERE m.content LIKE ? ESCAPE '\\' AND c.memory_scope_id = ?
+         WHERE m.content LIKE ? ESCAPE '\\' AND c.memory_scope_id = ?${dateClause}
          ORDER BY m.created_at DESC
          LIMIT ?`,
         likePattern,
         scopeId,
+        ...dateParams,
         limit,
       );
     }


### PR DESCRIPTION
## Summary
- Parse after/before date filters in handleArchiveRecall
- Add created_at conditions to both FTS and LIKE fallback SQL queries
- Date filters that were previously accepted but ignored now properly filter results

Part of plan: fix-memory-recall-bugs.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
