### PR TITLE
fix: sanitize identity fields in trusted contact notification templates

### DIFF
--- a/assistant/src/__tests__/copy-composer-tc-templates.test.ts
+++ b/assistant/src/__tests__/copy-composer-tc-templates.test.ts
@@ -205,6 +205,35 @@ describe("guardian_decision fallback copy", () => {
     expect(copy.body).toBe("Alice's access request has been denied by Bob.");
     expect(copy.body).not.toContain("<@");
   });
+
+  test("sanitizes control characters from display names", () => {
+    const signal = buildGuardianDecisionSignal({
+      requesterDisplayName: "Alice\x00\x07\nEvil",
+      decidedByDisplayName: "Bob\r\nMalicious",
+      decision: "approved",
+    });
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    expect(copy.body).not.toMatch(/[\x00-\x1f\x7f-\x9f]/);
+    expect(copy.body).toContain("Alice");
+    expect(copy.body).toContain("Bob");
+  });
+
+  test("clamps excessively long display names", () => {
+    const longName = "A".repeat(200);
+    const signal = buildGuardianDecisionSignal({
+      requesterDisplayName: longName,
+      decidedByDisplayName: "Bob",
+      decision: "denied",
+    });
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    // sanitizeIdentityField clamps to 120 chars + ellipsis
+    expect(copy.body.length).toBeLessThan(longName.length);
+    expect(copy.body).toContain("…");
+  });
 });
 
 // ── denied template ──────────────────────────────────────────────────────────
@@ -278,5 +307,29 @@ describe("trusted_contact.denied fallback copy", () => {
     const copy = result.vellum!;
 
     expect(copy.body).not.toContain("D0AQ9C5PPPF");
+  });
+
+  test("sanitizes control characters from display names", () => {
+    const signal = buildDeniedSignal({
+      requesterDisplayName: "Alice\x00\x07\nEvil",
+    });
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    expect(copy.body).not.toMatch(/[\x00-\x1f\x7f-\x9f]/);
+    expect(copy.body).toContain("Alice");
+  });
+
+  test("clamps excessively long display names", () => {
+    const longName = "A".repeat(200);
+    const signal = buildDeniedSignal({
+      requesterDisplayName: longName,
+    });
+    const result = composeFallbackCopy(signal, ["vellum"]);
+    const copy = result.vellum!;
+
+    // sanitizeIdentityField clamps to 120 chars + ellipsis
+    expect(copy.body.length).toBeLessThan(longName.length);
+    expect(copy.body).toContain("…");
   });
 });

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -416,14 +416,15 @@ const TEMPLATES: Partial<Record<NotificationSourceEventName, CopyTemplate>> = {
       payload.requesterExternalUserId.length > 0
         ? payload.requesterExternalUserId
         : undefined;
-    const requesterLabel =
+    const requesterLabel = sanitizeIdentityField(
       requesterDisplayName ??
-      (sourceChannel === "slack" &&
-      requesterExternalUserId &&
-      /^U[A-Z0-9]+$/i.test(requesterExternalUserId)
-        ? `<@${requesterExternalUserId}>`
-        : requesterExternalUserId) ??
-      "Someone";
+        (sourceChannel === "slack" &&
+        requesterExternalUserId &&
+        /^U[A-Z0-9]+$/i.test(requesterExternalUserId)
+          ? `<@${requesterExternalUserId}>`
+          : requesterExternalUserId) ??
+        "Someone",
+    );
 
     const decidedByDisplayName =
       typeof payload.decidedByDisplayName === "string" &&
@@ -435,14 +436,15 @@ const TEMPLATES: Partial<Record<NotificationSourceEventName, CopyTemplate>> = {
       payload.decidedByExternalUserId.length > 0
         ? payload.decidedByExternalUserId
         : undefined;
-    const decidedByLabel =
+    const decidedByLabel = sanitizeIdentityField(
       decidedByDisplayName ??
-      (sourceChannel === "slack" &&
-      decidedByExternalUserId &&
-      /^U[A-Z0-9]+$/i.test(decidedByExternalUserId)
-        ? `<@${decidedByExternalUserId}>`
-        : decidedByExternalUserId) ??
-      "a guardian";
+        (sourceChannel === "slack" &&
+        decidedByExternalUserId &&
+        /^U[A-Z0-9]+$/i.test(decidedByExternalUserId)
+          ? `<@${decidedByExternalUserId}>`
+          : decidedByExternalUserId) ??
+        "a guardian",
+    );
 
     const verb = decision === "approved" ? "approved" : "denied";
     return {
@@ -467,14 +469,15 @@ const TEMPLATES: Partial<Record<NotificationSourceEventName, CopyTemplate>> = {
       payload.requesterExternalUserId.length > 0
         ? payload.requesterExternalUserId
         : undefined;
-    const requesterLabel =
+    const requesterLabel = sanitizeIdentityField(
       requesterDisplayName ??
-      (sourceChannel === "slack" &&
-      requesterExternalUserId &&
-      /^U[A-Z0-9]+$/i.test(requesterExternalUserId)
-        ? `<@${requesterExternalUserId}>`
-        : requesterExternalUserId) ??
-      "Someone";
+        (sourceChannel === "slack" &&
+        requesterExternalUserId &&
+        /^U[A-Z0-9]+$/i.test(requesterExternalUserId)
+          ? `<@${requesterExternalUserId}>`
+          : requesterExternalUserId) ??
+        "Someone",
+    );
 
     return {
       title: "Trusted Contact Denied",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for tc-notif-display-names.md.

**Gap:** Missing sanitization in new copy-composer templates
**What was expected:** Templates should sanitize display names consistent with existing patterns
**What was found:** Display names were interpolated without sanitizeIdentityField()

- Applied `sanitizeIdentityField()` to `requesterLabel` and `decidedByLabel` in the `guardian_decision` template
- Applied `sanitizeIdentityField()` to `requesterLabel` in the `denied` template
- Added 4 new tests verifying control character stripping and length clamping
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
