### PR TITLE
fix: add @MainActor annotation to resolveSelectableRunMeasurement

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -295,7 +295,7 @@ struct MarkdownSegmentView: View, Equatable {
     /// for a selectable text run.  `internal` so `@testable import` tests can
     /// exercise the cache directly (SwiftUI `body` evaluation does not force
     /// `ForEach` row closures to execute in a unit-test context).
-    func resolveSelectableRunMeasurement(
+    @MainActor func resolveSelectableRunMeasurement(
         _ runSegments: [MarkdownSegment]
     ) -> (NSAttributedString, CGSize) {
         var hasher = Hasher()


### PR DESCRIPTION
## Summary
- Add explicit `@MainActor` annotation to `resolveSelectableRunMeasurement` since it accesses `@MainActor` static storage (`measuredTextCache`)
- Prevents future callers from accidentally invoking it off the main actor
- Addresses integration review feedback
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
