### PR TITLE
fix: suppress misleading empty-state when reconsolidation nodes exist

### DIFF
--- a/assistant/src/memory/graph/extraction.ts
+++ b/assistant/src/memory/graph/extraction.ts
@@ -193,7 +193,7 @@ Common duplicate mistakes to avoid:
 - Same fact restated in a later conversation → REINFORCE, don't create
 - An update to an existing situation (e.g. "project is now done") → UPDATE the existing node, don't create a parallel one
 
-${otherCandidates.length > 0 ? `### Existing memories (candidates for connection/reinforcement)\n${otherCandidates.map((n) => `- [${n.id}] (${n.type}) ${n.content}`).join("\n")}` : "No existing memories found — this may be an early conversation."}`;
+${otherCandidates.length > 0 ? `### Existing memories (candidates for connection/reinforcement)\n${otherCandidates.map((n) => `- [${n.id}] (${n.type}) ${n.content}`).join("\n")}` : reconsolidationNodes.length > 0 ? "All existing memories are shown in the reconsolidation section above." : "No existing memories found — this may be an early conversation."}`;
 
   return reconsolidationSection + candidateSection;
 })()}


### PR DESCRIPTION
Addresses feedback on #23123:
- When all candidate nodes are in the reconsolidation section, the empty-state text now says "All existing memories are shown in the reconsolidation section above." instead of the contradictory "No existing memories found — this may be an early conversation."
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
