### PR TITLE
fix: always load all pinned conversations on first page

### DIFF
--- a/assistant/src/memory/conversation-queries.ts
+++ b/assistant/src/memory/conversation-queries.ts
@@ -62,6 +62,23 @@ export function listConversations(
   return query.all().map(parseConversation);
 }
 
+export function listPinnedConversations(): ConversationRow[] {
+  ensureDisplayOrderMigration();
+  ensureGroupMigration();
+  const db = getDb();
+  const query = db
+    .select()
+    .from(conversations)
+    .where(
+      and(
+        sql`${conversations.conversationType} NOT IN ('background', 'private')`,
+        sql`is_pinned = 1`,
+      ),
+    )
+    .orderBy(desc(conversations.updatedAt));
+  return query.all().map(parseConversation);
+}
+
 export function countConversations(backgroundOnly = false): number {
   const db = getDb();
   const where = backgroundOnly

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -52,6 +52,7 @@ import { resolveConversationId } from "../memory/conversation-key-store.js";
 import {
   countConversations,
   listConversations,
+  listPinnedConversations,
 } from "../memory/conversation-queries.js";
 import type { ExternalConversationBinding } from "../memory/external-conversation-store.js";
 import * as externalConversationStore from "../memory/external-conversation-store.js";
@@ -1026,8 +1027,18 @@ export class RuntimeHttpServer {
           const offset = Number(url.searchParams.get("offset") ?? 0);
           const backgroundOnly =
             url.searchParams.get("conversationType") === "background";
-          const rows = listConversations(limit, backgroundOnly, offset);
+          let rows = listConversations(limit, backgroundOnly, offset);
           const totalCount = countConversations(backgroundOnly);
+          // On the first page, ensure all pinned conversations are included
+          // even if they fall outside the paginated window.
+          if (offset === 0 && !backgroundOnly) {
+            const pinned = listPinnedConversations();
+            const seen = new Set(rows.map((c) => c.id));
+            const missing = pinned.filter((c) => !seen.has(c.id));
+            if (missing.length > 0) {
+              rows = [...rows, ...missing];
+            }
+          }
           const conversationIds = rows.map((c) => c.id);
           const displayMeta = getDisplayMetaForConversations(conversationIds);
           const bindings =


### PR DESCRIPTION
## Summary
- Added `listPinnedConversations()` query that fetches all pinned (non-background, non-private) conversations
- On the first page of `GET /v1/conversations`, merges any pinned conversations missing from the paginated result
- Ensures the client always has the complete pinned set without needing to paginate through all conversations

## Original prompt
We should always pull ALL pinned conversations even before clicking "show more". Right now the pinned list is incomplete until we click "show more".