### PR TITLE
fix: add missing CSS token aliases for app-builder design system

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -238,7 +238,7 @@ export const Header: FunctionComponent<HeaderProps> = ({ title, count }) => (
 
 file_write("{workspaceDir}/data/apps/project-tracker/src/styles.css", `.app { padding: var(--v-spacing-lg); }
 .header { display: flex; justify-content: space-between; align-items: center; }
-.badge { background: var(--v-accent); color: white; padding: var(--v-spacing-xs) var(--v-spacing-sm); border-radius: var(--v-radius-pill); }`)
+.badge { background: var(--v-accent); color: var(--v-aux-white); padding: var(--v-spacing-xs) var(--v-spacing-sm); border-radius: var(--v-radius-pill); }`)
 
 # After all files are written, compile and refresh:
 app_refresh(app_id)
@@ -290,8 +290,11 @@ Available design tokens:
 | **Typography**  | `--v-font-family`, `--v-font-mono`, `--v-font-size-xs` (10px) / `-sm` (11px) / `-base` (14px) / `-lg` (17px) / `-xl` (22px) / `-2xl` (26px), `--v-line-height` |
 | **Animation**   | `--v-duration-fast` (0.15s) / `-standard` (0.25s) / `-slow` (0.4s)                                                                                             |
 | **Palettes**    | `--v-slate-{950..50}`, `--v-emerald-*`, `--v-violet-*`, `--v-indigo-*`, `--v-rose-*`, `--v-amber-*`                                                            |
+| **Constant**    | `--v-aux-white` (always `#FFFFFF` in both modes — use for text on filled/accent backgrounds)                                                                    |
 
 Utility classes: `.v-button` (`.secondary`/`.danger`/`.ghost`), `.v-card`, `.v-list`/`.v-list-item`, `.v-badge` (`.success`/`.warning`/`.danger`), `.v-input-row`, `.v-empty-state`, `.v-toggle`.
+
+**Never hardcode `color: white` or `color: #fff`.** Use `var(--v-aux-white)` for text on filled/accent backgrounds, or `var(--v-text)` / `var(--v-text-secondary)` for text on surface backgrounds. Hardcoded white causes invisible text on light surfaces.
 
 **Custom themes:** When the user wants a specific branded look, write complete CSS with hardcoded colors and `@media (prefers-color-scheme: dark)` for dark variants. Don't mix `--v-*` auto-switching variables with hardcoded colors in the same element.
 

--- a/clients/macos/vellum-assistant/Resources/vellum-design-system.css
+++ b/clients/macos/vellum-assistant/Resources/vellum-design-system.css
@@ -49,6 +49,45 @@
   --v-system-mid-weak: #FCF3DD;
   --v-aux-white: #FFFFFF;
 
+  /* ── Shorthand Aliases (referenced by app-builder SKILL.md) ── */
+  --v-bg: var(--v-surface-overlay);
+  --v-surface: var(--v-surface-base);
+  --v-surface-border: var(--v-border-base);
+  --v-text: var(--v-content-default);
+  --v-text-secondary: var(--v-content-secondary);
+  --v-text-muted: var(--v-content-tertiary);
+  --v-accent: var(--v-primary-base);
+  --v-accent-hover: var(--v-primary-hover);
+  --v-success: var(--v-system-positive-strong);
+  --v-danger: var(--v-system-negative-strong);
+  --v-warning: var(--v-system-mid-strong);
+
+  /* ── Palette Scales (Tailwind-style, referenced by SKILL.md) ─ */
+  --v-slate-50:  #F8FAFC; --v-slate-100: #F1F5F9; --v-slate-200: #E2E8F0;
+  --v-slate-300: #CBD5E1; --v-slate-400: #94A3B8; --v-slate-500: #64748B;
+  --v-slate-600: #475569; --v-slate-700: #334155; --v-slate-800: #1E293B;
+  --v-slate-900: #0F172A; --v-slate-950: #020617;
+  --v-emerald-50:  #ECFDF5; --v-emerald-100: #D1FAE5; --v-emerald-200: #A7F3D0;
+  --v-emerald-300: #6EE7B7; --v-emerald-400: #34D399; --v-emerald-500: #10B981;
+  --v-emerald-600: #059669; --v-emerald-700: #047857; --v-emerald-800: #065F46;
+  --v-emerald-900: #064E3B; --v-emerald-950: #022C22;
+  --v-violet-50:  #F5F3FF; --v-violet-100: #EDE9FE; --v-violet-200: #DDD6FE;
+  --v-violet-300: #C4B5FD; --v-violet-400: #A78BFA; --v-violet-500: #8B5CF6;
+  --v-violet-600: #7C3AED; --v-violet-700: #6D28D9; --v-violet-800: #5B21B6;
+  --v-violet-900: #4C1D95; --v-violet-950: #2E1065;
+  --v-indigo-50:  #EEF2FF; --v-indigo-100: #E0E7FF; --v-indigo-200: #C7D2FE;
+  --v-indigo-300: #A5B4FC; --v-indigo-400: #818CF8; --v-indigo-500: #6366F1;
+  --v-indigo-600: #4F46E5; --v-indigo-700: #4338CA; --v-indigo-800: #3730A3;
+  --v-indigo-900: #312E81; --v-indigo-950: #1E1B4B;
+  --v-rose-50:  #FFF1F2; --v-rose-100: #FFE4E6; --v-rose-200: #FECDD3;
+  --v-rose-300: #FDA4AF; --v-rose-400: #FB7185; --v-rose-500: #F43F5E;
+  --v-rose-600: #E11D48; --v-rose-700: #BE123C; --v-rose-800: #9F1239;
+  --v-rose-900: #881337; --v-rose-950: #4C0519;
+  --v-amber-50:  #FFFBEB; --v-amber-100: #FEF3C7; --v-amber-200: #FDE68A;
+  --v-amber-300: #FCD34D; --v-amber-400: #FBBF24; --v-amber-500: #F59E0B;
+  --v-amber-600: #D97706; --v-amber-700: #B45309; --v-amber-800: #92400E;
+  --v-amber-900: #78350F; --v-amber-950: #451A03;
+
   /* ── Spacing (4pt grid) ─────────────────────────────────────── */
   --v-spacing-xxs:  2px;
   --v-spacing-xs:   4px;
@@ -265,7 +304,7 @@ th { font-weight: 600; color: var(--v-content-secondary); font-size: var(--v-fon
   font-weight: 500;
   padding: var(--v-spacing-sm) var(--v-spacing-lg);
   background: var(--v-primary-base);
-  color: white;
+  color: var(--v-aux-white);
   border: none;
   border-radius: var(--v-radius-md);
   cursor: pointer;
@@ -1776,7 +1815,7 @@ input:focus-visible, textarea:focus-visible, select:focus-visible {
 }
 .v-pill-toggle.active {
   background: var(--v-primary-base);
-  color: white;
+  color: var(--v-aux-white);
   font-weight: 600;
   box-shadow: var(--v-shadow-sm);
 }


### PR DESCRIPTION
## Summary
- Added shorthand CSS aliases (`--v-bg`, `--v-text`, `--v-accent`, `--v-success`, `--v-danger`, `--v-warning`, etc.) to `vellum-design-system.css` — these were documented in the app-builder SKILL.md but never defined, causing apps to render with broken styling (e.g. white text on white pill backgrounds)
- Added Tailwind-style palette scales (`--v-slate-*`, `--v-emerald-*`, `--v-violet-*`, `--v-indigo-*`, `--v-rose-*`, `--v-amber-*`) that were also documented but missing
- Replaced hardcoded `color: white` with `var(--v-aux-white)` in `.v-button` and `.v-pill-toggle.active` to lead by example
- Added explicit guidance in SKILL.md against hardcoding `color: white`

## Original prompt
this text shouldn't be white on white
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
