### PR TITLE
refactor: use deleteSkillCapabilityNode in managed-store and catalog-install

### DIFF
--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -17,7 +17,7 @@ import { getPlatformBaseUrl } from "../config/env.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceSkillsDir, readPlatformToken } from "../util/platform.js";
 import { computeSkillHash, writeInstallMeta } from "./install-meta.js";
-import { deleteSkillCapabilityMemory } from "./skill-memory.js";
+import { deleteSkillCapabilityNode } from "../memory/graph/capability-seed.js";
 
 const log = getLogger("catalog-install");
 
@@ -264,7 +264,7 @@ export function uninstallSkillLocally(skillId: string): void {
 
   rmSync(skillDir, { recursive: true, force: true });
   removeSkillsIndexEntry(skillId);
-  deleteSkillCapabilityMemory(skillId);
+  deleteSkillCapabilityNode(skillId);
 }
 
 export async function installSkillLocally(

--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -14,7 +14,7 @@ import { stringify as stringifyYaml } from "yaml";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceSkillsDir } from "../util/platform.js";
 import { writeInstallMeta } from "./install-meta.js";
-import { deleteSkillCapabilityMemory } from "./skill-memory.js";
+import { deleteSkillCapabilityNode } from "../memory/graph/capability-seed.js";
 
 const log = getLogger("managed-store");
 
@@ -319,7 +319,7 @@ export function deleteManagedSkill(
   }
 
   rmSync(skillDir, { recursive: true });
-  deleteSkillCapabilityMemory(id);
+  deleteSkillCapabilityNode(id);
   log.info({ id, path: skillDir }, "Deleted managed skill");
 
   let indexUpdated = false;


### PR DESCRIPTION
## Summary
- Switch managed-store.ts and catalog-install.ts from old deleteSkillCapabilityMemory to new deleteSkillCapabilityNode
- Both files now use the capability-seed.ts system instead of skill-memory.ts

Part of plan: dedup-skill-memory.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
