### PR TITLE
fix: dark mode VSplitButton text invisible (white on white)

### DIFF
--- a/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
@@ -179,7 +179,9 @@ public struct VSplitButton<MenuContent: View>: View {
     private var foregroundColor: Color {
         guard !isDisabled else { return VColor.contentDisabled }
         switch style {
-        case .primary, .danger, .contrast:
+        case .primary, .contrast:
+            return VColor.contentInset
+        case .danger:
             return VColor.auxWhite
         case .outlined, .ghost:
             return VColor.primaryBase


### PR DESCRIPTION
## Summary

- **Bug**: The "Allow" split button in tool confirmation prompts was invisible in dark mode — white text (`auxWhite` #FFFFFF) on a near-white background (`primaryBase` #FDFDFC)
- **Fix**: Use `VColor.contentInset` for `.primary` and `.contrast` foreground in `VSplitButton`, matching `VButton`'s adaptive behavior. `.danger` keeps `auxWhite` since its red background is visible in both modes
- **Root cause**: `VSplitButton.foregroundColor` grouped `.primary`, `.danger`, and `.contrast` under a single `auxWhite` return, while `VButton.foregroundColor` correctly uses `contentInset` for `.primary`/`.contrast`

## Original prompt

fix the dark mode button color so it's not white on white
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
