### PR TITLE
Add DB migration to scrub HTML-as-image corrupted attachments

### DIFF
--- a/assistant/src/__tests__/scrub-corrupted-image-attachments.test.ts
+++ b/assistant/src/__tests__/scrub-corrupted-image-attachments.test.ts
@@ -1,0 +1,278 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { migrateScrubCorruptedImageAttachments } from "../memory/migrations/206-scrub-corrupted-image-attachments.js";
+import * as schema from "../memory/schema.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  sqlite.exec("PRAGMA foreign_keys = OFF");
+  return drizzle(sqlite, { schema });
+}
+
+type TestDb = ReturnType<typeof createTestDb>;
+
+function getRawSqlite(db: TestDb): Database {
+  return (db as unknown as { $client: Database }).$client;
+}
+
+function createRequiredTables(raw: Database) {
+  raw.exec(/*sql*/ `
+    CREATE TABLE memory_checkpoints (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  raw.exec(/*sql*/ `
+    CREATE TABLE attachments (
+      id TEXT PRIMARY KEY,
+      original_filename TEXT NOT NULL,
+      mime_type TEXT NOT NULL,
+      size_bytes INTEGER NOT NULL,
+      kind TEXT NOT NULL,
+      data_base64 TEXT NOT NULL DEFAULT '',
+      content_hash TEXT,
+      thumbnail_base64 TEXT,
+      file_path TEXT,
+      created_at INTEGER NOT NULL
+    )
+  `);
+
+  raw.exec(/*sql*/ `
+    CREATE TABLE message_attachments (
+      id TEXT PRIMARY KEY,
+      message_id TEXT NOT NULL,
+      attachment_id TEXT NOT NULL,
+      position INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL
+    )
+  `);
+}
+
+// A minimal valid PNG header (8 bytes)
+const VALID_PNG_BASE64 = Buffer.from(
+  Uint8Array.from([137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 0]),
+).toString("base64");
+
+// HTML error page encoded as base64 (simulating Slack CDN auth failure)
+const HTML_ERROR_BASE64 = Buffer.from(
+  "<!DOCTYPE html><html><head><title>Sign in</title></head><body>Please sign in</body></html>",
+).toString("base64");
+
+// HTML with leading whitespace/BOM
+const HTML_WITH_BOM_BASE64 = Buffer.from(
+  "\uFEFF  <!DOCTYPE html><html><body>Error</body></html>",
+).toString("base64");
+
+const HTML_UPPERCASE_BASE64 = Buffer.from(
+  "<HTML><BODY>Error page</BODY></HTML>",
+).toString("base64");
+
+describe("migrateScrubCorruptedImageAttachments", () => {
+  test("removes corrupted image attachment with HTML data_base64", () => {
+    const db = createTestDb();
+    const raw = getRawSqlite(db);
+    const now = Date.now();
+
+    createRequiredTables(raw);
+
+    // Insert corrupted attachment (HTML stored as image/png)
+    raw.exec(/*sql*/ `
+      INSERT INTO attachments (id, original_filename, mime_type, size_bytes, kind, data_base64, created_at)
+      VALUES ('corrupt-1', 'image.png', 'image/png', 100, 'image', '${HTML_ERROR_BASE64}', ${now})
+    `);
+
+    // Insert message_attachments link
+    raw.exec(/*sql*/ `
+      INSERT INTO message_attachments (id, message_id, attachment_id, position, created_at)
+      VALUES ('ma-1', 'msg-1', 'corrupt-1', 0, ${now})
+    `);
+
+    migrateScrubCorruptedImageAttachments(db);
+
+    const attachmentCount = raw
+      .query(`SELECT COUNT(*) AS count FROM attachments`)
+      .get() as { count: number };
+    expect(attachmentCount.count).toBe(0);
+
+    const linkCount = raw
+      .query(`SELECT COUNT(*) AS count FROM message_attachments`)
+      .get() as { count: number };
+    expect(linkCount.count).toBe(0);
+  });
+
+  test("does NOT remove valid PNG attachment", () => {
+    const db = createTestDb();
+    const raw = getRawSqlite(db);
+    const now = Date.now();
+
+    createRequiredTables(raw);
+
+    // Insert valid PNG attachment
+    raw.exec(/*sql*/ `
+      INSERT INTO attachments (id, original_filename, mime_type, size_bytes, kind, data_base64, created_at)
+      VALUES ('valid-1', 'photo.png', 'image/png', 200, 'image', '${VALID_PNG_BASE64}', ${now})
+    `);
+
+    raw.exec(/*sql*/ `
+      INSERT INTO message_attachments (id, message_id, attachment_id, position, created_at)
+      VALUES ('ma-valid', 'msg-2', 'valid-1', 0, ${now})
+    `);
+
+    migrateScrubCorruptedImageAttachments(db);
+
+    const attachmentCount = raw
+      .query(`SELECT COUNT(*) AS count FROM attachments`)
+      .get() as { count: number };
+    expect(attachmentCount.count).toBe(1);
+
+    const linkCount = raw
+      .query(`SELECT COUNT(*) AS count FROM message_attachments`)
+      .get() as { count: number };
+    expect(linkCount.count).toBe(1);
+  });
+
+  test("removes corrupted and preserves valid attachments together", () => {
+    const db = createTestDb();
+    const raw = getRawSqlite(db);
+    const now = Date.now();
+
+    createRequiredTables(raw);
+
+    // Corrupted attachment
+    raw.exec(/*sql*/ `
+      INSERT INTO attachments (id, original_filename, mime_type, size_bytes, kind, data_base64, created_at)
+      VALUES ('corrupt-1', 'slack-img.png', 'image/png', 100, 'image', '${HTML_ERROR_BASE64}', ${now})
+    `);
+    raw.exec(/*sql*/ `
+      INSERT INTO message_attachments (id, message_id, attachment_id, position, created_at)
+      VALUES ('ma-corrupt', 'msg-1', 'corrupt-1', 0, ${now})
+    `);
+
+    // Valid attachment
+    raw.exec(/*sql*/ `
+      INSERT INTO attachments (id, original_filename, mime_type, size_bytes, kind, data_base64, created_at)
+      VALUES ('valid-1', 'photo.png', 'image/png', 200, 'image', '${VALID_PNG_BASE64}', ${now})
+    `);
+    raw.exec(/*sql*/ `
+      INSERT INTO message_attachments (id, message_id, attachment_id, position, created_at)
+      VALUES ('ma-valid', 'msg-2', 'valid-1', 0, ${now})
+    `);
+
+    migrateScrubCorruptedImageAttachments(db);
+
+    const remaining = raw.query(`SELECT id FROM attachments`).all() as Array<{
+      id: string;
+    }>;
+    expect(remaining).toEqual([{ id: "valid-1" }]);
+
+    const links = raw
+      .query(`SELECT attachment_id FROM message_attachments`)
+      .all() as Array<{ attachment_id: string }>;
+    expect(links).toEqual([{ attachment_id: "valid-1" }]);
+  });
+
+  test("detects HTML with leading BOM and whitespace", () => {
+    const db = createTestDb();
+    const raw = getRawSqlite(db);
+    const now = Date.now();
+
+    createRequiredTables(raw);
+
+    raw.exec(/*sql*/ `
+      INSERT INTO attachments (id, original_filename, mime_type, size_bytes, kind, data_base64, created_at)
+      VALUES ('bom-1', 'img.jpg', 'image/jpeg', 50, 'image', '${HTML_WITH_BOM_BASE64}', ${now})
+    `);
+
+    migrateScrubCorruptedImageAttachments(db);
+
+    const count = raw
+      .query(`SELECT COUNT(*) AS count FROM attachments`)
+      .get() as { count: number };
+    expect(count.count).toBe(0);
+  });
+
+  test("detects uppercase <HTML> tag", () => {
+    const db = createTestDb();
+    const raw = getRawSqlite(db);
+    const now = Date.now();
+
+    createRequiredTables(raw);
+
+    raw.exec(/*sql*/ `
+      INSERT INTO attachments (id, original_filename, mime_type, size_bytes, kind, data_base64, created_at)
+      VALUES ('upper-1', 'img.gif', 'image/gif', 50, 'image', '${HTML_UPPERCASE_BASE64}', ${now})
+    `);
+
+    migrateScrubCorruptedImageAttachments(db);
+
+    const count = raw
+      .query(`SELECT COUNT(*) AS count FROM attachments`)
+      .get() as { count: number };
+    expect(count.count).toBe(0);
+  });
+
+  test("is idempotent — running twice does not error", () => {
+    const db = createTestDb();
+    const raw = getRawSqlite(db);
+    const now = Date.now();
+
+    createRequiredTables(raw);
+
+    raw.exec(/*sql*/ `
+      INSERT INTO attachments (id, original_filename, mime_type, size_bytes, kind, data_base64, created_at)
+      VALUES ('corrupt-1', 'image.png', 'image/png', 100, 'image', '${HTML_ERROR_BASE64}', ${now})
+    `);
+    raw.exec(/*sql*/ `
+      INSERT INTO message_attachments (id, message_id, attachment_id, position, created_at)
+      VALUES ('ma-1', 'msg-1', 'corrupt-1', 0, ${now})
+    `);
+
+    migrateScrubCorruptedImageAttachments(db);
+    migrateScrubCorruptedImageAttachments(db);
+
+    const attachmentCount = raw
+      .query(`SELECT COUNT(*) AS count FROM attachments`)
+      .get() as { count: number };
+    expect(attachmentCount.count).toBe(0);
+
+    const linkCount = raw
+      .query(`SELECT COUNT(*) AS count FROM message_attachments`)
+      .get() as { count: number };
+    expect(linkCount.count).toBe(0);
+
+    // The checkpoint should be set to '1' (completed)
+    const checkpoint = raw
+      .query(
+        `SELECT value FROM memory_checkpoints WHERE key = 'migration_scrub_corrupted_image_attachments_v1'`,
+      )
+      .get() as { value: string } | null;
+    expect(checkpoint?.value).toBe("1");
+  });
+
+  test("skips non-image MIME types", () => {
+    const db = createTestDb();
+    const raw = getRawSqlite(db);
+    const now = Date.now();
+
+    createRequiredTables(raw);
+
+    // HTML content with text/html MIME type — should NOT be touched
+    raw.exec(/*sql*/ `
+      INSERT INTO attachments (id, original_filename, mime_type, size_bytes, kind, data_base64, created_at)
+      VALUES ('html-1', 'page.html', 'text/html', 100, 'document', '${HTML_ERROR_BASE64}', ${now})
+    `);
+
+    migrateScrubCorruptedImageAttachments(db);
+
+    const count = raw
+      .query(`SELECT COUNT(*) AS count FROM attachments`)
+      .get() as { count: number };
+    expect(count.count).toBe(1);
+  });
+});

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -129,6 +129,7 @@ import {
   migrateScheduleOneShotRouting,
   migrateScheduleQuietFlag,
   migrateSchemaIndexesAndColumns,
+  migrateScrubCorruptedImageAttachments,
   migrateStripIntegrationPrefixFromProviderKeys,
   migrateUsageDashboardIndexes,
   migrateUsageLlmCallCount,
@@ -581,6 +582,9 @@ export function initializeDb(): void {
 
   // 104. Memory graph node edit history
   migrateCreateMemoryGraphNodeEdits(database);
+
+  // 105. Remove image attachments containing HTML error pages instead of image data
+  migrateScrubCorruptedImageAttachments(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/206-scrub-corrupted-image-attachments.ts
+++ b/assistant/src/memory/migrations/206-scrub-corrupted-image-attachments.ts
@@ -1,0 +1,132 @@
+import { readFileSync, unlinkSync } from "node:fs";
+
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+/**
+ * Remove image attachments that contain HTML error pages instead of actual
+ * image data. This can happen when a CDN (e.g. Slack) returns an HTML sign-in
+ * page due to a missing OAuth scope, and the gateway stores the response body
+ * as an image attachment.
+ *
+ * Handles both inline (data_base64) and on-disk (file_path) storage.
+ */
+
+const HTML_MARKERS = ["<!doctype", "<html"];
+
+function looksLikeHtml(bytes: Buffer): boolean {
+  // Strip leading BOM / whitespace
+  const text = bytes.toString("utf-8").trimStart().toLowerCase();
+  return HTML_MARKERS.some((marker) => text.startsWith(marker));
+}
+
+export function migrateScrubCorruptedImageAttachments(
+  database: DrizzleDb,
+): void {
+  withCrashRecovery(
+    database,
+    "migration_scrub_corrupted_image_attachments_v1",
+    () => {
+      const raw = getSqliteFrom(database);
+
+      function deleteCorruptedAttachment(
+        id: string,
+        filePath: string | null,
+      ): void {
+        raw
+          .query(`DELETE FROM message_attachments WHERE attachment_id = ?`)
+          .run(id);
+        raw.query(`DELETE FROM attachments WHERE id = ?`).run(id);
+
+        if (filePath) {
+          try {
+            unlinkSync(filePath);
+          } catch {
+            // File already missing — ignore
+          }
+        }
+
+        console.log(
+          `[scrub-corrupted-attachments] Removed corrupted attachment ${id}`,
+        );
+      }
+
+      // Step A — Find and remove corrupted attachments stored inline (data_base64)
+      // Process in batches, deleting corrupted rows immediately so the LIMIT
+      // query advances through the table.
+      const BATCH_SIZE = 100;
+      for (;;) {
+        const rows = raw
+          .query(
+            `SELECT id, data_base64, file_path FROM attachments
+             WHERE mime_type LIKE 'image/%'
+               AND data_base64 IS NOT NULL
+               AND data_base64 != ''
+             LIMIT ?`,
+          )
+          .all(BATCH_SIZE) as Array<{
+          id: string;
+          data_base64: string;
+          file_path: string | null;
+        }>;
+
+        if (rows.length === 0) break;
+
+        let deletedAny = false;
+        for (const row of rows) {
+          try {
+            const decoded = Buffer.from(
+              row.data_base64.slice(0, 200),
+              "base64",
+            );
+            if (looksLikeHtml(decoded)) {
+              deleteCorruptedAttachment(row.id, row.file_path);
+              deletedAny = true;
+            }
+          } catch {
+            // Skip rows with invalid base64
+          }
+        }
+
+        // If no corrupted rows were found (and deleted) in this batch, every
+        // remaining image attachment with inline data is valid — stop scanning.
+        if (!deletedAny) break;
+      }
+
+      // Step B — Find and remove corrupted attachments stored on disk (file_path)
+      // Disk-backed attachments are typically fewer; query all at once.
+      const diskRows = raw
+        .query(
+          `SELECT id, file_path FROM attachments
+           WHERE mime_type LIKE 'image/%'
+             AND file_path IS NOT NULL
+             AND (data_base64 IS NULL OR data_base64 = '')`,
+        )
+        .all() as Array<{ id: string; file_path: string }>;
+
+      for (const row of diskRows) {
+        try {
+          const bytes = readFileSync(row.file_path);
+          const head = bytes.subarray(0, 100);
+          if (looksLikeHtml(head)) {
+            deleteCorruptedAttachment(row.id, row.file_path);
+          }
+        } catch {
+          // File doesn't exist or can't be read — skip
+        }
+      }
+    },
+  );
+}
+
+/**
+ * Reverse: no-op.
+ *
+ * Corrupted data (HTML stored as image) has no value to restore.
+ */
+export function migrateScrubCorruptedImageAttachmentsDown(
+  _database: DrizzleDb,
+): void {
+  // No-op — corrupted data (HTML stored as image) has no value to restore.
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -147,6 +147,7 @@ export { migrateDropMemoryItemsTables } from "./203-drop-memory-items-tables.js"
 export { migrateRenameMemoryGraphTypeValues } from "./204-rename-memory-graph-type-values.js";
 export { migrateMemoryGraphImageRefs } from "./205-memory-graph-image-refs.js";
 export { migrateCreateMemoryGraphNodeEdits } from "./206-memory-graph-node-edits.js";
+export { migrateScrubCorruptedImageAttachments } from "./206-scrub-corrupted-image-attachments.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -40,6 +40,7 @@ import { migrateBackfillAudioAttachmentMimeTypesDown } from "./191-backfill-audi
 import { migrateAddSourceTypeColumnsDown } from "./193-add-source-type-columns.js";
 import { migrateStripIntegrationPrefixFromProviderKeysDown } from "./196-strip-integration-prefix-from-provider-keys.js";
 import { migrateRenameMemoryGraphTypeValuesDown } from "./204-rename-memory-graph-type-values.js";
+import { migrateScrubCorruptedImageAttachmentsDown } from "./206-scrub-corrupted-image-attachments.js";
 
 export interface MigrationRegistryEntry {
   /** The checkpoint key written to memory_checkpoints on completion. */
@@ -348,6 +349,13 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Rename legacy memory graph node type values: style → behavioral, relationship → semantic",
     down: migrateRenameMemoryGraphTypeValuesDown,
+  },
+  {
+    key: "migration_scrub_corrupted_image_attachments_v1",
+    version: 40,
+    description:
+      "Remove image attachments containing HTML error pages instead of image data",
+    down: migrateScrubCorruptedImageAttachmentsDown,
   },
 ];
 


### PR DESCRIPTION
## Summary
- Add a startup migration that finds image attachments containing HTML error pages (from Slack CDN auth failures) and removes them
- Cleans up both inline DB storage and on-disk files, along with message_attachments links
- Crash-safe via withCrashRecovery, idempotent, batched processing
- Includes tests for corrupted/valid attachment handling and idempotency

Part of plan: scrub-corrupted-image-attachments.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
