### PR TITLE
fix: render empty metric bar at zero value

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet+Helpers.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet+Helpers.swift
@@ -42,7 +42,7 @@ extension MemoryItemDetailSheet {
                 .frame(width: width, height: height)
             RoundedRectangle(cornerRadius: height / 2)
                 .fill(color)
-                .frame(width: max(height, width * CGFloat(min(max(value, 0), 1))), height: height)
+                .frame(width: value > 0 ? max(height, width * CGFloat(min(value, 1))) : 0, height: height)
         }
     }
 


### PR DESCRIPTION
Addresses feedback on #23096:
- Removes min-width clamp so zero-value bars render as completely empty instead of showing a visible 6pt segment
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
