### PR TITLE
fix: resolve relative redirect Location URLs in Slack file download

### DIFF
--- a/gateway/src/slack/download.ts
+++ b/gateway/src/slack/download.ts
@@ -41,7 +41,9 @@ export async function downloadSlackFile(
       );
     }
     // CDN redirect URLs are signed — no Authorization needed.
-    response = await fetchImpl(location, {
+    // Resolve against the original URL to handle relative Location headers.
+    const resolvedLocation = new URL(location, url).href;
+    response = await fetchImpl(resolvedLocation, {
       signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
     });
   }


### PR DESCRIPTION
Address review feedback on #23319 — use `new URL(location, url)` to resolve redirect targets, handling both absolute and relative Location headers.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
