### PR TITLE
fix: pass scopeId to extraction job from conversation lifecycle

### DIFF
--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -153,6 +153,8 @@ export interface DisposeContext extends AbortContext {
   trustContext?: { trustClass: TrustClass };
   /** Active memory node IDs snapshotted from the conversation's InContextTracker before disposal. */
   activeContextNodeIds?: string[];
+  /** Memory scope for extraction — defaults to "default" if omitted. */
+  memoryScopeId?: string;
   abort(): void;
 }
 
@@ -311,6 +313,7 @@ export function disposeConversation(ctx: DisposeContext): void {
     try {
       enqueueMemoryJob("graph_extract", {
         conversationId: ctx.conversationId,
+        scopeId: ctx.memoryScopeId ?? "default",
         ...(ctx.activeContextNodeIds?.length
           ? { activeContextNodeIds: ctx.activeContextNodeIds }
           : {}),

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -249,6 +249,7 @@ export class Conversation {
   public memoryPolicy: ConversationMemoryPolicy;
   /** @internal */ readonly graphMemory: ConversationGraphMemory;
   /** @internal */ activeContextNodeIds?: string[];
+  /** @internal */ memoryScopeId?: string;
   /** @internal */ streamThinking: boolean;
   /** @internal */ turnCount = 0;
   public lastAssistantAttachments: AssistantAttachmentDraft[] = [];
@@ -566,6 +567,7 @@ export class Conversation {
     // Do NOT close it here; the server manages the CES lifecycle.
     this.cesClient = undefined;
     this.activeContextNodeIds = this.graphMemory.tracker.getActiveNodeIds();
+    this.memoryScopeId = this.memoryPolicy.scopeId;
     disposeConversation(this);
   }
 


### PR DESCRIPTION
Addresses feedback on #23121:\n- Includes scopeId in the extraction job payload so private/scoped conversations use the correct memory scope
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
