### PR TITLE
fix: normalize memory recall candidate fields for LLM context inspector

### DIFF
--- a/assistant/src/__tests__/memory-recall-log-store.test.ts
+++ b/assistant/src/__tests__/memory-recall-log-store.test.ts
@@ -22,6 +22,7 @@ import { getDb, initializeDb } from "../memory/db.js";
 import {
   backfillMemoryRecallLogMessageId,
   getMemoryRecallLogByMessageIds,
+  normalizeTopCandidates,
   recordMemoryRecallLog,
 } from "../memory/memory-recall-log-store.js";
 import { memoryRecallLogs } from "../memory/schema.js";
@@ -147,5 +148,107 @@ describe("memory-recall-log-store", () => {
     const secondLog = getMemoryRecallLogByMessageIds(["msg-b"]);
     expect(secondLog).not.toBeNull();
     expect(secondLog!.degraded).toBe(true);
+  });
+
+  test("normalizes SSE-event format candidates to inspector format on read", () => {
+    const conversationId = "conv-normalize-sse";
+    const messageId = "msg-normalize-sse";
+
+    // Store candidates in SSE-event format (key/finalScore/semantic/recency/kind)
+    recordMemoryRecallLog({
+      conversationId,
+      enabled: true,
+      degraded: false,
+      semanticHits: 2,
+      mergedCount: 1,
+      selectedCount: 1,
+      tier1Count: 1,
+      tier2Count: 0,
+      hybridSearchLatencyMs: 100,
+      sparseVectorUsed: false,
+      injectedTokens: 200,
+      latencyMs: 120,
+      topCandidatesJson: [
+        {
+          key: "node-abc",
+          finalScore: 0.85,
+          semantic: 0.9,
+          recency: 0.1,
+          kind: "episode",
+          type: "episodic",
+        },
+      ],
+    });
+
+    backfillMemoryRecallLogMessageId(conversationId, messageId);
+
+    const result = getMemoryRecallLogByMessageIds([messageId]);
+    expect(result).not.toBeNull();
+    const candidates = result!.topCandidates as Array<Record<string, unknown>>;
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toEqual({
+      nodeId: "node-abc",
+      score: 0.85,
+      semanticSimilarity: 0.9,
+      recencyBoost: 0.1,
+      type: "episodic",
+    });
+    // kind should be stripped
+    expect(candidates[0]).not.toHaveProperty("kind");
+    // Old field names should not be present
+    expect(candidates[0]).not.toHaveProperty("key");
+    expect(candidates[0]).not.toHaveProperty("finalScore");
+    expect(candidates[0]).not.toHaveProperty("semantic");
+    expect(candidates[0]).not.toHaveProperty("recency");
+  });
+
+  test("passes through candidates already in inspector format unchanged", () => {
+    const conversationId = "conv-normalize-inspector";
+    const messageId = "msg-normalize-inspector";
+
+    // Store candidates already in inspector format (nodeId/score/semanticSimilarity/recencyBoost)
+    recordMemoryRecallLog({
+      conversationId,
+      enabled: true,
+      degraded: false,
+      semanticHits: 1,
+      mergedCount: 1,
+      selectedCount: 1,
+      tier1Count: 1,
+      tier2Count: 0,
+      hybridSearchLatencyMs: 80,
+      sparseVectorUsed: false,
+      injectedTokens: 100,
+      latencyMs: 90,
+      topCandidatesJson: [
+        {
+          nodeId: "node-xyz",
+          score: 0.92,
+          semanticSimilarity: 0.88,
+          recencyBoost: 0.05,
+          type: "semantic",
+        },
+      ],
+    });
+
+    backfillMemoryRecallLogMessageId(conversationId, messageId);
+
+    const result = getMemoryRecallLogByMessageIds([messageId]);
+    expect(result).not.toBeNull();
+    const candidates = result!.topCandidates as Array<Record<string, unknown>>;
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toEqual({
+      nodeId: "node-xyz",
+      score: 0.92,
+      semanticSimilarity: 0.88,
+      recencyBoost: 0.05,
+      type: "semantic",
+    });
+  });
+
+  test("normalizeTopCandidates handles non-array input", () => {
+    expect(normalizeTopCandidates(null)).toBeNull();
+    expect(normalizeTopCandidates("not-an-array")).toBe("not-an-array");
+    expect(normalizeTopCandidates(42)).toBe(42);
   });
 });

--- a/assistant/src/memory/memory-recall-log-store.ts
+++ b/assistant/src/memory/memory-recall-log-store.ts
@@ -92,6 +92,44 @@ export interface MemoryRecallLog {
   reason: string | null;
 }
 
+/**
+ * Normalizes top-candidate entries from the stored SSE-event format
+ * (key/finalScore/semantic/recency/kind) to the inspector format expected
+ * by the Swift MemoryRecallCandidate struct (nodeId/score/semanticSimilarity/recencyBoost).
+ * Entries already in inspector format pass through unchanged.
+ */
+export function normalizeTopCandidates(raw: unknown): unknown {
+  if (!Array.isArray(raw)) return raw;
+  return raw.map((entry: Record<string, unknown>) => {
+    // Start with a shallow copy, then apply field renames
+    const { key, finalScore, semantic, recency, kind, ...rest } = entry;
+
+    // nodeId: prefer existing nodeId, fall back to key
+    if (rest.nodeId === undefined && key !== undefined) {
+      rest.nodeId = key;
+    }
+
+    // score: prefer existing score, fall back to finalScore
+    if (rest.score === undefined && finalScore !== undefined) {
+      rest.score = finalScore;
+    }
+
+    // semanticSimilarity: prefer existing, fall back to semantic
+    if (rest.semanticSimilarity === undefined && semantic !== undefined) {
+      rest.semanticSimilarity = semantic;
+    }
+
+    // recencyBoost: prefer existing, fall back to recency
+    if (rest.recencyBoost === undefined && recency !== undefined) {
+      rest.recencyBoost = recency;
+    }
+
+    // kind is stripped (not in the Swift model) — already excluded via destructuring
+
+    return rest;
+  });
+}
+
 export function getMemoryRecallLogByMessageIds(
   messageIds: string[],
 ): MemoryRecallLog | null {
@@ -121,7 +159,7 @@ export function getMemoryRecallLogByMessageIds(
     sparseVectorUsed: !!row.sparseVectorUsed,
     injectedTokens: row.injectedTokens,
     latencyMs: row.latencyMs,
-    topCandidates: JSON.parse(row.topCandidatesJson),
+    topCandidates: normalizeTopCandidates(JSON.parse(row.topCandidatesJson)),
     injectedText: row.injectedText,
     reason: row.reason,
   };


### PR DESCRIPTION
## Summary
- Adds normalizeTopCandidates() to map stored SSE-event field names (key/finalScore/semantic/recency) to the Swift MemoryRecallCandidate expected names (nodeId/score/semanticSimilarity/recencyBoost)
- Handles both old and new stored formats gracefully
- Fixes LLM Context Inspector decode failure for messages with memory recall data

Part of plan: fix-inspector-recall-decode.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
