### PR TITLE
fix: update SKILL.md files to reference interface instead of channel in turn_context

### DIFF
--- a/assistant/src/config/bundled-skills/schedule/SKILL.md
+++ b/assistant/src/config/bundled-skills/schedule/SKILL.md
@@ -101,7 +101,7 @@ Optionally pass `routing_hints` (a JSON object) to influence routing decisions (
 
 - **Default to `all_channels`** for most notifications. Users usually want to be notified wherever they are.
 - **Use `single_channel`** only when the user explicitly specifies a single channel (e.g. "remind me on Telegram").
-- **Check `user_message_channel` (or `channel` when all channels are the same)** from the turn context. If the user is currently active on a specific channel, include it as a routing hint:
+- **Check the `interface` field** from the `<turn_context>` block. If the user is currently active on a specific interface (e.g. `macos`, `slack`, `telegram`), include it as a routing hint:
   ```
   routing_hints: { preferred_channels: ["vellum"] }
   routing_intent: "all_channels"

--- a/skills/time-based-actions/SKILL.md
+++ b/skills/time-based-actions/SKILL.md
@@ -125,7 +125,7 @@ Use the following heuristics to pick `routing_intent`:
 
 - **Default to `all_channels`** for most reminders. Users setting reminders usually want to be notified wherever they are, and redundant notifications are less harmful than missed ones.
 - **Use `single_channel`** only when the user explicitly specifies a single channel (e.g. "remind me on Telegram") or the reminder is low-stakes and noise reduction matters.
-- **Check `user_message_channel` (or `channel` when all channels are the same)** from the turn context. If the user is currently active on a specific channel (e.g. `vellum`), always include that channel. Pass it as a routing hint:
+- **Check the `interface` field** from the `<turn_context>` block. If the user is currently active on a specific interface (e.g. `macos`, `slack`, `telegram`), always include that channel. Pass it as a routing hint:
   ```
   routing_hints: { preferred_channels: ["vellum"] }
   routing_intent: "all_channels"


### PR DESCRIPTION
## Summary
Fixes gap from plan review round 2 for unify-turn-context-injection.md.

**Gap:** SKILL.md files reference channel/user_message_channel fields no longer emitted in turn_context
**Fix:** Updated to reference interface field instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)