### PR TITLE
fix: update channel turn context test assertion

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -2073,6 +2073,6 @@ describe("applyRuntimeInjections with unifiedTurnContext", () => {
     expect(allText).toContain(sampleBlock);
     expect(allText).toContain("<temporal_context>");
     // The channel turn context also uses <turn_context> tags
-    expect(allText).toContain("user_message_channel: telegram");
+    expect(allText).toContain("channel: telegram");
   });
 });


### PR DESCRIPTION
## Summary
- The `buildChannelTurnContextBlock` function was updated to emit `channel:` instead of `user_message_channel:`, but the "migration overlap" test still asserted against the old field name
- Updated the assertion in the `coexists with channelTurnContext and temporalContext` test to expect `channel: telegram`

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23891015367/job/69664138934
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
