### PR TITLE
fix: make FTS5 operator detection case-sensitive and require balanced quotes

### DIFF
--- a/assistant/src/memory/conversation-queries.ts
+++ b/assistant/src/memory/conversation-queries.ts
@@ -17,7 +17,7 @@ const log = getLogger("conversation-store");
 export function buildFtsMatchQuery(text: string): string | null {
   // If the query already contains FTS5 operators, pass it through directly
   // so users (and callers) can use exact-phrase, AND, OR, NOT, NEAR syntax.
-  if (/\bAND\b|\bOR\b|\bNOT\b|\bNEAR\s*\(|"/i.test(text)) {
+  if (/\bAND\b|\bOR\b|\bNOT\b|\bNEAR\s*\(|"[^"]+"/.test(text)) {
     return text.trim();
   }
 


### PR DESCRIPTION
## Summary
Fixes gap from plan review for fix-memory-recall-bugs.md.

**Gap:** FTS5 pass-through regex triggers on common English words
**What was expected:** Only uppercase FTS5 operators (AND, OR, NOT, NEAR) and balanced quoted phrases trigger pass-through
**What was found:** Case-insensitive flag caused lowercase 'not', 'and', 'or' to trigger pass-through; single stray quotes bypassed sanitization