### PR TITLE
fix: cache layout and model in context inspector to prevent scroll freeze

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorPromptTab.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorPromptTab.swift
@@ -5,33 +5,36 @@ import VellumAssistantShared
 struct MessageInspectorPromptTab: View {
     let entry: LLMRequestLogEntry
 
-    private var model: MessageInspectorPromptTabModel {
-        MessageInspectorPromptTabModel(entry: entry)
-    }
+    @State private var model: MessageInspectorPromptTabModel?
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: VSpacing.lg) {
-                headerCard
+            if let model {
+                VStack(alignment: .leading, spacing: VSpacing.lg) {
+                    headerCard(model)
 
-                if model.sections.isEmpty {
-                    emptyState
-                } else {
-                    LazyVStack(alignment: .leading, spacing: VSpacing.md) {
-                        ForEach(model.sections) { section in
-                            sectionCard(section)
+                    if model.sections.isEmpty {
+                        emptyState(model)
+                    } else {
+                        LazyVStack(alignment: .leading, spacing: VSpacing.md) {
+                            ForEach(model.sections) { section in
+                                sectionCard(section)
+                            }
                         }
                     }
                 }
+                .padding(VSpacing.lg)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
             }
-            .padding(VSpacing.lg)
-            .frame(maxWidth: .infinity, alignment: .topLeading)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(VColor.surfaceBase)
+        .task {
+            model = MessageInspectorPromptTabModel(entry: entry)
+        }
     }
 
-    private var headerCard: some View {
+    private func headerCard(_ model: MessageInspectorPromptTabModel) -> some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             Text("Prompt sections")
                 .font(VFont.bodyMediumDefault)
@@ -47,7 +50,7 @@ struct MessageInspectorPromptTab: View {
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
     }
 
-    private var emptyState: some View {
+    private func emptyState(_ model: MessageInspectorPromptTabModel) -> some View {
         VEmptyState(
             title: "No normalized prompt sections",
             subtitle: model.fallbackMessage,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
@@ -278,6 +278,7 @@ private struct CodeTextView: NSViewRepresentable {
         context.coordinator.parent = self
         guard let textView = scrollView.documentView as? CodeNSTextView else { return }
         if textView.string != text {
+            context.coordinator.cachedHeight = nil
             let selectedRanges = textView.selectedRanges
             textView.string = text
             let length = (text as NSString).length
@@ -303,9 +304,15 @@ private struct CodeTextView: NSViewRepresentable {
         guard let textView = nsView.documentView as? CodeNSTextView,
               let layoutManager = textView.layoutManager,
               let textContainer = textView.textContainer else { return nil }
-        layoutManager.ensureLayout(for: textContainer)
-        let usedRect = layoutManager.usedRect(for: textContainer)
-        let height = usedRect.height + textView.textContainerInset.height * 2
+        let height: CGFloat
+        if let cached = context.coordinator.cachedHeight {
+            height = cached
+        } else {
+            layoutManager.ensureLayout(for: textContainer)
+            let usedRect = layoutManager.usedRect(for: textContainer)
+            height = usedRect.height + textView.textContainerInset.height * 2
+            context.coordinator.cachedHeight = height
+        }
         return CGSize(width: proposal.width ?? 400, height: height)
     }
 
@@ -315,6 +322,7 @@ private struct CodeTextView: NSViewRepresentable {
 
     class Coordinator: NSObject, NSTextViewDelegate {
         var parent: CodeTextView
+        var cachedHeight: CGFloat?
 
         init(parent: CodeTextView) {
             self.parent = parent
@@ -322,6 +330,7 @@ private struct CodeTextView: NSViewRepresentable {
 
         func textDidChange(_ notification: Notification) {
             guard let textView = notification.object as? NSTextView else { return }
+            cachedHeight = nil
             parent.text = textView.string
             parent.onTextChange?(textView.string)
         }

--- a/clients/shared/DesignSystem/Components/Display/VCodeView.swift
+++ b/clients/shared/DesignSystem/Components/Display/VCodeView.swift
@@ -316,9 +316,15 @@ struct VCodeTextView: NSViewRepresentable {
         guard let textView = nsView.documentView as? ClickReportingTextView,
               let layoutManager = textView.layoutManager,
               let textContainer = textView.textContainer else { return nil }
-        layoutManager.ensureLayout(for: textContainer)
-        let usedRect = layoutManager.usedRect(for: textContainer)
-        let height = usedRect.height + textView.textContainerInset.height * 2
+        let height: CGFloat
+        if let cached = context.coordinator.cachedHeight {
+            height = cached
+        } else {
+            layoutManager.ensureLayout(for: textContainer)
+            let usedRect = layoutManager.usedRect(for: textContainer)
+            height = usedRect.height + textView.textContainerInset.height * 2
+            context.coordinator.cachedHeight = height
+        }
         return CGSize(width: proposal.width ?? 400, height: height)
     }
 
@@ -331,6 +337,7 @@ struct VCodeTextView: NSViewRepresentable {
         var lastMatchIndex: Int = -1
         var lastMatchCount: Int = 0
         var paragraphStyle: NSParagraphStyle?
+        var cachedHeight: CGFloat?
         private var highlightTask: Task<Void, Never>?
 
         deinit {
@@ -349,6 +356,7 @@ struct VCodeTextView: NSViewRepresentable {
             to textView: NSTextView
         ) {
             lastText = text
+            cachedHeight = nil
 
             // Apply plain text immediately so the view is never empty
             guard let textStorage = textView.textStorage else { return }
@@ -378,6 +386,10 @@ struct VCodeTextView: NSViewRepresentable {
                     storage.beginEditing()
                     storage.setAttributedString(highlighted)
                     storage.endEditing()
+
+                    // Invalidate cached height — font variants from highlighting
+                    // (bold/italic) may change line heights.
+                    self?.cachedHeight = nil
 
                     // Re-apply search highlights that were wiped by setAttributedString
                     if let self, !self.currentMatchRanges.isEmpty {


### PR DESCRIPTION
## Summary
- Cache `sizeThatFits` result in `VCodeTextView.Coordinator` and `CodeTextView.Coordinator` — `ensureLayout` was being called ~60x/sec per visible code block during scroll, saturating the main thread and freezing the app at 100% CPU
- Convert `MessageInspectorPromptTab.model` from a computed property to `@State` to eliminate repeated JSON serialization on every body evaluation during scroll
- Invalidate cached height when text changes, user edits, or async syntax highlighting completes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23347" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
