### PR TITLE
fix: update stale workspace_top_level references after tag rename

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -402,7 +402,7 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
       content: [
         {
           type: "text",
-          text: "<workspace_top_level>\nRoot: /sandbox\nDirectories: src, tests\n</workspace_top_level>",
+          text: "<workspace>\nRoot: /sandbox\nDirectories: src, tests\n</workspace>",
         },
         { type: "text", text: "What files are in src?" },
       ],
@@ -432,7 +432,7 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
       content: [
         {
           type: "text",
-          text: "<workspace_top_level>\nRoot: /sandbox\nDirectories: src, tests\n</workspace_top_level>",
+          text: "<workspace>\nRoot: /sandbox\nDirectories: src, tests\n</workspace>",
         },
         { type: "text", text: "Help me debug this" },
         {
@@ -550,7 +550,7 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
         content: [
           {
             type: "text",
-            text: "<workspace_top_level>\nRoot: /sandbox\n</workspace_top_level>",
+            text: "<workspace>\nRoot: /sandbox\n</workspace>",
           },
           {
             type: "tool_result",
@@ -1338,7 +1338,7 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
         content: [
           {
             type: "text",
-            text: "<workspace_top_level>\nRoot: /sandbox\nDirectories: src\n</workspace_top_level>",
+            text: "<workspace>\nRoot: /sandbox\nDirectories: src\n</workspace>",
           },
           { type: "text", text: "Turn 1" },
         ],
@@ -1350,7 +1350,7 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
         content: [
           {
             type: "text",
-            text: "<workspace_top_level>\nRoot: /sandbox\nDirectories: src, lib\n</workspace_top_level>",
+            text: "<workspace>\nRoot: /sandbox\nDirectories: src, lib\n</workspace>",
           },
           { type: "text", text: "Turn 2" },
         ],
@@ -1362,7 +1362,7 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
         content: [
           {
             type: "text",
-            text: "<workspace_top_level>\nRoot: /sandbox\nDirectories: src, lib, docs\n</workspace_top_level>",
+            text: "<workspace>\nRoot: /sandbox\nDirectories: src, lib, docs\n</workspace>",
           },
           { type: "text", text: "Turn 3" },
         ],

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -1293,7 +1293,7 @@ describe("applyRuntimeInjections — injection mode", () => {
 
   const fullOptions = {
     workspaceTopLevelContext:
-      "<workspace_top_level>\nRoot: /sandbox\n</workspace_top_level>",
+      "<workspace>\nRoot: /sandbox\n</workspace>",
     temporalContext:
       "<temporal_context>\nToday: 2026-03-04 (Tue) 12:00 +00:00\nTZ: UTC\n</temporal_context>",
     channelCommandContext: { type: "start" } as const,
@@ -1334,7 +1334,7 @@ describe("applyRuntimeInjections — injection mode", () => {
       .map((b) => b.text)
       .join("\n");
 
-    expect(allText).toContain("<workspace_top_level>");
+    expect(allText).toContain("<workspace>");
     expect(allText).toContain("<temporal_context>");
     expect(allText).toContain("<channel_command_context>");
     expect(allText).toContain("<active_workspace>");
@@ -1356,7 +1356,7 @@ describe("applyRuntimeInjections — injection mode", () => {
       .map((b) => b.text)
       .join("\n");
 
-    expect(allText).toContain("<workspace_top_level>");
+    expect(allText).toContain("<workspace>");
     expect(allText).toContain("<temporal_context>");
     expect(allText).toContain("<channel_command_context>");
     expect(allText).toContain("<active_workspace>");
@@ -1374,7 +1374,7 @@ describe("applyRuntimeInjections — injection mode", () => {
       .join("\n");
 
     // Skipped in minimal mode
-    expect(allText).not.toContain("<workspace_top_level>");
+    expect(allText).not.toContain("<workspace>");
     expect(allText).not.toContain("<temporal_context>");
     expect(allText).not.toContain("<channel_command_context>");
     expect(allText).not.toContain("<active_workspace>");

--- a/assistant/src/__tests__/conversation-runtime-workspace.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-workspace.test.ts
@@ -24,7 +24,7 @@ function assistantMsg(text: string): Message {
 // ---------------------------------------------------------------------------
 
 const sampleContext =
-  "<workspace_top_level>\nRoot: /sandbox\nDirectories: src, lib, tests\n</workspace_top_level>";
+  "<workspace>\nRoot: /sandbox\nDirectories: src, lib, tests\n</workspace>";
 
 describe("Workspace top-level context — injection", () => {
   test("prepends workspace block to user message content", () => {

--- a/assistant/src/__tests__/conversation-workspace-cache-state.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-cache-state.test.ts
@@ -227,16 +227,13 @@ describe("Conversation workspace cache state", () => {
     expect(conversation.isWorkspaceTopLevelDirty()).toBe(false);
     expect(conversation.getWorkspaceTopLevelContext()).not.toBeNull();
     expect(conversation.getWorkspaceTopLevelContext()!).toContain(
-      "<workspace_top_level>",
+      "<workspace>",
     );
     expect(conversation.getWorkspaceTopLevelContext()!).toContain(
-      "</workspace_top_level>",
+      "</workspace>",
     );
     expect(conversation.getWorkspaceTopLevelContext()!).toContain(
-      `Current conversation folder: ${conversationPath}`,
-    );
-    expect(conversation.getWorkspaceTopLevelContext()!).toContain(
-      `Attachment files: ${conversationAttachmentsPath}`,
+      `Current conversation attachments: ${conversationAttachmentsPath}`,
     );
   });
 
@@ -267,7 +264,7 @@ describe("Conversation workspace cache state", () => {
 
     expect(conversation.getWorkspaceTopLevelContext()).not.toBeNull();
     expect(conversation.getWorkspaceTopLevelContext()!).toContain(
-      "<workspace_top_level>",
+      "<workspace>",
     );
     expect(conversation.isWorkspaceTopLevelDirty()).toBe(false);
   });
@@ -286,10 +283,7 @@ describe("Conversation workspace cache state", () => {
       tempConversation.refreshWorkspaceTopLevelContextIfNeeded();
 
       expect(tempConversation.getWorkspaceTopLevelContext()!).toContain(
-        `Current conversation folder: conversations/${legacyDirName}/`,
-      );
-      expect(tempConversation.getWorkspaceTopLevelContext()!).toContain(
-        `Attachment files: conversations/${legacyDirName}/attachments/`,
+        `Current conversation attachments: conversations/${legacyDirName}/attachments/`,
       );
     } finally {
       rmSync(workspaceRoot, { recursive: true, force: true });

--- a/assistant/src/__tests__/conversation-workspace-injection.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-injection.test.ts
@@ -302,8 +302,8 @@ describe("Conversation workspace injection", () => {
     const runtimeUser = runCalls[0][runCalls[0].length - 1];
     expect(runtimeUser.role).toBe("user");
     const text = messageText(runtimeUser);
-    expect(text).toContain("<workspace_top_level>");
-    expect(text).toContain("</workspace_top_level>");
+    expect(text).toContain("<workspace>");
+    expect(text).toContain("</workspace>");
   });
 
   test("workspace context includes root path and directories", async () => {
@@ -316,8 +316,7 @@ describe("Conversation workspace injection", () => {
     const runtimeUser = runCalls[0][runCalls[0].length - 1];
     const text = messageText(runtimeUser);
     expect(text).toContain("Root: /tmp");
-    expect(text).toContain(`Current conversation folder: ${conversationPath}`);
-    expect(text).toContain(`Attachment files: ${conversationAttachmentsPath}`);
+    expect(text).toContain(`Current conversation attachments: ${conversationAttachmentsPath}`);
   });
 
   test("workspace context is prepended before user text", async () => {
@@ -331,7 +330,7 @@ describe("Conversation workspace injection", () => {
     const firstBlock = runtimeUser.content[0];
     expect(firstBlock.type).toBe("text");
     const firstText = (firstBlock as { type: "text"; text: string }).text;
-    expect(firstText).toContain("<workspace_top_level>");
+    expect(firstText).toContain("<workspace>");
   });
 
   test("workspace context is stripped from persisted history", async () => {
@@ -343,7 +342,7 @@ describe("Conversation workspace injection", () => {
     const persistedMessages = conversation.getMessages();
     for (const msg of persistedMessages) {
       const text = messageText(msg);
-      expect(text).not.toContain("<workspace_top_level>");
+      expect(text).not.toContain("<workspace>");
     }
   });
 

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1108,9 +1108,9 @@ export function injectWorkspaceTopLevelContext(
   };
 }
 
-/** Strip `<workspace_top_level>` blocks injected by `injectWorkspaceTopLevelContext`. */
+/** Strip `<workspace>` blocks injected by `injectWorkspaceTopLevelContext`. */
 export function stripWorkspaceTopLevelContext(messages: Message[]): Message[] {
-  return stripUserTextBlocksByPrefix(messages, ["<workspace_top_level>"]);
+  return stripUserTextBlocksByPrefix(messages, ["<workspace>"]);
 }
 
 /**
@@ -1220,7 +1220,7 @@ const RUNTIME_INJECTION_PREFIXES = [
   // the InContextTracker deduplicates nodes across turns, so accumulation
   // does not cause unbounded context growth.
   "<voice_call_control>",
-  "<workspace_top_level>",
+  "<workspace>",
   TEMPORAL_INJECTED_PREFIX,
   "<active_workspace>",
   "<active_dynamic_page>",

--- a/assistant/src/daemon/conversation-workspace.ts
+++ b/assistant/src/daemon/conversation-workspace.ts
@@ -33,8 +33,7 @@ export function refreshWorkspaceTopLevelContextIfNeeded(
     currentConversationPath = `conversations/${resolvedDirName}/`;
   }
   ctx.workspaceTopLevelContext = renderWorkspaceTopLevelContext(snapshot, {
-    currentConversationPath,
-    currentConversationAttachmentsPath: currentConversationPath
+    conversationAttachmentsPath: currentConversationPath
       ? `${currentConversationPath}attachments/`
       : null,
   });


### PR DESCRIPTION
## Summary
- Update `conversation-workspace.ts` to use the new `conversationAttachmentsPath` option after the renderer interface changed in #23169
- Update all test files that still referenced `<workspace_top_level>`, `Current conversation folder:`, and `Attachment files:` to match the new `<workspace>` tag and `Current conversation attachments:` format
- Update `conversation-runtime-assembly.ts` strip/prefix logic to use `<workspace>` instead of `<workspace_top_level>`

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23890772528/job/69663368284