### PR TITLE
wake local docker builds

### DIFF
--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -805,6 +805,9 @@ function affectedServices(
  * images and restart their containers.
  */
 function startFileWatcher(opts: {
+  signingKey?: string;
+  bootstrapSecret?: string;
+  cesServiceToken?: string;
   gatewayPort: number;
   imageTags: Record<ServiceName, string>;
   instanceName: string;
@@ -826,6 +829,9 @@ function startFileWatcher(opts: {
 
   const configs = serviceImageConfigs(repoRoot, imageTags);
   const runArgs = serviceDockerRunArgs({
+    signingKey: opts.signingKey,
+    bootstrapSecret: opts.bootstrapSecret,
+    cesServiceToken: opts.cesServiceToken,
     gatewayPort,
     imageTags,
     instanceName,
@@ -1106,6 +1112,9 @@ export async function hatchDocker(
       saveAssistantEntry({ ...dockerEntry, watcherPid: process.pid });
 
       const stopWatcher = startFileWatcher({
+        signingKey,
+        bootstrapSecret,
+        cesServiceToken,
         gatewayPort,
         imageTags,
         instanceName,

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -53,14 +53,14 @@ public final class GatewayConnectionManager: ObservableObject {
     // MARK: - Connection State (internal)
 
     /// Whether auto-wake should be attempted on disconnect.
-    /// Only applies to local assistants (not remote, Docker, or managed).
+    /// Applies to local and Docker assistants (not remote or managed).
     private var isLocal: Bool {
         #if os(macOS)
         guard let id = UserDefaults.standard.string(forKey: "connectedAssistantId"),
               let assistant = LockfileAssistant.loadByName(id) else {
             return false
         }
-        return !assistant.isRemote && !assistant.isManaged
+        return (!assistant.isRemote || assistant.isDocker) && !assistant.isManaged
         #else
         return false
         #endif


### PR DESCRIPTION
Match bare metal assistant behavior, and wake local docker assistants when reopening desktop app

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
