### PR TITLE
test: add .heif coverage to image classifier tests

### DIFF
--- a/clients/macos/vellum-assistantTests/ImageURLClassifierExtensionTests.swift
+++ b/clients/macos/vellum-assistantTests/ImageURLClassifierExtensionTests.swift
@@ -69,6 +69,11 @@ final class ImageURLClassifierExtensionTests: XCTestCase {
         XCTAssertEqual(ImageURLClassifier.classify(url), .image)
     }
 
+    func testHEIF() {
+        let url = URL(string: "https://example.com/apple.heif")!
+        XCTAssertEqual(ImageURLClassifier.classify(url), .image)
+    }
+
     // MARK: - Case insensitivity
 
     func testUppercasePNG() {

--- a/clients/macos/vellum-assistantTests/MediaEmbedFinalRegressionTests.swift
+++ b/clients/macos/vellum-assistantTests/MediaEmbedFinalRegressionTests.swift
@@ -348,7 +348,7 @@ final class MediaEmbedFinalRegressionTests: XCTestCase {
     // MARK: - ImageURLClassifier for all common extensions
 
     func testImageURLClassifierCommonExtensions() {
-        let extensions = ["png", "jpg", "jpeg", "gif", "webp", "svg", "bmp", "ico", "tiff", "tif", "avif", "heic"]
+        let extensions = ["png", "jpg", "jpeg", "gif", "webp", "svg", "bmp", "ico", "tiff", "tif", "avif", "heic", "heif"]
 
         for ext in extensions {
             let url = URL(string: "https://cdn.example.com/image.\(ext)")!

--- a/clients/shared/Tests/MediaEmbedResolverTests.swift
+++ b/clients/shared/Tests/MediaEmbedResolverTests.swift
@@ -115,7 +115,7 @@ final class MediaEmbedResolverTests: XCTestCase {
     // MARK: - ImageURLClassifier
 
     func testClassifiesImageExtensions() {
-        for ext in ["png", "jpg", "jpeg", "gif", "webp", "svg", "heic"] {
+        for ext in ["png", "jpg", "jpeg", "gif", "webp", "svg", "heic", "heif"] {
             let url = URL(string: "https://example.com/photo.\(ext)")!
             XCTAssertEqual(ImageURLClassifier.classify(url), .image, "Expected \(ext) to be classified as image")
         }


### PR DESCRIPTION
Address review feedback on #23155 — add heif to the extension lists in MediaEmbedFinalRegressionTests, MediaEmbedResolverTests, and ImageURLClassifierExtensionTests.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
