### PR TITLE
fix: backfill lastConsolidated for existing capability nodes

### DIFF
--- a/assistant/src/memory/graph/capability-seed.ts
+++ b/assistant/src/memory/graph/capability-seed.ts
@@ -181,9 +181,12 @@ function upsertCapabilityNode(sourceKey: string, content: string): void {
 
   if (existing) {
     if (existing.content === content && existing.fidelity !== "gone") {
-      // Same content — just touch lastAccessed
+      // Same content — just touch lastAccessed (and backfill lastConsolidated
+      // for nodes created before the fix so they don't decay immediately)
+      const updates: Record<string, number> = { lastAccessed: now };
+      if (existing.lastConsolidated === 0) updates.lastConsolidated = now;
       db.update(memoryGraphNodes)
-        .set({ lastAccessed: now })
+        .set(updates)
         .where(eq(memoryGraphNodes.id, existing.id))
         .run();
       return;
@@ -195,6 +198,7 @@ function upsertCapabilityNode(sourceKey: string, content: string): void {
         content,
         fidelity: "vivid",
         lastAccessed: now,
+        ...(existing.lastConsolidated === 0 ? { lastConsolidated: now } : {}),
       })
       .where(eq(memoryGraphNodes.id, existing.id))
       .run();


### PR DESCRIPTION
Addresses feedback on #23126:\n- Updates the capability seed 'already exists' path to set lastConsolidated=now when the current value is 0\n- Prevents existing capability nodes from immediately decaying
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
