### PR TITLE
fix: assign displayOrder when moving conversation to a group

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -1326,8 +1326,9 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
         }
     }
 
-    /// Move a conversation to a specific group. Clears displayOrder so the
-    /// conversation sorts by recency within the target group.
+    /// Move a conversation to a specific group. When moving to a group, assigns
+    /// displayOrder to place the conversation at the end of the target group.
+    /// When ungrouping, clears displayOrder and bumps recency.
     func moveConversationToGroup(_ conversationId: UUID, groupId: String?) {
         guard let index = conversations.firstIndex(where: { $0.id == conversationId }) else { return }
         // Save pre-pin provenance so unpinConversation can restore the original group.
@@ -1335,10 +1336,16 @@ final class ConversationManager: ObservableObject, ConversationRestorerDelegate 
             prePinGroupIds[conversationId] = conversations[index].groupId
         }
         conversations[index].groupId = groupId
-        conversations[index].displayOrder = nil
-        // When ungrouping, bump lastInteractedAt so the conversation appears
-        // at the top of the ungrouped list (which sorts by recency).
-        if groupId == nil {
+        if let groupId {
+            // Place at the end of the target group by assigning max + 1.
+            let maxOrder = conversations
+                .filter { $0.groupId == groupId && $0.id != conversationId }
+                .compactMap(\.displayOrder).max() ?? -1
+            conversations[index].displayOrder = maxOrder + 1
+        } else {
+            // When ungrouping, clear displayOrder and bump lastInteractedAt so
+            // the conversation appears at the top of the ungrouped list.
+            conversations[index].displayOrder = nil
             conversations[index].lastInteractedAt = Date()
         }
         sendReorderConversations()


### PR DESCRIPTION
## Summary
- When moving a conversation to a group via the non-drag "Move to group" action, assign `displayOrder = max + 1` so it lands at the end of the group instead of floating above manually-ordered conversations
- Ungrouping behavior unchanged (clears displayOrder, bumps recency)
- Follows the same pattern already used by `pinConversation`

## Original prompt
update move to group so that it sets the displayOrder to be the last value/position in that new group
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
