### PR TITLE
Improve telegram-setup skill verification step clarity

### DIFF
--- a/skills/telegram-setup/SKILL.md
+++ b/skills/telegram-setup/SKILL.md
@@ -128,13 +128,15 @@ curl -sf -X POST "https://api.telegram.org/bot${BOT_TOKEN}/setMyCommands" \
 
 Non-critical - warn on failure but don't block setup.
 
-## Step 5: Guardian Verification (Optional)
+## Step 5: Test Your Connection
 
-Link the user's Telegram account as a trusted guardian. Load the **guardian-verify-setup** skill:
+Now let's test the connection by verifying the user can receive your messages. This confirms everything works and links the user's Telegram identity for future message delivery.
+
+Load the **guardian-verify-setup** skill:
 
 - Call `skill_load` with `skill: "guardian-verify-setup"`.
 
-If the user declines, skip and continue.
+If the user explicitly wants to skip this step, proceed to Step 6, but let them know they can always verify later by saying "verify me on Telegram".
 
 ## Step 6: Report Success
 


### PR DESCRIPTION
## Summary
- Reframe Step 5 of the telegram-setup skill from "Guardian Verification (Optional)" to "Test Your Connection" to better communicate the step's purpose
- Add explanation that the step confirms message delivery works and links the user's Telegram identity
- Improve skip behavior messaging to let users know they can verify later
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
