### PR TITLE
feat: sort conversations by latest message timestamp instead of updatedAt

### DIFF
--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -172,6 +172,7 @@ export interface ConversationRow {
   forkParentMessageId: string | null;
   isAutoTitle: number;
   scheduleJobId: string | null;
+  lastMessageAt: number | null;
 }
 
 export const parseConversation = createRowMapper<
@@ -197,6 +198,7 @@ export const parseConversation = createRowMapper<
   forkParentMessageId: "forkParentMessageId",
   isAutoTitle: "isAutoTitle",
   scheduleJobId: "scheduleJobId",
+  lastMessageAt: "lastMessageAt",
 });
 
 export interface MessageRow {
@@ -885,7 +887,7 @@ export async function addMessage(
             .run();
         }
         tx.update(conversations)
-          .set({ updatedAt: now })
+          .set({ updatedAt: now, lastMessageAt: now })
           .where(eq(conversations.id, conversationId))
           .run();
       });
@@ -1260,8 +1262,13 @@ export function deleteLastExchange(conversationId: string): number {
 
   db.transaction((tx) => {
     tx.delete(messages).where(condition).run();
+    const maxResult = tx
+      .select({ maxCreatedAt: sql<number | null>`MAX(${messages.createdAt})` })
+      .from(messages)
+      .where(eq(messages.conversationId, conversationId))
+      .get();
     tx.update(conversations)
-      .set({ updatedAt: Date.now() })
+      .set({ updatedAt: Date.now(), lastMessageAt: maxResult?.maxCreatedAt ?? null })
       .where(eq(conversations.id, conversationId))
       .run();
   });
@@ -1379,6 +1386,13 @@ export function deleteMessageById(messageId: string): DeletedMemoryIds {
     .map((r) => r.attachmentId)
     .filter((id): id is string => id !== undefined);
 
+  // Look up the conversation before the transaction so we can recalculate lastMessageAt.
+  const msgRow = db
+    .select({ conversationId: messages.conversationId })
+    .from(messages)
+    .where(eq(messages.id, messageId))
+    .get();
+
   db.transaction((tx) => {
     // Collect memory segment IDs linked to this message before cascade.
     const linkedSegments = tx
@@ -1397,6 +1411,19 @@ export function deleteMessageById(messageId: string): DeletedMemoryIds {
     // Now safe to delete — NOT NULL cascades remove memory_segments
     // and message_attachments.
     tx.delete(messages).where(eq(messages.id, messageId)).run();
+
+    // Recalculate lastMessageAt after deletion.
+    if (msgRow) {
+      const maxResult = tx
+        .select({ maxCreatedAt: sql<number | null>`MAX(${messages.createdAt})` })
+        .from(messages)
+        .where(eq(messages.conversationId, msgRow.conversationId))
+        .get();
+      tx.update(conversations)
+        .set({ lastMessageAt: maxResult?.maxCreatedAt ?? null })
+        .where(eq(conversations.id, msgRow.conversationId))
+        .run();
+    }
 
     // Clean up segment embeddings from SQLite (Qdrant cleanup is the caller's job).
     if (result.segmentIds.length > 0) {

--- a/assistant/src/memory/conversation-queries.ts
+++ b/assistant/src/memory/conversation-queries.ts
@@ -56,7 +56,7 @@ export function listConversations(
     .select()
     .from(conversations)
     .where(where)
-    .orderBy(desc(conversations.updatedAt))
+    .orderBy(desc(sql`COALESCE(${conversations.lastMessageAt}, ${conversations.updatedAt})`))
     .limit(limit ?? 100)
     .offset(offset);
   return query.all().map(parseConversation);
@@ -75,7 +75,7 @@ export function listPinnedConversations(): ConversationRow[] {
         sql`is_pinned = 1`,
       ),
     )
-    .orderBy(desc(conversations.updatedAt));
+    .orderBy(desc(sql`COALESCE(${conversations.lastMessageAt}, ${conversations.updatedAt})`));
   return query.all().map(parseConversation);
 }
 
@@ -100,7 +100,7 @@ export function getLatestConversation(): ConversationRow | null {
     .where(
       sql`${conversations.conversationType} NOT IN ('background', 'private')`,
     )
-    .orderBy(desc(conversations.updatedAt))
+    .orderBy(desc(sql`COALESCE(${conversations.lastMessageAt}, ${conversations.updatedAt})`))
     .limit(1)
     .get();
   return row ? parseConversation(row) : null;

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -58,6 +58,7 @@ import {
   migrateContactsUserFileColumn,
   migrateConversationForkLineage,
   migrateConversationsThreadTypeIndex,
+  migrateConversationsLastMessageAt,
   migrateCreateConversationGraphMemoryState,
   migrateCreateMemoryGraphNodeEdits,
   migrateCreateMemoryGraphTables,
@@ -589,6 +590,9 @@ export function initializeDb(): void {
 
   // 106. Persist graph memory tracker state across conversation eviction
   migrateCreateConversationGraphMemoryState(database);
+
+  // 107. Add last_message_at denormalized column for message-based sorting
+  migrateConversationsLastMessageAt(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/208-conversations-last-message-at.ts
+++ b/assistant/src/memory/migrations/208-conversations-last-message-at.ts
@@ -1,0 +1,35 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Add last_message_at denormalized column to conversations for sorting by
+ * latest message timestamp instead of updatedAt (which is bumped by non-message
+ * events like title changes and context compaction).
+ *
+ * Idempotent — uses ALTER TABLE try/catch and IF NOT EXISTS guards.
+ */
+export function migrateConversationsLastMessageAt(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  try {
+    raw.exec(`ALTER TABLE conversations ADD COLUMN last_message_at INTEGER`);
+  } catch {
+    // Column already exists
+  }
+
+  // Backfill from the latest message in each conversation.
+  // Idempotent: re-running produces the same result.
+  raw.exec(`
+    UPDATE conversations
+    SET last_message_at = (
+      SELECT MAX(created_at) FROM messages
+      WHERE messages.conversation_id = conversations.id
+    )
+    WHERE last_message_at IS NULL
+  `);
+
+  raw.exec(`
+    CREATE INDEX IF NOT EXISTS idx_conversations_last_message_at
+    ON conversations(last_message_at)
+  `);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -149,6 +149,7 @@ export { migrateMemoryGraphImageRefs } from "./205-memory-graph-image-refs.js";
 export { migrateCreateMemoryGraphNodeEdits } from "./206-memory-graph-node-edits.js";
 export { migrateScrubCorruptedImageAttachments } from "./206-scrub-corrupted-image-attachments.js";
 export { migrateCreateConversationGraphMemoryState } from "./207-conversation-graph-memory-state.js";
+export { migrateConversationsLastMessageAt } from "./208-conversations-last-message-at.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/conversations.ts
+++ b/assistant/src/memory/schema/conversations.ts
@@ -30,9 +30,11 @@ export const conversations = sqliteTable(
     forkParentMessageId: text("fork_parent_message_id"),
     isAutoTitle: integer("is_auto_title").notNull().default(1),
     scheduleJobId: text("schedule_job_id"),
+    lastMessageAt: integer("last_message_at"),
   },
   (table) => [
     index("idx_conversations_updated_at").on(table.updatedAt),
+    index("idx_conversations_last_message_at").on(table.lastMessageAt),
     index("idx_conversations_conversation_type").on(table.conversationType),
     index("idx_conversations_fork_parent_conversation_id").on(
       table.forkParentConversationId,

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -828,6 +828,7 @@ export class RuntimeHttpServer {
       title: conversation.title ?? "Untitled",
       createdAt: conversation.createdAt,
       updatedAt: conversation.updatedAt,
+      lastMessageAt: conversation.lastMessageAt,
       conversationType: conversation.conversationType ?? "standard",
       source: conversation.source ?? "user",
       ...(conversation.scheduleJobId

--- a/clients/ios/App/IOSConversationStore.swift
+++ b/clients/ios/App/IOSConversationStore.swift
@@ -352,7 +352,7 @@ class IOSConversationStore: ObservableObject {
         var conversation = IOSConversation(
             title: item.title,
             createdAt: Date(timeIntervalSince1970: TimeInterval(effectiveCreatedAt) / 1000.0),
-            lastActivityAt: Date(timeIntervalSince1970: TimeInterval(item.updatedAt) / 1000.0),
+            lastActivityAt: Date(timeIntervalSince1970: TimeInterval(item.lastMessageAt ?? item.updatedAt) / 1000.0),
             conversationId: item.id,
             isPrivate: item.conversationType == "private",
             scheduleJobId: item.scheduleJobId,
@@ -1305,7 +1305,7 @@ class IOSConversationStore: ObservableObject {
             var mergedConversation = conversations[existingIndex]
             mergedConversation.title = item.title
             mergedConversation.lastActivityAt = Date(
-                timeIntervalSince1970: TimeInterval(item.updatedAt) / 1000.0
+                timeIntervalSince1970: TimeInterval(item.lastMessageAt ?? item.updatedAt) / 1000.0
             )
             mergeConversationMetadata(from: conversationFromListItem(item), into: &mergedConversation)
             conversations[existingIndex] = mergedConversation

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationListStore.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationListStore.swift
@@ -239,7 +239,7 @@ final class ConversationListStore {
             isArchived: isArchived,
             groupId: groupId,
             displayOrder: item.displayOrder.map { Int($0) },
-            lastInteractedAt: Date(timeIntervalSince1970: TimeInterval(item.updatedAt) / 1000.0),
+            lastInteractedAt: Date(timeIntervalSince1970: TimeInterval(item.lastMessageAt ?? item.updatedAt) / 1000.0),
             kind: item.conversationType == "private" ? .private : .standard,
             source: item.source,
             scheduleJobId: item.scheduleJobId,

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -279,7 +279,7 @@ final class ConversationRestorer {
                 isArchived: delegate.isConversationArchived(session.id),
                 groupId: groupId,
                 displayOrder: session.displayOrder.map { Int($0) },
-                lastInteractedAt: Date(timeIntervalSince1970: TimeInterval(session.updatedAt) / 1000.0),
+                lastInteractedAt: Date(timeIntervalSince1970: TimeInterval(session.lastMessageAt ?? session.updatedAt) / 1000.0),
                 kind: kind,
                 source: session.source,
                 scheduleJobId: session.scheduleJobId,

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -3473,6 +3473,7 @@ public struct ConversationListResponseItem: Codable, Sendable {
     public let title: String
     public let createdAt: Int?
     public let updatedAt: Int
+    public let lastMessageAt: Int?
     public let conversationType: String?
     public let source: String?
     public let scheduleJobId: String?
@@ -3487,11 +3488,12 @@ public struct ConversationListResponseItem: Codable, Sendable {
     public let groupId: String?
     public let forkParent: ConversationForkParent?
 
-    public init(id: String, title: String, createdAt: Int? = nil, updatedAt: Int, conversationType: String? = nil, source: String? = nil, scheduleJobId: String? = nil, channelBinding: ChannelBinding? = nil, conversationOriginChannel: String? = nil, conversationOriginInterface: String? = nil, assistantAttention: AssistantAttention? = nil, displayOrder: Double? = nil, isPinned: Bool? = nil, groupId: String? = nil, forkParent: ConversationForkParent? = nil) {
+    public init(id: String, title: String, createdAt: Int? = nil, updatedAt: Int, lastMessageAt: Int? = nil, conversationType: String? = nil, source: String? = nil, scheduleJobId: String? = nil, channelBinding: ChannelBinding? = nil, conversationOriginChannel: String? = nil, conversationOriginInterface: String? = nil, assistantAttention: AssistantAttention? = nil, displayOrder: Double? = nil, isPinned: Bool? = nil, groupId: String? = nil, forkParent: ConversationForkParent? = nil) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
         self.updatedAt = updatedAt
+        self.lastMessageAt = lastMessageAt
         self.conversationType = conversationType
         self.source = source
         self.scheduleJobId = scheduleJobId


### PR DESCRIPTION
## Summary
- Add `lastMessageAt` column to conversations table with DDL-guarded migration and backfill from existing messages
- Update `addMessage()`, `deleteLastExchange()`, and `deleteMessageById()` to maintain the denormalized field
- Change `listConversations`, `listPinnedConversations`, and `getLatestConversation` queries to sort by `COALESCE(last_message_at, updated_at)` instead of `updated_at`
- Expose `lastMessageAt` in the HTTP API and update macOS + iOS clients to use it for sidebar sort order (with `updatedAt` fallback for backward compat)

## Original prompt
Sort conversations by latest message timestamp instead of updatedAt
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
