### PR TITLE
fix: bootstrap managed assistant org ID before connecting in performSwitchAssistant

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -451,12 +451,22 @@ extension AppDelegate {
         //    cleared in step 3; without it the health check's
         //    Vellum-Organization-Id header would be missing and the connection
         //    would fail.
+        managedSwitchTask?.cancel()
+        managedSwitchTask = nil
         if assistant.isManaged {
-            Task {
+            let targetId = assistant.assistantId
+            managedSwitchTask = Task {
                 do {
                     _ = try await ManagedAssistantConnectionCoordinator().activateManagedAssistant()
                 } catch {
                     log.error("Managed bootstrap failed during switch — proceeding anyway: \(error.localizedDescription, privacy: .public)")
+                }
+                // Guard against a second switch that started while we were
+                // awaiting the bootstrap — only finish if this assistant is
+                // still the selected target.
+                guard UserDefaults.standard.string(forKey: "connectedAssistantId") == targetId else {
+                    log.info("Managed switch to \(targetId, privacy: .public) superseded — skipping finishSwitchAssistant")
+                    return
                 }
                 self.finishSwitchAssistant(assistant)
             }

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -458,13 +458,18 @@ extension AppDelegate {
             managedSwitchTask = Task {
                 do {
                     _ = try await ManagedAssistantConnectionCoordinator().activateManagedAssistant()
+                } catch is CancellationError {
+                    log.info("Managed switch to \(targetId, privacy: .public) cancelled")
+                    return
                 } catch {
                     log.error("Managed bootstrap failed during switch — proceeding anyway: \(error.localizedDescription, privacy: .public)")
                 }
                 // Guard against a second switch that started while we were
-                // awaiting the bootstrap — only finish if this assistant is
-                // still the selected target.
-                guard UserDefaults.standard.string(forKey: "connectedAssistantId") == targetId else {
+                // awaiting the bootstrap — only finish if this task hasn't
+                // been cancelled and this assistant is still the selected
+                // target.
+                guard !Task.isCancelled,
+                      UserDefaults.standard.string(forKey: "connectedAssistantId") == targetId else {
                     log.info("Managed switch to \(targetId, privacy: .public) superseded — skipping finishSwitchAssistant")
                     return
                 }

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -164,6 +164,10 @@ extension AppDelegate {
     }
 
     @objc public func performLogout() {
+        // Cancel any in-flight managed switch so it doesn't reconnect after logout.
+        managedSwitchTask?.cancel()
+        managedSwitchTask = nil
+
         Task {
             // Capture assistant ID before logout clears UserDefaults
             let connectedAssistantId = UserDefaults.standard.string(forKey: "connectedAssistantId")
@@ -456,8 +460,14 @@ extension AppDelegate {
         if assistant.isManaged {
             let targetId = assistant.assistantId
             managedSwitchTask = Task {
+                // Use ensureManagedAssistant() directly instead of the
+                // coordinator's activateManagedAssistant() — the coordinator
+                // calls persistManagedAssistant() which overwrites
+                // connectedAssistantId as a side effect, creating a race
+                // when a second switch fires before this task completes.
+                // We only need the org ID resolution from ensureManagedAssistant().
                 do {
-                    _ = try await ManagedAssistantConnectionCoordinator().activateManagedAssistant()
+                    _ = try await ManagedAssistantBootstrapService.shared.ensureManagedAssistant()
                 } catch is CancellationError {
                     log.info("Managed switch to \(targetId, privacy: .public) cancelled")
                     return
@@ -561,6 +571,9 @@ extension AppDelegate {
     }
 
     @objc func performRetire() {
+        // Cancel any in-flight managed switch so it doesn't reconnect after retire.
+        managedSwitchTask?.cancel()
+        managedSwitchTask = nil
         Task { await performRetireAsync() }
     }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -406,8 +406,10 @@ extension AppDelegate {
     /// 1. Clear assistant-scoped runtime state (recording, windows, callbacks)
     /// 2. Disconnect transport (leave old assistant running)
     /// 3. Persist the new assistant selection
-    /// 4. Reconfigure transport and reconnect
-    /// 5. Resume credential bootstrap
+    /// 4. For managed assistants, bootstrap via the platform API to re-resolve
+    ///    the organization ID (cleared in step 3) before connecting
+    /// 5. Reconfigure transport and reconnect
+    /// 6. Resume credential bootstrap
     func performSwitchAssistant(to assistant: LockfileAssistant) {
         // If switching to a managed assistant while logged out, prompt login first.
         if assistant.isManaged && !authManager.isAuthenticated {
@@ -444,11 +446,33 @@ extension AppDelegate {
         actorTokenBootstrapTask = nil
         ActorTokenManager.deleteToken()
 
-        // 4. Reconfigure transport and reconnect
+        // 4. For managed assistants, bootstrap via the platform API to
+        //    re-resolve the organization ID before connecting. The org ID was
+        //    cleared in step 3; without it the health check's
+        //    Vellum-Organization-Id header would be missing and the connection
+        //    would fail.
+        if assistant.isManaged {
+            Task {
+                do {
+                    _ = try await ManagedAssistantConnectionCoordinator().activateManagedAssistant()
+                } catch {
+                    log.error("Managed bootstrap failed during switch — proceeding anyway: \(error.localizedDescription, privacy: .public)")
+                }
+                self.finishSwitchAssistant(assistant)
+            }
+        } else {
+            finishSwitchAssistant(assistant)
+        }
+    }
+
+    /// Steps 5-6 of the switch sequence: reconfigure transport, resume
+    /// credential bootstrap, sync keys, reload flags/avatar, and show UI.
+    private func finishSwitchAssistant(_ assistant: LockfileAssistant) {
+        // 5. Reconfigure transport and reconnect
         hasSetupDaemon = false
         setupGatewayConnectionManager()
 
-        // 5. Resume credential bootstrap and show UI
+        // 6. Resume credential bootstrap and show UI
         if !isCurrentAssistantManaged {
             ensureActorCredentials()
         }
@@ -458,10 +482,10 @@ extension AppDelegate {
         localBootstrapDidComplete = false
         ensureLocalAssistantApiKey()
 
-        // 6. Sync locally-stored API keys to the new assistant. The assistant may
-        //    have started without ANTHROPIC_API_KEY in its environment (e.g.
-        //    when the app was launched via Finder/open). Push keys from
-        //    UserDefaults so the assistant can initialize its LLM providers.
+        // Sync locally-stored API keys to the new assistant. The assistant may
+        // have started without ANTHROPIC_API_KEY in its environment (e.g.
+        // when the app was launched via Finder/open). Push keys from
+        // UserDefaults so the assistant can initialize its LLM providers.
         syncApiKeysToAssistant(assistant)
 
         // Clear the UserDefaults feature-flag cache before reloading so

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -148,6 +148,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     /// cancelled before creating a new subscription (e.g. on reconnection or
     /// assistant switch), preventing duplicate event processing.
     var eventSubscriptionTask: Task<Void, Never>?
+    /// In-flight managed-assistant switch task. Cancelled when a new switch
+    /// begins so a stale bootstrap cannot reconnect the wrong assistant.
+    var managedSwitchTask: Task<Void, Never>?
     /// Pending fallback notification tokens, keyed by conversationId.
     /// Used to avoid duplicate native alerts when notification_intent arrives.
     var pendingFallbackNotifications: [String: UUID] = [:]

--- a/clients/macos/vellum-assistantTests/ManagedAssistantConnectionCoordinatorTests.swift
+++ b/clients/macos/vellum-assistantTests/ManagedAssistantConnectionCoordinatorTests.swift
@@ -90,6 +90,37 @@ final class ManagedAssistantConnectionCoordinatorTests: XCTestCase {
         XCTAssertTrue(defaults.bool(forKey: "tosAccepted"))
     }
 
+    func testActivateManagedAssistantRePopulatesOrgIdAfterCleared() async throws {
+        // Simulate performSwitchAssistant clearing the org ID
+        defaults.removeObject(forKey: "connectedOrganizationId")
+        XCTAssertNil(defaults.string(forKey: "connectedOrganizationId"))
+
+        let defaults = self.defaults!
+        let coordinator = ManagedAssistantConnectionCoordinator(
+            bootstrapService: MockManagedAssistantBootstrapService(
+                outcome: .createdNew(PlatformAssistant(id: "managed-switch")),
+                onEnsureManagedAssistant: {
+                    // The real ManagedAssistantBootstrapService.ensureManagedAssistant()
+                    // calls resolveOrganizationId() which sets connectedOrganizationId.
+                    // Simulate that behavior here to verify the coordinator contract.
+                    defaults.set("org-resolved-123", forKey: "connectedOrganizationId")
+                }
+            ),
+            userDefaults: defaults,
+            runtimeURLProvider: { "https://platform.example.com" },
+            updateAssistantTag: { _ in },
+            lockfilePath: lockfilePath
+        )
+
+        let result = try await coordinator.activateManagedAssistant()
+
+        XCTAssertEqual(result.assistant.id, "managed-switch")
+        // Verify the org ID was re-populated by the bootstrap (via resolveOrganizationId)
+        XCTAssertEqual(defaults.string(forKey: "connectedOrganizationId"), "org-resolved-123")
+        // Verify the assistant ID was persisted by the coordinator
+        XCTAssertEqual(defaults.string(forKey: "connectedAssistantId"), "managed-switch")
+    }
+
     func testActivateManagedAssistantAfterReauthClearsPersistedOrganizationBeforeBootstrap() async throws {
         defaults.set("stale-org", forKey: "connectedOrganizationId")
         var orgIdSeenDuringEnsure: String?


### PR DESCRIPTION
## Summary
- Extract finishSwitchAssistant() from performSwitchAssistant() to separate connection setup from pre-connection bootstrapping
- For managed assistant switches, run ManagedAssistantConnectionCoordinator.activateManagedAssistant() before connecting to re-resolve the org ID that was cleared
- Add test verifying activateManagedAssistant() re-populates connectedOrganizationId after it's been cleared

Part of plan: fix-switch-org-id.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
