### PR TITLE
fix: use client platform instead of daemon platform for macOS prompt …

### DIFF
--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -457,6 +457,8 @@ export interface SkillProjectionContext {
   };
   /** True when no client is connected (HTTP-only). */
   readonly hasNoClient?: boolean;
+  /** True when the connected client is a macOS or iOS app. */
+  readonly clientIsMacOS?: boolean;
 }
 
 // ── Conditional tool sets ────────────────────────────────────────────
@@ -495,7 +497,7 @@ export function isToolActiveForContext(
     return !ctx.hasNoClient;
   }
   if (PLATFORM_TOOL_NAMES.has(name)) {
-    return process.platform === "darwin" && !ctx.hasNoClient;
+    return (ctx.clientIsMacOS ?? process.platform === "darwin") && !ctx.hasNoClient;
   }
   return true;
 }

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -174,6 +174,10 @@ export class Conversation {
   /** @internal */ contextCompactedAt: number | null = null;
   /** @internal */ currentRequestId?: string;
   /** @internal */ hasNoClient = false;
+  /** @internal */ get clientIsMacOS(): boolean {
+    const iface = this.currentTurnInterfaceContext?.userMessageInterface;
+    return iface === "macos" || iface === "ios";
+  }
   /** @internal */ headlessLock = false;
   /** @internal */ taskRunId?: string;
   /** @internal */ callSessionId?: string;
@@ -391,8 +395,12 @@ export class Conversation {
                 this.currentTurnTrustContext,
                 this.currentTurnChannelCapabilities,
               );
+              const clientInterface =
+                this.currentTurnInterfaceContext?.userMessageInterface;
               return buildSystemPrompt({
                 hasNoClient: this.hasNoClient,
+                clientIsMacOS:
+                  clientInterface === "macos" || clientInterface === "ios",
                 userPersona: persona.userPersona,
                 channelPersona: persona.channelPersona,
                 userSlug: persona.userSlug,

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -161,6 +161,8 @@ export function ensurePromptFiles(): void {
  */
 export interface BuildSystemPromptOptions {
   hasNoClient?: boolean;
+  /** True when the connected client is a macOS or iOS app (host supports osascript). */
+  clientIsMacOS?: boolean;
   excludeBootstrap?: boolean;
   userPersona?: string | null;
   channelPersona?: string | null;
@@ -177,6 +179,7 @@ export interface BuildSystemPromptOptions {
  */
 export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   const hasNoClient = options?.hasNoClient ?? false;
+  const clientIsMacOS = options?.clientIsMacOS ?? isMacOS();
 
   // ── Static instruction sections (stable across turns) ──
   // These sections are deterministic within a process lifetime.  They form
@@ -192,7 +195,7 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   staticParts.push(buildInChatConfigurationSection());
   // System Permissions section removed — guidance lives in request_system_permission tool description.
   // Parallel Task Orchestration section removed — orchestration skill description + hints cover this.
-  staticParts.push(buildAccessPreferenceSection(hasNoClient));
+  staticParts.push(buildAccessPreferenceSection(hasNoClient, clientIsMacOS));
   staticParts.push(buildCredentialSecuritySection());
   // Memory Persistence, Memory Recall, Workspace Reflection, Learning from Mistakes
   // sections removed — guidance lives in memory_manage/memory_recall tool descriptions
@@ -306,7 +309,10 @@ function buildInChatConfigurationSection(): string {
   ].join("\n");
 }
 
-function buildAccessPreferenceSection(hasNoClient: boolean): string {
+function buildAccessPreferenceSection(
+  hasNoClient: boolean,
+  clientIsMacOS: boolean,
+): string {
   if (hasNoClient) {
     return [
       "## External Service Access",
@@ -319,7 +325,7 @@ function buildAccessPreferenceSection(hasNoClient: boolean): string {
     "## External Service Access",
     "",
     "Priority: (1) sandbox `bash` - install tools yourself, only fall back to host when you need local files/auth; (2) `host_bash` with CLIs (gh, aws, etc.) using --json flags; (3) browser automation as last resort (no API, visual interaction, or OAuth consent).",
-    ...(isMacOS()
+    ...(clientIsMacOS
       ? [
           "",
           "On macOS, prefer osascript/CLI via `host_bash` over computer use tools, which take over the user's cursor. Use foreground computer use only when no scripting alternative exists or the user explicitly asks.",


### PR DESCRIPTION
…hints

On platform-hosted assistants (Linux), the system prompt's macOS hint about preferring osascript via host_bash was never included because it checked the daemon's process.platform. Similarly, request_system_permission was gated on the daemon being macOS. Both now check the connected client's interface (macos/ios) instead, so platform-hosted assistants with macOS desktop clients get the correct behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
