### PR TITLE
fix: push date range filters into Qdrant query instead of post-retrieval filtering

### DIFF
--- a/assistant/src/memory/graph/graph-search.ts
+++ b/assistant/src/memory/graph/graph-search.ts
@@ -43,6 +43,7 @@ export async function searchGraphNodes(
   limit: number,
   scopeIds?: string[],
   sparseVector?: QdrantSparseVector,
+  dateRange?: { afterMs?: number; beforeMs?: number },
 ): Promise<GraphSearchResult[]> {
   if (isQdrantBreakerOpen()) {
     log.warn("Qdrant circuit breaker open, skipping graph search");
@@ -54,13 +55,20 @@ export async function searchGraphNodes(
   // Use hybrid search (dense + sparse with RRF fusion) when a non-empty
   // sparse vector is available; otherwise fall back to dense-only search.
   if (sparseVector && sparseVector.indices.length > 0) {
+    const must: Record<string, unknown>[] = [
+      { key: "target_type", match: { value: "graph_node" } },
+      ...(scopeIds && scopeIds.length > 0
+        ? [{ key: "memory_scope_id", match: { any: scopeIds } }]
+        : []),
+    ];
+    if (dateRange?.afterMs != null) {
+      must.push({ key: "created_at", range: { gte: dateRange.afterMs } });
+    }
+    if (dateRange?.beforeMs != null) {
+      must.push({ key: "created_at", range: { lte: dateRange.beforeMs } });
+    }
     const filter = {
-      must: [
-        { key: "target_type", match: { value: "graph_node" } },
-        ...(scopeIds && scopeIds.length > 0
-          ? [{ key: "memory_scope_id", match: { any: scopeIds } }]
-          : []),
-      ],
+      must,
       must_not: [{ key: "_meta", match: { value: true } }],
     };
 
@@ -82,21 +90,27 @@ export async function searchGraphNodes(
   }
 
   // Dense-only fallback
-  const filter: Record<string, unknown> = {
-    must: [
-      {
-        key: "target_type",
-        match: { value: "graph_node" },
-      },
-    ],
-  };
+  const denseMusts: Record<string, unknown>[] = [
+    {
+      key: "target_type",
+      match: { value: "graph_node" },
+    },
+  ];
 
   if (scopeIds && scopeIds.length > 0) {
-    (filter.must as unknown[]).push({
+    denseMusts.push({
       key: "memory_scope_id",
       match: { any: scopeIds },
     });
   }
+  if (dateRange?.afterMs != null) {
+    denseMusts.push({ key: "created_at", range: { gte: dateRange.afterMs } });
+  }
+  if (dateRange?.beforeMs != null) {
+    denseMusts.push({ key: "created_at", range: { lte: dateRange.beforeMs } });
+  }
+
+  const filter: Record<string, unknown> = { must: denseMusts };
 
   const results: QdrantSearchResult[] = await withQdrantBreaker(async () => {
     return client.search(queryVector, limit, filter);

--- a/assistant/src/memory/graph/tool-handlers.ts
+++ b/assistant/src/memory/graph/tool-handlers.ts
@@ -95,6 +95,17 @@ async function handleMemoryRecall(
   // Generate sparse embedding for hybrid search (dense + sparse with RRF fusion)
   const sparseVector = generateSparseEmbedding(input.query);
 
+  // Build date range filter for Qdrant-level filtering
+  const dateRange: { afterMs?: number; beforeMs?: number } = {};
+  if (input.filters?.after) {
+    const afterMs = new Date(input.filters.after).getTime();
+    if (!isNaN(afterMs)) dateRange.afterMs = afterMs;
+  }
+  if (input.filters?.before) {
+    const beforeMs = new Date(input.filters.before).getTime();
+    if (!isNaN(beforeMs)) dateRange.beforeMs = beforeMs;
+  }
+
   // Search graph nodes
   const limit = Math.max(1, Math.min(input.num_results ?? 20, 50));
   const searchResults = await searchGraphNodes(
@@ -102,6 +113,9 @@ async function handleMemoryRecall(
     limit,
     [scopeId],
     sparseVector,
+    dateRange.afterMs != null || dateRange.beforeMs != null
+      ? dateRange
+      : undefined,
   );
   if (searchResults.length === 0) {
     return { results: [], mode: "memory", query: input.query };
@@ -119,16 +133,6 @@ async function handleMemoryRecall(
     // Type filter
     if (input.filters?.types && input.filters.types.length > 0) {
       if (!input.filters.types.includes(node.type)) return [];
-    }
-
-    // Date filters
-    if (input.filters?.after) {
-      const afterMs = new Date(input.filters.after).getTime();
-      if (!isNaN(afterMs) && node.created < afterMs) return [];
-    }
-    if (input.filters?.before) {
-      const beforeMs = new Date(input.filters.before).getTime();
-      if (!isNaN(beforeMs) && node.created > beforeMs) return [];
     }
 
     return [


### PR DESCRIPTION
## Summary
- Add optional dateRange parameter to searchGraphNodes for Qdrant-level date filtering
- Push after/before date filters into Qdrant must conditions (both hybrid and dense paths)
- Remove post-retrieval date filtering from handleMemoryRecall since Qdrant now handles it

Part of plan: fix-memory-recall-bugs.md (PR 3 of 5)