### PR TITLE
fix: use lstatSync in copyDirContents and sort lastCompletedRun by completedAt

### DIFF
--- a/assistant/src/daemon/profiler-run-store.ts
+++ b/assistant/src/daemon/profiler-run-store.ts
@@ -518,7 +518,8 @@ export function getProfilerRuntimeStatus(): ProfilerRuntimeStatus {
     .filter((m) => m.status === "completed")
     .sort(
       (a, b) =>
-        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+        new Date(b.completedAt ?? b.createdAt).getTime() -
+        new Date(a.completedAt ?? a.createdAt).getTime(),
     );
 
   let lastCompletedRun: ProfilerLastCompletedRun | null = null;

--- a/assistant/src/runtime/routes/profiler-routes.ts
+++ b/assistant/src/runtime/routes/profiler-routes.ts
@@ -14,12 +14,12 @@
 
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
   readFileSync,
   rmSync,
-  statSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -244,7 +244,10 @@ function copyDirContents(src: string, dest: string): void {
     const srcPath = join(src, entry);
     const destPath = join(dest, entry);
     try {
-      const stat = statSync(srcPath);
+      const stat = lstatSync(srcPath);
+      // Skip symlinks for defense-in-depth — a symlink inside a run
+      // directory could point outside the run and exfiltrate files.
+      if (stat.isSymbolicLink()) continue;
       if (stat.isDirectory()) {
         mkdirSync(destPath, { recursive: true });
         copyDirContents(srcPath, destPath);


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for managed-assistant-profiler-runtime.md.

**Gap 3:** copyDirContents follows symlinks (security)
**What was expected:** Defense-in-depth: skip symlinks during export, matching log-export-routes pattern
**What was found:** statSync follows symlinks, allowing potential file exfiltration via crafted symlinks

**Gap 4:** lastCompletedRun sorted by createdAt instead of completedAt
**What was expected:** Sort by completion time to find the most recently finished run
**What was found:** Sorted by creation time, which could select the wrong run for long-running profiles
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23303" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
