### PR TITLE
fix: normalize tokens and expand scope in related memories

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet+Content.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet+Content.swift
@@ -142,18 +142,18 @@ extension MemoryItemDetailSheet {
             displayItem.subject
                 .lowercased()
                 .split(separator: " ")
-                .map(String.init)
+                .map { $0.filter(\.isLetter) }
                 .filter { $0.count > 3 && !stopWords.contains($0) }
         )
         guard !words.isEmpty else { return [] }
 
-        return store.items
+        return store.allLoadedItems
             .filter { $0.id != displayItem.id && $0.kind == displayItem.kind }
             .filter { candidate in
                 let candidateWords = Set(
                     candidate.subject.lowercased()
                         .split(separator: " ")
-                        .map(String.init)
+                        .map { $0.filter(\.isLetter) }
                         .filter { $0.count > 3 && !stopWords.contains($0) }
                 )
                 return !words.isDisjoint(with: candidateWords)

--- a/clients/shared/Features/Memory/MemoryItemsStore.swift
+++ b/clients/shared/Features/Memory/MemoryItemsStore.swift
@@ -5,6 +5,9 @@ import Foundation
 @MainActor @Observable
 public final class MemoryItemsStore {
     public var items: [MemoryItemPayload] = []
+    /// Superset of `items` — accumulates entries across filter/search/page loads
+    /// so cross-reference features (e.g. "Possibly Related") have a wider pool.
+    public private(set) var allLoadedItems: [MemoryItemPayload] = []
     public var total: Int = 0
     public var kindCounts: [String: Int] = [:]
     public var isLoading = false
@@ -39,6 +42,7 @@ public final class MemoryItemsStore {
         )
         if let response {
             items = response.items
+            mergeIntoAllLoaded(response.items)
             total = response.total
             if let serverCounts = response.kindCounts {
                 kindCounts = serverCounts
@@ -70,6 +74,7 @@ public final class MemoryItemsStore {
         )
         if let response {
             items.append(contentsOf: response.items)
+            mergeIntoAllLoaded(response.items)
             total = response.total
         }
         isLoading = false
@@ -131,5 +136,15 @@ public final class MemoryItemsStore {
         let success = await memoryItemClient.deleteMemoryItem(id: id)
         if success { await loadItems() }
         return success
+    }
+
+    private func mergeIntoAllLoaded(_ newItems: [MemoryItemPayload]) {
+        for item in newItems {
+            if let idx = allLoadedItems.firstIndex(where: { $0.id == item.id }) {
+                allLoadedItems[idx] = item
+            } else {
+                allLoadedItems.append(item)
+            }
+        }
     }
 }


### PR DESCRIPTION
Addresses feedback on #23103:\n- Strips punctuation from subject tokens before comparison so "travel," matches "travel"\n- Adds allLoadedItems to MemoryItemsStore that accumulates items across filter/search/page loads\n- Uses allLoadedItems instead of filtered items for related memory matching
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
