### PR TITLE
test: add MarkdownSegmentView measurement caching regression test

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -211,6 +211,12 @@ struct MarkdownSegmentView: View, Equatable {
         cache.totalCostLimit = 20_000_000 // ~20 MB
         return cache
     }()
+
+    #if DEBUG
+    /// Exposed for testing: number of cache insertions into `measuredTextCache`.
+    /// NSCache doesn't expose its count, so we maintain a parallel counter.
+    @MainActor static var _measuredTextCacheInsertCount: Int = 0
+    #endif
     #endif
 
     // MARK: - Cache Guardrails
@@ -228,6 +234,9 @@ struct MarkdownSegmentView: View, Equatable {
         MarkdownTableView.clearCellAttributedStringCache()
         #if os(macOS)
         measuredTextCache.removeAllObjects()
+        #if DEBUG
+        _measuredTextCacheInsertCount = 0
+        #endif
         #endif
     }
 
@@ -319,6 +328,9 @@ struct MarkdownSegmentView: View, Equatable {
                 forKey: keyNS,
                 cost: textLen * 15
             )
+            #if DEBUG
+            Self._measuredTextCacheInsertCount += 1
+            #endif
         }
         return (nsAttributed, size)
     }

--- a/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
@@ -368,4 +368,67 @@ final class MessageListScrollPerformanceTests: XCTestCase {
             }
         }
     }
+
+    // MARK: - Test 9: MarkdownSegmentView Measurement Caching
+
+    /// Verifies that resolveSelectableRunMeasurement caches results so repeated
+    /// body evaluations do not re-run TextKit layout passes. This prevents the
+    /// 12-24s main-thread hangs observed in the LazyVStack layout cascade.
+    @MainActor
+    func testMarkdownSegmentMeasurementCaching() {
+        // Clear any pre-existing cache entries.
+        MarkdownSegmentView.clearAttributedStringCache()
+
+        let segments: [MarkdownSegment] = [
+            .text("Hello world, this is a test message with some representative content for benchmarking layout measurement caching.")
+        ]
+
+        // Create two identical MarkdownSegmentView instances (simulates
+        // repeated body evaluation by SwiftUI's layout engine).
+        let view1 = MarkdownSegmentView(segments: segments)
+        let view2 = MarkdownSegmentView(segments: segments)
+
+        // Access the body to trigger measurement (first call = cache miss).
+        _ = view1.body
+        let insertCountAfterFirst = MarkdownSegmentView._measuredTextCacheInsertCount
+
+        // Second evaluation with identical inputs should hit the cache.
+        _ = view2.body
+        let insertCountAfterSecond = MarkdownSegmentView._measuredTextCacheInsertCount
+
+        // The insert count should NOT increase on the second evaluation,
+        // proving that the TextKit measurement was served from cache.
+        XCTAssertEqual(insertCountAfterFirst, insertCountAfterSecond,
+            "Second evaluation must hit the measurement cache — no new TextKit layout pass")
+        XCTAssertGreaterThan(insertCountAfterFirst, 0,
+            "First evaluation must have inserted at least one cache entry")
+    }
+
+    // MARK: - Test 10: MarkdownSegmentView Body Evaluation Performance
+
+    /// Measures repeated MarkdownSegmentView body evaluations with cached
+    /// measurements. Ensures the per-evaluation cost stays negligible (cache
+    /// lookups only, no TextKit layout). Baseline regression detection via
+    /// XCTest's statistical comparison.
+    @MainActor
+    func testMarkdownSegmentBodyEvaluationPerformance() {
+        let segments: [MarkdownSegment] = [
+            .text("First paragraph with some representative text content."),
+            .text("Second paragraph with **bold** and *italic* formatting."),
+            .heading(level: 2, text: "A Section Heading"),
+            .text("Third paragraph after the heading with a [link](https://example.com).")
+        ]
+
+        // Pre-warm the cache with a first evaluation.
+        let warmup = MarkdownSegmentView(segments: segments)
+        _ = warmup.body
+
+        // Measure repeated evaluations — should all be cache hits.
+        measure(metrics: [XCTClockMetric()]) {
+            for _ in 0..<200 {
+                let view = MarkdownSegmentView(segments: segments)
+                _ = view.body
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Expose a DEBUG-only insert counter on the measurement cache for test observability
- Add test verifying cache hits prevent repeated TextKit layout passes
- Add performance regression test measuring cached body evaluation time

Part of plan: fix-layout-cascade-hangs.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
