### PR TITLE
fix: add brandMini typography token to Component Gallery

### DIFF
--- a/clients/shared/DesignSystem/Gallery/Sections/TokensGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/TokensGallerySection.swift
@@ -98,6 +98,8 @@ struct TokensGallerySection: View {
                         typeMatrixDivider()
                         typeMatrixRow(group: "", size: "22", regular: ("Brand/Small", VFont.brandSmall), medium: nil, semiBold: nil)
                         typeMatrixDivider()
+                        typeMatrixRow(group: "", size: "16", regular: ("Brand/Mini", VFont.brandMini), medium: nil, semiBold: nil)
+                        typeMatrixDivider()
 
                         typeMatrixRow(group: "TITLE", size: "24", regular: nil, medium: ("Title/Large", VFont.titleLarge), semiBold: nil)
                         typeMatrixDivider()
@@ -133,6 +135,7 @@ struct TokensGallerySection: View {
                         let tokens: [(String, String, String, Font)] = [
                             ("brandMedium", "Regular 32 (Instrument Serif)", "Brand headings", VFont.brandMedium),
                             ("brandSmall", "Regular 22 (Instrument Serif)", "Brand subheadings", VFont.brandSmall),
+                            ("brandMini", "Regular 16 (Instrument Serif)", "Brand inline accents", VFont.brandMini),
                             ("titleLarge", "Medium 24", "Headings, page titles", VFont.titleLarge),
                             ("titleMedium", "Medium 20", "Section headings", VFont.titleMedium),
                             ("titleSmall", "Medium 16", "Card titles, subheadings", VFont.titleSmall),


### PR DESCRIPTION
Addresses feedback on #23094:
- Adds brandMini to the typography type matrix (size 16, Brand group)
- Adds brandMini to the token reference list
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
