### PR TITLE
fix: initialize auth signing key in CLI notifications send command

### DIFF
--- a/assistant/src/cli/commands/notifications.ts
+++ b/assistant/src/cli/commands/notifications.ts
@@ -10,6 +10,10 @@ import {
   NOTIFICATION_SOURCE_EVENT_NAMES,
 } from "../../notifications/signal.js";
 import type { NotificationChannel } from "../../notifications/types.js";
+import {
+  initAuthSigningKey,
+  loadOrCreateSigningKey,
+} from "../../runtime/auth/token-service.js";
 import { initializeDb } from "../db.js";
 import { log } from "../logger.js";
 import { shouldOutputJson, writeOutput } from "../output.js";
@@ -251,6 +255,7 @@ Examples:
           }
 
           initializeDb();
+          initAuthSigningKey(loadOrCreateSigningKey());
 
           const sourceContextId = opts.conversationId ?? `cli-${Date.now()}`;
 


### PR DESCRIPTION
## Summary
- The `assistant notifications send` CLI command was failing to deliver to Slack (and any external channel) because it never initialized the auth signing key needed to mint delivery tokens for the gateway
- Added `initAuthSigningKey(loadOrCreateSigningKey())` before `emitNotificationSignal()`, matching the established pattern in other CLI commands

## Test plan
- [ ] Type-check passes (`bunx tsc --noEmit`)
- [ ] Run `assistant notifications send --source-channel assistant_tool --source-event-name user.send_notification --message "test" --preferred-channels slack` and confirm delivery succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
