### PR TITLE
fix: polish memories UI — readable fonts, stable hover, working view toggle

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -105,7 +105,7 @@ struct MemoriesPanel: View {
             // Memory count header
             HStack(alignment: .firstTextBaseline, spacing: VSpacing.sm) {
                 Text("\(store.total)")
-                    .font(VFont.brandSmall)
+                    .font(VFont.titleLarge)
                     .foregroundStyle(VColor.contentEmphasized)
                 Text(store.total == 1 ? "memory" : "memories")
                     .font(VFont.bodyMediumLighter)
@@ -236,7 +236,7 @@ struct MemoriesPanel: View {
             )
 
             VTabs(
-                items: MemoryViewMode.allCases.map { (label: $0.rawValue, icon: $0.icon, tag: $0) },
+                items: MemoryViewMode.allCases.map { (label: $0.rawValue, tag: $0) },
                 selection: $viewMode,
                 style: .pill,
                 size: .compact

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -29,7 +29,7 @@ struct MemoryItemRow: View {
                     // Top row: subject + timestamp + delete
                     HStack(alignment: .center, spacing: VSpacing.sm) {
                         Text(item.subject)
-                            .font(VFont.brandMini)
+                            .font(VFont.titleSmall)
                             .foregroundStyle(VColor.contentEmphasized)
                             .lineLimit(1)
                             .truncationMode(.tail)
@@ -40,16 +40,15 @@ struct MemoryItemRow: View {
                             .font(VFont.labelDefault)
                             .foregroundStyle(VColor.contentTertiary)
 
-                        if isHovered {
-                            VButton(
-                                label: "Delete",
-                                iconOnly: VIcon.trash.rawValue,
-                                style: .dangerGhost,
-                                size: .compact,
-                                action: onDelete
-                            )
-                            .accessibilityLabel("Delete memory")
-                        }
+                        VButton(
+                            label: "Delete",
+                            iconOnly: VIcon.trash.rawValue,
+                            style: .dangerGhost,
+                            size: .compact,
+                            action: onDelete
+                        )
+                        .opacity(isHovered ? 1 : 0)
+                        .accessibilityLabel("Delete memory")
                     }
 
                     // Metadata row: kind tag + confidence + source + importance dots
@@ -78,15 +77,6 @@ struct MemoryItemRow: View {
                         }
 
                         Spacer()
-
-                        // Importance dots
-                        HStack(spacing: 2) {
-                            ForEach(0..<item.importanceLevel.rawValue, id: \.self) { _ in
-                                Circle()
-                                    .fill(VColor.contentTertiary)
-                                    .frame(width: 8, height: 8)
-                            }
-                        }
                     }
                 }
                 .padding(.leading, VSpacing.md)


### PR DESCRIPTION
## Summary
- Replace Instrument Serif (brandMini/brandSmall) with DM Sans (titleSmall/titleLarge) for card subjects and count header — fixes hard-to-read text
- Fix hover jitter by using `.opacity()` instead of conditional rendering for the delete button
- Fix Cards/Compact toggle by using label-only VTabs pills instead of icon-only (PillSegment renders only the icon when icon is non-nil, hiding the label)
- Remove importance dots (1-3 gray circles) that looked like a '...' menu button

## Original prompt
it