### PR TITLE
feat: skip confirmation modal when deleting empty custom groups

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -159,7 +159,11 @@ extension MainWindowView {
                 sidebar.renamingGroupId = nil
             },
             onDelete: group.isSystemGroup ? nil : {
-                groupToDelete = group
+                if conversations.isEmpty {
+                    Task<Void, Never> { await conversationManager.deleteGroup(group.id) }
+                } else {
+                    groupToDelete = group
+                }
             },
             selectedConversationId: conversationManager.activeConversationId,
             onToggleExpand: { sidebar.toggleSection(group.id) },

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
@@ -139,7 +139,8 @@ struct SidebarSectionHeader: View {
         }
         .modifier(ConditionalGroupContextMenu(
             onRename: onRename.map { rename in { rename(group.name) } },
-            onDelete: onDelete
+            onDelete: onDelete,
+            hasConversations: conversationCount > 0
         ))
         .conditionalOnDrag(enabled: !group.isSystemGroup) {
             sidebar?.draggingGroupId = group.id
@@ -155,6 +156,7 @@ struct SidebarSectionHeader: View {
 private struct ConditionalGroupContextMenu: ViewModifier {
     let onRename: (() -> Void)?
     let onDelete: (() -> Void)?
+    let hasConversations: Bool
 
     func body(content: Content) -> some View {
         if onRename != nil || onDelete != nil {
@@ -163,7 +165,7 @@ private struct ConditionalGroupContextMenu: ViewModifier {
                     VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename") { onRename() }
                 }
                 if let onDelete {
-                    VMenuItem(icon: VIcon.trash.rawValue, label: "Delete group\u{2026}") { onDelete() }
+                    VMenuItem(icon: VIcon.trash.rawValue, label: hasConversations ? "Delete group\u{2026}" : "Delete group") { onDelete() }
                 }
             }
         } else {


### PR DESCRIPTION
## Summary
- When a custom group has no conversations, the context menu shows "Delete group" (no ellipsis) and deletes immediately without a confirmation modal
- When a custom group has conversations, behavior is unchanged: shows "Delete group…" and presents the confirmation modal

## Original prompt
if a custom group does not have any conversations under it, the option to delete the group should just be "Delete Group" without a confirmation modal. If there are conversations, then the behavior should remain: option as "Delete group..." and then a confirmation modal.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
