### PR TITLE
fix: add .heif to pasteboard and image URL classifier

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerTextView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerTextView.swift
@@ -140,7 +140,7 @@ final class ComposerTextView: NSTextView {
             .urlReadingFileURLsOnly: true,
         ]) as? [URL])?.contains { url in
             let ext = url.pathExtension.lowercased()
-            return ["png", "jpg", "jpeg", "gif", "webp", "heic", "tiff", "bmp"].contains(ext)
+            return ["png", "jpg", "jpeg", "gif", "webp", "heic", "heif", "tiff", "bmp"].contains(ext)
         } ?? false
         let hasImageData = pasteboard.data(forType: .png) != nil || pasteboard.data(forType: .tiff) != nil
         return hasImageFile || hasImageData

--- a/clients/shared/Features/Chat/MediaEmbeds/ImageURLClassifier.swift
+++ b/clients/shared/Features/Chat/MediaEmbeds/ImageURLClassifier.swift
@@ -15,7 +15,7 @@ public enum ImageURLClassifier {
 
     private static let imageExtensions: Set<String> = [
         "png", "jpg", "jpeg", "gif", "webp", "svg",
-        "bmp", "ico", "tiff", "tif", "avif", "heic"
+        "bmp", "ico", "tiff", "tif", "avif", "heic", "heif"
     ]
 
     public static func classify(_ url: URL) -> ImageURLClassification {


### PR DESCRIPTION
Addresses feedback on #23143:
- Adds 'heif' to pasteboard image content check in ComposerTextView
- Adds 'heif' to ImageURLClassifier's imageExtensions set
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
