### PR TITLE
fix: replace tool hooks with fs watcher for app auto-refresh

### DIFF
--- a/assistant/src/__tests__/app-source-watcher.test.ts
+++ b/assistant/src/__tests__/app-source-watcher.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for AppSourceWatcher — filesystem watcher that detects app source
+ * file changes and triggers debounced recompile + surface refresh.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be set up before importing the module under test
+// ---------------------------------------------------------------------------
+
+const TEST_APPS_DIR = "/tmp/test-apps";
+const testDirNameMap = new Map<string, string>([["my-app", "app-id-1"]]);
+
+let capturedWatchCallback: ((eventType: string, filename: string | null) => void) | null = null;
+const mockWatcher = { close: mock(() => {}) };
+
+mock.module("node:fs", () => {
+  const actual = require("node:fs");
+  return {
+    ...actual,
+    existsSync: mock((p: string) => p === TEST_APPS_DIR),
+    watch: mock(
+      (
+        _path: string,
+        _opts: Record<string, unknown>,
+        callback: (eventType: string, filename: string | null) => void,
+      ) => {
+        capturedWatchCallback = callback;
+        return mockWatcher;
+      },
+    ),
+  };
+});
+
+mock.module("../memory/app-store.js", () => ({
+  getAppsDir: mock(() => TEST_APPS_DIR),
+  resolveAppIdByDirName: mock(
+    (dirName: string) => testDirNameMap.get(dirName) ?? null,
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import { AppSourceWatcher } from "../daemon/app-source-watcher.js";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AppSourceWatcher", () => {
+  let watcher: AppSourceWatcher;
+  let onChangeSpy: ReturnType<typeof mock>;
+
+  beforeEach(() => {
+    watcher = new AppSourceWatcher();
+    onChangeSpy = mock(() => {});
+    capturedWatchCallback = null;
+    mockWatcher.close.mockClear();
+  });
+
+  afterEach(() => {
+    watcher.stop();
+  });
+
+  test("start() creates a recursive watcher on the apps directory", () => {
+    watcher.start(onChangeSpy);
+    expect(capturedWatchCallback).not.toBeNull();
+  });
+
+  test("source file change triggers callback with resolved appId", async () => {
+    watcher.start(onChangeSpy);
+    capturedWatchCallback!("change", "my-app/src/main.tsx");
+
+    // Wait for debounce (500ms + margin)
+    await new Promise((r) => setTimeout(r, 600));
+    expect(onChangeSpy).toHaveBeenCalledTimes(1);
+    expect(onChangeSpy).toHaveBeenCalledWith("app-id-1");
+  });
+
+  test("root-level app file triggers callback", async () => {
+    watcher.start(onChangeSpy);
+    capturedWatchCallback!("change", "my-app/index.html");
+
+    await new Promise((r) => setTimeout(r, 600));
+    expect(onChangeSpy).toHaveBeenCalledTimes(1);
+    expect(onChangeSpy).toHaveBeenCalledWith("app-id-1");
+  });
+
+  test("dist/ files are filtered out", async () => {
+    watcher.start(onChangeSpy);
+    capturedWatchCallback!("change", "my-app/dist/index.html");
+
+    await new Promise((r) => setTimeout(r, 600));
+    expect(onChangeSpy).not.toHaveBeenCalled();
+  });
+
+  test("records/ files are filtered out", async () => {
+    watcher.start(onChangeSpy);
+    capturedWatchCallback!("change", "my-app/records/rec-1.json");
+
+    await new Promise((r) => setTimeout(r, 600));
+    expect(onChangeSpy).not.toHaveBeenCalled();
+  });
+
+  test("files directly in apps/ (no subdirectory) are filtered out", async () => {
+    watcher.start(onChangeSpy);
+    capturedWatchCallback!("change", "my-app.json");
+
+    await new Promise((r) => setTimeout(r, 600));
+    expect(onChangeSpy).not.toHaveBeenCalled();
+  });
+
+  test("unknown app directory is filtered out", async () => {
+    watcher.start(onChangeSpy);
+    capturedWatchCallback!("change", "unknown-app/src/main.tsx");
+
+    await new Promise((r) => setTimeout(r, 600));
+    expect(onChangeSpy).not.toHaveBeenCalled();
+  });
+
+  test("null filename is ignored", async () => {
+    watcher.start(onChangeSpy);
+    capturedWatchCallback!("change", null);
+
+    await new Promise((r) => setTimeout(r, 600));
+    expect(onChangeSpy).not.toHaveBeenCalled();
+  });
+
+  test("rapid changes to same app are debounced into single callback", async () => {
+    watcher.start(onChangeSpy);
+
+    capturedWatchCallback!("change", "my-app/src/main.tsx");
+    capturedWatchCallback!("change", "my-app/src/styles.css");
+    capturedWatchCallback!("change", "my-app/src/utils.ts");
+
+    await new Promise((r) => setTimeout(r, 600));
+    expect(onChangeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("stop() closes watcher and cancels pending timers", () => {
+    watcher.start(onChangeSpy);
+    capturedWatchCallback!("change", "my-app/src/main.tsx");
+
+    watcher.stop();
+
+    expect(mockWatcher.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-app-refresh.test.ts
@@ -2,13 +2,15 @@
  * Regression tests for app surface refresh and eventing side effects in
  * createToolExecutor (conversation-tool-setup.ts).
  *
- * Tests verify that app_refresh, app_create, app_delete, and file_write/
- * file_edit (for app source files) hooks fire correctly, and that removed
- * hooks (app_update, app_file_edit, app_file_write) no longer trigger
- * side effects.
+ * Tests verify that app_refresh, app_create, and app_delete hooks fire
+ * correctly, and that removed hooks (app_update, app_file_edit,
+ * app_file_write) no longer trigger side effects.
+ *
+ * File-change detection for file_write/file_edit is handled by
+ * AppSourceWatcher (see app-source-watcher.test.ts).
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { ToolSetupContext } from "../daemon/conversation-tool-setup.js";
 import type { SurfaceData, SurfaceType } from "../daemon/message-protocol.js";
@@ -42,18 +44,14 @@ mock.module("../tools/browser/browser-screencast.js", () => ({
   registerConversationSender: mock(() => {}),
 }));
 
-// Mock app-store functions used by the file-edit auto-refresh hook
-const TEST_APPS_DIR = "/tmp/test-apps";
-const testDirNameMap = new Map<string, string>([["my-app", "app-id-1"]]);
-
+// Mock app-store functions used by handleAppChange in tool-side-effects
 mock.module("../memory/app-store.js", () => ({
   getApp: mock(() => null),
-  getAppDirPath: mock((id: string) => `${TEST_APPS_DIR}/${id}`),
+  getAppDirPath: mock(() => "/tmp/test-apps/dummy"),
   isMultifileApp: mock(() => false),
-  getAppsDir: mock(() => TEST_APPS_DIR),
-  resolveAppIdByDirName: mock(
-    (dirName: string) => testDirNameMap.get(dirName) ?? null,
-  ),
+  getAppsDir: mock(() => "/tmp/test-apps"),
+  resolveAppIdByDirName: mock(() => null),
+  resolveAppIdFromPath: mock(() => null),
 }));
 
 // ---------------------------------------------------------------------------
@@ -61,7 +59,6 @@ mock.module("../memory/app-store.js", () => ({
 // ---------------------------------------------------------------------------
 
 import { createToolExecutor } from "../daemon/conversation-tool-setup.js";
-import { _testing } from "../daemon/tool-side-effects.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -439,227 +436,4 @@ describe("session-tool-setup app refresh side effects", () => {
     });
   });
 
-  // ── resolveAppIdFromPath unit tests ────────────────────────────────
-
-  describe("resolveAppIdFromPath", () => {
-    const { resolveAppIdFromPath } = _testing;
-
-    test("returns app ID for a source file in an app directory", () => {
-      expect(
-        resolveAppIdFromPath(`${TEST_APPS_DIR}/my-app/src/main.tsx`),
-      ).toBe("app-id-1");
-    });
-
-    test("returns app ID for root-level file in app directory", () => {
-      expect(
-        resolveAppIdFromPath(`${TEST_APPS_DIR}/my-app/index.html`),
-      ).toBe("app-id-1");
-    });
-
-    test("returns null for file directly in apps dir (JSON definition)", () => {
-      expect(resolveAppIdFromPath(`${TEST_APPS_DIR}/my-app.json`)).toBeNull();
-    });
-
-    test("returns null for path outside apps directory", () => {
-      expect(resolveAppIdFromPath("/tmp/other/file.ts")).toBeNull();
-    });
-
-    test("returns null for records/ subdirectory", () => {
-      expect(
-        resolveAppIdFromPath(`${TEST_APPS_DIR}/my-app/records/rec-1.json`),
-      ).toBeNull();
-    });
-
-    test("returns null for dist/ subdirectory", () => {
-      expect(
-        resolveAppIdFromPath(`${TEST_APPS_DIR}/my-app/dist/index.html`),
-      ).toBeNull();
-    });
-
-    test("returns null for unknown app directory", () => {
-      expect(
-        resolveAppIdFromPath(`${TEST_APPS_DIR}/unknown-app/src/main.tsx`),
-      ).toBeNull();
-    });
-  });
-
-  // ── file_write/file_edit auto-refresh ─────────────────────────────
-
-  describe("file_write/file_edit auto-refresh", () => {
-    afterEach(() => {
-      _testing.appRefreshDebouncer.cancelAll();
-      _testing.pendingAppRefreshCtx.clear();
-    });
-
-    test("file_write to app source file schedules debounced refresh", async () => {
-      const ctx = makeCtx();
-      const executor = makeFakeExecutor({
-        content: "wrote file",
-        isError: false,
-        diff: {
-          filePath: `${TEST_APPS_DIR}/my-app/src/main.tsx`,
-          oldContent: "",
-          newContent: "new",
-          isNewFile: false,
-        },
-      });
-      const broadcastSpy = mock(() => {});
-
-      const toolFn = createToolExecutor(
-        executor as unknown as ToolExecutor,
-        noopPrompter,
-        noopSecretPrompter,
-        ctx,
-        noopLifecycleHandler,
-        broadcastSpy,
-      );
-
-      await toolFn("file_write", {
-        path: `${TEST_APPS_DIR}/my-app/src/main.tsx`,
-      });
-
-      // Debounce is pending — context should be stored
-      expect(_testing.pendingAppRefreshCtx.has("app-id-1")).toBe(true);
-
-      // Wait for debounce to fire
-      await new Promise((r) => setTimeout(r, 600));
-
-      expect(refreshSpy).toHaveBeenCalledTimes(1);
-      expect(broadcastSpy).toHaveBeenCalledWith({
-        type: "app_files_changed",
-        appId: "app-id-1",
-      });
-    });
-
-    test("file_edit to app source file schedules debounced refresh", async () => {
-      const ctx = makeCtx();
-      const executor = makeFakeExecutor({
-        content: "edited file",
-        isError: false,
-        diff: {
-          filePath: `${TEST_APPS_DIR}/my-app/src/styles.css`,
-          oldContent: "old",
-          newContent: "new",
-          isNewFile: false,
-        },
-      });
-      const broadcastSpy = mock(() => {});
-
-      const toolFn = createToolExecutor(
-        executor as unknown as ToolExecutor,
-        noopPrompter,
-        noopSecretPrompter,
-        ctx,
-        noopLifecycleHandler,
-        broadcastSpy,
-      );
-
-      await toolFn("file_edit", {
-        path: `${TEST_APPS_DIR}/my-app/src/styles.css`,
-      });
-
-      expect(_testing.pendingAppRefreshCtx.has("app-id-1")).toBe(true);
-
-      await new Promise((r) => setTimeout(r, 600));
-      expect(refreshSpy).toHaveBeenCalledTimes(1);
-    });
-
-    test("file_write to non-app path does not trigger refresh", async () => {
-      const ctx = makeCtx();
-      const executor = makeFakeExecutor({
-        content: "wrote file",
-        isError: false,
-        diff: {
-          filePath: "/tmp/other/file.ts",
-          oldContent: "",
-          newContent: "new",
-          isNewFile: true,
-        },
-      });
-
-      const toolFn = createToolExecutor(
-        executor as unknown as ToolExecutor,
-        noopPrompter,
-        noopSecretPrompter,
-        ctx,
-        noopLifecycleHandler,
-        mock(() => {}),
-      );
-
-      await toolFn("file_write", { path: "/tmp/other/file.ts" });
-
-      expect(_testing.pendingAppRefreshCtx.size).toBe(0);
-      await new Promise((r) => setTimeout(r, 600));
-      expect(refreshSpy).not.toHaveBeenCalled();
-    });
-
-    test("rapid edits are coalesced into a single refresh", async () => {
-      const ctx = makeCtx();
-      const broadcastSpy = mock(() => {});
-
-      // Simulate 3 rapid file edits to the same app
-      for (const file of ["main.tsx", "styles.css", "utils.ts"]) {
-        const executor = makeFakeExecutor({
-          content: "edited",
-          isError: false,
-          diff: {
-            filePath: `${TEST_APPS_DIR}/my-app/src/${file}`,
-            oldContent: "old",
-            newContent: "new",
-            isNewFile: false,
-          },
-        });
-
-        const toolFn = createToolExecutor(
-          executor as unknown as ToolExecutor,
-          noopPrompter,
-          noopSecretPrompter,
-          ctx,
-          noopLifecycleHandler,
-          broadcastSpy,
-        );
-
-        await toolFn("file_edit", {
-          path: `${TEST_APPS_DIR}/my-app/src/${file}`,
-        });
-      }
-
-      // All 3 edits share one pending context
-      expect(_testing.pendingAppRefreshCtx.size).toBe(1);
-
-      // Wait for debounce — should only fire once
-      await new Promise((r) => setTimeout(r, 600));
-      expect(refreshSpy).toHaveBeenCalledTimes(1);
-      expect(broadcastSpy).toHaveBeenCalledTimes(1);
-    });
-
-    test("error results do not trigger auto-refresh", async () => {
-      const ctx = makeCtx();
-      const executor = makeFakeExecutor({
-        content: "Error: file not found",
-        isError: true,
-        diff: {
-          filePath: `${TEST_APPS_DIR}/my-app/src/main.tsx`,
-          oldContent: "",
-          newContent: "",
-          isNewFile: false,
-        },
-      });
-
-      const toolFn = createToolExecutor(
-        executor as unknown as ToolExecutor,
-        noopPrompter,
-        noopSecretPrompter,
-        ctx,
-        noopLifecycleHandler,
-        mock(() => {}),
-      );
-
-      await toolFn("file_write", {
-        path: `${TEST_APPS_DIR}/my-app/src/main.tsx`,
-      });
-
-      expect(_testing.pendingAppRefreshCtx.size).toBe(0);
-    });
-  });
 });

--- a/assistant/src/daemon/app-source-watcher.ts
+++ b/assistant/src/daemon/app-source-watcher.ts
@@ -1,0 +1,90 @@
+/**
+ * Filesystem watcher for app source directories.
+ *
+ * Watches the apps root directory recursively using fs.watch (FSEvents on
+ * macOS). When a source file changes, debounces per app ID and calls the
+ * provided callback so the server can recompile + refresh surfaces.
+ *
+ * This catches ALL modification sources (file_edit, file_write, bash, etc.)
+ * without relying on individual tool hooks.
+ */
+
+import { existsSync, type FSWatcher, watch } from "node:fs";
+
+import {
+  getAppsDir,
+  resolveAppIdByDirName,
+} from "../memory/app-store.js";
+import { DebouncerMap } from "../util/debounce.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("app-source-watcher");
+
+const APP_REFRESH_DEBOUNCE_MS = 500;
+
+export type AppSourceChangeCallback = (appId: string) => void;
+
+/**
+ * Resolve app ID from a relative path within the apps directory.
+ * Returns null if the path is not an app source file (e.g. dist/, records/).
+ */
+function resolveAppIdFromRelPath(relPath: string): string | null {
+  const slashIdx = relPath.indexOf("/");
+  if (slashIdx === -1) return null; // file directly in apps/ (e.g. .json definition)
+
+  const dirName = relPath.slice(0, slashIdx);
+  const innerPath = relPath.slice(slashIdx + 1);
+
+  // Skip non-source directories
+  if (innerPath.startsWith("records/") || innerPath.startsWith("dist/")) {
+    return null;
+  }
+
+  return resolveAppIdByDirName(dirName);
+}
+
+export class AppSourceWatcher {
+  private watcher: FSWatcher | null = null;
+  private debouncer = new DebouncerMap({
+    defaultDelayMs: APP_REFRESH_DEBOUNCE_MS,
+    maxEntries: 50,
+  });
+
+  start(onChange: AppSourceChangeCallback): void {
+    let appsDir: string;
+    try {
+      appsDir = getAppsDir();
+    } catch {
+      log.warn("Could not resolve apps directory; app source watching disabled");
+      return;
+    }
+
+    if (!existsSync(appsDir)) {
+      log.info("Apps directory does not exist yet; skipping source watcher");
+      return;
+    }
+
+    try {
+      this.watcher = watch(appsDir, { recursive: true }, (_eventType, filename) => {
+        if (!filename) return;
+
+        const appId = resolveAppIdFromRelPath(filename);
+        if (!appId) return;
+
+        this.debouncer.schedule(`app:${appId}`, () => {
+          onChange(appId);
+        });
+      });
+    } catch (err) {
+      log.warn({ err }, "Failed to watch apps directory; source watching disabled");
+    }
+  }
+
+  stop(): void {
+    this.debouncer.cancelAll();
+    if (this.watcher) {
+      this.watcher.close();
+      this.watcher = null;
+    }
+  }
+}

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -6,6 +6,7 @@ import {
   getAcpSessionManager,
   setBroadcastToAllClients,
 } from "../acp/index.js";
+import { compileApp } from "../bundler/app-compiler.js";
 import { enrichMessageWithSourcePaths } from "../agent/attachments.js";
 import {
   createAssistantMessage,
@@ -22,6 +23,11 @@ import { onContactChange } from "../contacts/contact-events.js";
 import type { CesClient } from "../credential-execution/client.js";
 import type { CesProcessManager } from "../credential-execution/process-manager.js";
 import type { HeartbeatService } from "../heartbeat/heartbeat-service.js";
+import {
+  getApp,
+  getAppDirPath,
+  isMultifileApp,
+} from "../memory/app-store.js";
 import * as attachmentsStore from "../memory/attachments-store.js";
 import {
   createCanonicalGuardianRequest,
@@ -49,6 +55,7 @@ import { bridgeConfirmationRequestToGuardian } from "../runtime/confirmation-req
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { checkIngressForSecrets } from "../security/secret-ingress.js";
 import { redactSecrets } from "../security/secret-scanner.js";
+import { updatePublishedAppDeployment } from "../services/published-app-updater.js";
 import { registerCancelCallback } from "../signals/cancel.js";
 import { registerConversationUndoCallback } from "../signals/conversation-undo.js";
 import { appendEventToStream } from "../signals/event-stream.js";
@@ -61,6 +68,7 @@ import {
   getWorkspacePromptPath,
 } from "../util/platform.js";
 import { registerDaemonCallbacks } from "../work-items/work-item-runner.js";
+import { AppSourceWatcher } from "./app-source-watcher.js";
 import { ConfigWatcher } from "./config-watcher.js";
 import {
   Conversation,
@@ -69,6 +77,7 @@ import {
 } from "./conversation.js";
 import { ConversationEvictor } from "./conversation-evictor.js";
 import { formatCompactResult } from "./conversation-process.js";
+import { refreshSurfacesForApp } from "./conversation-surfaces.js";
 import { resolveChannelCapabilities } from "./conversation-runtime-assembly.js";
 import { resolveSlash, type SlashContext } from "./conversation-slash.js";
 import { undoLastMessage } from "./handlers/conversations.js";
@@ -271,6 +280,7 @@ export class DaemonServer {
 
   // Composed subsystems
   private configWatcher = new ConfigWatcher();
+  private appSourceWatcher = new AppSourceWatcher();
 
   // CES (Credential Execution Service) — process-level singleton.
   // Lifecycle is managed by startCesProcess() in lifecycle.ts; the server
@@ -523,6 +533,44 @@ export class DaemonServer {
     }
   }
 
+  /**
+   * Handle a detected app source file change from the filesystem watcher.
+   * Recompiles multifile apps and refreshes surfaces across ALL conversations.
+   */
+  private handleAppSourceChange(appId: string): void {
+    const app = getApp(appId);
+    if (!app) return;
+
+    const doRefresh = () => {
+      for (const conversation of this.conversations.values()) {
+        refreshSurfacesForApp(conversation, appId, { fileChange: true });
+      }
+      this.broadcast({ type: "app_files_changed", appId });
+      void updatePublishedAppDeployment(appId);
+    };
+
+    if (isMultifileApp(app)) {
+      const appDir = getAppDirPath(appId);
+      void compileApp(appDir)
+        .then((result) => {
+          if (!result.ok) {
+            log.warn(
+              { appId, errors: result.errors },
+              "Recompile failed on app source change",
+            );
+          }
+          doRefresh();
+        })
+        .catch((err) => {
+          log.warn({ appId, err }, "Recompile threw on app source change");
+          doRefresh();
+        });
+      return;
+    }
+
+    doRefresh();
+  }
+
   // ── Server lifecycle ────────────────────────────────────────────────
 
   async start(): Promise<void> {
@@ -674,6 +722,10 @@ export class DaemonServer {
       () => this.broadcastIdentityChanged(),
     );
 
+    this.appSourceWatcher.start((appId) =>
+      this.handleAppSourceChange(appId),
+    );
+
     // Broadcast contacts_changed to all clients when any contact mutation occurs.
     this.unsubscribeContactChange = onContactChange(() => {
       this.broadcast({ type: "contacts_changed" });
@@ -687,6 +739,7 @@ export class DaemonServer {
     disposeAcpSessionManager();
     this.evictor.stop();
     this.configWatcher.stop();
+    this.appSourceWatcher.stop();
     if (this.unsubscribeContactChange) {
       this.unsubscribeContactChange();
       this.unsubscribeContactChange = null;

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -9,17 +9,11 @@
 
 import { compileApp } from "../bundler/app-compiler.js";
 import { generateAppIcon } from "../media/app-icon-generator.js";
-import {
-  getApp,
-  getAppDirPath,
-  isMultifileApp,
-  resolveAppIdFromPath,
-} from "../memory/app-store.js";
+import { getApp, getAppDirPath, isMultifileApp } from "../memory/app-store.js";
 import { findActiveSession } from "../runtime/channel-verification-service.js";
 import { deliverVerificationSlack } from "../runtime/verification-outbound-actions.js";
 import { updatePublishedAppDeployment } from "../services/published-app-updater.js";
 import type { ToolExecutionResult } from "../tools/types.js";
-import { DebouncerMap } from "../util/debounce.js";
 import { getLogger } from "../util/logger.js";
 import { refreshSurfacesForApp } from "./conversation-surfaces.js";
 import type { ToolSetupContext } from "./conversation-tool-setup.js";
@@ -175,49 +169,6 @@ registerHook(
   },
 );
 
-// ── File-edit auto-refresh for apps ─────────────────────────────────
-
-const APP_REFRESH_DEBOUNCE_MS = 500;
-
-/** Per-app debounce timers for coalescing rapid file edits. */
-const appRefreshDebouncer = new DebouncerMap({
-  defaultDelayMs: APP_REFRESH_DEBOUNCE_MS,
-  maxEntries: 50,
-});
-
-/** Stores the latest SideEffectContext per app ID for debounced callbacks. */
-const pendingAppRefreshCtx = new Map<string, SideEffectContext>();
-
-// Trigger debounced app recompile + surface refresh when file_write or
-// file_edit modifies a source file inside an app directory.
-registerHook(
-  ["file_write", "file_edit"],
-  (_name, input, result, sideEffectCtx) => {
-    const filePath =
-      result.diff?.filePath ?? (input.path as string | undefined);
-    if (!filePath) return;
-
-    const appId = resolveAppIdFromPath(filePath);
-    if (!appId) return;
-
-    // Store the latest context so the debounced callback uses fresh state
-    pendingAppRefreshCtx.set(appId, sideEffectCtx);
-
-    appRefreshDebouncer.schedule(`app:${appId}`, () => {
-      const latestCtx = pendingAppRefreshCtx.get(appId);
-      pendingAppRefreshCtx.delete(appId);
-      if (!latestCtx) return;
-
-      handleAppChange(
-        latestCtx.ctx,
-        appId,
-        latestCtx.broadcastToAllClients,
-        { fileChange: true },
-      );
-    });
-  },
-);
-
 // Broadcast tasks_changed so connected clients (e.g. macOS Tasks window)
 // auto-refresh when the LLM mutates the task queue via tools
 registerHook(
@@ -347,9 +298,3 @@ export function runPostExecutionSideEffects(
   }
 }
 
-/** @internal Exposed for testing only. */
-export const _testing = {
-  appRefreshDebouncer,
-  pendingAppRefreshCtx,
-  resolveAppIdFromPath,
-};


### PR DESCRIPTION
## Summary

- Adds `AppSourceWatcher` class (follows `ConfigWatcher` pattern) that watches the apps directory recursively and triggers debounced recompile + surface refresh on source file changes
- Integrates watcher into `DaemonServer` lifecycle — `handleAppSourceChange` iterates ALL conversations to refresh surfaces, not just the current one
- Removes the `file_edit`/`file_write` tool-level hooks from `tool-side-effects.ts` — the watcher makes them redundant and also catches bash edits

## Original prompt

Bug report followup: "What do you think about using a file watcher instead so it works even if the assistant uses bash to edit the files?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)