### PR TITLE
fix: clear stale detail on delete and add menu accessibility label

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -336,6 +336,9 @@ struct MemoriesPanel: View {
                                 item: item,
                                 onSelect: { withAnimation(VAnimation.panel) { selectedItem = item } },
                                 onDelete: {
+                                    if selectedItem?.id == item.id {
+                                        withAnimation(VAnimation.panel) { selectedItem = nil }
+                                    }
                                     Task { _ = await store.deleteItem(id: item.id) }
                                 }
                             )
@@ -347,6 +350,9 @@ struct MemoriesPanel: View {
                                 isSelected: selectedItem?.id == item.id,
                                 onSelect: { withAnimation(VAnimation.panel) { selectedItem = item } },
                                 onDelete: {
+                                    if selectedItem?.id == item.id {
+                                        withAnimation(VAnimation.panel) { selectedItem = nil }
+                                    }
                                     Task { _ = await store.deleteItem(id: item.id) }
                                 }
                             )

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet.swift
@@ -108,6 +108,7 @@ struct MemoryItemDetailSheet: View {
                         .padding(VSpacing.sm)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("More options")
                 .padding(.top, VSpacing.md)
                 .padding(.trailing, VSpacing.md)
             }


### PR DESCRIPTION
Addresses feedback on #23107:
- Clears selectedItem when the selected memory is deleted from the list
- Adds accessibility label to the overflow menu trigger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
