### PR TITLE
fix: inject NOW.md context into greeting generation for varied outputs

### DIFF
--- a/assistant/src/runtime/routes/btw-routes.ts
+++ b/assistant/src/runtime/routes/btw-routes.ts
@@ -17,6 +17,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { z } from "zod";
 
 import { getConfig } from "../../config/loader.js";
+import { readNowScratchpad } from "../../daemon/conversation-runtime-assembly.js";
 import { getConversationByKey } from "../../memory/conversation-key-store.js";
 import {
   resolveChannelPersona,
@@ -136,6 +137,18 @@ async function handleBtw(
     }
   }
 
+  // ----- Greeting context enrichment -----
+  // Inject NOW.md scratchpad so the model has contextual awareness (mood,
+  // current activity) and produces varied, relevant greetings instead of
+  // the same deterministic output each time.
+  let effectiveContent = trimmedContent;
+  if (conversationKey === GREETING_KEY) {
+    const now = readNowScratchpad();
+    if (now) {
+      effectiveContent = `${trimmedContent}\n\n<context>\n${now}\n</context>`;
+    }
+  }
+
   // Look up an existing conversation — never create one.  BTW is ephemeral
   // (the file header promises "No messages are persisted"), so we must not
   // call getOrCreateConversation which would insert a DB row.  When no
@@ -158,7 +171,7 @@ async function handleBtw(
           const userPersona = resolveGuardianPersona();
           const channelPersona = resolveChannelPersona(undefined);
           const result = await runBtwSidechain({
-            content: trimmedContent,
+            content: effectiveContent,
             conversation,
             signal: req.signal,
             userPersona,


### PR DESCRIPTION
## Summary

- The empty-state greeting was always identical because the BTW sidechain sent the exact same inputs to Haiku every time — prompt caching made outputs deterministic
- Inject NOW.md scratchpad content into the greeting prompt via `readNowScratchpad()`, giving the model contextual awareness (mood, current activity, time of day) that naturally varies between requests
- Gracefully falls back to the original prompt when NOW.md is missing or empty

## Original prompt

Inject NOW.md into the greeting BTW prompt so greetings are contextually varied instead of deterministic.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
