### PR TITLE
fix: guard normalizeTopCandidates against null array entries

### DIFF
--- a/assistant/src/memory/memory-recall-log-store.ts
+++ b/assistant/src/memory/memory-recall-log-store.ts
@@ -101,6 +101,8 @@ export interface MemoryRecallLog {
 export function normalizeTopCandidates(raw: unknown): unknown {
   if (!Array.isArray(raw)) return raw;
   return raw.map((entry: Record<string, unknown>) => {
+    if (!entry || typeof entry !== "object") return entry;
+
     // Start with a shallow copy, then apply field renames
     const { key, finalScore, semantic, recency, kind, ...rest } = entry;
 


### PR DESCRIPTION
Address review feedback on #23320 — add a runtime object check in normalizeTopCandidates to skip null/undefined entries from legacy or corrupted data.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
