### PR TITLE
Add managed profiler HTTP routes to the assistant runtime

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -634,14 +634,14 @@ The assistant feature-flag resolver (`src/config/assistant-feature-flags.ts`) is
 
 **Skill-gating guarantee:** Skill feature-flag gating is **opt-in**: only skills whose SKILL.md frontmatter contains a `featureFlag` field are gated. Skills without the field are always available regardless of feature flag state. For skills that declare a `featureFlag`, when the corresponding flag is OFF the skill is unavailable everywhere — it cannot appear in client UIs, model context, or runtime tool execution. This is enforced at six independent points:
 
-| Enforcement Point                  | Module                                                        | Effect                                                                                                                                                                                                      |
-| ---------------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **1. Client skill list**           | `resolveSkillStates()` in `config/skill-state.ts`             | Skills with flag OFF are excluded from the resolved list returned to clients (macOS skill list, settings UI). The skill never appears in the client.                                                        |
-| **2. Capability memory seeding**   | `seedSkillGraphNodes()` in `memory/graph/capability-seed.ts`  | Skills with flag OFF are excluded from capability memory seeding. The model cannot discover them via semantic recall.                                                                                        |
-| **3. `skill_load` tool**           | `executeSkillLoad()` in `tools/skills/load.ts`                | If the model attempts to load a flagged-off skill by name, the tool returns an error: `"skill is currently unavailable (disabled by feature flag)"`.                                                        |
-| **4. Runtime tool projection**     | `projectSkillTools()` in `daemon/conversation-skill-tools.ts` | Even if a skill was previously active in a session (has `<loaded_skill>` markers in history), the per-turn projection drops it when the flag is OFF. Already-registered tools are unregistered.             |
-| **5. Included child skills**       | `executeSkillLoad()` in `tools/skills/load.ts`                | When a parent skill includes children via the `includes` directive, each child is independently checked against its feature flag. Flagged-off children are silently excluded from the loaded skill content. |
-| **6. Skill install gate**          | `installSkill()` in `daemon/handlers/skills.ts`               | When a client requests skill installation, the function checks the skill's feature flag before proceeding. If the flag is OFF, the install is rejected with an error.                                       |
+| Enforcement Point                | Module                                                        | Effect                                                                                                                                                                                                      |
+| -------------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **1. Client skill list**         | `resolveSkillStates()` in `config/skill-state.ts`             | Skills with flag OFF are excluded from the resolved list returned to clients (macOS skill list, settings UI). The skill never appears in the client.                                                        |
+| **2. Capability memory seeding** | `seedSkillGraphNodes()` in `memory/graph/capability-seed.ts`  | Skills with flag OFF are excluded from capability memory seeding. The model cannot discover them via semantic recall.                                                                                       |
+| **3. `skill_load` tool**         | `executeSkillLoad()` in `tools/skills/load.ts`                | If the model attempts to load a flagged-off skill by name, the tool returns an error: `"skill is currently unavailable (disabled by feature flag)"`.                                                        |
+| **4. Runtime tool projection**   | `projectSkillTools()` in `daemon/conversation-skill-tools.ts` | Even if a skill was previously active in a session (has `<loaded_skill>` markers in history), the per-turn projection drops it when the flag is OFF. Already-registered tools are unregistered.             |
+| **5. Included child skills**     | `executeSkillLoad()` in `tools/skills/load.ts`                | When a parent skill includes children via the `includes` directive, each child is independently checked against its feature flag. Flagged-off children are silently excluded from the loaded skill content. |
+| **6. Skill install gate**        | `installSkill()` in `daemon/handlers/skills.ts`               | When a client requests skill installation, the function checks the skill's feature flag before proceeding. If the flag is OFF, the install is rejected with an error.                                       |
 
 All six enforcement points derive the flag key via `skillFlagKey(skill)` — which returns `undefined` for ungated skills, short-circuiting the check — and then call `isAssistantFeatureFlagEnabled(flagKey, config)` for consistency.
 
@@ -868,12 +868,12 @@ The session loop implements a deterministic overflow convergence pipeline that r
 
 The reducer (`context-overflow-reducer.ts`) applies four monotonically more aggressive tiers, each idempotent:
 
-| Tier                      | Reduction                                                                  | Effect                                                                                       |
-| ------------------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| 1. Forced compaction      | Emergency `maybeCompact()` with `force: true`, `minKeepRecentUserTurns: 0` | Summarizes older history more aggressively than normal compaction                            |
-| 2. Tool-result truncation | `truncateToolResultsAcrossHistory()` at 4,000 chars per result             | Shrinks verbose tool outputs (shell, file reads) across all retained messages                |
+| Tier                      | Reduction                                                                  | Effect                                                                                                                                                                     |
+| ------------------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1. Forced compaction      | Emergency `maybeCompact()` with `force: true`, `minKeepRecentUserTurns: 0` | Summarizes older history more aggressively than normal compaction                                                                                                          |
+| 2. Tool-result truncation | `truncateToolResultsAcrossHistory()` at 4,000 chars per result             | Shrinks verbose tool outputs (shell, file reads) across all retained messages                                                                                              |
 | 3. Media/file stubbing    | `stripMediaPayloadsForRetry()`                                             | Replaces image and file content blocks with lightweight text stubs; media in the latest user message is retained based on available token budget rather than a fixed count |
-| 4. Injection downgrade    | Sets `injectionMode` to `"minimal"`                                        | Drops runtime injections (workspace listing, temporal context, memory recall) to minimal set |
+| 4. Injection downgrade    | Sets `injectionMode` to `"minimal"`                                        | Drops runtime injections (workspace listing, temporal context, memory recall) to minimal set                                                                               |
 
 After each tier, the reducer re-estimates tokens. If the estimate is within budget, the loop breaks and the provider call proceeds. The loop is bounded by `maxAttempts` (default 3).
 
@@ -2025,3 +2025,56 @@ The guardian trust system uses a three-valued `TrustClass` — `'guardian'`, `'t
 | `src/runtime/channel-retry-sweep.ts`          | Strict `trustClass` parser for retry sweep            |
 | `src/memory/channel-verification-sessions.ts` | `GuardianBinding` with required `guardianPrincipalId` |
 | `src/__tests__/trust-context-guards.test.ts`  | Guard tests enforcing trust-context type invariants   |
+
+### Managed Profiler Runtime
+
+Managed cloud assistants use Bun's built-in CPU and heap profiling to capture runtime performance data. The profiler subsystem consists of a persistent on-disk run store, a retention/pruning sweep, and HTTP routes for remote management.
+
+**Bun profiler flags:** Managed containers activate profiling by setting `VELLUM_PROFILER_MODE` (e.g. `cpu`, `heap`, `cpu+heap`) and `VELLUM_PROFILER_RUN_ID` environment variables before boot. Bun writes profiler artifacts (`.cpuprofile`, `.heapprofile`, markdown summaries) into the run directory.
+
+**Directory contract:**
+
+```
+<workspace>/data/profiler/
+  runs/
+    <runId>/
+      manifest.json          — run metadata (status, timestamps, byte count)
+      profile.cpuprofile     — Bun CPU profile output
+      profile-summary.md     — Bun-generated markdown summary
+      *.heapprofile          — Bun heap profile output (when heap mode active)
+```
+
+Each profiler run lives in its own sub-directory under `<workspace>/data/profiler/runs/<runId>/`. A `manifest.json` in each run directory records metadata: status (`active` or `completed`), creation/update timestamps, and total byte count. The active run (identified by `VELLUM_PROFILER_RUN_ID`) is never pruned.
+
+**Retention budgets:** On daemon startup and after explicit cleanup operations, the profiler sweep enforces three budgets:
+
+| Budget                                    | Env var                       | Default |
+| ----------------------------------------- | ----------------------------- | ------- |
+| Max total bytes across all completed runs | `VELLUM_PROFILER_MAX_BYTES`   | 500 MB  |
+| Max number of completed runs retained     | `VELLUM_PROFILER_MAX_RUNS`    | 10      |
+| Minimum free disk space                   | `VELLUM_PROFILER_MIN_FREE_MB` | 200 MB  |
+
+Completed runs are pruned oldest-first until all budgets are satisfied. The active run is never deleted, even if it alone exceeds the byte budget.
+
+**Runtime HTTP endpoints (gateway-only, `internal.write` scope):**
+
+| Method   | Endpoint                          | Description                                                                      |
+| -------- | --------------------------------- | -------------------------------------------------------------------------------- |
+| `GET`    | `/v1/profiler/runs`               | List all profiler runs with manifest metadata, sorted newest-first               |
+| `GET`    | `/v1/profiler/runs/:runId`        | Detail view: manifest metadata, Bun markdown summary, active/retention state     |
+| `POST`   | `/v1/profiler/runs/:runId/export` | Package a single run directory as a tar.gz bundle (same size cap as log exports) |
+| `DELETE` | `/v1/profiler/runs/:runId`        | Delete a completed run; rejects active run deletion; recalculates disk budget    |
+
+These endpoints allow the platform (via vembda proxy) to enumerate, inspect, export, and clean up profiler runs without opening a shell on the assistant pod.
+
+**Key files:**
+
+| File                                       | Purpose                                                                  |
+| ------------------------------------------ | ------------------------------------------------------------------------ |
+| `src/daemon/profiler-run-store.ts`         | Manifest management, rescan, retention sweep                             |
+| `src/runtime/routes/profiler-routes.ts`    | HTTP route handlers for profiler run management                          |
+| `src/runtime/routes/archive-utils.ts`      | Shared tar.gz creation and size-cap utilities                            |
+| `src/config/env-registry.ts`               | Profiler env var accessors (`getProfilerRunId`, `getProfilerMode`, etc.) |
+| `src/util/platform.ts`                     | Profiler directory path helpers                                          |
+| `src/__tests__/profiler-run-store.test.ts` | Profiler store unit tests                                                |
+| `src/__tests__/profiler-routes.test.ts`    | Profiler HTTP route tests                                                |

--- a/assistant/src/__tests__/profiler-routes.test.ts
+++ b/assistant/src/__tests__/profiler-routes.test.ts
@@ -196,6 +196,40 @@ describe("Profiler routes", () => {
     });
   });
 
+  describe("path traversal rejection", () => {
+    const traversalPayloads = [
+      "../../../etc/passwd",
+      "..%2F..%2Fetc%2Fpasswd",
+      "foo/bar",
+      "foo\\bar",
+      "..\\..\\windows",
+    ];
+
+    for (const payload of traversalPayloads) {
+      test(`GET rejects runId "${payload}"`, async () => {
+        const route = findRoute("profiler/runs/:runId", "GET")!;
+        const response = await route.handler(makeCtx({ runId: payload }));
+        expect(response.status).toBe(400);
+      });
+
+      test(`POST export rejects runId "${payload}"`, async () => {
+        const route = findRoute("profiler/runs/:runId/export", "POST")!;
+        const response = await route.handler(
+          makeCtx({ runId: payload }, "POST"),
+        );
+        expect(response.status).toBe(400);
+      });
+
+      test(`DELETE rejects runId "${payload}"`, async () => {
+        const route = findRoute("profiler/runs/:runId", "DELETE")!;
+        const response = await route.handler(
+          makeCtx({ runId: payload }, "DELETE"),
+        );
+        expect(response.status).toBe(400);
+      });
+    }
+  });
+
   describe("GET /v1/profiler/runs/:runId (detail)", () => {
     test("returns 404 for missing run", async () => {
       const route = findRoute("profiler/runs/:runId", "GET")!;

--- a/assistant/src/__tests__/profiler-routes.test.ts
+++ b/assistant/src/__tests__/profiler-routes.test.ts
@@ -1,0 +1,468 @@
+/**
+ * Tests for profiler HTTP route handlers: empty-state listings, missing-run
+ * 404s, active-run delete rejection, tarball export success, archive failure
+ * when a run directory exceeds the configured bundle size cap, and post-delete
+ * budget recalculation.
+ */
+
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { ProfilerRunManifest } from "../daemon/profiler-run-store.js";
+import type { AuthContext } from "../runtime/auth/types.js";
+import type { RouteContext, RouteParams } from "../runtime/http-router.js";
+import { profilerRouteDefinitions } from "../runtime/routes/profiler-routes.js";
+
+// ── Test scaffolding ────────────────────────────────────────────────────
+
+let testDir: string;
+let runsDir: string;
+let origEnv: Record<string, string | undefined>;
+
+const routes = profilerRouteDefinitions();
+
+function findRoute(
+  endpoint: string,
+  method: string,
+): (typeof routes)[number] | undefined {
+  return routes.find((r) => r.endpoint === endpoint && r.method === method);
+}
+
+/**
+ * Build a minimal RouteContext for testing route handlers.
+ */
+function makeCtx(
+  params: RouteParams = {},
+  method: string = "GET",
+): RouteContext {
+  return {
+    req: new Request("http://localhost:7821/v1/profiler/runs", { method }),
+    url: new URL("http://localhost:7821/v1/profiler/runs"),
+    server: {} as ReturnType<typeof Bun.serve>,
+    authContext: {
+      subject: "svc:gateway:self",
+      principalType: "svc_gateway",
+      assistantId: "self",
+      scopeProfile: "gateway_service_v1",
+      scopes: new Set(["internal.write"]),
+      policyEpoch: 1,
+    } as AuthContext,
+    params,
+  };
+}
+
+/**
+ * Create a fake profiler run directory with some payload files.
+ */
+function createRun(
+  runId: string,
+  opts?: {
+    sizeBytes?: number;
+    manifest?: Partial<ProfilerRunManifest>;
+    markdownSummary?: string;
+  },
+): string {
+  const dir = join(runsDir, runId);
+  mkdirSync(dir, { recursive: true });
+
+  // Write a payload file of the requested size
+  const size = opts?.sizeBytes ?? 1024;
+  writeFileSync(join(dir, "profile.cpuprofile"), Buffer.alloc(size));
+
+  // Optionally write a pre-existing manifest
+  if (opts?.manifest) {
+    const m: ProfilerRunManifest = {
+      runId,
+      status: opts.manifest.status ?? "completed",
+      createdAt: opts.manifest.createdAt ?? new Date().toISOString(),
+      updatedAt: opts.manifest.updatedAt ?? new Date().toISOString(),
+      totalBytes: opts.manifest.totalBytes ?? size,
+    };
+    writeFileSync(join(dir, "manifest.json"), JSON.stringify(m, null, 2));
+  }
+
+  // Optionally write a markdown summary
+  if (opts?.markdownSummary) {
+    writeFileSync(join(dir, "profile-summary.md"), opts.markdownSummary);
+  }
+
+  return dir;
+}
+
+beforeEach(() => {
+  testDir = join(
+    tmpdir(),
+    `vellum-profiler-routes-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  runsDir = join(testDir, "data", "profiler", "runs");
+  mkdirSync(runsDir, { recursive: true });
+
+  // Save and override env
+  origEnv = {
+    VELLUM_WORKSPACE_DIR: process.env.VELLUM_WORKSPACE_DIR,
+    VELLUM_PROFILER_RUN_ID: process.env.VELLUM_PROFILER_RUN_ID,
+    VELLUM_PROFILER_MAX_BYTES: process.env.VELLUM_PROFILER_MAX_BYTES,
+    VELLUM_PROFILER_MAX_RUNS: process.env.VELLUM_PROFILER_MAX_RUNS,
+    VELLUM_PROFILER_MIN_FREE_MB: process.env.VELLUM_PROFILER_MIN_FREE_MB,
+  };
+
+  // Point workspace dir to our temp directory
+  process.env.VELLUM_WORKSPACE_DIR = testDir;
+
+  // Clear profiler env vars
+  delete process.env.VELLUM_PROFILER_RUN_ID;
+  delete process.env.VELLUM_PROFILER_MAX_BYTES;
+  delete process.env.VELLUM_PROFILER_MAX_RUNS;
+  delete process.env.VELLUM_PROFILER_MIN_FREE_MB;
+});
+
+afterEach(() => {
+  // Restore env
+  for (const [key, value] of Object.entries(origEnv)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  // Clean up temp directory
+  if (existsSync(testDir)) {
+    rmSync(testDir, { recursive: true, force: true });
+  }
+});
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe("Profiler routes", () => {
+  describe("GET /v1/profiler/runs (list)", () => {
+    test("returns empty list when no runs exist", async () => {
+      const route = findRoute("profiler/runs", "GET")!;
+      const response = await route.handler(makeCtx());
+      const body = (await response.json()) as {
+        runs: unknown[];
+        totalRuns: number;
+        activeRunId: string | null;
+      };
+
+      expect(response.status).toBe(200);
+      expect(body.runs).toEqual([]);
+      expect(body.totalRuns).toBe(0);
+      expect(body.activeRunId).toBeNull();
+    });
+
+    test("returns runs sorted newest-first", async () => {
+      createRun("old-run", {
+        sizeBytes: 1024,
+        manifest: {
+          status: "completed",
+          createdAt: "2025-01-01T00:00:00Z",
+        },
+      });
+      createRun("new-run", {
+        sizeBytes: 1024,
+        manifest: {
+          status: "completed",
+          createdAt: "2025-06-01T00:00:00Z",
+        },
+      });
+
+      const route = findRoute("profiler/runs", "GET")!;
+      const response = await route.handler(makeCtx());
+      const body = (await response.json()) as {
+        runs: ProfilerRunManifest[];
+        totalRuns: number;
+      };
+
+      expect(response.status).toBe(200);
+      expect(body.totalRuns).toBe(2);
+      expect(body.runs[0]!.runId).toBe("new-run");
+      expect(body.runs[1]!.runId).toBe("old-run");
+    });
+
+    test("reports active run ID when set", async () => {
+      process.env.VELLUM_PROFILER_RUN_ID = "active-run";
+      createRun("active-run", { sizeBytes: 512 });
+
+      const route = findRoute("profiler/runs", "GET")!;
+      const response = await route.handler(makeCtx());
+      const body = (await response.json()) as {
+        activeRunId: string | null;
+      };
+
+      expect(body.activeRunId).toBe("active-run");
+    });
+  });
+
+  describe("GET /v1/profiler/runs/:runId (detail)", () => {
+    test("returns 404 for missing run", async () => {
+      const route = findRoute("profiler/runs/:runId", "GET")!;
+      const response = await route.handler(makeCtx({ runId: "nonexistent" }));
+
+      expect(response.status).toBe(404);
+      const body = (await response.json()) as {
+        error: { code: string };
+      };
+      expect(body.error.code).toBe("NOT_FOUND");
+    });
+
+    test("returns manifest metadata and markdown summary", async () => {
+      createRun("run-with-summary", {
+        sizeBytes: 2048,
+        manifest: {
+          status: "completed",
+          createdAt: "2025-03-15T10:00:00Z",
+        },
+        markdownSummary: "# CPU Profile\n\nTop functions by self-time...",
+      });
+
+      const route = findRoute("profiler/runs/:runId", "GET")!;
+      const response = await route.handler(
+        makeCtx({ runId: "run-with-summary" }),
+      );
+      const body = (await response.json()) as {
+        runId: string;
+        status: string;
+        summary: string | null;
+        isActive: boolean;
+      };
+
+      expect(response.status).toBe(200);
+      expect(body.runId).toBe("run-with-summary");
+      expect(body.status).toBe("completed");
+      expect(body.summary).toContain("CPU Profile");
+      expect(body.isActive).toBe(false);
+    });
+
+    test("returns null summary when no markdown file exists", async () => {
+      createRun("run-no-summary", {
+        sizeBytes: 1024,
+        manifest: { status: "completed" },
+      });
+
+      const route = findRoute("profiler/runs/:runId", "GET")!;
+      const response = await route.handler(
+        makeCtx({ runId: "run-no-summary" }),
+      );
+      const body = (await response.json()) as {
+        summary: string | null;
+      };
+
+      expect(response.status).toBe(200);
+      expect(body.summary).toBeNull();
+    });
+
+    test("marks active run correctly", async () => {
+      process.env.VELLUM_PROFILER_RUN_ID = "live-run";
+      createRun("live-run", {
+        sizeBytes: 1024,
+        manifest: { status: "active" },
+      });
+
+      const route = findRoute("profiler/runs/:runId", "GET")!;
+      const response = await route.handler(makeCtx({ runId: "live-run" }));
+      const body = (await response.json()) as {
+        isActive: boolean;
+      };
+
+      expect(response.status).toBe(200);
+      expect(body.isActive).toBe(true);
+    });
+  });
+
+  describe("POST /v1/profiler/runs/:runId/export", () => {
+    test("returns 404 for missing run", async () => {
+      const route = findRoute("profiler/runs/:runId/export", "POST")!;
+      const response = await route.handler(
+        makeCtx({ runId: "nonexistent" }, "POST"),
+      );
+
+      expect(response.status).toBe(404);
+    });
+
+    test("returns tar.gz for a valid run", async () => {
+      createRun("exportable-run", {
+        sizeBytes: 512,
+        manifest: { status: "completed" },
+      });
+
+      const route = findRoute("profiler/runs/:runId/export", "POST")!;
+      const response = await route.handler(
+        makeCtx({ runId: "exportable-run" }, "POST"),
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Content-Type")).toBe("application/gzip");
+      expect(response.headers.get("Content-Disposition")).toContain(
+        "profiler-exportable-run.tar.gz",
+      );
+
+      const arrayBuffer = await response.arrayBuffer();
+      expect(arrayBuffer.byteLength).toBeGreaterThan(0);
+    });
+
+    test("returns 500 when archive exceeds size limit", async () => {
+      // Create a run with a very large file that will exceed the 50MB archive cap.
+      // We mock this by creating a run directory and writing enough data to push
+      // past the limit. Since createTarGz uses MAX_ARCHIVE_BYTES as the maxBuffer,
+      // a large-enough payload will trigger the failure path.
+      const runDir = join(runsDir, "huge-run");
+      mkdirSync(runDir, { recursive: true });
+
+      // Write manifest so the route can find the run
+      const manifest: ProfilerRunManifest = {
+        runId: "huge-run",
+        status: "completed",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        totalBytes: 60 * 1024 * 1024,
+      };
+      writeFileSync(
+        join(runDir, "manifest.json"),
+        JSON.stringify(manifest, null, 2),
+      );
+
+      // Write a file large enough that the compressed tar exceeds 50MB.
+      // Random data doesn't compress well, so 55MB of random data should
+      // produce a tar.gz larger than 50MB.
+      const chunkSize = 1024 * 1024; // 1 MB
+      const chunks = 55;
+      for (let i = 0; i < chunks; i++) {
+        const buf = Buffer.alloc(chunkSize);
+        // Fill with pseudo-random data to defeat compression
+        for (let j = 0; j < chunkSize; j += 4) {
+          buf.writeUInt32LE((Math.random() * 0xffffffff) >>> 0, j);
+        }
+        writeFileSync(join(runDir, `chunk-${i}.bin`), buf);
+      }
+
+      const route = findRoute("profiler/runs/:runId/export", "POST")!;
+      const response = await route.handler(
+        makeCtx({ runId: "huge-run" }, "POST"),
+      );
+
+      expect(response.status).toBe(500);
+      const body = (await response.json()) as {
+        error: { code: string; message: string };
+      };
+      expect(body.error.code).toBe("INTERNAL_ERROR");
+      expect(body.error.message).toContain("archive size");
+    });
+  });
+
+  describe("DELETE /v1/profiler/runs/:runId", () => {
+    test("returns 404 for missing run", async () => {
+      const route = findRoute("profiler/runs/:runId", "DELETE")!;
+      const response = await route.handler(
+        makeCtx({ runId: "nonexistent" }, "DELETE"),
+      );
+
+      expect(response.status).toBe(404);
+    });
+
+    test("rejects deletion of the currently active run", async () => {
+      process.env.VELLUM_PROFILER_RUN_ID = "active-run";
+      createRun("active-run", {
+        sizeBytes: 1024,
+        manifest: { status: "active" },
+      });
+
+      const route = findRoute("profiler/runs/:runId", "DELETE")!;
+      const response = await route.handler(
+        makeCtx({ runId: "active-run" }, "DELETE"),
+      );
+
+      expect(response.status).toBe(409);
+      const body = (await response.json()) as {
+        error: { code: string };
+      };
+      expect(body.error.code).toBe("CONFLICT");
+
+      // Run directory should still exist
+      expect(existsSync(join(runsDir, "active-run"))).toBe(true);
+    });
+
+    test("deletes a completed run and returns budget state", async () => {
+      process.env.VELLUM_PROFILER_MAX_BYTES = "999999999";
+      process.env.VELLUM_PROFILER_MAX_RUNS = "100";
+      process.env.VELLUM_PROFILER_MIN_FREE_MB = "0";
+
+      createRun("completed-run", {
+        sizeBytes: 2048,
+        manifest: {
+          status: "completed",
+          createdAt: "2025-01-01T00:00:00Z",
+        },
+      });
+      createRun("other-run", {
+        sizeBytes: 1024,
+        manifest: {
+          status: "completed",
+          createdAt: "2025-02-01T00:00:00Z",
+        },
+      });
+
+      const route = findRoute("profiler/runs/:runId", "DELETE")!;
+      const response = await route.handler(
+        makeCtx({ runId: "completed-run" }, "DELETE"),
+      );
+      const body = (await response.json()) as {
+        deleted: boolean;
+        runId: string;
+        remainingRuns: number;
+        activeRunOverBudget: boolean;
+      };
+
+      expect(response.status).toBe(200);
+      expect(body.deleted).toBe(true);
+      expect(body.runId).toBe("completed-run");
+      expect(body.remainingRuns).toBe(1);
+      expect(body.activeRunOverBudget).toBe(false);
+
+      // Run directory should be gone
+      expect(existsSync(join(runsDir, "completed-run"))).toBe(false);
+      // Other run should still exist
+      expect(existsSync(join(runsDir, "other-run"))).toBe(true);
+    });
+
+    test("post-delete budget recalculation reflects freed space", async () => {
+      process.env.VELLUM_PROFILER_MAX_BYTES = "5000";
+      process.env.VELLUM_PROFILER_MAX_RUNS = "100";
+      process.env.VELLUM_PROFILER_MIN_FREE_MB = "0";
+
+      // Create two runs that together exceed the 5000 byte budget
+      createRun("over-budget-a", {
+        sizeBytes: 3000,
+        manifest: {
+          status: "completed",
+          createdAt: "2025-01-01T00:00:00Z",
+        },
+      });
+      createRun("over-budget-b", {
+        sizeBytes: 3000,
+        manifest: {
+          status: "completed",
+          createdAt: "2025-02-01T00:00:00Z",
+        },
+      });
+
+      // Delete one of the runs
+      const route = findRoute("profiler/runs/:runId", "DELETE")!;
+      const response = await route.handler(
+        makeCtx({ runId: "over-budget-a" }, "DELETE"),
+      );
+      const body = (await response.json()) as {
+        deleted: boolean;
+        remainingRuns: number;
+      };
+
+      expect(response.status).toBe(200);
+      expect(body.deleted).toBe(true);
+      // The remaining run should survive since it's within budget now
+      expect(body.remainingRuns).toBe(1);
+      expect(existsSync(join(runsDir, "over-budget-b"))).toBe(true);
+    });
+  });
+});

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -532,3 +532,14 @@ registerPolicy("admin/rollback-migrations", {
   requiredScopes: ["internal.write"],
   allowedPrincipalTypes: ["svc_gateway"],
 });
+
+// Profiler management: gateway-only control-plane endpoints
+registerPolicy("profiler/runs", {
+  requiredScopes: ["internal.write"],
+  allowedPrincipalTypes: ["svc_gateway"],
+});
+
+registerPolicy("profiler/runs/export", {
+  requiredScopes: ["internal.write"],
+  allowedPrincipalTypes: ["svc_gateway"],
+});

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -171,6 +171,7 @@ import {
   handlePairingStatus,
   pairingRouteDefinitions,
 } from "./routes/pairing-routes.js";
+import { profilerRouteDefinitions } from "./routes/profiler-routes.js";
 import { recordingRouteDefinitions } from "./routes/recording-routes.js";
 import { scheduleRouteDefinitions } from "./routes/schedule-routes.js";
 import { secretRouteDefinitions } from "./routes/secret-routes.js";
@@ -961,6 +962,7 @@ export class RuntimeHttpServer {
       ...notificationRouteDefinitions(),
       ...diagnosticsRouteDefinitions(),
       ...logExportRouteDefinitions(),
+      ...profilerRouteDefinitions(),
       ...documentRouteDefinitions(),
       ...workItemRouteDefinitions(
         this.sendMessageDeps

--- a/assistant/src/runtime/routes/archive-utils.ts
+++ b/assistant/src/runtime/routes/archive-utils.ts
@@ -6,7 +6,7 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readdirSync, rmSync, statSync } from "node:fs";
+import { existsSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 /** Maximum compressed archive size before pruning workspace directories (50 MB). */
@@ -87,18 +87,4 @@ export function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
-
-/**
- * Prune the largest subdirectory from `wsDir` and return its name and size.
- * Used by the iterative archive-pruning loop. Returns `undefined` if no
- * subdirectory can be found (nothing left to prune).
- */
-export function pruneAndRemoveLargest(
-  wsDir: string,
-): { name: string; bytes: number } | undefined {
-  const largest = findLargestSubdirectory(wsDir);
-  if (!largest) return undefined;
-  rmSync(join(wsDir, largest.name), { recursive: true, force: true });
-  return largest;
 }

--- a/assistant/src/runtime/routes/archive-utils.ts
+++ b/assistant/src/runtime/routes/archive-utils.ts
@@ -1,0 +1,104 @@
+/**
+ * Shared tar.gz archive creation and size-cap enforcement utilities.
+ *
+ * Extracted from log-export-routes so that profiler exports can reuse the
+ * same archive safeguards without duplicating tar logic.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync, rmSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/** Maximum compressed archive size before pruning workspace directories (50 MB). */
+export const MAX_ARCHIVE_BYTES = 50 * 1024 * 1024;
+
+/**
+ * Attempts to create a tar.gz archive of `staging` into a Buffer.
+ * Returns the Buffer on success, or `undefined` if the archive exceeds
+ * the size limit or tar otherwise fails.
+ */
+export function createTarGz(
+  staging: string,
+  maxBytes: number = MAX_ARCHIVE_BYTES,
+): ArrayBuffer | undefined {
+  const proc = spawnSync("tar", ["czf", "-", "-C", staging, "."], {
+    maxBuffer: maxBytes,
+    timeout: 30_000,
+  });
+  if (proc.status !== 0) return undefined;
+  const buf = Buffer.isBuffer(proc.stdout)
+    ? proc.stdout
+    : Buffer.from(proc.stdout);
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+}
+
+/**
+ * Returns the name and total byte size of the largest top-level subdirectory
+ * inside `dir`, or `undefined` if `dir` has no subdirectories.
+ */
+export function findLargestSubdirectory(
+  dir: string,
+): { name: string; bytes: number } | undefined {
+  if (!existsSync(dir)) return undefined;
+
+  let largest: { name: string; bytes: number } | undefined;
+
+  for (const entry of readdirSync(dir)) {
+    const fullPath = join(dir, entry);
+    try {
+      if (!statSync(fullPath).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    const bytes = directorySize(fullPath);
+    if (!largest || bytes > largest.bytes) {
+      largest = { name: entry, bytes };
+    }
+  }
+
+  return largest;
+}
+
+/** Recursively sums the byte size of all files in `dir`. */
+export function directorySize(dir: string): number {
+  let total = 0;
+  try {
+    for (const entry of readdirSync(dir)) {
+      const fullPath = join(dir, entry);
+      try {
+        const stat = statSync(fullPath);
+        if (stat.isDirectory()) {
+          total += directorySize(fullPath);
+        } else if (stat.isFile()) {
+          total += stat.size;
+        }
+      } catch {
+        // skip
+      }
+    }
+  } catch {
+    // skip
+  }
+  return total;
+}
+
+/** Formats a byte count as a human-readable string (e.g. "12.3 MB"). */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * Prune the largest subdirectory from `wsDir` and return its name and size.
+ * Used by the iterative archive-pruning loop. Returns `undefined` if no
+ * subdirectory can be found (nothing left to prune).
+ */
+export function pruneAndRemoveLargest(
+  wsDir: string,
+): { name: string; bytes: number } | undefined {
+  const largest = findLargestSubdirectory(wsDir);
+  if (!largest) return undefined;
+  rmSync(join(wsDir, largest.name), { recursive: true, force: true });
+  return largest;
+}

--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -41,14 +41,16 @@ import {
 import { APP_VERSION, COMMIT_SHA } from "../../version.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
+import {
+  createTarGz,
+  findLargestSubdirectory,
+  formatBytes,
+} from "./archive-utils.js";
 
 const log = getLogger("log-export-routes");
 
 /** Maximum total payload size for log file contents (10 MB). */
 const MAX_LOG_PAYLOAD_BYTES = 10 * 1024 * 1024;
-
-/** Maximum compressed archive size before pruning workspace directories (50 MB). */
-const MAX_ARCHIVE_BYTES = 50 * 1024 * 1024;
 
 interface ExportRequestBody {
   auditLimit?: number;
@@ -369,80 +371,6 @@ async function handleExport(body: ExportRequestBody): Promise<Response> {
       // Best-effort cleanup
     }
   }
-}
-
-/**
- * Attempts to create a tar.gz archive of `staging` into a Buffer.
- * Returns the Buffer on success, or `undefined` if the archive exceeds
- * the size limit or tar otherwise fails.
- */
-function createTarGz(staging: string): ArrayBuffer | undefined {
-  const proc = spawnSync("tar", ["czf", "-", "-C", staging, "."], {
-    maxBuffer: MAX_ARCHIVE_BYTES,
-    timeout: 30_000,
-  });
-  if (proc.status !== 0) return undefined;
-  const buf = Buffer.isBuffer(proc.stdout)
-    ? proc.stdout
-    : Buffer.from(proc.stdout);
-  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
-}
-
-/**
- * Returns the name and total byte size of the largest top-level subdirectory
- * inside `dir`, or `undefined` if `dir` has no subdirectories.
- */
-function findLargestSubdirectory(
-  dir: string,
-): { name: string; bytes: number } | undefined {
-  if (!existsSync(dir)) return undefined;
-
-  let largest: { name: string; bytes: number } | undefined;
-
-  for (const entry of readdirSync(dir)) {
-    const fullPath = join(dir, entry);
-    try {
-      if (!statSync(fullPath).isDirectory()) continue;
-    } catch {
-      continue;
-    }
-    const bytes = directorySize(fullPath);
-    if (!largest || bytes > largest.bytes) {
-      largest = { name: entry, bytes };
-    }
-  }
-
-  return largest;
-}
-
-/** Recursively sums the byte size of all files in `dir`. */
-function directorySize(dir: string): number {
-  let total = 0;
-  try {
-    for (const entry of readdirSync(dir)) {
-      const fullPath = join(dir, entry);
-      try {
-        const stat = statSync(fullPath);
-        if (stat.isDirectory()) {
-          total += directorySize(fullPath);
-        } else if (stat.isFile()) {
-          total += stat.size;
-        }
-      } catch {
-        // skip
-      }
-    }
-  } catch {
-    // skip
-  }
-  return total;
-}
-
-/** Formats a byte count as a human-readable string (e.g. "12.3 MB"). */
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 /** Directory prefixes to skip when collecting workspace files. */

--- a/assistant/src/runtime/routes/profiler-routes.ts
+++ b/assistant/src/runtime/routes/profiler-routes.ts
@@ -95,6 +95,10 @@ function handleListRuns(): Response {
  * GET /v1/profiler/runs/:runId — detail view with manifest + markdown summary.
  */
 function handleGetRun(runId: string): Response {
+  if (runId.includes("..") || runId.includes("/") || runId.includes("\\")) {
+    return httpError("BAD_REQUEST", "Invalid run ID", 400);
+  }
+
   const runDir = getProfilerRunDir(runId);
   if (!existsSync(runDir)) {
     return httpError("NOT_FOUND", `Profiler run '${runId}' not found`, 404);
@@ -123,6 +127,10 @@ function handleGetRun(runId: string): Response {
  * POST /v1/profiler/runs/:runId/export — package a single run as tar.gz.
  */
 function handleExportRun(runId: string): Response {
+  if (runId.includes("..") || runId.includes("/") || runId.includes("\\")) {
+    return httpError("BAD_REQUEST", "Invalid run ID", 400);
+  }
+
   const runDir = getProfilerRunDir(runId);
   if (!existsSync(runDir)) {
     return httpError("NOT_FOUND", `Profiler run '${runId}' not found`, 404);
@@ -179,6 +187,10 @@ function handleExportRun(runId: string): Response {
  * disk-budget state.
  */
 function handleDeleteRun(runId: string): Response {
+  if (runId.includes("..") || runId.includes("/") || runId.includes("\\")) {
+    return httpError("BAD_REQUEST", "Invalid run ID", 400);
+  }
+
   const activeRunId = getProfilerRunId();
   if (runId === activeRunId) {
     return httpError(

--- a/assistant/src/runtime/routes/profiler-routes.ts
+++ b/assistant/src/runtime/routes/profiler-routes.ts
@@ -1,0 +1,322 @@
+/**
+ * HTTP route handlers for managed profiler run management.
+ *
+ * Control-plane callers (proxied via vembda) can enumerate, inspect, export,
+ * and delete completed profiler runs without opening a shell on the assistant
+ * pod.
+ *
+ * Routes:
+ *   GET    /v1/profiler/runs              — list all profiler runs
+ *   GET    /v1/profiler/runs/:runId       — detail for a single run
+ *   POST   /v1/profiler/runs/:runId/export — tar.gz export of a single run
+ *   DELETE /v1/profiler/runs/:runId       — delete a completed run
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { z } from "zod";
+
+import { getProfilerRunId } from "../../config/env-registry.js";
+import type { ProfilerRunManifest } from "../../daemon/profiler-run-store.js";
+import {
+  rescanRuns,
+  runProfilerSweep,
+} from "../../daemon/profiler-run-store.js";
+import { getLogger } from "../../util/logger.js";
+import { getProfilerRunDir } from "../../util/platform.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+import { createTarGz, MAX_ARCHIVE_BYTES } from "./archive-utils.js";
+
+const log = getLogger("profiler-routes");
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+/**
+ * Read the Bun-generated profiler markdown summary from a run directory.
+ * Bun writes CPU profile summaries as `.md` files; we look for the first
+ * markdown file in the run directory.
+ */
+function readProfileSummary(runDir: string): string | undefined {
+  try {
+    const entries = readdirSync(runDir);
+    const mdFile = entries.find((e) => e.endsWith(".md"));
+    if (!mdFile) return undefined;
+    return readFileSync(join(runDir, mdFile), "utf-8");
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Read and parse a manifest.json from a run directory.
+ */
+function readManifest(runDir: string): ProfilerRunManifest | null {
+  try {
+    const raw = readFileSync(join(runDir, "manifest.json"), "utf-8");
+    return JSON.parse(raw) as ProfilerRunManifest;
+  } catch {
+    return null;
+  }
+}
+
+// ── Route handlers ─────────────────────────────────────────────────────
+
+/**
+ * GET /v1/profiler/runs — list all profiler runs with manifest metadata.
+ */
+function handleListRuns(): Response {
+  const manifests = rescanRuns();
+
+  // Sort newest-first for the listing
+  manifests.sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
+
+  return Response.json({
+    runs: manifests,
+    totalRuns: manifests.length,
+    activeRunId: getProfilerRunId() ?? null,
+  });
+}
+
+/**
+ * GET /v1/profiler/runs/:runId — detail view with manifest + markdown summary.
+ */
+function handleGetRun(runId: string): Response {
+  const runDir = getProfilerRunDir(runId);
+  if (!existsSync(runDir)) {
+    return httpError("NOT_FOUND", `Profiler run '${runId}' not found`, 404);
+  }
+
+  const manifest = readManifest(runDir);
+  if (!manifest) {
+    return httpError(
+      "INTERNAL_ERROR",
+      `Manifest missing for profiler run '${runId}'`,
+      500,
+    );
+  }
+
+  const summary = readProfileSummary(runDir);
+  const activeRunId = getProfilerRunId();
+
+  return Response.json({
+    ...manifest,
+    summary: summary ?? null,
+    isActive: runId === activeRunId,
+  });
+}
+
+/**
+ * POST /v1/profiler/runs/:runId/export — package a single run as tar.gz.
+ */
+function handleExportRun(runId: string): Response {
+  const runDir = getProfilerRunDir(runId);
+  if (!existsSync(runDir)) {
+    return httpError("NOT_FOUND", `Profiler run '${runId}' not found`, 404);
+  }
+
+  // Stage the run directory contents into a temp directory to avoid
+  // including parent path structure in the archive.
+  const staging = mkdtempSync(join(tmpdir(), "vellum-profiler-export-"));
+
+  try {
+    // Copy run directory contents into the staging area
+    copyDirContents(runDir, staging);
+
+    const archiveBytes = createTarGz(staging);
+    if (!archiveBytes) {
+      log.error(
+        { runId },
+        "Profiler run archive exceeds size limit or tar failed",
+      );
+      return httpError(
+        "INTERNAL_ERROR",
+        `Profiler run '${runId}' exceeds the maximum archive size of ${MAX_ARCHIVE_BYTES} bytes`,
+        500,
+      );
+    }
+
+    return new Response(archiveBytes, {
+      status: 200,
+      headers: {
+        "Content-Type": "application/gzip",
+        "Content-Disposition": `attachment; filename="profiler-${runId}.tar.gz"`,
+        "Content-Length": String(archiveBytes.byteLength),
+      },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err, runId }, "Failed to export profiler run");
+    return httpError(
+      "INTERNAL_ERROR",
+      `Failed to export profiler run: ${message}`,
+      500,
+    );
+  } finally {
+    try {
+      rmSync(staging, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup
+    }
+  }
+}
+
+/**
+ * DELETE /v1/profiler/runs/:runId — delete a completed run and recalculate
+ * disk-budget state.
+ */
+function handleDeleteRun(runId: string): Response {
+  const activeRunId = getProfilerRunId();
+  if (runId === activeRunId) {
+    return httpError(
+      "CONFLICT",
+      `Cannot delete the currently active profiler run '${runId}'`,
+      409,
+    );
+  }
+
+  const runDir = getProfilerRunDir(runId);
+  if (!existsSync(runDir)) {
+    return httpError("NOT_FOUND", `Profiler run '${runId}' not found`, 404);
+  }
+
+  try {
+    rmSync(runDir, { recursive: true, force: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err, runId }, "Failed to delete profiler run directory");
+    return httpError(
+      "INTERNAL_ERROR",
+      `Failed to delete profiler run: ${message}`,
+      500,
+    );
+  }
+
+  // Re-run the sweep to recompute disk-budget state after deletion
+  const sweepResult = runProfilerSweep();
+
+  log.info(
+    { runId, remainingRuns: sweepResult.remainingRuns },
+    "Profiler run deleted",
+  );
+
+  return Response.json({
+    deleted: true,
+    runId,
+    remainingRuns: sweepResult.remainingRuns,
+    activeRunOverBudget: sweepResult.activeRunOverBudget,
+  });
+}
+
+// ── File copying helper ────────────────────────────────────────────────
+
+/**
+ * Recursively copy all files and directories from `src` into `dest`.
+ */
+function copyDirContents(src: string, dest: string): void {
+  const entries = readdirSync(src);
+  for (const entry of entries) {
+    const srcPath = join(src, entry);
+    const destPath = join(dest, entry);
+    try {
+      const stat = statSync(srcPath);
+      if (stat.isDirectory()) {
+        mkdirSync(destPath, { recursive: true });
+        copyDirContents(srcPath, destPath);
+      } else if (stat.isFile()) {
+        const content = readFileSync(srcPath);
+        writeFileSync(destPath, content);
+      }
+    } catch {
+      // Skip unreadable entries
+    }
+  }
+}
+
+// ── Route definitions ──────────────────────────────────────────────────
+
+export function profilerRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "profiler/runs",
+      method: "GET",
+      policyKey: "profiler/runs",
+      summary: "List profiler runs",
+      description:
+        "Enumerate all profiler run directories with manifest metadata, sorted newest-first.",
+      tags: ["profiler"],
+      responseBody: z.object({
+        runs: z.array(
+          z.object({
+            runId: z.string(),
+            status: z.enum(["active", "completed"]),
+            createdAt: z.string(),
+            updatedAt: z.string(),
+            totalBytes: z.number(),
+          }),
+        ),
+        totalRuns: z.number(),
+        activeRunId: z.string().nullable(),
+      }),
+      handler: () => handleListRuns(),
+    },
+    {
+      endpoint: "profiler/runs/:runId",
+      method: "GET",
+      policyKey: "profiler/runs",
+      summary: "Get profiler run detail",
+      description:
+        "Return manifest metadata, Bun-generated markdown summary, and current retention state for a single profiler run.",
+      tags: ["profiler"],
+      responseBody: z.object({
+        runId: z.string(),
+        status: z.enum(["active", "completed"]),
+        createdAt: z.string(),
+        updatedAt: z.string(),
+        totalBytes: z.number(),
+        summary: z.string().nullable(),
+        isActive: z.boolean(),
+      }),
+      handler: ({ params }) => handleGetRun(params.runId),
+    },
+    {
+      endpoint: "profiler/runs/:runId/export",
+      method: "POST",
+      policyKey: "profiler/runs/export",
+      summary: "Export profiler run",
+      description:
+        "Package a single profiler run directory as a tar.gz bundle, subject to the same archive size limits used by runtime log exports.",
+      tags: ["profiler"],
+      handler: ({ params }) => handleExportRun(params.runId),
+    },
+    {
+      endpoint: "profiler/runs/:runId",
+      method: "DELETE",
+      policyKey: "profiler/runs",
+      summary: "Delete profiler run",
+      description:
+        "Delete a completed profiler run and recalculate disk-budget state. Rejects deletion of the currently active run.",
+      tags: ["profiler"],
+      responseBody: z.object({
+        deleted: z.boolean(),
+        runId: z.string(),
+        remainingRuns: z.number(),
+        activeRunOverBudget: z.boolean(),
+      }),
+      handler: ({ params }) => handleDeleteRun(params.runId),
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Extract tar.gz archive creation and size-cap logic from log-export-routes into shared archive-utils
- Add authenticated profiler routes: list runs, get run detail with markdown summary, export as tar.gz, delete with budget recalculation
- Register profiler routes in http-server alongside existing operational routes
- Add comprehensive profiler-routes tests covering empty state, 404s, active-run rejection, export, and budget recalculation
- Update ARCHITECTURE.md with profiler directory contract and runtime endpoint documentation

Part of plan: managed-assistant-profiler-runtime.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
