### PR TITLE
fix: map topCandidatesJson field names to match Swift client expectations

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -646,7 +646,14 @@ export async function runAgentLoopImpl(
           sparseVectorUsed: m?.sparseVectorUsed ?? false,
           injectedTokens: graphResult.injectedTokens,
           latencyMs: graphResult.latencyMs,
-          topCandidatesJson: m?.topCandidates ?? [],
+          topCandidatesJson: (m?.topCandidates ?? []).map((c) => ({
+            key: c.nodeId,
+            type: c.type,
+            kind: "graph",
+            finalScore: c.score,
+            semantic: c.semanticSimilarity,
+            recency: c.recencyBoost,
+          })),
           injectedText: graphResult.injectedBlockText ?? undefined,
           reason: `graph:${graphResult.mode}`,
         });


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-memory-inspector-metrics.md.

**Gap:** topCandidatesJson stored in DB has wrong field names for Swift client
**What was expected:** Fields matching Swift MemoryRecallCandidate: key, kind, finalScore, semantic, recency
**What was found:** Fields from RetrievalMetrics: nodeId, score, semanticSimilarity, recencyBoost
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
