### PR TITLE
fix: set CALLBACK_URL in non-platform path of telegram-setup skill

### DIFF
--- a/skills/telegram-setup/SKILL.md
+++ b/skills/telegram-setup/SKILL.md
@@ -72,6 +72,13 @@ Otherwise:
 
 - Telegram needs a publicly reachable URL to send webhook events to. Load the `public-ingress` skill to determine whether a public ingress has been configured and walk the user through setting one up if not.
 
+- After `public-ingress` completes, construct the callback URL from the persisted base URL:
+
+```bash
+PUBLIC_BASE_URL=$(assistant config get ingress.publicBaseUrl)
+CALLBACK_URL="${PUBLIC_BASE_URL}/webhooks/telegram"
+```
+
 ### Generate Webhook Secret
 
 Check to see if one already exists:

--- a/skills/telegram-setup/SKILL.md
+++ b/skills/telegram-setup/SKILL.md
@@ -57,7 +57,9 @@ First check whether managed platform callback routes are available:
 assistant platform status --json
 ```
 
-If `isPlatform` is `true` and both `baseUrl` and `assistantId` are present:
+If `isPlatform` is `true` and both `baseUrl` and `assistantId` are present, then we should use Platform Routing, otherwise, use Self-Hosted Routing.
+
+**Platform Routing:**
 
 - Register the managed callback route:
 
@@ -68,7 +70,7 @@ CALLBACK_URL=$(echo "$ROUTE_RESPONSE" | jq -r '.callbackUrl')
 
 - In this mode, do **not** load `public-ingress` or mention ngrok. The managed platform callback route is the Telegram webhook URL.
 
-Otherwise:
+**Self-Hosted Routing:**
 
 - Telegram needs a publicly reachable URL to send webhook events to. Load the `public-ingress` skill to determine whether a public ingress has been configured and walk the user through setting one up if not.
 


### PR DESCRIPTION
## Summary

- The telegram-setup skill's "Register Webhook with Telegram" section uses `CALLBACK_URL`, but that variable was only assigned in the platform (managed callback route) code path
- In the non-platform path (public-ingress/ngrok), `CALLBACK_URL` was never set, causing `setWebhook` to register an empty URL with Telegram
- Added instructions to construct `CALLBACK_URL` from `ingress.publicBaseUrl` after the public-ingress skill completes

## Original prompt

Address PR review feedback from #23219 — both Devin and Codex flagged that `CALLBACK_URL` is undefined in the non-platform code path
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
