### PR TITLE
fix: guard pagination sentinel against spurious loadMore on remount

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -357,11 +357,11 @@ struct MemoriesPanel: View {
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, VSpacing.md)
                             .onAppear {
+                                guard !store.isLoading else { return }
                                 Task { await store.loadMore() }
                             }
                     }
                 }
-                .id(viewMode)
                 .background { OverlayScrollerStyle() }
             }
             .scrollContentBackground(.hidden)


### PR DESCRIPTION
Addresses feedback on #23138:
- Removes `.id(viewMode)` from LazyVStack which forced full destroy/recreate on view mode toggle, re-triggering the pagination sentinel's `.onAppear` and causing spurious `loadMore()` calls
- Adds `guard !store.isLoading` in the sentinel's `.onAppear` as belt-and-suspenders protection
- The `switch viewMode` already uses distinct view types per branch, and the conditional spacing expression naturally forces SwiftUI to recreate the `LazyVStack` when the mode changes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
