### PR TITLE
fix: make clear-search reload cancelable via debounce path

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift
@@ -205,15 +205,10 @@ struct MemoriesPanel: View {
             VSearchBar(placeholder: "Search Memories", text: $store.searchText)
                 .onChange(of: store.searchText) {
                     searchDebounceTask?.cancel()
-                    if store.searchText.isEmpty {
-                        // Clearing the search — reload immediately with no debounce
-                        searchDebounceTask = Task { await store.loadItems() }
-                    } else {
-                        searchDebounceTask = Task {
-                            try? await Task.sleep(nanoseconds: 300_000_000)
-                            guard !Task.isCancelled else { return }
-                            await store.loadItems()
-                        }
+                    searchDebounceTask = Task {
+                        try? await Task.sleep(nanoseconds: 300_000_000)
+                        guard !Task.isCancelled else { return }
+                        await store.loadItems()
                     }
                 }
 


### PR DESCRIPTION
Address review feedback on #23151 — route the empty-search reload through the debounced path so clearing and quickly re-typing doesn't race with an immediate fetch.

Previously, clearing the search field launched an immediate `Task { await store.loadItems() }` that bypassed the debounce. If the user cleared and quickly retyped, the immediate fetch could return stale results before the debounced query ran. Now all search text changes go through the same debounced/cancelable path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
