### PR TITLE
fix: test measurement cache directly instead of through SwiftUI body

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -291,7 +291,11 @@ struct MarkdownSegmentView: View, Equatable {
     }
 
     #if os(macOS)
-    private func resolveSelectableRunMeasurement(
+    /// Computes or retrieves from cache the `(NSAttributedString, CGSize)` pair
+    /// for a selectable text run.  `internal` so `@testable import` tests can
+    /// exercise the cache directly (SwiftUI `body` evaluation does not force
+    /// `ForEach` row closures to execute in a unit-test context).
+    func resolveSelectableRunMeasurement(
         _ runSegments: [MarkdownSegment]
     ) -> (NSAttributedString, CGSize) {
         var hasher = Hasher()

--- a/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
@@ -372,8 +372,12 @@ final class MessageListScrollPerformanceTests: XCTestCase {
     // MARK: - Test 9: MarkdownSegmentView Measurement Caching
 
     /// Verifies that resolveSelectableRunMeasurement caches results so repeated
-    /// body evaluations do not re-run TextKit layout passes. This prevents the
-    /// 12-24s main-thread hangs observed in the LazyVStack layout cascade.
+    /// calls do not re-run TextKit layout passes. This prevents the 12-24s
+    /// main-thread hangs observed in the LazyVStack layout cascade.
+    ///
+    /// Calls `resolveSelectableRunMeasurement` directly because SwiftUI's
+    /// `body` evaluation does not execute `ForEach` row closures in a
+    /// unit-test context (no rendering host).
     @MainActor
     func testMarkdownSegmentMeasurementCaching() {
         // Clear any pre-existing cache entries.
@@ -383,35 +387,32 @@ final class MessageListScrollPerformanceTests: XCTestCase {
             .text("Hello world, this is a test message with some representative content for benchmarking layout measurement caching.")
         ]
 
-        // Create two identical MarkdownSegmentView instances (simulates
-        // repeated body evaluation by SwiftUI's layout engine).
-        let view1 = MarkdownSegmentView(segments: segments)
-        let view2 = MarkdownSegmentView(segments: segments)
+        let view = MarkdownSegmentView(segments: segments)
 
-        // Access the body to trigger measurement (first call = cache miss).
-        _ = view1.body
+        // First call = cache miss, triggers TextKit layout.
+        _ = view.resolveSelectableRunMeasurement(segments)
         let insertCountAfterFirst = MarkdownSegmentView._measuredTextCacheInsertCount
 
-        // Second evaluation with identical inputs should hit the cache.
-        _ = view2.body
+        // Second call with identical inputs should hit the cache.
+        _ = view.resolveSelectableRunMeasurement(segments)
         let insertCountAfterSecond = MarkdownSegmentView._measuredTextCacheInsertCount
 
-        // The insert count should NOT increase on the second evaluation,
+        // The insert count should NOT increase on the second call,
         // proving that the TextKit measurement was served from cache.
         XCTAssertEqual(insertCountAfterFirst, insertCountAfterSecond,
-            "Second evaluation must hit the measurement cache — no new TextKit layout pass")
+            "Second call must hit the measurement cache — no new TextKit layout pass")
         XCTAssertGreaterThan(insertCountAfterFirst, 0,
-            "First evaluation must have inserted at least one cache entry")
+            "First call must have inserted at least one cache entry")
     }
 
-    // MARK: - Test 10: MarkdownSegmentView Body Evaluation Performance
+    // MARK: - Test 10: MarkdownSegmentView Measurement Performance
 
-    /// Measures repeated MarkdownSegmentView body evaluations with cached
-    /// measurements. Ensures the per-evaluation cost stays negligible (cache
-    /// lookups only, no TextKit layout). Baseline regression detection via
-    /// XCTest's statistical comparison.
+    /// Measures repeated resolveSelectableRunMeasurement calls with a warm
+    /// cache. Ensures the per-call cost stays negligible (cache lookups only,
+    /// no TextKit layout). Baseline regression detection via XCTest's
+    /// statistical comparison.
     @MainActor
-    func testMarkdownSegmentBodyEvaluationPerformance() {
+    func testMarkdownSegmentMeasurementPerformance() {
         let segments: [MarkdownSegment] = [
             .text("First paragraph with some representative text content."),
             .text("Second paragraph with **bold** and *italic* formatting."),
@@ -419,15 +420,15 @@ final class MessageListScrollPerformanceTests: XCTestCase {
             .text("Third paragraph after the heading with a [link](https://example.com).")
         ]
 
-        // Pre-warm the cache with a first evaluation.
-        let warmup = MarkdownSegmentView(segments: segments)
-        _ = warmup.body
+        let view = MarkdownSegmentView(segments: segments)
 
-        // Measure repeated evaluations — should all be cache hits.
+        // Pre-warm the cache.
+        _ = view.resolveSelectableRunMeasurement(segments)
+
+        // Measure repeated calls — should all be cache hits.
         measure(metrics: [XCTClockMetric()]) {
             for _ in 0..<200 {
-                let view = MarkdownSegmentView(segments: segments)
-                _ = view.body
+                _ = view.resolveSelectableRunMeasurement(segments)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Address Codex review feedback: `_ = view.body` doesn't execute ForEach row closures in unit tests, so the measurement cache was never exercised
- Change tests to call `resolveSelectableRunMeasurement` directly, which exercises the actual TextKit measurement + caching hot path
- Make `resolveSelectableRunMeasurement` internal (was private) so `@testable import` can access it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
