### PR TITLE
Add assistant profiler run store and local disk budgets

### DIFF
--- a/assistant/src/__tests__/profiler-run-store.test.ts
+++ b/assistant/src/__tests__/profiler-run-store.test.ts
@@ -1,0 +1,441 @@
+/**
+ * Tests for the profiler run store: manifest management, retention sweep,
+ * active-run protection, oldest-first pruning, max-run-count pruning,
+ * active-run-over-budget signaling, and idempotent rescans.
+ */
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { ProfilerRunManifest } from "../daemon/profiler-run-store.js";
+import { rescanRuns, runProfilerSweep } from "../daemon/profiler-run-store.js";
+
+// ── Test scaffolding ────────────────────────────────────────────────────
+
+let testDir: string;
+let runsDir: string;
+let origEnv: Record<string, string | undefined>;
+
+/**
+ * Create a fake profiler run directory with some payload files.
+ */
+function createRun(
+  runId: string,
+  opts?: {
+    sizeBytes?: number;
+    manifest?: Partial<ProfilerRunManifest>;
+  },
+): string {
+  const dir = join(runsDir, runId);
+  mkdirSync(dir, { recursive: true });
+
+  // Write a payload file of the requested size
+  const size = opts?.sizeBytes ?? 1024;
+  writeFileSync(join(dir, "profile.cpuprofile"), Buffer.alloc(size));
+
+  // Optionally write a pre-existing manifest
+  if (opts?.manifest) {
+    const m: ProfilerRunManifest = {
+      runId,
+      status: opts.manifest.status ?? "completed",
+      createdAt: opts.manifest.createdAt ?? new Date().toISOString(),
+      updatedAt: opts.manifest.updatedAt ?? new Date().toISOString(),
+      totalBytes: opts.manifest.totalBytes ?? size,
+    };
+    writeFileSync(join(dir, "manifest.json"), JSON.stringify(m, null, 2));
+  }
+
+  return dir;
+}
+
+function readManifestFromDisk(runId: string): ProfilerRunManifest | null {
+  const manifestPath = join(runsDir, runId, "manifest.json");
+  try {
+    return JSON.parse(readFileSync(manifestPath, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+beforeEach(() => {
+  testDir = join(
+    tmpdir(),
+    `vellum-profiler-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  runsDir = join(testDir, "data", "profiler", "runs");
+  mkdirSync(runsDir, { recursive: true });
+
+  // Save and override env
+  origEnv = {
+    VELLUM_WORKSPACE_DIR: process.env.VELLUM_WORKSPACE_DIR,
+    VELLUM_PROFILER_RUN_ID: process.env.VELLUM_PROFILER_RUN_ID,
+    VELLUM_PROFILER_MAX_BYTES: process.env.VELLUM_PROFILER_MAX_BYTES,
+    VELLUM_PROFILER_MAX_RUNS: process.env.VELLUM_PROFILER_MAX_RUNS,
+    VELLUM_PROFILER_MIN_FREE_MB: process.env.VELLUM_PROFILER_MIN_FREE_MB,
+  };
+
+  // Point workspace dir to our temp directory
+  process.env.VELLUM_WORKSPACE_DIR = testDir;
+
+  // Clear profiler env vars
+  delete process.env.VELLUM_PROFILER_RUN_ID;
+  delete process.env.VELLUM_PROFILER_MAX_BYTES;
+  delete process.env.VELLUM_PROFILER_MAX_RUNS;
+  delete process.env.VELLUM_PROFILER_MIN_FREE_MB;
+});
+
+afterEach(() => {
+  // Restore env
+  for (const [key, value] of Object.entries(origEnv)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  // Clean up temp directory
+  if (existsSync(testDir)) {
+    rmSync(testDir, { recursive: true, force: true });
+  }
+});
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe("Profiler run store", () => {
+  describe("rescanRuns", () => {
+    test("returns empty array when no runs directory exists", () => {
+      // Remove the runs directory
+      rmSync(runsDir, { recursive: true, force: true });
+      const manifests = rescanRuns();
+      expect(manifests).toEqual([]);
+    });
+
+    test("returns empty array when runs directory is empty", () => {
+      const manifests = rescanRuns();
+      expect(manifests).toEqual([]);
+    });
+
+    test("creates manifests for run directories without existing manifests", () => {
+      createRun("run-001", { sizeBytes: 2048 });
+      createRun("run-002", { sizeBytes: 4096 });
+
+      const manifests = rescanRuns();
+      expect(manifests).toHaveLength(2);
+
+      const run1 = manifests.find((m) => m.runId === "run-001");
+      expect(run1).toBeDefined();
+      expect(run1!.status).toBe("completed");
+      // totalBytes includes manifest.json that rescan just wrote
+      expect(run1!.totalBytes).toBeGreaterThanOrEqual(2048);
+
+      const run2 = manifests.find((m) => m.runId === "run-002");
+      expect(run2).toBeDefined();
+      expect(run2!.status).toBe("completed");
+      expect(run2!.totalBytes).toBeGreaterThanOrEqual(4096);
+    });
+
+    test("marks the active run correctly", () => {
+      process.env.VELLUM_PROFILER_RUN_ID = "active-run";
+      createRun("active-run", { sizeBytes: 1024 });
+      createRun("old-run", { sizeBytes: 1024 });
+
+      const manifests = rescanRuns();
+      const active = manifests.find((m) => m.runId === "active-run");
+      const old = manifests.find((m) => m.runId === "old-run");
+
+      expect(active!.status).toBe("active");
+      expect(old!.status).toBe("completed");
+    });
+
+    test("transitions previously-active run to completed when no longer active", () => {
+      // Create a run with an "active" manifest
+      createRun("old-active", {
+        sizeBytes: 1024,
+        manifest: { status: "active", createdAt: "2025-01-01T00:00:00Z" },
+      });
+
+      // No VELLUM_PROFILER_RUN_ID set, so nothing is active
+      const manifests = rescanRuns();
+      const run = manifests.find((m) => m.runId === "old-active");
+
+      expect(run!.status).toBe("completed");
+
+      // Verify it was persisted to disk
+      const onDisk = readManifestFromDisk("old-active");
+      expect(onDisk!.status).toBe("completed");
+    });
+
+    test("is idempotent — repeated calls after initial scan produce the same result", () => {
+      createRun("run-a", { sizeBytes: 1024 });
+      process.env.VELLUM_PROFILER_RUN_ID = "run-a";
+
+      // First call writes the manifest, which changes totalBytes
+      rescanRuns();
+      // Second and third calls should be stable
+      const second = rescanRuns();
+      const third = rescanRuns();
+
+      expect(second).toHaveLength(1);
+      expect(third).toHaveLength(1);
+      expect(second[0]!.runId).toBe(third[0]!.runId);
+      expect(second[0]!.status).toBe(third[0]!.status);
+      expect(second[0]!.totalBytes).toBe(third[0]!.totalBytes);
+    });
+
+    test("preserves createdAt from existing manifest", () => {
+      const originalCreatedAt = "2024-06-15T12:00:00Z";
+      createRun("preserved-run", {
+        sizeBytes: 1024,
+        manifest: {
+          status: "completed",
+          createdAt: originalCreatedAt,
+        },
+      });
+
+      const manifests = rescanRuns();
+      const run = manifests.find((m) => m.runId === "preserved-run");
+      expect(run!.createdAt).toBe(originalCreatedAt);
+    });
+  });
+
+  describe("runProfilerSweep", () => {
+    test("no-ops when no runs exist", () => {
+      const result = runProfilerSweep();
+      expect(result.prunedCount).toBe(0);
+      expect(result.freedBytes).toBe(0);
+      expect(result.activeRunOverBudget).toBe(false);
+      expect(result.remainingRuns).toBe(0);
+    });
+
+    test("does not prune when under all budgets", () => {
+      process.env.VELLUM_PROFILER_MAX_BYTES = "1000000"; // 1 MB
+      process.env.VELLUM_PROFILER_MAX_RUNS = "10";
+
+      createRun("run-1", { sizeBytes: 1024 });
+      createRun("run-2", { sizeBytes: 1024 });
+
+      const result = runProfilerSweep();
+      expect(result.prunedCount).toBe(0);
+      expect(result.remainingRuns).toBe(2);
+
+      // Both directories still exist
+      expect(existsSync(join(runsDir, "run-1"))).toBe(true);
+      expect(existsSync(join(runsDir, "run-2"))).toBe(true);
+    });
+
+    test("prunes oldest completed runs when byte budget exceeded", () => {
+      // Set a very small byte budget
+      process.env.VELLUM_PROFILER_MAX_BYTES = "3000";
+      process.env.VELLUM_PROFILER_MAX_RUNS = "100";
+      process.env.VELLUM_PROFILER_MIN_FREE_MB = "0";
+
+      // Create runs with explicit timestamps for ordering
+      createRun("oldest", {
+        sizeBytes: 2000,
+        manifest: {
+          status: "completed",
+          createdAt: "2025-01-01T00:00:00Z",
+        },
+      });
+      createRun("middle", {
+        sizeBytes: 2000,
+        manifest: {
+          status: "completed",
+          createdAt: "2025-02-01T00:00:00Z",
+        },
+      });
+      createRun("newest", {
+        sizeBytes: 2000,
+        manifest: {
+          status: "completed",
+          createdAt: "2025-03-01T00:00:00Z",
+        },
+      });
+
+      const result = runProfilerSweep();
+
+      // Should prune until total bytes fit within 3000.
+      // Each run is ~2000 payload + manifest overhead. The sweep recomputes
+      // sizes so actual totals include the manifest file. At least 1 run
+      // should be pruned (the oldest).
+      expect(result.prunedCount).toBeGreaterThanOrEqual(1);
+      expect(result.freedBytes).toBeGreaterThan(0);
+
+      // The oldest should be gone
+      expect(existsSync(join(runsDir, "oldest"))).toBe(false);
+    });
+
+    test("prunes oldest completed runs when max-run-count exceeded", () => {
+      process.env.VELLUM_PROFILER_MAX_BYTES = "999999999";
+      process.env.VELLUM_PROFILER_MAX_RUNS = "2";
+      process.env.VELLUM_PROFILER_MIN_FREE_MB = "0";
+
+      createRun("run-a", {
+        sizeBytes: 100,
+        manifest: {
+          status: "completed",
+          createdAt: "2025-01-01T00:00:00Z",
+        },
+      });
+      createRun("run-b", {
+        sizeBytes: 100,
+        manifest: {
+          status: "completed",
+          createdAt: "2025-02-01T00:00:00Z",
+        },
+      });
+      createRun("run-c", {
+        sizeBytes: 100,
+        manifest: {
+          status: "completed",
+          createdAt: "2025-03-01T00:00:00Z",
+        },
+      });
+      createRun("run-d", {
+        sizeBytes: 100,
+        manifest: {
+          status: "completed",
+          createdAt: "2025-04-01T00:00:00Z",
+        },
+      });
+
+      const result = runProfilerSweep();
+
+      // 4 completed runs, max 2: should prune 2 oldest
+      expect(result.prunedCount).toBe(2);
+      expect(existsSync(join(runsDir, "run-a"))).toBe(false);
+      expect(existsSync(join(runsDir, "run-b"))).toBe(false);
+      expect(existsSync(join(runsDir, "run-c"))).toBe(true);
+      expect(existsSync(join(runsDir, "run-d"))).toBe(true);
+      expect(result.remainingRuns).toBe(2);
+    });
+
+    test("never deletes the active run", () => {
+      process.env.VELLUM_PROFILER_RUN_ID = "current";
+      process.env.VELLUM_PROFILER_MAX_BYTES = "500";
+      process.env.VELLUM_PROFILER_MAX_RUNS = "1";
+      process.env.VELLUM_PROFILER_MIN_FREE_MB = "0";
+
+      createRun("current", { sizeBytes: 2000 });
+      createRun("old-completed", {
+        sizeBytes: 2000,
+        manifest: {
+          status: "completed",
+          createdAt: "2025-01-01T00:00:00Z",
+        },
+      });
+
+      const result = runProfilerSweep();
+
+      // old-completed should be pruned, current should survive
+      expect(existsSync(join(runsDir, "current"))).toBe(true);
+      expect(existsSync(join(runsDir, "old-completed"))).toBe(false);
+      expect(result.prunedCount).toBe(1);
+    });
+
+    test("signals active-run-over-budget when active run exceeds byte budget", () => {
+      process.env.VELLUM_PROFILER_RUN_ID = "big-active";
+      process.env.VELLUM_PROFILER_MAX_BYTES = "500";
+      process.env.VELLUM_PROFILER_MAX_RUNS = "100";
+      process.env.VELLUM_PROFILER_MIN_FREE_MB = "0";
+
+      createRun("big-active", { sizeBytes: 10000 });
+
+      const result = runProfilerSweep();
+
+      expect(result.activeRunOverBudget).toBe(true);
+      // Active run must still exist
+      expect(existsSync(join(runsDir, "big-active"))).toBe(true);
+      expect(result.remainingRuns).toBe(1);
+    });
+
+    test("deletes single oversized completed run to recover space", () => {
+      process.env.VELLUM_PROFILER_MAX_BYTES = "100";
+      process.env.VELLUM_PROFILER_MAX_RUNS = "100";
+      process.env.VELLUM_PROFILER_MIN_FREE_MB = "0";
+
+      createRun("huge-completed", {
+        sizeBytes: 50000,
+        manifest: {
+          status: "completed",
+          createdAt: "2025-01-01T00:00:00Z",
+        },
+      });
+
+      const result = runProfilerSweep();
+
+      expect(result.prunedCount).toBe(1);
+      expect(result.freedBytes).toBeGreaterThanOrEqual(50000);
+      expect(existsSync(join(runsDir, "huge-completed"))).toBe(false);
+    });
+
+    test("creates profiler directories on first sweep if missing", () => {
+      // Remove everything
+      rmSync(join(testDir, "data", "profiler"), {
+        recursive: true,
+        force: true,
+      });
+
+      const result = runProfilerSweep();
+      expect(result.prunedCount).toBe(0);
+      expect(existsSync(runsDir)).toBe(true);
+    });
+
+    test("sweep is idempotent — repeated calls produce consistent state", () => {
+      process.env.VELLUM_PROFILER_MAX_BYTES = "999999";
+      process.env.VELLUM_PROFILER_MAX_RUNS = "10";
+      process.env.VELLUM_PROFILER_MIN_FREE_MB = "0";
+
+      createRun("stable-1", { sizeBytes: 1024 });
+      createRun("stable-2", { sizeBytes: 1024 });
+
+      const first = runProfilerSweep();
+      const second = runProfilerSweep();
+
+      expect(first.prunedCount).toBe(0);
+      expect(second.prunedCount).toBe(0);
+      expect(first.remainingRuns).toBe(second.remainingRuns);
+    });
+
+    test("active run is not counted against max completed runs", () => {
+      process.env.VELLUM_PROFILER_RUN_ID = "live";
+      process.env.VELLUM_PROFILER_MAX_BYTES = "999999";
+      process.env.VELLUM_PROFILER_MAX_RUNS = "2";
+      process.env.VELLUM_PROFILER_MIN_FREE_MB = "0";
+
+      createRun("live", { sizeBytes: 100 });
+      createRun("done-1", {
+        sizeBytes: 100,
+        manifest: {
+          status: "completed",
+          createdAt: "2025-01-01T00:00:00Z",
+        },
+      });
+      createRun("done-2", {
+        sizeBytes: 100,
+        manifest: {
+          status: "completed",
+          createdAt: "2025-02-01T00:00:00Z",
+        },
+      });
+
+      const result = runProfilerSweep();
+
+      // 2 completed runs = max, so nothing should be pruned
+      expect(result.prunedCount).toBe(0);
+      // Active + 2 completed = 3 remaining
+      expect(result.remainingRuns).toBe(3);
+      expect(existsSync(join(runsDir, "live"))).toBe(true);
+      expect(existsSync(join(runsDir, "done-1"))).toBe(true);
+      expect(existsSync(join(runsDir, "done-2"))).toBe(true);
+    });
+  });
+});

--- a/assistant/src/config/env-registry.ts
+++ b/assistant/src/config/env-registry.ts
@@ -24,6 +24,13 @@ function flag(name: string): boolean {
   return raw === "true" || raw === "1";
 }
 
+function int(name: string): number | undefined {
+  const raw = str(name);
+  if (raw === undefined) return undefined;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) ? n : undefined;
+}
+
 // ── Registry ─────────────────────────────────────────────────────────────────
 // Each entry documents the env var name, type, default, and purpose.
 
@@ -74,6 +81,57 @@ export function getWorkspaceDirOverride(): string | undefined {
   return str("VELLUM_WORKSPACE_DIR");
 }
 
+// ── Profiler env vars ───────────────────────────────────────────────────
+// These are injected by the platform when running a managed assistant in
+// profiler mode. The runtime uses them to locate, scope, and budget-limit
+// profiler output on the workspace volume.
+
+/**
+ * VELLUM_PROFILER_RUN_ID — string, default: undefined
+ * Unique identifier for the current profiler run. When set, the profiler
+ * run store treats this run as "active" and will never prune its directory.
+ */
+export function getProfilerRunId(): string | undefined {
+  return str("VELLUM_PROFILER_RUN_ID");
+}
+
+/**
+ * VELLUM_PROFILER_MODE — string, default: undefined
+ * The profiling mode to activate (e.g. "cpu", "heap", "cpu+heap").
+ * When unset, profiling is disabled.
+ */
+export function getProfilerMode(): string | undefined {
+  return str("VELLUM_PROFILER_MODE");
+}
+
+/**
+ * VELLUM_PROFILER_MAX_BYTES — integer, default: undefined
+ * Maximum total bytes retained across all completed profiler runs.
+ * The startup sweep prunes oldest completed runs to stay within budget.
+ */
+export function getProfilerMaxBytes(): number | undefined {
+  return int("VELLUM_PROFILER_MAX_BYTES");
+}
+
+/**
+ * VELLUM_PROFILER_MAX_RUNS — integer, default: undefined
+ * Maximum number of completed profiler runs retained on disk.
+ * The startup sweep prunes oldest completed runs to stay within budget.
+ */
+export function getProfilerMaxRuns(): number | undefined {
+  return int("VELLUM_PROFILER_MAX_RUNS");
+}
+
+/**
+ * VELLUM_PROFILER_MIN_FREE_MB — integer, default: undefined
+ * Minimum free disk space (in megabytes) that must remain after profiler
+ * runs are accounted for. The startup sweep prunes oldest completed runs
+ * until at least this much free space is available.
+ */
+export function getProfilerMinFreeMb(): number | undefined {
+  return int("VELLUM_PROFILER_MIN_FREE_MB");
+}
+
 // ── Known env var names ──────────────────────────────────────────────────────
 
 /**
@@ -97,6 +155,11 @@ const KNOWN_VELLUM_VARS = new Set([
   "VELLUM_HOOK_SETTINGS",
   "VELLUM_LOCKFILE_DIR",
   "VELLUM_PLATFORM_URL",
+  "VELLUM_PROFILER_MAX_BYTES",
+  "VELLUM_PROFILER_MAX_RUNS",
+  "VELLUM_PROFILER_MIN_FREE_MB",
+  "VELLUM_PROFILER_MODE",
+  "VELLUM_PROFILER_RUN_ID",
   "VELLUM_ROOT_DIR",
   "VELLUM_SSH_USER",
   "VELLUM_UNSAFE_AUTH_BYPASS",

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -123,6 +123,7 @@ import {
 } from "./handlers/conversations.js";
 import { installAssistantSymlink } from "./install-symlink.js";
 import type { ServerMessage } from "./message-protocol.js";
+import { runProfilerSweep } from "./profiler-run-store.js";
 import {
   initializeProvidersAndTools,
   registerMessagingProviders,
@@ -285,6 +286,26 @@ export async function runDaemon(): Promise<void> {
 
     await runWorkspaceMigrations(getWorkspaceDir(), WORKSPACE_MIGRATIONS);
     log.info("Daemon startup: workspace migrations complete");
+
+    // Profiler retention sweep — prune completed profiler runs to stay
+    // within configured byte-count, run-count, and free-space budgets.
+    // Runs on every startup and is safe to call from explicit cleanup routes.
+    try {
+      const sweepResult = runProfilerSweep();
+      if (sweepResult.prunedCount > 0 || sweepResult.activeRunOverBudget) {
+        log.info(
+          {
+            prunedCount: sweepResult.prunedCount,
+            freedBytes: sweepResult.freedBytes,
+            activeRunOverBudget: sweepResult.activeRunOverBudget,
+            remainingRuns: sweepResult.remainingRuns,
+          },
+          "Profiler retention sweep completed on startup",
+        );
+      }
+    } catch (err) {
+      log.warn({ err }, "Profiler retention sweep failed — continuing startup");
+    }
 
     // Backfill oauth_connection rows for manual-token providers (Telegram,
     // Slack channel) that already have stored credentials from before the

--- a/assistant/src/daemon/profiler-run-store.ts
+++ b/assistant/src/daemon/profiler-run-store.ts
@@ -182,10 +182,22 @@ export function rescanRuns(): ProfilerRunManifest[] {
     const existing = readManifest(runDir);
     const isActive = runId === activeRunId;
 
+    // For first-time manifests (no existing manifest.json), seed createdAt
+    // from the directory's mtime so legacy runs preserve their actual age
+    // for oldest-first pruning order.
+    let createdAt = existing?.createdAt ?? now;
+    if (!existing) {
+      try {
+        createdAt = statSync(runDir).mtime.toISOString();
+      } catch {
+        // Fall back to current time if stat fails
+      }
+    }
+
     const manifest: ProfilerRunManifest = {
       runId,
       status: isActive ? "active" : "completed",
-      createdAt: existing?.createdAt ?? now,
+      createdAt,
       updatedAt: now,
       totalBytes,
     };
@@ -280,16 +292,15 @@ export function runProfilerSweep(): ProfilerSweepResult {
 
     try {
       rmSync(runDir, { recursive: true, force: true });
+      totalBytes -= oldest.totalBytes;
+      freedBytes += oldest.totalBytes;
+      prunedCount++;
     } catch (err) {
       log.warn(
         { runId: oldest.runId, err },
         "Failed to remove profiler run directory",
       );
     }
-
-    totalBytes -= oldest.totalBytes;
-    freedBytes += oldest.totalBytes;
-    prunedCount++;
   }
 
   // Check if the active run alone exceeds the byte budget

--- a/assistant/src/daemon/profiler-run-store.ts
+++ b/assistant/src/daemon/profiler-run-store.ts
@@ -89,17 +89,18 @@ function computeDirBytes(dirPath: string): number {
   let total = 0;
   if (!existsSync(dirPath)) return 0;
 
-  const entries = readdirSync(dirPath, { withFileTypes: true });
-  for (const entry of entries) {
-    const entryPath = join(dirPath, entry.name);
-    if (entry.isDirectory()) {
-      total += computeDirBytes(entryPath);
-    } else if (entry.isFile()) {
-      try {
-        total += statSync(entryPath).size;
-      } catch {
-        // File may have been removed between readdir and stat
+  const names = readdirSync(dirPath);
+  for (const name of names) {
+    const entryPath = join(dirPath, name);
+    try {
+      const stat = statSync(entryPath);
+      if (stat.isDirectory()) {
+        total += computeDirBytes(entryPath);
+      } else if (stat.isFile()) {
+        total += stat.size;
       }
+    } catch {
+      // Entry may have been removed between readdir and stat
     }
   }
   return total;
@@ -162,18 +163,20 @@ export function rescanRuns(): ProfilerRunManifest[] {
   const manifests: ProfilerRunManifest[] = [];
   const now = new Date().toISOString();
 
-  let entries: ReturnType<typeof readdirSync>;
+  let names: string[];
   try {
-    entries = readdirSync(runsDir, { withFileTypes: true });
+    names = readdirSync(runsDir);
   } catch {
     return [];
   }
 
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-
-    const runId = entry.name;
+  for (const runId of names) {
     const runDir = getProfilerRunDir(runId);
+    try {
+      if (!statSync(runDir).isDirectory()) continue;
+    } catch {
+      continue;
+    }
     const totalBytes = computeDirBytes(runDir);
 
     const existing = readManifest(runDir);

--- a/assistant/src/daemon/profiler-run-store.ts
+++ b/assistant/src/daemon/profiler-run-store.ts
@@ -1,0 +1,323 @@
+/**
+ * Profiler run store — manages profiler run directories, manifest state,
+ * and retention budget enforcement.
+ *
+ * Each profiler run lives in its own sub-directory under the profiler runs
+ * directory (<workspace>/data/profiler/runs/<runId>/). A small manifest.json
+ * in each run directory records metadata (status, timestamps, byte count).
+ *
+ * The startup sweep enumerates all run directories, recomputes sizes,
+ * updates manifests, and prunes completed runs oldest-first until the
+ * configured byte-count, run-count, and free-space budgets are satisfied.
+ * The active run (identified by VELLUM_PROFILER_RUN_ID) is never deleted.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statfsSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+import {
+  getProfilerMaxBytes,
+  getProfilerMaxRuns,
+  getProfilerMinFreeMb,
+  getProfilerRunId,
+} from "../config/env-registry.js";
+import { getLogger } from "../util/logger.js";
+import {
+  getProfilerRootDir,
+  getProfilerRunDir,
+  getProfilerRunsDir,
+} from "../util/platform.js";
+
+const log = getLogger("profiler-run-store");
+
+// ── Manifest schema ─────────────────────────────────────────────────────
+
+export interface ProfilerRunManifest {
+  /** Unique run identifier (matches the directory name). */
+  runId: string;
+  /** "active" while profiling is in progress; "completed" once finished. */
+  status: "active" | "completed";
+  /** ISO-8601 timestamp when the run was first observed. */
+  createdAt: string;
+  /** ISO-8601 timestamp of the last manifest update. */
+  updatedAt: string;
+  /** Total bytes consumed by all files in the run directory. */
+  totalBytes: number;
+}
+
+const MANIFEST_FILENAME = "manifest.json";
+
+// ── Default budgets ─────────────────────────────────────────────────────
+
+/** Default max total bytes across all completed runs: 500 MB */
+const DEFAULT_MAX_BYTES = 500 * 1024 * 1024;
+
+/** Default max number of completed runs retained: 10 */
+const DEFAULT_MAX_RUNS = 10;
+
+/** Default minimum free disk space: 200 MB */
+const DEFAULT_MIN_FREE_MB = 200;
+
+// ── Result type ─────────────────────────────────────────────────────────
+
+export interface ProfilerSweepResult {
+  /** Number of completed runs pruned during this sweep. */
+  prunedCount: number;
+  /** Total bytes freed by pruning. */
+  freedBytes: number;
+  /** When true, the active run alone exceeds the byte budget. */
+  activeRunOverBudget: boolean;
+  /** Number of runs remaining after the sweep (including active). */
+  remainingRuns: number;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Recursively compute the total byte size of all files in a directory.
+ */
+function computeDirBytes(dirPath: string): number {
+  let total = 0;
+  if (!existsSync(dirPath)) return 0;
+
+  const entries = readdirSync(dirPath, { withFileTypes: true });
+  for (const entry of entries) {
+    const entryPath = join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      total += computeDirBytes(entryPath);
+    } else if (entry.isFile()) {
+      try {
+        total += statSync(entryPath).size;
+      } catch {
+        // File may have been removed between readdir and stat
+      }
+    }
+  }
+  return total;
+}
+
+/**
+ * Read a manifest.json from a run directory, returning null if missing or
+ * unparseable.
+ */
+function readManifest(runDir: string): ProfilerRunManifest | null {
+  const manifestPath = join(runDir, MANIFEST_FILENAME);
+  try {
+    const raw = readFileSync(manifestPath, "utf-8");
+    return JSON.parse(raw) as ProfilerRunManifest;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write a manifest.json into a run directory, creating the directory if
+ * needed.
+ */
+function writeManifest(runDir: string, manifest: ProfilerRunManifest): void {
+  if (!existsSync(runDir)) {
+    mkdirSync(runDir, { recursive: true });
+  }
+  writeFileSync(
+    join(runDir, MANIFEST_FILENAME),
+    JSON.stringify(manifest, null, 2) + "\n",
+    "utf-8",
+  );
+}
+
+/**
+ * Get the available free bytes on the filesystem containing the given path.
+ */
+function getFreeDiskBytes(path: string): number {
+  try {
+    const stats = statfsSync(path);
+    return stats.bavail * stats.bsize;
+  } catch {
+    // If statfs fails (e.g. unsupported FS), return a large value so the
+    // free-space budget doesn't spuriously trigger pruning.
+    return Number.MAX_SAFE_INTEGER;
+  }
+}
+
+// ── Core operations ─────────────────────────────────────────────────────
+
+/**
+ * Enumerate all profiler run directories, recompute sizes, and return
+ * up-to-date manifests. Also writes updated manifests back to disk.
+ */
+export function rescanRuns(): ProfilerRunManifest[] {
+  const runsDir = getProfilerRunsDir();
+  if (!existsSync(runsDir)) return [];
+
+  const activeRunId = getProfilerRunId();
+  const manifests: ProfilerRunManifest[] = [];
+  const now = new Date().toISOString();
+
+  let entries: ReturnType<typeof readdirSync>;
+  try {
+    entries = readdirSync(runsDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+
+    const runId = entry.name;
+    const runDir = getProfilerRunDir(runId);
+    const totalBytes = computeDirBytes(runDir);
+
+    const existing = readManifest(runDir);
+    const isActive = runId === activeRunId;
+
+    const manifest: ProfilerRunManifest = {
+      runId,
+      status: isActive ? "active" : "completed",
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+      totalBytes,
+    };
+
+    // If a previously-active run is no longer the current active run,
+    // mark it completed.
+    if (existing?.status === "active" && !isActive) {
+      manifest.status = "completed";
+    }
+
+    writeManifest(runDir, manifest);
+    manifests.push(manifest);
+  }
+
+  return manifests;
+}
+
+/**
+ * Run the profiler retention sweep. This is the primary entry point,
+ * called on daemon startup and after explicit cleanup operations.
+ *
+ * The sweep:
+ * 1. Rescans all run directories and updates manifests.
+ * 2. Separates completed runs from the active run.
+ * 3. Sorts completed runs oldest-first by createdAt.
+ * 4. Prunes completed runs until all budgets are satisfied:
+ *    - Total bytes across all runs <= maxBytes
+ *    - Total completed run count <= maxRuns
+ *    - Free disk space >= minFreeMb
+ *
+ * If the active run alone exceeds the byte budget, no runs are pruned
+ * (you can't prune the active run), and the over-budget condition is
+ * reported.
+ */
+export function runProfilerSweep(): ProfilerSweepResult {
+  const runsDir = getProfilerRunsDir();
+
+  // Ensure the runs directory exists for clean first-boot
+  if (!existsSync(runsDir)) {
+    const rootDir = getProfilerRootDir();
+    mkdirSync(rootDir, { recursive: true });
+    mkdirSync(runsDir, { recursive: true });
+  }
+
+  const manifests = rescanRuns();
+  const activeRunId = getProfilerRunId();
+
+  // Budget configuration
+  const maxBytes = getProfilerMaxBytes() ?? DEFAULT_MAX_BYTES;
+  const maxRuns = getProfilerMaxRuns() ?? DEFAULT_MAX_RUNS;
+  const minFreeMb = getProfilerMinFreeMb() ?? DEFAULT_MIN_FREE_MB;
+  const minFreeBytes = minFreeMb * 1024 * 1024;
+
+  // Separate active vs completed
+  const activeManifest = manifests.find(
+    (m) => m.runId === activeRunId && m.status === "active",
+  );
+  const completedRuns = manifests
+    .filter((m) => m.status === "completed")
+    .sort(
+      (a, b) =>
+        new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+    );
+
+  let totalBytes = manifests.reduce((sum, m) => sum + m.totalBytes, 0);
+  let prunedCount = 0;
+  let freedBytes = 0;
+
+  // Prune completed runs oldest-first until all budgets are met
+  while (completedRuns.length > 0) {
+    const overBytesBudget = totalBytes > maxBytes;
+    const overRunCount = completedRuns.length > maxRuns;
+    const overFreeSpace = getFreeDiskBytes(runsDir) < minFreeBytes;
+
+    if (!overBytesBudget && !overRunCount && !overFreeSpace) break;
+
+    const oldest = completedRuns.shift()!;
+    const runDir = getProfilerRunDir(oldest.runId);
+
+    log.info(
+      {
+        runId: oldest.runId,
+        bytes: oldest.totalBytes,
+        reason: overBytesBudget
+          ? "byte_budget"
+          : overRunCount
+            ? "run_count"
+            : "free_space",
+      },
+      `Pruning completed profiler run`,
+    );
+
+    try {
+      rmSync(runDir, { recursive: true, force: true });
+    } catch (err) {
+      log.warn(
+        { runId: oldest.runId, err },
+        "Failed to remove profiler run directory",
+      );
+    }
+
+    totalBytes -= oldest.totalBytes;
+    freedBytes += oldest.totalBytes;
+    prunedCount++;
+  }
+
+  // Check if the active run alone exceeds the byte budget
+  const activeRunOverBudget =
+    activeManifest !== undefined && activeManifest.totalBytes > maxBytes;
+
+  if (activeRunOverBudget) {
+    log.warn(
+      {
+        runId: activeManifest.runId,
+        activeBytes: activeManifest.totalBytes,
+        maxBytes,
+      },
+      "Active profiler run exceeds byte budget — cannot prune live artifacts",
+    );
+  }
+
+  const remainingRuns =
+    completedRuns.length + (activeManifest !== undefined ? 1 : 0);
+
+  if (prunedCount > 0) {
+    log.info(
+      { prunedCount, freedBytes, remainingRuns },
+      "Profiler retention sweep complete",
+    );
+  }
+
+  return {
+    prunedCount,
+    freedBytes,
+    activeRunOverBudget,
+    remainingRuns,
+  };
+}

--- a/assistant/src/tools/terminal/safe-env.ts
+++ b/assistant/src/tools/terminal/safe-env.ts
@@ -37,6 +37,11 @@ const SAFE_ENV_VARS = [
   "IS_CONTAINERIZED",
   "IS_PLATFORM",
   "CES_SERVICE_TOKEN",
+  "VELLUM_PROFILER_RUN_ID",
+  "VELLUM_PROFILER_MODE",
+  "VELLUM_PROFILER_MAX_BYTES",
+  "VELLUM_PROFILER_MAX_RUNS",
+  "VELLUM_PROFILER_MIN_FREE_MB",
 ] as const;
 
 export function buildSanitizedEnv(): Record<string, string> {

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -330,6 +330,35 @@ export function getWorkspacePromptPath(file: string): string {
   return join(getWorkspaceDir(), file);
 }
 
+// ── Profiler filesystem layout ──────────────────────────────────────────
+// Managed profiler runs live under <workspace>/data/profiler/. These
+// helpers enforce a single canonical layout so every runtime caller
+// resolves the same paths.
+
+/**
+ * Returns the profiler root directory (<workspace>/data/profiler).
+ * All profiler state (runs directory, global metadata) lives here.
+ */
+export function getProfilerRootDir(): string {
+  return join(getDataDir(), "profiler");
+}
+
+/**
+ * Returns the profiler runs directory (<workspace>/data/profiler/runs).
+ * Each completed or active profiler run gets its own sub-directory here.
+ */
+export function getProfilerRunsDir(): string {
+  return join(getProfilerRootDir(), "runs");
+}
+
+/**
+ * Returns the directory for a specific profiler run by ID
+ * (<workspace>/data/profiler/runs/<runId>).
+ */
+export function getProfilerRunDir(runId: string): string {
+  return join(getProfilerRunsDir(), runId);
+}
+
 export function ensureDataDir(): void {
   const root = vellumRoot();
   const workspace = getWorkspaceDir();


### PR DESCRIPTION
## Summary
- Add profiler env var accessors and register in KNOWN_VELLUM_VARS to suppress unknown-env warnings
- Add workspace-derived profiler path helpers (getProfilerRootDir, getProfilerRunsDir, getProfilerRunDir)
- Create profiler-run-store.ts with disk budget enforcement, manifest management, and oldest-first pruning
- Integrate startup sweep into daemon lifecycle after workspace migrations
- Add comprehensive tests covering pruning, active-run protection, and budget signaling

Part of plan: managed-assistant-profiler-runtime.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
