### PR TITLE
fix: ignore dist directory events in app source watcher

### DIFF
--- a/assistant/src/daemon/app-source-watcher.ts
+++ b/assistant/src/daemon/app-source-watcher.ts
@@ -35,8 +35,11 @@ function resolveAppIdFromRelPath(relPath: string): string | null {
   const dirName = relPath.slice(0, slashIdx);
   const innerPath = relPath.slice(slashIdx + 1);
 
-  // Skip non-source directories
-  if (innerPath.startsWith("records/") || innerPath.startsWith("dist/")) {
+  // Skip non-source directories (include bare directory names for fs.watch events)
+  if (
+    innerPath === "records" || innerPath.startsWith("records/") ||
+    innerPath === "dist" || innerPath.startsWith("dist/")
+  ) {
     return null;
   }
 


### PR DESCRIPTION
Address review feedback on #23287 — also filter directory-level `dist` and `records` events (not just `dist/` and `records/` prefixed paths) to prevent self-triggering compile loops when `fs.watch` emits bare directory names.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
