### PR TITLE
feat: record memory edit history when consolidation modifies node content

### DIFF
--- a/assistant/src/memory/graph/consolidation.ts
+++ b/assistant/src/memory/graph/consolidation.ts
@@ -27,6 +27,7 @@ import {
   getEdgesForNode,
   getTriggersForNode,
   queryNodes,
+  recordNodeEdit,
   updateNode,
 } from "./store.js";
 import type { MemoryNode } from "./types.js";
@@ -195,7 +196,9 @@ function getTopSignificanceNodes(
     scopeId,
     fidelityNot: ["gone"],
     minSignificance: 0.6,
-  }).filter((n) => !isCapabilityNode(n)).slice(0, n);
+  })
+    .filter((n) => !isCapabilityNode(n))
+    .slice(0, n);
 }
 
 function getDecayedNodes(scopeId: string): MemoryNode[] {
@@ -203,7 +206,10 @@ function getDecayedNodes(scopeId: string): MemoryNode[] {
     scopeId,
     limit: 10000,
   });
-  return all.filter((n) => (n.fidelity === "faded" || n.fidelity === "gist") && !isCapabilityNode(n));
+  return all.filter(
+    (n) =>
+      (n.fidelity === "faded" || n.fidelity === "gist") && !isCapabilityNode(n),
+  );
 }
 
 function getRandomSample(scopeId: string, n: number = 30): MemoryNode[] {
@@ -507,6 +513,21 @@ async function consolidateChunk(
 
     if (Object.keys(changes).length > 1) {
       // more than just lastConsolidated
+
+      // Record edit history before the DB write so previousContent is pre-change
+      if (changes.content) {
+        const cleanContent = deduplicateParagraphs(changes.content);
+        const node = nodeMap.get(update.id);
+        if (node && node.content !== cleanContent) {
+          recordNodeEdit({
+            nodeId: update.id,
+            previousContent: node.content,
+            newContent: cleanContent,
+            source: "consolidation",
+          });
+        }
+      }
+
       updateNode(update.id, changes);
       result.nodesUpdated++;
       // Sync in-memory state with what updateNode actually wrote to the DB


### PR DESCRIPTION
## Summary
- Record edit history entries when consolidation modifies node content
- Uses deduplicateParagraphs for clean content comparison
- Records previous content before in-memory nodeMap update

Part of plan: memory-reconsolidation.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
