### PR TITLE
fix: replace `as ServerMessage` cast with typed `MemoryRecalled` variable

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -122,6 +122,7 @@ import type {
   SurfaceType,
   UsageStats,
 } from "./message-protocol.js";
+import type { MemoryRecalled } from "./message-types/memory.js";
 import type { TraceEmitter } from "./trace-emitter.js";
 
 const log = getLogger("conversation-agent-loop");
@@ -662,7 +663,7 @@ export async function runAgentLoopImpl(
       }
 
       if (m) {
-        onEvent({
+        const memoryRecalledEvent: MemoryRecalled = {
           type: "memory_recalled",
           provider: m.embeddingProvider ?? "unknown",
           model: m.embeddingModel ?? "unknown",
@@ -683,7 +684,8 @@ export async function runAgentLoopImpl(
             semantic: c.semanticSimilarity,
             recency: c.recencyBoost,
           })),
-        } as ServerMessage);
+        };
+        onEvent(memoryRecalledEvent);
       }
     }
 


### PR DESCRIPTION
## Summary
Removes the `as ServerMessage` type assertion on the memory_recalled SSE event
in the agent loop. Uses a typed `MemoryRecalled` variable instead, letting
TypeScript verify all fields at compile time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
