### PR TITLE
Cherry-pick fixes onto release/v0.6.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,12 @@ Error reporting uses Sentry. Two projects exist: one for the daemon/runtime (Nod
 
 **Sentry CLI**: Use the newer `sentry` CLI (not the legacy `sentry-cli`). Install from `https://cli.sentry.dev/install`. Authenticate with `sentry auth login`.
 
+## No New Daemon HTTP Port Consumers
+
+Do not introduce new callers of the daemon's internal HTTP port from CLI commands or other out-of-process code. The daemon HTTP API is an internal surface consumed by the gateway and native clients — CLI commands run **in-process** and must use the service/store layer directly (see `assistant/src/cli/AGENTS.md`).
+
+When you need to publish events to connected clients (e.g. `open_url`, `avatar_updated`) from code running inside the daemon process, import and call the `assistantEventHub` singleton directly rather than adding a new HTTP endpoint. For CLI commands (which run in-process but may not share the daemon's singleton context), use the file-based signal pattern: write a JSON `ServerMessage` to `signals/emit-event` via `getSignalsDir()` — the daemon's `ConfigWatcher` picks it up and publishes via `assistantEventHub`. See `assistant/src/cli/commands/platform/connect.ts` for an example.
+
 ## See Also
 
 - **HTTP API patterns & new endpoints**: `assistant/src/runtime/AGENTS.md`

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.0.0
 info:
   title: Vellum Assistant API
-  version: 0.5.16
+  version: 0.6.0
   description: Auto-generated OpenAPI specification for the Vellum Assistant runtime HTTP server.
 servers:
   - url: http://127.0.0.1:7821

--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -40,10 +40,15 @@ import {
 } from "../memory/canonical-guardian-store.js";
 import { getDb, initializeDb } from "../memory/db.js";
 import {
+  buildDecisionActions,
+  GUARDIAN_DECISION_ACTIONS,
+} from "../runtime/guardian-decision-types.js";
+import {
   type GuardianReplyContext,
   routeGuardianReply,
 } from "../runtime/guardian-reply-router.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
+import { listGuardianDecisionPrompts } from "../runtime/routes/guardian-action-routes.js";
 
 initializeDb();
 
@@ -1699,5 +1704,134 @@ describe("routing invariant: expired requests are excluded from pending discover
     expect(result.consumed).toBe(false);
     expect(result.type).toBe("not_consumed");
     expect(result.decisionApplied).toBe(false);
+  });
+});
+
+// ===========================================================================
+// SECTION 12: Kind-specific action sets in prompt mapping
+// ===========================================================================
+
+describe("routing invariant: kind-specific action sets in prompt mapping", () => {
+  beforeEach(() => resetTables());
+
+  test("buildDecisionActions({ forGuardianOnBehalf: true }) includes temporal actions", () => {
+    const actions = buildDecisionActions({ forGuardianOnBehalf: true });
+    const actionIds = actions.map((a) => a.action);
+    expect(actionIds).toContain("approve_once");
+    expect(actionIds).toContain("approve_10m");
+    expect(actionIds).toContain("approve_conversation");
+    expect(actionIds).toContain("reject");
+    // approve_always must NOT be present for guardian-on-behalf
+    expect(actionIds).not.toContain("approve_always");
+  });
+
+  test("non-tool-approval action set is approve_once + reject only", () => {
+    const actions = [
+      GUARDIAN_DECISION_ACTIONS.approve_once,
+      GUARDIAN_DECISION_ACTIONS.reject,
+    ];
+    expect(actions).toHaveLength(2);
+    expect(actions[0].action).toBe("approve_once");
+    expect(actions[1].action).toBe("reject");
+  });
+
+  test("source-code invariant: guardian-action-routes.ts contains kind guard", () => {
+    const srcRoot = resolve(__dirname, "..");
+    const fullPath = join(srcRoot, "runtime/routes/guardian-action-routes.ts");
+    const source = readFileSync(fullPath, "utf-8");
+    expect(source).toContain('req.kind === "tool_approval"');
+  });
+
+  // Integration tests: verify listGuardianDecisionPrompts returns correct
+  // action sets for each canonical request kind.
+
+  test("tool_approval prompt includes temporal actions (approve_10m, approve_conversation)", () => {
+    const convId = "conv-kind-tool-approval";
+    createCanonicalGuardianRequest({
+      kind: "tool_approval",
+      sourceType: "channel",
+      conversationId: convId,
+      guardianExternalUserId: "guardian-1",
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      toolName: "shell",
+      expiresAt: Date.now() + 60_000,
+    });
+
+    const prompts = listGuardianDecisionPrompts({ conversationId: convId });
+    expect(prompts).toHaveLength(1);
+
+    const actionIds = prompts[0].actions.map((a) => a.action);
+    expect(actionIds).toContain("approve_once");
+    expect(actionIds).toContain("approve_10m");
+    expect(actionIds).toContain("approve_conversation");
+    expect(actionIds).toContain("reject");
+    expect(actionIds).not.toContain("approve_always");
+  });
+
+  test("pending_question prompt has approve_once + reject only (no temporal actions)", () => {
+    const convId = "conv-kind-pending-question";
+    createCanonicalGuardianRequest({
+      kind: "pending_question",
+      sourceType: "voice",
+      sourceChannel: "phone",
+      conversationId: convId,
+      guardianExternalUserId: "guardian-1",
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      callSessionId: "call-pq",
+      pendingQuestionId: "pq-kind-test",
+      questionText: "What time works best?",
+      expiresAt: Date.now() + 60_000,
+    });
+
+    const prompts = listGuardianDecisionPrompts({ conversationId: convId });
+    expect(prompts).toHaveLength(1);
+
+    const actionIds = prompts[0].actions.map((a) => a.action);
+    expect(actionIds).toEqual(["approve_once", "reject"]);
+    expect(actionIds).not.toContain("approve_10m");
+    expect(actionIds).not.toContain("approve_conversation");
+  });
+
+  test("access_request prompt has approve_once + reject only (no temporal actions)", () => {
+    const convId = "conv-kind-access-request";
+    createCanonicalGuardianRequest({
+      kind: "access_request",
+      sourceType: "channel",
+      sourceChannel: "telegram",
+      conversationId: convId,
+      guardianExternalUserId: "guardian-1",
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      toolName: "ingress_access_request",
+      expiresAt: Date.now() + 60_000,
+    });
+
+    const prompts = listGuardianDecisionPrompts({ conversationId: convId });
+    expect(prompts).toHaveLength(1);
+
+    const actionIds = prompts[0].actions.map((a) => a.action);
+    expect(actionIds).toEqual(["approve_once", "reject"]);
+    expect(actionIds).not.toContain("approve_10m");
+    expect(actionIds).not.toContain("approve_conversation");
+  });
+
+  test("tool_grant_request prompt has approve_once + reject only (no temporal actions)", () => {
+    const convId = "conv-kind-tool-grant-request";
+    createCanonicalGuardianRequest({
+      kind: "tool_grant_request",
+      sourceType: "channel",
+      conversationId: convId,
+      guardianExternalUserId: "guardian-1",
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      toolName: "file_write",
+      expiresAt: Date.now() + 60_000,
+    });
+
+    const prompts = listGuardianDecisionPrompts({ conversationId: convId });
+    expect(prompts).toHaveLength(1);
+
+    const actionIds = prompts[0].actions.map((a) => a.action);
+    expect(actionIds).toEqual(["approve_once", "reject"]);
+    expect(actionIds).not.toContain("approve_10m");
+    expect(actionIds).not.toContain("approve_conversation");
   });
 });

--- a/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
@@ -88,7 +88,7 @@ mock.module("../../../../platform/client.js", () => ({
 }));
 
 mock.module("../../../../util/browser.js", () => ({
-  openInBrowser: (url: string) => {
+  openInHostBrowser: async (url: string) => {
     mockOpenInBrowserCalls.push(url);
   },
 }));

--- a/assistant/src/cli/commands/oauth/__tests__/disconnect.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/disconnect.test.ts
@@ -112,7 +112,7 @@ mock.module("../../../../platform/client.js", () => ({
 }));
 
 mock.module("../../../../util/browser.js", () => ({
-  openInBrowser: () => {},
+  openInHostBrowser: async () => {},
 }));
 
 mock.module("../../../../util/logger.js", () => ({

--- a/assistant/src/cli/commands/oauth/__tests__/status.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/status.test.ts
@@ -71,7 +71,7 @@ mock.module("../../../../platform/client.js", () => ({
 }));
 
 mock.module("../../../../util/browser.js", () => ({
-  openInBrowser: () => {},
+  openInHostBrowser: async () => {},
 }));
 
 mock.module("../../../../util/logger.js", () => ({

--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -9,7 +9,7 @@ import {
   getProvider,
 } from "../../../oauth/oauth-store.js";
 import { renderOAuthCompletionPage } from "../../../security/oauth-completion-page.js";
-import { openInBrowser } from "../../../util/browser.js";
+import { openInHostBrowser } from "../../../util/browser.js";
 import { getSecureKeyViaDaemon } from "../../lib/daemon-credential-client.js";
 import { getCliLogger } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
@@ -234,7 +234,7 @@ Examples:
                 }
                 const snapshotIds = new Set(snapshotEntries.map((e) => e.id));
 
-                openInBrowser(result.connect_url);
+                await openInHostBrowser(result.connect_url);
 
                 if (!jsonMode) {
                   log.info(
@@ -379,7 +379,7 @@ Examples:
               clientSecret,
               callbackTransport: opts.callbackTransport,
               isInteractive: opts.browser !== false,
-              openUrl: opts.browser !== false ? openInBrowser : undefined,
+              openUrl: opts.browser !== false ? openInHostBrowser : undefined,
               ...(opts.scopes ? { requestedScopes: opts.scopes } : {}),
             });
 

--- a/assistant/src/runtime/routes/guardian-action-routes.ts
+++ b/assistant/src/runtime/routes/guardian-action-routes.ts
@@ -23,7 +23,10 @@ import { requireBoundGuardian } from "../auth/require-bound-guardian.js";
 import type { AuthContext } from "../auth/types.js";
 import { processGuardianDecision } from "../guardian-action-service.js";
 import type { GuardianDecisionPrompt } from "../guardian-decision-types.js";
-import { buildDecisionActions } from "../guardian-decision-types.js";
+import {
+  buildDecisionActions,
+  GUARDIAN_DECISION_ACTIONS,
+} from "../guardian-decision-types.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 
@@ -190,13 +193,15 @@ export function listGuardianDecisionPrompts(params: {
  * Map a canonical guardian request to the client-facing prompt format.
  *
  * Generates kind-specific questionText and action sets:
- * - `tool_approval`: "Approve tool: <name>" with approve/reject actions
- * - `pending_question`: voice-originated question with approve/reject actions
- * - `access_request`: explicit "Access Request" label with approve/reject actions
- *   and text fallback instructions (request code + "open invite flow")
+ * - `tool_approval`: temporal modes (approve_once, approve_10m, approve_conversation) + reject
+ * - `pending_question`: approve_once + reject only
+ * - `access_request`: approve_once + reject only, with text fallback instructions
+ *   (request code + "open invite flow")
+ * - `tool_grant_request`: approve_once + reject only
  *
- * All kinds use `forGuardianOnBehalf: true` (no approve_always) since the
- * guardian is acting on behalf of a requester.
+ * Only `tool_approval` receives temporal modes because time-scoped grants
+ * are meaningful only for tool execution. All other kinds get a simple
+ * approve_once/reject pair.
  */
 function mapCanonicalRequestToPrompt(
   req: CanonicalGuardianRequest,
@@ -204,9 +209,15 @@ function mapCanonicalRequestToPrompt(
 ): GuardianDecisionPrompt {
   const questionText = buildKindAwareQuestionText(req);
 
-  // Guardian-on-behalf prompts include approve_once, temporal modes
-  // (approve_10m, approve_conversation), and reject — but not approve_always.
-  const actions = buildDecisionActions({ forGuardianOnBehalf: true });
+  // Only tool_approval gets temporal modes (approve_10m, approve_conversation);
+  // all other kinds get a simple approve_once + reject pair.
+  const actions =
+    req.kind === "tool_approval"
+      ? buildDecisionActions({ forGuardianOnBehalf: true })
+      : [
+          GUARDIAN_DECISION_ACTIONS.approve_once,
+          GUARDIAN_DECISION_ACTIONS.reject,
+        ];
 
   const expiresAt = req.expiresAt
     ? new Date(req.expiresAt).getTime()

--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -61,7 +61,7 @@ export interface OAuth2TokenResult {
 
 export interface OAuth2FlowCallbacks {
   /** Open a URL in the user's browser (e.g. via `open_url` message). */
-  openUrl: (url: string) => void;
+  openUrl: (url: string) => void | Promise<void>;
 }
 
 export interface OAuth2FlowOptions {

--- a/assistant/src/util/browser.ts
+++ b/assistant/src/util/browser.ts
@@ -1,15 +1,30 @@
-import { isLinux, isMacOS } from "./platform.js";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "./logger.js";
+import { getSignalsDir } from "./platform.js";
+
+const log = getLogger("browser");
 
 /**
- * Open a URL in the user's default browser, falling back to printing the URL
- * to stderr on unsupported platforms.
+ * Open a URL on the user's host machine.
+ *
+ * Writes an `open_url` event to the `signals/emit-event` file so that the
+ * daemon's ConfigWatcher picks it up and publishes it to connected clients
+ * (e.g. the Swift macOS app) via the assistant event hub.
  */
-export function openInBrowser(url: string): void {
-  if (isMacOS()) {
-    Bun.spawn(["open", url], { stdout: "ignore", stderr: "ignore" });
-  } else if (isLinux()) {
-    Bun.spawn(["xdg-open", url], { stdout: "ignore", stderr: "ignore" });
-  } else {
-    process.stderr.write(`Open this URL to authorize:\n\n${url}\n`);
+export async function openInHostBrowser(url: string): Promise<void> {
+  try {
+    const signalsDir = getSignalsDir();
+    mkdirSync(signalsDir, { recursive: true });
+    writeFileSync(
+      join(signalsDir, "emit-event"),
+      JSON.stringify({ type: "open_url", url }),
+    );
+  } catch (err) {
+    log.warn(
+      { error: err instanceof Error ? err.message : String(err) },
+      "Failed to write open_url signal",
+    );
   }
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -820,6 +820,15 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             onboardingState = nil
             return
         }
+        // Eagerly apply onboarding avatar traits so the ComingAliveOverlay
+        // (and any other UI) can render the character avatar immediately
+        // instead of falling back to the bundled green V logo while the
+        // async daemon sync completes.
+        if AvatarAppearanceManager.shared.customAvatarImage == nil,
+           AvatarAppearanceManager.shared.characterBodyShape == nil {
+            let image = AvatarCompositor.render(bodyShape: body, eyeStyle: eyes, color: color)
+            AvatarAppearanceManager.shared.saveAvatar(image, bodyShape: body, eyeStyle: eyes, color: color)
+        }
         Task {
             await AvatarAppearanceManager.shared.syncTraitsToDaemon(
                 bodyShape: body, eyeStyle: eyes, color: color

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -8,6 +8,17 @@ private final class AttributedStringCacheEntry: NSObject {
     init(_ attributedString: AttributedString) { self.attributedString = attributedString }
 }
 
+#if os(macOS)
+private final class MeasuredTextCacheEntry: NSObject {
+    let nsAttributedString: NSAttributedString
+    let size: CGSize
+    init(nsAttributedString: NSAttributedString, size: CGSize) {
+        self.nsAttributedString = nsAttributedString
+        self.size = size
+    }
+}
+#endif
+
 /// Reusable view that renders parsed `MarkdownSegment` arrays.
 /// Groups consecutive text-selectable segments (text, headings, lists) into
 /// unified Text views so that text selection can span across paragraphs.
@@ -45,17 +56,7 @@ struct MarkdownSegmentView: View, Equatable {
                 switch group {
                 case .selectableRun(let runSegments):
                     #if os(macOS)
-                    let attributed = buildCombinedAttributedString(from: runSegments)
-                    let nsAttributed = Self.convertToNSAttributedString(
-                        attributed,
-                        font: VFont.nsChat,
-                        textColor: NSColor(textColor)
-                    )
-                    let measuredSize = VSelectableTextView.measureSize(
-                        attributedString: nsAttributed,
-                        lineSpacing: 4,
-                        maxWidth: maxContentWidth ?? VSpacing.chatBubbleMaxWidth
-                    )
+                    let (nsAttributed, measuredSize) = resolveSelectableRunMeasurement(runSegments)
                     VSelectableTextView(
                         attributedString: nsAttributed,
                         maxWidth: maxContentWidth,
@@ -203,6 +204,21 @@ struct MarkdownSegmentView: View, Equatable {
         return cache
     }()
 
+    #if os(macOS)
+    @MainActor private static var measuredTextCache: NSCache<NSNumber, MeasuredTextCacheEntry> = {
+        let cache = NSCache<NSNumber, MeasuredTextCacheEntry>()
+        cache.countLimit = 500
+        cache.totalCostLimit = 20_000_000 // ~20 MB
+        return cache
+    }()
+
+    #if DEBUG
+    /// Exposed for testing: number of cache insertions into `measuredTextCache`.
+    /// NSCache doesn't expose its count, so we maintain a parallel counter.
+    @MainActor static var _measuredTextCacheInsertCount: Int = 0
+    #endif
+    #endif
+
     // MARK: - Cache Guardrails
 
     private static let maxCacheableTextLength = 10_000
@@ -216,6 +232,12 @@ struct MarkdownSegmentView: View, Equatable {
         prefixWidthCache.removeAll()
         groupedSegmentsCache.removeAll()
         MarkdownTableView.clearCellAttributedStringCache()
+        #if os(macOS)
+        measuredTextCache.removeAllObjects()
+        #if DEBUG
+        _measuredTextCacheInsertCount = 0
+        #endif
+        #endif
     }
 
     /// Rough character count of the text content within a segment array.
@@ -267,6 +289,56 @@ struct MarkdownSegmentView: View, Equatable {
         Self.attributedStringCache.setObject(AttributedStringCacheEntry(result), forKey: cacheKeyNS, cost: textLen * 10)
         return result
     }
+
+    #if os(macOS)
+    /// Computes or retrieves from cache the `(NSAttributedString, CGSize)` pair
+    /// for a selectable text run.  `internal` so `@testable import` tests can
+    /// exercise the cache directly (SwiftUI `body` evaluation does not force
+    /// `ForEach` row closures to execute in a unit-test context).
+    @MainActor func resolveSelectableRunMeasurement(
+        _ runSegments: [MarkdownSegment]
+    ) -> (NSAttributedString, CGSize) {
+        var hasher = Hasher()
+        for segment in runSegments { hasher.combine(segment) }
+        hasher.combine(textColor.description)
+        hasher.combine(secondaryTextColor.description)
+        hasher.combine(codeTextColor.description)
+        hasher.combine(codeBackgroundColor.description)
+        let effectiveMaxWidth = maxContentWidth ?? VSpacing.chatBubbleMaxWidth
+        hasher.combine(effectiveMaxWidth)
+        let key = hasher.finalize()
+
+        let keyNS = key as NSNumber
+        if let cached = Self.measuredTextCache.object(forKey: keyNS) {
+            return (cached.nsAttributedString, cached.size)
+        }
+
+        os_signpost(.begin, log: PerfSignposts.log, name: "selectableRunMeasure")
+        let attributed = buildCombinedAttributedString(from: runSegments)
+        let nsAttributed = Self.convertToNSAttributedString(
+            attributed, font: VFont.nsChat, textColor: NSColor(textColor)
+        )
+        let size = VSelectableTextView.measureSize(
+            attributedString: nsAttributed,
+            lineSpacing: 4,
+            maxWidth: effectiveMaxWidth
+        )
+        os_signpost(.end, log: PerfSignposts.log, name: "selectableRunMeasure")
+
+        let textLen = Self.segmentTextLength(runSegments)
+        if textLen <= Self.maxCacheableTextLength {
+            Self.measuredTextCache.setObject(
+                MeasuredTextCacheEntry(nsAttributedString: nsAttributed, size: size),
+                forKey: keyNS,
+                cost: textLen * 15
+            )
+            #if DEBUG
+            Self._measuredTextCacheInsertCount += 1
+            #endif
+        }
+        return (nsAttributed, size)
+    }
+    #endif
 
     /// Pure builder with no side effects — separated for caching.
     private static func buildAttributedStringUncached(

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -6,7 +6,7 @@ enum OnboardingHostingModeResolver {
         userHostedEnabled: Bool,
         localDockerEnabled: Bool
     ) -> [OnboardingState.HostingMode] {
-        var modes: [OnboardingState.HostingMode] = [.local, .vellumCloud]
+        var modes: [OnboardingState.HostingMode] = [.vellumCloud, .local]
         if localDockerEnabled {
             // Keep "Local" as the default choice and expose the legacy
             // non-Docker hatch explicitly as an escape hatch.
@@ -215,7 +215,7 @@ struct APIKeyStepView: View {
             }
             .padding(.horizontal, VSpacing.lg)
             .padding(.vertical, VSpacing.md)
-            .frame(minHeight: 64)
+            .frame(minHeight: 80)
             .contentShape(Rectangle())
             .background(
                 RoundedRectangle(cornerRadius: VRadius.xl)

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -317,28 +317,53 @@ struct OnboardingFlowView: View {
                         .foregroundStyle(VColor.contentSecondary)
                 }
             } else {
-                Text("Setup failed")
-                    .font(VFont.titleMedium)
-                    .foregroundStyle(VColor.contentDefault)
+                VStack(spacing: VSpacing.xl) {
+                    VStack(spacing: VSpacing.sm) {
+                        VIconView(.circleX, size: 32)
+                            .foregroundStyle(VColor.systemNegativeStrong)
 
-                if let error = managedBootstrapError {
-                    Text(error)
-                        .font(VFont.labelDefault)
-                        .foregroundStyle(VColor.systemNegativeStrong)
-                        .multilineTextAlignment(.center)
-                        .frame(maxWidth: 280)
-                }
+                        Text("Setup failed")
+                            .font(VFont.titleMedium)
+                            .foregroundStyle(VColor.contentDefault)
 
-                VButton(label: "Try again", style: .primary, isFullWidth: true) {
-                    Task {
-                        await performManagedBootstrap()
+                        Text("Something went wrong while setting up your assistant.")
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentSecondary)
+                            .multilineTextAlignment(.center)
+                    }
+
+                    if let error = managedBootstrapError {
+                        VInlineMessage(humanReadableError(from: error), tone: .error)
+                    }
+
+                    VStack(spacing: VSpacing.sm) {
+                        VButton(label: "Try again", style: .primary, isFullWidth: true) {
+                            Task {
+                                await performManagedBootstrap()
+                            }
+                        }
+
+                        VButton(label: "Go back", style: .ghost) {
+                            isBootstrappingManaged = false
+                            managedBootstrapError = nil
+                        }
                     }
                 }
-                .frame(maxWidth: 280)
+                .frame(maxWidth: 320)
             }
         }
 
         Spacer()
+    }
+
+    /// Extracts a human-readable message from an error string that may be JSON.
+    private func humanReadableError(from raw: String) -> String {
+        guard let data = raw.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let detail = json["detail"] as? String else {
+            return raw
+        }
+        return detail
     }
 
     private func performManagedBootstrap() async {

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -36,7 +36,7 @@ final class OnboardingState {
     var skippedAPIKeyEntry: Bool = false
 
     /// The hosting mode selected in onboarding step 1.
-    var selectedHostingMode: HostingMode = .local
+    var selectedHostingMode: HostingMode = .vellumCloud
 
     enum HostingMode: String {
         case vellumCloud = "vellum-cloud"

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -140,6 +140,10 @@ final class OnboardingState {
             hasHatched = UserDefaults.standard.bool(forKey: "onboarding.hatched")
             cloudProvider = UserDefaults.standard.string(forKey: "onboarding.cloudProvider") ?? "local"
             skippedAPIKeyEntry = UserDefaults.standard.bool(forKey: "onboarding.skippedAPIKeyEntry")
+            if let rawHosting = UserDefaults.standard.string(forKey: "onboarding.selectedHostingMode"),
+               let mode = HostingMode(rawValue: rawHosting) {
+                selectedHostingMode = mode
+            }
         }
         // Clamp restored step to the valid range.
         let maxStep = 3
@@ -176,6 +180,7 @@ final class OnboardingState {
         UserDefaults.standard.set(cloudProvider, forKey: "onboarding.cloudProvider")
         UserDefaults.standard.set(Self.currentFlowVersion, forKey: "onboarding.flowVersion")
         UserDefaults.standard.set(skippedAPIKeyEntry, forKey: "onboarding.skippedAPIKeyEntry")
+        UserDefaults.standard.set(selectedHostingMode.rawValue, forKey: "onboarding.selectedHostingMode")
     }
 
     /// Resets all hatch-related and credential state for a clean retry,
@@ -212,7 +217,8 @@ final class OnboardingState {
         selectedProvider = "anthropic"
         selectedModel = "claude-opus-4-6"
 
-        // Reset cloud credentials (in-memory only; not persisted)
+        // Reset hosting selection and cloud credentials
+        selectedHostingMode = .vellumCloud
         cloudProvider = "local"
         gcpProjectId = ""
         gcpZone = "us-central1-a"
@@ -229,7 +235,7 @@ final class OnboardingState {
     }
 
     static func clearPersistedState() {
-        for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.flowVersion", "onboarding.cloudProvider", "onboarding.skippedAPIKeyEntry", "onboarding.variant", "onboarding.firstMeetingCrackProgress"] {
+        for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.flowVersion", "onboarding.cloudProvider", "onboarding.skippedAPIKeyEntry", "onboarding.selectedHostingMode", "onboarding.variant", "onboarding.firstMeetingCrackProgress"] {
             UserDefaults.standard.removeObject(forKey: key)
         }
     }

--- a/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
@@ -368,4 +368,68 @@ final class MessageListScrollPerformanceTests: XCTestCase {
             }
         }
     }
+
+    // MARK: - Test 9: MarkdownSegmentView Measurement Caching
+
+    /// Verifies that resolveSelectableRunMeasurement caches results so repeated
+    /// calls do not re-run TextKit layout passes. This prevents the 12-24s
+    /// main-thread hangs observed in the LazyVStack layout cascade.
+    ///
+    /// Calls `resolveSelectableRunMeasurement` directly because SwiftUI's
+    /// `body` evaluation does not execute `ForEach` row closures in a
+    /// unit-test context (no rendering host).
+    @MainActor
+    func testMarkdownSegmentMeasurementCaching() {
+        // Clear any pre-existing cache entries.
+        MarkdownSegmentView.clearAttributedStringCache()
+
+        let segments: [MarkdownSegment] = [
+            .text("Hello world, this is a test message with some representative content for benchmarking layout measurement caching.")
+        ]
+
+        let view = MarkdownSegmentView(segments: segments)
+
+        // First call = cache miss, triggers TextKit layout.
+        _ = view.resolveSelectableRunMeasurement(segments)
+        let insertCountAfterFirst = MarkdownSegmentView._measuredTextCacheInsertCount
+
+        // Second call with identical inputs should hit the cache.
+        _ = view.resolveSelectableRunMeasurement(segments)
+        let insertCountAfterSecond = MarkdownSegmentView._measuredTextCacheInsertCount
+
+        // The insert count should NOT increase on the second call,
+        // proving that the TextKit measurement was served from cache.
+        XCTAssertEqual(insertCountAfterFirst, insertCountAfterSecond,
+            "Second call must hit the measurement cache — no new TextKit layout pass")
+        XCTAssertGreaterThan(insertCountAfterFirst, 0,
+            "First call must have inserted at least one cache entry")
+    }
+
+    // MARK: - Test 10: MarkdownSegmentView Measurement Performance
+
+    /// Measures repeated resolveSelectableRunMeasurement calls with a warm
+    /// cache. Ensures the per-call cost stays negligible (cache lookups only,
+    /// no TextKit layout). Baseline regression detection via XCTest's
+    /// statistical comparison.
+    @MainActor
+    func testMarkdownSegmentMeasurementPerformance() {
+        let segments: [MarkdownSegment] = [
+            .text("First paragraph with some representative text content."),
+            .text("Second paragraph with **bold** and *italic* formatting."),
+            .heading(level: 2, text: "A Section Heading"),
+            .text("Third paragraph after the heading with a [link](https://example.com).")
+        ]
+
+        let view = MarkdownSegmentView(segments: segments)
+
+        // Pre-warm the cache.
+        _ = view.resolveSelectableRunMeasurement(segments)
+
+        // Measure repeated calls — should all be cache hits.
+        measure(metrics: [XCTClockMetric()]) {
+            for _ in 0..<200 {
+                _ = view.resolveSelectableRunMeasurement(segments)
+            }
+        }
+    }
 }

--- a/clients/macos/vellum-assistantTests/OnboardingHostingModeResolverTests.swift
+++ b/clients/macos/vellum-assistantTests/OnboardingHostingModeResolverTests.swift
@@ -9,7 +9,7 @@ final class OnboardingHostingModeResolverTests: XCTestCase {
             localDockerEnabled: true
         )
 
-        XCTAssertEqual(modes, [.local, .vellumCloud, .oldLocal])
+        XCTAssertEqual(modes, [.vellumCloud, .local, .oldLocal])
     }
 
     func testAvailableHostingModesAddsUserHostedOptionsWithoutDockerCard() {
@@ -18,7 +18,7 @@ final class OnboardingHostingModeResolverTests: XCTestCase {
             localDockerEnabled: false
         )
 
-        XCTAssertEqual(modes, [.local, .vellumCloud, .aws, .gcp, .customHardware])
+        XCTAssertEqual(modes, [.vellumCloud, .local, .aws, .gcp, .customHardware])
         XCTAssertFalse(modes.contains(.docker))
     }
 

--- a/skills/telegram-setup/SKILL.md
+++ b/skills/telegram-setup/SKILL.md
@@ -57,7 +57,9 @@ First check whether managed platform callback routes are available:
 assistant platform status --json
 ```
 
-If `isPlatform` is `true` and both `baseUrl` and `assistantId` are present:
+If `isPlatform` is `true` and both `baseUrl` and `assistantId` are present, then we should use Platform Routing, otherwise, use Self-Hosted Routing.
+
+**Platform Routing:**
 
 - Register the managed callback route:
 
@@ -68,9 +70,16 @@ CALLBACK_URL=$(echo "$ROUTE_RESPONSE" | jq -r '.callbackUrl')
 
 - In this mode, do **not** load `public-ingress` or mention ngrok. The managed platform callback route is the Telegram webhook URL.
 
-Otherwise:
+**Self-Hosted Routing:**
 
 - Telegram needs a publicly reachable URL to send webhook events to. Load the `public-ingress` skill to determine whether a public ingress has been configured and walk the user through setting one up if not.
+
+- After `public-ingress` completes, construct the callback URL from the persisted base URL:
+
+```bash
+PUBLIC_BASE_URL=$(assistant config get ingress.publicBaseUrl)
+CALLBACK_URL="${PUBLIC_BASE_URL}/webhooks/telegram"
+```
 
 ### Generate Webhook Secret
 

--- a/skills/telegram-setup/SKILL.md
+++ b/skills/telegram-setup/SKILL.md
@@ -62,7 +62,8 @@ If `isPlatform` is `true` and both `baseUrl` and `assistantId` are present:
 - Register the managed callback route:
 
 ```bash
-assistant platform callback-routes register --path webhooks/telegram --type telegram --json
+ROUTE_RESPONSE=$(assistant platform callback-routes register --path webhooks/telegram --type telegram --json)
+CALLBACK_URL=$(echo "$ROUTE_RESPONSE" | jq -r '.callbackUrl')
 ```
 
 - In this mode, do **not** load `public-ingress` or mention ngrok. The managed platform callback route is the Telegram webhook URL.
@@ -85,6 +86,28 @@ If not, generate and set one:
 assistant credentials set --service telegram --field webhook_secret "$(uuidgen)"
 ```
 
+### Register Webhook with Telegram
+
+After registering the platform route (or obtaining a public ingress URL), you **must** also tell Telegram to send updates to that URL. The gateway may do this automatically on restart, but its safest to also register explicitly:
+
+```bash
+BOT_TOKEN=$(assistant credentials reveal --service telegram --field bot_token)
+WEBHOOK_SECRET=$(assistant credentials reveal --service telegram --field webhook_secret)
+curl -s "https://api.telegram.org/bot${BOT_TOKEN}/setWebhook?url=${CALLBACK_URL}&secret_token=${WEBHOOK_SECRET}"
+```
+
+### Verify Webhook
+
+Confirm Telegram has the correct URL registered:
+
+```bash
+WEBHOOK_INFO=$(curl -sf "https://api.telegram.org/bot${BOT_TOKEN}/getWebhookInfo")
+echo "$WEBHOOK_INFO" | jq .
+REGISTERED_URL=$(echo "$WEBHOOK_INFO" | jq -r '.result.url')
+```
+
+Compare `REGISTERED_URL` to `CALLBACK_URL`. If they don't match, the webhook was not set correctly. Retry the `setWebhook` call. **Do not report success until `getWebhookInfo` confirms the correct URL and shows no `last_error_message`.**
+
 ## Step 4: Register Bot Commands
 
 ```bash
@@ -104,11 +127,12 @@ Link the user's Telegram account as a trusted guardian. Load the **guardian-veri
 
 If the user declines, skip and continue.
 
-## Step 7: Report Success
+## Step 6: Report Success
 
 Summarize:
 
 - Bot verified and credentials stored
+- Webhook registered and verified with Telegram (show the confirmed URL)
 - Bot commands registered: /new, /help
 - Guardian identity: {verified | skipped}
 


### PR DESCRIPTION
## Summary
Cherry-picks the following fixes onto the `release/v0.6.0` branch:

- fix: eagerly apply avatar traits during managed onboarding to prevent green V flash (#23097)
- fix: add explicit Telegram webhook registration and verification to setup skill (#23219)
- fix: set CALLBACK_URL in non-platform path of telegram-setup skill (#23220)
- fix: make Vellum Cloud first and default in hosting selector, polish error state (#23218)
- fix: persist selectedHostingMode across onboarding app restarts (#23221)
- fix: restrict temporal approval buttons to tool_approval kind only (#23227)
- fix: eliminate LazyVStack layout cascade hangs in message list (#23228)

## Test plan
- [ ] Verify each fix behaves correctly in the release build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
