### PR TITLE
fix: update stale ordering comment in db-init.ts

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -566,8 +566,6 @@ export function initializeDb(): void {
   migrateCreateMemoryGraphTables(database);
 
   // 101a. Add nullable image_refs TEXT column to memory_graph_nodes.
-  // MUST run before migrateToolCreatedItems (101b) because that migration
-  // inserts rows into memory_graph_nodes including the image_refs column.
   migrateMemoryGraphImageRefs(database);
 
   // 101b. Migrate tool-created items from legacy memory_items → graph nodes.


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-migration-image-refs-crash.md.

**Gap:** Stale ordering comment in db-init.ts references removed behavior
**What was expected:** Comment should accurately reflect the current code
**What was found:** Comment at lines 568-570 says migrateToolCreatedItems inserts rows including the image_refs column, which is no longer true after PR #23290 removed image_refs from the INSERT
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23293" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
