### PR TITLE
fix: restrict temp file permissions and add cleanup on shutdown

### DIFF
--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -7,6 +7,7 @@ import { getSqlite, resetDb } from "../memory/db.js";
 import type { QdrantManager } from "../memory/qdrant-manager.js";
 import type { RuntimeHttpServer } from "../runtime/http-server.js";
 import { browserManager } from "../tools/browser/browser-manager.js";
+import { cleanupShellOutputTempFiles } from "../tools/shared/shell-output.js";
 import { getLogger } from "../util/logger.js";
 import { getEnrichmentService } from "../workspace/commit-message-enrichment-service.js";
 import type { WorkspaceHeartbeatService } from "../workspace/heartbeat-service.js";
@@ -105,6 +106,7 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
 
     if (deps.runtimeHttp) await deps.runtimeHttp.stop();
     await browserManager.closeAllPages();
+    cleanupShellOutputTempFiles();
     deps.scheduler.stop();
     deps.getMemoryWorker()?.stop();
 

--- a/assistant/src/tools/shared/shell-output.ts
+++ b/assistant/src/tools/shared/shell-output.ts
@@ -1,9 +1,24 @@
 import { randomUUID } from "node:crypto";
-import { writeFileSync } from "node:fs";
+import { unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 export const MAX_OUTPUT_LENGTH = 20_000;
+
+/** Tracks temp files created for truncated shell output so they can be cleaned up on shutdown. */
+const trackedTempFiles = new Set<string>();
+
+/** Remove all tracked truncated-output temp files. Safe to call multiple times. */
+export function cleanupShellOutputTempFiles(): void {
+  for (const filePath of trackedTempFiles) {
+    try {
+      unlinkSync(filePath);
+    } catch {
+      // File may already be gone — ignore.
+    }
+  }
+  trackedTempFiles.clear();
+}
 
 export interface ShellOutputResult {
   content: string;
@@ -41,7 +56,8 @@ export function formatShellOutput(
     let fullOutputPath: string | undefined;
     try {
       fullOutputPath = join(tmpdir(), `vellum-shell-output-${randomUUID()}.txt`);
-      writeFileSync(fullOutputPath, output, "utf-8");
+      writeFileSync(fullOutputPath, output, { encoding: "utf-8", mode: 0o600 });
+      trackedTempFiles.add(fullOutputPath);
     } catch {
       fullOutputPath = undefined;
     }


### PR DESCRIPTION
Address review feedback on #23187 — write truncated shell output files with 0o600 permissions and register cleanup on daemon shutdown.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
