### PR TITLE
fix: restrict temporal approval buttons to tool_approval kind only

### DIFF
--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -40,6 +40,10 @@ import {
 } from "../memory/canonical-guardian-store.js";
 import { getDb, initializeDb } from "../memory/db.js";
 import {
+  buildDecisionActions,
+  GUARDIAN_DECISION_ACTIONS,
+} from "../runtime/guardian-decision-types.js";
+import {
   type GuardianReplyContext,
   routeGuardianReply,
 } from "../runtime/guardian-reply-router.js";
@@ -1699,5 +1703,39 @@ describe("routing invariant: expired requests are excluded from pending discover
     expect(result.consumed).toBe(false);
     expect(result.type).toBe("not_consumed");
     expect(result.decisionApplied).toBe(false);
+  });
+});
+
+// ===========================================================================
+// SECTION 12: Kind-specific action sets in prompt mapping
+// ===========================================================================
+
+describe("routing invariant: kind-specific action sets in prompt mapping", () => {
+  test("buildDecisionActions({ forGuardianOnBehalf: true }) includes temporal actions", () => {
+    const actions = buildDecisionActions({ forGuardianOnBehalf: true });
+    const actionIds = actions.map((a) => a.action);
+    expect(actionIds).toContain("approve_once");
+    expect(actionIds).toContain("approve_10m");
+    expect(actionIds).toContain("approve_conversation");
+    expect(actionIds).toContain("reject");
+    // approve_always must NOT be present for guardian-on-behalf
+    expect(actionIds).not.toContain("approve_always");
+  });
+
+  test("non-tool-approval action set is approve_once + reject only", () => {
+    const actions = [
+      GUARDIAN_DECISION_ACTIONS.approve_once,
+      GUARDIAN_DECISION_ACTIONS.reject,
+    ];
+    expect(actions).toHaveLength(2);
+    expect(actions[0].action).toBe("approve_once");
+    expect(actions[1].action).toBe("reject");
+  });
+
+  test("source-code invariant: guardian-action-routes.ts contains kind guard", () => {
+    const srcRoot = resolve(__dirname, "..");
+    const fullPath = join(srcRoot, "runtime/routes/guardian-action-routes.ts");
+    const source = readFileSync(fullPath, "utf-8");
+    expect(source).toContain('req.kind === "tool_approval"');
   });
 });

--- a/assistant/src/runtime/routes/guardian-action-routes.ts
+++ b/assistant/src/runtime/routes/guardian-action-routes.ts
@@ -23,7 +23,10 @@ import { requireBoundGuardian } from "../auth/require-bound-guardian.js";
 import type { AuthContext } from "../auth/types.js";
 import { processGuardianDecision } from "../guardian-action-service.js";
 import type { GuardianDecisionPrompt } from "../guardian-decision-types.js";
-import { buildDecisionActions } from "../guardian-decision-types.js";
+import {
+  buildDecisionActions,
+  GUARDIAN_DECISION_ACTIONS,
+} from "../guardian-decision-types.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 
@@ -190,13 +193,15 @@ export function listGuardianDecisionPrompts(params: {
  * Map a canonical guardian request to the client-facing prompt format.
  *
  * Generates kind-specific questionText and action sets:
- * - `tool_approval`: "Approve tool: <name>" with approve/reject actions
- * - `pending_question`: voice-originated question with approve/reject actions
- * - `access_request`: explicit "Access Request" label with approve/reject actions
- *   and text fallback instructions (request code + "open invite flow")
+ * - `tool_approval`: temporal modes (approve_once, approve_10m, approve_conversation) + reject
+ * - `pending_question`: approve_once + reject only
+ * - `access_request`: approve_once + reject only, with text fallback instructions
+ *   (request code + "open invite flow")
+ * - `tool_grant_request`: approve_once + reject only
  *
- * All kinds use `forGuardianOnBehalf: true` (no approve_always) since the
- * guardian is acting on behalf of a requester.
+ * Only `tool_approval` receives temporal modes because time-scoped grants
+ * are meaningful only for tool execution. All other kinds get a simple
+ * approve_once/reject pair.
  */
 function mapCanonicalRequestToPrompt(
   req: CanonicalGuardianRequest,
@@ -204,9 +209,15 @@ function mapCanonicalRequestToPrompt(
 ): GuardianDecisionPrompt {
   const questionText = buildKindAwareQuestionText(req);
 
-  // Guardian-on-behalf prompts include approve_once, temporal modes
-  // (approve_10m, approve_conversation), and reject — but not approve_always.
-  const actions = buildDecisionActions({ forGuardianOnBehalf: true });
+  // Only tool_approval gets temporal modes (approve_10m, approve_conversation);
+  // all other kinds get a simple approve_once + reject pair.
+  const actions =
+    req.kind === "tool_approval"
+      ? buildDecisionActions({ forGuardianOnBehalf: true })
+      : [
+          GUARDIAN_DECISION_ACTIONS.approve_once,
+          GUARDIAN_DECISION_ACTIONS.reject,
+        ];
 
   const expiresAt = req.expiresAt
     ? new Date(req.expiresAt).getTime()


### PR DESCRIPTION
## Summary
- Gate temporal approval actions (approve_10m, approve_conversation) to only appear for tool_approval requests
- Non-tool-approval kinds (pending_question, access_request, tool_grant_request) now only get approve_once + reject
- Add source-code invariant tests to prevent future regressions

Part of plan: fix-guardian-temporal-actions.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
