### PR TITLE
fix: add completedAt to profiler list endpoint Zod schema

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5127,6 +5127,8 @@ paths:
                           type: string
                         totalBytes:
                           type: number
+                        completedAt:
+                          type: string
                       required:
                         - runId
                         - status
@@ -5207,6 +5209,8 @@ paths:
                     type: string
                   totalBytes:
                     type: number
+                  completedAt:
+                    type: string
                   summary:
                     anyOf:
                       - type: string

--- a/assistant/src/runtime/routes/profiler-routes.ts
+++ b/assistant/src/runtime/routes/profiler-routes.ts
@@ -304,6 +304,7 @@ export function profilerRouteDefinitions(): RouteDefinition[] {
             createdAt: z.string(),
             updatedAt: z.string(),
             totalBytes: z.number(),
+            completedAt: z.string().optional(),
           }),
         ),
         totalRuns: z.number(),
@@ -325,6 +326,7 @@ export function profilerRouteDefinitions(): RouteDefinition[] {
         createdAt: z.string(),
         updatedAt: z.string(),
         totalBytes: z.number(),
+        completedAt: z.string().optional(),
         summary: z.string().nullable(),
         isActive: z.boolean(),
         budget: z.object({


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for managed-assistant-profiler-runtime.md.

**Gap:** List endpoint response includes undocumented completedAt field
**What was expected:** Zod schema should include all fields the endpoint returns
**What was found:** completedAt from ProfilerRunManifest was omitted from the Zod response schema, violating additionalProperties: false in the generated OpenAPI spec
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
