### PR TITLE
fix: resolve lint errors in server.ts and app-source-watcher test

### DIFF
--- a/assistant/src/__tests__/app-source-watcher.test.ts
+++ b/assistant/src/__tests__/app-source-watcher.test.ts
@@ -3,6 +3,7 @@
  * file changes and triggers debounced recompile + surface refresh.
  */
 
+import * as actualFs from "node:fs";
 import {
   afterEach,
   beforeEach,
@@ -23,9 +24,8 @@ let capturedWatchCallback: ((eventType: string, filename: string | null) => void
 const mockWatcher = { close: mock(() => {}) };
 
 mock.module("node:fs", () => {
-  const actual = require("node:fs");
   return {
-    ...actual,
+    ...actualFs,
     existsSync: mock((p: string) => p === TEST_APPS_DIR),
     watch: mock(
       (

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -6,12 +6,12 @@ import {
   getAcpSessionManager,
   setBroadcastToAllClients,
 } from "../acp/index.js";
-import { compileApp } from "../bundler/app-compiler.js";
 import { enrichMessageWithSourcePaths } from "../agent/attachments.js";
 import {
   createAssistantMessage,
   createUserMessage,
 } from "../agent/message-types.js";
+import { compileApp } from "../bundler/app-compiler.js";
 import {
   type ChannelId,
   type InterfaceId,
@@ -77,9 +77,9 @@ import {
 } from "./conversation.js";
 import { ConversationEvictor } from "./conversation-evictor.js";
 import { formatCompactResult } from "./conversation-process.js";
-import { refreshSurfacesForApp } from "./conversation-surfaces.js";
 import { resolveChannelCapabilities } from "./conversation-runtime-assembly.js";
 import { resolveSlash, type SlashContext } from "./conversation-slash.js";
+import { refreshSurfacesForApp } from "./conversation-surfaces.js";
 import { undoLastMessage } from "./handlers/conversations.js";
 import { parseIdentityFields } from "./handlers/identity.js";
 import type {


### PR DESCRIPTION
## Summary
- Fixed `simple-import-sort/imports` error in `daemon/server.ts` by sorting imports alphabetically (`../agent/` before `../bundler/`)
- Fixed `@typescript-eslint/no-require-imports` error in `app-source-watcher.test.ts` by replacing `require("node:fs")` with a top-level `import * as actualFs`

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23922707996/job/69772617527
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
