### PR TITLE
Auto-initiate guardian verification on bare `/start` when no channel guardian exists

### DIFF
--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -44,6 +44,7 @@ import { processChannelMessageInBackground } from "./inbound-stages/background-d
 import { handleBootstrapIntercept } from "./inbound-stages/bootstrap-intercept.js";
 import { handleEditIntercept } from "./inbound-stages/edit-intercept.js";
 import { handleEscalationIntercept } from "./inbound-stages/escalation-intercept.js";
+import { handleGuardianActivationIntercept } from "./inbound-stages/guardian-activation-intercept.js";
 import { handleGuardianReplyIntercept } from "./inbound-stages/guardian-reply-intercept.js";
 import { runSecretIngressCheck } from "./inbound-stages/secret-ingress-check.js";
 import { tryTranscribeAudioAttachments } from "./inbound-stages/transcribe-audio.js";
@@ -198,6 +199,23 @@ export async function handleChannelInbound(
   // represents an explicit (malformed) identity claim that must enter the
   // ACL deny path rather than bypassing it.
   const hasSenderIdentityClaim = rawSenderId !== undefined;
+
+  // ── Guardian channel activation ──
+  // When a bare /start arrives on a channel with no guardian, auto-initiate
+  // guardian verification so the first user can claim the channel.
+  const guardianActivationResponse = await handleGuardianActivationIntercept({
+    sourceChannel,
+    conversationExternalId,
+    rawSenderId,
+    canonicalSenderId,
+    actorDisplayName: body.actorDisplayName,
+    actorUsername: body.actorUsername,
+    sourceMetadata: body.sourceMetadata,
+    replyCallbackUrl: body.replyCallbackUrl,
+    mintBearerToken,
+    assistantId,
+  });
+  if (guardianActivationResponse) return guardianActivationResponse;
 
   // ── Ingress ACL enforcement ──
   const aclResult = await enforceIngressAcl({

--- a/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.test.ts
@@ -14,34 +14,41 @@ let mockSessionResult = {
   ttlSeconds: 600,
 };
 
-const mockCreateOutboundSession = mock(() => mockSessionResult);
-const mockFindActiveSession = mock(() => mockActiveSession);
-const mockDeliverChannelReply = mock(async () => ({ ok: true }));
-const mockEmitNotificationSignal = mock(async () => ({
-  signalId: "sig-1",
-  deduplicated: false,
-  dispatched: true,
-  reason: "ok",
-  deliveryResults: [],
-}));
+// Track calls manually to avoid TypeScript issues with mock() generics
+let createOutboundSessionCalls: unknown[] = [];
+let deliverChannelReplyCalls: unknown[][] = [];
+let emitNotificationSignalCalls: unknown[] = [];
 
 mock.module("../../../contacts/contact-store.js", () => ({
   findGuardianForChannel: () => mockGuardian,
 }));
 
 mock.module("../../channel-verification-service.js", () => ({
-  createOutboundSession: (...args: unknown[]) =>
-    mockCreateOutboundSession(...args),
-  findActiveSession: (...args: unknown[]) => mockFindActiveSession(...args),
+  createOutboundSession: (params: unknown) => {
+    createOutboundSessionCalls.push(params);
+    return mockSessionResult;
+  },
+  findActiveSession: () => mockActiveSession,
 }));
 
 mock.module("../../gateway-client.js", () => ({
-  deliverChannelReply: (...args: unknown[]) => mockDeliverChannelReply(...args),
+  deliverChannelReply: (url: unknown, payload: unknown, token: unknown) => {
+    deliverChannelReplyCalls.push([url, payload, token]);
+    return Promise.resolve({ ok: true });
+  },
 }));
 
 mock.module("../../../notifications/emit-signal.js", () => ({
-  emitNotificationSignal: (...args: unknown[]) =>
-    mockEmitNotificationSignal(...args),
+  emitNotificationSignal: (params: unknown) => {
+    emitNotificationSignalCalls.push(params);
+    return Promise.resolve({
+      signalId: "sig-1",
+      deduplicated: false,
+      dispatched: true,
+      reason: "ok",
+      deliveryResults: [],
+    });
+  },
 }));
 
 mock.module("../../../util/logger.js", () => ({
@@ -96,17 +103,15 @@ describe("handleGuardianActivationIntercept", () => {
       expiresAt: Date.now() + 600_000,
       ttlSeconds: 600,
     };
-    mockCreateOutboundSession.mockClear();
-    mockFindActiveSession.mockClear();
-    mockDeliverChannelReply.mockClear();
-    mockEmitNotificationSignal.mockClear();
+    createOutboundSessionCalls = [];
+    deliverChannelReplyCalls = [];
+    emitNotificationSignalCalls = [];
   });
 
   afterEach(() => {
-    mockCreateOutboundSession.mockClear();
-    mockFindActiveSession.mockClear();
-    mockDeliverChannelReply.mockClear();
-    mockEmitNotificationSignal.mockClear();
+    createOutboundSessionCalls = [];
+    deliverChannelReplyCalls = [];
+    emitNotificationSignalCalls = [];
   });
 
   test("bare /start with no guardian creates session and returns early", async () => {
@@ -117,9 +122,8 @@ describe("handleGuardianActivationIntercept", () => {
     expect(body).toEqual({ accepted: true, guardianActivation: true });
 
     // Verify createOutboundSession was called with correct params
-    expect(mockCreateOutboundSession).toHaveBeenCalledTimes(1);
-    const sessionArgs = mockCreateOutboundSession.mock.calls[0][0];
-    expect(sessionArgs).toEqual({
+    expect(createOutboundSessionCalls).toHaveLength(1);
+    expect(createOutboundSessionCalls[0]).toEqual({
       channel: "telegram",
       expectedExternalUserId: "user-42",
       expectedChatId: "chat-123",
@@ -129,18 +133,17 @@ describe("handleGuardianActivationIntercept", () => {
     });
 
     // Verify deliverChannelReply was called with the welcome/verify message
-    expect(mockDeliverChannelReply).toHaveBeenCalledTimes(1);
-    const replyArgs = mockDeliverChannelReply.mock.calls[0];
-    expect(replyArgs[0]).toBe("https://gateway/reply");
-    expect(replyArgs[1]).toEqual({
+    expect(deliverChannelReplyCalls).toHaveLength(1);
+    expect(deliverChannelReplyCalls[0][0]).toBe("https://gateway/reply");
+    expect(deliverChannelReplyCalls[0][1]).toEqual({
       chatId: "chat-123",
       text: "Welcome! To verify your identity as guardian, check your assistant app for a verification code and enter it here.",
       assistantId: "self",
     });
 
     // Verify emitNotificationSignal was called with guardian.channel_activation
-    expect(mockEmitNotificationSignal).toHaveBeenCalledTimes(1);
-    const signalArgs = mockEmitNotificationSignal.mock.calls[0][0];
+    expect(emitNotificationSignalCalls).toHaveLength(1);
+    const signalArgs = emitNotificationSignalCalls[0] as Record<string, any>;
     expect(signalArgs.sourceEventName).toBe("guardian.channel_activation");
     expect(signalArgs.contextPayload.verificationCode).toBe("123456");
     expect(signalArgs.contextPayload.sourceChannel).toBe("telegram");
@@ -157,7 +160,7 @@ describe("handleGuardianActivationIntercept", () => {
 
     const result = await handleGuardianActivationIntercept(makeParams());
     expect(result).toBeNull();
-    expect(mockCreateOutboundSession).not.toHaveBeenCalled();
+    expect(createOutboundSessionCalls).toHaveLength(0);
   });
 
   test("/start with payload returns null", async () => {
@@ -169,7 +172,7 @@ describe("handleGuardianActivationIntercept", () => {
       }),
     );
     expect(result).toBeNull();
-    expect(mockCreateOutboundSession).not.toHaveBeenCalled();
+    expect(createOutboundSessionCalls).toHaveLength(0);
   });
 
   test("non-/start message returns null", async () => {
@@ -179,7 +182,7 @@ describe("handleGuardianActivationIntercept", () => {
       }),
     );
     expect(result).toBeNull();
-    expect(mockCreateOutboundSession).not.toHaveBeenCalled();
+    expect(createOutboundSessionCalls).toHaveLength(0);
   });
 
   test("no commandIntent returns null", async () => {
@@ -192,7 +195,7 @@ describe("handleGuardianActivationIntercept", () => {
       makeParams({ sourceMetadata: undefined }),
     );
     expect(result2).toBeNull();
-    expect(mockCreateOutboundSession).not.toHaveBeenCalled();
+    expect(createOutboundSessionCalls).toHaveLength(0);
   });
 
   test("non-telegram channel returns null", async () => {
@@ -200,7 +203,7 @@ describe("handleGuardianActivationIntercept", () => {
       makeParams({ sourceChannel: "slack" as any }),
     );
     expect(result).toBeNull();
-    expect(mockCreateOutboundSession).not.toHaveBeenCalled();
+    expect(createOutboundSessionCalls).toHaveLength(0);
   });
 
   test("missing sender ID returns null", async () => {
@@ -208,7 +211,7 @@ describe("handleGuardianActivationIntercept", () => {
       makeParams({ rawSenderId: undefined }),
     );
     expect(result).toBeNull();
-    expect(mockCreateOutboundSession).not.toHaveBeenCalled();
+    expect(createOutboundSessionCalls).toHaveLength(0);
   });
 
   test("existing active session sends 'already in progress' reply", async () => {
@@ -225,18 +228,17 @@ describe("handleGuardianActivationIntercept", () => {
     expect(body).toEqual({ accepted: true, guardianActivationPending: true });
 
     // createOutboundSession should NOT be called
-    expect(mockCreateOutboundSession).not.toHaveBeenCalled();
+    expect(createOutboundSessionCalls).toHaveLength(0);
 
     // deliverChannelReply should be called with the "already in progress" message
-    expect(mockDeliverChannelReply).toHaveBeenCalledTimes(1);
-    const replyArgs = mockDeliverChannelReply.mock.calls[0];
-    expect(replyArgs[1]).toEqual({
+    expect(deliverChannelReplyCalls).toHaveLength(1);
+    expect(deliverChannelReplyCalls[0][1]).toEqual({
       chatId: "chat-123",
       text: "A verification is already in progress. Check your assistant app for the code and enter it here.",
       assistantId: "self",
     });
 
     // emitNotificationSignal should NOT be called
-    expect(mockEmitNotificationSignal).not.toHaveBeenCalled();
+    expect(emitNotificationSignalCalls).toHaveLength(0);
   });
 });

--- a/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be set up before importing the module under test
+// ---------------------------------------------------------------------------
+
+let mockGuardian: { contact: unknown; channel: unknown } | null = null;
+let mockActiveSession: unknown = null;
+let mockSessionResult = {
+  sessionId: "sess-1",
+  secret: "123456",
+  challengeHash: "hash-1",
+  expiresAt: Date.now() + 600_000,
+  ttlSeconds: 600,
+};
+
+const mockCreateOutboundSession = mock(() => mockSessionResult);
+const mockFindActiveSession = mock(() => mockActiveSession);
+const mockDeliverChannelReply = mock(async () => ({ ok: true }));
+const mockEmitNotificationSignal = mock(async () => ({
+  signalId: "sig-1",
+  deduplicated: false,
+  dispatched: true,
+  reason: "ok",
+  deliveryResults: [],
+}));
+
+mock.module("../../../contacts/contact-store.js", () => ({
+  findGuardianForChannel: () => mockGuardian,
+}));
+
+mock.module("../../channel-verification-service.js", () => ({
+  createOutboundSession: (...args: unknown[]) =>
+    mockCreateOutboundSession(...args),
+  findActiveSession: (...args: unknown[]) => mockFindActiveSession(...args),
+}));
+
+mock.module("../../gateway-client.js", () => ({
+  deliverChannelReply: (...args: unknown[]) => mockDeliverChannelReply(...args),
+}));
+
+mock.module("../../../notifications/emit-signal.js", () => ({
+  emitNotificationSignal: (...args: unknown[]) =>
+    mockEmitNotificationSignal(...args),
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => ({
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  }),
+}));
+
+// Import after mocks are installed
+const { handleGuardianActivationIntercept } =
+  await import("./guardian-activation-intercept.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeParams(
+  overrides: Partial<
+    Parameters<typeof handleGuardianActivationIntercept>[0]
+  > = {},
+) {
+  return {
+    sourceChannel: "telegram" as const,
+    conversationExternalId: "chat-123",
+    rawSenderId: "user-42",
+    canonicalSenderId: "user-42",
+    actorDisplayName: "Alice",
+    actorUsername: "alice",
+    sourceMetadata: { commandIntent: { type: "start" } },
+    replyCallbackUrl: "https://gateway/reply",
+    mintBearerToken: () => "token-123",
+    assistantId: "self",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("handleGuardianActivationIntercept", () => {
+  beforeEach(() => {
+    mockGuardian = null;
+    mockActiveSession = null;
+    mockSessionResult = {
+      sessionId: "sess-1",
+      secret: "123456",
+      challengeHash: "hash-1",
+      expiresAt: Date.now() + 600_000,
+      ttlSeconds: 600,
+    };
+    mockCreateOutboundSession.mockClear();
+    mockFindActiveSession.mockClear();
+    mockDeliverChannelReply.mockClear();
+    mockEmitNotificationSignal.mockClear();
+  });
+
+  afterEach(() => {
+    mockCreateOutboundSession.mockClear();
+    mockFindActiveSession.mockClear();
+    mockDeliverChannelReply.mockClear();
+    mockEmitNotificationSignal.mockClear();
+  });
+
+  test("bare /start with no guardian creates session and returns early", async () => {
+    const result = await handleGuardianActivationIntercept(makeParams());
+
+    expect(result).not.toBeNull();
+    const body = await result!.json();
+    expect(body).toEqual({ accepted: true, guardianActivation: true });
+
+    // Verify createOutboundSession was called with correct params
+    expect(mockCreateOutboundSession).toHaveBeenCalledTimes(1);
+    const sessionArgs = mockCreateOutboundSession.mock.calls[0][0];
+    expect(sessionArgs).toEqual({
+      channel: "telegram",
+      expectedExternalUserId: "user-42",
+      expectedChatId: "chat-123",
+      identityBindingStatus: "bound",
+      destinationAddress: "chat-123",
+      verificationPurpose: "guardian",
+    });
+
+    // Verify deliverChannelReply was called with the welcome/verify message
+    expect(mockDeliverChannelReply).toHaveBeenCalledTimes(1);
+    const replyArgs = mockDeliverChannelReply.mock.calls[0];
+    expect(replyArgs[0]).toBe("https://gateway/reply");
+    expect(replyArgs[1]).toEqual({
+      chatId: "chat-123",
+      text: "Welcome! To verify your identity as guardian, check your assistant app for a verification code and enter it here.",
+      assistantId: "self",
+    });
+
+    // Verify emitNotificationSignal was called with guardian.channel_activation
+    expect(mockEmitNotificationSignal).toHaveBeenCalledTimes(1);
+    const signalArgs = mockEmitNotificationSignal.mock.calls[0][0];
+    expect(signalArgs.sourceEventName).toBe("guardian.channel_activation");
+    expect(signalArgs.contextPayload.verificationCode).toBe("123456");
+    expect(signalArgs.contextPayload.sourceChannel).toBe("telegram");
+    expect(signalArgs.contextPayload.actorExternalId).toBe("user-42");
+    expect(signalArgs.contextPayload.sessionId).toBe("sess-1");
+    expect(signalArgs.dedupeKey).toBe("guardian-activation:sess-1");
+  });
+
+  test("bare /start with existing guardian returns null", async () => {
+    mockGuardian = {
+      contact: { id: "contact-1", role: "guardian" },
+      channel: { id: "ch-1", type: "telegram" },
+    };
+
+    const result = await handleGuardianActivationIntercept(makeParams());
+    expect(result).toBeNull();
+    expect(mockCreateOutboundSession).not.toHaveBeenCalled();
+  });
+
+  test("/start with payload returns null", async () => {
+    const result = await handleGuardianActivationIntercept(
+      makeParams({
+        sourceMetadata: {
+          commandIntent: { type: "start", payload: "gv_token" },
+        },
+      }),
+    );
+    expect(result).toBeNull();
+    expect(mockCreateOutboundSession).not.toHaveBeenCalled();
+  });
+
+  test("non-/start message returns null", async () => {
+    const result = await handleGuardianActivationIntercept(
+      makeParams({
+        sourceMetadata: { commandIntent: { type: "other" } },
+      }),
+    );
+    expect(result).toBeNull();
+    expect(mockCreateOutboundSession).not.toHaveBeenCalled();
+  });
+
+  test("no commandIntent returns null", async () => {
+    const result = await handleGuardianActivationIntercept(
+      makeParams({ sourceMetadata: {} }),
+    );
+    expect(result).toBeNull();
+
+    const result2 = await handleGuardianActivationIntercept(
+      makeParams({ sourceMetadata: undefined }),
+    );
+    expect(result2).toBeNull();
+    expect(mockCreateOutboundSession).not.toHaveBeenCalled();
+  });
+
+  test("non-telegram channel returns null", async () => {
+    const result = await handleGuardianActivationIntercept(
+      makeParams({ sourceChannel: "slack" as any }),
+    );
+    expect(result).toBeNull();
+    expect(mockCreateOutboundSession).not.toHaveBeenCalled();
+  });
+
+  test("missing sender ID returns null", async () => {
+    const result = await handleGuardianActivationIntercept(
+      makeParams({ rawSenderId: undefined }),
+    );
+    expect(result).toBeNull();
+    expect(mockCreateOutboundSession).not.toHaveBeenCalled();
+  });
+
+  test("existing active session sends 'already in progress' reply", async () => {
+    mockActiveSession = {
+      id: "existing-sess",
+      channel: "telegram",
+      status: "awaiting_response",
+    };
+
+    const result = await handleGuardianActivationIntercept(makeParams());
+
+    expect(result).not.toBeNull();
+    const body = await result!.json();
+    expect(body).toEqual({ accepted: true, guardianActivationPending: true });
+
+    // createOutboundSession should NOT be called
+    expect(mockCreateOutboundSession).not.toHaveBeenCalled();
+
+    // deliverChannelReply should be called with the "already in progress" message
+    expect(mockDeliverChannelReply).toHaveBeenCalledTimes(1);
+    const replyArgs = mockDeliverChannelReply.mock.calls[0];
+    expect(replyArgs[1]).toEqual({
+      chatId: "chat-123",
+      text: "A verification is already in progress. Check your assistant app for the code and enter it here.",
+      assistantId: "self",
+    });
+
+    // emitNotificationSignal should NOT be called
+    expect(mockEmitNotificationSignal).not.toHaveBeenCalled();
+  });
+});

--- a/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.ts
@@ -1,0 +1,160 @@
+/**
+ * Guardian activation intercept stage: when a bare /start arrives on a
+ * Telegram channel with no existing guardian, auto-initiate a verification
+ * session so the first user can claim the channel as guardian.
+ *
+ * This runs BEFORE ACL enforcement — a bare /start from an unknown user
+ * would otherwise be rejected. When the user subsequently enters the
+ * 6-digit code, the existing verification intercept validates it, creates
+ * the guardian binding, and sends a success reply.
+ */
+import type { ChannelId } from "../../../channels/types.js";
+import { findGuardianForChannel } from "../../../contacts/contact-store.js";
+import { emitNotificationSignal } from "../../../notifications/emit-signal.js";
+import type { NotificationSourceChannel } from "../../../notifications/signal.js";
+import { getLogger } from "../../../util/logger.js";
+import {
+  createOutboundSession,
+  findActiveSession,
+} from "../../channel-verification-service.js";
+import { deliverChannelReply } from "../../gateway-client.js";
+
+const log = getLogger("runtime-http");
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface GuardianActivationInterceptParams {
+  sourceChannel: ChannelId;
+  conversationExternalId: string;
+  rawSenderId: string | undefined;
+  canonicalSenderId: string | null;
+  actorDisplayName: string | undefined;
+  actorUsername: string | undefined;
+  sourceMetadata: Record<string, unknown> | undefined;
+  replyCallbackUrl: string | undefined;
+  mintBearerToken: () => string;
+  assistantId: string;
+}
+
+export async function handleGuardianActivationIntercept(
+  params: GuardianActivationInterceptParams,
+): Promise<Response | null> {
+  const {
+    sourceChannel,
+    conversationExternalId,
+    rawSenderId,
+    actorDisplayName,
+    actorUsername,
+    sourceMetadata,
+    replyCallbackUrl,
+    mintBearerToken,
+    assistantId,
+  } = params;
+
+  // ── Extract commandIntent ──
+  const rawCommandIntent = sourceMetadata?.commandIntent;
+  const commandIntent =
+    rawCommandIntent &&
+    typeof rawCommandIntent === "object" &&
+    !Array.isArray(rawCommandIntent)
+      ? (rawCommandIntent as Record<string, unknown>)
+      : undefined;
+
+  // Only proceed for /start commands
+  if (!commandIntent || commandIntent.type !== "start") return null;
+
+  // If /start has a payload (e.g. gv_token, iv_token), let the existing
+  // bootstrap/invite handlers deal with it.
+  if (
+    typeof commandIntent.payload === "string" &&
+    commandIntent.payload.length > 0
+  ) {
+    return null;
+  }
+
+  // Only proceed for Telegram (can be extended later)
+  if (sourceChannel !== "telegram") return null;
+
+  // If a guardian already exists for this channel, continue to normal flow
+  if (findGuardianForChannel(sourceChannel)) return null;
+
+  // Can't bind a session without sender identity
+  if (!rawSenderId) return null;
+
+  // ── Idempotency: check for an existing active session ──
+  const existingSession = findActiveSession(sourceChannel);
+  if (existingSession) {
+    if (replyCallbackUrl) {
+      deliverChannelReply(
+        replyCallbackUrl,
+        {
+          chatId: conversationExternalId,
+          text: "A verification is already in progress. Check your assistant app for the code and enter it here.",
+          assistantId,
+        },
+        mintBearerToken(),
+      ).catch((err) => {
+        log.error(
+          { err, sourceChannel, conversationExternalId },
+          "Failed to deliver guardian activation idempotency reply",
+        );
+      });
+    }
+    return Response.json({ accepted: true, guardianActivationPending: true });
+  }
+
+  // ── Create verification session ──
+  const sessionResult = createOutboundSession({
+    channel: sourceChannel,
+    expectedExternalUserId: rawSenderId,
+    expectedChatId: conversationExternalId,
+    identityBindingStatus: "bound",
+    destinationAddress: conversationExternalId,
+    verificationPurpose: "guardian",
+  });
+
+  // ── Send deterministic Telegram reply ──
+  if (replyCallbackUrl) {
+    deliverChannelReply(
+      replyCallbackUrl,
+      {
+        chatId: conversationExternalId,
+        text: "Welcome! To verify your identity as guardian, check your assistant app for a verification code and enter it here.",
+        assistantId,
+      },
+      mintBearerToken(),
+    ).catch((err) => {
+      log.error(
+        { err, sourceChannel, conversationExternalId },
+        "Failed to deliver guardian activation welcome reply",
+      );
+    });
+  }
+
+  // ── Emit notification signal to deliver code to macOS app ──
+  void emitNotificationSignal({
+    sourceEventName: "guardian.channel_activation",
+    sourceChannel: sourceChannel as NotificationSourceChannel,
+    sourceContextId: `guardian-activation-${sourceChannel}-${rawSenderId}`,
+    attentionHints: {
+      requiresAction: true,
+      urgency: "high",
+      isAsyncBackground: false,
+      visibleInSourceNow: false,
+    },
+    contextPayload: {
+      verificationCode: sessionResult.secret,
+      sourceChannel,
+      actorExternalId: rawSenderId,
+      actorDisplayName: actorDisplayName ?? null,
+      actorUsername: actorUsername ?? null,
+      sessionId: sessionResult.sessionId,
+      expiresAt: sessionResult.expiresAt,
+    },
+    dedupeKey: `guardian-activation:${sessionResult.sessionId}`,
+  });
+
+  return Response.json({ accepted: true, guardianActivation: true });
+}


### PR DESCRIPTION
## Summary
- Add guardian-activation-intercept stage that detects bare /start + no guardian and creates a verification session
- Wire the intercept into the inbound pipeline before ACL enforcement
- Emit guardian.channel_activation notification signal to deliver verification code to macOS app
- Include comprehensive tests covering all edge cases

Part of plan: tg-start-guardian-activation.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
