### PR TITLE
fix: guard recovery backfill against concurrent message linking

### DIFF
--- a/assistant/src/memory/llm-request-log-store.ts
+++ b/assistant/src/memory/llm-request-log-store.ts
@@ -99,7 +99,9 @@ export function setMessageIdOnLogs(
   const db = getDb();
   db.update(llmRequestLogs)
     .set({ messageId })
-    .where(inArray(llmRequestLogs.id, logIds))
+    .where(
+      and(inArray(llmRequestLogs.id, logIds), isNull(llmRequestLogs.messageId)),
+    )
     .run();
 }
 


### PR DESCRIPTION
Address review feedback on #23164 — make the recovery write conditional on message_id IS NULL to avoid overwriting concurrent link updates.

The `setMessageIdOnLogs` function now includes an `isNull(messageId)` guard in its WHERE clause. This prevents the opportunistic recovery backfill in `getRequestLogsByMessageId` from overwriting a `messageId` that `handleMessageComplete` concurrently linked between the read and write. All existing callers target logs with NULL messageId, so this guard is safe for every call site.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
