### PR TITLE
fix: exclude profiler from log exports, use fresh manifest in detail, fix remainingRuns undercount

### DIFF
--- a/assistant/src/daemon/profiler-run-store.ts
+++ b/assistant/src/daemon/profiler-run-store.ts
@@ -308,7 +308,7 @@ export function runProfilerSweep(): ProfilerSweepResult {
 
     if (!overBytesBudget && !overRunCount && !overFreeSpace) break;
 
-    const oldest = completedRuns.shift()!;
+    const oldest = completedRuns[0]!;
     const runDir = getProfilerRunDir(oldest.runId);
 
     log.info(
@@ -326,6 +326,7 @@ export function runProfilerSweep(): ProfilerSweepResult {
 
     try {
       rmSync(runDir, { recursive: true, force: true });
+      completedRuns.shift();
       totalBytes -= oldest.totalBytes;
       freedBytes += oldest.totalBytes;
       prunedCount++;
@@ -334,6 +335,10 @@ export function runProfilerSweep(): ProfilerSweepResult {
         { runId: oldest.runId, err },
         "Failed to remove profiler run directory",
       );
+      // The run still exists on disk — leave it in completedRuns so
+      // remainingRuns stays accurate. Break to avoid an infinite retry
+      // loop on the same un-deletable run.
+      break;
     }
   }
 

--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -380,6 +380,7 @@ const WORKSPACE_SKIP_DIRS = new Set([
   "data/qdrant",
   "data/attachments",
   "data/sounds",
+  "data/profiler",
   "conversations",
   "signals",
   "deprecated",

--- a/assistant/src/runtime/routes/profiler-routes.ts
+++ b/assistant/src/runtime/routes/profiler-routes.ts
@@ -31,7 +31,6 @@ import {
   getProfilerMaxBytes,
   getProfilerRunId,
 } from "../../config/env-registry.js";
-import type { ProfilerRunManifest } from "../../daemon/profiler-run-store.js";
 import {
   rescanRuns,
   runProfilerSweep,
@@ -59,18 +58,6 @@ function readProfileSummary(runDir: string): string | undefined {
     return readFileSync(join(runDir, mdFile), "utf-8");
   } catch {
     return undefined;
-  }
-}
-
-/**
- * Read and parse a manifest.json from a run directory.
- */
-function readManifest(runDir: string): ProfilerRunManifest | null {
-  try {
-    const raw = readFileSync(join(runDir, "manifest.json"), "utf-8");
-    return JSON.parse(raw) as ProfilerRunManifest;
-  } catch {
-    return null;
   }
 }
 
@@ -106,25 +93,20 @@ function handleGetRun(runId: string): Response {
     return httpError("BAD_REQUEST", "Invalid run ID", 400);
   }
 
-  const runDir = getProfilerRunDir(runId);
-  if (!existsSync(runDir)) {
+  // Rescan all runs first to get freshly computed totalBytes for every run,
+  // then find the target run in the results. This avoids using a stale
+  // manifest from the last write-through rescan.
+  const allManifests = rescanRuns({ readOnly: true });
+  const manifest = allManifests.find((m) => m.runId === runId);
+  if (!manifest) {
     return httpError("NOT_FOUND", `Profiler run '${runId}' not found`, 404);
   }
 
-  const manifest = readManifest(runDir);
-  if (!manifest) {
-    return httpError(
-      "INTERNAL_ERROR",
-      `Manifest missing for profiler run '${runId}'`,
-      500,
-    );
-  }
-
+  const runDir = getProfilerRunDir(runId);
   const summary = readProfileSummary(runDir);
   const activeRunId = getProfilerRunId();
 
-  // Compute budget state from all runs (read-only to avoid disk writes)
-  const allManifests = rescanRuns({ readOnly: true });
+  // Compute budget state from all runs
   const maxBytes = getProfilerMaxBytes() ?? DEFAULT_MAX_BYTES;
   const totalBytesAllRuns = allManifests.reduce(
     (sum, m) => sum + m.totalBytes,


### PR DESCRIPTION
## Summary
Fixes three integration gaps identified during plan review for managed-assistant-profiler-runtime.md.

**Gap 1:** data/profiler missing from WORKSPACE_SKIP_DIRS — profiler artifacts would leak into log exports
**Gap 2:** Detail endpoint used stale manifest totalBytes — now uses fresh rescan result
**Gap 3:** remainingRuns undercounted when rmSync fails — now only removes from array after confirmed deletion
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
