### PR TITLE
fix(macos): fix destructive button text color in dark mode

### DIFF
--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -97,8 +97,10 @@ public struct VButton: View {
     private var iconOnlyForegroundColor: Color {
         if isDisabled { return VColor.contentDisabled }
         switch style {
-        case .primary, .danger:
+        case .primary:
             return VColor.contentInset
+        case .danger:
+            return VColor.auxWhite
         case .contrast:
             return VColor.contentInset
         case .ghost, .outlined:
@@ -233,7 +235,7 @@ public struct VButtonStyle: ButtonStyle {
 
         switch style {
         case .primary: return VColor.contentInset
-        case .danger: return VColor.contentInset
+        case .danger: return VColor.auxWhite
         case .contrast: return VColor.contentInset
         case .outlined: return isHovered ? VColor.primaryActive : VColor.contentDefault
         case .dangerOutline: return isHovered ? VColor.systemNegativeHover : VColor.systemNegativeStrong
@@ -257,7 +259,7 @@ public struct VButtonStyle: ButtonStyle {
             if isHovered { return VColor.borderElement }
             return VColor.borderElement
         case .dangerOutline:
-            guard isEnabled else { return VColor.borderDisabled }
+            guard isEnabled else { return VColor.primaryDisabled }
             if isPressed { return VColor.systemNegativeHover }
             if isHovered { return VColor.systemNegativeHover }
             return VColor.systemNegativeStrong


### PR DESCRIPTION
## Summary
- Danger button text: use `auxWhite` instead of `contentInset` — ensures white text on red buttons in both light and dark mode (was flipping to dark text in dark mode)
- Danger-outline disabled border: use `primaryDisabled` instead of `borderDisabled` to match Figma spec

## Test plan
- [ ] Destructive buttons (e.g. "Delete Contact") should have white text in both light and dark mode
- [ ] Disabled destructive-outline buttons should have subtle border matching primaryDisabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
