### PR TITLE
fix: capture hybrid search latency on failed attempts

### DIFF
--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -397,17 +397,18 @@ export async function loadContextMemory(
   const semanticCandidateIds = new Map<string, number>(); // nodeId → score
   let hybridSearchLatencyMs = 0;
   if (queryVector) {
+    const searchStart = Date.now();
     try {
-      const searchStart = Date.now();
       const results = await searchGraphNodes(queryVector, maxNodes * 3, [
         opts.scopeId,
       ]);
-      hybridSearchLatencyMs = Date.now() - searchStart;
       for (const r of results) {
         semanticCandidateIds.set(r.nodeId, r.score);
       }
     } catch (err) {
       log.warn({ err }, "Qdrant search failed for context load");
+    } finally {
+      hybridSearchLatencyMs = Date.now() - searchStart;
     }
   }
   const pureSemanticHits = semanticCandidateIds.size;


### PR DESCRIPTION
Address review feedback on #23196 — move hybridSearchLatencyMs capture to a finally block so failed/timed-out searches still emit accurate latency.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
