### PR TITLE
fix: update SKILL.md files to reference turn_context instead of temporal_context

### DIFF
--- a/assistant/docs/architecture/memory.md
+++ b/assistant/docs/architecture/memory.md
@@ -558,49 +558,47 @@ The Anthropic provider places `cache_control: { type: 'ephemeral' }` on the **la
 | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | `assistant/src/workspace/top-level-scanner.ts`          | Synchronous directory scanner with `MAX_TOP_LEVEL_ENTRIES` cap                                                                             |
 | `assistant/src/workspace/top-level-renderer.ts`         | Renders `TopLevelSnapshot` to `<workspace_top_level>` XML block                                                                            |
-| `assistant/src/daemon/conversation-runtime-assembly.ts` | Runtime injections and strip helpers (`<workspace_top_level>`, `<temporal_context>`, `<channel_onboarding_playbook>`, `<onboarding_mode>`) |
+| `assistant/src/daemon/conversation-runtime-assembly.ts` | Runtime injections and strip helpers (`<workspace_top_level>`, `<turn_context>`, `<channel_onboarding_playbook>`, `<onboarding_mode>`) |
 | `assistant/src/onboarding/onboarding-orchestrator.ts`   | Builds assistant-owned onboarding runtime guidance from channel playbook + transport metadata                                              |
 | `assistant/src/daemon/conversation-agent-loop.ts`       | Agent loop orchestration, runtime injection wiring, strip chain                                                                            |
 
 ---
 
-## Temporal Context Injection — Date Grounding
+## Turn Context Injection — Date & Actor Grounding
 
-The session injects a `<temporal_context>` block into every user message at runtime, giving the model awareness of the current date, current local time, current UTC time, and timezone source metadata. This enables reliable reasoning about dates and times without persisting volatile temporal data in conversation history.
+The session injects a unified `<turn_context>` block into every user message at runtime, giving the model awareness of the current timestamp (with timezone), interface, channel, and actor identity. This replaces the former separate `<temporal_context>`, `<inbound_actor_context>`, and per-channel turn context blocks.
+
+The `timestamp:` field format is: `2026-04-02 (Wed) 14:30:00 -05:00 (America/Chicago)` — date, abbreviated weekday, local time, UTC offset, and IANA timezone name.
 
 ### Per-turn flow
 
 ```mermaid
 graph TB
     subgraph "Per-Turn Flow"
-        BUILD["buildTemporalContext(timeZone, hostTimeZone, userTimeZone)<br/>→ compact XML block"]
-        INJECT["applyRuntimeInjections<br/>prepend temporal block<br/>to user message"]
+        BUILD["buildUnifiedTurnContext(options)<br/>→ unified XML block"]
+        INJECT["applyRuntimeInjections<br/>prepend turn context block<br/>to user message"]
         AGENT["AgentLoop.run(runMessages)"]
-        STRIP["stripTemporalContext<br/>remove block from persisted history"]
     end
 
     BUILD --> INJECT
     INJECT --> AGENT
-    AGENT --> STRIP
 ```
 
 ### Key design decisions
 
-- **Fresh each turn**: `buildTemporalContext()` is called at the start of every agent loop invocation, ensuring the model always sees the current date even in long-running conversations.
+- **Fresh each turn**: Turn context is built at the start of every agent loop invocation, ensuring the model always sees the current timestamp even in long-running conversations.
 - **Clock source invariant**: Absolute time (`now`) always comes from the assistant host clock (`Date.now()`), never from channel/client clocks.
 - **Timezone precedence**: If `ui.userTimezone` is configured, temporal context uses it for local-date interpretation. Otherwise it falls back to memory-stored timezone, then assistant host timezone.
 - **Timezone-aware**: Uses `Intl.DateTimeFormat` APIs for DST-safe date arithmetic and timezone validation/canonicalization.
-- **Runtime-only**: The injected `<temporal_context>` block is stripped from `this.messages` after the agent loop completes via `stripTemporalContext`. It never persists in conversation history.
-- **Specific strip prefix**: The strip function matches the exact injected prefix (`<temporal_context>\nToday:`) to avoid accidentally removing user-authored text that starts with `<temporal_context>`.
-- **Retry paths**: Temporal context is included in all three `applyRuntimeInjections` call sites (main path, compact retry, media-trim retry).
+- **Persisted in history**: Unlike the former `<temporal_context>` block, unified `<turn_context>` blocks persist in conversation history so the assistant retains temporal and actor grounding across turns. Legacy `<temporal_context>` blocks from pre-unification history are still stripped for backward compatibility.
+- **Retry paths**: Turn context is included in all `applyRuntimeInjections` call sites (main path, compact retry, media-trim retry).
 
 ### Key files
 
-| File                                                    | Role                                                                                    |
-| ------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| `assistant/src/daemon/date-context.ts`                  | `buildTemporalContext()` — generates the `<temporal_context>` XML block                 |
-| `assistant/src/daemon/conversation-runtime-assembly.ts` | `injectTemporalContext()` / `stripTemporalContext()` helpers                            |
-| `assistant/src/daemon/conversation-agent-loop.ts`       | Wiring: computes temporal context, passes to `applyRuntimeInjections`, strips after run |
+| File                                                    | Role                                                                                          |
+| ------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `assistant/src/daemon/conversation-runtime-assembly.ts` | `buildUnifiedTurnContext()` — generates the `<turn_context>` XML block; strip helpers          |
+| `assistant/src/daemon/conversation-agent-loop.ts`       | Wiring: computes turn context options, passes to `applyRuntimeInjections`                      |
 
 ---
 

--- a/assistant/src/config/bundled-skills/gmail/SKILL.md
+++ b/assistant/src/config/bundled-skills/gmail/SKILL.md
@@ -156,9 +156,9 @@ Scan tools (`gmail_sender_digest`, `gmail_outreach_scan`) return a `scan_id` tha
 
 Before composing any email that references a date or time:
 
-1. Check the `<temporal_context>` block in the current turn for today's date and timezone
+1. Check the `timestamp:` field in the `<turn_context>` block for today's date and timezone
 2. Verify that "tomorrow" means the day after today's date, "next week" means the upcoming Monday–Friday, etc.
-3. If the email references a date from another message, cross-check it against the temporal context to ensure it's in the future
+3. If the email references a date from another message, cross-check it against the turn context to ensure it's in the future
 
 ## Confidence Scores
 

--- a/skills/time-based-actions/SKILL.md
+++ b/skills/time-based-actions/SKILL.md
@@ -45,19 +45,19 @@ If you use `send_notification` for any of these, the notification fires immediat
 
 ## Time Grounding Source
 
-Use the injected `<temporal_context>` block as the authoritative clock source:
+Use the `timestamp:` field from the injected `<turn_context>` block as the authoritative clock source. The timestamp format is:
 
-- `Today:` line contains the date, abbreviated weekday, local time (HH:MM), and UTC offset.
-- `TZ:` line is the IANA timezone identifier. When followed by `(host fallback)`, the timezone was inferred from the assistant host — not the user.
+```
+timestamp: 2026-04-02 (Wed) 14:30:00 -05:00 (America/Chicago)
+```
 
-When `TZ:` shows `(host fallback)` and the request is locale-specific (e.g. "at 3pm", "tomorrow morning", "tonight"), ask once for their timezone and then proceed.
-If the user confirms a timezone, suggest saving it in Settings -> Appearance -> User timezone so future reminders resolve correctly without re-asking.
+It contains the date, abbreviated weekday, local time (HH:MM:SS), UTC offset, and IANA timezone name in parentheses.
 
 ## Relative Time Parsing
 
 When the user says "in X minutes/hours", compute the ISO 8601 timestamp yourself:
 
-- Take the time and offset from the `Today:` line (e.g. `23:26 -05:00`)
+- Take the time and offset from the `timestamp:` field (e.g. `23:26:00 -05:00`)
 - Add the requested offset
 - Format as ISO 8601 with timezone: `2025-03-15T09:05:00-05:00`
 - Pass to `reminder_create` as `fire_at`


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for unify-turn-context-injection.md.

**Gap:** SKILL.md files reference removed temporal_context block
**What was expected:** References to current turn_context format with timestamp field
**What was found:** Two SKILL.md files still reference the removed temporal_context block

- Updated `skills/time-based-actions/SKILL.md` to reference `<turn_context>` and `timestamp:` field, removed `(host fallback)` timezone instructions since timezone is always present
- Updated `assistant/src/config/bundled-skills/gmail/SKILL.md` to reference `<turn_context>` and `timestamp:` field
- Updated `assistant/docs/architecture/memory.md` to document the unified `<turn_context>` block instead of the removed `<temporal_context>` block
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
