### PR TITLE
fix: persist selectedHostingMode across onboarding app restarts

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -217,7 +217,8 @@ final class OnboardingState {
         selectedProvider = "anthropic"
         selectedModel = "claude-opus-4-6"
 
-        // Reset cloud credentials (in-memory only; not persisted)
+        // Reset hosting selection and cloud credentials
+        selectedHostingMode = .vellumCloud
         cloudProvider = "local"
         gcpProjectId = ""
         gcpZone = "us-central1-a"

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -140,6 +140,10 @@ final class OnboardingState {
             hasHatched = UserDefaults.standard.bool(forKey: "onboarding.hatched")
             cloudProvider = UserDefaults.standard.string(forKey: "onboarding.cloudProvider") ?? "local"
             skippedAPIKeyEntry = UserDefaults.standard.bool(forKey: "onboarding.skippedAPIKeyEntry")
+            if let rawHosting = UserDefaults.standard.string(forKey: "onboarding.selectedHostingMode"),
+               let mode = HostingMode(rawValue: rawHosting) {
+                selectedHostingMode = mode
+            }
         }
         // Clamp restored step to the valid range.
         let maxStep = 3
@@ -176,6 +180,7 @@ final class OnboardingState {
         UserDefaults.standard.set(cloudProvider, forKey: "onboarding.cloudProvider")
         UserDefaults.standard.set(Self.currentFlowVersion, forKey: "onboarding.flowVersion")
         UserDefaults.standard.set(skippedAPIKeyEntry, forKey: "onboarding.skippedAPIKeyEntry")
+        UserDefaults.standard.set(selectedHostingMode.rawValue, forKey: "onboarding.selectedHostingMode")
     }
 
     /// Resets all hatch-related and credential state for a clean retry,
@@ -229,7 +234,7 @@ final class OnboardingState {
     }
 
     static func clearPersistedState() {
-        for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.flowVersion", "onboarding.cloudProvider", "onboarding.skippedAPIKeyEntry", "onboarding.variant", "onboarding.firstMeetingCrackProgress"] {
+        for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.flowVersion", "onboarding.cloudProvider", "onboarding.skippedAPIKeyEntry", "onboarding.selectedHostingMode", "onboarding.variant", "onboarding.firstMeetingCrackProgress"] {
             UserDefaults.standard.removeObject(forKey: key)
         }
     }


### PR DESCRIPTION
## Summary
- Persist `selectedHostingMode` to UserDefaults so the user's hosting choice survives mid-onboarding app restarts (e.g. during screen-recording permission toggle)
- Without this, the field resets to the `.vellumCloud` default on restart, which could incorrectly trigger a managed cloud bootstrap for a user who chose Local
- Adds save in `persist()`, restore in `init()`, and cleanup in `clearPersistedState()`

## Original prompt
Persist `selectedHostingMode` across app restarts in OnboardingState.swift. The field was never saved to UserDefaults, so after a mid-onboarding restart it resets to the default. With the default recently changed to `.vellumCloud` (PR #23218), a user who chose Local would incorrectly get the managed bootstrap path on restart.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
