### PR TITLE
fix: resolve guardian decision submit infinite loading state

### DIFF
--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -241,9 +241,6 @@ final class ChatActionHandler {
         case .guardianActionsPendingResponse(let response):
             vm.handleGuardianActionsPendingResponse(response)
 
-        case .guardianActionDecisionResponse(let response):
-            vm.handleGuardianActionDecisionResponse(response)
-
         case .usageUpdate(let update):
             guard belongsToConversation(update.conversationId) else { return }
             if let tokens = update.contextWindowTokens {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -149,6 +149,10 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     /// send-in-progress indicator gets stuck.
     @ObservationIgnored private var sendingWatchdogTask: Task<Void, Never>?
 
+    /// Safety-net timeout that clears the submitting spinner if the guardian
+    /// decision HTTP response takes longer than 15 seconds.
+    @ObservationIgnored private var guardianDecisionTimeoutTask: Task<Void, Never>?
+
     // MARK: - Observation compatibility
 
     /// No-op — retained for protocol conformance (MessageSendCoordinatorDelegate).
@@ -2168,6 +2172,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         // btwTask cancellation is handled by ChatBtwState's deinit.
         greetingState.cancelAll()
         sendingWatchdogTask?.cancel()
+        guardianDecisionTimeoutTask?.cancel()
         memoryPressureSource?.cancel()
         if let observer = reconnectObserver {
             NotificationCenter.default.removeObserver(observer)
@@ -2214,8 +2219,27 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
 
         Task {
             let response = await guardianClient.submitDecision(requestId: requestId, action: action, conversationId: conversationId)
+
+            // Cancel the safety-net timeout — we have an HTTP response.
+            guardianDecisionTimeoutTask?.cancel()
+            guardianDecisionTimeoutTask = nil
+
             if let response {
-                handleGuardianActionDecisionResponse(response)
+                if response.applied {
+                    // Real server decision — route to the handler for resolved state.
+                    handleGuardianActionDecisionResponse(response)
+                } else {
+                    // Transport failure (HTTP error, network timeout) or server
+                    // explicitly said stale/not-found. GuardianClient synthesizes
+                    // applied=false for HTTP errors — don't mark the prompt as
+                    // .stale on a transient 5xx. Instead, revert submitting state
+                    // and let the user retry.
+                    pendingGuardianActions.removeValue(forKey: requestId)
+                    if let idx = messages.firstIndex(where: { $0.guardianDecision?.requestId == requestId }) {
+                        messages[idx].guardianDecision?.isSubmitting = false
+                    }
+                    refreshGuardianPrompts()
+                }
             } else {
                 log.error("Failed to submit guardian decision for requestId \(requestId)")
                 pendingGuardianActions.removeValue(forKey: requestId)
@@ -2227,15 +2251,18 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         }
 
         // Safety-net timeout: if the decision is still submitting after 15s,
-        // clear the spinner and re-sync with the server.
-        Task {
+        // clear the spinner and re-sync with the server. Don't remove from
+        // pendingGuardianActions — let the main response handler or refresh
+        // handle the cleanup so the action label is preserved.
+        guardianDecisionTimeoutTask?.cancel()
+        guardianDecisionTimeoutTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: 15_000_000_000)
-            if let idx = messages.firstIndex(where: { $0.guardianDecision?.requestId == requestId }),
-               messages[idx].guardianDecision?.isSubmitting == true {
+            guard !Task.isCancelled, let self else { return }
+            if let idx = self.messages.firstIndex(where: { $0.guardianDecision?.requestId == requestId }),
+               self.messages[idx].guardianDecision?.isSubmitting == true {
                 log.warning("Guardian decision submit timed out for requestId \(requestId, privacy: .public)")
-                messages[idx].guardianDecision?.isSubmitting = false
-                pendingGuardianActions.removeValue(forKey: requestId)
-                refreshGuardianPrompts()
+                self.messages[idx].guardianDecision?.isSubmitting = false
+                self.refreshGuardianPrompts()
             }
         }
     }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2214,13 +2214,28 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
 
         Task {
             let response = await guardianClient.submitDecision(requestId: requestId, action: action, conversationId: conversationId)
-            if response == nil {
+            if let response {
+                handleGuardianActionDecisionResponse(response)
+            } else {
                 log.error("Failed to submit guardian decision for requestId \(requestId)")
                 pendingGuardianActions.removeValue(forKey: requestId)
                 // Revert submitting state on failure
                 if let idx = messages.firstIndex(where: { $0.guardianDecision?.requestId == requestId }) {
                     messages[idx].guardianDecision?.isSubmitting = false
                 }
+            }
+        }
+
+        // Safety-net timeout: if the decision is still submitting after 15s,
+        // clear the spinner and re-sync with the server.
+        Task {
+            try? await Task.sleep(nanoseconds: 15_000_000_000)
+            if let idx = messages.firstIndex(where: { $0.guardianDecision?.requestId == requestId }),
+               messages[idx].guardianDecision?.isSubmitting == true {
+                log.warning("Guardian decision submit timed out for requestId \(requestId, privacy: .public)")
+                messages[idx].guardianDecision?.isSubmitting = false
+                pendingGuardianActions.removeValue(forKey: requestId)
+                refreshGuardianPrompts()
             }
         }
     }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -149,9 +149,10 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     /// send-in-progress indicator gets stuck.
     @ObservationIgnored private var sendingWatchdogTask: Task<Void, Never>?
 
-    /// Safety-net timeout that clears the submitting spinner if the guardian
-    /// decision HTTP response takes longer than 15 seconds.
-    @ObservationIgnored private var guardianDecisionTimeoutTask: Task<Void, Never>?
+    /// Per-requestId safety-net timeouts that clear the submitting spinner if
+    /// a guardian decision HTTP response takes longer than 15 seconds.  Keyed
+    /// by requestId so concurrent submissions each get an independent timeout.
+    @ObservationIgnored private var guardianDecisionTimeoutTasks: [String: Task<Void, Never>] = [:]
 
     // MARK: - Observation compatibility
 
@@ -2172,7 +2173,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         // btwTask cancellation is handled by ChatBtwState's deinit.
         greetingState.cancelAll()
         sendingWatchdogTask?.cancel()
-        guardianDecisionTimeoutTask?.cancel()
+        guardianDecisionTimeoutTasks.values.forEach { $0.cancel() }
         memoryPressureSource?.cancel()
         if let observer = reconnectObserver {
             NotificationCenter.default.removeObserver(observer)
@@ -2220,9 +2221,9 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         Task {
             let response = await guardianClient.submitDecision(requestId: requestId, action: action, conversationId: conversationId)
 
-            // Cancel the safety-net timeout — we have an HTTP response.
-            guardianDecisionTimeoutTask?.cancel()
-            guardianDecisionTimeoutTask = nil
+            // Cancel the safety-net timeout for this specific requestId — we have an HTTP response.
+            guardianDecisionTimeoutTasks[requestId]?.cancel()
+            guardianDecisionTimeoutTasks[requestId] = nil
 
             if let response {
                 if response.applied {
@@ -2254,8 +2255,10 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         // clear the spinner and re-sync with the server. Don't remove from
         // pendingGuardianActions — let the main response handler or refresh
         // handle the cleanup so the action label is preserved.
-        guardianDecisionTimeoutTask?.cancel()
-        guardianDecisionTimeoutTask = Task { [weak self] in
+        // Cancel any previous timeout for the SAME requestId only — other
+        // in-flight submissions keep their own independent timeouts.
+        guardianDecisionTimeoutTasks[requestId]?.cancel()
+        guardianDecisionTimeoutTasks[requestId] = Task { [weak self] in
             try? await Task.sleep(nanoseconds: 15_000_000_000)
             guard !Task.isCancelled, let self else { return }
             if let idx = self.messages.firstIndex(where: { $0.guardianDecision?.requestId == requestId }),
@@ -2264,6 +2267,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
                 self.messages[idx].guardianDecision?.isSubmitting = false
                 self.refreshGuardianPrompts()
             }
+            self.guardianDecisionTimeoutTasks[requestId] = nil
         }
     }
 

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2219,7 +2219,6 @@ public enum ServerMessage: Decodable, Sendable {
     case approvedDevicesListResponse(ApprovedDevicesListResponseMessage)
     case approvedDeviceRemoveResponse(ApprovedDeviceRemoveResponseMessage)
     case guardianActionsPendingResponse(GuardianActionsPendingResponseMessage)
-    case guardianActionDecisionResponse(GuardianActionDecisionResponseMessage)
     case recordingPause(RecordingPause)
     case recordingResume(RecordingResume)
     case recordingStart(RecordingStart)
@@ -2620,9 +2619,6 @@ public enum ServerMessage: Decodable, Sendable {
         case "guardian_actions_pending_response":
             let message = try GuardianActionsPendingResponseMessage(from: decoder)
             self = .guardianActionsPendingResponse(message)
-        case "guardian_action_decision_response":
-            let message = try GuardianActionDecisionResponseMessage(from: decoder)
-            self = .guardianActionDecisionResponse(message)
         case "recording_pause":
             let message = try RecordingPause(from: decoder)
             self = .recordingPause(message)


### PR DESCRIPTION
## Summary
Fixes the infinite "Submitting..." loading state when clicking "Approve once" (or any action) on an `ingress_access_request` guardian decision prompt in the desktop app.

**Root cause:** `submitGuardianDecision` discarded the HTTP response from the daemon — it only checked for `nil` (total failure) and otherwise did nothing. It was designed to rely on a `guardian_action_decision_response` SSE event that was defined in message types but never emitted by the daemon.

**Fix:**
- Route the HTTP response directly to `handleGuardianActionDecisionResponse`, which already handles setting `isSubmitting = false`, marking the state as resolved/stale, displaying reply text, and refreshing prompts
- Add a 15-second safety-net timeout that clears the submitting state if response handling ever fails silently
- Remove the dead `guardian_action_decision_response` SSE handler that was never emitted

## PRs merged into feature branch
- #23243: fix: resolve guardian decision submit infinite loading state

Part of plan: fix-guardian-decision-submit.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
