### PR TITLE
feat: save truncated shell output to temp file and reduce limit to 20K

### DIFF
--- a/assistant/src/__tests__/sandbox-host-parity.test.ts
+++ b/assistant/src/__tests__/sandbox-host-parity.test.ts
@@ -705,10 +705,11 @@ describe("Terminal output format: formatShellOutput shared by sandbox and host",
     const longOutput = "x".repeat(MAX_OUTPUT_LENGTH + 100);
     const result = formatShellOutput(longOutput, "", 0, false, 120);
 
-    expect(result.content.length).toBe(
-      MAX_OUTPUT_LENGTH + 1 + '<output_truncated limit="50K" />'.length,
-    );
-    expect(result.content).toContain("<output_truncated");
+    expect(result.content).toContain('limit="20K"');
+    expect(result.content).toContain('file="');
+    // The <output_truncated tag starts right after MAX_OUTPUT_LENGTH chars + 1 newline
+    const tagStart = result.content.indexOf("<output_truncated");
+    expect(tagStart).toBe(MAX_OUTPUT_LENGTH + 1);
   });
 
   test("timed-out command appends timeout tag and sets isError", () => {

--- a/assistant/src/__tests__/terminal-tools.test.ts
+++ b/assistant/src/__tests__/terminal-tools.test.ts
@@ -1,3 +1,4 @@
+import { existsSync, readFileSync } from "node:fs";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { ShellOutputResult } from "../tools/shared/shell-output.js";
@@ -722,9 +723,14 @@ describe("formatShellOutput", () => {
   });
 
   test("truncates very long output", () => {
-    const longOutput = "x".repeat(60_000);
+    const longOutput = "x".repeat(30_000);
     const result = formatShellOutput(longOutput, "", 0, false, 120);
-    expect(result.content).toContain('<output_truncated limit="50K" />');
-    expect(result.content.length).toBeLessThan(60_000);
+    expect(result.content).toContain('limit="20K"');
+    // Extract the file="..." attribute from the truncation tag
+    const fileMatch = result.content.match(/file="([^"]+)"/);
+    expect(fileMatch).not.toBeNull();
+    const filePath = fileMatch![1];
+    expect(existsSync(filePath)).toBe(true);
+    expect(readFileSync(filePath, "utf-8")).toBe(longOutput);
   });
 });

--- a/assistant/src/tools/shared/shell-output.ts
+++ b/assistant/src/tools/shared/shell-output.ts
@@ -1,4 +1,9 @@
-export const MAX_OUTPUT_LENGTH = 50_000;
+import { writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+export const MAX_OUTPUT_LENGTH = 20_000;
 
 export interface ShellOutputResult {
   content: string;
@@ -33,7 +38,15 @@ export function formatShellOutput(
   }
 
   if (output.length > MAX_OUTPUT_LENGTH) {
-    const msg = '<output_truncated limit="50K" />';
+    let fullOutputPath: string | undefined;
+    try {
+      fullOutputPath = join(tmpdir(), `vellum-shell-output-${randomUUID()}.txt`);
+      writeFileSync(fullOutputPath, output, "utf-8");
+    } catch {
+      fullOutputPath = undefined;
+    }
+    const fileAttr = fullOutputPath ? ` file="${fullOutputPath}"` : "";
+    const msg = `<output_truncated limit="20K"${fileAttr} />`;
     output = output.slice(0, MAX_OUTPUT_LENGTH) + `\n${msg}`;
     statusParts.push(msg);
   }


### PR DESCRIPTION
## Summary
- Reduce MAX_OUTPUT_LENGTH from 50K to 20K characters
- When output is truncated, save the full output to a temp file in os.tmpdir()
- Include the temp file path in the truncation XML tag so the assistant can read it later
- Graceful degradation: if temp file write fails, truncation still works without file attribute

Part of plan: shell-truncation-tempfile.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
