### PR TITLE
chore: remove dead stripWorkspaceTopLevelContext and related dead code

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-workspace.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-workspace.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, test } from "bun:test";
 import {
   applyRuntimeInjections,
   injectWorkspaceTopLevelContext,
-  stripWorkspaceTopLevelContext,
 } from "../daemon/conversation-runtime-assembly.js";
 import type { Message } from "../providers/types.js";
 
@@ -13,10 +12,6 @@ import type { Message } from "../providers/types.js";
 
 function userMsg(text: string): Message {
   return { role: "user", content: [{ type: "text", text }] };
-}
-
-function assistantMsg(text: string): Message {
-  return { role: "assistant", content: [{ type: "text", text }] };
 }
 
 // ---------------------------------------------------------------------------
@@ -59,93 +54,6 @@ describe("Workspace top-level context — injection", () => {
     injectWorkspaceTopLevelContext(original, sampleContext);
 
     expect(original.content).toHaveLength(originalContentLength);
-  });
-});
-
-describe("Workspace top-level context — stripping", () => {
-  test("strips injected workspace block from user messages", () => {
-    const messages: Message[] = [
-      {
-        role: "user",
-        content: [
-          { type: "text", text: sampleContext },
-          { type: "text", text: "Hello" },
-        ],
-      },
-      assistantMsg("Hi there"),
-    ];
-
-    const stripped = stripWorkspaceTopLevelContext(messages);
-
-    expect(stripped).toHaveLength(2);
-    expect(stripped[0].content).toHaveLength(1);
-    expect((stripped[0].content[0] as { text: string }).text).toBe("Hello");
-  });
-
-  test("does not strip non-workspace text blocks", () => {
-    const messages: Message[] = [
-      userMsg("Regular message"),
-      assistantMsg("Response"),
-    ];
-
-    const stripped = stripWorkspaceTopLevelContext(messages);
-    expect(stripped).toEqual(messages);
-  });
-
-  test("removes user message entirely when only workspace block remains", () => {
-    const messages: Message[] = [
-      { role: "user", content: [{ type: "text", text: sampleContext }] },
-      assistantMsg("Response"),
-    ];
-
-    const stripped = stripWorkspaceTopLevelContext(messages);
-    expect(stripped).toHaveLength(1);
-    expect(stripped[0].role).toBe("assistant");
-  });
-
-  test("does not strip from assistant messages", () => {
-    const messages: Message[] = [assistantMsg(sampleContext)];
-
-    const stripped = stripWorkspaceTopLevelContext(messages);
-    expect(stripped).toHaveLength(1);
-    expect((stripped[0].content[0] as { text: string }).text).toBe(
-      sampleContext,
-    );
-  });
-
-  test("preserves tool_result blocks during stripping", () => {
-    const messages: Message[] = [
-      {
-        role: "user",
-        content: [
-          { type: "text", text: sampleContext },
-          {
-            type: "tool_result",
-            tool_use_id: "tu_1",
-            content: "result",
-            is_error: false,
-          },
-        ],
-      },
-    ];
-
-    const stripped = stripWorkspaceTopLevelContext(messages);
-    expect(stripped).toHaveLength(1);
-    expect(stripped[0].content).toHaveLength(1);
-    expect(stripped[0].content[0].type).toBe("tool_result");
-  });
-
-  test("no empty-message artifacts after stripping", () => {
-    const messages: Message[] = [
-      userMsg("Before"),
-      { role: "user", content: [{ type: "text", text: sampleContext }] },
-      assistantMsg("After"),
-    ];
-
-    const stripped = stripWorkspaceTopLevelContext(messages);
-    expect(stripped).toHaveLength(2);
-    expect(stripped[0].role).toBe("user");
-    expect(stripped[1].role).toBe("assistant");
   });
 });
 

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -875,11 +875,6 @@ export function injectWorkspaceTopLevelContext(
   };
 }
 
-/** Strip `<workspace>` blocks injected by `injectWorkspaceTopLevelContext`. */
-export function stripWorkspaceTopLevelContext(messages: Message[]): Message[] {
-  return stripUserTextBlocksByPrefix(messages, ["<workspace>"]);
-}
-
 /**
  * Strip `<active_workspace>` (and legacy `<active_dynamic_page>`) blocks
  * injected by `injectActiveSurfaceContext`.


### PR DESCRIPTION
## Summary
Fixes gap from plan review round 2 for unify-turn-context-injection.md.

**Gap:** stripWorkspaceTopLevelContext is dead code that contradicts workspace persistence design
**Fix:** Removed the dead function and its tests

- Removed `stripWorkspaceTopLevelContext()` from `conversation-runtime-assembly.ts` — it was never called from any production path, and if ever invoked would incorrectly destroy persistent workspace context from history
- Removed the 6 stripping tests from `conversation-runtime-workspace.test.ts`
- Removed unused `assistantMsg` test helper
- Kept `injectWorkspaceTopLevelContext()` which is still actively used by `applyRuntimeInjections`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
