### PR TITLE
fix: reorder image memory injections before text memory

### DIFF
--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -576,9 +576,7 @@ function injectMemoryBlock(
   const userTail = cleaned[cleaned.length - 1];
   if (!userTail || userTail.role !== "user") return messages;
 
-  const blocks: ContentBlock[] = [
-    { type: "text" as const, text: `<memory __injected>\n${text}\n</memory>` },
-  ];
+  const blocks: ContentBlock[] = [];
 
   for (const [_nodeId, img] of images) {
     blocks.push({
@@ -594,6 +592,11 @@ function injectMemoryBlock(
       },
     } as ImageContent);
   }
+
+  blocks.push({
+    type: "text" as const,
+    text: `<memory __injected>\n${text}\n</memory>`,
+  });
 
   return [
     ...cleaned.slice(0, -1),


### PR DESCRIPTION
## Summary
- Reorder content blocks in `injectMemoryBlock()` so image memories are injected **before** the `<memory __injected>` text block, not after
- The stripping logic already handles any interleaving of memory block types, so no other changes needed

## Original prompt
reorder the image memory injections to be before the other items, not after