### PR TITLE
fix: add missing deepMergeOverwrite to config/loader mock

### DIFF
--- a/assistant/src/__tests__/skill-load-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-load-feature-flag.test.ts
@@ -39,6 +39,7 @@ mock.module("../config/loader.js", () => ({
   invalidateConfigCache: () => {},
   getNestedValue: () => undefined,
   setNestedValue: () => {},
+  deepMergeOverwrite: (a: unknown) => a,
   API_KEY_PROVIDERS: [
     "anthropic",
     "openai",


### PR DESCRIPTION
## Summary
- Add missing `deepMergeOverwrite` export to the `config/loader.js` mock in `skill-load-feature-flag.test.ts`
- The mock was missing this named export, causing a `SyntaxError` when Bun tried to resolve the module during test import

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23891473147/job/69665649132
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
