### PR TITLE
fix(macos): don't trigger microphone permission prompt on quit

### DIFF
--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -86,6 +86,12 @@ final class VoiceInputManager {
     /// Used to guard against duplicate registration from deferred startup.
     private(set) var hasStarted = false
 
+    /// True after we first access `audioEngine.inputNode` (in `beginRecording`).
+    /// Accessing `inputNode` before microphone permission has been granted triggers
+    /// the system permission dialog, so teardown paths must not touch it unless
+    /// a recording session actually started.
+    private var hasInstalledTap = false
+
     /// All active event monitors, consolidated for clean teardown.
     private var monitors: [Any] = []
 
@@ -211,8 +217,10 @@ final class VoiceInputManager {
     /// Safe to call regardless of `isRecording` — used as the shared cleanup path for all
     /// stop methods and as a recovery mechanism when state becomes inconsistent.
     private func tearDownAudioState() {
-        audioEngine.stop()
-        audioEngine.inputNode.removeTap(onBus: 0)
+        if hasInstalledTap {
+            audioEngine.stop()
+            audioEngine.inputNode.removeTap(onBus: 0)
+        }
         recognitionTask?.cancel()
         recognitionTask = nil
         recognitionRequest?.endAudio()
@@ -240,8 +248,10 @@ final class VoiceInputManager {
         Self.amplitudeSubject.send(0)
         onAmplitudeChanged?(0)
 
-        audioEngine.stop()
-        audioEngine.inputNode.removeTap(onBus: 0)
+        if hasInstalledTap {
+            audioEngine.stop()
+            audioEngine.inputNode.removeTap(onBus: 0)
+        }
 
         // Signal end of audio — the recognizer will process remaining audio
         // and fire the callback with isFinal = true.
@@ -252,8 +262,10 @@ final class VoiceInputManager {
     /// Clears any stale internal buffers or format caches that accumulate
     /// after failed start/stop cycles.
     private func resetAudioEngine() {
-        audioEngine.stop()
-        audioEngine.inputNode.removeTap(onBus: 0)
+        if hasInstalledTap {
+            audioEngine.stop()
+            audioEngine.inputNode.removeTap(onBus: 0)
+        }
         audioEngine.reset()
     }
 
@@ -623,6 +635,7 @@ final class VoiceInputManager {
         // See: https://stackoverflow.com/questions/41805381
         let inputNode = audioEngine.inputNode
         inputNode.removeTap(onBus: 0)
+        hasInstalledTap = true
 
         let recordingFormat = inputNode.outputFormat(forBus: 0)
 


### PR DESCRIPTION
I don't typically grant microphone perms when testing, and it's annoying that I get prompted for them when quitting the app.

----

Accessing AVAudioEngine.inputNode causes macOS to request microphone
permission. Teardown paths (called during Cmd+Q) were unconditionally
touching inputNode even when no recording session had ever started.
Guard these accesses behind a hasInstalledTap flag that is only set
once beginRecording() actually installs an audio tap.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
