### PR TITLE
fix: auto-refresh app surfaces on file_edit/file_write

### DIFF
--- a/assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
@@ -2,13 +2,13 @@
  * Regression tests for app surface refresh and eventing side effects in
  * createToolExecutor (conversation-tool-setup.ts).
  *
- * The app_refresh hook is the sole hook for app change refresh. These tests
- * verify that app_refresh, app_create, and app_delete hooks fire correctly,
- * and that removed hooks (app_update, app_file_edit, app_file_write) no
- * longer trigger side effects.
+ * Tests verify that app_refresh, app_create, app_delete, and file_write/
+ * file_edit (for app source files) hooks fire correctly, and that removed
+ * hooks (app_update, app_file_edit, app_file_write) no longer trigger
+ * side effects.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { ToolSetupContext } from "../daemon/conversation-tool-setup.js";
 import type { SurfaceData, SurfaceType } from "../daemon/message-protocol.js";
@@ -42,11 +42,26 @@ mock.module("../tools/browser/browser-screencast.js", () => ({
   registerConversationSender: mock(() => {}),
 }));
 
+// Mock app-store functions used by the file-edit auto-refresh hook
+const TEST_APPS_DIR = "/tmp/test-apps";
+const testDirNameMap = new Map<string, string>([["my-app", "app-id-1"]]);
+
+mock.module("../memory/app-store.js", () => ({
+  getApp: mock(() => null),
+  getAppDirPath: mock((id: string) => `${TEST_APPS_DIR}/${id}`),
+  isMultifileApp: mock(() => false),
+  getAppsDir: mock(() => TEST_APPS_DIR),
+  resolveAppIdByDirName: mock(
+    (dirName: string) => testDirNameMap.get(dirName) ?? null,
+  ),
+}));
+
 // ---------------------------------------------------------------------------
 // Import createToolExecutor after mocks are in place
 // ---------------------------------------------------------------------------
 
 import { createToolExecutor } from "../daemon/conversation-tool-setup.js";
+import { _testing } from "../daemon/tool-side-effects.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -421,6 +436,230 @@ describe("session-tool-setup app refresh side effects", () => {
       expect(result.isError).toBe(false);
       expect(refreshSpy).toHaveBeenCalledTimes(1);
       expect(updatePublishedSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── resolveAppIdFromPath unit tests ────────────────────────────────
+
+  describe("resolveAppIdFromPath", () => {
+    const { resolveAppIdFromPath } = _testing;
+
+    test("returns app ID for a source file in an app directory", () => {
+      expect(
+        resolveAppIdFromPath(`${TEST_APPS_DIR}/my-app/src/main.tsx`),
+      ).toBe("app-id-1");
+    });
+
+    test("returns app ID for root-level file in app directory", () => {
+      expect(
+        resolveAppIdFromPath(`${TEST_APPS_DIR}/my-app/index.html`),
+      ).toBe("app-id-1");
+    });
+
+    test("returns null for file directly in apps dir (JSON definition)", () => {
+      expect(resolveAppIdFromPath(`${TEST_APPS_DIR}/my-app.json`)).toBeNull();
+    });
+
+    test("returns null for path outside apps directory", () => {
+      expect(resolveAppIdFromPath("/tmp/other/file.ts")).toBeNull();
+    });
+
+    test("returns null for records/ subdirectory", () => {
+      expect(
+        resolveAppIdFromPath(`${TEST_APPS_DIR}/my-app/records/rec-1.json`),
+      ).toBeNull();
+    });
+
+    test("returns null for dist/ subdirectory", () => {
+      expect(
+        resolveAppIdFromPath(`${TEST_APPS_DIR}/my-app/dist/index.html`),
+      ).toBeNull();
+    });
+
+    test("returns null for unknown app directory", () => {
+      expect(
+        resolveAppIdFromPath(`${TEST_APPS_DIR}/unknown-app/src/main.tsx`),
+      ).toBeNull();
+    });
+  });
+
+  // ── file_write/file_edit auto-refresh ─────────────────────────────
+
+  describe("file_write/file_edit auto-refresh", () => {
+    afterEach(() => {
+      _testing.appRefreshDebouncer.cancelAll();
+      _testing.pendingAppRefreshCtx.clear();
+    });
+
+    test("file_write to app source file schedules debounced refresh", async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({
+        content: "wrote file",
+        isError: false,
+        diff: {
+          filePath: `${TEST_APPS_DIR}/my-app/src/main.tsx`,
+          oldContent: "",
+          newContent: "new",
+          isNewFile: false,
+        },
+      });
+      const broadcastSpy = mock(() => {});
+
+      const toolFn = createToolExecutor(
+        executor as unknown as ToolExecutor,
+        noopPrompter,
+        noopSecretPrompter,
+        ctx,
+        noopLifecycleHandler,
+        broadcastSpy,
+      );
+
+      await toolFn("file_write", {
+        path: `${TEST_APPS_DIR}/my-app/src/main.tsx`,
+      });
+
+      // Debounce is pending — context should be stored
+      expect(_testing.pendingAppRefreshCtx.has("app-id-1")).toBe(true);
+
+      // Wait for debounce to fire
+      await new Promise((r) => setTimeout(r, 600));
+
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+      expect(broadcastSpy).toHaveBeenCalledWith({
+        type: "app_files_changed",
+        appId: "app-id-1",
+      });
+    });
+
+    test("file_edit to app source file schedules debounced refresh", async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({
+        content: "edited file",
+        isError: false,
+        diff: {
+          filePath: `${TEST_APPS_DIR}/my-app/src/styles.css`,
+          oldContent: "old",
+          newContent: "new",
+          isNewFile: false,
+        },
+      });
+      const broadcastSpy = mock(() => {});
+
+      const toolFn = createToolExecutor(
+        executor as unknown as ToolExecutor,
+        noopPrompter,
+        noopSecretPrompter,
+        ctx,
+        noopLifecycleHandler,
+        broadcastSpy,
+      );
+
+      await toolFn("file_edit", {
+        path: `${TEST_APPS_DIR}/my-app/src/styles.css`,
+      });
+
+      expect(_testing.pendingAppRefreshCtx.has("app-id-1")).toBe(true);
+
+      await new Promise((r) => setTimeout(r, 600));
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("file_write to non-app path does not trigger refresh", async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({
+        content: "wrote file",
+        isError: false,
+        diff: {
+          filePath: "/tmp/other/file.ts",
+          oldContent: "",
+          newContent: "new",
+          isNewFile: true,
+        },
+      });
+
+      const toolFn = createToolExecutor(
+        executor as unknown as ToolExecutor,
+        noopPrompter,
+        noopSecretPrompter,
+        ctx,
+        noopLifecycleHandler,
+        mock(() => {}),
+      );
+
+      await toolFn("file_write", { path: "/tmp/other/file.ts" });
+
+      expect(_testing.pendingAppRefreshCtx.size).toBe(0);
+      await new Promise((r) => setTimeout(r, 600));
+      expect(refreshSpy).not.toHaveBeenCalled();
+    });
+
+    test("rapid edits are coalesced into a single refresh", async () => {
+      const ctx = makeCtx();
+      const broadcastSpy = mock(() => {});
+
+      // Simulate 3 rapid file edits to the same app
+      for (const file of ["main.tsx", "styles.css", "utils.ts"]) {
+        const executor = makeFakeExecutor({
+          content: "edited",
+          isError: false,
+          diff: {
+            filePath: `${TEST_APPS_DIR}/my-app/src/${file}`,
+            oldContent: "old",
+            newContent: "new",
+            isNewFile: false,
+          },
+        });
+
+        const toolFn = createToolExecutor(
+          executor as unknown as ToolExecutor,
+          noopPrompter,
+          noopSecretPrompter,
+          ctx,
+          noopLifecycleHandler,
+          broadcastSpy,
+        );
+
+        await toolFn("file_edit", {
+          path: `${TEST_APPS_DIR}/my-app/src/${file}`,
+        });
+      }
+
+      // All 3 edits share one pending context
+      expect(_testing.pendingAppRefreshCtx.size).toBe(1);
+
+      // Wait for debounce — should only fire once
+      await new Promise((r) => setTimeout(r, 600));
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+      expect(broadcastSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("error results do not trigger auto-refresh", async () => {
+      const ctx = makeCtx();
+      const executor = makeFakeExecutor({
+        content: "Error: file not found",
+        isError: true,
+        diff: {
+          filePath: `${TEST_APPS_DIR}/my-app/src/main.tsx`,
+          oldContent: "",
+          newContent: "",
+          isNewFile: false,
+        },
+      });
+
+      const toolFn = createToolExecutor(
+        executor as unknown as ToolExecutor,
+        noopPrompter,
+        noopSecretPrompter,
+        ctx,
+        noopLifecycleHandler,
+        mock(() => {}),
+      );
+
+      await toolFn("file_write", {
+        path: `${TEST_APPS_DIR}/my-app/src/main.tsx`,
+      });
+
+      expect(_testing.pendingAppRefreshCtx.size).toBe(0);
     });
   });
 });

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -9,11 +9,18 @@
 
 import { compileApp } from "../bundler/app-compiler.js";
 import { generateAppIcon } from "../media/app-icon-generator.js";
-import { getApp, getAppDirPath, isMultifileApp } from "../memory/app-store.js";
+import {
+  getApp,
+  getAppDirPath,
+  getAppsDir,
+  isMultifileApp,
+  resolveAppIdByDirName,
+} from "../memory/app-store.js";
 import { findActiveSession } from "../runtime/channel-verification-service.js";
 import { deliverVerificationSlack } from "../runtime/verification-outbound-actions.js";
 import { updatePublishedAppDeployment } from "../services/published-app-updater.js";
 import type { ToolExecutionResult } from "../tools/types.js";
+import { DebouncerMap } from "../util/debounce.js";
 import { getLogger } from "../util/logger.js";
 import { refreshSurfacesForApp } from "./conversation-surfaces.js";
 import type { ToolSetupContext } from "./conversation-tool-setup.js";
@@ -169,6 +176,77 @@ registerHook(
   },
 );
 
+// ── File-edit auto-refresh for apps ─────────────────────────────────
+
+const APP_REFRESH_DEBOUNCE_MS = 500;
+
+/** Per-app debounce timers for coalescing rapid file edits. */
+const appRefreshDebouncer = new DebouncerMap({
+  defaultDelayMs: APP_REFRESH_DEBOUNCE_MS,
+  maxEntries: 50,
+});
+
+/** Stores the latest SideEffectContext per app ID for debounced callbacks. */
+const pendingAppRefreshCtx = new Map<string, SideEffectContext>();
+
+/**
+ * Extract app ID from an absolute file path if it falls within the apps
+ * directory and targets a source file (not records/ or dist/).
+ */
+function resolveAppIdFromPath(filePath: string): string | null {
+  let appsDir: string;
+  try {
+    appsDir = getAppsDir();
+  } catch {
+    return null;
+  }
+  if (!filePath.startsWith(appsDir + "/")) return null;
+
+  const relPath = filePath.slice(appsDir.length + 1);
+  const slashIdx = relPath.indexOf("/");
+  if (slashIdx === -1) return null; // file directly in apps/ (e.g. the .json definition)
+
+  const dirName = relPath.slice(0, slashIdx);
+  const innerPath = relPath.slice(slashIdx + 1);
+
+  // Skip non-source directories
+  if (innerPath.startsWith("records/") || innerPath.startsWith("dist/")) {
+    return null;
+  }
+
+  return resolveAppIdByDirName(dirName);
+}
+
+// Trigger debounced app recompile + surface refresh when file_write or
+// file_edit modifies a source file inside an app directory.
+registerHook(
+  ["file_write", "file_edit"],
+  (_name, input, result, sideEffectCtx) => {
+    const filePath =
+      result.diff?.filePath ?? (input.path as string | undefined);
+    if (!filePath) return;
+
+    const appId = resolveAppIdFromPath(filePath);
+    if (!appId) return;
+
+    // Store the latest context so the debounced callback uses fresh state
+    pendingAppRefreshCtx.set(appId, sideEffectCtx);
+
+    appRefreshDebouncer.schedule(`app:${appId}`, () => {
+      const latestCtx = pendingAppRefreshCtx.get(appId);
+      pendingAppRefreshCtx.delete(appId);
+      if (!latestCtx) return;
+
+      handleAppChange(
+        latestCtx.ctx,
+        appId,
+        latestCtx.broadcastToAllClients,
+        { fileChange: true },
+      );
+    });
+  },
+);
+
 // Broadcast tasks_changed so connected clients (e.g. macOS Tasks window)
 // auto-refresh when the LLM mutates the task queue via tools
 registerHook(
@@ -297,3 +375,10 @@ export function runPostExecutionSideEffects(
     updateDoordashProgress(sideEffectCtx.ctx, input, result.isError);
   }
 }
+
+/** @internal Exposed for testing only. */
+export const _testing = {
+  appRefreshDebouncer,
+  pendingAppRefreshCtx,
+  resolveAppIdFromPath,
+};

--- a/assistant/src/memory/app-store.ts
+++ b/assistant/src/memory/app-store.ts
@@ -216,6 +216,8 @@ export function generateAppDirName(
 
 /** Cache of id -> dirName mappings to avoid repeated filesystem scans. */
 const idToDirNameCache = new Map<string, string>();
+/** Reverse cache: dirName -> id. */
+const dirNameToIdCache = new Map<string, string>();
 
 /**
  * Resolve an app's directory name and path from its ID.
@@ -265,12 +267,51 @@ export function getAppDirPath(appId: string): string {
   return resolveAppDir(appId).appDir;
 }
 
+/**
+ * Resolve an app ID from its directory name (slug).
+ * Checks caches first, then reads the JSON definition file directly.
+ */
+export function resolveAppIdByDirName(dirName: string): string | null {
+  const cached = dirNameToIdCache.get(dirName);
+  if (cached) return cached;
+
+  // Check forward cache (reverse iteration)
+  for (const [id, dn] of idToDirNameCache) {
+    if (dn === dirName) {
+      dirNameToIdCache.set(dirName, id);
+      return id;
+    }
+  }
+
+  // Read the JSON definition file directly
+  const dir = getAppsDir();
+  const jsonPath = join(dir, `${dirName}.json`);
+  if (existsSync(jsonPath)) {
+    try {
+      const raw = readFileSync(jsonPath, "utf-8");
+      const parsed = JSON.parse(raw) as { id?: string; dirName?: string };
+      if (parsed.id) {
+        dirNameToIdCache.set(dirName, parsed.id);
+        idToDirNameCache.set(parsed.id, dirName);
+        return parsed.id;
+      }
+    } catch {
+      // skip malformed files
+    }
+  }
+
+  return null;
+}
+
 /** Invalidate the id->dirName cache for a specific app or all apps. */
 function invalidateDirNameCache(appId?: string): void {
   if (appId) {
+    const dirName = idToDirNameCache.get(appId);
     idToDirNameCache.delete(appId);
+    if (dirName) dirNameToIdCache.delete(dirName);
   } else {
     idToDirNameCache.clear();
+    dirNameToIdCache.clear();
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds debounced side effect hooks for `file_edit` and `file_write` that detect when the edited file is inside an app directory and auto-trigger `handleAppChange` (recompile + surface refresh + broadcast)
- Adds `resolveAppIdByDirName()` reverse lookup to `app-store.ts` so we can resolve app IDs from directory names in file paths
- Skips non-source paths (`records/`, `dist/`) to avoid unnecessary refreshes

## Original prompt

Bug report: "Apps don't auto update when the assistant edits them. I have to ask the assistant to reopen the app after every little change."

Root cause: `file_edit`/`file_write` had no app-aware side effect hooks. The existing `handleAppChange` infrastructure (recompile, surface refresh, broadcast) was only wired to `app_refresh`, `app_create`, and `app_delete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)