### PR TITLE
fix: capture embedding provider/model on image-only retrieval turns

### DIFF
--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -866,6 +866,10 @@ export async function retrieveForTurn(
           const imgResult = await embedWithRetry(opts.config, [imageInput], {
             signal: opts.signal,
           });
+          if (!embeddingProvider) {
+            embeddingProvider = imgResult.provider;
+            embeddingModel = imgResult.model;
+          }
           const imgVector = imgResult.vectors[0];
           if (imgVector) {
             const imgResults = await searchGraphNodes(imgVector, 40, [


### PR DESCRIPTION
## Summary
Fixes gap: image-only turns reported null embedding provider/model in retrieval metrics.

The image embed path in retrieveForTurn() calls embedWithRetry but didn't capture
provider/model from the result. Now captures them from the first successful image embed.