### PR TITLE
fix: Return key selects from picker popups regardless of send-mode

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
@@ -62,6 +62,7 @@ struct ComposerTextEditor: NSViewRepresentable {
     var onDownArrow: (() -> Bool)? = nil
     var onEscape: (() -> Bool)? = nil
     var onPasteImage: (() -> Void)? = nil
+    var shouldOverrideReturn: (() -> Bool)? = nil
     @Binding var cursorPosition: Int
     var textReplacer: TextReplacementProxy? = nil
 
@@ -218,6 +219,7 @@ struct ComposerTextEditor: NSViewRepresentable {
         textView.onDownArrow = onDownArrow
         textView.onEscape = onEscape
         textView.onPasteImage = onPasteImage
+        textView.shouldOverrideReturn = shouldOverrideReturn
         textView.onFocusChanged = { [weak coordinator = context.coordinator] focused in
             guard let coordinator, coordinator.parent.isFocused != focused else { return }
             coordinator.parent.isFocused = focused

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerTextView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerTextView.swift
@@ -23,6 +23,11 @@ final class ComposerTextView: NSTextView {
     var onEscape: (() -> Bool)?
     var onPasteImage: (() -> Void)?
     var onFocusChanged: ((Bool) -> Void)?
+    /// When this returns `true`, Return bypasses ``ComposerReturnKeyRouting``
+    /// and fires ``onSubmit`` directly. Used to let active picker popups
+    /// (emoji, slash commands) intercept Return regardless of the
+    /// send-mode preference.
+    var shouldOverrideReturn: (() -> Bool)?
 
     // MARK: - Placeholder Drawing
 
@@ -74,6 +79,10 @@ final class ComposerTextView: NSTextView {
         let isReturn = event.keyCode == 36 || event.keyCode == 76
 
         if isReturn {
+            if shouldOverrideReturn?() == true {
+                onSubmit?()
+                return
+            }
             let action = ComposerReturnKeyRouting.resolve(
                 cmdEnterToSend: cmdEnterToSend,
                 modifiers: modifiers

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -272,6 +272,9 @@ struct ComposerView: View {
                     return false
                 },
                 onPasteImage: onPaste,
+                shouldOverrideReturn: {
+                    showSlashMenu || showEmojiMenu
+                },
                 cursorPosition: $cursorPosition,
                 textReplacer: textReplacer
             )


### PR DESCRIPTION
## Summary
- Add `shouldOverrideReturn` callback to ComposerTextView that bypasses ComposerReturnKeyRouting when a picker popup (emoji or slash command) is active
- When emoji or slash command picker is showing, Return always fires `onSubmit` → `performSendAction` which handles picker selection, instead of potentially inserting a newline (when Cmd+Enter-to-send is enabled)

## Original prompt
Pressing enter here should accept the selected suggestion and NOT send the message or create a new line