### PR TITLE
refactor: rename workspace_top_level tag to workspace and update format

### DIFF
--- a/assistant/src/__tests__/top-level-renderer.test.ts
+++ b/assistant/src/__tests__/top-level-renderer.test.ts
@@ -15,11 +15,11 @@ describe("renderWorkspaceTopLevelContext", () => {
     const result = renderWorkspaceTopLevelContext(snapshot);
     expect(result).toBe(
       [
-        "<workspace_top_level>",
+        "<workspace>",
         "Root: /sandbox",
         "Directories: lib, src, tests",
         "Files: README.md, package.json",
-        "</workspace_top_level>",
+        "</workspace>",
       ].join("\n"),
     );
   });
@@ -61,11 +61,11 @@ describe("renderWorkspaceTopLevelContext", () => {
     const result = renderWorkspaceTopLevelContext(snapshot);
     expect(result).toBe(
       [
-        "<workspace_top_level>",
+        "<workspace>",
         "Root: /empty",
         "Directories: ",
         "Files: ",
-        "</workspace_top_level>",
+        "</workspace>",
       ].join("\n"),
     );
   });
@@ -92,8 +92,8 @@ describe("renderWorkspaceTopLevelContext", () => {
     };
 
     const result = renderWorkspaceTopLevelContext(snapshot);
-    expect(result.startsWith("<workspace_top_level>")).toBe(true);
-    expect(result.endsWith("</workspace_top_level>")).toBe(true);
+    expect(result.startsWith("<workspace>")).toBe(true);
+    expect(result.endsWith("</workspace>")).toBe(true);
   });
 
   test("includes hidden directories", () => {
@@ -124,7 +124,7 @@ describe("renderWorkspaceTopLevelContext", () => {
     expect(result).toContain("Files: a.txt, b.txt");
   });
 
-  test("renders current conversation and attachment paths when provided", () => {
+  test("renders attachment path when provided", () => {
     const snapshot: TopLevelSnapshot = {
       rootPath: "/sandbox",
       directories: ["src"],
@@ -133,16 +133,13 @@ describe("renderWorkspaceTopLevelContext", () => {
     };
 
     const result = renderWorkspaceTopLevelContext(snapshot, {
-      currentConversationPath: "conversations/2026-03-19T12-00-00.000Z_conv-1/",
-      currentConversationAttachmentsPath:
+      conversationAttachmentsPath:
         "conversations/2026-03-19T12-00-00.000Z_conv-1/attachments/",
     });
 
     expect(result).toContain(
-      "Current conversation folder: conversations/2026-03-19T12-00-00.000Z_conv-1/",
+      "Current conversation attachments: conversations/2026-03-19T12-00-00.000Z_conv-1/attachments/",
     );
-    expect(result).toContain(
-      "Attachment files: conversations/2026-03-19T12-00-00.000Z_conv-1/attachments/",
-    );
+    expect(result).not.toContain("Current conversation folder");
   });
 });

--- a/assistant/src/workspace/top-level-renderer.ts
+++ b/assistant/src/workspace/top-level-renderer.ts
@@ -1,8 +1,7 @@
 import type { TopLevelSnapshot } from "./top-level-scanner.js";
 
 export interface WorkspaceTopLevelRenderOptions {
-  currentConversationPath?: string | null;
-  currentConversationAttachmentsPath?: string | null;
+  conversationAttachmentsPath?: string | null;
 }
 
 /**
@@ -15,19 +14,16 @@ export function renderWorkspaceTopLevelContext(
   snapshot: TopLevelSnapshot,
   options: WorkspaceTopLevelRenderOptions = {},
 ): string {
-  const lines: string[] = ["<workspace_top_level>"];
+  const lines: string[] = ["<workspace>"];
   lines.push(`Root: ${snapshot.rootPath}`);
   lines.push(`Directories: ${snapshot.directories.join(", ")}`);
   lines.push(`Files: ${snapshot.files.join(", ")}`);
-  if (options.currentConversationPath) {
-    lines.push(`Current conversation folder: ${options.currentConversationPath}`);
-  }
-  if (options.currentConversationAttachmentsPath) {
-    lines.push(`Attachment files: ${options.currentConversationAttachmentsPath}`);
+  if (options.conversationAttachmentsPath) {
+    lines.push(`Current conversation attachments: ${options.conversationAttachmentsPath}`);
   }
   if (snapshot.truncated) {
     lines.push("(list truncated — more entries exist)");
   }
-  lines.push("</workspace_top_level>");
+  lines.push("</workspace>");
   return lines.join("\n");
 }


### PR DESCRIPTION
## Summary
- Rename XML tag from `<workspace_top_level>` to `<workspace>`
- Drop 'Current conversation folder' line from rendered output
- Rename 'Attachment files' to 'Current conversation attachments'

Part of plan: unify-turn-context-injection.md (PR 1 of 6)