### PR TITLE
fix: add missing API_KEY_PROVIDERS mock in skill-load-feature-flag test

### DIFF
--- a/assistant/src/__tests__/skill-load-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-load-feature-flag.test.ts
@@ -39,6 +39,16 @@ mock.module("../config/loader.js", () => ({
   invalidateConfigCache: () => {},
   getNestedValue: () => undefined,
   setNestedValue: () => {},
+  API_KEY_PROVIDERS: [
+    "anthropic",
+    "openai",
+    "gemini",
+    "ollama",
+    "fireworks",
+    "openrouter",
+    "brave",
+    "perplexity",
+  ],
 }));
 
 await import("../tools/skills/load.js");


### PR DESCRIPTION
## Summary
- The `skill-load-feature-flag.test.ts` mock of `config/loader.js` was missing the `API_KEY_PROVIDERS` export, causing a `SyntaxError` at import time and failing CI
- Added the missing export to the mock

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23891300624/job/69665077095