### PR TITLE
fix: add missing Bun profiler markdown flags and correct heap profile extension

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -2030,7 +2030,7 @@ The guardian trust system uses a three-valued `TrustClass` — `'guardian'`, `'t
 
 Managed cloud assistants use Bun's built-in CPU and heap profiling to capture runtime performance data. The profiler subsystem consists of a persistent on-disk run store, a retention/pruning sweep, and HTTP routes for remote management.
 
-**Bun profiler flags:** Managed containers activate profiling by setting `VELLUM_PROFILER_MODE` (e.g. `cpu`, `heap`, `cpu+heap`) and `VELLUM_PROFILER_RUN_ID` environment variables before boot. Bun writes profiler artifacts (`.cpuprofile`, `.heapprofile`, markdown summaries) into the run directory.
+**Bun profiler flags:** Managed containers activate profiling by setting `VELLUM_PROFILER_MODE` (e.g. `cpu`, `heap`, `cpu+heap`) and `VELLUM_PROFILER_RUN_ID` environment variables before boot. Bun writes profiler artifacts (`.cpuprofile`, `.heapsnapshot`, markdown summaries) into the run directory.
 
 **Directory contract:**
 
@@ -2041,7 +2041,7 @@ Managed cloud assistants use Bun's built-in CPU and heap profiling to capture ru
       manifest.json          — run metadata (status, timestamps, byte count)
       profile.cpuprofile     — Bun CPU profile output
       profile-summary.md     — Bun-generated markdown summary
-      *.heapprofile          — Bun heap profile output (when heap mode active)
+      *.heapsnapshot          — Bun heap profile output (when heap mode active)
 ```
 
 Each profiler run lives in its own sub-directory under `<workspace>/data/profiler/runs/<runId>/`. A `manifest.json` in each run directory records metadata: status (`active` or `completed`), creation/update timestamps, and total byte count. The active run (identified by `VELLUM_PROFILER_RUN_ID`) is never pruned.

--- a/assistant/docker-entrypoint.sh
+++ b/assistant/docker-entrypoint.sh
@@ -10,7 +10,7 @@ fi
 # When VELLUM_PROFILER_RUN_ID and VELLUM_PROFILER_MODE are set, prepare the
 # run directory on the workspace volume and append the appropriate Bun
 # profiler flags to BUN_OPTIONS. Bun's native --cpu-prof / --heap-prof
-# flags write Chrome-compatible .cpuprofile and .heapprofile artifacts.
+# flags write Chrome-compatible .cpuprofile and .heapsnapshot artifacts.
 BUN_OPTIONS="${BUN_OPTIONS:-}"
 
 if [ -n "${VELLUM_PROFILER_RUN_ID:-}" ] && [ -n "${VELLUM_PROFILER_MODE:-}" ]; then
@@ -22,13 +22,13 @@ if [ -n "${VELLUM_PROFILER_RUN_ID:-}" ] && [ -n "${VELLUM_PROFILER_MODE:-}" ]; t
 
   case "${VELLUM_PROFILER_MODE}" in
     cpu)
-      BUN_OPTIONS="${BUN_OPTIONS} --cpu-prof --cpu-prof-dir=${PROFILER_RUN_DIR}"
+      BUN_OPTIONS="${BUN_OPTIONS} --cpu-prof --cpu-prof-md --cpu-prof-dir=${PROFILER_RUN_DIR}"
       ;;
     heap)
-      BUN_OPTIONS="${BUN_OPTIONS} --heap-prof --heap-prof-dir=${PROFILER_RUN_DIR}"
+      BUN_OPTIONS="${BUN_OPTIONS} --heap-prof --heap-prof-md --heap-prof-dir=${PROFILER_RUN_DIR}"
       ;;
     cpu+heap|heap+cpu)
-      BUN_OPTIONS="${BUN_OPTIONS} --cpu-prof --cpu-prof-dir=${PROFILER_RUN_DIR} --heap-prof --heap-prof-dir=${PROFILER_RUN_DIR}"
+      BUN_OPTIONS="${BUN_OPTIONS} --cpu-prof --cpu-prof-md --cpu-prof-dir=${PROFILER_RUN_DIR} --heap-prof --heap-prof-md --heap-prof-dir=${PROFILER_RUN_DIR}"
       ;;
     *)
       echo "Warning: unknown VELLUM_PROFILER_MODE '${VELLUM_PROFILER_MODE}', skipping profiler flags" >&2

--- a/assistant/src/__tests__/identity-routes.test.ts
+++ b/assistant/src/__tests__/identity-routes.test.ts
@@ -307,14 +307,14 @@ describe("identity routes — health endpoint", () => {
         createdAt: "2025-01-01T00:00:00Z",
         updatedAt: "2025-01-01T01:00:00Z",
       });
-      writeArtifactFile("older-completed", "old.heapprofile", 512);
+      writeArtifactFile("older-completed", "old.heapsnapshot", 512);
 
       writeRunManifest("newer-completed", {
         status: "completed",
         createdAt: "2025-06-15T00:00:00Z",
         updatedAt: "2025-06-15T01:00:00Z",
       });
-      writeArtifactFile("newer-completed", "new.heapprofile", 1024);
+      writeArtifactFile("newer-completed", "new.heapsnapshot", 1024);
 
       const res = handleDetailedHealth();
       const body = (await res.json()) as Record<string, unknown>;

--- a/assistant/src/daemon/profiler-run-store.ts
+++ b/assistant/src/daemon/profiler-run-store.ts
@@ -418,7 +418,7 @@ export interface ProfilerRuntimeStatus {
 }
 
 /** File extensions that Bun profiler writes as raw artifacts. */
-const PROFILER_ARTIFACT_EXTENSIONS = [".cpuprofile", ".heapprofile"];
+const PROFILER_ARTIFACT_EXTENSIONS = [".cpuprofile", ".heapsnapshot"];
 
 /** File extensions for Bun-generated markdown summaries. */
 const PROFILER_SUMMARY_EXTENSIONS = [".md"];


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for managed-assistant-profiler-runtime.md.

**Gap 1:** Missing --cpu-prof-md and --heap-prof-md Bun flags in docker-entrypoint.sh
**What was expected:** Bun markdown summary flags so runtime can detect and serve .md summaries
**What was found:** Only --cpu-prof and --heap-prof were set; markdown summaries were never generated

**Gap 2:** Wrong heap profile extension (.heapprofile → .heapsnapshot)
**What was expected:** Bun generates .heapsnapshot files
**What was found:** Code looked for .heapprofile, which Bun never creates
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
