### PR TITLE
fix: filter pill accessibility and double reload

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -137,7 +137,6 @@ struct MemoriesPanel: View {
                     if !store.searchText.isEmpty {
                         filterPill(label: "\"\(store.searchText)\"", color: VColor.contentSecondary) {
                             store.searchText = ""
-                            Task { await store.loadItems() }
                         }
                     }
                 }
@@ -206,10 +205,15 @@ struct MemoriesPanel: View {
             VSearchBar(placeholder: "Search Memories", text: $store.searchText)
                 .onChange(of: store.searchText) {
                     searchDebounceTask?.cancel()
-                    searchDebounceTask = Task {
-                        try? await Task.sleep(nanoseconds: 300_000_000)
-                        guard !Task.isCancelled else { return }
-                        await store.loadItems()
+                    if store.searchText.isEmpty {
+                        // Clearing the search — reload immediately with no debounce
+                        searchDebounceTask = Task { await store.loadItems() }
+                    } else {
+                        searchDebounceTask = Task {
+                            try? await Task.sleep(nanoseconds: 300_000_000)
+                            guard !Task.isCancelled else { return }
+                            await store.loadItems()
+                        }
                     }
                 }
 
@@ -295,6 +299,7 @@ struct MemoriesPanel: View {
                     .foregroundStyle(VColor.contentTertiary)
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("Remove \(label) filter")
         }
         .padding(.horizontal, VSpacing.sm)
         .padding(.vertical, VSpacing.xxs)


### PR DESCRIPTION
Addresses feedback on #23105:
- Adds accessibility labels to filter pill close buttons (`Remove <label> filter`)
- Prevents double reload when clearing search filter pill by removing the immediate `loadItems()` call and letting `onChange` handle it — with an optimization to skip the 300ms debounce when text is cleared to empty
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
