### PR TITLE
fix(macos): add horizontal padding to conversation title

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
@@ -28,6 +28,7 @@ struct ConversationTitleActionsControl: View {
             }
             .lineLimit(1)
             .fixedSize(horizontal: false, vertical: true)
+            .padding(.horizontal, VSpacing.xl)
 
             if let parentTitle = presentation.forkParentTitle, presentation.showsForkParentLink {
                 Button(action: onOpenForkParent) {

--- a/clients/shared/DesignSystem/Gallery/Sections/DisplayGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/DisplayGallerySection.swift
@@ -6,6 +6,8 @@ struct DisplayGallerySection: View {
 
     @State private var waveformAmplitude: Float = 0.5
     @State private var waveformActive: Bool = true
+    @State private var basicSectionExpanded: Bool = true
+    @State private var subtitleSectionExpanded: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.xxl) {
@@ -157,7 +159,7 @@ struct DisplayGallerySection: View {
 
                 VDisclosureSection(
                     title: "Basic Section",
-                    isExpanded: .constant(true)
+                    isExpanded: $basicSectionExpanded
                 ) {
                     Text("Expanded content is visible")
                         .font(VFont.bodyMediumLighter)
@@ -169,9 +171,9 @@ struct DisplayGallerySection: View {
                 VDisclosureSection(
                     title: "With Subtitle",
                     subtitle: "Additional context shown below the title",
-                    isExpanded: .constant(false)
+                    isExpanded: $subtitleSectionExpanded
                 ) {
-                    Text("This content is hidden")
+                    Text("This content is hidden when collapsed")
                         .font(VFont.bodyMediumLighter)
                         .foregroundStyle(VColor.contentSecondary)
                 }


### PR DESCRIPTION
## Summary
- Add VSpacing.xl (24pt) horizontal padding to the conversation title button so it doesn't sit flush against surrounding elements
- Fix VDisclosureSection gallery examples that used `.constant()` bindings (non-interactive) — replaced with `@State` variables

## Test plan
- [ ] Open a conversation — verify the title has breathing room on left and right
- [ ] Open Component Gallery → VDisclosureSection — verify sections toggle on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
