### PR TITLE
fix: add missing mergeDefaultWorkspaceConfig mock in skill-load-feature-flag test

### DIFF
--- a/assistant/src/__tests__/skill-load-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-load-feature-flag.test.ts
@@ -40,6 +40,7 @@ mock.module("../config/loader.js", () => ({
   getNestedValue: () => undefined,
   setNestedValue: () => {},
   deepMergeOverwrite: (a: unknown) => a,
+  mergeDefaultWorkspaceConfig: () => {},
   API_KEY_PROVIDERS: [
     "anthropic",
     "openai",


### PR DESCRIPTION
## Summary
- Add `mergeDefaultWorkspaceConfig` to the `config/loader.js` mock in `skill-load-feature-flag.test.ts` — the function was added to the real module but not the test mock, causing a `SyntaxError: Export named 'mergeDefaultWorkspaceConfig' not found` in CI.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23891613881/job/69666108666