### PR TITLE
fix: populate memory recall log with real graph retrieval metrics

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -628,25 +628,55 @@ export async function runAgentLoopImpl(
         }
       }
 
+      const m = graphResult.metrics;
+
       try {
         recordMemoryRecallLog({
           conversationId: ctx.conversationId,
           enabled: true,
           degraded: false,
-          semanticHits: 0,
-          mergedCount: 0,
-          selectedCount: 0,
-          tier1Count: 0,
-          tier2Count: 0,
-          hybridSearchLatencyMs: 0,
-          sparseVectorUsed: false,
+          provider: m?.embeddingProvider ?? undefined,
+          model: m?.embeddingModel ?? undefined,
+          semanticHits: m?.semanticHits ?? 0,
+          mergedCount: m?.mergedCount ?? 0,
+          selectedCount: m?.selectedCount ?? 0,
+          tier1Count: m?.tier1Count ?? 0,
+          tier2Count: m?.tier2Count ?? 0,
+          hybridSearchLatencyMs: m?.hybridSearchLatencyMs ?? 0,
+          sparseVectorUsed: m?.sparseVectorUsed ?? false,
           injectedTokens: graphResult.injectedTokens,
           latencyMs: graphResult.latencyMs,
-          topCandidatesJson: [],
+          topCandidatesJson: m?.topCandidates ?? [],
+          injectedText: graphResult.injectedBlockText ?? undefined,
           reason: `graph:${graphResult.mode}`,
         });
       } catch (err) {
         log.warn({ err }, "Failed to persist memory recall log (non-fatal)");
+      }
+
+      if (m) {
+        onEvent({
+          type: "memory_recalled",
+          provider: m.embeddingProvider ?? "unknown",
+          model: m.embeddingModel ?? "unknown",
+          semanticHits: m.semanticHits,
+          mergedCount: m.mergedCount,
+          selectedCount: m.selectedCount,
+          tier1Count: m.tier1Count,
+          tier2Count: m.tier2Count,
+          hybridSearchLatencyMs: m.hybridSearchLatencyMs,
+          sparseVectorUsed: m.sparseVectorUsed,
+          injectedTokens: graphResult.injectedTokens,
+          latencyMs: graphResult.latencyMs,
+          topCandidates: m.topCandidates.map((c) => ({
+            key: c.nodeId,
+            type: c.type,
+            kind: "graph",
+            finalScore: c.score,
+            semantic: c.semanticSimilarity,
+            recency: c.recencyBoost,
+          })),
+        } as ServerMessage);
       }
     }
 


### PR DESCRIPTION
## Summary
- Replaces hardcoded zeros in `recordMemoryRecallLog()` with real metrics from graph retriever
- Emits `memory_recalled` SSE event with real data for CLI telemetry
- Closes the loop: Memory tab in LLM Context Inspector now shows actual retrieval funnel data

Part of plan: fix-memory-inspector-metrics.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
