### PR TITLE
fix: extend message_complete guard to cover thinking phase

### DIFF
--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -348,11 +348,11 @@ final class ChatActionHandler {
         guard belongsToConversation(complete.conversationId) else { return }
         // Auxiliary message_complete events (watch notifiers, call notifications)
         // that lack a messageId should not reset the main agent turn state.
-        // Only filter when a main agent turn is actively streaming
-        // (currentAssistantMessageId is set). This allows slash commands and other
-        // non-auxiliary completions (which don't set currentAssistantMessageId)
-        // to process normally.
-        if complete.messageId == nil && vm.currentAssistantMessageId != nil {
+        // Filter when a main agent turn is actively streaming (currentAssistantMessageId
+        // is set) OR still in the thinking phase (isThinking is true but
+        // currentAssistantMessageId hasn't been set yet by the first streaming flush).
+        // This allows slash commands and other non-auxiliary completions to process normally.
+        if complete.messageId == nil && (vm.currentAssistantMessageId != nil || vm.isThinking) {
             return
         }
         // Flush any buffered streaming text before finalizing the message.


### PR DESCRIPTION
Addresses feedback on #23075:\n- Adds vm.isThinking to the guard condition to prevent auxiliary message_complete events from prematurely clearing thinking/sending state during the window before currentAssistantMessageId is set
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
