### PR TITLE
fix: only append skill_load activation hint to skills, not CLI commands

### DIFF
--- a/assistant/src/__tests__/injection-block.test.ts
+++ b/assistant/src/__tests__/injection-block.test.ts
@@ -125,6 +125,18 @@ describe("assembleInjectionBlock", () => {
     expect(result).toContain("[skill]");
     expect(result).toContain("→ use skill_load to activate");
   });
+
+  test("assembleInjectionBlock omits skill_load suffix for CLI commands", () => {
+    const node = makeScoredNode({
+      type: "procedural",
+      content:
+        'cli:bash\nThe "assistant bash" CLI command is available. Execute a shell command.',
+    });
+    const result = assembleInjectionBlock([node]);
+    expect(result).not.toContain("[skill]");
+    expect(result).not.toContain("skill_load to activate");
+    expect(result).toContain("CLI command is available");
+  });
 });
 
 describe("assembleContextBlock — procedural nodes", () => {
@@ -137,6 +149,18 @@ describe("assembleContextBlock — procedural nodes", () => {
     const result = assembleContextBlock([node]);
     expect(result).toContain("### Skills You Can Use");
     expect(result).toContain("use skill_load to activate");
+  });
+
+  test("omits skill_load suffix for CLI commands", () => {
+    const node = makeScoredNode({
+      type: "procedural",
+      content:
+        'cli:bash\nThe "assistant bash" CLI command is available. Execute a shell command.',
+    });
+    const result = assembleContextBlock([node]);
+    expect(result).toContain("### Skills You Can Use");
+    expect(result).not.toContain("skill_load to activate");
+    expect(result).toContain("CLI command is available");
   });
 
   test("strips skill: prefix from old-format content", () => {

--- a/assistant/src/memory/graph/injection.ts
+++ b/assistant/src/memory/graph/injection.ts
@@ -339,7 +339,10 @@ export function assembleContextBlock(
   if (capabilities.length > 0) {
     const entries = capabilities.slice(0, 5).map((scored) => {
       const content = scored.node.content.replace(/^(?:skill|cli):\S+\n/, "");
-      return `- ${content} → use skill_load to activate`;
+      const suffix = /skill \(/.test(content)
+        ? " → use skill_load to activate"
+        : "";
+      return `- ${content}${suffix}`;
     });
     parts.push(`### Skills You Can Use\n${entries.join("\n")}`);
   }
@@ -395,7 +398,10 @@ export function assembleInjectionBlock(nodes: ScoredNode[]): string {
     .map((scored) => {
       if (isCapabilityNode(scored.node)) {
         const content = scored.node.content.replace(/^(?:skill|cli):\S+\n/, "");
-        return `- [skill] ${content} → use skill_load to activate`;
+        if (/skill \(/.test(content)) {
+          return `- [skill] ${content} → use skill_load to activate`;
+        }
+        return `- ${content}`;
       }
       if (scored.node.eventDate != null) {
         return formatUpcomingEntry(scored);


### PR DESCRIPTION
## Summary
- Only append `→ use skill_load to activate` to actual skill capability nodes, not CLI command nodes
- Use positive matching (`/skill \(/`) instead of negative exclusion
- Add test coverage for CLI command rendering in both `assembleContextBlock` and `assembleInjectionBlock`