### PR TITLE
fix: Show More loads all remaining conversations

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -904,6 +904,23 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         }
     }
 
+    /// Load all remaining conversations from the daemon in a loop until none remain.
+    func loadAllRemainingConversations() {
+        guard !isLoadingMoreConversations, hasMoreConversations else { return }
+        isLoadingMoreConversations = true
+        Task { [weak self] in
+            guard let self else { return }
+            while self.hasMoreConversations {
+                let response = await self.conversationListClient.fetchConversationList(
+                    offset: self.serverOffset, limit: 200, conversationType: nil
+                )
+                guard let response else { break }
+                self.appendConversations(from: response)
+            }
+            self.isLoadingMoreConversations = false
+        }
+    }
+
     /// Handle appended conversations from a "load more" response.
     func appendConversations(from response: ConversationListResponseMessage) {
         // Increment offset by the unfiltered count so pagination stays aligned

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -325,7 +325,11 @@ extension MainWindowView {
                     style: .ghost,
                     size: .compact
                 ) {
+                    let wasCollapsed = !sidebar.showAllInSection.contains("ungrouped")
                     withAnimation(VAnimation.fast) { sidebar.toggleShowAll("ungrouped") }
+                    if wasCollapsed {
+                        conversationManager.loadAllRemainingConversations()
+                    }
                 }
                 Spacer()
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
@@ -221,6 +221,7 @@ struct ConversationSwitcherDrawer: View {
                         expandedSections.remove(sectionId)
                     } else {
                         expandedSections.insert(sectionId)
+                        conversationManager.loadAllRemainingConversations()
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -321,6 +321,9 @@ struct SidebarSectionView: View {
                     size: .compact
                 ) {
                     withAnimation(VAnimation.fast) { onToggleShowAll() }
+                    if !showAll {
+                        conversationManager?.loadAllRemainingConversations()
+                    }
                 }
                 Spacer()
             }


### PR DESCRIPTION
## Summary
- Add `loadAllRemainingConversations()` to `ConversationManager` that loops fetching pages (200/request) until all conversations are loaded
- Wire the "Show more" button in the ungrouped sidebar section, grouped `SidebarSectionView`, and `ConversationSwitcherDrawer` to trigger loading all remaining conversations when expanding
- Only triggers on expand (not collapse), and guards against redundant fetches via existing `isLoadingMoreConversations` / `hasMoreConversations` flags

## Original prompt
When the user clicks Show More, it should load all the remaining conversations instead of a limited number

🤖 Generated with [Claude Code](https://claude.com/claude-code)