### PR TITLE
fix: align MemoryRecallCandidate fields with server JSON shape

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorMemoryTab.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorMemoryTab.swift
@@ -14,10 +14,9 @@ struct MessageInspectorMemoryTabModel: Equatable {
 
     struct CandidateRow: Identifiable, Equatable {
         let id: String
-        let key: String
+        let nodeId: String
         let type: String
-        let kind: String
-        let finalScore: String
+        let score: String
         let semanticScore: String
         let recencyScore: String
     }
@@ -90,17 +89,16 @@ struct MessageInspectorMemoryTabModel: Equatable {
         ]
 
         candidates = recall.topCandidates
-            .sorted { $0.finalScore > $1.finalScore }
+            .sorted { $0.score > $1.score }
             .enumerated()
             .map { index, candidate in
                 CandidateRow(
-                    id: "\(index)-\(candidate.key)",
-                    key: candidate.key,
+                    id: "\(index)-\(candidate.nodeId)",
+                    nodeId: candidate.nodeId,
                     type: candidate.type,
-                    kind: candidate.kind,
-                    finalScore: Self.formatScore(candidate.finalScore),
-                    semanticScore: Self.formatScore(candidate.semantic),
-                    recencyScore: Self.formatScore(candidate.recency)
+                    score: Self.formatScore(candidate.score),
+                    semanticScore: Self.formatScore(candidate.semanticSimilarity),
+                    recencyScore: Self.formatScore(candidate.recencyBoost)
                 )
             }
 
@@ -279,21 +277,18 @@ struct MessageInspectorMemoryTab: View {
     private func candidateRow(_ candidate: MessageInspectorMemoryTabModel.CandidateRow) -> some View {
         HStack(alignment: .top, spacing: VSpacing.md) {
             VStack(alignment: .leading, spacing: VSpacing.xxs) {
-                Text(candidate.key)
+                Text(candidate.nodeId)
                     .font(.system(.caption, design: .monospaced))
                     .foregroundStyle(VColor.contentDefault)
                     .lineLimit(2)
 
-                HStack(spacing: VSpacing.xs) {
-                    chip(candidate.type)
-                    chip(candidate.kind)
-                }
+                chip(candidate.type)
             }
 
             Spacer(minLength: VSpacing.sm)
 
             VStack(alignment: .trailing, spacing: VSpacing.xxs) {
-                Text(candidate.finalScore)
+                Text(candidate.score)
                     .font(VFont.bodyMediumDefault)
                     .foregroundStyle(VColor.contentDefault)
 

--- a/clients/macos/vellum-assistantTests/MessageInspectorMemoryTabTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageInspectorMemoryTabTests.swift
@@ -132,20 +132,19 @@ final class MessageInspectorMemoryTabTests: XCTestCase {
         let recall = makeRecall(
             enabled: true,
             topCandidates: [
-                MemoryRecallCandidate(key: "low", type: "fact", kind: "core", finalScore: 0.3, semantic: 0.2, recency: 0.5),
-                MemoryRecallCandidate(key: "high", type: "preference", kind: "inferred", finalScore: 0.9, semantic: 0.8, recency: 0.7),
-                MemoryRecallCandidate(key: "mid", type: "fact", kind: "core", finalScore: 0.6, semantic: 0.5, recency: 0.4),
+                MemoryRecallCandidate(nodeId: "low", type: "fact", score: 0.3, semanticSimilarity: 0.2, recencyBoost: 0.5),
+                MemoryRecallCandidate(nodeId: "high", type: "preference", score: 0.9, semanticSimilarity: 0.8, recencyBoost: 0.7),
+                MemoryRecallCandidate(nodeId: "mid", type: "fact", score: 0.6, semanticSimilarity: 0.5, recencyBoost: 0.4),
             ]
         )
         let model = MessageInspectorMemoryTabModel(memoryRecall: recall)
 
         XCTAssertEqual(model.candidates.count, 3)
-        XCTAssertEqual(model.candidates.map(\.key), ["high", "mid", "low"])
-        XCTAssertEqual(model.candidates[0].finalScore, "0.900")
+        XCTAssertEqual(model.candidates.map(\.nodeId), ["high", "mid", "low"])
+        XCTAssertEqual(model.candidates[0].score, "0.900")
         XCTAssertEqual(model.candidates[0].semanticScore, "0.800")
         XCTAssertEqual(model.candidates[0].recencyScore, "0.700")
         XCTAssertEqual(model.candidates[0].type, "preference")
-        XCTAssertEqual(model.candidates[0].kind, "inferred")
     }
 
     func testEmptyCandidatesProducesEmptyArray() {

--- a/clients/shared/Network/LLMContextClient.swift
+++ b/clients/shared/Network/LLMContextClient.swift
@@ -484,12 +484,11 @@ private extension KeyedEncodingContainer where Key == LLMContextCodingKey {
 }
 
 public struct MemoryRecallCandidate: Codable, Sendable, Equatable {
-    public let key: String
+    public let nodeId: String
     public let type: String
-    public let kind: String
-    public let finalScore: Double
-    public let semantic: Double
-    public let recency: Double
+    public let score: Double
+    public let semanticSimilarity: Double
+    public let recencyBoost: Double
 }
 
 public struct MemoryRecallDegradation: Codable, Sendable, Equatable {
@@ -581,29 +580,65 @@ public struct LLMContextClient: LLMContextClientProtocol {
     }
 
     public func fetchContextResult(messageId: String) async throws -> LLMContextFetchResult {
+        let response: GatewayHTTPClient.Response
         do {
             try Task.checkCancellation()
-            let response = try await GatewayHTTPClient.get(
+            response = try await GatewayHTTPClient.get(
                 path: "assistants/{assistantId}/messages/\(messageId)/llm-context",
                 timeout: 15
             )
             try Task.checkCancellation()
-            guard response.isSuccess else {
-                log.error("fetchContext failed (HTTP \(response.statusCode))")
-                return .failed
-            }
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            if Task.isCancelled { throw CancellationError() }
+            log.error("fetchContext network error: \(error.localizedDescription)")
+            return .failed
+        }
+
+        guard response.isSuccess else {
+            log.error("fetchContext failed (HTTP \(response.statusCode))")
+            return .failed
+        }
+
+        do {
             let decoded = try JSONDecoder().decode(LLMContextResponse.self, from: response.data)
             try Task.checkCancellation()
             return decoded.logs.isEmpty ? .empty : .loaded(decoded)
         } catch is CancellationError {
             throw CancellationError()
         } catch {
-            if Task.isCancelled {
-                throw CancellationError()
-            }
-            log.error("fetchContext error: \(error.localizedDescription)")
+            if Task.isCancelled { throw CancellationError() }
+            log.error("fetchContext decode error: \(Self.describeDecodingError(error))")
+            let snippet = String(data: response.data.prefix(2048), encoding: .utf8) ?? "<non-utf8>"
+            log.error("fetchContext body prefix (\(response.data.count) bytes): \(snippet)")
             return .failed
         }
+    }
+
+    private static func describeDecodingError(_ error: Error) -> String {
+        guard let decodingError = error as? DecodingError else {
+            return error.localizedDescription
+        }
+        let path: String
+        let detail: String
+        switch decodingError {
+        case .typeMismatch(let type, let context):
+            path = context.codingPath.map(\.stringValue).joined(separator: ".")
+            detail = "typeMismatch(\(type)) — \(context.debugDescription)"
+        case .valueNotFound(let type, let context):
+            path = context.codingPath.map(\.stringValue).joined(separator: ".")
+            detail = "valueNotFound(\(type)) — \(context.debugDescription)"
+        case .keyNotFound(let key, let context):
+            path = context.codingPath.map(\.stringValue).joined(separator: ".")
+            detail = "keyNotFound(\(key.stringValue)) — \(context.debugDescription)"
+        case .dataCorrupted(let context):
+            path = context.codingPath.map(\.stringValue).joined(separator: ".")
+            detail = "dataCorrupted — \(context.debugDescription)"
+        @unknown default:
+            return decodingError.localizedDescription
+        }
+        return "at \(path.isEmpty ? "<root>" : path): \(detail)"
     }
 
     public func fetchLogPayload(logId: String) async -> LLMLogPayloadResponse? {


### PR DESCRIPTION
## Summary
- **Root cause**: `MemoryRecallCandidate` Swift struct had field names (`key`, `kind`, `finalScore`, `semantic`, `recency`) that didn't match the server's JSON (`nodeId`, `score`, `semanticSimilarity`, `recencyBoost`). Every decode threw `keyNotFound` when memory recall data was present.
- Updated `MemoryRecallCandidate`, `CandidateRow`, inspector memory tab view, and tests to use the server's actual field names.
- Added diagnostic `DecodingError` logging to `fetchContextResult()` so future decode failures are immediately diagnosable.

## Test plan
- [ ] Build and run macOS app (`./build.sh run`)
- [ ] Open LLM Context Inspector on any assistant message — should load without error
- [ ] Check Memory tab shows recall candidates with correct scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
