### PR TITLE
fix: scope FTS5 syntax pass-through to archive recall only

### DIFF
--- a/assistant/src/memory/conversation-queries.ts
+++ b/assistant/src/memory/conversation-queries.ts
@@ -14,10 +14,19 @@ const log = getLogger("conversation-store");
  * Build an FTS5 MATCH query string from natural text by extracting tokens.
  * Used for messages_fts full-text search over conversation content.
  */
-export function buildFtsMatchQuery(text: string): string | null {
+export function buildFtsMatchQuery(
+  text: string,
+  opts?: { allowFts5Syntax?: boolean },
+): string | null {
   // If the query already contains FTS5 operators, pass it through directly
-  // so users (and callers) can use exact-phrase, AND, OR, NOT, NEAR syntax.
-  if (/\bAND\b|\bOR\b|\bNOT\b|\bNEAR\s*\(|"[^"]+"/.test(text)) {
+  // so callers (e.g. the archive recall tool) can use exact-phrase, AND, OR,
+  // NOT, NEAR syntax. Only enabled when the caller explicitly opts in —
+  // user-facing search should always go through normal tokenization to avoid
+  // FTS5 boolean semantics leaking into sidebar/global search.
+  if (
+    opts?.allowFts5Syntax &&
+    /\bAND\b|\bOR\b|\bNOT\b|\bNEAR\s*\(|"[^"]+"/.test(text)
+  ) {
     return text.trim();
   }
 

--- a/assistant/src/memory/graph/tool-handlers.ts
+++ b/assistant/src/memory/graph/tool-handlers.ts
@@ -161,7 +161,9 @@ async function handleArchiveRecall(
 
   try {
     const limit = Math.max(1, Math.min(input.num_results ?? 20, 50));
-    const ftsMatch = buildFtsMatchQuery(input.query.trim());
+    const ftsMatch = buildFtsMatchQuery(input.query.trim(), {
+      allowFts5Syntax: true,
+    });
 
     const afterMs = input.filters?.after
       ? new Date(input.filters.after).getTime()


### PR DESCRIPTION
## Summary
Fixes gap from plan review for fix-memory-recall-bugs.md.

**Gap:** FTS5 pass-through regex affects user-facing conversation search
**Fix:** Add opt-in allowFts5Syntax parameter to buildFtsMatchQuery, only enabled from handleArchiveRecall. Sidebar/global search always uses normal tokenization.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
