### PR TITLE
fix: capture pure semantic hits before trigger additions in per-turn retrieval

### DIFF
--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -954,6 +954,9 @@ export async function retrieveForTurn(
     hybridSearchLatencyMs = Date.now() - searchStart;
   }
 
+  // Snapshot pure vector-search results before triggers inflate the set
+  const pureSemanticHits = allCandidateIds.size;
+
   // 3. Evaluate semantic triggers
   const semanticTriggers = getActiveTriggersByType("semantic", opts.scopeId);
   const triggeredSemantic =
@@ -987,7 +990,7 @@ export async function retrieveForTurn(
       latencyMs: Date.now() - start,
       metrics: {
         ...ZERO_METRICS,
-        semanticHits: allCandidateIds.size,
+        semanticHits: pureSemanticHits,
         hybridSearchLatencyMs,
         embeddingProvider,
         embeddingModel,
@@ -1115,7 +1118,7 @@ export async function retrieveForTurn(
     triggeredNodes: triggeredSemantic,
     latencyMs: Date.now() - start,
     metrics: {
-      semanticHits: allCandidateIds.size,
+      semanticHits: pureSemanticHits,
       mergedCount: scored.length,
       selectedCount: allInjected.length,
       tier1Count: 0,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-memory-inspector-metrics.md.

**Gap:** Per-turn semanticHits includes triggered nodes, inflating the count
**What was expected:** semanticHits should reflect only pure vector search results
**What was found:** allCandidateIds.size was measured after triggered nodes were added
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
