### PR TITLE
feat: tune per-turn injection — 5 max nodes, 2 images, 1 serendipity slot

### DIFF
--- a/assistant/src/memory/graph/injection.ts
+++ b/assistant/src/memory/graph/injection.ts
@@ -13,7 +13,7 @@ import { isCapabilityNode } from "./types.js";
 // ---------------------------------------------------------------------------
 
 export const MAX_CONTEXT_LOAD_IMAGES = 3;
-export const MAX_PER_TURN_IMAGES = 1;
+export const MAX_PER_TURN_IMAGES = 2;
 
 // ---------------------------------------------------------------------------
 // Types

--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -759,6 +759,8 @@ export interface TurnRetrievalOpts {
 export interface TurnRetrievalResult {
   /** New nodes to inject (not already in context). */
   nodes: ScoredNode[];
+  /** Serendipity picks included in nodes. */
+  serendipityNodes: ScoredNode[];
   /** Triggers that fired this turn. */
   triggeredNodes: TriggeredResult[];
   latencyMs: number;
@@ -828,7 +830,7 @@ export async function retrieveForTurn(
   }
 
   if (queryText.trim().length === 0 && allCandidateIds.size === 0) {
-    return { nodes: [], triggeredNodes: [], latencyMs: Date.now() - start };
+    return { nodes: [], serendipityNodes: [], triggeredNodes: [], latencyMs: Date.now() - start };
   }
 
   // Chunk if too large (8k token ≈ 32k chars conservative estimate)
@@ -885,7 +887,7 @@ export async function retrieveForTurn(
     } catch (err) {
       log.warn({ err }, "Embedding/search failed for turn retrieval");
       if (allCandidateIds.size === 0) {
-        return { nodes: [], triggeredNodes: [], latencyMs: Date.now() - start };
+        return { nodes: [], serendipityNodes: [], triggeredNodes: [], latencyMs: Date.now() - start };
       }
     }
   }
@@ -918,6 +920,7 @@ export async function retrieveForTurn(
   if (newCandidateIds.length === 0) {
     return {
       nodes: [],
+      serendipityNodes: [],
       triggeredNodes: triggeredSemantic,
       latencyMs: Date.now() - start,
     };
@@ -961,8 +964,8 @@ export async function retrieveForTurn(
   // Sort and apply threshold — pull a wider pool for dedup, then trim
   scored.sort((a, b) => b.score - a.score);
   const INJECTION_THRESHOLD = 0.3;
-  const PRE_DEDUP_POOL = 40;
-  const MAX_INJECTED = 8;
+  const PRE_DEDUP_POOL = 20;
+  const MAX_INJECTED = 4;
   const pool = scored
     .filter((s) => s.score >= INJECTION_THRESHOLD)
     .slice(0, PRE_DEDUP_POOL);
@@ -973,8 +976,17 @@ export async function retrieveForTurn(
       ? await dedupForTurn(pool, MAX_INJECTED, opts.userLastMessage)
       : pool;
 
+  // Reserve 1 serendipity slot from scored candidates not in the deterministic set
+  const deterministicIds = new Set(injected.map((n) => n.node.id));
+  const serendipityPool = scored.filter(
+    (s) => s.score >= INJECTION_THRESHOLD && !deterministicIds.has(s.node.id),
+  );
+  const serendipityPicks = sampleSerendipity(serendipityPool, 1);
+  const allInjected = [...injected, ...serendipityPicks];
+
   return {
-    nodes: injected,
+    nodes: allInjected,
+    serendipityNodes: serendipityPicks,
     triggeredNodes: triggeredSemantic,
     latencyMs: Date.now() - start,
   };


### PR DESCRIPTION
## Summary
- Change MAX_PER_TURN_IMAGES from 1 to 2
- Reduce MAX_INJECTED from 8 to 4 deterministic slots, PRE_DEDUP_POOL from 40 to 20
- Add 1 serendipity slot (weighted random pick from mid-tier above-threshold candidates)
- Expose serendipityNodes on TurnRetrievalResult for caller visibility

Part of plan: consolidate-memory-per-turn.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
