### PR TITLE
fix: add memory_recalled case to Swift SSE decoder

### DIFF
--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2112,6 +2112,7 @@ public enum ServerMessage: Decodable, Sendable {
     case conversationListResponse(ConversationListResponseMessage)
     case historyResponse(HistoryResponse)
     case memoryStatus(MemoryStatusMessage)
+    case memoryRecalled(MemoryRecalledMessage)
     case dictationResponse(DictationResponseMessage)
     case error(ErrorMessage)
     case uiSurfaceShow(UiSurfaceShowMessage)
@@ -2294,6 +2295,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "memory_status":
             let message = try MemoryStatusMessage(from: decoder)
             self = .memoryStatus(message)
+        case "memory_recalled":
+            let message = try MemoryRecalledMessage(from: decoder)
+            self = .memoryRecalled(message)
         case "dictation_response":
             let message = try DictationResponseMessage(from: decoder)
             self = .dictationResponse(message)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-memory-inspector-metrics.md.

**Gap:** Swift SSE decoder missing memory_recalled case
**What was expected:** macOS client should decode memory_recalled SSE events
**What was found:** The event falls through to unknown and is silently dropped
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
