### PR TITLE
fix: cache NSAttributedString conversion and TextKit size measurements in MarkdownSegmentView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -8,6 +8,17 @@ private final class AttributedStringCacheEntry: NSObject {
     init(_ attributedString: AttributedString) { self.attributedString = attributedString }
 }
 
+#if os(macOS)
+private final class MeasuredTextCacheEntry: NSObject {
+    let nsAttributedString: NSAttributedString
+    let size: CGSize
+    init(nsAttributedString: NSAttributedString, size: CGSize) {
+        self.nsAttributedString = nsAttributedString
+        self.size = size
+    }
+}
+#endif
+
 /// Reusable view that renders parsed `MarkdownSegment` arrays.
 /// Groups consecutive text-selectable segments (text, headings, lists) into
 /// unified Text views so that text selection can span across paragraphs.
@@ -45,17 +56,7 @@ struct MarkdownSegmentView: View, Equatable {
                 switch group {
                 case .selectableRun(let runSegments):
                     #if os(macOS)
-                    let attributed = buildCombinedAttributedString(from: runSegments)
-                    let nsAttributed = Self.convertToNSAttributedString(
-                        attributed,
-                        font: VFont.nsChat,
-                        textColor: NSColor(textColor)
-                    )
-                    let measuredSize = VSelectableTextView.measureSize(
-                        attributedString: nsAttributed,
-                        lineSpacing: 4,
-                        maxWidth: maxContentWidth ?? VSpacing.chatBubbleMaxWidth
-                    )
+                    let (nsAttributed, measuredSize) = resolveSelectableRunMeasurement(runSegments)
                     VSelectableTextView(
                         attributedString: nsAttributed,
                         maxWidth: maxContentWidth,
@@ -203,6 +204,15 @@ struct MarkdownSegmentView: View, Equatable {
         return cache
     }()
 
+    #if os(macOS)
+    @MainActor private static var measuredTextCache: NSCache<NSNumber, MeasuredTextCacheEntry> = {
+        let cache = NSCache<NSNumber, MeasuredTextCacheEntry>()
+        cache.countLimit = 500
+        cache.totalCostLimit = 20_000_000 // ~20 MB
+        return cache
+    }()
+    #endif
+
     // MARK: - Cache Guardrails
 
     private static let maxCacheableTextLength = 10_000
@@ -216,6 +226,9 @@ struct MarkdownSegmentView: View, Equatable {
         prefixWidthCache.removeAll()
         groupedSegmentsCache.removeAll()
         MarkdownTableView.clearCellAttributedStringCache()
+        #if os(macOS)
+        measuredTextCache.removeAllObjects()
+        #endif
     }
 
     /// Rough character count of the text content within a segment array.
@@ -267,6 +280,49 @@ struct MarkdownSegmentView: View, Equatable {
         Self.attributedStringCache.setObject(AttributedStringCacheEntry(result), forKey: cacheKeyNS, cost: textLen * 10)
         return result
     }
+
+    #if os(macOS)
+    private func resolveSelectableRunMeasurement(
+        _ runSegments: [MarkdownSegment]
+    ) -> (NSAttributedString, CGSize) {
+        var hasher = Hasher()
+        for segment in runSegments { hasher.combine(segment) }
+        hasher.combine(textColor.description)
+        hasher.combine(secondaryTextColor.description)
+        hasher.combine(codeTextColor.description)
+        hasher.combine(codeBackgroundColor.description)
+        let effectiveMaxWidth = maxContentWidth ?? VSpacing.chatBubbleMaxWidth
+        hasher.combine(effectiveMaxWidth)
+        let key = hasher.finalize()
+
+        let keyNS = key as NSNumber
+        if let cached = Self.measuredTextCache.object(forKey: keyNS) {
+            return (cached.nsAttributedString, cached.size)
+        }
+
+        os_signpost(.begin, log: PerfSignposts.log, name: "selectableRunMeasure")
+        let attributed = buildCombinedAttributedString(from: runSegments)
+        let nsAttributed = Self.convertToNSAttributedString(
+            attributed, font: VFont.nsChat, textColor: NSColor(textColor)
+        )
+        let size = VSelectableTextView.measureSize(
+            attributedString: nsAttributed,
+            lineSpacing: 4,
+            maxWidth: effectiveMaxWidth
+        )
+        os_signpost(.end, log: PerfSignposts.log, name: "selectableRunMeasure")
+
+        let textLen = Self.segmentTextLength(runSegments)
+        if textLen <= Self.maxCacheableTextLength {
+            Self.measuredTextCache.setObject(
+                MeasuredTextCacheEntry(nsAttributedString: nsAttributed, size: size),
+                forKey: keyNS,
+                cost: textLen * 15
+            )
+        }
+        return (nsAttributed, size)
+    }
+    #endif
 
     /// Pure builder with no side effects — separated for caching.
     private static func buildAttributedStringUncached(


### PR DESCRIPTION
## Summary
- Cache the combined (NSAttributedString, CGSize) result of TextKit measurement alongside existing AttributedString cache
- Eliminate repeated TextKit layout passes during SwiftUI body evaluation that caused 12-24s main-thread hangs
- Add os_signpost markers for cold-cache measurements to enable Instruments profiling

Part of plan: fix-layout-cascade-hangs.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
