### PR TITLE
Cherry-pick fixes onto release/v0.6.0

### DIFF
--- a/assistant/src/notifications/adapters/macos.ts
+++ b/assistant/src/notifications/adapters/macos.ts
@@ -37,6 +37,7 @@ const GUARDIAN_SENSITIVE_EVENT_PREFIXES = [
   "guardian.question",
   "ingress.escalation",
   "ingress.access_request",
+  "guardian.channel_activation",
 ] as const;
 
 export function isGuardianSensitiveEvent(sourceEventName: string): boolean {

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -353,6 +353,15 @@ const TEMPLATES: Partial<Record<NotificationSourceEventName, CopyTemplate>> = {
     };
   },
 
+  "guardian.channel_activation": (payload) => {
+    const code = str(payload.verificationCode, "------");
+    const channel = str(payload.sourceChannel, "a channel");
+    return {
+      title: "Guardian Verification Code",
+      body: `Your ${channel} verification code is: ${code}\n\nEnter this code in your ${channel} chat to verify your identity as guardian.`,
+    };
+  },
+
   "ingress.access_request": (payload) => ({
     title: "Access Request",
     body: buildAccessRequestContractText(payload),

--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -46,6 +46,11 @@ export const NOTIFICATION_SOURCE_EVENT_NAMES = [
     id: "guardian.question",
     description: "Guardian approval question requiring response",
   },
+  {
+    id: "guardian.channel_activation",
+    description:
+      "Guardian channel activation code delivered for /start verification",
+  },
   { id: "ingress.access_request", description: "Non-member requesting access" },
   {
     id: "ingress.access_request.callback_handoff",
@@ -155,9 +160,20 @@ export interface AccessRequestContextPayload {
   messagePreview: string | null;
 }
 
+export interface GuardianChannelActivationPayload {
+  verificationCode: string;
+  sourceChannel: string;
+  actorExternalId: string;
+  actorDisplayName: string | null;
+  actorUsername: string | null;
+  sessionId: string;
+  expiresAt: number;
+}
+
 export interface NotificationEventContextPayloadMap {
   "guardian.question": GuardianQuestionPayload;
   "ingress.access_request": AccessRequestContextPayload;
+  "guardian.channel_activation": GuardianChannelActivationPayload;
 }
 
 export type NotificationContextPayload<TEventName extends string = string> =

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -44,6 +44,7 @@ import { processChannelMessageInBackground } from "./inbound-stages/background-d
 import { handleBootstrapIntercept } from "./inbound-stages/bootstrap-intercept.js";
 import { handleEditIntercept } from "./inbound-stages/edit-intercept.js";
 import { handleEscalationIntercept } from "./inbound-stages/escalation-intercept.js";
+import { handleGuardianActivationIntercept } from "./inbound-stages/guardian-activation-intercept.js";
 import { handleGuardianReplyIntercept } from "./inbound-stages/guardian-reply-intercept.js";
 import { runSecretIngressCheck } from "./inbound-stages/secret-ingress-check.js";
 import { tryTranscribeAudioAttachments } from "./inbound-stages/transcribe-audio.js";
@@ -198,6 +199,24 @@ export async function handleChannelInbound(
   // represents an explicit (malformed) identity claim that must enter the
   // ACL deny path rather than bypassing it.
   const hasSenderIdentityClaim = rawSenderId !== undefined;
+
+  // ── Guardian channel activation ──
+  // When a bare /start arrives on a channel with no guardian, auto-initiate
+  // guardian verification so the first user can claim the channel.
+  const guardianActivationResponse = await handleGuardianActivationIntercept({
+    sourceChannel,
+    conversationExternalId,
+    rawSenderId,
+    canonicalSenderId,
+    actorDisplayName: body.actorDisplayName,
+    actorUsername: body.actorUsername,
+    sourceMetadata: body.sourceMetadata,
+    replyCallbackUrl: body.replyCallbackUrl,
+    mintBearerToken,
+    assistantId,
+    externalMessageId,
+  });
+  if (guardianActivationResponse) return guardianActivationResponse;
 
   // ── Ingress ACL enforcement ──
   const aclResult = await enforceIngressAcl({

--- a/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.test.ts
@@ -1,0 +1,292 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be set up before importing the module under test
+// ---------------------------------------------------------------------------
+
+let mockGuardian: { contact: unknown; channel: unknown } | null = null;
+let mockActiveSession: Record<string, unknown> | null = null;
+let mockSessionResult = {
+  sessionId: "sess-1",
+  secret: "123456",
+  challengeHash: "hash-1",
+  expiresAt: Date.now() + 600_000,
+  ttlSeconds: 600,
+};
+
+// Track calls manually to avoid TypeScript issues with mock() generics
+let createOutboundSessionCalls: unknown[] = [];
+let deliverChannelReplyCalls: unknown[][] = [];
+let emitNotificationSignalCalls: unknown[] = [];
+let messageIdCounter = 0;
+
+mock.module("../../../contacts/contact-store.js", () => ({
+  findGuardianForChannel: () => mockGuardian,
+}));
+
+mock.module("../../channel-verification-service.js", () => ({
+  createOutboundSession: (params: unknown) => {
+    createOutboundSessionCalls.push(params);
+    return mockSessionResult;
+  },
+  findActiveSession: () => mockActiveSession,
+}));
+
+mock.module("../../gateway-client.js", () => ({
+  deliverChannelReply: (url: unknown, payload: unknown, token: unknown) => {
+    deliverChannelReplyCalls.push([url, payload, token]);
+    return Promise.resolve({ ok: true });
+  },
+}));
+
+mock.module("../../../notifications/emit-signal.js", () => ({
+  emitNotificationSignal: (params: unknown) => {
+    emitNotificationSignalCalls.push(params);
+    return Promise.resolve({
+      signalId: "sig-1",
+      deduplicated: false,
+      dispatched: true,
+      reason: "ok",
+      deliveryResults: [],
+    });
+  },
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => ({
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  }),
+}));
+
+// Import after mocks are installed
+const { handleGuardianActivationIntercept } =
+  await import("./guardian-activation-intercept.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeParams(
+  overrides: Partial<
+    Parameters<typeof handleGuardianActivationIntercept>[0]
+  > = {},
+) {
+  messageIdCounter++;
+  return {
+    sourceChannel: "telegram" as const,
+    conversationExternalId: "chat-123",
+    rawSenderId: "user-42",
+    canonicalSenderId: "user-42",
+    actorDisplayName: "Alice",
+    actorUsername: "alice",
+    sourceMetadata: { commandIntent: { type: "start" } },
+    replyCallbackUrl: "https://gateway/reply",
+    mintBearerToken: () => "token-123",
+    assistantId: "self",
+    externalMessageId: `msg-${messageIdCounter}`,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("handleGuardianActivationIntercept", () => {
+  beforeEach(() => {
+    mockGuardian = null;
+    mockActiveSession = null;
+    mockSessionResult = {
+      sessionId: "sess-1",
+      secret: "123456",
+      challengeHash: "hash-1",
+      expiresAt: Date.now() + 600_000,
+      ttlSeconds: 600,
+    };
+    createOutboundSessionCalls = [];
+    deliverChannelReplyCalls = [];
+    emitNotificationSignalCalls = [];
+  });
+
+  afterEach(() => {
+    createOutboundSessionCalls = [];
+    deliverChannelReplyCalls = [];
+    emitNotificationSignalCalls = [];
+  });
+
+  test("bare /start with no guardian creates session and returns early", async () => {
+    const result = await handleGuardianActivationIntercept(makeParams());
+
+    expect(result).not.toBeNull();
+    const body = await result!.json();
+    expect(body).toEqual({ accepted: true, guardianActivation: true });
+
+    // Verify createOutboundSession was called with correct params
+    expect(createOutboundSessionCalls).toHaveLength(1);
+    expect(createOutboundSessionCalls[0]).toEqual({
+      channel: "telegram",
+      expectedExternalUserId: "user-42",
+      expectedChatId: "chat-123",
+      identityBindingStatus: "bound",
+      destinationAddress: "chat-123",
+      verificationPurpose: "guardian",
+    });
+
+    // Verify deliverChannelReply was called with the welcome/verify message
+    expect(deliverChannelReplyCalls).toHaveLength(1);
+    expect(deliverChannelReplyCalls[0][0]).toBe("https://gateway/reply");
+    expect(deliverChannelReplyCalls[0][1]).toEqual({
+      chatId: "chat-123",
+      text: "Welcome! To verify your identity as guardian, check your assistant app for a verification code and enter it here.",
+      assistantId: "self",
+    });
+
+    // Verify emitNotificationSignal was called with guardian.channel_activation
+    expect(emitNotificationSignalCalls).toHaveLength(1);
+    const signalArgs = emitNotificationSignalCalls[0] as Record<string, any>;
+    expect(signalArgs.sourceEventName).toBe("guardian.channel_activation");
+    expect(signalArgs.contextPayload.verificationCode).toBe("123456");
+    expect(signalArgs.contextPayload.sourceChannel).toBe("telegram");
+    expect(signalArgs.contextPayload.actorExternalId).toBe("user-42");
+    expect(signalArgs.contextPayload.sessionId).toBe("sess-1");
+    expect(signalArgs.dedupeKey).toBe("guardian-activation:sess-1");
+  });
+
+  test("bare /start with existing guardian returns null", async () => {
+    mockGuardian = {
+      contact: { id: "contact-1", role: "guardian" },
+      channel: { id: "ch-1", type: "telegram" },
+    };
+
+    const result = await handleGuardianActivationIntercept(makeParams());
+    expect(result).toBeNull();
+    expect(createOutboundSessionCalls).toHaveLength(0);
+  });
+
+  test("/start with payload returns null", async () => {
+    const result = await handleGuardianActivationIntercept(
+      makeParams({
+        sourceMetadata: {
+          commandIntent: { type: "start", payload: "gv_token" },
+        },
+      }),
+    );
+    expect(result).toBeNull();
+    expect(createOutboundSessionCalls).toHaveLength(0);
+  });
+
+  test("non-/start message returns null", async () => {
+    const result = await handleGuardianActivationIntercept(
+      makeParams({
+        sourceMetadata: { commandIntent: { type: "other" } },
+      }),
+    );
+    expect(result).toBeNull();
+    expect(createOutboundSessionCalls).toHaveLength(0);
+  });
+
+  test("no commandIntent returns null", async () => {
+    const result = await handleGuardianActivationIntercept(
+      makeParams({ sourceMetadata: {} }),
+    );
+    expect(result).toBeNull();
+
+    const result2 = await handleGuardianActivationIntercept(
+      makeParams({ sourceMetadata: undefined }),
+    );
+    expect(result2).toBeNull();
+    expect(createOutboundSessionCalls).toHaveLength(0);
+  });
+
+  test("non-telegram channel returns null", async () => {
+    const result = await handleGuardianActivationIntercept(
+      makeParams({ sourceChannel: "slack" as any }),
+    );
+    expect(result).toBeNull();
+    expect(createOutboundSessionCalls).toHaveLength(0);
+  });
+
+  test("missing sender ID returns null", async () => {
+    const result = await handleGuardianActivationIntercept(
+      makeParams({ rawSenderId: undefined }),
+    );
+    expect(result).toBeNull();
+    expect(createOutboundSessionCalls).toHaveLength(0);
+  });
+
+  test("existing active session from same sender sends 'already in progress' reply", async () => {
+    mockActiveSession = {
+      id: "existing-sess",
+      channel: "telegram",
+      status: "awaiting_response",
+      expectedExternalUserId: "user-42",
+      expectedChatId: "chat-123",
+    };
+
+    const result = await handleGuardianActivationIntercept(makeParams());
+
+    expect(result).not.toBeNull();
+    const body = await result!.json();
+    expect(body).toEqual({ accepted: true, guardianActivationPending: true });
+
+    // createOutboundSession should NOT be called
+    expect(createOutboundSessionCalls).toHaveLength(0);
+
+    // deliverChannelReply should be called with the "already in progress" message
+    expect(deliverChannelReplyCalls).toHaveLength(1);
+    expect(deliverChannelReplyCalls[0][1]).toEqual({
+      chatId: "chat-123",
+      text: "A verification is already in progress. Check your assistant app for the code and enter it here.",
+      assistantId: "self",
+    });
+
+    // emitNotificationSignal should NOT be called
+    expect(emitNotificationSignalCalls).toHaveLength(0);
+  });
+
+  test("existing active session from different sender allows superseding", async () => {
+    mockActiveSession = {
+      id: "existing-sess",
+      channel: "telegram",
+      status: "awaiting_response",
+      expectedExternalUserId: "user-OTHER",
+      expectedChatId: "chat-OTHER",
+    };
+
+    const result = await handleGuardianActivationIntercept(makeParams());
+
+    // Should proceed and create a new session (superseding the stale one)
+    expect(result).not.toBeNull();
+    const body = await result!.json();
+    expect(body).toEqual({ accepted: true, guardianActivation: true });
+    expect(createOutboundSessionCalls).toHaveLength(1);
+    expect(emitNotificationSignalCalls).toHaveLength(1);
+  });
+
+  test("duplicate webhook retry is silently deduped", async () => {
+    const params = makeParams({ externalMessageId: "dedup-test-msg" });
+
+    // First call should process normally
+    const result1 = await handleGuardianActivationIntercept(params);
+    expect(result1).not.toBeNull();
+    const body1 = await result1!.json();
+    expect(body1).toEqual({ accepted: true, guardianActivation: true });
+    expect(createOutboundSessionCalls).toHaveLength(1);
+    expect(deliverChannelReplyCalls).toHaveLength(1);
+    expect(emitNotificationSignalCalls).toHaveLength(1);
+
+    // Second call with same externalMessageId should be deduped
+    const result2 = await handleGuardianActivationIntercept(params);
+    expect(result2).not.toBeNull();
+    const body2 = await result2!.json();
+    expect(body2).toEqual({ accepted: true, guardianActivation: true });
+
+    // No additional session/reply/signal calls
+    expect(createOutboundSessionCalls).toHaveLength(1);
+    expect(deliverChannelReplyCalls).toHaveLength(1);
+    expect(emitNotificationSignalCalls).toHaveLength(1);
+  });
+});

--- a/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.ts
@@ -1,0 +1,207 @@
+/**
+ * Guardian activation intercept stage: when a bare /start arrives on a
+ * Telegram channel with no existing guardian, auto-initiate a verification
+ * session so the first user can claim the channel as guardian.
+ *
+ * This runs BEFORE ACL enforcement — a bare /start from an unknown user
+ * would otherwise be rejected. When the user subsequently enters the
+ * 6-digit code, the existing verification intercept validates it, creates
+ * the guardian binding, and sends a success reply.
+ */
+import type { ChannelId } from "../../../channels/types.js";
+import { findGuardianForChannel } from "../../../contacts/contact-store.js";
+import { emitNotificationSignal } from "../../../notifications/emit-signal.js";
+import type { NotificationSourceChannel } from "../../../notifications/signal.js";
+import { getLogger } from "../../../util/logger.js";
+import {
+  createOutboundSession,
+  findActiveSession,
+} from "../../channel-verification-service.js";
+import { deliverChannelReply } from "../../gateway-client.js";
+
+const log = getLogger("runtime-http");
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface GuardianActivationInterceptParams {
+  sourceChannel: ChannelId;
+  conversationExternalId: string;
+  rawSenderId: string | undefined;
+  canonicalSenderId: string | null;
+  actorDisplayName: string | undefined;
+  actorUsername: string | undefined;
+  sourceMetadata: Record<string, unknown> | undefined;
+  replyCallbackUrl: string | undefined;
+  mintBearerToken: () => string;
+  assistantId: string;
+  externalMessageId: string;
+}
+
+/**
+ * Lightweight dedup set for guardian activation intercepts.
+ * Prevents duplicate replies when Telegram retries the same webhook.
+ * Entries are evicted after DEDUP_TTL_MS to avoid unbounded growth.
+ */
+const DEDUP_TTL_MS = 60_000;
+const processedMessageIds = new Map<string, number>();
+
+function isAlreadyProcessed(messageId: string): boolean {
+  const now = Date.now();
+  // Evict stale entries
+  for (const [key, ts] of processedMessageIds) {
+    if (now - ts > DEDUP_TTL_MS) processedMessageIds.delete(key);
+  }
+  return processedMessageIds.has(messageId);
+}
+
+function markProcessed(messageId: string): void {
+  processedMessageIds.set(messageId, Date.now());
+}
+
+export async function handleGuardianActivationIntercept(
+  params: GuardianActivationInterceptParams,
+): Promise<Response | null> {
+  const {
+    sourceChannel,
+    conversationExternalId,
+    rawSenderId,
+    actorDisplayName,
+    actorUsername,
+    sourceMetadata,
+    replyCallbackUrl,
+    mintBearerToken,
+    assistantId,
+    externalMessageId,
+  } = params;
+
+  // ── Extract commandIntent ──
+  const rawCommandIntent = sourceMetadata?.commandIntent;
+  const commandIntent =
+    rawCommandIntent &&
+    typeof rawCommandIntent === "object" &&
+    !Array.isArray(rawCommandIntent)
+      ? (rawCommandIntent as Record<string, unknown>)
+      : undefined;
+
+  // Only proceed for /start commands
+  if (!commandIntent || commandIntent.type !== "start") return null;
+
+  // If /start has a payload (e.g. gv_token, iv_token), let the existing
+  // bootstrap/invite handlers deal with it.
+  if (
+    typeof commandIntent.payload === "string" &&
+    commandIntent.payload.length > 0
+  ) {
+    return null;
+  }
+
+  // Only proceed for Telegram (can be extended later)
+  if (sourceChannel !== "telegram") return null;
+
+  // If a guardian already exists for this channel, continue to normal flow
+  if (findGuardianForChannel(sourceChannel)) return null;
+
+  // Can't bind a session without sender identity
+  if (!rawSenderId) return null;
+
+  // ── Webhook retry dedup ──
+  // The intercept runs before recordInbound, so use a lightweight in-memory
+  // dedup to prevent duplicate replies when Telegram retries the webhook.
+  // Only checked here; marked as processed after successful session creation
+  // so transient failures remain retryable.
+  if (isAlreadyProcessed(externalMessageId)) {
+    return Response.json({ accepted: true, guardianActivation: true });
+  }
+
+  // ── Idempotency: check for an existing active session from this sender ──
+  const existingSession = findActiveSession(sourceChannel);
+  if (existingSession) {
+    // Only block if the session belongs to the same sender. If a different
+    // user triggered the session, let this sender proceed (they'll supersede
+    // the stale session via createOutboundSession's revocation logic).
+    const sessionOwner =
+      existingSession.expectedExternalUserId ?? existingSession.expectedChatId;
+    if (
+      sessionOwner === rawSenderId ||
+      sessionOwner === conversationExternalId
+    ) {
+      if (replyCallbackUrl) {
+        deliverChannelReply(
+          replyCallbackUrl,
+          {
+            chatId: conversationExternalId,
+            text: "A verification is already in progress. Check your assistant app for the code and enter it here.",
+            assistantId,
+          },
+          mintBearerToken(),
+        ).catch((err) => {
+          log.error(
+            { err, sourceChannel, conversationExternalId },
+            "Failed to deliver guardian activation idempotency reply",
+          );
+        });
+      }
+      markProcessed(externalMessageId);
+      return Response.json({ accepted: true, guardianActivationPending: true });
+    }
+  }
+
+  // ── Create verification session ──
+  const sessionResult = createOutboundSession({
+    channel: sourceChannel,
+    expectedExternalUserId: rawSenderId,
+    expectedChatId: conversationExternalId,
+    identityBindingStatus: "bound",
+    destinationAddress: conversationExternalId,
+    verificationPurpose: "guardian",
+  });
+
+  // Mark as processed only after session creation succeeds so transient
+  // failures (e.g. temporary DB issues) remain retryable on the next webhook.
+  markProcessed(externalMessageId);
+
+  // ── Send deterministic Telegram reply ──
+  if (replyCallbackUrl) {
+    deliverChannelReply(
+      replyCallbackUrl,
+      {
+        chatId: conversationExternalId,
+        text: "Welcome! To verify your identity as guardian, check your assistant app for a verification code and enter it here.",
+        assistantId,
+      },
+      mintBearerToken(),
+    ).catch((err) => {
+      log.error(
+        { err, sourceChannel, conversationExternalId },
+        "Failed to deliver guardian activation welcome reply",
+      );
+    });
+  }
+
+  // ── Emit notification signal to deliver code to macOS app ──
+  void emitNotificationSignal({
+    sourceEventName: "guardian.channel_activation",
+    sourceChannel: sourceChannel as NotificationSourceChannel,
+    sourceContextId: `guardian-activation-${sourceChannel}-${rawSenderId}`,
+    attentionHints: {
+      requiresAction: true,
+      urgency: "high",
+      isAsyncBackground: false,
+      visibleInSourceNow: false,
+    },
+    contextPayload: {
+      verificationCode: sessionResult.secret,
+      sourceChannel,
+      actorExternalId: rawSenderId,
+      actorDisplayName: actorDisplayName ?? null,
+      actorUsername: actorUsername ?? null,
+      sessionId: sessionResult.sessionId,
+      expiresAt: sessionResult.expiresAt,
+    },
+    dedupeKey: `guardian-activation:${sessionResult.sessionId}`,
+  });
+
+  return Response.json({ accepted: true, guardianActivation: true });
+}

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -164,6 +164,10 @@ extension AppDelegate {
     }
 
     @objc public func performLogout() {
+        // Cancel any in-flight managed switch so it doesn't reconnect after logout.
+        managedSwitchTask?.cancel()
+        managedSwitchTask = nil
+
         Task {
             // Capture assistant ID before logout clears UserDefaults
             let connectedAssistantId = UserDefaults.standard.string(forKey: "connectedAssistantId")
@@ -406,8 +410,10 @@ extension AppDelegate {
     /// 1. Clear assistant-scoped runtime state (recording, windows, callbacks)
     /// 2. Disconnect transport (leave old assistant running)
     /// 3. Persist the new assistant selection
-    /// 4. Reconfigure transport and reconnect
-    /// 5. Resume credential bootstrap
+    /// 4. For managed assistants, bootstrap via the platform API to re-resolve
+    ///    the organization ID (cleared in step 3) before connecting
+    /// 5. Reconfigure transport and reconnect
+    /// 6. Resume credential bootstrap
     func performSwitchAssistant(to assistant: LockfileAssistant) {
         // If switching to a managed assistant while logged out, prompt login first.
         if assistant.isManaged && !authManager.isAuthenticated {
@@ -444,11 +450,73 @@ extension AppDelegate {
         actorTokenBootstrapTask = nil
         ActorTokenManager.deleteToken()
 
-        // 4. Reconfigure transport and reconnect
+        // 4. For managed assistants, bootstrap via the platform API to
+        //    re-resolve the organization ID before connecting. The org ID was
+        //    cleared in step 3; without it the health check's
+        //    Vellum-Organization-Id header would be missing and the connection
+        //    would fail.
+        managedSwitchTask?.cancel()
+        managedSwitchTask = nil
+        if assistant.isManaged {
+            let targetId = assistant.assistantId
+            managedSwitchTask = Task {
+                // Use ensureManagedAssistant() directly instead of the
+                // coordinator's activateManagedAssistant() — the coordinator
+                // calls persistManagedAssistant() which overwrites
+                // connectedAssistantId as a side effect, creating a race
+                // when a second switch fires before this task completes.
+                // We only need the org ID resolution from ensureManagedAssistant().
+                do {
+                    _ = try await ManagedAssistantBootstrapService.shared.ensureManagedAssistant()
+                } catch is CancellationError {
+                    log.info("Managed switch to \(targetId, privacy: .public) cancelled")
+                    return
+                } catch {
+                    log.error("Managed bootstrap failed during switch: \(error.localizedDescription, privacy: .public)")
+                    // If resolveOrganizationId() failed, connectedOrganizationId
+                    // is still nil and the connection would fail for the same
+                    // reason this fix exists. Only proceed if the org ID was
+                    // actually resolved (it's set as a side effect of
+                    // resolveOrganizationId() inside ensureManagedAssistant()).
+                    if UserDefaults.standard.string(forKey: "connectedOrganizationId") == nil {
+                        log.error("Organization ID not resolved — aborting managed switch to \(targetId, privacy: .public)")
+                        // The main window was already closed in step 2.
+                        // Re-show it so the user isn't stranded without UI.
+                        self.showMainWindow()
+                        return
+                    }
+                }
+                // ensureManagedAssistant() clears connectedAssistantId when the
+                // platform returns 404 (deleted) or 403 (revoked). Restore it
+                // so the guard below doesn't confuse this with a concurrent
+                // switch that wrote a different assistant ID.
+                if UserDefaults.standard.string(forKey: "connectedAssistantId") == nil, !Task.isCancelled {
+                    UserDefaults.standard.set(targetId, forKey: "connectedAssistantId")
+                }
+                // Guard against a second switch that started while we were
+                // awaiting the bootstrap — only finish if this task hasn't
+                // been cancelled and this assistant is still the selected
+                // target.
+                guard !Task.isCancelled,
+                      UserDefaults.standard.string(forKey: "connectedAssistantId") == targetId else {
+                    log.info("Managed switch to \(targetId, privacy: .public) superseded — skipping finishSwitchAssistant")
+                    return
+                }
+                self.finishSwitchAssistant(assistant)
+            }
+        } else {
+            finishSwitchAssistant(assistant)
+        }
+    }
+
+    /// Steps 5-6 of the switch sequence: reconfigure transport, resume
+    /// credential bootstrap, sync keys, reload flags/avatar, and show UI.
+    private func finishSwitchAssistant(_ assistant: LockfileAssistant) {
+        // 5. Reconfigure transport and reconnect
         hasSetupDaemon = false
         setupGatewayConnectionManager()
 
-        // 5. Resume credential bootstrap and show UI
+        // 6. Resume credential bootstrap and show UI
         if !isCurrentAssistantManaged {
             ensureActorCredentials()
         }
@@ -458,10 +526,10 @@ extension AppDelegate {
         localBootstrapDidComplete = false
         ensureLocalAssistantApiKey()
 
-        // 6. Sync locally-stored API keys to the new assistant. The assistant may
-        //    have started without ANTHROPIC_API_KEY in its environment (e.g.
-        //    when the app was launched via Finder/open). Push keys from
-        //    UserDefaults so the assistant can initialize its LLM providers.
+        // Sync locally-stored API keys to the new assistant. The assistant may
+        // have started without ANTHROPIC_API_KEY in its environment (e.g.
+        // when the app was launched via Finder/open). Push keys from
+        // UserDefaults so the assistant can initialize its LLM providers.
         syncApiKeysToAssistant(assistant)
 
         // Clear the UserDefaults feature-flag cache before reloading so
@@ -522,6 +590,9 @@ extension AppDelegate {
     }
 
     @objc func performRetire() {
+        // Cancel any in-flight managed switch so it doesn't reconnect after retire.
+        managedSwitchTask?.cancel()
+        managedSwitchTask = nil
         Task { await performRetireAsync() }
     }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -148,6 +148,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     /// cancelled before creating a new subscription (e.g. on reconnection or
     /// assistant switch), preventing duplicate event processing.
     var eventSubscriptionTask: Task<Void, Never>?
+    /// In-flight managed-assistant switch task. Cancelled when a new switch
+    /// begins so a stale bootstrap cannot reconnect the wrong assistant.
+    var managedSwitchTask: Task<Void, Never>?
     /// Pending fallback notification tokens, keyed by conversationId.
     /// Used to avoid duplicate native alerts when notification_intent arrives.
     var pendingFallbackNotifications: [String: UUID] = [:]

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -135,11 +135,7 @@ struct TeleportSection: View {
 
     @ViewBuilder
     private var teleportContent: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text("Teleport")
-                .font(VFont.titleSmall)
-                .foregroundStyle(VColor.contentDefault)
-
+        SettingsCard(title: "Teleport", subtitle: "Move your assistant to a different hosting environment") {
             if case .verifying = phase {
                 verifyingBanner
             } else if case .transferring(let step) = phase {
@@ -156,21 +152,13 @@ struct TeleportSection: View {
                 destinationPicker
             }
         }
-        .padding(VSpacing.lg)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .vCard(background: VColor.surfaceOverlay)
     }
 
     // MARK: - Destination Picker
 
     @ViewBuilder
     private var destinationPicker: some View {
-        if assistant.cloud.lowercased() == "local" {
-            // Bare metal local: show both Docker and Platform options
-            destinationButton(for: .docker)
-            destinationButton(for: .platform)
-        } else if assistant.isDocker {
-            // Docker: show only Platform option
+        if assistant.cloud.lowercased() == "local" || assistant.isDocker {
             destinationButton(for: .platform)
         }
     }
@@ -184,7 +172,7 @@ struct TeleportSection: View {
 
             VButton(
                 label: destination.displayLabel,
-                style: .primary,
+                style: .outlined,
                 isDisabled: isDestinationDisabled(destination)
             ) {
                 pendingDestination = destination

--- a/clients/macos/vellum-assistantTests/ManagedAssistantConnectionCoordinatorTests.swift
+++ b/clients/macos/vellum-assistantTests/ManagedAssistantConnectionCoordinatorTests.swift
@@ -90,6 +90,37 @@ final class ManagedAssistantConnectionCoordinatorTests: XCTestCase {
         XCTAssertTrue(defaults.bool(forKey: "tosAccepted"))
     }
 
+    func testActivateManagedAssistantRePopulatesOrgIdAfterCleared() async throws {
+        // Simulate performSwitchAssistant clearing the org ID
+        defaults.removeObject(forKey: "connectedOrganizationId")
+        XCTAssertNil(defaults.string(forKey: "connectedOrganizationId"))
+
+        let defaults = self.defaults!
+        let coordinator = ManagedAssistantConnectionCoordinator(
+            bootstrapService: MockManagedAssistantBootstrapService(
+                outcome: .createdNew(PlatformAssistant(id: "managed-switch")),
+                onEnsureManagedAssistant: {
+                    // The real ManagedAssistantBootstrapService.ensureManagedAssistant()
+                    // calls resolveOrganizationId() which sets connectedOrganizationId.
+                    // Simulate that behavior here to verify the coordinator contract.
+                    defaults.set("org-resolved-123", forKey: "connectedOrganizationId")
+                }
+            ),
+            userDefaults: defaults,
+            runtimeURLProvider: { "https://platform.example.com" },
+            updateAssistantTag: { _ in },
+            lockfilePath: lockfilePath
+        )
+
+        let result = try await coordinator.activateManagedAssistant()
+
+        XCTAssertEqual(result.assistant.id, "managed-switch")
+        // Verify the org ID was re-populated by the bootstrap (via resolveOrganizationId)
+        XCTAssertEqual(defaults.string(forKey: "connectedOrganizationId"), "org-resolved-123")
+        // Verify the assistant ID was persisted by the coordinator
+        XCTAssertEqual(defaults.string(forKey: "connectedAssistantId"), "managed-switch")
+    }
+
     func testActivateManagedAssistantAfterReauthClearsPersistedOrganizationBeforeBootstrap() async throws {
         defaults.set("stale-org", forKey: "connectedOrganizationId")
         var orgIdSeenDuringEnsure: String?

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -241,9 +241,6 @@ final class ChatActionHandler {
         case .guardianActionsPendingResponse(let response):
             vm.handleGuardianActionsPendingResponse(response)
 
-        case .guardianActionDecisionResponse(let response):
-            vm.handleGuardianActionDecisionResponse(response)
-
         case .usageUpdate(let update):
             guard belongsToConversation(update.conversationId) else { return }
             if let tokens = update.contextWindowTokens {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -149,6 +149,11 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     /// send-in-progress indicator gets stuck.
     @ObservationIgnored private var sendingWatchdogTask: Task<Void, Never>?
 
+    /// Per-requestId safety-net timeouts that clear the submitting spinner if
+    /// a guardian decision HTTP response takes longer than 15 seconds.  Keyed
+    /// by requestId so concurrent submissions each get an independent timeout.
+    @ObservationIgnored private var guardianDecisionTimeoutTasks: [String: Task<Void, Never>] = [:]
+
     // MARK: - Observation compatibility
 
     /// No-op — retained for protocol conformance (MessageSendCoordinatorDelegate).
@@ -2168,6 +2173,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         // btwTask cancellation is handled by ChatBtwState's deinit.
         greetingState.cancelAll()
         sendingWatchdogTask?.cancel()
+        guardianDecisionTimeoutTasks.values.forEach { $0.cancel() }
         memoryPressureSource?.cancel()
         if let observer = reconnectObserver {
             NotificationCenter.default.removeObserver(observer)
@@ -2214,7 +2220,28 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
 
         Task {
             let response = await guardianClient.submitDecision(requestId: requestId, action: action, conversationId: conversationId)
-            if response == nil {
+
+            // Cancel the safety-net timeout for this specific requestId — we have an HTTP response.
+            guardianDecisionTimeoutTasks[requestId]?.cancel()
+            guardianDecisionTimeoutTasks[requestId] = nil
+
+            if let response {
+                if response.applied {
+                    // Real server decision — route to the handler for resolved state.
+                    handleGuardianActionDecisionResponse(response)
+                } else {
+                    // Transport failure (HTTP error, network timeout) or server
+                    // explicitly said stale/not-found. GuardianClient synthesizes
+                    // applied=false for HTTP errors — don't mark the prompt as
+                    // .stale on a transient 5xx. Instead, revert submitting state
+                    // and let the user retry.
+                    pendingGuardianActions.removeValue(forKey: requestId)
+                    if let idx = messages.firstIndex(where: { $0.guardianDecision?.requestId == requestId }) {
+                        messages[idx].guardianDecision?.isSubmitting = false
+                    }
+                    refreshGuardianPrompts()
+                }
+            } else {
                 log.error("Failed to submit guardian decision for requestId \(requestId)")
                 pendingGuardianActions.removeValue(forKey: requestId)
                 // Revert submitting state on failure
@@ -2222,6 +2249,25 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
                     messages[idx].guardianDecision?.isSubmitting = false
                 }
             }
+        }
+
+        // Safety-net timeout: if the decision is still submitting after 15s,
+        // clear the spinner and re-sync with the server. Don't remove from
+        // pendingGuardianActions — let the main response handler or refresh
+        // handle the cleanup so the action label is preserved.
+        // Cancel any previous timeout for the SAME requestId only — other
+        // in-flight submissions keep their own independent timeouts.
+        guardianDecisionTimeoutTasks[requestId]?.cancel()
+        guardianDecisionTimeoutTasks[requestId] = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 15_000_000_000)
+            guard !Task.isCancelled, let self else { return }
+            if let idx = self.messages.firstIndex(where: { $0.guardianDecision?.requestId == requestId }),
+               self.messages[idx].guardianDecision?.isSubmitting == true {
+                log.warning("Guardian decision submit timed out for requestId \(requestId, privacy: .public)")
+                self.messages[idx].guardianDecision?.isSubmitting = false
+                self.refreshGuardianPrompts()
+            }
+            self.guardianDecisionTimeoutTasks[requestId] = nil
         }
     }
 

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2218,7 +2218,6 @@ public enum ServerMessage: Decodable, Sendable {
     case approvedDevicesListResponse(ApprovedDevicesListResponseMessage)
     case approvedDeviceRemoveResponse(ApprovedDeviceRemoveResponseMessage)
     case guardianActionsPendingResponse(GuardianActionsPendingResponseMessage)
-    case guardianActionDecisionResponse(GuardianActionDecisionResponseMessage)
     case recordingPause(RecordingPause)
     case recordingResume(RecordingResume)
     case recordingStart(RecordingStart)
@@ -2616,9 +2615,6 @@ public enum ServerMessage: Decodable, Sendable {
         case "guardian_actions_pending_response":
             let message = try GuardianActionsPendingResponseMessage(from: decoder)
             self = .guardianActionsPendingResponse(message)
-        case "guardian_action_decision_response":
-            let message = try GuardianActionDecisionResponseMessage(from: decoder)
-            self = .guardianActionDecisionResponse(message)
         case "recording_pause":
             let message = try RecordingPause(from: decoder)
             self = .recordingPause(message)

--- a/skills/telegram-setup/SKILL.md
+++ b/skills/telegram-setup/SKILL.md
@@ -128,13 +128,15 @@ curl -sf -X POST "https://api.telegram.org/bot${BOT_TOKEN}/setMyCommands" \
 
 Non-critical - warn on failure but don't block setup.
 
-## Step 5: Guardian Verification (Optional)
+## Step 5: Test Your Connection
 
-Link the user's Telegram account as a trusted guardian. Load the **guardian-verify-setup** skill:
+Now let's test the connection by verifying the user can receive your messages. This confirms everything works and links the user's Telegram identity for future message delivery.
+
+Load the **guardian-verify-setup** skill:
 
 - Call `skill_load` with `skill: "guardian-verify-setup"`.
 
-If the user declines, skip and continue.
+If the user explicitly wants to skip this step, proceed to Step 6, but let them know they can always verify later by saying "verify me on Telegram".
 
 ## Step 6: Report Success
 


### PR DESCRIPTION
## Summary
- Cherry-pick fixes onto release/v0.6.0:
  - fix: resolve guardian decision submit infinite loading state (#23244)
  - Improve telegram-setup skill verification step clarity (#23254)
  - fix: bootstrap managed assistant org ID before connecting in performSwitchAssistant (#23238)
  - Auto-initiate guardian verification on Telegram /start (#23259)

## Test plan
- [ ] Verify each cherry-picked change works correctly on the release branch
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
