### PR TITLE
refactor: use capability-seed functions in skill handlers

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -52,10 +52,10 @@ import {
   validateManagedSkillId,
 } from "../../skills/managed-store.js";
 import {
-  deleteSkillCapabilityMemory,
-  seedCatalogSkillMemories,
+  deleteSkillCapabilityNode,
+  seedSkillGraphNodes,
   seedUninstalledCatalogSkillMemories,
-} from "../../skills/skill-memory.js";
+} from "../../memory/graph/capability-seed.js";
 import {
   installExternalSkill,
   resolveSkillSource,
@@ -242,7 +242,7 @@ export function postInstallSkill(
   }
 
   // Seed skill memories
-  seedCatalogSkillMemories();
+  seedSkillGraphNodes();
   void seedUninstalledCatalogSkillMemories().catch(() => {});
 }
 
@@ -603,7 +603,7 @@ export function enableSkill(
       name: skillId,
       state: "enabled",
     });
-    seedCatalogSkillMemories();
+    seedSkillGraphNodes();
     void seedUninstalledCatalogSkillMemories().catch(() => {});
     return { success: true };
   } catch (err) {
@@ -626,7 +626,7 @@ export function disableSkill(
       name: skillId,
       state: "disabled",
     });
-    seedCatalogSkillMemories();
+    seedSkillGraphNodes();
     void seedUninstalledCatalogSkillMemories().catch(() => {});
     return { success: true };
   } catch (err) {
@@ -719,7 +719,7 @@ export async function installSkill(
           "Failed to auto-enable bundled skill",
         );
       }
-      seedCatalogSkillMemories();
+      seedSkillGraphNodes();
       void seedUninstalledCatalogSkillMemories().catch(() => {});
       return { success: true };
     }
@@ -847,14 +847,7 @@ export async function uninstallSkill(
       }
       // Best-effort cleanup of capability memory for uninstalled skill
       // (managed path handles this internally via deleteManagedSkill)
-      deleteSkillCapabilityMemory(skillId);
-      try {
-        const { deleteSkillCapabilityNode } =
-          await import("../../memory/graph/capability-seed.js");
-        deleteSkillCapabilityNode(skillId);
-      } catch {
-        /* best effort */
-      }
+      deleteSkillCapabilityNode(skillId);
     }
 
     // Clean config entry
@@ -1255,7 +1248,7 @@ export async function createSkill(
       );
     }
 
-    seedCatalogSkillMemories();
+    seedSkillGraphNodes();
     void seedUninstalledCatalogSkillMemories().catch(() => {});
     return { success: true };
   } catch (err) {


### PR DESCRIPTION
## Summary
- Replace all seedCatalogSkillMemories/deleteSkillCapabilityMemory calls in handlers/skills.ts
- Now uses seedSkillGraphNodes, seedUninstalledCatalogSkillMemories, and deleteSkillCapabilityNode from capability-seed.ts
- Removes dynamic import of deleteSkillCapabilityNode in favor of static import

Part of plan: dedup-skill-memory.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
