### PR TITLE
refactor: remove old skill memory seeding from lifecycle startup

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -82,10 +82,6 @@ import {
   setCesClient,
   setCesReconnect,
 } from "../security/secure-keys.js";
-import {
-  seedCatalogSkillMemories,
-  seedUninstalledCatalogSkillMemories,
-} from "../skills/skill-memory.js";
 import { UsageTelemetryReporter } from "../telemetry/usage-telemetry-reporter.js";
 import { getDeviceId } from "../util/device-id.js";
 import { getLogger, initLogger } from "../util/logger.js";
@@ -645,23 +641,6 @@ export async function runDaemon(): Promise<void> {
       log.info("Daemon startup: starting memory worker");
       bgRefs.memoryWorker = startMemoryJobsWorker();
 
-      // Seed capability memories for all enabled skills so the memory
-      // pipeline can surface relevant skills via semantic search.
-      try {
-        seedCatalogSkillMemories();
-      } catch (err) {
-        log.warn({ err }, "Catalog skill memory seeding failed — continuing");
-      }
-
-      // Seed memories for catalog skills not yet installed so they're
-      // discoverable via memory injection and can be auto-installed.
-      void seedUninstalledCatalogSkillMemories().catch((err) =>
-        log.warn(
-          { err },
-          "Uninstalled catalog skill memory seeding failed — continuing",
-        ),
-      );
-
       try {
         seedCliCommandMemories();
       } catch (err) {
@@ -670,10 +649,16 @@ export async function runDaemon(): Promise<void> {
 
       // Seed capability graph nodes (new memory graph system)
       try {
-        const { seedSkillGraphNodes, seedCliGraphNodes } =
+        const { seedSkillGraphNodes, seedCliGraphNodes, seedUninstalledCatalogSkillMemories } =
           await import("../memory/graph/capability-seed.js");
         seedSkillGraphNodes();
         seedCliGraphNodes();
+        void seedUninstalledCatalogSkillMemories().catch((err) =>
+          log.warn(
+            { err },
+            "Uninstalled catalog skill memory seeding failed — continuing",
+          ),
+        );
       } catch (err) {
         log.warn({ err }, "Graph capability seeding failed — continuing");
       }


### PR DESCRIPTION
## Summary
- Remove old seedCatalogSkillMemories() and seedUninstalledCatalogSkillMemories() calls from lifecycle.ts
- Only the new capability-seed.ts system now seeds skill memories on startup
- Uninstalled catalog skills still seeded via the new seedUninstalledCatalogSkillMemories from capability-seed.ts

Part of plan: dedup-skill-memory.md (PR 4 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
