### PR TITLE
fix: disable hit testing on hidden delete button

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemRow.swift
@@ -49,6 +49,7 @@ struct MemoryItemRow: View {
                         )
                         .opacity(isHovered ? 1 : 0)
                         .allowsHitTesting(isHovered)
+                        .accessibilityHidden(!isHovered)
                         .accessibilityLabel("Delete memory")
                     }
 


### PR DESCRIPTION
Addresses feedback on #23135:\n- Adds .accessibilityHidden(!isHovered) to hide from VoiceOver when not visible\n\nNote: .allowsHitTesting(isHovered) was already present.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
