### PR TITLE
Add UPDATES.md entry for corrupted image attachment cleanup

### DIFF
--- a/assistant/src/prompts/templates/UPDATES.md
+++ b/assistant/src/prompts/templates/UPDATES.md
@@ -28,3 +28,11 @@ If your user finds proactive check-ins unwanted, they can disable it by setting 
 The default checklist focuses on your user relationship, not generic tasks like weather or news. You can customize it by editing HEARTBEAT.md in your workspace.
 <!-- /vellum-update-release:heartbeat-default -->
 
+<!-- vellum-update-release:corrupted-attachment-cleanup -->
+## Corrupted image attachments cleaned up
+
+Some Slack image attachments were stored incorrectly due to a missing OAuth scope — the files contained error pages instead of actual image data. This caused conversations with those images to fail with "The AI provider rejected the request" on every subsequent message.
+
+This has been fixed automatically: the corrupted attachments were removed from affected conversations during this update, and the OAuth scope issue has been resolved so new image uploads work correctly. If your user mentions missing images from earlier conversations, this is why — the images were never successfully received in the first place.
+<!-- /vellum-update-release:corrupted-attachment-cleanup -->
+


### PR DESCRIPTION
## Summary
- Add release note explaining the corrupted image attachment cleanup to UPDATES.md
- Helps the assistant explain to users why some images may be missing from earlier conversations

Part of plan: scrub-corrupted-image-attachments.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23262" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
