### PR TITLE
fix: force SwiftUI re-render when switching memory view modes

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -323,7 +323,7 @@ struct MemoriesPanel: View {
             )
         } else {
             ScrollView {
-                LazyVStack(spacing: VSpacing.sm) {
+                LazyVStack(spacing: viewMode == .compact ? VSpacing.xxs : VSpacing.sm) {
                     switch viewMode {
                     case .cards:
                         ForEach(store.items) { item in
@@ -356,6 +356,7 @@ struct MemoriesPanel: View {
                             }
                     }
                 }
+                .id(viewMode)
                 .background { OverlayScrollerStyle() }
             }
             .scrollContentBackground(.hidden)


### PR DESCRIPTION
## Summary
- Add `.id(viewMode)` to the LazyVStack so SwiftUI treats Cards and Compact as distinct views and rebuilds the list when toggling
- Without this, SwiftUI sees two ForEach blocks over the same `store.items` as structurally identical and skips the re-render
- Also tighten spacing in compact mode (`xxs` vs `sm`) for denser rows

## Original prompt
The card and compact views are still the same
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
