### PR TITLE
fix: lazy-load raw payloads in LLM Context Inspector

### DIFF
--- a/assistant/src/__tests__/llm-context-route-provider.test.ts
+++ b/assistant/src/__tests__/llm-context-route-provider.test.ts
@@ -33,6 +33,27 @@ function dispatchLlmContext(messageId: string): Promise<Response> | Response {
   });
 }
 
+function dispatchLogPayload(logId: string): Promise<Response> | Response {
+  const url = new URL(
+    `http://localhost/v1/llm-request-logs/${logId}/payload`,
+  );
+  const route = routes.find(
+    (r) =>
+      r.method === "GET" && r.endpoint === "llm-request-logs/:id/payload",
+  );
+  if (!route) {
+    throw new Error("No llm-request-logs payload route found");
+  }
+
+  return route.handler({
+    req: new Request(url.toString(), { method: "GET" }),
+    url,
+    server: null as never,
+    authContext: {} as never,
+    params: { id: logId },
+  });
+}
+
 function clearRequestLogs(): void {
   getDb().delete(llmRequestLogs).run();
 }
@@ -188,5 +209,85 @@ describe("GET /v1/messages/:id/llm-context provider preference", () => {
 
     expect(body.logs).toHaveLength(1);
     expect(body.logs[0]?.summary).toEqual({ provider: "ollama" });
+  });
+
+  test("returns null payloads to keep the initial response lightweight", async () => {
+    seedRequestLog({
+      id: "log-null-payload",
+      messageId: "msg-null-payload",
+      provider: "openrouter",
+      requestPayload: openAiRequestPayload,
+      responsePayload: openAiResponsePayload,
+    });
+
+    const response = await dispatchLlmContext("msg-null-payload");
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      logs: Array<{
+        requestPayload: unknown;
+        responsePayload: unknown;
+      }>;
+    };
+
+    expect(body.logs).toHaveLength(1);
+    expect(body.logs[0]?.requestPayload).toBeNull();
+    expect(body.logs[0]?.responsePayload).toBeNull();
+  });
+});
+
+describe("GET /v1/llm-request-logs/:id/payload", () => {
+  test("returns parsed payloads for a valid log", async () => {
+    const reqPayload = JSON.stringify({ model: "gpt-4.1", messages: [] });
+    const resPayload = JSON.stringify({
+      choices: [{ message: { content: "hi" } }],
+    });
+    seedRequestLog({
+      id: "log-payload-ok",
+      messageId: "msg-payload-ok",
+      provider: "openai",
+      requestPayload: reqPayload,
+      responsePayload: resPayload,
+    });
+
+    const response = await dispatchLogPayload("log-payload-ok");
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      id: string;
+      requestPayload: unknown;
+      responsePayload: unknown;
+    };
+
+    expect(body.id).toBe("log-payload-ok");
+    expect(body.requestPayload).toEqual(JSON.parse(reqPayload));
+    expect(body.responsePayload).toEqual(JSON.parse(resPayload));
+  });
+
+  test("returns 404 for a nonexistent log", async () => {
+    const response = await dispatchLogPayload("does-not-exist");
+    expect(response.status).toBe(404);
+  });
+
+  test("falls back to string values for non-JSON payloads", async () => {
+    seedRequestLog({
+      id: "log-raw-strings",
+      messageId: "msg-raw-strings",
+      provider: null,
+      requestPayload: "raw-request-text",
+      responsePayload: "raw-response-text",
+    });
+
+    const response = await dispatchLogPayload("log-raw-strings");
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      id: string;
+      requestPayload: unknown;
+      responsePayload: unknown;
+    };
+
+    expect(body.requestPayload).toBe("raw-request-text");
+    expect(body.responsePayload).toBe("raw-response-text");
   });
 });

--- a/assistant/src/memory/llm-request-log-store.ts
+++ b/assistant/src/memory/llm-request-log-store.ts
@@ -223,6 +223,25 @@ function selectUnlinkedLogsInRange(
     .all();
 }
 
+export function getRequestLogById(logId: string): LogRow | null {
+  const db = getDb();
+  return (
+    db
+      .select({
+        id: llmRequestLogs.id,
+        conversationId: llmRequestLogs.conversationId,
+        messageId: llmRequestLogs.messageId,
+        provider: llmRequestLogs.provider,
+        requestPayload: llmRequestLogs.requestPayload,
+        responsePayload: llmRequestLogs.responsePayload,
+        createdAt: llmRequestLogs.createdAt,
+      })
+      .from(llmRequestLogs)
+      .where(eq(llmRequestLogs.id, logId))
+      .get() ?? null
+  );
+}
+
 export function getRequestLogsByMessageId(messageId: string): LogRow[] {
   // Resolve all assistant message IDs in the same turn so the inspector
   // shows every LLM call from the entire agent turn, not just the queried message.

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -374,6 +374,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   // Message content
   { endpoint: "messages/content", scopes: ["chat.read"] },
   { endpoint: "messages/llm-context", scopes: ["chat.read"] },
+  { endpoint: "llm-request-logs/payload", scopes: ["chat.read"] },
   { endpoint: "messages/tts", scopes: ["chat.read"] },
 
   // Queued message deletion

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -43,7 +43,10 @@ import {
 } from "../../daemon/handlers/conversation-history.js";
 import { deleteQueuedMessage } from "../../daemon/handlers/conversations.js";
 import { getAssistantMessageIdsInTurn } from "../../memory/conversation-crud.js";
-import { getRequestLogsByMessageId } from "../../memory/llm-request-log-store.js";
+import {
+  getRequestLogById,
+  getRequestLogsByMessageId,
+} from "../../memory/llm-request-log-store.js";
 import { getMemoryRecallLogByMessageIds } from "../../memory/memory-recall-log-store.js";
 import { resolvePricingForUsage } from "../../util/pricing.js";
 import { httpError } from "../http-errors.js";
@@ -487,13 +490,56 @@ export function conversationQueryRouteDefinitions(
             );
             return {
               id: log.id,
-              requestPayload,
-              responsePayload,
+              requestPayload: null,
+              responsePayload: null,
               createdAt: log.createdAt,
               ...result,
             };
           }),
           memoryRecall: memoryRecallLog ?? null,
+        });
+      },
+    },
+
+    // ── Raw payload for a single LLM request log ─────────────────────
+    {
+      endpoint: "llm-request-logs/:id/payload",
+      method: "GET",
+      policyKey: "llm-request-logs/payload",
+      summary: "Get raw payload for a single LLM request log",
+      description:
+        "Return the full request and response payloads for a specific log entry.",
+      tags: ["messages"],
+      responseBody: z.object({
+        id: z.string(),
+        requestPayload: z.unknown(),
+        responsePayload: z.unknown(),
+      }),
+      handler: ({ params }) => {
+        const logId = params.id;
+        if (!logId) {
+          return httpError("BAD_REQUEST", "log id is required", 400);
+        }
+        const log = getRequestLogById(logId);
+        if (!log) {
+          return httpError("NOT_FOUND", "log not found", 404);
+        }
+        let requestPayload: unknown;
+        try {
+          requestPayload = JSON.parse(log.requestPayload);
+        } catch {
+          requestPayload = log.requestPayload;
+        }
+        let responsePayload: unknown;
+        try {
+          responsePayload = JSON.parse(log.responsePayload);
+        } catch {
+          responsePayload = log.responsePayload;
+        }
+        return Response.json({
+          id: log.id,
+          requestPayload,
+          responsePayload,
         });
       },
     },

--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
@@ -10,6 +10,8 @@ struct MessageInspectorView: View {
 
     @State private var viewState = MessageInspectorViewState()
     @State private var payloadModels: [String: MessageInspectorPayloadModel] = [:]
+    @State private var payloadLoadingIDs: Set<String> = []
+    @State private var payloadFailedIDs: Set<String> = []
 
     init(
         messageId: String,
@@ -319,33 +321,60 @@ struct MessageInspectorView: View {
         }
     }
 
+    @ViewBuilder
     private func rawPayloadTab(for entry: LLMRequestLogEntry) -> some View {
-        VStack(spacing: 0) {
-            HStack {
-                VTabs(
-                    items: RawPayloadPane.allCases.map { (label: $0.label, tag: $0) },
-                    selection: rawPaneBinding,
-                    style: .pill,
-                    size: .compact
-                )
-                .fixedSize()
-
+        if payloadLoadingIDs.contains(entry.id) {
+            VStack {
+                ProgressView()
+                    .padding(.top, VSpacing.xl)
+                Text("Loading raw payloads…")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+                    .padding(.top, VSpacing.sm)
                 Spacer()
             }
-            .padding(.horizontal, VSpacing.lg)
-            .padding(.vertical, VSpacing.sm)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if payloadFailedIDs.contains(entry.id) {
+            VEmptyState(
+                title: "Couldn't load raw payloads",
+                subtitle: "The payload request failed. Try again.",
+                icon: VIcon.triangleAlert.rawValue,
+                actionLabel: "Retry",
+                actionIcon: VIcon.refreshCw.rawValue
+            ) {
+                Task { await loadPayloadIfNeeded(for: entry) }
+            }
+        } else {
+            VStack(spacing: 0) {
+                HStack {
+                    VTabs(
+                        items: RawPayloadPane.allCases.map { (label: $0.label, tag: $0) },
+                        selection: rawPaneBinding,
+                        style: .pill,
+                        size: .compact
+                    )
+                    .fixedSize()
 
-            MessageInspectorPayloadView(
-                title: viewState.selectedRawPane.label,
-                model: payloadBinding(
-                    for: payloadKey(for: entry.id, kind: viewState.selectedRawPane.rawValue)
+                    Spacer()
+                }
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.vertical, VSpacing.sm)
+
+                MessageInspectorPayloadView(
+                    title: viewState.selectedRawPane.label,
+                    model: payloadBinding(
+                        for: payloadKey(for: entry.id, kind: viewState.selectedRawPane.rawValue)
+                    )
                 )
-            )
-            .padding(.horizontal, VSpacing.lg)
-            .padding(.bottom, VSpacing.lg)
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.bottom, VSpacing.lg)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .background(VColor.surfaceBase)
+            .task(id: entry.id) {
+                await loadPayloadIfNeeded(for: entry)
+            }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .background(VColor.surfaceBase)
     }
 
     private var rawPaneBinding: Binding<RawPayloadPane> {
@@ -370,14 +399,26 @@ struct MessageInspectorView: View {
     private func reloadContext(resetSelection: Bool) async {
         let requestToken = viewState.beginLoading(resetSelection: resetSelection)
         payloadModels = [:]
+        payloadLoadingIDs = []
+        payloadFailedIDs = []
 
         do {
             let result = try await llmContextClient.fetchContextResult(messageId: messageId)
             try Task.checkCancellation()
             guard viewState.isActiveLoad(requestToken) else { return }
 
+            // If an older daemon still includes inline payloads, populate eagerly.
             if case let .loaded(response) = result {
-                payloadModels = payloadModelsByKey(for: response.logs)
+                for entry in response.logs {
+                    if let req = entry.requestPayload, req.value != nil {
+                        payloadModels[payloadKey(for: entry.id, kind: "request")] =
+                            MessageInspectorPayloadModel(payload: req)
+                    }
+                    if let res = entry.responsePayload, res.value != nil {
+                        payloadModels[payloadKey(for: entry.id, kind: "response")] =
+                            MessageInspectorPayloadModel(payload: res)
+                    }
+                }
             }
 
             viewState.finishLoading(with: result, requestToken: requestToken)
@@ -389,15 +430,28 @@ struct MessageInspectorView: View {
         }
     }
 
-    private func payloadModelsByKey(for logs: [LLMRequestLogEntry]) -> [String: MessageInspectorPayloadModel] {
-        MessageInspectorViewState.ordered(logs).reduce(into: [:]) { models, entry in
-            models[payloadKey(for: entry.id, kind: "request")] = MessageInspectorPayloadModel(
-                payload: entry.requestPayload
-            )
-            models[payloadKey(for: entry.id, kind: "response")] = MessageInspectorPayloadModel(
-                payload: entry.responsePayload
-            )
+    @MainActor
+    private func loadPayloadIfNeeded(for entry: LLMRequestLogEntry) async {
+        let reqKey = payloadKey(for: entry.id, kind: "request")
+        let resKey = payloadKey(for: entry.id, kind: "response")
+
+        // Already loaded or in flight.
+        if payloadModels[reqKey] != nil || payloadLoadingIDs.contains(entry.id) {
+            return
         }
+
+        payloadLoadingIDs.insert(entry.id)
+        payloadFailedIDs.remove(entry.id)
+
+        guard let payload = await llmContextClient.fetchLogPayload(logId: entry.id) else {
+            payloadLoadingIDs.remove(entry.id)
+            payloadFailedIDs.insert(entry.id)
+            return
+        }
+
+        payloadModels[reqKey] = MessageInspectorPayloadModel(payload: payload.requestPayload)
+        payloadModels[resKey] = MessageInspectorPayloadModel(payload: payload.responsePayload)
+        payloadLoadingIDs.remove(entry.id)
     }
 
     private func payloadKey(for entryID: String, kind: String) -> String {

--- a/clients/shared/Network/LLMContextClient.swift
+++ b/clients/shared/Network/LLMContextClient.swift
@@ -519,14 +519,23 @@ public struct MemoryRecallData: Codable, Sendable, Equatable {
 }
 
 /// A single LLM request/response log entry returned by the context endpoint.
+/// `requestPayload` and `responsePayload` are nil in the initial response and
+/// fetched on demand via the dedicated payload endpoint.
 public struct LLMRequestLogEntry: Codable, Identifiable, Sendable {
     public let id: String
-    public let requestPayload: AnyCodable
-    public let responsePayload: AnyCodable
+    public let requestPayload: AnyCodable?
+    public let responsePayload: AnyCodable?
     public let createdAt: Int
     public let summary: LLMCallSummary?
     public let requestSections: [LLMContextSection]?
     public let responseSections: [LLMContextSection]?
+}
+
+/// Response from the dedicated log payload endpoint.
+public struct LLMLogPayloadResponse: Codable, Sendable {
+    public let id: String
+    public let requestPayload: AnyCodable
+    public let responsePayload: AnyCodable
 }
 
 /// Response wrapper for the LLM context endpoint.
@@ -548,6 +557,7 @@ public enum LLMContextFetchResult: Sendable {
 public protocol LLMContextClientProtocol {
     func fetchContext(messageId: String) async -> LLMContextResponse?
     func fetchContextResult(messageId: String) async throws -> LLMContextFetchResult
+    func fetchLogPayload(logId: String) async -> LLMLogPayloadResponse?
 }
 
 /// Gateway-backed implementation of ``LLMContextClientProtocol``.
@@ -595,6 +605,23 @@ public struct LLMContextClient: LLMContextClientProtocol {
             return .failed
         }
     }
+
+    public func fetchLogPayload(logId: String) async -> LLMLogPayloadResponse? {
+        do {
+            let response = try await GatewayHTTPClient.get(
+                path: "assistants/{assistantId}/llm-request-logs/\(logId)/payload",
+                timeout: 30
+            )
+            guard response.isSuccess else {
+                log.error("fetchLogPayload failed (HTTP \(response.statusCode))")
+                return nil
+            }
+            return try JSONDecoder().decode(LLMLogPayloadResponse.self, from: response.data)
+        } catch {
+            log.error("fetchLogPayload error: \(error.localizedDescription)")
+            return nil
+        }
+    }
 }
 
 public extension LLMContextClientProtocol {
@@ -604,5 +631,9 @@ public extension LLMContextClientProtocol {
         }
 
         return response.logs.isEmpty ? .empty : .loaded(response)
+    }
+
+    func fetchLogPayload(logId: String) async -> LLMLogPayloadResponse? {
+        nil
     }
 }


### PR DESCRIPTION
## Summary
- The LLM Context Inspector failed on turns with large request payloads (~3.8 MB each from base64 images, ~15 MB total). The backend returned 200 but the Swift JSONDecoder couldn't decode the massive AnyCodable tree.
- The `/llm-context` endpoint now returns `null` for raw payloads, keeping the initial response lightweight (just summary/sections). A new `GET /v1/llm-request-logs/:id/payload` endpoint serves full payloads on demand.
- The Swift client lazy-loads raw payloads only when the Raw tab is selected, with loading/error/retry states.

## Original prompt
it (from plan: fix LLM Context Inspector failing on large payloads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23213" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
