### PR TITLE
fix: make memory row delete button accessible

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -48,6 +48,7 @@ struct MemoryItemRow: View {
                             action: onDelete
                         )
                         .opacity(isHovered ? 1 : 0)
+                        .allowsHitTesting(isHovered)
                         .accessibilityLabel("Delete memory")
                     }
 


### PR DESCRIPTION
Addresses feedback on #23101:
- Adds allowsHitTesting(isHovered) to prevent accidental taps when visually hidden
- Delete button is always rendered (opacity-based) so VoiceOver can discover it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
