### PR TITLE
fix: remove dead turnCount and lastCompactedAt fields after refresh removal

### DIFF
--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -45,9 +45,7 @@ const ESTIMATED_IMAGE_TOKENS = 1000;
  */
 export class ConversationGraphMemory {
   readonly tracker = new InContextTracker();
-  private turnCount = 0;
   private initialized = false;
-  private lastCompactedAt: number | null = null;
   private needsReload = false;
   private scopeId: string;
   private conversationId: string;
@@ -127,7 +125,6 @@ export class ConversationGraphMemory {
     // so we conservatively clear everything and reload.
     this.tracker.evictCompactedTurns(this.tracker.getTurn());
     this.needsReload = true;
-    this.lastCompactedAt = Date.now();
     log.info(
       { compactedMessageCount },
       "Compaction detected — will reload context on next turn",
@@ -196,7 +193,6 @@ export class ConversationGraphMemory {
     /** The raw text content of the injected block (without XML wrapper), or null if nothing was injected. */
     injectedBlockText: string | null;
   }> {
-    this.turnCount++;
     this.tracker.advanceTurn();
 
     const noopResult = {


### PR DESCRIPTION
## Summary
Remove two dead private fields in ConversationGraphMemory that were only used by the now-removed refresh path:
- `turnCount`: was only read by the `turnCount % REFRESH_INTERVAL_TURNS` check
- `lastCompactedAt`: was only read by the refresh timing logic

Fixes gaps from plan review of consolidate-memory-per-turn.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
