### PR TITLE
fix: distinguish nil confidence from zero confidence

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet+Content.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet+Content.swift
@@ -55,16 +55,18 @@ extension MemoryItemDetailSheet {
             Text("Strength")
                 .font(VFont.bodySmallEmphasised)
                 .foregroundStyle(VColor.contentTertiary)
-            HStack(spacing: VSpacing.xs) {
-                Text("Confidence")
-                    .font(VFont.bodyMediumLighter)
-                    .foregroundStyle(VColor.contentTertiary)
-                    .frame(width: 90, alignment: .leading)
-                metricBar(value: displayItem.confidence ?? 0,
-                          color: confidenceColor(displayItem.confidence ?? 0))
-                Text("\(Int((displayItem.confidence ?? 0) * 100))%")
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(VColor.contentTertiary)
+            if let confidence = displayItem.confidence {
+                HStack(spacing: VSpacing.xs) {
+                    Text("Confidence")
+                        .font(VFont.bodyMediumLighter)
+                        .foregroundStyle(VColor.contentTertiary)
+                        .frame(width: 90, alignment: .leading)
+                    metricBar(value: confidence,
+                              color: confidenceColor(confidence))
+                    Text("\(Int(confidence * 100))%")
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.contentTertiary)
+                }
             }
             if let importance = displayItem.importance {
                 HStack(spacing: VSpacing.xs) {


### PR DESCRIPTION
Addresses feedback on #23102:\n- Wraps confidence bar in `if let` guard so nil confidence hides the row entirely (matching how importance already works)\n- Previously nil defaulted to 0, rendering a misleading red bar at 0%
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
