### PR TITLE
fix: use channel-agnostic guardian lookup for recipient notes

### DIFF
--- a/assistant/src/__tests__/notification-decision-recipient-context.test.ts
+++ b/assistant/src/__tests__/notification-decision-recipient-context.test.ts
@@ -49,11 +49,11 @@ mock.module("../prompts/system-prompt.js", () => ({
 
 let mockGuardianResult: {
   contact: { notes: string | null };
-  channel: Record<string, unknown>;
+  channels: Record<string, unknown>[];
 } | null = null;
 
 mock.module("../contacts/contact-store.js", () => ({
-  findGuardianForChannel: () => mockGuardianResult,
+  listGuardianChannels: () => mockGuardianResult,
 }));
 
 // ── Provider mock with system prompt capture ──────────────────────────
@@ -153,7 +153,7 @@ describe("recipient context in notification decision engine", () => {
   test("guardian contact notes appear in system prompt as <recipient-context>", async () => {
     mockGuardianResult = {
       contact: { notes: "Prefers formal tone. Address as Dr. Smith." },
-      channel: { type: "vellum" },
+      channels: [{ type: "vellum" }],
     };
     setupLLMProvider();
 
@@ -183,7 +183,7 @@ describe("recipient context in notification decision engine", () => {
   test("recipient-context is omitted when guardian notes are null", async () => {
     mockGuardianResult = {
       contact: { notes: null },
-      channel: { type: "vellum" },
+      channels: [{ type: "vellum" }],
     };
     setupLLMProvider();
 
@@ -198,7 +198,7 @@ describe("recipient context in notification decision engine", () => {
   test("recipient-context is omitted when guardian notes are empty string", async () => {
     mockGuardianResult = {
       contact: { notes: "" },
-      channel: { type: "vellum" },
+      channels: [{ type: "vellum" }],
     };
     setupLLMProvider();
 
@@ -213,7 +213,7 @@ describe("recipient context in notification decision engine", () => {
   test("large guardian notes are truncated to prevent oversized prompts", async () => {
     mockGuardianResult = {
       contact: { notes: "N".repeat(3000) },
-      channel: { type: "vellum" },
+      channels: [{ type: "vellum" }],
     };
     setupLLMProvider();
 
@@ -240,7 +240,7 @@ describe("recipient context in notification decision engine", () => {
   test("fallback path works correctly without recipient context", async () => {
     mockGuardianResult = {
       contact: { notes: "Prefers formal tone." },
-      channel: { type: "vellum" },
+      channels: [{ type: "vellum" }],
     };
     // null provider forces fallback path
     configuredProvider = null;
@@ -261,7 +261,7 @@ describe("recipient context in notification decision engine", () => {
   test("recipient-context appears after user-preferences in prompt", async () => {
     mockGuardianResult = {
       contact: { notes: "Prefers brief updates." },
-      channel: { type: "vellum" },
+      channels: [{ type: "vellum" }],
     };
     setupLLMProvider();
 

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -13,7 +13,7 @@ import { v4 as uuid } from "uuid";
 
 import { getDeliverableChannels } from "../channels/config.js";
 import { getConfig } from "../config/loader.js";
-import { findGuardianForChannel } from "../contacts/contact-store.js";
+import { listGuardianChannels } from "../contacts/contact-store.js";
 import { resolveGuardianPersona } from "../prompts/persona-resolver.js";
 import { buildCoreIdentityContext } from "../prompts/system-prompt.js";
 import {
@@ -820,20 +820,18 @@ async function classifyWithLLM(
     ? truncate(rawIdentityContext, MAX_IDENTITY_CONTEXT_CHARS, "\n…[truncated]")
     : undefined;
 
-  // Resolve guardian contact notes for recipient context. Try each available
-  // channel in order and use the first guardian that has non-empty notes.
+  // Resolve guardian contact notes for recipient context. Use the channel-
+  // agnostic guardian lookup so notes are available even when the only
+  // deliverable channel is "vellum" (which has no contact channel type).
   let recipientNotes: string | undefined;
   try {
-    for (const ch of availableChannels) {
-      const guardianResult = findGuardianForChannel(ch);
-      if (guardianResult?.contact.notes) {
-        recipientNotes = truncate(
-          guardianResult.contact.notes,
-          MAX_IDENTITY_CONTEXT_CHARS,
-          "\n…[truncated]",
-        );
-        break;
-      }
+    const guardianResult = listGuardianChannels();
+    if (guardianResult?.contact.notes) {
+      recipientNotes = truncate(
+        guardianResult.contact.notes,
+        MAX_IDENTITY_CONTEXT_CHARS,
+        "\n…[truncated]",
+      );
     }
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for contact-notes-in-outbound-ctx.md.

**Gap:** Guardian contact notes never injected for vellum-only notifications
**What was expected:** Recipient notes should be available regardless of which notification channels are active
**What was found:** `findGuardianForChannel("vellum")` always returns null because "vellum" is not a contact channel type

Switches from `findGuardianForChannel(ch)` per-channel iteration to `listGuardianChannels()` which returns the guardian contact directly without requiring a matching channel type.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
