### PR TITLE
Wire Bun profiler mode into managed assistant startup

### DIFF
--- a/assistant/docker-entrypoint.sh
+++ b/assistant/docker-entrypoint.sh
@@ -6,4 +6,35 @@ if [ "$(id -u)" = "0" ] && [ "${VELLUM_WORKSPACE_DIR:-}" = "/workspace" ] && [ -
   git config --global --add safe.directory '/workspace/*' >/dev/null 2>&1 || true
 fi
 
-exec bun run src/daemon/main.ts
+# ── Bun profiler bootstrap ──────────────────────────────────────────────
+# When VELLUM_PROFILER_RUN_ID and VELLUM_PROFILER_MODE are set, prepare the
+# run directory on the workspace volume and append the appropriate Bun
+# profiler flags to BUN_OPTIONS. Bun's native --cpu-prof / --heap-prof
+# flags write Chrome-compatible .cpuprofile and .heapprofile artifacts.
+BUN_OPTIONS="${BUN_OPTIONS:-}"
+
+if [ -n "${VELLUM_PROFILER_RUN_ID:-}" ] && [ -n "${VELLUM_PROFILER_MODE:-}" ]; then
+  PROFILER_WORKSPACE="${VELLUM_WORKSPACE_DIR:-$HOME/.vellum/workspace}"
+  PROFILER_RUN_DIR="${PROFILER_WORKSPACE}/data/profiler/runs/${VELLUM_PROFILER_RUN_ID}"
+
+  # Ensure the run directory exists
+  mkdir -p "${PROFILER_RUN_DIR}"
+
+  case "${VELLUM_PROFILER_MODE}" in
+    cpu)
+      BUN_OPTIONS="${BUN_OPTIONS} --cpu-prof --cpu-prof-dir=${PROFILER_RUN_DIR}"
+      ;;
+    heap)
+      BUN_OPTIONS="${BUN_OPTIONS} --heap-prof --heap-prof-dir=${PROFILER_RUN_DIR}"
+      ;;
+    cpu+heap|heap+cpu)
+      BUN_OPTIONS="${BUN_OPTIONS} --cpu-prof --cpu-prof-dir=${PROFILER_RUN_DIR} --heap-prof --heap-prof-dir=${PROFILER_RUN_DIR}"
+      ;;
+    *)
+      echo "Warning: unknown VELLUM_PROFILER_MODE '${VELLUM_PROFILER_MODE}', skipping profiler flags" >&2
+      ;;
+  esac
+fi
+
+# shellcheck disable=SC2086
+exec bun ${BUN_OPTIONS} run src/daemon/main.ts

--- a/assistant/src/__tests__/identity-routes.test.ts
+++ b/assistant/src/__tests__/identity-routes.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Tests for identity/health route handlers, focusing on profiler metadata
+ * in /v1/health and /v1/healthz responses.
+ *
+ * Proves:
+ * - Backward compatibility: health endpoints return expected shape when
+ *   profiler mode is off (no env vars).
+ * - Profiler payload: when profiler env vars are set, the response includes
+ *   a `profiler` object with the expected structure and budget state.
+ * - Artifact detection: when run manifests and Bun summary files exist,
+ *   the response correctly reports artifact counts and lastCompletedRun.
+ */
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Silence logger before any imports that use it
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { handleDetailedHealth } from "../runtime/routes/identity-routes.js";
+import { getWorkspaceDir } from "../util/platform.js";
+
+// ── Env helpers ─────────────────────────────────────────────────────────
+
+let savedEnv: Record<string, string | undefined>;
+
+const PROFILER_ENV_KEYS = [
+  "VELLUM_PROFILER_RUN_ID",
+  "VELLUM_PROFILER_MODE",
+  "VELLUM_PROFILER_MAX_BYTES",
+  "VELLUM_PROFILER_MAX_RUNS",
+  "VELLUM_PROFILER_MIN_FREE_MB",
+] as const;
+
+function clearProfilerEnv(): void {
+  for (const key of PROFILER_ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
+function setProfilerEnv(
+  mode: string,
+  runId: string,
+  opts?: { maxBytes?: number; maxRuns?: number; minFreeMb?: number },
+): void {
+  process.env.VELLUM_PROFILER_RUN_ID = runId;
+  process.env.VELLUM_PROFILER_MODE = mode;
+  if (opts?.maxBytes !== undefined) {
+    process.env.VELLUM_PROFILER_MAX_BYTES = String(opts.maxBytes);
+  }
+  if (opts?.maxRuns !== undefined) {
+    process.env.VELLUM_PROFILER_MAX_RUNS = String(opts.maxRuns);
+  }
+  if (opts?.minFreeMb !== undefined) {
+    process.env.VELLUM_PROFILER_MIN_FREE_MB = String(opts.minFreeMb);
+  }
+}
+
+// ── Filesystem helpers ──────────────────────────────────────────────────
+
+function ensureProfilerRunDir(runId: string): string {
+  const wsDir = getWorkspaceDir();
+  const runDir = join(wsDir, "data", "profiler", "runs", runId);
+  mkdirSync(runDir, { recursive: true });
+  return runDir;
+}
+
+function writeRunManifest(
+  runId: string,
+  manifest: {
+    status: "active" | "completed";
+    createdAt?: string;
+    updatedAt?: string;
+    totalBytes?: number;
+  },
+): void {
+  const runDir = ensureProfilerRunDir(runId);
+  const m = {
+    runId,
+    status: manifest.status,
+    createdAt: manifest.createdAt ?? new Date().toISOString(),
+    updatedAt: manifest.updatedAt ?? new Date().toISOString(),
+    totalBytes: manifest.totalBytes ?? 0,
+  };
+  writeFileSync(join(runDir, "manifest.json"), JSON.stringify(m, null, 2));
+}
+
+function writeArtifactFile(
+  runId: string,
+  filename: string,
+  sizeBytes: number,
+): void {
+  const runDir = ensureProfilerRunDir(runId);
+  writeFileSync(join(runDir, filename), Buffer.alloc(sizeBytes));
+}
+
+// ── Setup / teardown ────────────────────────────────────────────────────
+
+beforeEach(() => {
+  savedEnv = {};
+  for (const key of PROFILER_ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+  }
+  clearProfilerEnv();
+
+  // Clean up any profiler run directories from previous tests so
+  // rescanRuns() doesn't pick up stale state in the shared workspace.
+  const profilerRunsDir = join(getWorkspaceDir(), "data", "profiler", "runs");
+  if (existsSync(profilerRunsDir)) {
+    rmSync(profilerRunsDir, { recursive: true, force: true });
+  }
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe("identity routes — health endpoint", () => {
+  describe("backward compatibility (profiler disabled)", () => {
+    test("/v1/health returns expected shape without profiler key when env vars are absent", async () => {
+      const res = handleDetailedHealth();
+      expect(res.status).toBe(200);
+
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.status).toBe("healthy");
+      expect(body.timestamp).toBeDefined();
+      expect(body.version).toBeDefined();
+      expect(body.disk).toBeDefined();
+      expect(body.memory).toBeDefined();
+      expect(body.cpu).toBeDefined();
+      expect(body.migrations).toBeDefined();
+
+      // Profiler should either be absent or show enabled: false
+      if ("profiler" in body) {
+        const profiler = body.profiler as Record<string, unknown>;
+        expect(profiler.enabled).toBe(false);
+        expect(profiler.mode).toBeNull();
+        expect(profiler.runId).toBeNull();
+        expect(profiler.budget).toBeNull();
+      }
+    });
+
+    test("/v1/healthz returns the same shape as /v1/health", async () => {
+      // Both endpoints call handleDetailedHealth, so the shape must match
+      const res = handleDetailedHealth();
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(body.status).toBe("healthy");
+      expect(body.timestamp).toBeDefined();
+      expect(body.migrations).toBeDefined();
+    });
+  });
+
+  describe("profiler payload (profiler enabled)", () => {
+    test("returns profiler object with enabled=true when env vars are set", async () => {
+      setProfilerEnv("cpu", "run-health-test-1", {
+        maxBytes: 10_000_000,
+        minFreeMb: 10,
+      });
+      ensureProfilerRunDir("run-health-test-1");
+
+      const res = handleDetailedHealth();
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(body.profiler).toBeDefined();
+      const profiler = body.profiler as Record<string, unknown>;
+      expect(profiler.enabled).toBe(true);
+      expect(profiler.mode).toBe("cpu");
+      expect(profiler.runId).toBe("run-health-test-1");
+      expect(profiler.runDir).toContain("run-health-test-1");
+      expect(typeof profiler.totalBytes).toBe("number");
+      expect(typeof profiler.artifactCount).toBe("number");
+    });
+
+    test("includes budget block with expected fields", async () => {
+      setProfilerEnv("heap", "run-budget-test", {
+        maxBytes: 50_000_000,
+        minFreeMb: 100,
+      });
+      ensureProfilerRunDir("run-budget-test");
+
+      const res = handleDetailedHealth();
+      const body = (await res.json()) as Record<string, unknown>;
+      const profiler = body.profiler as Record<string, unknown>;
+      const budget = profiler.budget as Record<string, unknown>;
+
+      expect(budget).toBeDefined();
+      expect(budget.maxBytes).toBe(50_000_000);
+      expect(typeof budget.remainingBytes).toBe("number");
+      expect(budget.minFreeMb).toBe(100);
+      expect(typeof budget.freeMb).toBe("number");
+      expect(typeof budget.overBudget).toBe("boolean");
+    });
+
+    test("reports artifact count from .cpuprofile files", async () => {
+      setProfilerEnv("cpu", "run-artifact-count", {
+        maxBytes: 100_000_000,
+        minFreeMb: 0,
+      });
+      writeArtifactFile("run-artifact-count", "profile-1.cpuprofile", 1024);
+      writeArtifactFile("run-artifact-count", "profile-2.cpuprofile", 2048);
+      // Non-artifact file should not count
+      writeArtifactFile("run-artifact-count", "log.txt", 512);
+
+      const res = handleDetailedHealth();
+      const body = (await res.json()) as Record<string, unknown>;
+      const profiler = body.profiler as Record<string, unknown>;
+
+      expect(profiler.artifactCount).toBe(2);
+    });
+
+    test("detects over-budget state when total bytes exceed maxBytes", async () => {
+      setProfilerEnv("cpu+heap", "run-over-budget", {
+        maxBytes: 100, // Very small budget
+        minFreeMb: 0,
+      });
+      // Write a file larger than the budget
+      writeArtifactFile("run-over-budget", "big.cpuprofile", 5000);
+
+      const res = handleDetailedHealth();
+      const body = (await res.json()) as Record<string, unknown>;
+      const profiler = body.profiler as Record<string, unknown>;
+      const budget = profiler.budget as Record<string, unknown>;
+
+      expect(budget.overBudget).toBe(true);
+      expect(budget.remainingBytes).toBe(0);
+    });
+  });
+
+  describe("lastCompletedRun", () => {
+    test("returns null when no completed runs exist", async () => {
+      setProfilerEnv("cpu", "run-no-completed", {
+        maxBytes: 100_000_000,
+        minFreeMb: 0,
+      });
+      ensureProfilerRunDir("run-no-completed");
+
+      const res = handleDetailedHealth();
+      const body = (await res.json()) as Record<string, unknown>;
+      const profiler = body.profiler as Record<string, unknown>;
+
+      expect(profiler.lastCompletedRun).toBeNull();
+    });
+
+    test("returns completed run summary with artifact count and hasSummaries", async () => {
+      setProfilerEnv("cpu", "active-run-xyz", {
+        maxBytes: 100_000_000,
+        minFreeMb: 0,
+      });
+      ensureProfilerRunDir("active-run-xyz");
+
+      // Create a completed run with artifacts and a summary file
+      const completedId = "completed-run-abc";
+      writeRunManifest(completedId, {
+        status: "completed",
+        createdAt: "2025-06-01T00:00:00Z",
+        updatedAt: "2025-06-01T01:00:00Z",
+        totalBytes: 4096,
+      });
+      writeArtifactFile(completedId, "profile.cpuprofile", 3072);
+      writeArtifactFile(completedId, "summary.md", 256);
+
+      const res = handleDetailedHealth();
+      const body = (await res.json()) as Record<string, unknown>;
+      const profiler = body.profiler as Record<string, unknown>;
+      const last = profiler.lastCompletedRun as Record<string, unknown>;
+
+      expect(last).toBeDefined();
+      expect(last.runId).toBe(completedId);
+      expect(last.artifactCount).toBe(1); // Only .cpuprofile counts
+      expect(last.hasSummaries).toBe(true);
+      expect(typeof last.totalBytes).toBe("number");
+      expect(typeof last.completedAt).toBe("string");
+    });
+
+    test("selects the most recent completed run when multiple exist", async () => {
+      setProfilerEnv("heap", "active-multi", {
+        maxBytes: 100_000_000,
+        maxRuns: 100,
+        minFreeMb: 0,
+      });
+      ensureProfilerRunDir("active-multi");
+
+      writeRunManifest("older-completed", {
+        status: "completed",
+        createdAt: "2025-01-01T00:00:00Z",
+        updatedAt: "2025-01-01T01:00:00Z",
+      });
+      writeArtifactFile("older-completed", "old.heapprofile", 512);
+
+      writeRunManifest("newer-completed", {
+        status: "completed",
+        createdAt: "2025-06-15T00:00:00Z",
+        updatedAt: "2025-06-15T01:00:00Z",
+      });
+      writeArtifactFile("newer-completed", "new.heapprofile", 1024);
+
+      const res = handleDetailedHealth();
+      const body = (await res.json()) as Record<string, unknown>;
+      const profiler = body.profiler as Record<string, unknown>;
+      const last = profiler.lastCompletedRun as Record<string, unknown>;
+
+      expect(last).toBeDefined();
+      expect(last.runId).toBe("newer-completed");
+    });
+  });
+});

--- a/assistant/src/__tests__/identity-routes.test.ts
+++ b/assistant/src/__tests__/identity-routes.test.ts
@@ -76,17 +76,21 @@ function writeRunManifest(
     status: "active" | "completed";
     createdAt?: string;
     updatedAt?: string;
+    completedAt?: string;
     totalBytes?: number;
   },
 ): void {
   const runDir = ensureProfilerRunDir(runId);
-  const m = {
+  const m: Record<string, unknown> = {
     runId,
     status: manifest.status,
     createdAt: manifest.createdAt ?? new Date().toISOString(),
     updatedAt: manifest.updatedAt ?? new Date().toISOString(),
     totalBytes: manifest.totalBytes ?? 0,
   };
+  if (manifest.completedAt) {
+    m.completedAt = manifest.completedAt;
+  }
   writeFileSync(join(runDir, "manifest.json"), JSON.stringify(m, null, 2));
 }
 
@@ -264,10 +268,12 @@ describe("identity routes — health endpoint", () => {
 
       // Create a completed run with artifacts and a summary file
       const completedId = "completed-run-abc";
+      const expectedCompletedAt = "2025-06-01T00:30:00Z";
       writeRunManifest(completedId, {
         status: "completed",
         createdAt: "2025-06-01T00:00:00Z",
         updatedAt: "2025-06-01T01:00:00Z",
+        completedAt: expectedCompletedAt,
         totalBytes: 4096,
       });
       writeArtifactFile(completedId, "profile.cpuprofile", 3072);
@@ -283,7 +289,9 @@ describe("identity routes — health endpoint", () => {
       expect(last.artifactCount).toBe(1); // Only .cpuprofile counts
       expect(last.hasSummaries).toBe(true);
       expect(typeof last.totalBytes).toBe("number");
-      expect(typeof last.completedAt).toBe("string");
+      // completedAt should reflect the manifest's completedAt value,
+      // not the current time or updatedAt.
+      expect(last.completedAt).toBe(expectedCompletedAt);
     });
 
     test("selects the most recent completed run when multiple exist", async () => {

--- a/assistant/src/daemon/profiler-run-store.ts
+++ b/assistant/src/daemon/profiler-run-store.ts
@@ -28,6 +28,7 @@ import {
   getProfilerMaxBytes,
   getProfilerMaxRuns,
   getProfilerMinFreeMb,
+  getProfilerMode,
   getProfilerRunId,
 } from "../config/env-registry.js";
 import { getLogger } from "../util/logger.js";
@@ -333,5 +334,180 @@ export function runProfilerSweep(): ProfilerSweepResult {
     freedBytes,
     activeRunOverBudget,
     remainingRuns,
+  };
+}
+
+// ── Runtime status helpers ──────────────────────────────────────────────
+// These derive the current profiler state from env vars + filesystem for
+// health-endpoint reporting and control-plane polling.
+
+/** Budget state for the active profiler run. */
+export interface ProfilerBudgetStatus {
+  /** Configured maximum bytes across all runs. */
+  maxBytes: number;
+  /** Bytes remaining before the byte-count budget is exceeded. */
+  remainingBytes: number;
+  /** Configured minimum free disk space in MB. */
+  minFreeMb: number;
+  /** Current free disk space in MB. */
+  freeMb: number;
+  /** True when any budget constraint is currently violated. */
+  overBudget: boolean;
+}
+
+/** Summary of the most recently completed profiler run. */
+export interface ProfilerLastCompletedRun {
+  runId: string;
+  totalBytes: number;
+  artifactCount: number;
+  hasSummaries: boolean;
+  completedAt: string;
+}
+
+/** Full runtime status snapshot for health-endpoint embedding. */
+export interface ProfilerRuntimeStatus {
+  /** Whether profiling is enabled (env vars present). */
+  enabled: boolean;
+  /** The profiling mode ("cpu", "heap", "cpu+heap"), or null when disabled. */
+  mode: string | null;
+  /** The active run ID, or null when disabled. */
+  runId: string | null;
+  /** Path to the active run directory, or null when disabled. */
+  runDir: string | null;
+  /** Total bytes consumed by the active run, or 0 when no active run. */
+  totalBytes: number;
+  /** Number of profiler artifact files in the active run directory. */
+  artifactCount: number;
+  /** Budget headroom for the active run. Null when profiling is disabled. */
+  budget: ProfilerBudgetStatus | null;
+  /** Summary of the most recently completed run, or null when none exist. */
+  lastCompletedRun: ProfilerLastCompletedRun | null;
+}
+
+/** File extensions that Bun profiler writes as raw artifacts. */
+const PROFILER_ARTIFACT_EXTENSIONS = [".cpuprofile", ".heapprofile"];
+
+/** File extensions for Bun-generated markdown summaries. */
+const PROFILER_SUMMARY_EXTENSIONS = [".md"];
+
+/**
+ * Count profiler artifact files (raw profiles) in a run directory.
+ */
+function countArtifacts(runDir: string): number {
+  if (!existsSync(runDir)) return 0;
+  try {
+    return readdirSync(runDir).filter((name) =>
+      PROFILER_ARTIFACT_EXTENSIONS.some((ext) => name.endsWith(ext)),
+    ).length;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Check whether any Bun-generated markdown summary files exist in a run
+ * directory.
+ */
+function hasSummaryFiles(runDir: string): boolean {
+  if (!existsSync(runDir)) return false;
+  try {
+    return readdirSync(runDir).some((name) =>
+      PROFILER_SUMMARY_EXTENSIONS.some((ext) => name.endsWith(ext)),
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Derive the full profiler runtime status from environment variables and
+ * the filesystem. This is the main entry point for health-endpoint
+ * integration — it never throws.
+ */
+export function getProfilerRuntimeStatus(): ProfilerRuntimeStatus {
+  const runId = getProfilerRunId() ?? null;
+  const mode = getProfilerMode() ?? null;
+  const enabled = runId !== null && mode !== null;
+
+  if (!enabled) {
+    return {
+      enabled: false,
+      mode: null,
+      runId: null,
+      runDir: null,
+      totalBytes: 0,
+      artifactCount: 0,
+      budget: null,
+      lastCompletedRun: null,
+    };
+  }
+
+  const runDir = getProfilerRunDir(runId!);
+  const runsDir = getProfilerRunsDir();
+
+  // Rescan to get up-to-date manifests
+  let manifests: ProfilerRunManifest[];
+  try {
+    manifests = rescanRuns();
+  } catch {
+    manifests = [];
+  }
+
+  const activeManifest = manifests.find(
+    (m) => m.runId === runId && m.status === "active",
+  );
+  const totalBytes = activeManifest?.totalBytes ?? 0;
+  const artifactCount = countArtifacts(runDir);
+
+  // Compute budget state
+  const maxBytes = getProfilerMaxBytes() ?? DEFAULT_MAX_BYTES;
+  const minFreeMb = getProfilerMinFreeMb() ?? DEFAULT_MIN_FREE_MB;
+  const allRunBytes = manifests.reduce((sum, m) => sum + m.totalBytes, 0);
+  const remainingBytes = Math.max(0, maxBytes - allRunBytes);
+  const freeDiskBytes = getFreeDiskBytes(
+    existsSync(runsDir) ? runsDir : runDir,
+  );
+  const freeMb = Math.round((freeDiskBytes / (1024 * 1024)) * 100) / 100;
+  const overBudget =
+    allRunBytes > maxBytes || freeDiskBytes < minFreeMb * 1024 * 1024;
+
+  const budget: ProfilerBudgetStatus = {
+    maxBytes,
+    remainingBytes,
+    minFreeMb,
+    freeMb,
+    overBudget,
+  };
+
+  // Find most recent completed run for lastCompletedRun summary
+  const completedRuns = manifests
+    .filter((m) => m.status === "completed")
+    .sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    );
+
+  let lastCompletedRun: ProfilerLastCompletedRun | null = null;
+  if (completedRuns.length > 0) {
+    const latest = completedRuns[0]!;
+    const latestDir = getProfilerRunDir(latest.runId);
+    lastCompletedRun = {
+      runId: latest.runId,
+      totalBytes: latest.totalBytes,
+      artifactCount: countArtifacts(latestDir),
+      hasSummaries: hasSummaryFiles(latestDir),
+      completedAt: latest.updatedAt,
+    };
+  }
+
+  return {
+    enabled,
+    mode,
+    runId,
+    runDir,
+    totalBytes,
+    artifactCount,
+    budget,
+    lastCompletedRun,
   };
 }

--- a/assistant/src/daemon/profiler-run-store.ts
+++ b/assistant/src/daemon/profiler-run-store.ts
@@ -53,6 +53,8 @@ export interface ProfilerRunManifest {
   updatedAt: string;
   /** Total bytes consumed by all files in the run directory. */
   totalBytes: number;
+  /** ISO-8601 timestamp when the run transitioned to "completed". */
+  completedAt?: string;
 }
 
 const MANIFEST_FILENAME = "manifest.json";
@@ -152,11 +154,24 @@ function getFreeDiskBytes(path: string): number {
 
 // ── Core operations ─────────────────────────────────────────────────────
 
+/** Options for {@link rescanRuns}. */
+export interface RescanRunsOptions {
+  /**
+   * When true, skip all `writeManifest()` calls — just read existing
+   * manifests and recompute sizes without mutating the filesystem.
+   * Used by health endpoints to avoid write side-effects on every poll.
+   */
+  readOnly?: boolean;
+}
+
 /**
  * Enumerate all profiler run directories, recompute sizes, and return
- * up-to-date manifests. Also writes updated manifests back to disk.
+ * up-to-date manifests. By default also writes updated manifests back
+ * to disk; pass `{ readOnly: true }` to suppress writes (e.g. from
+ * health-check callers).
  */
-export function rescanRuns(): ProfilerRunManifest[] {
+export function rescanRuns(options?: RescanRunsOptions): ProfilerRunManifest[] {
+  const readOnly = options?.readOnly ?? false;
   const runsDir = getProfilerRunsDir();
   if (!existsSync(runsDir)) return [];
 
@@ -195,21 +210,39 @@ export function rescanRuns(): ProfilerRunManifest[] {
       }
     }
 
-    const manifest: ProfilerRunManifest = {
-      runId,
-      status: isActive ? "active" : "completed",
-      createdAt,
-      updatedAt: now,
-      totalBytes,
-    };
+    const newStatus: "active" | "completed" = isActive ? "active" : "completed";
 
-    // If a previously-active run is no longer the current active run,
-    // mark it completed.
-    if (existing?.status === "active" && !isActive) {
-      manifest.status = "completed";
+    // Determine completedAt: set it when a run transitions to completed
+    // for the first time, otherwise preserve the existing value.
+    let completedAt = existing?.completedAt;
+    if (
+      newStatus === "completed" &&
+      !completedAt &&
+      (existing?.status === "active" || !existing)
+    ) {
+      completedAt = now;
     }
 
-    writeManifest(runDir, manifest);
+    // Only bump updatedAt when something meaningful changed compared to
+    // the on-disk manifest (status, totalBytes, or first creation).
+    const somethingChanged =
+      !existing ||
+      existing.status !== newStatus ||
+      existing.totalBytes !== totalBytes;
+    const updatedAt = somethingChanged ? now : existing.updatedAt;
+
+    const manifest: ProfilerRunManifest = {
+      runId,
+      status: newStatus,
+      createdAt,
+      updatedAt,
+      totalBytes,
+      ...(completedAt ? { completedAt } : {}),
+    };
+
+    if (!readOnly) {
+      writeManifest(runDir, manifest);
+    }
     manifests.push(manifest);
   }
 
@@ -445,10 +478,11 @@ export function getProfilerRuntimeStatus(): ProfilerRuntimeStatus {
   const runDir = getProfilerRunDir(runId!);
   const runsDir = getProfilerRunsDir();
 
-  // Rescan to get up-to-date manifests
+  // Rescan to get up-to-date manifests — read-only so health checks
+  // don't write to disk on every poll.
   let manifests: ProfilerRunManifest[];
   try {
-    manifests = rescanRuns();
+    manifests = rescanRuns({ readOnly: true });
   } catch {
     manifests = [];
   }
@@ -496,7 +530,7 @@ export function getProfilerRuntimeStatus(): ProfilerRuntimeStatus {
       totalBytes: latest.totalBytes,
       artifactCount: countArtifacts(latestDir),
       hasSummaries: hasSummaryFiles(latestDir),
-      completedAt: latest.updatedAt,
+      completedAt: latest.completedAt ?? latest.updatedAt,
     };
   }
 

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -10,6 +10,7 @@ import { fileURLToPath } from "node:url";
 import { z } from "zod";
 
 import { parseIdentityFields } from "../../daemon/handlers/identity.js";
+import { getProfilerRuntimeStatus } from "../../daemon/profiler-run-store.js";
 import { getMaxMigrationVersion } from "../../memory/migrations/registry.js";
 import {
   getWorkspaceDir,
@@ -144,6 +145,13 @@ export function handleHealth(): Response {
 }
 
 export function handleDetailedHealth(): Response {
+  let profiler: ReturnType<typeof getProfilerRuntimeStatus> | undefined;
+  try {
+    profiler = getProfilerRuntimeStatus();
+  } catch {
+    // Profiler status is non-critical — omit on error
+  }
+
   return Response.json({
     status: "healthy",
     timestamp: new Date().toISOString(),
@@ -156,6 +164,7 @@ export function handleDetailedHealth(): Response {
       lastWorkspaceMigrationId:
         getLastWorkspaceMigrationId(WORKSPACE_MIGRATIONS),
     },
+    ...(profiler ? { profiler } : {}),
   });
 }
 
@@ -240,6 +249,48 @@ export function handleGetIdentityIntro(): Response {
 }
 
 // ---------------------------------------------------------------------------
+// Zod schemas for profiler health metadata
+// ---------------------------------------------------------------------------
+
+const profilerBudgetSchema = z.object({
+  maxBytes: z.number(),
+  remainingBytes: z.number(),
+  minFreeMb: z.number(),
+  freeMb: z.number(),
+  overBudget: z.boolean(),
+});
+
+const profilerLastCompletedRunSchema = z.object({
+  runId: z.string(),
+  totalBytes: z.number(),
+  artifactCount: z.number(),
+  hasSummaries: z.boolean(),
+  completedAt: z.string(),
+});
+
+const profilerStatusSchema = z.object({
+  enabled: z.boolean(),
+  mode: z.string().nullable(),
+  runId: z.string().nullable(),
+  runDir: z.string().nullable(),
+  totalBytes: z.number(),
+  artifactCount: z.number(),
+  budget: profilerBudgetSchema.nullable(),
+  lastCompletedRun: profilerLastCompletedRunSchema.nullable(),
+});
+
+const detailedHealthSchema = z.object({
+  status: z.string(),
+  timestamp: z.string(),
+  version: z.string(),
+  disk: z.object({}).passthrough(),
+  memory: z.object({}).passthrough(),
+  cpu: z.object({}).passthrough(),
+  migrations: z.object({}).passthrough(),
+  profiler: profilerStatusSchema.optional(),
+});
+
+// ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
 
@@ -253,15 +304,7 @@ export function identityRouteDefinitions(): RouteDefinition[] {
       description:
         "Returns runtime health including version, disk, memory, CPU, and migration status.",
       tags: ["system"],
-      responseBody: z.object({
-        status: z.string(),
-        timestamp: z.string(),
-        version: z.string(),
-        disk: z.object({}).passthrough(),
-        memory: z.object({}).passthrough(),
-        cpu: z.object({}).passthrough(),
-        migrations: z.object({}).passthrough(),
-      }),
+      responseBody: detailedHealthSchema,
     },
     {
       endpoint: "healthz",
@@ -272,15 +315,7 @@ export function identityRouteDefinitions(): RouteDefinition[] {
       description:
         "Alias for /v1/health. Returns runtime health including version, disk, memory, CPU, and migration status.",
       tags: ["system"],
-      responseBody: z.object({
-        status: z.string(),
-        timestamp: z.string(),
-        version: z.string(),
-        disk: z.object({}).passthrough(),
-        memory: z.object({}).passthrough(),
-        cpu: z.object({}).passthrough(),
-        migrations: z.object({}).passthrough(),
-      }),
+      responseBody: detailedHealthSchema,
     },
     {
       endpoint: "identity",


### PR DESCRIPTION
## Summary
- Update docker-entrypoint.sh to append Bun CPU/heap profiler flags when profiler env vars are set
- Extend profiler-run-store with runtime status helpers for active run state, budget headroom, and artifact detection
- Add profiler metadata to health endpoint responses with Zod schemas for control-plane polling
- Add identity-routes tests proving backward compatibility and profiler payload correctness

Part of plan: managed-assistant-profiler-runtime.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
