### PR TITLE
fix: restore require() pattern in app-source-watcher test mock

### DIFF
--- a/assistant/src/__tests__/app-source-watcher.test.ts
+++ b/assistant/src/__tests__/app-source-watcher.test.ts
@@ -3,7 +3,6 @@
  * file changes and triggers debounced recompile + surface refresh.
  */
 
-import * as actualFs from "node:fs";
 import {
   afterEach,
   beforeEach,
@@ -24,6 +23,8 @@ let capturedWatchCallback: ((eventType: string, filename: string | null) => void
 const mockWatcher = { close: mock(() => {}) };
 
 mock.module("node:fs", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const actualFs = require("node:fs");
   return {
     ...actualFs,
     existsSync: mock((p: string) => p === TEST_APPS_DIR),


### PR DESCRIPTION
Address review feedback on #23288 — replace the top-level import with require() inside the mock.module factory to avoid Bun's hoisting circular reference, matching the established codebase pattern.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
