### PR TITLE
fix: use dedup-only tool schema for cross-category dedup pass

### DIFF
--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -235,6 +235,24 @@ async function dedupForTurn(
 // Cross-category dedup — dedup-only (no relevance filtering)
 // ---------------------------------------------------------------------------
 
+const DEDUP_ITEMS_TOOL = {
+  name: "select_items",
+  description:
+    "Select ALL items that survive deduplication. When multiple items describe the same event/fact, keep only the richest version. Do not filter by relevance — keep everything that is not a duplicate.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      items: {
+        type: "array" as const,
+        description:
+          "Item numbers to keep (1-indexed). Remove duplicates — when multiple entries describe the same event/fact, keep ONLY the richest version. Keep all non-duplicate items.",
+        items: { type: "number" as const },
+      },
+    },
+    required: ["items"] as const,
+  },
+};
+
 /**
  * Dedup-only pass for cross-category duplicate removal. Unlike `dedupForTurn`,
  * this does NOT filter by relevance to a query — it ONLY removes duplicates
@@ -263,7 +281,7 @@ async function dedupCrossCategory(
 
     const response = await provider.sendMessage(
       [userMessage(listing)],
-      [SELECT_ITEMS_TOOL],
+      [DEDUP_ITEMS_TOOL],
       `Deduplicate the following numbered items. When multiple items describe the same event, fact, or status, keep ONLY the richest version. Keep ALL items that are not duplicates — do not filter by relevance or topic. Call the select_items tool with every item that survives dedup.`,
       {
         config: {


### PR DESCRIPTION
Addresses feedback on #23090:
- Creates a separate `DEDUP_ITEMS_TOOL` definition for the cross-category dedup path
- Removes relevance-ordering language from the tool description and item schema to match the dedup-only system prompt
- `SELECT_ITEMS_TOOL` (with relevance language) remains used only by `dedupForTurn` where relevance ordering is desired

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
