### PR TITLE
fix: onboarding hosting selector — Vellum Cloud first, equal card heights, polished error state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -6,7 +6,7 @@ enum OnboardingHostingModeResolver {
         userHostedEnabled: Bool,
         localDockerEnabled: Bool
     ) -> [OnboardingState.HostingMode] {
-        var modes: [OnboardingState.HostingMode] = [.local, .vellumCloud]
+        var modes: [OnboardingState.HostingMode] = [.vellumCloud, .local]
         if localDockerEnabled {
             // Keep "Local" as the default choice and expose the legacy
             // non-Docker hatch explicitly as an escape hatch.
@@ -215,7 +215,7 @@ struct APIKeyStepView: View {
             }
             .padding(.horizontal, VSpacing.lg)
             .padding(.vertical, VSpacing.md)
-            .frame(minHeight: 64)
+            .frame(minHeight: 80)
             .contentShape(Rectangle())
             .background(
                 RoundedRectangle(cornerRadius: VRadius.xl)

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -317,28 +317,53 @@ struct OnboardingFlowView: View {
                         .foregroundStyle(VColor.contentSecondary)
                 }
             } else {
-                Text("Setup failed")
-                    .font(VFont.titleMedium)
-                    .foregroundStyle(VColor.contentDefault)
+                VStack(spacing: VSpacing.xl) {
+                    VStack(spacing: VSpacing.sm) {
+                        VIconView(.circleX, size: 32)
+                            .foregroundStyle(VColor.systemNegativeStrong)
 
-                if let error = managedBootstrapError {
-                    Text(error)
-                        .font(VFont.labelDefault)
-                        .foregroundStyle(VColor.systemNegativeStrong)
-                        .multilineTextAlignment(.center)
-                        .frame(maxWidth: 280)
-                }
+                        Text("Setup failed")
+                            .font(VFont.titleMedium)
+                            .foregroundStyle(VColor.contentDefault)
 
-                VButton(label: "Try again", style: .primary, isFullWidth: true) {
-                    Task {
-                        await performManagedBootstrap()
+                        Text("Something went wrong while setting up your assistant.")
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentSecondary)
+                            .multilineTextAlignment(.center)
+                    }
+
+                    if let error = managedBootstrapError {
+                        VInlineMessage(humanReadableError(from: error), tone: .error)
+                    }
+
+                    VStack(spacing: VSpacing.sm) {
+                        VButton(label: "Try again", style: .primary, isFullWidth: true) {
+                            Task {
+                                await performManagedBootstrap()
+                            }
+                        }
+
+                        VButton(label: "Go back", style: .ghost) {
+                            isBootstrappingManaged = false
+                            managedBootstrapError = nil
+                        }
                     }
                 }
-                .frame(maxWidth: 280)
+                .frame(maxWidth: 320)
             }
         }
 
         Spacer()
+    }
+
+    /// Extracts a human-readable message from an error string that may be JSON.
+    private func humanReadableError(from raw: String) -> String {
+        guard let data = raw.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let detail = json["detail"] as? String else {
+            return raw
+        }
+        return detail
     }
 
     private func performManagedBootstrap() async {

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -36,7 +36,7 @@ final class OnboardingState {
     var skippedAPIKeyEntry: Bool = false
 
     /// The hosting mode selected in onboarding step 1.
-    var selectedHostingMode: HostingMode = .local
+    var selectedHostingMode: HostingMode = .vellumCloud
 
     enum HostingMode: String {
         case vellumCloud = "vellum-cloud"

--- a/clients/macos/vellum-assistantTests/OnboardingHostingModeResolverTests.swift
+++ b/clients/macos/vellum-assistantTests/OnboardingHostingModeResolverTests.swift
@@ -9,7 +9,7 @@ final class OnboardingHostingModeResolverTests: XCTestCase {
             localDockerEnabled: true
         )
 
-        XCTAssertEqual(modes, [.local, .vellumCloud, .oldLocal])
+        XCTAssertEqual(modes, [.vellumCloud, .local, .oldLocal])
     }
 
     func testAvailableHostingModesAddsUserHostedOptionsWithoutDockerCard() {
@@ -18,7 +18,7 @@ final class OnboardingHostingModeResolverTests: XCTestCase {
             localDockerEnabled: false
         )
 
-        XCTAssertEqual(modes, [.local, .vellumCloud, .aws, .gcp, .customHardware])
+        XCTAssertEqual(modes, [.vellumCloud, .local, .aws, .gcp, .customHardware])
         XCTAssertFalse(modes.contains(.docker))
     }
 


### PR DESCRIPTION
## Summary
- Reorder hosting cards so Vellum Cloud appears first and is selected by default (instead of Local)
- Equalize hosting card heights by increasing `minHeight` from 64 to 80 so cards with different subtitle lengths render consistently
- Redesign the managed bootstrap error state: parse JSON error strings to extract human-readable messages, display them in a `VInlineMessage` error banner with a proper icon and subtitle, and add a "Go back" button so users aren't stuck on the error screen
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
