### PR TITLE
fix: resolve CI lint and guard test failures

### DIFF
--- a/assistant/src/__tests__/app-dir-path-guard.test.ts
+++ b/assistant/src/__tests__/app-dir-path-guard.test.ts
@@ -18,6 +18,7 @@ import { describe, expect, test } from "bun:test";
 const ALLOWLIST = new Set([
   "assistant/src/memory/app-store.ts", // defines getAppsDir
   "assistant/src/memory/app-git-service.ts", // uses getAppsDir for git repo root, not per-app paths
+  "assistant/src/daemon/app-source-watcher.ts", // uses getAppsDir for recursive fs.watch root, not per-app paths
 ]);
 
 function isTestFile(filePath: string): boolean {


### PR DESCRIPTION
## Summary
- Add `app-source-watcher.ts` to the `getAppsDir` guard test allowlist (it uses `getAppsDir()` for the recursive `fs.watch` root, not for per-app path construction)
- Add `eslint-disable` comment for the `require("node:fs")` in the watcher test mock (same pattern as `config-watcher.test.ts`)
- Fix import sort order in `server.ts`

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23922707996/job/69772617487
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
