### PR TITLE
feat: instruct messaging skill to look up contact notes before composing

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -148,6 +148,7 @@ Telegram is supported as a messaging provider with limited capabilities compared
 - `send_notification` is provided by the **notifications** skill (always active) -- use it when the user asks for an alert/notification (for example "send this as a desktop notification").
 - Use `messaging_send` when the user asks to send a message into a specific chat/email destination.
 - `send_notification` channel routing is LLM-driven; `preferred_channels` are hints, not hard channel forcing.
+- Before using `messaging_send` or `send_notification`, look up the recipient's contact record with `contact_search` to inform tone and content (see **Recipient Context** below).
 
 ## Personalized Drafting
 
@@ -156,6 +157,12 @@ When drafting messages, check your `<dynamic-user-profile>` for style items (e.g
 If no style items exist and the user asks you to draft a message, suggest running `messaging_analyze_style`:
 
 > "I can analyze your sent messages to learn your writing style so drafts sound like you. Want me to do that?"
+
+## Recipient Context
+
+Before composing or sending a message to someone, look up their contact record with `contact_search` using their name or channel address. If the contact has notes (e.g. relationship context, communication preferences, response expectations), use that context to inform the message's tone, level of detail, and content. This ensures outbound messages are personalized to the recipient — not just the sender's style.
+
+If no contact record exists, proceed without recipient context.
 
 ## Confidence Scores
 


### PR DESCRIPTION
## Summary
- Add Recipient Context section to messaging SKILL.md instructing the assistant to look up contact notes before composing outbound messages
- Update Notifications vs Messages section to reference contact_search for recipient context

Part of plan: contact-notes-in-outbound-ctx.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
