### PR TITLE
fix(macos): update input chrome to match Figma redesign

### DIFF
--- a/clients/shared/DesignSystem/Core/Inputs/VTextField.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VTextField.swift
@@ -71,18 +71,11 @@ public struct VInputChromeModifier: ViewModifier {
         let shape = RoundedRectangle(cornerRadius: cornerRadius)
 
         content
-            .background(shape.fill(isDisabled ? VColor.surfaceOverlay : VColor.surfaceBase))
+            .background(shape.fill(VColor.surfaceLift))
             .overlay(
-                shape.strokeBorder(
-                    borderColor,
-                    lineWidth: (isFocused || isError) ? 1.5 : 1
-                )
+                shape.strokeBorder(borderColor, lineWidth: 1)
             )
             .clipShape(shape)
-            .shadow(
-                color: isFocused && !isError ? VColor.primaryBase.opacity(0.10) : .clear,
-                radius: 4
-            )
             .opacity(isDisabled ? 0.6 : 1.0)
     }
 
@@ -93,7 +86,7 @@ public struct VInputChromeModifier: ViewModifier {
         if isFocused {
             return VColor.borderActive
         }
-        return VColor.borderBase.opacity(0.72)
+        return VColor.borderElement
     }
 }
 


### PR DESCRIPTION
## Summary
- Update `VInputChromeModifier` to use `surfaceLift` background, `borderElement` default border, 1px uniform border width, and remove focus shadow
- Cascades automatically to VTextField, VTextEditor, VSearchBar, and VDropdown

## Test plan
- [ ] Check inputs in Settings (API key fields, keyword input, etc.) in light and dark mode
- [ ] Verify focus state shows `borderActive` border
- [ ] Verify error state shows red border
- [ ] Verify disabled state at 60% opacity

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
