### PR TITLE
fix: restore appendConversations protocol conformance

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -915,14 +915,15 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
                     offset: self.serverOffset, limit: 200, conversationType: nil
                 )
                 guard let response else { break }
-                self.appendConversations(from: response, clearLoadingFlag: false)
+                self.appendConversations(from: response)
+                self.isLoadingMoreConversations = true
             }
             self.isLoadingMoreConversations = false
         }
     }
 
     /// Handle appended conversations from a "load more" response.
-    func appendConversations(from response: ConversationListResponseMessage, clearLoadingFlag: Bool = true) {
+    func appendConversations(from response: ConversationListResponseMessage) {
         // Increment offset by the unfiltered count so pagination stays aligned
         // with the daemon's row numbering regardless of client-side filtering.
         serverOffset += response.conversations.count
@@ -962,9 +963,7 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             hasMoreConversations = hasMore
         }
         scheduleEvictionIfNeeded()
-        if clearLoadingFlag {
-            isLoadingMoreConversations = false
-        }
+        isLoadingMoreConversations = false
     }
 
     /// Clear the `activeSurfaceId` on a specific conversation's ChatViewModel.


### PR DESCRIPTION
## Summary
- Commit 19c25ff added `clearLoadingFlag: Bool = true` to `appendConversations(from:)`, changing its Swift selector to `appendConversations(from:clearLoadingFlag:)` which no longer satisfies the `ConversationRestorerDelegate` protocol requirement for `appendConversations(from:)`.
- Fix restores the original single-parameter signature and has `loadAllRemainingConversations` re-set `isLoadingMoreConversations = true` after each append call to preserve the pagination lock race fix.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23888033822/job/69654952088
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
