### PR TITLE
Add `guardian.channel_activation` notification signal type for auto-activation code delivery

### DIFF
--- a/assistant/src/notifications/adapters/macos.ts
+++ b/assistant/src/notifications/adapters/macos.ts
@@ -37,6 +37,7 @@ const GUARDIAN_SENSITIVE_EVENT_PREFIXES = [
   "guardian.question",
   "ingress.escalation",
   "ingress.access_request",
+  "guardian.channel_activation",
 ] as const;
 
 export function isGuardianSensitiveEvent(sourceEventName: string): boolean {

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -353,6 +353,15 @@ const TEMPLATES: Partial<Record<NotificationSourceEventName, CopyTemplate>> = {
     };
   },
 
+  "guardian.channel_activation": (payload) => {
+    const code = str(payload.verificationCode, "------");
+    const channel = str(payload.sourceChannel, "a channel");
+    return {
+      title: "Guardian Verification Code",
+      body: `Your ${channel} verification code is: ${code}\n\nEnter this code in your ${channel} chat to verify your identity as guardian.`,
+    };
+  },
+
   "ingress.access_request": (payload) => ({
     title: "Access Request",
     body: buildAccessRequestContractText(payload),

--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -46,6 +46,11 @@ export const NOTIFICATION_SOURCE_EVENT_NAMES = [
     id: "guardian.question",
     description: "Guardian approval question requiring response",
   },
+  {
+    id: "guardian.channel_activation",
+    description:
+      "Guardian channel activation code delivered for /start verification",
+  },
   { id: "ingress.access_request", description: "Non-member requesting access" },
   {
     id: "ingress.access_request.callback_handoff",
@@ -155,9 +160,20 @@ export interface AccessRequestContextPayload {
   messagePreview: string | null;
 }
 
+export interface GuardianChannelActivationPayload {
+  verificationCode: string;
+  sourceChannel: string;
+  actorExternalId: string;
+  actorDisplayName: string | null;
+  actorUsername: string | null;
+  sessionId: string;
+  expiresAt: number;
+}
+
 export interface NotificationEventContextPayloadMap {
   "guardian.question": GuardianQuestionPayload;
   "ingress.access_request": AccessRequestContextPayload;
+  "guardian.channel_activation": GuardianChannelActivationPayload;
 }
 
 export type NotificationContextPayload<TEventName extends string = string> =


### PR DESCRIPTION
## Summary
- Add `guardian.channel_activation` to the notification source event registry
- Define typed `GuardianChannelActivationPayload` context payload interface
- Add fallback copy template and mark as guardian-sensitive event

Part of plan: tg-start-guardian-activation.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
