### PR TITLE
fix: restore timezone fallback guidance in time-based-actions SKILL.md

### DIFF
--- a/skills/time-based-actions/SKILL.md
+++ b/skills/time-based-actions/SKILL.md
@@ -53,6 +53,8 @@ timestamp: 2026-04-02 (Wed) 14:30:00 -05:00 (America/Chicago)
 
 It contains the date, abbreviated weekday, local time (HH:MM:SS), UTC offset, and IANA timezone name in parentheses.
 
+**Timezone confidence check:** The timezone shown may be the assistant host's timezone rather than the user's actual timezone (this happens when the user hasn't configured `Settings → Appearance → User timezone`). If you have no prior confirmation of the user's timezone (from conversation history or memory) and the request is locale-specific (e.g. "at 3pm", "tomorrow morning", "tonight"), confirm the timezone once before scheduling. If the user confirms, suggest saving it in Settings → Appearance → User timezone so future requests resolve correctly without re-asking.
+
 ## Relative Time Parsing
 
 When the user says "in X minutes/hours", compute the ISO 8601 timestamp yourself:


### PR DESCRIPTION
Address review feedback on #23192:

1. **Timezone fallback guidance restored** — Codex flagged that the PR removed guidance for the model to confirm timezone when it's using the host fallback. Added a "Timezone confidence check" paragraph that tells the model to confirm timezone for locale-specific requests when no prior confirmation exists, and to suggest saving it in Settings.

2. **Architecture doc function name** — Devin flagged `buildUnifiedTurnContext()` vs `buildUnifiedTurnContextBlock()` mismatch, but this was already fixed in #23193.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
