### PR TITLE
fix: allow .HEIC and .HEIF image attachments in macOS file picker

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -578,7 +578,7 @@ struct ChatView: View {
         panel.allowsMultipleSelection = true
         panel.canChooseDirectories = false
         panel.allowedContentTypes = [
-            .png, .jpeg, .gif, .webP, .pdf, .plainText, .commaSeparatedText,
+            .png, .jpeg, .gif, .webP, .heic, .heif, .pdf, .plainText, .commaSeparatedText,
             UTType("net.daringfireball.markdown") ?? .plainText,
             .movie, .mpeg4Movie, .quickTimeMovie, .avi,
             .mp3, .wav, .aiff, .audio,


### PR DESCRIPTION
## Summary
- Add `.heic` and `.heif` to the `allowedContentTypes` array in the macOS file picker (`NSOpenPanel`)
- The server already accepts `image/heic` and `image/heif` MIME types, and `ChatAttachmentManager` already handles HEIC→PNG conversion — only the file picker was filtering them out

## Original prompt
I should be able to attach .HEIC images
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
