### PR TITLE
fix: update RawUpdateNode event_date type and fix malformed trigger cleanup

### DIFF
--- a/assistant/src/memory/graph/extraction.ts
+++ b/assistant/src/memory/graph/extraction.ts
@@ -444,7 +444,7 @@ interface RawUpdateNode {
   significance?: number;
   confidence?: number;
   fidelity?: string;
-  event_date?: number;
+  event_date?: number | null;
 }
 
 interface RawNewEdge {
@@ -646,15 +646,16 @@ export function parseExtractionResponse(
       (!Array.isArray(raw.triggers) ||
         !raw.triggers.some((t) => t.type === "event" && t.event_date != null))
     ) {
-      // Remove any malformed event triggers (type=event but missing event_date)
-      const malformedIdx = deferredTriggers.findIndex(
-        (dt) =>
+      // Remove all malformed event triggers (type=event but missing event_date)
+      for (let i = deferredTriggers.length - 1; i >= 0; i--) {
+        const dt = deferredTriggers[i];
+        if (
           dt.newNodeIndex === nodeIndex &&
           dt.trigger.type === "event" &&
-          dt.trigger.eventDate == null,
-      );
-      if (malformedIdx !== -1) {
-        deferredTriggers.splice(malformedIdx, 1);
+          dt.trigger.eventDate == null
+        ) {
+          deferredTriggers.splice(i, 1);
+        }
       }
 
       deferredTriggers.push({


### PR DESCRIPTION
Addresses feedback on #23070:\n- Update RawUpdateNode.event_date to number | null | undefined to match JSON schema\n- Use reverse-iteration to remove all malformed event triggers, not just the first
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
