### PR TITLE
fix: move resolveAppIdFromPath to app-store to satisfy path guard

### DIFF
--- a/assistant/src/__tests__/tool-side-effects-slack-dm.test.ts
+++ b/assistant/src/__tests__/tool-side-effects-slack-dm.test.ts
@@ -31,6 +31,7 @@ mock.module("../memory/app-store.js", () => ({
   getApp: mock(() => null),
   getAppDirPath: mock(() => ""),
   isMultifileApp: mock(() => false),
+  resolveAppIdFromPath: mock(() => null),
 }));
 mock.module("../services/published-app-updater.js", () => ({
   updatePublishedAppDeployment: mock(() => Promise.resolve()),

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -12,9 +12,8 @@ import { generateAppIcon } from "../media/app-icon-generator.js";
 import {
   getApp,
   getAppDirPath,
-  getAppsDir,
   isMultifileApp,
-  resolveAppIdByDirName,
+  resolveAppIdFromPath,
 } from "../memory/app-store.js";
 import { findActiveSession } from "../runtime/channel-verification-service.js";
 import { deliverVerificationSlack } from "../runtime/verification-outbound-actions.js";
@@ -188,34 +187,6 @@ const appRefreshDebouncer = new DebouncerMap({
 
 /** Stores the latest SideEffectContext per app ID for debounced callbacks. */
 const pendingAppRefreshCtx = new Map<string, SideEffectContext>();
-
-/**
- * Extract app ID from an absolute file path if it falls within the apps
- * directory and targets a source file (not records/ or dist/).
- */
-function resolveAppIdFromPath(filePath: string): string | null {
-  let appsDir: string;
-  try {
-    appsDir = getAppsDir();
-  } catch {
-    return null;
-  }
-  if (!filePath.startsWith(appsDir + "/")) return null;
-
-  const relPath = filePath.slice(appsDir.length + 1);
-  const slashIdx = relPath.indexOf("/");
-  if (slashIdx === -1) return null; // file directly in apps/ (e.g. the .json definition)
-
-  const dirName = relPath.slice(0, slashIdx);
-  const innerPath = relPath.slice(slashIdx + 1);
-
-  // Skip non-source directories
-  if (innerPath.startsWith("records/") || innerPath.startsWith("dist/")) {
-    return null;
-  }
-
-  return resolveAppIdByDirName(dirName);
-}
 
 // Trigger debounced app recompile + surface refresh when file_write or
 // file_edit modifies a source file inside an app directory.

--- a/assistant/src/memory/app-store.ts
+++ b/assistant/src/memory/app-store.ts
@@ -303,6 +303,34 @@ export function resolveAppIdByDirName(dirName: string): string | null {
   return null;
 }
 
+/**
+ * Extract app ID from an absolute file path if it falls within the apps
+ * directory and targets a source file (not records/ or dist/).
+ */
+export function resolveAppIdFromPath(filePath: string): string | null {
+  let appsDir: string;
+  try {
+    appsDir = getAppsDir();
+  } catch {
+    return null;
+  }
+  if (!filePath.startsWith(appsDir + "/")) return null;
+
+  const relPath = filePath.slice(appsDir.length + 1);
+  const slashIdx = relPath.indexOf("/");
+  if (slashIdx === -1) return null; // file directly in apps/ (e.g. the .json definition)
+
+  const dirName = relPath.slice(0, slashIdx);
+  const innerPath = relPath.slice(slashIdx + 1);
+
+  // Skip non-source directories
+  if (innerPath.startsWith("records/") || innerPath.startsWith("dist/")) {
+    return null;
+  }
+
+  return resolveAppIdByDirName(dirName);
+}
+
 /** Invalidate the id->dirName cache for a specific app or all apps. */
 function invalidateDirNameCache(appId?: string): void {
   if (appId) {


### PR DESCRIPTION
## Summary
- Moved `resolveAppIdFromPath` from `tool-side-effects.ts` into `app-store.ts` (the allowlisted module), fixing the `app-dir-path-guard` test that rejects non-allowlisted files importing `getAppsDir()`
- Updated mock in `tool-side-effects-slack-dm.test.ts` to include the new `resolveAppIdFromPath` export, fixing the module resolution error

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23922012382/job/69770335277
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
