### PR TITLE
feat: add `RetrievalMetrics` interface for graph memory retrieval telemetry

### DIFF
--- a/assistant/src/memory/graph/types.ts
+++ b/assistant/src/memory/graph/types.ts
@@ -254,6 +254,29 @@ export interface ScoredNode {
 }
 
 // ---------------------------------------------------------------------------
+// Retrieval Metrics
+// ---------------------------------------------------------------------------
+
+export interface RetrievalMetrics {
+  semanticHits: number;
+  mergedCount: number;
+  selectedCount: number;
+  tier1Count: number;
+  tier2Count: number;
+  hybridSearchLatencyMs: number;
+  sparseVectorUsed: boolean;
+  embeddingProvider: string | null;
+  embeddingModel: string | null;
+  topCandidates: Array<{
+    nodeId: string;
+    type: string;
+    score: number;
+    semanticSimilarity: number;
+    recencyBoost: number;
+  }>;
+}
+
+// ---------------------------------------------------------------------------
 // Results
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Defines a shared `RetrievalMetrics` interface in `types.ts` for graph memory retrieval telemetry
- Includes fields for semantic hits, tier counts, hybrid search latency, embedding provider/model, and top candidates

Part of plan: fix-memory-inspector-metrics.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
