### PR TITLE
fix: add kind-specific integration tests for prompt action mapping

### DIFF
--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -48,6 +48,7 @@ import {
   routeGuardianReply,
 } from "../runtime/guardian-reply-router.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
+import { listGuardianDecisionPrompts } from "../runtime/routes/guardian-action-routes.js";
 
 initializeDb();
 
@@ -1711,6 +1712,8 @@ describe("routing invariant: expired requests are excluded from pending discover
 // ===========================================================================
 
 describe("routing invariant: kind-specific action sets in prompt mapping", () => {
+  beforeEach(() => resetTables());
+
   test("buildDecisionActions({ forGuardianOnBehalf: true }) includes temporal actions", () => {
     const actions = buildDecisionActions({ forGuardianOnBehalf: true });
     const actionIds = actions.map((a) => a.action);
@@ -1737,5 +1740,98 @@ describe("routing invariant: kind-specific action sets in prompt mapping", () =>
     const fullPath = join(srcRoot, "runtime/routes/guardian-action-routes.ts");
     const source = readFileSync(fullPath, "utf-8");
     expect(source).toContain('req.kind === "tool_approval"');
+  });
+
+  // Integration tests: verify listGuardianDecisionPrompts returns correct
+  // action sets for each canonical request kind.
+
+  test("tool_approval prompt includes temporal actions (approve_10m, approve_conversation)", () => {
+    const convId = "conv-kind-tool-approval";
+    createCanonicalGuardianRequest({
+      kind: "tool_approval",
+      sourceType: "channel",
+      conversationId: convId,
+      guardianExternalUserId: "guardian-1",
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      toolName: "shell",
+      expiresAt: Date.now() + 60_000,
+    });
+
+    const prompts = listGuardianDecisionPrompts({ conversationId: convId });
+    expect(prompts).toHaveLength(1);
+
+    const actionIds = prompts[0].actions.map((a) => a.action);
+    expect(actionIds).toContain("approve_once");
+    expect(actionIds).toContain("approve_10m");
+    expect(actionIds).toContain("approve_conversation");
+    expect(actionIds).toContain("reject");
+    expect(actionIds).not.toContain("approve_always");
+  });
+
+  test("pending_question prompt has approve_once + reject only (no temporal actions)", () => {
+    const convId = "conv-kind-pending-question";
+    createCanonicalGuardianRequest({
+      kind: "pending_question",
+      sourceType: "voice",
+      sourceChannel: "phone",
+      conversationId: convId,
+      guardianExternalUserId: "guardian-1",
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      callSessionId: "call-pq",
+      pendingQuestionId: "pq-kind-test",
+      questionText: "What time works best?",
+      expiresAt: Date.now() + 60_000,
+    });
+
+    const prompts = listGuardianDecisionPrompts({ conversationId: convId });
+    expect(prompts).toHaveLength(1);
+
+    const actionIds = prompts[0].actions.map((a) => a.action);
+    expect(actionIds).toEqual(["approve_once", "reject"]);
+    expect(actionIds).not.toContain("approve_10m");
+    expect(actionIds).not.toContain("approve_conversation");
+  });
+
+  test("access_request prompt has approve_once + reject only (no temporal actions)", () => {
+    const convId = "conv-kind-access-request";
+    createCanonicalGuardianRequest({
+      kind: "access_request",
+      sourceType: "channel",
+      sourceChannel: "telegram",
+      conversationId: convId,
+      guardianExternalUserId: "guardian-1",
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      toolName: "ingress_access_request",
+      expiresAt: Date.now() + 60_000,
+    });
+
+    const prompts = listGuardianDecisionPrompts({ conversationId: convId });
+    expect(prompts).toHaveLength(1);
+
+    const actionIds = prompts[0].actions.map((a) => a.action);
+    expect(actionIds).toEqual(["approve_once", "reject"]);
+    expect(actionIds).not.toContain("approve_10m");
+    expect(actionIds).not.toContain("approve_conversation");
+  });
+
+  test("tool_grant_request prompt has approve_once + reject only (no temporal actions)", () => {
+    const convId = "conv-kind-tool-grant-request";
+    createCanonicalGuardianRequest({
+      kind: "tool_grant_request",
+      sourceType: "channel",
+      conversationId: convId,
+      guardianExternalUserId: "guardian-1",
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      toolName: "file_write",
+      expiresAt: Date.now() + 60_000,
+    });
+
+    const prompts = listGuardianDecisionPrompts({ conversationId: convId });
+    expect(prompts).toHaveLength(1);
+
+    const actionIds = prompts[0].actions.map((a) => a.action);
+    expect(actionIds).toEqual(["approve_once", "reject"]);
+    expect(actionIds).not.toContain("approve_10m");
+    expect(actionIds).not.toContain("approve_conversation");
   });
 });


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-guardian-temporal-actions.md.

**Gap:** Tests don't exercise the actual prompt mapping for each non-tool-approval kind
**What was expected:** Tests that create canonical requests of each kind and verify actions
**What was found:** Tests only verified building blocks, not the actual mapping logic per kind
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
