### PR TITLE
Auto-initiate guardian verification on Telegram /start

### DIFF
--- a/assistant/src/notifications/adapters/macos.ts
+++ b/assistant/src/notifications/adapters/macos.ts
@@ -37,6 +37,7 @@ const GUARDIAN_SENSITIVE_EVENT_PREFIXES = [
   "guardian.question",
   "ingress.escalation",
   "ingress.access_request",
+  "guardian.channel_activation",
 ] as const;
 
 export function isGuardianSensitiveEvent(sourceEventName: string): boolean {

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -353,6 +353,15 @@ const TEMPLATES: Partial<Record<NotificationSourceEventName, CopyTemplate>> = {
     };
   },
 
+  "guardian.channel_activation": (payload) => {
+    const code = str(payload.verificationCode, "------");
+    const channel = str(payload.sourceChannel, "a channel");
+    return {
+      title: "Guardian Verification Code",
+      body: `Your ${channel} verification code is: ${code}\n\nEnter this code in your ${channel} chat to verify your identity as guardian.`,
+    };
+  },
+
   "ingress.access_request": (payload) => ({
     title: "Access Request",
     body: buildAccessRequestContractText(payload),

--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -46,6 +46,11 @@ export const NOTIFICATION_SOURCE_EVENT_NAMES = [
     id: "guardian.question",
     description: "Guardian approval question requiring response",
   },
+  {
+    id: "guardian.channel_activation",
+    description:
+      "Guardian channel activation code delivered for /start verification",
+  },
   { id: "ingress.access_request", description: "Non-member requesting access" },
   {
     id: "ingress.access_request.callback_handoff",
@@ -155,9 +160,20 @@ export interface AccessRequestContextPayload {
   messagePreview: string | null;
 }
 
+export interface GuardianChannelActivationPayload {
+  verificationCode: string;
+  sourceChannel: string;
+  actorExternalId: string;
+  actorDisplayName: string | null;
+  actorUsername: string | null;
+  sessionId: string;
+  expiresAt: number;
+}
+
 export interface NotificationEventContextPayloadMap {
   "guardian.question": GuardianQuestionPayload;
   "ingress.access_request": AccessRequestContextPayload;
+  "guardian.channel_activation": GuardianChannelActivationPayload;
 }
 
 export type NotificationContextPayload<TEventName extends string = string> =

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -214,6 +214,7 @@ export async function handleChannelInbound(
     replyCallbackUrl: body.replyCallbackUrl,
     mintBearerToken,
     assistantId,
+    externalMessageId,
   });
   if (guardianActivationResponse) return guardianActivationResponse;
 

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -44,6 +44,7 @@ import { processChannelMessageInBackground } from "./inbound-stages/background-d
 import { handleBootstrapIntercept } from "./inbound-stages/bootstrap-intercept.js";
 import { handleEditIntercept } from "./inbound-stages/edit-intercept.js";
 import { handleEscalationIntercept } from "./inbound-stages/escalation-intercept.js";
+import { handleGuardianActivationIntercept } from "./inbound-stages/guardian-activation-intercept.js";
 import { handleGuardianReplyIntercept } from "./inbound-stages/guardian-reply-intercept.js";
 import { runSecretIngressCheck } from "./inbound-stages/secret-ingress-check.js";
 import { tryTranscribeAudioAttachments } from "./inbound-stages/transcribe-audio.js";
@@ -198,6 +199,23 @@ export async function handleChannelInbound(
   // represents an explicit (malformed) identity claim that must enter the
   // ACL deny path rather than bypassing it.
   const hasSenderIdentityClaim = rawSenderId !== undefined;
+
+  // ── Guardian channel activation ──
+  // When a bare /start arrives on a channel with no guardian, auto-initiate
+  // guardian verification so the first user can claim the channel.
+  const guardianActivationResponse = await handleGuardianActivationIntercept({
+    sourceChannel,
+    conversationExternalId,
+    rawSenderId,
+    canonicalSenderId,
+    actorDisplayName: body.actorDisplayName,
+    actorUsername: body.actorUsername,
+    sourceMetadata: body.sourceMetadata,
+    replyCallbackUrl: body.replyCallbackUrl,
+    mintBearerToken,
+    assistantId,
+  });
+  if (guardianActivationResponse) return guardianActivationResponse;
 
   // ── Ingress ACL enforcement ──
   const aclResult = await enforceIngressAcl({

--- a/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 // ---------------------------------------------------------------------------
 
 let mockGuardian: { contact: unknown; channel: unknown } | null = null;
-let mockActiveSession: unknown = null;
+let mockActiveSession: Record<string, unknown> | null = null;
 let mockSessionResult = {
   sessionId: "sess-1",
   secret: "123456",
@@ -18,6 +18,7 @@ let mockSessionResult = {
 let createOutboundSessionCalls: unknown[] = [];
 let deliverChannelReplyCalls: unknown[][] = [];
 let emitNotificationSignalCalls: unknown[] = [];
+let messageIdCounter = 0;
 
 mock.module("../../../contacts/contact-store.js", () => ({
   findGuardianForChannel: () => mockGuardian,
@@ -73,6 +74,7 @@ function makeParams(
     Parameters<typeof handleGuardianActivationIntercept>[0]
   > = {},
 ) {
+  messageIdCounter++;
   return {
     sourceChannel: "telegram" as const,
     conversationExternalId: "chat-123",
@@ -84,6 +86,7 @@ function makeParams(
     replyCallbackUrl: "https://gateway/reply",
     mintBearerToken: () => "token-123",
     assistantId: "self",
+    externalMessageId: `msg-${messageIdCounter}`,
     ...overrides,
   };
 }
@@ -214,11 +217,13 @@ describe("handleGuardianActivationIntercept", () => {
     expect(createOutboundSessionCalls).toHaveLength(0);
   });
 
-  test("existing active session sends 'already in progress' reply", async () => {
+  test("existing active session from same sender sends 'already in progress' reply", async () => {
     mockActiveSession = {
       id: "existing-sess",
       channel: "telegram",
       status: "awaiting_response",
+      expectedExternalUserId: "user-42",
+      expectedChatId: "chat-123",
     };
 
     const result = await handleGuardianActivationIntercept(makeParams());
@@ -240,5 +245,48 @@ describe("handleGuardianActivationIntercept", () => {
 
     // emitNotificationSignal should NOT be called
     expect(emitNotificationSignalCalls).toHaveLength(0);
+  });
+
+  test("existing active session from different sender allows superseding", async () => {
+    mockActiveSession = {
+      id: "existing-sess",
+      channel: "telegram",
+      status: "awaiting_response",
+      expectedExternalUserId: "user-OTHER",
+      expectedChatId: "chat-OTHER",
+    };
+
+    const result = await handleGuardianActivationIntercept(makeParams());
+
+    // Should proceed and create a new session (superseding the stale one)
+    expect(result).not.toBeNull();
+    const body = await result!.json();
+    expect(body).toEqual({ accepted: true, guardianActivation: true });
+    expect(createOutboundSessionCalls).toHaveLength(1);
+    expect(emitNotificationSignalCalls).toHaveLength(1);
+  });
+
+  test("duplicate webhook retry is silently deduped", async () => {
+    const params = makeParams({ externalMessageId: "dedup-test-msg" });
+
+    // First call should process normally
+    const result1 = await handleGuardianActivationIntercept(params);
+    expect(result1).not.toBeNull();
+    const body1 = await result1!.json();
+    expect(body1).toEqual({ accepted: true, guardianActivation: true });
+    expect(createOutboundSessionCalls).toHaveLength(1);
+    expect(deliverChannelReplyCalls).toHaveLength(1);
+    expect(emitNotificationSignalCalls).toHaveLength(1);
+
+    // Second call with same externalMessageId should be deduped
+    const result2 = await handleGuardianActivationIntercept(params);
+    expect(result2).not.toBeNull();
+    const body2 = await result2!.json();
+    expect(body2).toEqual({ accepted: true, guardianActivation: true });
+
+    // No additional session/reply/signal calls
+    expect(createOutboundSessionCalls).toHaveLength(1);
+    expect(deliverChannelReplyCalls).toHaveLength(1);
+    expect(emitNotificationSignalCalls).toHaveLength(1);
   });
 });

--- a/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be set up before importing the module under test
+// ---------------------------------------------------------------------------
+
+let mockGuardian: { contact: unknown; channel: unknown } | null = null;
+let mockActiveSession: unknown = null;
+let mockSessionResult = {
+  sessionId: "sess-1",
+  secret: "123456",
+  challengeHash: "hash-1",
+  expiresAt: Date.now() + 600_000,
+  ttlSeconds: 600,
+};
+
+// Track calls manually to avoid TypeScript issues with mock() generics
+let createOutboundSessionCalls: unknown[] = [];
+let deliverChannelReplyCalls: unknown[][] = [];
+let emitNotificationSignalCalls: unknown[] = [];
+
+mock.module("../../../contacts/contact-store.js", () => ({
+  findGuardianForChannel: () => mockGuardian,
+}));
+
+mock.module("../../channel-verification-service.js", () => ({
+  createOutboundSession: (params: unknown) => {
+    createOutboundSessionCalls.push(params);
+    return mockSessionResult;
+  },
+  findActiveSession: () => mockActiveSession,
+}));
+
+mock.module("../../gateway-client.js", () => ({
+  deliverChannelReply: (url: unknown, payload: unknown, token: unknown) => {
+    deliverChannelReplyCalls.push([url, payload, token]);
+    return Promise.resolve({ ok: true });
+  },
+}));
+
+mock.module("../../../notifications/emit-signal.js", () => ({
+  emitNotificationSignal: (params: unknown) => {
+    emitNotificationSignalCalls.push(params);
+    return Promise.resolve({
+      signalId: "sig-1",
+      deduplicated: false,
+      dispatched: true,
+      reason: "ok",
+      deliveryResults: [],
+    });
+  },
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => ({
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  }),
+}));
+
+// Import after mocks are installed
+const { handleGuardianActivationIntercept } =
+  await import("./guardian-activation-intercept.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeParams(
+  overrides: Partial<
+    Parameters<typeof handleGuardianActivationIntercept>[0]
+  > = {},
+) {
+  return {
+    sourceChannel: "telegram" as const,
+    conversationExternalId: "chat-123",
+    rawSenderId: "user-42",
+    canonicalSenderId: "user-42",
+    actorDisplayName: "Alice",
+    actorUsername: "alice",
+    sourceMetadata: { commandIntent: { type: "start" } },
+    replyCallbackUrl: "https://gateway/reply",
+    mintBearerToken: () => "token-123",
+    assistantId: "self",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("handleGuardianActivationIntercept", () => {
+  beforeEach(() => {
+    mockGuardian = null;
+    mockActiveSession = null;
+    mockSessionResult = {
+      sessionId: "sess-1",
+      secret: "123456",
+      challengeHash: "hash-1",
+      expiresAt: Date.now() + 600_000,
+      ttlSeconds: 600,
+    };
+    createOutboundSessionCalls = [];
+    deliverChannelReplyCalls = [];
+    emitNotificationSignalCalls = [];
+  });
+
+  afterEach(() => {
+    createOutboundSessionCalls = [];
+    deliverChannelReplyCalls = [];
+    emitNotificationSignalCalls = [];
+  });
+
+  test("bare /start with no guardian creates session and returns early", async () => {
+    const result = await handleGuardianActivationIntercept(makeParams());
+
+    expect(result).not.toBeNull();
+    const body = await result!.json();
+    expect(body).toEqual({ accepted: true, guardianActivation: true });
+
+    // Verify createOutboundSession was called with correct params
+    expect(createOutboundSessionCalls).toHaveLength(1);
+    expect(createOutboundSessionCalls[0]).toEqual({
+      channel: "telegram",
+      expectedExternalUserId: "user-42",
+      expectedChatId: "chat-123",
+      identityBindingStatus: "bound",
+      destinationAddress: "chat-123",
+      verificationPurpose: "guardian",
+    });
+
+    // Verify deliverChannelReply was called with the welcome/verify message
+    expect(deliverChannelReplyCalls).toHaveLength(1);
+    expect(deliverChannelReplyCalls[0][0]).toBe("https://gateway/reply");
+    expect(deliverChannelReplyCalls[0][1]).toEqual({
+      chatId: "chat-123",
+      text: "Welcome! To verify your identity as guardian, check your assistant app for a verification code and enter it here.",
+      assistantId: "self",
+    });
+
+    // Verify emitNotificationSignal was called with guardian.channel_activation
+    expect(emitNotificationSignalCalls).toHaveLength(1);
+    const signalArgs = emitNotificationSignalCalls[0] as Record<string, any>;
+    expect(signalArgs.sourceEventName).toBe("guardian.channel_activation");
+    expect(signalArgs.contextPayload.verificationCode).toBe("123456");
+    expect(signalArgs.contextPayload.sourceChannel).toBe("telegram");
+    expect(signalArgs.contextPayload.actorExternalId).toBe("user-42");
+    expect(signalArgs.contextPayload.sessionId).toBe("sess-1");
+    expect(signalArgs.dedupeKey).toBe("guardian-activation:sess-1");
+  });
+
+  test("bare /start with existing guardian returns null", async () => {
+    mockGuardian = {
+      contact: { id: "contact-1", role: "guardian" },
+      channel: { id: "ch-1", type: "telegram" },
+    };
+
+    const result = await handleGuardianActivationIntercept(makeParams());
+    expect(result).toBeNull();
+    expect(createOutboundSessionCalls).toHaveLength(0);
+  });
+
+  test("/start with payload returns null", async () => {
+    const result = await handleGuardianActivationIntercept(
+      makeParams({
+        sourceMetadata: {
+          commandIntent: { type: "start", payload: "gv_token" },
+        },
+      }),
+    );
+    expect(result).toBeNull();
+    expect(createOutboundSessionCalls).toHaveLength(0);
+  });
+
+  test("non-/start message returns null", async () => {
+    const result = await handleGuardianActivationIntercept(
+      makeParams({
+        sourceMetadata: { commandIntent: { type: "other" } },
+      }),
+    );
+    expect(result).toBeNull();
+    expect(createOutboundSessionCalls).toHaveLength(0);
+  });
+
+  test("no commandIntent returns null", async () => {
+    const result = await handleGuardianActivationIntercept(
+      makeParams({ sourceMetadata: {} }),
+    );
+    expect(result).toBeNull();
+
+    const result2 = await handleGuardianActivationIntercept(
+      makeParams({ sourceMetadata: undefined }),
+    );
+    expect(result2).toBeNull();
+    expect(createOutboundSessionCalls).toHaveLength(0);
+  });
+
+  test("non-telegram channel returns null", async () => {
+    const result = await handleGuardianActivationIntercept(
+      makeParams({ sourceChannel: "slack" as any }),
+    );
+    expect(result).toBeNull();
+    expect(createOutboundSessionCalls).toHaveLength(0);
+  });
+
+  test("missing sender ID returns null", async () => {
+    const result = await handleGuardianActivationIntercept(
+      makeParams({ rawSenderId: undefined }),
+    );
+    expect(result).toBeNull();
+    expect(createOutboundSessionCalls).toHaveLength(0);
+  });
+
+  test("existing active session sends 'already in progress' reply", async () => {
+    mockActiveSession = {
+      id: "existing-sess",
+      channel: "telegram",
+      status: "awaiting_response",
+    };
+
+    const result = await handleGuardianActivationIntercept(makeParams());
+
+    expect(result).not.toBeNull();
+    const body = await result!.json();
+    expect(body).toEqual({ accepted: true, guardianActivationPending: true });
+
+    // createOutboundSession should NOT be called
+    expect(createOutboundSessionCalls).toHaveLength(0);
+
+    // deliverChannelReply should be called with the "already in progress" message
+    expect(deliverChannelReplyCalls).toHaveLength(1);
+    expect(deliverChannelReplyCalls[0][1]).toEqual({
+      chatId: "chat-123",
+      text: "A verification is already in progress. Check your assistant app for the code and enter it here.",
+      assistantId: "self",
+    });
+
+    // emitNotificationSignal should NOT be called
+    expect(emitNotificationSignalCalls).toHaveLength(0);
+  });
+});

--- a/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.ts
@@ -1,0 +1,160 @@
+/**
+ * Guardian activation intercept stage: when a bare /start arrives on a
+ * Telegram channel with no existing guardian, auto-initiate a verification
+ * session so the first user can claim the channel as guardian.
+ *
+ * This runs BEFORE ACL enforcement — a bare /start from an unknown user
+ * would otherwise be rejected. When the user subsequently enters the
+ * 6-digit code, the existing verification intercept validates it, creates
+ * the guardian binding, and sends a success reply.
+ */
+import type { ChannelId } from "../../../channels/types.js";
+import { findGuardianForChannel } from "../../../contacts/contact-store.js";
+import { emitNotificationSignal } from "../../../notifications/emit-signal.js";
+import type { NotificationSourceChannel } from "../../../notifications/signal.js";
+import { getLogger } from "../../../util/logger.js";
+import {
+  createOutboundSession,
+  findActiveSession,
+} from "../../channel-verification-service.js";
+import { deliverChannelReply } from "../../gateway-client.js";
+
+const log = getLogger("runtime-http");
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface GuardianActivationInterceptParams {
+  sourceChannel: ChannelId;
+  conversationExternalId: string;
+  rawSenderId: string | undefined;
+  canonicalSenderId: string | null;
+  actorDisplayName: string | undefined;
+  actorUsername: string | undefined;
+  sourceMetadata: Record<string, unknown> | undefined;
+  replyCallbackUrl: string | undefined;
+  mintBearerToken: () => string;
+  assistantId: string;
+}
+
+export async function handleGuardianActivationIntercept(
+  params: GuardianActivationInterceptParams,
+): Promise<Response | null> {
+  const {
+    sourceChannel,
+    conversationExternalId,
+    rawSenderId,
+    actorDisplayName,
+    actorUsername,
+    sourceMetadata,
+    replyCallbackUrl,
+    mintBearerToken,
+    assistantId,
+  } = params;
+
+  // ── Extract commandIntent ──
+  const rawCommandIntent = sourceMetadata?.commandIntent;
+  const commandIntent =
+    rawCommandIntent &&
+    typeof rawCommandIntent === "object" &&
+    !Array.isArray(rawCommandIntent)
+      ? (rawCommandIntent as Record<string, unknown>)
+      : undefined;
+
+  // Only proceed for /start commands
+  if (!commandIntent || commandIntent.type !== "start") return null;
+
+  // If /start has a payload (e.g. gv_token, iv_token), let the existing
+  // bootstrap/invite handlers deal with it.
+  if (
+    typeof commandIntent.payload === "string" &&
+    commandIntent.payload.length > 0
+  ) {
+    return null;
+  }
+
+  // Only proceed for Telegram (can be extended later)
+  if (sourceChannel !== "telegram") return null;
+
+  // If a guardian already exists for this channel, continue to normal flow
+  if (findGuardianForChannel(sourceChannel)) return null;
+
+  // Can't bind a session without sender identity
+  if (!rawSenderId) return null;
+
+  // ── Idempotency: check for an existing active session ──
+  const existingSession = findActiveSession(sourceChannel);
+  if (existingSession) {
+    if (replyCallbackUrl) {
+      deliverChannelReply(
+        replyCallbackUrl,
+        {
+          chatId: conversationExternalId,
+          text: "A verification is already in progress. Check your assistant app for the code and enter it here.",
+          assistantId,
+        },
+        mintBearerToken(),
+      ).catch((err) => {
+        log.error(
+          { err, sourceChannel, conversationExternalId },
+          "Failed to deliver guardian activation idempotency reply",
+        );
+      });
+    }
+    return Response.json({ accepted: true, guardianActivationPending: true });
+  }
+
+  // ── Create verification session ──
+  const sessionResult = createOutboundSession({
+    channel: sourceChannel,
+    expectedExternalUserId: rawSenderId,
+    expectedChatId: conversationExternalId,
+    identityBindingStatus: "bound",
+    destinationAddress: conversationExternalId,
+    verificationPurpose: "guardian",
+  });
+
+  // ── Send deterministic Telegram reply ──
+  if (replyCallbackUrl) {
+    deliverChannelReply(
+      replyCallbackUrl,
+      {
+        chatId: conversationExternalId,
+        text: "Welcome! To verify your identity as guardian, check your assistant app for a verification code and enter it here.",
+        assistantId,
+      },
+      mintBearerToken(),
+    ).catch((err) => {
+      log.error(
+        { err, sourceChannel, conversationExternalId },
+        "Failed to deliver guardian activation welcome reply",
+      );
+    });
+  }
+
+  // ── Emit notification signal to deliver code to macOS app ──
+  void emitNotificationSignal({
+    sourceEventName: "guardian.channel_activation",
+    sourceChannel: sourceChannel as NotificationSourceChannel,
+    sourceContextId: `guardian-activation-${sourceChannel}-${rawSenderId}`,
+    attentionHints: {
+      requiresAction: true,
+      urgency: "high",
+      isAsyncBackground: false,
+      visibleInSourceNow: false,
+    },
+    contextPayload: {
+      verificationCode: sessionResult.secret,
+      sourceChannel,
+      actorExternalId: rawSenderId,
+      actorDisplayName: actorDisplayName ?? null,
+      actorUsername: actorUsername ?? null,
+      sessionId: sessionResult.sessionId,
+      expiresAt: sessionResult.expiresAt,
+    },
+    dedupeKey: `guardian-activation:${sessionResult.sessionId}`,
+  });
+
+  return Response.json({ accepted: true, guardianActivation: true });
+}

--- a/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.ts
@@ -36,6 +36,26 @@ export interface GuardianActivationInterceptParams {
   replyCallbackUrl: string | undefined;
   mintBearerToken: () => string;
   assistantId: string;
+  externalMessageId: string;
+}
+
+/**
+ * Lightweight dedup set for guardian activation intercepts.
+ * Prevents duplicate replies when Telegram retries the same webhook.
+ * Entries are evicted after DEDUP_TTL_MS to avoid unbounded growth.
+ */
+const DEDUP_TTL_MS = 60_000;
+const processedMessageIds = new Map<string, number>();
+
+function isDuplicateActivation(messageId: string): boolean {
+  const now = Date.now();
+  // Evict stale entries
+  for (const [key, ts] of processedMessageIds) {
+    if (now - ts > DEDUP_TTL_MS) processedMessageIds.delete(key);
+  }
+  if (processedMessageIds.has(messageId)) return true;
+  processedMessageIds.set(messageId, now);
+  return false;
 }
 
 export async function handleGuardianActivationIntercept(
@@ -51,6 +71,7 @@ export async function handleGuardianActivationIntercept(
     replyCallbackUrl,
     mintBearerToken,
     assistantId,
+    externalMessageId,
   } = params;
 
   // ── Extract commandIntent ──
@@ -83,26 +104,43 @@ export async function handleGuardianActivationIntercept(
   // Can't bind a session without sender identity
   if (!rawSenderId) return null;
 
-  // ── Idempotency: check for an existing active session ──
+  // ── Webhook retry dedup ──
+  // The intercept runs before recordInbound, so use a lightweight in-memory
+  // dedup to prevent duplicate replies when Telegram retries the webhook.
+  if (isDuplicateActivation(externalMessageId)) {
+    return Response.json({ accepted: true, guardianActivation: true });
+  }
+
+  // ── Idempotency: check for an existing active session from this sender ──
   const existingSession = findActiveSession(sourceChannel);
   if (existingSession) {
-    if (replyCallbackUrl) {
-      deliverChannelReply(
-        replyCallbackUrl,
-        {
-          chatId: conversationExternalId,
-          text: "A verification is already in progress. Check your assistant app for the code and enter it here.",
-          assistantId,
-        },
-        mintBearerToken(),
-      ).catch((err) => {
-        log.error(
-          { err, sourceChannel, conversationExternalId },
-          "Failed to deliver guardian activation idempotency reply",
-        );
-      });
+    // Only block if the session belongs to the same sender. If a different
+    // user triggered the session, let this sender proceed (they'll supersede
+    // the stale session via createOutboundSession's revocation logic).
+    const sessionOwner =
+      existingSession.expectedExternalUserId ?? existingSession.expectedChatId;
+    if (
+      sessionOwner === rawSenderId ||
+      sessionOwner === conversationExternalId
+    ) {
+      if (replyCallbackUrl) {
+        deliverChannelReply(
+          replyCallbackUrl,
+          {
+            chatId: conversationExternalId,
+            text: "A verification is already in progress. Check your assistant app for the code and enter it here.",
+            assistantId,
+          },
+          mintBearerToken(),
+        ).catch((err) => {
+          log.error(
+            { err, sourceChannel, conversationExternalId },
+            "Failed to deliver guardian activation idempotency reply",
+          );
+        });
+      }
+      return Response.json({ accepted: true, guardianActivationPending: true });
     }
-    return Response.json({ accepted: true, guardianActivationPending: true });
   }
 
   // ── Create verification session ──

--- a/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.ts
@@ -143,6 +143,7 @@ export async function handleGuardianActivationIntercept(
           );
         });
       }
+      markProcessed(externalMessageId);
       return Response.json({ accepted: true, guardianActivationPending: true });
     }
   }

--- a/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.ts
@@ -47,15 +47,17 @@ export interface GuardianActivationInterceptParams {
 const DEDUP_TTL_MS = 60_000;
 const processedMessageIds = new Map<string, number>();
 
-function isDuplicateActivation(messageId: string): boolean {
+function isAlreadyProcessed(messageId: string): boolean {
   const now = Date.now();
   // Evict stale entries
   for (const [key, ts] of processedMessageIds) {
     if (now - ts > DEDUP_TTL_MS) processedMessageIds.delete(key);
   }
-  if (processedMessageIds.has(messageId)) return true;
-  processedMessageIds.set(messageId, now);
-  return false;
+  return processedMessageIds.has(messageId);
+}
+
+function markProcessed(messageId: string): void {
+  processedMessageIds.set(messageId, Date.now());
 }
 
 export async function handleGuardianActivationIntercept(
@@ -107,7 +109,9 @@ export async function handleGuardianActivationIntercept(
   // ── Webhook retry dedup ──
   // The intercept runs before recordInbound, so use a lightweight in-memory
   // dedup to prevent duplicate replies when Telegram retries the webhook.
-  if (isDuplicateActivation(externalMessageId)) {
+  // Only checked here; marked as processed after successful session creation
+  // so transient failures remain retryable.
+  if (isAlreadyProcessed(externalMessageId)) {
     return Response.json({ accepted: true, guardianActivation: true });
   }
 
@@ -152,6 +156,10 @@ export async function handleGuardianActivationIntercept(
     destinationAddress: conversationExternalId,
     verificationPurpose: "guardian",
   });
+
+  // Mark as processed only after session creation succeeds so transient
+  // failures (e.g. temporary DB issues) remain retryable on the next webhook.
+  markProcessed(externalMessageId);
 
   // ── Send deterministic Telegram reply ──
   if (replyCallbackUrl) {


### PR DESCRIPTION
## Summary
When a user sends bare `/start` in Telegram and no guardian has been verified for the Telegram channel, the system now automatically creates a guardian verification session, sends a deterministic reply in Telegram asking the user to enter a code, and delivers the code to the macOS app via notification signal. This enables a seamless setup flow where the first user to `/start` the bot can immediately become the Telegram guardian.

## PRs merged into feature branch
- #23255: Add `guardian.channel_activation` notification signal type for auto-activation code delivery
- #23258: Auto-initiate guardian verification on bare `/start` when no channel guardian exists

Part of plan: tg-start-guardian-activation.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
