### PR TITLE
fix: update stale comment referencing removed refresh mode

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -599,8 +599,8 @@ export async function runAgentLoopImpl(
 
     let runMessages = ctx.messages;
 
-    // Memory graph retrieval — dispatches to context-load / per-turn / refresh
-    // based on conversation state.
+    // Memory graph retrieval — dispatches to context-load / per-turn based on
+    // conversation state.
     const isTrustedActor = resolveTrustClass(ctx.trustContext) === "guardian";
     if (isTrustedActor) {
       const graphResult = await ctx.graphMemory.prepareMemory(
@@ -1048,9 +1048,7 @@ export async function runAgentLoopImpl(
           midLoopCompact.summaryCacheReadInputTokens ?? 0,
           collapseRawResponses(midLoopCompact.summaryRawResponses),
         );
-        ctx.graphMemory.onCompacted(
-          midLoopCompact.compactedPersistedMessages,
-        );
+        ctx.graphMemory.onCompacted(midLoopCompact.compactedPersistedMessages);
       }
 
       // Re-inject runtime context and re-enter the agent loop
@@ -1375,7 +1373,8 @@ export async function runAgentLoopImpl(
               mode: currentInjectionMode,
             });
             if (isTrustedActor && currentInjectionMode !== "minimal") {
-              const memResult = ctx.graphMemory.reinjectCachedMemory(runMessages);
+              const memResult =
+                ctx.graphMemory.reinjectCachedMemory(runMessages);
               runMessages = memResult.runMessages;
             }
             preRepairMessages = runMessages;


### PR DESCRIPTION
## Summary
- Update comment in conversation-agent-loop.ts that still referenced the removed `refresh` dispatch mode

Follow-up to #23165 which removed the refresh path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
