### PR TITLE
fix: protect uninstalled catalog skills from pruning in seedSkillGraphNodes

### DIFF
--- a/assistant/src/memory/graph/capability-seed.ts
+++ b/assistant/src/memory/graph/capability-seed.ts
@@ -13,7 +13,10 @@ import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-fl
 import { getConfig } from "../../config/loader.js";
 import { resolveSkillStates } from "../../config/skill-state.js";
 import { loadSkillCatalog } from "../../config/skills.js";
-import { getCatalog } from "../../skills/catalog-cache.js";
+import {
+  getCatalog,
+  getCachedCatalogSync,
+} from "../../skills/catalog-cache.js";
 import {
   fromCatalogSkill,
   fromSkillSummary,
@@ -110,11 +113,22 @@ export function seedSkillGraphNodes(): void {
       seenKeys.add(`${SKILL_SOURCE_PREFIX}${summary.id}`);
     }
 
-    // Always prune stale capability nodes — this cleans up nodes from
-    // previously-seeded uninstalled skills that are no longer refreshed.
-    // seenKeys already contains all locally-installed-and-enabled skills
-    // which is sufficient to identify what should be kept.
-    pruneStaleCapabilities(SKILL_SOURCE_PREFIX, seenKeys);
+    // Protect uninstalled catalog skills from pruning — they are seeded
+    // asynchronously by seedUninstalledCatalogSkillMemories() and should
+    // not be marked as "gone" just because they aren't locally installed.
+    // This mirrors the old seedCatalogSkillMemories() behavior.
+    const cachedCatalog = getCachedCatalogSync();
+    if (cachedCatalog.length === 0) {
+      // Cold start: catalog cache is empty (async fetch hasn't completed).
+      // We can't distinguish stale nodes from valid uninstalled catalog
+      // skill nodes, so skip pruning entirely to avoid churn.
+      log.info("Skipping skill capability pruning — catalog cache is empty");
+    } else {
+      for (const entry of cachedCatalog) {
+        seenKeys.add(`${SKILL_SOURCE_PREFIX}${entry.id}`);
+      }
+      pruneStaleCapabilities(SKILL_SOURCE_PREFIX, seenKeys);
+    }
 
     // Clean up old-format nodes created by the legacy skill-memory.ts system.
     // Those nodes have content like "skill:{id}\n..." instead of the current


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for dedup-skill-memory.md.

**Gap:** seedSkillGraphNodes prunes nodes created by seedUninstalledCatalogSkillMemories
**What was expected:** Uninstalled catalog skill nodes should not be pruned
**What was found:** pruneStaleCapabilities only knew about enabled skills, pruning uninstalled catalog entries