### PR TITLE
fix: address review feedback on guardian decision submit

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -149,6 +149,10 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     /// send-in-progress indicator gets stuck.
     @ObservationIgnored private var sendingWatchdogTask: Task<Void, Never>?
 
+    /// Safety-net timeout that clears the submitting spinner if the guardian
+    /// decision HTTP response takes longer than 15 seconds.
+    @ObservationIgnored private var guardianDecisionTimeoutTask: Task<Void, Never>?
+
     // MARK: - Observation compatibility
 
     /// No-op — retained for protocol conformance (MessageSendCoordinatorDelegate).
@@ -2168,6 +2172,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         // btwTask cancellation is handled by ChatBtwState's deinit.
         greetingState.cancelAll()
         sendingWatchdogTask?.cancel()
+        guardianDecisionTimeoutTask?.cancel()
         memoryPressureSource?.cancel()
         if let observer = reconnectObserver {
             NotificationCenter.default.removeObserver(observer)
@@ -2214,8 +2219,27 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
 
         Task {
             let response = await guardianClient.submitDecision(requestId: requestId, action: action, conversationId: conversationId)
+
+            // Cancel the safety-net timeout — we have an HTTP response.
+            guardianDecisionTimeoutTask?.cancel()
+            guardianDecisionTimeoutTask = nil
+
             if let response {
-                handleGuardianActionDecisionResponse(response)
+                if response.applied {
+                    // Real server decision — route to the handler for resolved state.
+                    handleGuardianActionDecisionResponse(response)
+                } else {
+                    // Transport failure (HTTP error, network timeout) or server
+                    // explicitly said stale/not-found. GuardianClient synthesizes
+                    // applied=false for HTTP errors — don't mark the prompt as
+                    // .stale on a transient 5xx. Instead, revert submitting state
+                    // and let the user retry.
+                    pendingGuardianActions.removeValue(forKey: requestId)
+                    if let idx = messages.firstIndex(where: { $0.guardianDecision?.requestId == requestId }) {
+                        messages[idx].guardianDecision?.isSubmitting = false
+                    }
+                    refreshGuardianPrompts()
+                }
             } else {
                 log.error("Failed to submit guardian decision for requestId \(requestId)")
                 pendingGuardianActions.removeValue(forKey: requestId)
@@ -2227,15 +2251,18 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         }
 
         // Safety-net timeout: if the decision is still submitting after 15s,
-        // clear the spinner and re-sync with the server.
-        Task {
+        // clear the spinner and re-sync with the server. Don't remove from
+        // pendingGuardianActions — let the main response handler or refresh
+        // handle the cleanup so the action label is preserved.
+        guardianDecisionTimeoutTask?.cancel()
+        guardianDecisionTimeoutTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: 15_000_000_000)
-            if let idx = messages.firstIndex(where: { $0.guardianDecision?.requestId == requestId }),
-               messages[idx].guardianDecision?.isSubmitting == true {
+            guard !Task.isCancelled, let self else { return }
+            if let idx = self.messages.firstIndex(where: { $0.guardianDecision?.requestId == requestId }),
+               self.messages[idx].guardianDecision?.isSubmitting == true {
                 log.warning("Guardian decision submit timed out for requestId \(requestId, privacy: .public)")
-                messages[idx].guardianDecision?.isSubmitting = false
-                pendingGuardianActions.removeValue(forKey: requestId)
-                refreshGuardianPrompts()
+                self.messages[idx].guardianDecision?.isSubmitting = false
+                self.refreshGuardianPrompts()
             }
         }
     }


### PR DESCRIPTION
## Summary
- Store the safety-net timeout Task and use [weak self] per AGENTS.md patterns
- Differentiate transport failures from real server decisions to avoid incorrectly marking prompts as stale on transient errors
- Don't remove pendingGuardianActions in the timeout to preserve action labels for late-arriving responses

Addresses review feedback on #23244
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
