### PR TITLE
fix: eliminate LazyVStack layout cascade hangs in message list

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -291,7 +291,11 @@ struct MarkdownSegmentView: View, Equatable {
     }
 
     #if os(macOS)
-    private func resolveSelectableRunMeasurement(
+    /// Computes or retrieves from cache the `(NSAttributedString, CGSize)` pair
+    /// for a selectable text run.  `internal` so `@testable import` tests can
+    /// exercise the cache directly (SwiftUI `body` evaluation does not force
+    /// `ForEach` row closures to execute in a unit-test context).
+    func resolveSelectableRunMeasurement(
         _ runSegments: [MarkdownSegment]
     ) -> (NSAttributedString, CGSize) {
         var hasher = Hasher()

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -211,6 +211,12 @@ struct MarkdownSegmentView: View, Equatable {
         cache.totalCostLimit = 20_000_000 // ~20 MB
         return cache
     }()
+
+    #if DEBUG
+    /// Exposed for testing: number of cache insertions into `measuredTextCache`.
+    /// NSCache doesn't expose its count, so we maintain a parallel counter.
+    @MainActor static var _measuredTextCacheInsertCount: Int = 0
+    #endif
     #endif
 
     // MARK: - Cache Guardrails
@@ -228,6 +234,9 @@ struct MarkdownSegmentView: View, Equatable {
         MarkdownTableView.clearCellAttributedStringCache()
         #if os(macOS)
         measuredTextCache.removeAllObjects()
+        #if DEBUG
+        _measuredTextCacheInsertCount = 0
+        #endif
         #endif
     }
 
@@ -319,6 +328,9 @@ struct MarkdownSegmentView: View, Equatable {
                 forKey: keyNS,
                 cost: textLen * 15
             )
+            #if DEBUG
+            Self._measuredTextCacheInsertCount += 1
+            #endif
         }
         return (nsAttributed, size)
     }

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -8,6 +8,17 @@ private final class AttributedStringCacheEntry: NSObject {
     init(_ attributedString: AttributedString) { self.attributedString = attributedString }
 }
 
+#if os(macOS)
+private final class MeasuredTextCacheEntry: NSObject {
+    let nsAttributedString: NSAttributedString
+    let size: CGSize
+    init(nsAttributedString: NSAttributedString, size: CGSize) {
+        self.nsAttributedString = nsAttributedString
+        self.size = size
+    }
+}
+#endif
+
 /// Reusable view that renders parsed `MarkdownSegment` arrays.
 /// Groups consecutive text-selectable segments (text, headings, lists) into
 /// unified Text views so that text selection can span across paragraphs.
@@ -45,17 +56,7 @@ struct MarkdownSegmentView: View, Equatable {
                 switch group {
                 case .selectableRun(let runSegments):
                     #if os(macOS)
-                    let attributed = buildCombinedAttributedString(from: runSegments)
-                    let nsAttributed = Self.convertToNSAttributedString(
-                        attributed,
-                        font: VFont.nsChat,
-                        textColor: NSColor(textColor)
-                    )
-                    let measuredSize = VSelectableTextView.measureSize(
-                        attributedString: nsAttributed,
-                        lineSpacing: 4,
-                        maxWidth: maxContentWidth ?? VSpacing.chatBubbleMaxWidth
-                    )
+                    let (nsAttributed, measuredSize) = resolveSelectableRunMeasurement(runSegments)
                     VSelectableTextView(
                         attributedString: nsAttributed,
                         maxWidth: maxContentWidth,
@@ -203,6 +204,15 @@ struct MarkdownSegmentView: View, Equatable {
         return cache
     }()
 
+    #if os(macOS)
+    @MainActor private static var measuredTextCache: NSCache<NSNumber, MeasuredTextCacheEntry> = {
+        let cache = NSCache<NSNumber, MeasuredTextCacheEntry>()
+        cache.countLimit = 500
+        cache.totalCostLimit = 20_000_000 // ~20 MB
+        return cache
+    }()
+    #endif
+
     // MARK: - Cache Guardrails
 
     private static let maxCacheableTextLength = 10_000
@@ -216,6 +226,9 @@ struct MarkdownSegmentView: View, Equatable {
         prefixWidthCache.removeAll()
         groupedSegmentsCache.removeAll()
         MarkdownTableView.clearCellAttributedStringCache()
+        #if os(macOS)
+        measuredTextCache.removeAllObjects()
+        #endif
     }
 
     /// Rough character count of the text content within a segment array.
@@ -267,6 +280,49 @@ struct MarkdownSegmentView: View, Equatable {
         Self.attributedStringCache.setObject(AttributedStringCacheEntry(result), forKey: cacheKeyNS, cost: textLen * 10)
         return result
     }
+
+    #if os(macOS)
+    private func resolveSelectableRunMeasurement(
+        _ runSegments: [MarkdownSegment]
+    ) -> (NSAttributedString, CGSize) {
+        var hasher = Hasher()
+        for segment in runSegments { hasher.combine(segment) }
+        hasher.combine(textColor.description)
+        hasher.combine(secondaryTextColor.description)
+        hasher.combine(codeTextColor.description)
+        hasher.combine(codeBackgroundColor.description)
+        let effectiveMaxWidth = maxContentWidth ?? VSpacing.chatBubbleMaxWidth
+        hasher.combine(effectiveMaxWidth)
+        let key = hasher.finalize()
+
+        let keyNS = key as NSNumber
+        if let cached = Self.measuredTextCache.object(forKey: keyNS) {
+            return (cached.nsAttributedString, cached.size)
+        }
+
+        os_signpost(.begin, log: PerfSignposts.log, name: "selectableRunMeasure")
+        let attributed = buildCombinedAttributedString(from: runSegments)
+        let nsAttributed = Self.convertToNSAttributedString(
+            attributed, font: VFont.nsChat, textColor: NSColor(textColor)
+        )
+        let size = VSelectableTextView.measureSize(
+            attributedString: nsAttributed,
+            lineSpacing: 4,
+            maxWidth: effectiveMaxWidth
+        )
+        os_signpost(.end, log: PerfSignposts.log, name: "selectableRunMeasure")
+
+        let textLen = Self.segmentTextLength(runSegments)
+        if textLen <= Self.maxCacheableTextLength {
+            Self.measuredTextCache.setObject(
+                MeasuredTextCacheEntry(nsAttributedString: nsAttributed, size: size),
+                forKey: keyNS,
+                cost: textLen * 15
+            )
+        }
+        return (nsAttributed, size)
+    }
+    #endif
 
     /// Pure builder with no side effects — separated for caching.
     private static func buildAttributedStringUncached(

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -295,7 +295,7 @@ struct MarkdownSegmentView: View, Equatable {
     /// for a selectable text run.  `internal` so `@testable import` tests can
     /// exercise the cache directly (SwiftUI `body` evaluation does not force
     /// `ForEach` row closures to execute in a unit-test context).
-    func resolveSelectableRunMeasurement(
+    @MainActor func resolveSelectableRunMeasurement(
         _ runSegments: [MarkdownSegment]
     ) -> (NSAttributedString, CGSize) {
         var hasher = Hasher()

--- a/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
@@ -368,4 +368,67 @@ final class MessageListScrollPerformanceTests: XCTestCase {
             }
         }
     }
+
+    // MARK: - Test 9: MarkdownSegmentView Measurement Caching
+
+    /// Verifies that resolveSelectableRunMeasurement caches results so repeated
+    /// body evaluations do not re-run TextKit layout passes. This prevents the
+    /// 12-24s main-thread hangs observed in the LazyVStack layout cascade.
+    @MainActor
+    func testMarkdownSegmentMeasurementCaching() {
+        // Clear any pre-existing cache entries.
+        MarkdownSegmentView.clearAttributedStringCache()
+
+        let segments: [MarkdownSegment] = [
+            .text("Hello world, this is a test message with some representative content for benchmarking layout measurement caching.")
+        ]
+
+        // Create two identical MarkdownSegmentView instances (simulates
+        // repeated body evaluation by SwiftUI's layout engine).
+        let view1 = MarkdownSegmentView(segments: segments)
+        let view2 = MarkdownSegmentView(segments: segments)
+
+        // Access the body to trigger measurement (first call = cache miss).
+        _ = view1.body
+        let insertCountAfterFirst = MarkdownSegmentView._measuredTextCacheInsertCount
+
+        // Second evaluation with identical inputs should hit the cache.
+        _ = view2.body
+        let insertCountAfterSecond = MarkdownSegmentView._measuredTextCacheInsertCount
+
+        // The insert count should NOT increase on the second evaluation,
+        // proving that the TextKit measurement was served from cache.
+        XCTAssertEqual(insertCountAfterFirst, insertCountAfterSecond,
+            "Second evaluation must hit the measurement cache — no new TextKit layout pass")
+        XCTAssertGreaterThan(insertCountAfterFirst, 0,
+            "First evaluation must have inserted at least one cache entry")
+    }
+
+    // MARK: - Test 10: MarkdownSegmentView Body Evaluation Performance
+
+    /// Measures repeated MarkdownSegmentView body evaluations with cached
+    /// measurements. Ensures the per-evaluation cost stays negligible (cache
+    /// lookups only, no TextKit layout). Baseline regression detection via
+    /// XCTest's statistical comparison.
+    @MainActor
+    func testMarkdownSegmentBodyEvaluationPerformance() {
+        let segments: [MarkdownSegment] = [
+            .text("First paragraph with some representative text content."),
+            .text("Second paragraph with **bold** and *italic* formatting."),
+            .heading(level: 2, text: "A Section Heading"),
+            .text("Third paragraph after the heading with a [link](https://example.com).")
+        ]
+
+        // Pre-warm the cache with a first evaluation.
+        let warmup = MarkdownSegmentView(segments: segments)
+        _ = warmup.body
+
+        // Measure repeated evaluations — should all be cache hits.
+        measure(metrics: [XCTClockMetric()]) {
+            for _ in 0..<200 {
+                let view = MarkdownSegmentView(segments: segments)
+                _ = view.body
+            }
+        }
+    }
 }

--- a/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
@@ -372,8 +372,12 @@ final class MessageListScrollPerformanceTests: XCTestCase {
     // MARK: - Test 9: MarkdownSegmentView Measurement Caching
 
     /// Verifies that resolveSelectableRunMeasurement caches results so repeated
-    /// body evaluations do not re-run TextKit layout passes. This prevents the
-    /// 12-24s main-thread hangs observed in the LazyVStack layout cascade.
+    /// calls do not re-run TextKit layout passes. This prevents the 12-24s
+    /// main-thread hangs observed in the LazyVStack layout cascade.
+    ///
+    /// Calls `resolveSelectableRunMeasurement` directly because SwiftUI's
+    /// `body` evaluation does not execute `ForEach` row closures in a
+    /// unit-test context (no rendering host).
     @MainActor
     func testMarkdownSegmentMeasurementCaching() {
         // Clear any pre-existing cache entries.
@@ -383,35 +387,32 @@ final class MessageListScrollPerformanceTests: XCTestCase {
             .text("Hello world, this is a test message with some representative content for benchmarking layout measurement caching.")
         ]
 
-        // Create two identical MarkdownSegmentView instances (simulates
-        // repeated body evaluation by SwiftUI's layout engine).
-        let view1 = MarkdownSegmentView(segments: segments)
-        let view2 = MarkdownSegmentView(segments: segments)
+        let view = MarkdownSegmentView(segments: segments)
 
-        // Access the body to trigger measurement (first call = cache miss).
-        _ = view1.body
+        // First call = cache miss, triggers TextKit layout.
+        _ = view.resolveSelectableRunMeasurement(segments)
         let insertCountAfterFirst = MarkdownSegmentView._measuredTextCacheInsertCount
 
-        // Second evaluation with identical inputs should hit the cache.
-        _ = view2.body
+        // Second call with identical inputs should hit the cache.
+        _ = view.resolveSelectableRunMeasurement(segments)
         let insertCountAfterSecond = MarkdownSegmentView._measuredTextCacheInsertCount
 
-        // The insert count should NOT increase on the second evaluation,
+        // The insert count should NOT increase on the second call,
         // proving that the TextKit measurement was served from cache.
         XCTAssertEqual(insertCountAfterFirst, insertCountAfterSecond,
-            "Second evaluation must hit the measurement cache — no new TextKit layout pass")
+            "Second call must hit the measurement cache — no new TextKit layout pass")
         XCTAssertGreaterThan(insertCountAfterFirst, 0,
-            "First evaluation must have inserted at least one cache entry")
+            "First call must have inserted at least one cache entry")
     }
 
-    // MARK: - Test 10: MarkdownSegmentView Body Evaluation Performance
+    // MARK: - Test 10: MarkdownSegmentView Measurement Performance
 
-    /// Measures repeated MarkdownSegmentView body evaluations with cached
-    /// measurements. Ensures the per-evaluation cost stays negligible (cache
-    /// lookups only, no TextKit layout). Baseline regression detection via
-    /// XCTest's statistical comparison.
+    /// Measures repeated resolveSelectableRunMeasurement calls with a warm
+    /// cache. Ensures the per-call cost stays negligible (cache lookups only,
+    /// no TextKit layout). Baseline regression detection via XCTest's
+    /// statistical comparison.
     @MainActor
-    func testMarkdownSegmentBodyEvaluationPerformance() {
+    func testMarkdownSegmentMeasurementPerformance() {
         let segments: [MarkdownSegment] = [
             .text("First paragraph with some representative text content."),
             .text("Second paragraph with **bold** and *italic* formatting."),
@@ -419,15 +420,15 @@ final class MessageListScrollPerformanceTests: XCTestCase {
             .text("Third paragraph after the heading with a [link](https://example.com).")
         ]
 
-        // Pre-warm the cache with a first evaluation.
-        let warmup = MarkdownSegmentView(segments: segments)
-        _ = warmup.body
+        let view = MarkdownSegmentView(segments: segments)
 
-        // Measure repeated evaluations — should all be cache hits.
+        // Pre-warm the cache.
+        _ = view.resolveSelectableRunMeasurement(segments)
+
+        // Measure repeated calls — should all be cache hits.
         measure(metrics: [XCTClockMetric()]) {
             for _ in 0..<200 {
-                let view = MarkdownSegmentView(segments: segments)
-                _ = view.body
+                _ = view.resolveSelectableRunMeasurement(segments)
             }
         }
     }


### PR DESCRIPTION
## Summary
Cache NSAttributedString conversion and TextKit size measurements in MarkdownSegmentView to eliminate 12-24 second main-thread hangs caused by repeated TextKit layout passes during SwiftUI's LazyVStack measurement cascade. Add regression tests to prevent recurrence.

## PRs merged into feature branch
- #23223: fix: cache NSAttributedString conversion and TextKit size measurements in MarkdownSegmentView
- #23226: test: add MarkdownSegmentView measurement caching regression test

Part of plan: fix-layout-cascade-hangs.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
