### PR TITLE
fix: use rowid cursor for inline attachment scan

### DIFF
--- a/assistant/src/memory/migrations/206-scrub-corrupted-image-attachments.ts
+++ b/assistant/src/memory/migrations/206-scrub-corrupted-image-attachments.ts
@@ -53,19 +53,23 @@ export function migrateScrubCorruptedImageAttachments(
       }
 
       // Step A — Find and remove corrupted attachments stored inline (data_base64)
-      // Process in batches, deleting corrupted rows immediately so the LIMIT
-      // query advances through the table.
+      // Process in batches using rowid cursor to ensure all rows are scanned
+      // even when corrupted rows are non-contiguous.
       const BATCH_SIZE = 100;
+      let lastRowid = 0;
       for (;;) {
         const rows = raw
           .query(
-            `SELECT id, data_base64, file_path FROM attachments
+            `SELECT rowid, id, data_base64, file_path FROM attachments
              WHERE mime_type LIKE 'image/%'
                AND data_base64 IS NOT NULL
                AND data_base64 != ''
+               AND rowid > ?
+             ORDER BY rowid
              LIMIT ?`,
           )
-          .all(BATCH_SIZE) as Array<{
+          .all(lastRowid, BATCH_SIZE) as Array<{
+          rowid: number;
           id: string;
           data_base64: string;
           file_path: string | null;
@@ -73,8 +77,8 @@ export function migrateScrubCorruptedImageAttachments(
 
         if (rows.length === 0) break;
 
-        let deletedAny = false;
         for (const row of rows) {
+          lastRowid = row.rowid;
           try {
             const decoded = Buffer.from(
               row.data_base64.slice(0, 200),
@@ -82,16 +86,11 @@ export function migrateScrubCorruptedImageAttachments(
             );
             if (looksLikeHtml(decoded)) {
               deleteCorruptedAttachment(row.id, row.file_path);
-              deletedAny = true;
             }
           } catch {
             // Skip rows with invalid base64
           }
         }
-
-        // If no corrupted rows were found (and deleted) in this batch, every
-        // remaining image attachment with inline data is valid — stop scanning.
-        if (!deletedAny) break;
       }
 
       // Step B — Find and remove corrupted attachments stored on disk (file_path)


### PR DESCRIPTION
## Summary
Fixes a bug where the batch scan would exit early if a batch of 100 valid attachments was encountered before reaching subsequent corrupted ones. Now uses rowid-based cursor pagination to guarantee all rows are scanned.

**Gap:** Batching early-exit can miss corrupted rows
**What was expected:** All corrupted inline attachments are found regardless of position
**What was found:** `if (!deletedAny) break` exits after first clean batch
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
