### PR TITLE
fix: add budget state to run detail endpoint and use read-only rescan in list

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -3370,6 +3370,81 @@ paths:
                     type: object
                     properties: {}
                     additionalProperties: {}
+                  profiler:
+                    type: object
+                    properties:
+                      enabled:
+                        type: boolean
+                      mode:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      runId:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      runDir:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      totalBytes:
+                        type: number
+                      artifactCount:
+                        type: number
+                      budget:
+                        anyOf:
+                          - type: object
+                            properties:
+                              maxBytes:
+                                type: number
+                              remainingBytes:
+                                type: number
+                              minFreeMb:
+                                type: number
+                              freeMb:
+                                type: number
+                              overBudget:
+                                type: boolean
+                            required:
+                              - maxBytes
+                              - remainingBytes
+                              - minFreeMb
+                              - freeMb
+                              - overBudget
+                            additionalProperties: false
+                          - type: "null"
+                      lastCompletedRun:
+                        anyOf:
+                          - type: object
+                            properties:
+                              runId:
+                                type: string
+                              totalBytes:
+                                type: number
+                              artifactCount:
+                                type: number
+                              hasSummaries:
+                                type: boolean
+                              completedAt:
+                                type: string
+                            required:
+                              - runId
+                              - totalBytes
+                              - artifactCount
+                              - hasSummaries
+                              - completedAt
+                            additionalProperties: false
+                          - type: "null"
+                    required:
+                      - enabled
+                      - mode
+                      - runId
+                      - runDir
+                      - totalBytes
+                      - artifactCount
+                      - budget
+                      - lastCompletedRun
+                    additionalProperties: false
                 required:
                   - status
                   - timestamp
@@ -3416,6 +3491,81 @@ paths:
                     type: object
                     properties: {}
                     additionalProperties: {}
+                  profiler:
+                    type: object
+                    properties:
+                      enabled:
+                        type: boolean
+                      mode:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      runId:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      runDir:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      totalBytes:
+                        type: number
+                      artifactCount:
+                        type: number
+                      budget:
+                        anyOf:
+                          - type: object
+                            properties:
+                              maxBytes:
+                                type: number
+                              remainingBytes:
+                                type: number
+                              minFreeMb:
+                                type: number
+                              freeMb:
+                                type: number
+                              overBudget:
+                                type: boolean
+                            required:
+                              - maxBytes
+                              - remainingBytes
+                              - minFreeMb
+                              - freeMb
+                              - overBudget
+                            additionalProperties: false
+                          - type: "null"
+                      lastCompletedRun:
+                        anyOf:
+                          - type: object
+                            properties:
+                              runId:
+                                type: string
+                              totalBytes:
+                                type: number
+                              artifactCount:
+                                type: number
+                              hasSummaries:
+                                type: boolean
+                              completedAt:
+                                type: string
+                            required:
+                              - runId
+                              - totalBytes
+                              - artifactCount
+                              - hasSummaries
+                              - completedAt
+                            additionalProperties: false
+                          - type: "null"
+                    required:
+                      - enabled
+                      - mode
+                      - runId
+                      - runDir
+                      - totalBytes
+                      - artifactCount
+                      - budget
+                      - lastCompletedRun
+                    additionalProperties: false
                 required:
                   - status
                   - timestamp
@@ -4944,6 +5094,176 @@ paths:
           schema:
             type: string
           description: Conversation ID
+  /v1/profiler/runs:
+    get:
+      operationId: profiler_runs_get
+      summary: List profiler runs
+      description: Enumerate all profiler run directories with manifest metadata, sorted newest-first.
+      tags:
+        - profiler
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  runs:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        runId:
+                          type: string
+                        status:
+                          type: string
+                          enum:
+                            - active
+                            - completed
+                        createdAt:
+                          type: string
+                        updatedAt:
+                          type: string
+                        totalBytes:
+                          type: number
+                      required:
+                        - runId
+                        - status
+                        - createdAt
+                        - updatedAt
+                        - totalBytes
+                      additionalProperties: false
+                  totalRuns:
+                    type: number
+                  activeRunId:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                required:
+                  - runs
+                  - totalRuns
+                  - activeRunId
+                additionalProperties: false
+  /v1/profiler/runs/{runId}:
+    delete:
+      operationId: profiler_runs_by_runId_delete
+      summary: Delete profiler run
+      description: Delete a completed profiler run and recalculate disk-budget state. Rejects deletion of the currently active run.
+      tags:
+        - profiler
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted:
+                    type: boolean
+                  runId:
+                    type: string
+                  remainingRuns:
+                    type: number
+                  activeRunOverBudget:
+                    type: boolean
+                required:
+                  - deleted
+                  - runId
+                  - remainingRuns
+                  - activeRunOverBudget
+                additionalProperties: false
+      parameters:
+        - name: runId
+          in: path
+          required: true
+          schema:
+            type: string
+    get:
+      operationId: profiler_runs_by_runId_get
+      summary: Get profiler run detail
+      description: Return manifest metadata, Bun-generated markdown summary, and current retention state for a single profiler run.
+      tags:
+        - profiler
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  runId:
+                    type: string
+                  status:
+                    type: string
+                    enum:
+                      - active
+                      - completed
+                  createdAt:
+                    type: string
+                  updatedAt:
+                    type: string
+                  totalBytes:
+                    type: number
+                  summary:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                  isActive:
+                    type: boolean
+                  budget:
+                    type: object
+                    properties:
+                      maxBytes:
+                        type: number
+                      totalBytesAllRuns:
+                        type: number
+                      remainingBytes:
+                        type: number
+                      overBudget:
+                        type: boolean
+                    required:
+                      - maxBytes
+                      - totalBytesAllRuns
+                      - remainingBytes
+                      - overBudget
+                    additionalProperties: false
+                required:
+                  - runId
+                  - status
+                  - createdAt
+                  - updatedAt
+                  - totalBytes
+                  - summary
+                  - isActive
+                  - budget
+                additionalProperties: false
+      parameters:
+        - name: runId
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/profiler/runs/{runId}/export:
+    post:
+      operationId: profiler_runs_by_runId_export_post
+      summary: Export profiler run
+      description:
+        Package a single profiler run directory as a tar.gz bundle, subject to the same archive size limits used by
+        runtime log exports.
+      tags:
+        - profiler
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: runId
+          in: path
+          required: true
+          schema:
+            type: string
   /v1/recordings/pause:
     post:
       operationId: recordings_pause_post

--- a/assistant/src/runtime/routes/profiler-routes.ts
+++ b/assistant/src/runtime/routes/profiler-routes.ts
@@ -27,7 +27,10 @@ import { join } from "node:path";
 
 import { z } from "zod";
 
-import { getProfilerRunId } from "../../config/env-registry.js";
+import {
+  getProfilerMaxBytes,
+  getProfilerRunId,
+} from "../../config/env-registry.js";
 import type { ProfilerRunManifest } from "../../daemon/profiler-run-store.js";
 import {
   rescanRuns,
@@ -77,7 +80,7 @@ function readManifest(runDir: string): ProfilerRunManifest | null {
  * GET /v1/profiler/runs — list all profiler runs with manifest metadata.
  */
 function handleListRuns(): Response {
-  const manifests = rescanRuns();
+  const manifests = rescanRuns({ readOnly: true });
 
   // Sort newest-first for the listing
   manifests.sort(
@@ -91,8 +94,12 @@ function handleListRuns(): Response {
   });
 }
 
+/** Default max total bytes across all completed runs: 500 MB */
+const DEFAULT_MAX_BYTES = 500 * 1024 * 1024;
+
 /**
- * GET /v1/profiler/runs/:runId — detail view with manifest + markdown summary.
+ * GET /v1/profiler/runs/:runId — detail view with manifest + markdown summary
+ * plus current budget/retention state.
  */
 function handleGetRun(runId: string): Response {
   if (runId.includes("..") || runId.includes("/") || runId.includes("\\")) {
@@ -116,10 +123,26 @@ function handleGetRun(runId: string): Response {
   const summary = readProfileSummary(runDir);
   const activeRunId = getProfilerRunId();
 
+  // Compute budget state from all runs (read-only to avoid disk writes)
+  const allManifests = rescanRuns({ readOnly: true });
+  const maxBytes = getProfilerMaxBytes() ?? DEFAULT_MAX_BYTES;
+  const totalBytesAllRuns = allManifests.reduce(
+    (sum, m) => sum + m.totalBytes,
+    0,
+  );
+  const remainingBytes = Math.max(0, maxBytes - totalBytesAllRuns);
+  const overBudget = totalBytesAllRuns > maxBytes;
+
   return Response.json({
     ...manifest,
     summary: summary ?? null,
     isActive: runId === activeRunId,
+    budget: {
+      maxBytes,
+      totalBytesAllRuns,
+      remainingBytes,
+      overBudget,
+    },
   });
 }
 
@@ -301,6 +324,12 @@ export function profilerRouteDefinitions(): RouteDefinition[] {
         totalBytes: z.number(),
         summary: z.string().nullable(),
         isActive: z.boolean(),
+        budget: z.object({
+          maxBytes: z.number(),
+          totalBytesAllRuns: z.number(),
+          remainingBytes: z.number(),
+          overBudget: z.boolean(),
+        }),
       }),
       handler: ({ params }) => handleGetRun(params.runId),
     },


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for managed-assistant-profiler-runtime.md.

**Gap 5:** Detail endpoint missing retention/budget state
**What was expected:** Run detail response includes current budget/retention context
**What was found:** Only manifest metadata and summary returned; no budget info

**Gap 6:** List endpoint calls rescanRuns() in mutable mode
**What was expected:** GET endpoints should be read-only
**What was found:** List endpoint writes manifest files on every request, inconsistent with health endpoint
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
