### PR TITLE
fix: document midnight UTC hasTime limitation in formatEventDate

### DIFF
--- a/assistant/src/memory/graph/injection.ts
+++ b/assistant/src/memory/graph/injection.ts
@@ -166,9 +166,12 @@ export function formatEventDate(epochMs: number): string {
   const monthName = monthNames[date.getMonth()];
   const dayOfMonth = date.getDate();
 
-  // Include time only when hours/minutes are non-zero (midnight = date-only event)
-  // Use UTC methods: date-only events are stored as midnight UTC, so local timezone
-  // methods would show non-zero hours in west-of-UTC timezones, defeating the check.
+  // Heuristic: date-only events are stored as midnight UTC, so we treat
+  // midnight-UTC epochs as "no time component".  This is lossy — a timed event
+  // genuinely scheduled at 00:00 UTC will have its time display silently dropped.
+  // Fixing this properly requires the event storage layer to carry an explicit
+  // `hasTime` flag; until then this is the best available approximation.
+  // Use UTC methods so west-of-UTC local offsets don't defeat the check.
   const hasTime = date.getUTCHours() !== 0 || date.getUTCMinutes() !== 0;
   let datePart = `${dayName} ${monthName} ${dayOfMonth}`;
   if (hasTime) {


### PR DESCRIPTION
Addresses feedback on #23073:
- Documents the edge case where timed events at midnight UTC lose their time display
- The date-only heuristic (midnight UTC = no time) is lossy but the best available without schema changes
- Notes that a proper fix requires an explicit `hasTime` flag from the event storage layer
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
