### PR TITLE
fix: downgrade proxied network request risk from high to medium

### DIFF
--- a/assistant/src/__tests__/proxy-approval-callback.test.ts
+++ b/assistant/src/__tests__/proxy-approval-callback.test.ts
@@ -189,7 +189,7 @@ describe("createProxyApprovalCallback", () => {
     expect(prompterSendToClient).not.toHaveBeenCalled();
   });
 
-  test("high-risk with plain allow rule (no allowHighRisk) falls through to prompt", async () => {
+  test("ask_missing_credential with allow rule auto-allows (medium risk)", async () => {
     findHighestPriorityRuleMock.mockReturnValue({
       id: "rule-hr-1",
       tool: "network_request",
@@ -198,42 +198,6 @@ describe("createProxyApprovalCallback", () => {
       decision: "allow" as const,
       priority: 100,
       createdAt: Date.now(),
-      // No allowHighRisk — should NOT auto-allow for high-risk decisions
-    });
-
-    const ctx = makeContext();
-    const prompterSendToClient = mock(() => {});
-    const prompter = new PermissionPrompter(prompterSendToClient);
-
-    const originalPrompt = prompter.prompt.bind(prompter);
-    prompter.prompt = async (...args) => {
-      const p = originalPrompt(...args);
-      await new Promise((r) => setTimeout(r, 10));
-      const call = (prompterSendToClient.mock.calls as unknown[][])[0];
-      const msg = call[0] as { requestId: string };
-      prompter.resolveConfirmation(msg.requestId, "allow");
-      return p;
-    };
-
-    const callback = createProxyApprovalCallback(prompter, ctx);
-    // ask_missing_credential is high risk
-    const result = await callback(makeAskMissingCredentialRequest());
-
-    expect(result).toBe(true);
-    // Prompter SHOULD have been called — plain allow rule doesn't auto-allow high-risk
-    expect(prompterSendToClient).toHaveBeenCalled();
-  });
-
-  test("high-risk with allowHighRisk allow rule auto-allows without prompting", async () => {
-    findHighestPriorityRuleMock.mockReturnValue({
-      id: "rule-hr-2",
-      tool: "network_request",
-      pattern: "network_request:https://api.fal.ai:443/*",
-      scope: "/tmp/test-project",
-      decision: "allow" as const,
-      priority: 100,
-      createdAt: Date.now(),
-      allowHighRisk: true,
     });
 
     const ctx = makeContext();
@@ -244,7 +208,7 @@ describe("createProxyApprovalCallback", () => {
     const result = await callback(makeAskMissingCredentialRequest());
 
     expect(result).toBe(true);
-    // Prompter should NOT have been called — allowHighRisk rule auto-allows
+    // Plain allow rule auto-allows medium-risk requests
     expect(prompterSendToClient).not.toHaveBeenCalled();
   });
 
@@ -436,7 +400,7 @@ describe("createProxyApprovalCallback", () => {
     await callback(makeAskUnauthenticatedRequest());
   });
 
-  test("uses high risk level for ask_missing_credential decisions", async () => {
+  test("uses medium risk level for ask_missing_credential decisions", async () => {
     const ctx = makeContext();
     const prompterSendToClient = mock(() => {});
     const prompter = new PermissionPrompter(prompterSendToClient);
@@ -447,8 +411,7 @@ describe("createProxyApprovalCallback", () => {
       await new Promise((r) => setTimeout(r, 10));
       const call = (prompterSendToClient.mock.calls as unknown[][])[0];
       const msg = call[0] as { requestId: string; riskLevel: string };
-      // Missing credential prompts are high risk — the target wants auth
-      expect(msg.riskLevel).toBe("high");
+      expect(msg.riskLevel).toBe("medium");
       prompter.resolveConfirmation(msg.requestId, "allow");
       return p;
     };

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -320,8 +320,7 @@ export function createProxyApprovalCallback(
       input.matching_patterns = decision.matchingPatterns;
     }
 
-    const riskLevel =
-      decision.kind === "ask_missing_credential" ? "high" : "medium";
+    const riskLevel = "medium";
 
     // Check trust store before prompting — build candidates that mirror
     // buildCommandCandidates() in checker.ts for network_request.


### PR DESCRIPTION
## Summary
- Change proxied network request (`ask_missing_credential`) risk level from "high" to "medium" in the proxy approval callback
- Plain allow trust rules now auto-approve `ask_missing_credential` decisions without prompting (consistent with `ask_unauthenticated`)
- Update tests to reflect the new medium-risk classification

## Original prompt
network request with mode proxied should be medium risk not high risk
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
