### PR TITLE
fix: cap proxied bash risk at medium

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -4400,7 +4400,7 @@ describe("Permission Checker", () => {
   });
 });
 
-describe("bash network_mode=proxied — no special-casing", () => {
+describe("bash network_mode=proxied — risk capped at medium", () => {
   beforeEach(() => {
     clearCache();
     testConfig.permissions = { mode: "workspace" };
@@ -4408,11 +4408,37 @@ describe("bash network_mode=proxied — no special-casing", () => {
   });
 
   test("proxied bash follows normal rules (auto-allowed by default rule)", async () => {
-    // Proxied bash is no longer force-prompted — the default allow-bash rule
-    // auto-allows low/medium risk commands regardless of network_mode.
     const result = await check(
       "bash",
       { command: "curl https://api.example.com", network_mode: "proxied" },
+      "/tmp",
+    );
+    expect(result.decision).toBe("allow");
+  });
+
+  test("proxied bash caps high-risk commands to medium", async () => {
+    // pipe-to-interpreter is normally High risk, but proxied mode caps at Medium
+    const risk = await classifyRisk("bash", {
+      command: 'cat data.json | python3 -c "import sys; print(sys.stdin.read())"',
+      network_mode: "proxied",
+    });
+    expect(risk).toBe(RiskLevel.Medium);
+  });
+
+  test("non-proxied bash keeps high-risk commands at high", async () => {
+    const risk = await classifyRisk("bash", {
+      command: 'cat data.json | python3 -c "import sys; print(sys.stdin.read())"',
+    });
+    expect(risk).toBe(RiskLevel.High);
+  });
+
+  test("proxied bash with high-risk command is auto-allowed by default rule", async () => {
+    const result = await check(
+      "bash",
+      {
+        command: 'cat data.json | python3 -c "import sys; print(sys.stdin.read())"',
+        network_mode: "proxied",
+      },
       "/tmp",
     );
     expect(result.decision).toBe("allow");
@@ -4790,15 +4816,14 @@ describe("workspace mode — auto-allow workspace-scoped operations", () => {
     }
   });
 
-  // ── proxied bash — follows normal rules (no special-casing) ──
+  // ── proxied bash — risk capped at medium ──
 
-  test("bash with network_mode=proxied → allow (follows normal rules in workspace mode)", async () => {
+  test("bash with network_mode=proxied → allow (risk capped at medium)", async () => {
     const result = await check(
       "bash",
       { command: "curl https://api.example.com", network_mode: "proxied" },
       workspaceDir,
     );
-    // Default allow-bash rule auto-allows; proxied mode is not special-cased.
     expect(result.decision).toBe("allow");
   });
 

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -677,13 +677,24 @@ export async function classifyRisk(
     }
   }
 
-  const result = await classifyRiskUncached(
+  let result = await classifyRiskUncached(
     toolName,
     input,
     workingDir,
     preParsed,
     manifestOverride,
   );
+
+  // Proxied bash commands route through the credential proxy which handles
+  // per-request approval separately. Cap the bash tool's own risk at Medium
+  // so trust rules can auto-allow the command execution.
+  if (
+    (toolName === "bash" || toolName === "host_bash") &&
+    input.network_mode === "proxied" &&
+    result === RiskLevel.High
+  ) {
+    result = RiskLevel.Medium;
+  }
 
   if (cacheKey) {
     if (riskCache.size >= RISK_CACHE_MAX) {


### PR DESCRIPTION
## Summary
- Cap bash/host_bash risk at Medium when `network_mode` is `"proxied"` — the credential proxy handles per-request approval separately, so the bash tool itself doesn't need High risk classification
- Commands like `cat data.json | python3 -c "..."` with proxied mode are now auto-allowed by the default bash trust rule instead of requiring interactive approval
- Fixes heartbeat sessions (non-interactive) being denied for proxied bash commands that contain pipe-to-interpreter patterns

## Original prompt
network request with mode proxied should be medium risk not high risk — preventing permission denials during Velissa's heartbeats
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23343" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
