### PR TITLE
fix: resolve lint errors on main

### DIFF
--- a/assistant/src/__tests__/skill-memory.test.ts
+++ b/assistant/src/__tests__/skill-memory.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import type { SkillSummary } from "../config/skills.js";
-import {
-  fromSkillSummary,
-  type SkillCapabilityInput,
-} from "../skills/skill-memory.js";
+import { fromSkillSummary } from "../skills/skill-memory.js";
 
 function makeSkillSummary(
   overrides: Partial<SkillSummary> = {},

--- a/assistant/src/daemon/date-context.ts
+++ b/assistant/src/daemon/date-context.ts
@@ -290,28 +290,6 @@ function formatLocalDate(date: Date, timeZone: string): string {
 }
 
 /**
- * Format HH:MM and UTC offset for the given instant in the given timezone.
- */
-function formatCompactTimeAndOffset(
-  date: Date,
-  timeZone: string,
-): { time: string; offset: string } {
-  const fmt = new Intl.DateTimeFormat("en-US", {
-    timeZone,
-    hour: "2-digit",
-    minute: "2-digit",
-    hourCycle: "h23",
-    timeZoneName: "shortOffset",
-  });
-  const parts = fmt.formatToParts(date);
-  const get = (t: string) => parts.find((p) => p.type === t)?.value ?? "";
-  const hour = get("hour");
-  const minute = get("minute");
-  const offset = normalizeOffsetToken(get("timeZoneName"));
-  return { time: `${hour}:${minute}`, offset };
-}
-
-/**
  * Format time as HH:MM:SS with UTC offset and timezone name.
  *
  * Uses the timezone resolution cascade:

--- a/assistant/src/memory/graph/capability-seed.ts
+++ b/assistant/src/memory/graph/capability-seed.ts
@@ -13,8 +13,8 @@ import { getConfig } from "../../config/loader.js";
 import { resolveSkillStates } from "../../config/skill-state.js";
 import { loadSkillCatalog } from "../../config/skills.js";
 import {
-  getCatalog,
   getCachedCatalogSync,
+  getCatalog,
 } from "../../skills/catalog-cache.js";
 import {
   fromCatalogSkill,

--- a/assistant/src/tools/shared/shell-output.ts
+++ b/assistant/src/tools/shared/shell-output.ts
@@ -1,7 +1,7 @@
+import { randomUUID } from "node:crypto";
 import { writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { randomUUID } from "node:crypto";
 
 export const MAX_OUTPUT_LENGTH = 20_000;
 


### PR DESCRIPTION
## Summary
- Remove unused `SkillCapabilityInput` type import from `skill-memory.test.ts`
- Remove unused `formatCompactTimeAndOffset` function from `date-context.ts`
- Fix import sort order in `capability-seed.ts` and `shell-output.ts`

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23891871701/job/69666946948
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
