### PR TITLE
feat: instruct slack skill to use contact notes when messaging

### DIFF
--- a/assistant/src/config/bundled-skills/slack/SKILL.md
+++ b/assistant/src/config/bundled-skills/slack/SKILL.md
@@ -68,6 +68,8 @@ When you need to send a DM or look up a Slack user by name, check contacts first
 
 1. **Before calling `users.list`**: Use `contact_search` with `query: "<name>"` and `channel_type: "slack"`. If a matching contact has `externalUserId` (Slack user ID) and `externalChatId` (DM channel ID), skip the API lookups and use those IDs directly with `chat.postMessage`.
 
+   When `contact_search` returns notes for the recipient, use them to inform the message's tone, formality, and content. Contact notes capture relationship context and communication preferences that should shape how you write to this person.
+
 2. **After resolving via API**: When you had to call `users.list` or `conversations.open` to resolve a user, save the contact with `contact_upsert` so you can find them by name next time. External Slack IDs (user ID, DM channel ID) are cached automatically by the messaging layer and should not be passed through `contact_upsert`.
 
 ## Privacy Rules


### PR DESCRIPTION
## Summary
- Expand User Resolution section in slack SKILL.md to instruct the assistant to use contact notes when composing messages
- Contact notes from contact_search results inform message tone, formality, and content

Part of plan: contact-notes-in-outbound-ctx.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
