### PR TITLE
fix: resolve guardian decision submit infinite loading state

### DIFF
--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -241,9 +241,6 @@ final class ChatActionHandler {
         case .guardianActionsPendingResponse(let response):
             vm.handleGuardianActionsPendingResponse(response)
 
-        case .guardianActionDecisionResponse(let response):
-            vm.handleGuardianActionDecisionResponse(response)
-
         case .usageUpdate(let update):
             guard belongsToConversation(update.conversationId) else { return }
             if let tokens = update.contextWindowTokens {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2214,13 +2214,28 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
 
         Task {
             let response = await guardianClient.submitDecision(requestId: requestId, action: action, conversationId: conversationId)
-            if response == nil {
+            if let response {
+                handleGuardianActionDecisionResponse(response)
+            } else {
                 log.error("Failed to submit guardian decision for requestId \(requestId)")
                 pendingGuardianActions.removeValue(forKey: requestId)
                 // Revert submitting state on failure
                 if let idx = messages.firstIndex(where: { $0.guardianDecision?.requestId == requestId }) {
                     messages[idx].guardianDecision?.isSubmitting = false
                 }
+            }
+        }
+
+        // Safety-net timeout: if the decision is still submitting after 15s,
+        // clear the spinner and re-sync with the server.
+        Task {
+            try? await Task.sleep(nanoseconds: 15_000_000_000)
+            if let idx = messages.firstIndex(where: { $0.guardianDecision?.requestId == requestId }),
+               messages[idx].guardianDecision?.isSubmitting == true {
+                log.warning("Guardian decision submit timed out for requestId \(requestId, privacy: .public)")
+                messages[idx].guardianDecision?.isSubmitting = false
+                pendingGuardianActions.removeValue(forKey: requestId)
+                refreshGuardianPrompts()
             }
         }
     }

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2219,7 +2219,6 @@ public enum ServerMessage: Decodable, Sendable {
     case approvedDevicesListResponse(ApprovedDevicesListResponseMessage)
     case approvedDeviceRemoveResponse(ApprovedDeviceRemoveResponseMessage)
     case guardianActionsPendingResponse(GuardianActionsPendingResponseMessage)
-    case guardianActionDecisionResponse(GuardianActionDecisionResponseMessage)
     case recordingPause(RecordingPause)
     case recordingResume(RecordingResume)
     case recordingStart(RecordingStart)
@@ -2620,9 +2619,6 @@ public enum ServerMessage: Decodable, Sendable {
         case "guardian_actions_pending_response":
             let message = try GuardianActionsPendingResponseMessage(from: decoder)
             self = .guardianActionsPendingResponse(message)
-        case "guardian_action_decision_response":
-            let message = try GuardianActionDecisionResponseMessage(from: decoder)
-            self = .guardianActionDecisionResponse(message)
         case "recording_pause":
             let message = try RecordingPause(from: decoder)
             self = .recordingPause(message)


### PR DESCRIPTION
## Summary
- Route guardian decision HTTP response to the existing handler instead of discarding it, fixing the infinite 'Submitting...' loading state on access request approvals
- Add a 15-second safety-net timeout that clears the submitting state if response handling fails silently
- Remove the dead `guardian_action_decision_response` SSE handler that was never emitted by the daemon

Part of plan: fix-guardian-decision-submit.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
