### PR TITLE
fix: handle Slack file download redirects and detect missing files:read scope

### DIFF
--- a/gateway/src/slack/download.test.ts
+++ b/gateway/src/slack/download.test.ts
@@ -105,6 +105,54 @@ describe("downloadSlackFile", () => {
     );
   });
 
+  test("uses redirect: manual to prevent auth header stripping", async () => {
+    const fileBuffer = makePngBuffer();
+    fetchMock = mock(async () => new Response(fileBuffer));
+
+    const file = makeSlackFile();
+    await downloadSlackFile(file, "xoxb-test-token");
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect((init as RequestInit).redirect).toBe("manual");
+  });
+
+  test("follows redirect to CDN without auth header", async () => {
+    const fileBuffer = makePngBuffer();
+    let callCount = 0;
+    fetchMock = mock(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return new Response(null, {
+          status: 302,
+          headers: { Location: "https://files-edge.slack.com/signed/F12345" },
+        });
+      }
+      return new Response(fileBuffer);
+    });
+
+    const file = makeSlackFile();
+    const result = await downloadSlackFile(file, "xoxb-test-token");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // Second call should be to the redirect URL without auth
+    const [redirectUrl, redirectInit] = fetchMock.mock.calls[1];
+    expect(redirectUrl).toBe("https://files-edge.slack.com/signed/F12345");
+    expect((redirectInit as RequestInit).headers).toBeUndefined();
+    expect(result.mimeType).toBe("image/png");
+  });
+
+  test("throws when redirect has no Location header", async () => {
+    fetchMock = mock(
+      async () => new Response(null, { status: 302 }),
+    );
+
+    const file = makeSlackFile();
+
+    await expect(downloadSlackFile(file, "xoxb-test-token")).rejects.toThrow(
+      "returned 302 redirect with no Location header",
+    );
+  });
+
   test("throws on HTTP error response", async () => {
     fetchMock = mock(
       async () =>

--- a/gateway/src/slack/download.ts
+++ b/gateway/src/slack/download.ts
@@ -24,10 +24,27 @@ export async function downloadSlackFile(
     throw new Error(`Slack file ${file.id} has no download URL`);
   }
 
-  const response = await fetchImpl(url, {
+  // Use manual redirect handling — Slack may redirect to a CDN subdomain
+  // (e.g. files-edge.slack.com) and the Fetch spec strips the Authorization
+  // header on cross-origin redirects, causing the CDN request to fail.
+  let response = await fetchImpl(url, {
     headers: { Authorization: `Bearer ${botToken}` },
+    redirect: "manual",
     signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
   });
+
+  if (response.status >= 300 && response.status < 400) {
+    const location = response.headers.get("Location");
+    if (!location) {
+      throw new Error(
+        `Slack file ${file.id} returned ${response.status} redirect with no Location header`,
+      );
+    }
+    // CDN redirect URLs are signed — no Authorization needed.
+    response = await fetchImpl(location, {
+      signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+    });
+  }
 
   if (!response.ok) {
     throw new Error(

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -103,6 +103,16 @@ export class SlackSocketModeClient {
         if (data.team) {
           this.config.teamName = data.team;
         }
+        // Warn if the bot token is missing scopes needed for file downloads.
+        const scopes = resp.headers.get("x-oauth-scopes") ?? "";
+        if (!scopes.split(",").some((s) => s.trim() === "files:read")) {
+          log.warn(
+            "Slack bot token is missing the 'files:read' scope — file/image " +
+              "attachments will not be downloaded. Add 'files:read' to your " +
+              "Slack app's Bot Token Scopes and reinstall the app.",
+          );
+        }
+
         log.info(
           {
             botUserId: data.user_id,


### PR DESCRIPTION
## Summary
- Handle Slack file download redirects manually (`redirect: 'manual'`) to prevent the Fetch spec from stripping the Authorization header on cross-origin CDN redirects
- Detect missing `files:read` OAuth scope at Socket Mode startup and log a warning with remediation steps
- Add tests for redirect handling (CDN follow, missing Location header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)