### PR TITLE
fix: add suppressEmojiReopen to prevent picker reopening after Escape dismiss

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerEmojiPicker.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerEmojiPicker.swift
@@ -49,6 +49,10 @@ extension ComposerView {
     }
 
     func updateEmojiState() {
+        if suppressEmojiReopen {
+            suppressEmojiReopen = false
+            return
+        }
         if let trigger = emojiTriggerRange() {
             let results = EmojiCatalog.search(prefix: trigger.filter)
             if !results.isEmpty {
@@ -98,6 +102,7 @@ extension ComposerView {
                 selectEmoji(filtered[emojiSelectedIndex])
             case .dismiss:
                 withAnimation(VAnimation.fast) { showEmojiMenu = false }
+                suppressEmojiReopen = true
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -80,6 +80,7 @@ struct ComposerView: View {
     @State var slashFilter = ""
     @State var slashSelectedIndex = 0
     @State var suppressSlashReopen = false
+    @State var suppressEmojiReopen = false
     @State var showEmojiMenu = false
     @State var emojiFilter = ""
     @State var emojiSelectedIndex = 0
@@ -181,6 +182,7 @@ struct ComposerView: View {
                 showSlashMenu = false
                 showEmojiMenu = false
                 suppressSlashReopen = false
+                suppressEmojiReopen = false
             }
         }
         .onChange(of: hasPendingConfirmation) { _, pending in


### PR DESCRIPTION
## Summary
Adds a suppressEmojiReopen flag mirroring the existing suppressSlashReopen pattern. When the user presses Escape to dismiss the emoji picker, the flag prevents the next updateEmojiState() call from immediately reopening it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
