### PR TITLE
fix: prevent pagination lock race in load-all conversations

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -915,14 +915,14 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
                     offset: self.serverOffset, limit: 200, conversationType: nil
                 )
                 guard let response else { break }
-                self.appendConversations(from: response)
+                self.appendConversations(from: response, clearLoadingFlag: false)
             }
             self.isLoadingMoreConversations = false
         }
     }
 
     /// Handle appended conversations from a "load more" response.
-    func appendConversations(from response: ConversationListResponseMessage) {
+    func appendConversations(from response: ConversationListResponseMessage, clearLoadingFlag: Bool = true) {
         // Increment offset by the unfiltered count so pagination stays aligned
         // with the daemon's row numbering regardless of client-side filtering.
         serverOffset += response.conversations.count
@@ -962,7 +962,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             hasMoreConversations = hasMore
         }
         scheduleEvictionIfNeeded()
-        isLoadingMoreConversations = false
+        if clearLoadingFlag {
+            isLoadingMoreConversations = false
+        }
     }
 
     /// Clear the `activeSurfaceId` on a specific conversation's ChatViewModel.


### PR DESCRIPTION
## Summary
- Adds `clearLoadingFlag` parameter to `appendConversations()` (default `true` for backward compat)
- `loadAllRemainingConversations()` passes `clearLoadingFlag: false` so the loading guard is held for the entire loop
- Flag is cleared once after the loop completes, preventing concurrent fetches

Addresses feedback on #23140.

## Test plan
- [ ] Verify "Show More" still loads a single page and clears the loading state
- [ ] Verify expanding a section triggers load-all and holds the lock until complete
- [ ] Verify rapid clicks on "Show More" during a load-all don't trigger concurrent fetches

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
