### PR TITLE
fix: persist graph memory tracker state across conversation eviction

### DIFF
--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -441,6 +441,7 @@ export class Conversation {
   async loadFromDb(): Promise<void> {
     await loadFromDbImpl(this);
     this.restoreSurfaceStateFromHistory();
+    this.graphMemory.restoreState();
   }
 
   /**
@@ -568,6 +569,7 @@ export class Conversation {
     this.cesClient = undefined;
     this.activeContextNodeIds = this.graphMemory.tracker.getActiveNodeIds();
     this.memoryScopeId = this.memoryPolicy.scopeId;
+    this.graphMemory.persistState();
     disposeConversation(this);
   }
 

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -58,6 +58,7 @@ import {
   migrateContactsUserFileColumn,
   migrateConversationForkLineage,
   migrateConversationsThreadTypeIndex,
+  migrateCreateConversationGraphMemoryState,
   migrateCreateMemoryGraphNodeEdits,
   migrateCreateMemoryGraphTables,
   migrateCreateMemoryRecallLogs,
@@ -585,6 +586,9 @@ export function initializeDb(): void {
 
   // 105. Remove image attachments containing HTML error pages instead of image data
   migrateScrubCorruptedImageAttachments(database);
+
+  // 106. Persist graph memory tracker state across conversation eviction
+  migrateCreateConversationGraphMemoryState(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -21,9 +21,14 @@ import { getDb } from "../db.js";
 import { memorySummaries } from "../schema.js";
 import { conversations } from "../schema/conversations.js";
 import {
+  loadGraphMemoryState,
+  saveGraphMemoryState,
+} from "./graph-memory-state-store.js";
+import {
   assembleContextBlock,
   assembleInjectionBlock,
   InContextTracker,
+  type InContextTrackerSnapshot,
   MAX_CONTEXT_LOAD_IMAGES,
   MAX_PER_TURN_IMAGES,
   type ResolvedImage,
@@ -57,6 +62,57 @@ export class ConversationGraphMemory {
   constructor(scopeId: string, conversationId: string) {
     this.scopeId = scopeId;
     this.conversationId = conversationId;
+  }
+
+  /**
+   * Persist tracker state to the database so it survives eviction.
+   * Called during conversation disposal.
+   */
+  persistState(): void {
+    if (!this.initialized) return;
+    try {
+      const snapshot: InContextTrackerSnapshot & { initialized: boolean } = {
+        initialized: this.initialized,
+        ...this.tracker.toJSON(),
+      };
+      saveGraphMemoryState(this.conversationId, JSON.stringify(snapshot));
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "Failed to persist graph memory state (non-fatal)",
+      );
+    }
+  }
+
+  /**
+   * Restore tracker state from the database after eviction + recreation.
+   * On failure or missing row, silently falls back to full context-load.
+   */
+  restoreState(): void {
+    try {
+      const json = loadGraphMemoryState(this.conversationId);
+      if (!json) return;
+
+      const snapshot = JSON.parse(json) as InContextTrackerSnapshot & {
+        initialized: boolean;
+      };
+      this.initialized = snapshot.initialized;
+      this.tracker.restoreFrom(snapshot);
+
+      log.info(
+        {
+          conversationId: this.conversationId,
+          turn: snapshot.currentTurn,
+          inContextCount: snapshot.inContext.length,
+        },
+        "Restored graph memory state after eviction",
+      );
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "Failed to restore graph memory state — will do full context load",
+      );
+    }
   }
 
   /**

--- a/assistant/src/memory/graph/graph-memory-state-store.ts
+++ b/assistant/src/memory/graph/graph-memory-state-store.ts
@@ -1,0 +1,37 @@
+import { eq } from "drizzle-orm";
+
+import { getDb } from "../db.js";
+import { conversationGraphMemoryState } from "../schema.js";
+
+/**
+ * Persist graph memory state for a conversation (upsert).
+ */
+export function saveGraphMemoryState(
+  conversationId: string,
+  stateJson: string,
+): void {
+  const db = getDb();
+  const now = Date.now();
+  db.insert(conversationGraphMemoryState)
+    .values({ conversationId, stateJson, createdAt: now, updatedAt: now })
+    .onConflictDoUpdate({
+      target: conversationGraphMemoryState.conversationId,
+      set: { stateJson, updatedAt: now },
+    })
+    .run();
+}
+
+/**
+ * Load graph memory state for a conversation, or null if none exists.
+ */
+export function loadGraphMemoryState(
+  conversationId: string,
+): string | null {
+  const db = getDb();
+  const row = db
+    .select({ stateJson: conversationGraphMemoryState.stateJson })
+    .from(conversationGraphMemoryState)
+    .where(eq(conversationGraphMemoryState.conversationId, conversationId))
+    .get();
+  return row?.stateJson ?? null;
+}

--- a/assistant/src/memory/graph/injection.ts
+++ b/assistant/src/memory/graph/injection.ts
@@ -29,9 +29,15 @@ export interface ResolvedImage {
 // InContextTracker — tracks which node IDs are visible to the LLM
 // ---------------------------------------------------------------------------
 
-interface InjectionLogEntry {
+export interface InjectionLogEntry {
   nodeId: string;
   turn: number;
+}
+
+export interface InContextTrackerSnapshot {
+  inContext: string[];
+  log: InjectionLogEntry[];
+  currentTurn: number;
 }
 
 /**
@@ -105,6 +111,22 @@ export class InContextTracker {
   /** Current turn number. */
   getTurn(): number {
     return this.currentTurn;
+  }
+
+  /** Serialize tracker state for persistence across eviction. */
+  toJSON(): InContextTrackerSnapshot {
+    return {
+      inContext: [...this.inContext],
+      log: [...this.log],
+      currentTurn: this.currentTurn,
+    };
+  }
+
+  /** Restore tracker state from a persisted snapshot. Replaces current state. */
+  restoreFrom(snapshot: InContextTrackerSnapshot): void {
+    this.inContext = new Set(snapshot.inContext);
+    this.log = [...snapshot.log];
+    this.currentTurn = snapshot.currentTurn;
   }
 }
 

--- a/assistant/src/memory/migrations/207-conversation-graph-memory-state.ts
+++ b/assistant/src/memory/migrations/207-conversation-graph-memory-state.ts
@@ -1,0 +1,20 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Persist ConversationGraphMemory + InContextTracker state across eviction.
+ * Idempotent — uses CREATE TABLE IF NOT EXISTS.
+ */
+export function migrateCreateConversationGraphMemoryState(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+  raw.exec(`
+    CREATE TABLE IF NOT EXISTS conversation_graph_memory_state (
+      conversation_id TEXT PRIMARY KEY REFERENCES conversations(id) ON DELETE CASCADE,
+      state_json TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -148,6 +148,7 @@ export { migrateRenameMemoryGraphTypeValues } from "./204-rename-memory-graph-ty
 export { migrateMemoryGraphImageRefs } from "./205-memory-graph-image-refs.js";
 export { migrateCreateMemoryGraphNodeEdits } from "./206-memory-graph-node-edits.js";
 export { migrateScrubCorruptedImageAttachments } from "./206-scrub-corrupted-image-attachments.js";
+export { migrateCreateConversationGraphMemoryState } from "./207-conversation-graph-memory-state.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/conversations.ts
+++ b/assistant/src/memory/schema/conversations.ts
@@ -109,6 +109,18 @@ export const messageAttachments = sqliteTable("message_attachments", {
   createdAt: integer("created_at").notNull(),
 });
 
+export const conversationGraphMemoryState = sqliteTable(
+  "conversation_graph_memory_state",
+  {
+    conversationId: text("conversation_id")
+      .primaryKey()
+      .references(() => conversations.id, { onDelete: "cascade" }),
+    stateJson: text("state_json").notNull(),
+    createdAt: integer("created_at").notNull(),
+    updatedAt: integer("updated_at").notNull(),
+  },
+);
+
 export const channelInboundEvents = sqliteTable("channel_inbound_events", {
   id: text("id").primaryKey(),
   sourceChannel: text("source_channel").notNull(),


### PR DESCRIPTION
## Summary

- When conversations are evicted after 30min idle, the `ConversationGraphMemory` tracker state was lost, forcing a wasteful full context-load on the next message instead of resuming per-turn injection
- Added `persistState()`/`restoreState()` to `ConversationGraphMemory` backed by a new `conversation_graph_memory_state` SQLite table with cascade delete
- Wired persist into `Conversation.dispose()` and restore into `Conversation.loadFromDb()` so conversations resume seamlessly after any idle duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)