### PR TITLE
feat: append-only conversation history for Anthropic prefix caching

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -225,33 +225,23 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
   });
 
   // -----------------------------------------------------------------------
-  // User turn cache breakpoints — second-to-last user turn only
+  // Automatic caching — request-level cache_control
   // -----------------------------------------------------------------------
-  test("single user turn does NOT get cache_control (no second-to-last)", async () => {
+  test("request has top-level cache_control with 1h TTL", async () => {
     await provider.sendMessage([userMsg("Hello")]);
 
-    const messages = lastStreamParams!.messages as Array<{
-      role: string;
-      content: Array<{
-        type: string;
-        text: string;
-        cache_control?: { type: string; ttl?: string };
-      }>;
-    }>;
-    const lastUser = messages[messages.length - 1];
-    expect(lastUser.role).toBe("user");
     expect(
-      lastUser.content[lastUser.content.length - 1].cache_control,
-    ).toBeUndefined();
+      (lastStreamParams as Record<string, unknown>).cache_control,
+    ).toEqual({ type: "ephemeral", ttl: "1h" });
   });
 
-  test("second-to-last user turn gets cache_control, others do not", async () => {
+  test("no manual cache_control on user messages", async () => {
     const messages: Message[] = [
-      userMsg("Turn 1"), // user turn 0 — no cache
+      userMsg("Turn 1"),
       assistantMsg("Response 1"),
-      userMsg("Turn 2"), // user turn 1 — cache (second-to-last)
+      userMsg("Turn 2"),
       assistantMsg("Response 2"),
-      userMsg("Turn 3"), // user turn 2 — no cache (last)
+      userMsg("Turn 3"),
     ];
     await provider.sendMessage(messages);
 
@@ -264,72 +254,13 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
       }>;
     }>;
 
-    // Find user messages in order
+    // No user message should have manual cache_control
     const userMessages = sent.filter((m) => m.role === "user");
-    expect(userMessages).toHaveLength(3);
-
-    // First user turn: no cache_control
-    const firstUserLastBlock =
-      userMessages[0].content[userMessages[0].content.length - 1];
-    expect(firstUserLastBlock.cache_control).toBeUndefined();
-
-    // Second user turn (second-to-last): cache_control ephemeral
-    const secondUserLastBlock =
-      userMessages[1].content[userMessages[1].content.length - 1];
-    expect(secondUserLastBlock.cache_control).toEqual({
-      type: "ephemeral",
-      ttl: "1h",
-    });
-
-    // Third user turn (last): no cache_control
-    const thirdUserLastBlock =
-      userMessages[2].content[userMessages[2].content.length - 1];
-    expect(thirdUserLastBlock.cache_control).toBeUndefined();
-  });
-
-  test("single user turn does NOT get cache_control (only one user = no second-to-last)", async () => {
-    await provider.sendMessage([userMsg("Only turn")]);
-
-    const sent = lastStreamParams!.messages as Array<{
-      role: string;
-      content: Array<{
-        type: string;
-        text: string;
-        cache_control?: { type: string; ttl?: string };
-      }>;
-    }>;
-    const userMessages = sent.filter((m) => m.role === "user");
-    expect(userMessages).toHaveLength(1);
-    expect(
-      userMessages[0].content[userMessages[0].content.length - 1].cache_control,
-    ).toBeUndefined();
-  });
-
-  // -----------------------------------------------------------------------
-  // User turn with tool_result — cache breakpoint on second-to-last
-  // -----------------------------------------------------------------------
-  test("user turn containing tool_result gets cache_control on second-to-last user turn only", async () => {
-    const messages: Message[] = [
-      userMsg("Read file"),
-      toolUseMsg("tu_1", "file_read"),
-      toolResultMsg("tu_1", "file contents here"),
-    ];
-    await provider.sendMessage(messages);
-
-    const sent = lastStreamParams!.messages as Array<{
-      role: string;
-      content: Array<{
-        type: string;
-        cache_control?: { type: string; ttl?: string };
-      }>;
-    }>;
-    const userMsgs = sent.filter((m) => m.role === "user");
-    // First user msg (second-to-last) should get cache
-    const firstLast = userMsgs[0].content[userMsgs[0].content.length - 1];
-    expect(firstLast.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
-    // tool_result msg (last) should NOT get cache
-    const secondLast = userMsgs[1].content[userMsgs[1].content.length - 1];
-    expect(secondLast.cache_control).toBeUndefined();
+    for (const user of userMessages) {
+      for (const block of user.content) {
+        expect(block.cache_control).toBeUndefined();
+      }
+    }
   });
 
   // -----------------------------------------------------------------------
@@ -1336,9 +1267,8 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     expect(sent[4].content[0].text).toBe("Follow-up question");
   });
 
-  test("multi-turn with workspace injection: cache on second-to-last user turn only", async () => {
+  test("multi-turn with workspace injection: no manual cache on user messages (automatic caching handles it)", async () => {
     const messages: Message[] = [
-      // Turn 1: workspace + user text (no cache - 3rd-to-last)
       {
         role: "user",
         content: [
@@ -1350,7 +1280,6 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
         ],
       },
       assistantMsg("Response 1"),
-      // Turn 2: workspace + user text (cache - second-to-last)
       {
         role: "user",
         content: [
@@ -1362,7 +1291,6 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
         ],
       },
       assistantMsg("Response 2"),
-      // Turn 3: workspace + user text (no cache - last)
       {
         role: "user",
         content: [
@@ -1387,20 +1315,17 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     const userMsgs = sent.filter((m) => m.role === "user");
     expect(userMsgs).toHaveLength(3);
 
-    // Turn 1: no cache on any block
-    expect(userMsgs[0].content[0].cache_control).toBeUndefined();
-    expect(userMsgs[0].content[1].cache_control).toBeUndefined();
+    // No user messages should have manual cache_control — automatic caching handles it
+    for (const user of userMsgs) {
+      for (const block of user.content) {
+        expect(block.cache_control).toBeUndefined();
+      }
+    }
 
-    // Turn 2 (second-to-last): cache on last block only
-    expect(userMsgs[1].content[0].cache_control).toBeUndefined();
-    expect(userMsgs[1].content[1].cache_control).toEqual({
-      type: "ephemeral",
-      ttl: "1h",
-    });
-
-    // Turn 3 (last): no cache
-    expect(userMsgs[2].content[0].cache_control).toBeUndefined();
-    expect(userMsgs[2].content[1].cache_control).toBeUndefined();
+    // Request-level automatic caching is set
+    expect(
+      (lastStreamParams as Record<string, unknown>).cache_control,
+    ).toEqual({ type: "ephemeral", ttl: "1h" });
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -206,7 +206,9 @@ mock.module("../daemon/conversation-memory.js", () => ({
 let mockApplyRuntimeInjections: (msgs: Message[]) => Message[] = (msgs) => msgs;
 mock.module("../daemon/conversation-runtime-assembly.js", () => ({
   applyRuntimeInjections: (msgs: Message[]) => mockApplyRuntimeInjections(msgs),
-  stripInjectedContext: (msgs: Message[]) => msgs,
+  stripInjectionsForCompaction: (msgs: Message[]) => msgs,
+  findLastInjectedNowContent: () => null,
+  readNowScratchpad: () => null,
 }));
 
 mock.module("../daemon/date-context.js", () => ({
@@ -224,10 +226,6 @@ mock.module("../daemon/history-repair.js", () => ({
     },
   }),
   deepRepairHistory: (msgs: Message[]) => ({ messages: msgs, stats: {} }),
-}));
-
-mock.module("../daemon/conversation-history.js", () => ({
-  consolidateAssistantMessages: () => {},
 }));
 
 const recordUsageMock = mock(() => {});

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -195,7 +195,9 @@ mock.module("../daemon/conversation-memory.js", () => ({
 
 mock.module("../daemon/conversation-runtime-assembly.js", () => ({
   applyRuntimeInjections: (msgs: Message[]) => msgs,
-  stripInjectedContext: (msgs: Message[]) => msgs,
+  stripInjectionsForCompaction: (msgs: Message[]) => msgs,
+  findLastInjectedNowContent: () => null,
+  readNowScratchpad: () => null,
 }));
 
 mock.module("../daemon/date-context.js", () => ({
@@ -213,11 +215,6 @@ mock.module("../daemon/history-repair.js", () => ({
     },
   }),
   deepRepairHistory: (msgs: Message[]) => ({ messages: msgs, stats: {} }),
-}));
-
-const consolidateAssistantMessagesMock = mock(() => false);
-mock.module("../daemon/conversation-history.js", () => ({
-  consolidateAssistantMessages: consolidateAssistantMessagesMock,
 }));
 
 const recordUsageMock = mock(() => {});
@@ -471,8 +468,6 @@ beforeEach(() => {
   recordRequestLogMock.mockClear();
   syncMessageToDiskMock.mockClear();
   rebuildConversationDiskViewFromDbStateMock.mockClear();
-  consolidateAssistantMessagesMock.mockReset();
-  consolidateAssistantMessagesMock.mockImplementation(() => false);
 });
 
 describe("session-agent-loop", () => {
@@ -1944,48 +1939,6 @@ describe("session-agent-loop", () => {
       expect(drainReason).toBe("loop_complete");
     });
 
-    test("rebuilds disk view after consolidation mutates persisted history", async () => {
-      consolidateAssistantMessagesMock.mockReturnValue(true);
-
-      const ctx = makeCtx({
-        agentLoopRun: async (
-          messages: Message[],
-          onEvent: (event: AgentEvent) => void,
-        ) => {
-          onEvent({
-            type: "message_complete",
-            message: {
-              role: "assistant",
-              content: [{ type: "text", text: "done" }],
-            },
-          });
-          onEvent({
-            type: "usage",
-            inputTokens: 10,
-            outputTokens: 5,
-            model: "test",
-            providerDurationMs: 50,
-          });
-          return [
-            ...messages,
-            {
-              role: "assistant" as const,
-              content: [{ type: "text", text: "done" }] as ContentBlock[],
-            },
-          ];
-        },
-      });
-
-      await runAgentLoopImpl(ctx, "hi", "msg-consolidate", () => {});
-
-      expect(consolidateAssistantMessagesMock).toHaveBeenCalledWith(
-        "test-conv",
-        "msg-consolidate",
-      );
-      expect(rebuildConversationDiskViewFromDbStateMock).toHaveBeenCalledWith(
-        "test-conv",
-      );
-    });
   });
 
   describe("stale pending surface cleanup", () => {

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -7,13 +7,14 @@ import type {
 import {
   applyRuntimeInjections,
   buildUnifiedTurnContextBlock,
+  findLastInjectedNowContent,
   injectChannelCapabilityContext,
   injectChannelCommandContext,
   injectNowScratchpad,
   isGroupChatType,
   resolveChannelCapabilities,
   stripChannelCapabilityContext,
-  stripInjectedContext,
+  stripInjectionsForCompaction,
   stripNowScratchpad,
 } from "../daemon/conversation-runtime-assembly.js";
 import type { Message } from "../providers/types.js";
@@ -840,10 +841,10 @@ describe("stripNowScratchpad", () => {
 });
 
 // ---------------------------------------------------------------------------
-// stripInjectedContext removes NOW.md blocks
+// stripInjectionsForCompaction removes NOW.md blocks
 // ---------------------------------------------------------------------------
 
-describe("stripInjectedContext with NOW.md", () => {
+describe("stripInjectionsForCompaction with NOW.md", () => {
   test("strips NOW.md blocks alongside other injections", () => {
     const messages: Message[] = [
       {
@@ -862,7 +863,7 @@ describe("stripInjectedContext with NOW.md", () => {
       },
     ];
 
-    const result = stripInjectedContext(messages);
+    const result = stripInjectionsForCompaction(messages);
     expect(result.length).toBe(1);
     expect(result[0].content.length).toBe(1);
     expect((result[0].content[0] as { type: "text"; text: string }).text).toBe(
@@ -872,10 +873,10 @@ describe("stripInjectedContext with NOW.md", () => {
 });
 
 // ---------------------------------------------------------------------------
-// stripInjectedContext — persistent blocks
+// stripInjectionsForCompaction — persistent blocks
 // ---------------------------------------------------------------------------
 
-describe("stripInjectedContext preserves persistent blocks", () => {
+describe("stripInjectionsForCompaction preserves persistent blocks", () => {
   test("<turn_context> blocks are NOT stripped", () => {
     const messages: Message[] = [
       {
@@ -890,7 +891,7 @@ describe("stripInjectedContext preserves persistent blocks", () => {
       },
     ];
 
-    const result = stripInjectedContext(messages);
+    const result = stripInjectionsForCompaction(messages);
     expect(result.length).toBe(1);
     expect(result[0].content.length).toBe(2);
     expect(
@@ -912,7 +913,7 @@ describe("stripInjectedContext preserves persistent blocks", () => {
       },
     ];
 
-    const result = stripInjectedContext(messages);
+    const result = stripInjectionsForCompaction(messages);
     expect(result.length).toBe(1);
     expect(result[0].content.length).toBe(2);
     expect(
@@ -934,7 +935,7 @@ describe("stripInjectedContext preserves persistent blocks", () => {
       },
     ];
 
-    const result = stripInjectedContext(messages);
+    const result = stripInjectionsForCompaction(messages);
     expect(result.length).toBe(1);
     expect(result[0].content.length).toBe(1);
     expect((result[0].content[0] as { type: "text"; text: string }).text).toBe(
@@ -956,7 +957,7 @@ describe("stripInjectedContext preserves persistent blocks", () => {
       },
     ];
 
-    const result = stripInjectedContext(messages);
+    const result = stripInjectionsForCompaction(messages);
     expect(result.length).toBe(1);
     expect(result[0].content.length).toBe(1);
     expect((result[0].content[0] as { type: "text"; text: string }).text).toBe(
@@ -978,7 +979,7 @@ describe("stripInjectedContext preserves persistent blocks", () => {
       },
     ];
 
-    const result = stripInjectedContext(messages);
+    const result = stripInjectionsForCompaction(messages);
     expect(result.length).toBe(1);
     expect(result[0].content.length).toBe(1);
     expect((result[0].content[0] as { type: "text"; text: string }).text).toBe(
@@ -1409,4 +1410,83 @@ describe("applyRuntimeInjections with unifiedTurnContext", () => {
     expect(allText).toContain("<turn_context>");
   });
 
+});
+
+// ---------------------------------------------------------------------------
+// findLastInjectedNowContent
+// ---------------------------------------------------------------------------
+
+describe("findLastInjectedNowContent", () => {
+  test("extracts NOW.md content from the last user message", () => {
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "<NOW.md Always keep this up to date>\nCurrent focus: fix the bug\n</NOW.md>",
+          },
+          { type: "text", text: "Hello" },
+        ],
+      },
+    ];
+
+    expect(findLastInjectedNowContent(messages)).toBe(
+      "Current focus: fix the bug",
+    );
+  });
+
+  test("returns null when no NOW.md injection exists", () => {
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "Hello" }],
+      },
+    ];
+
+    expect(findLastInjectedNowContent(messages)).toBeNull();
+  });
+
+  test("returns the most recent injection when multiple exist", () => {
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "<NOW.md Always keep this up to date>\nOld focus\n</NOW.md>",
+          },
+        ],
+      },
+      { role: "assistant", content: [{ type: "text", text: "OK" }] },
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "<NOW.md Always keep this up to date>\nNew focus\n</NOW.md>",
+          },
+        ],
+      },
+    ];
+
+    expect(findLastInjectedNowContent(messages)).toBe("New focus");
+  });
+
+  test("skips assistant messages", () => {
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "<NOW.md Always keep this up to date>\nUser focus\n</NOW.md>",
+          },
+        ],
+      },
+      { role: "assistant", content: [{ type: "text", text: "response" }] },
+    ];
+
+    expect(findLastInjectedNowContent(messages)).toBe("User focus");
+  });
 });

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -44,10 +44,7 @@ import {
   updateConversationTitle,
   updateMessageMetadata,
 } from "../memory/conversation-crud.js";
-import {
-  rebuildConversationDiskViewFromDbState,
-  syncMessageToDisk,
-} from "../memory/conversation-disk-view.js";
+import { syncMessageToDisk } from "../memory/conversation-disk-view.js";
 import {
   isReplaceableTitle,
   queueGenerateConversationTitle,
@@ -91,7 +88,6 @@ import {
   classifyConversationError,
   isUserCancellation,
 } from "./conversation-error.js";
-import { consolidateAssistantMessages } from "./conversation-history.js";
 import { raceWithTimeout } from "./conversation-media-retry.js";
 import type { MessageQueue } from "./conversation-queue-manager.js";
 import type { QueueDrainReason } from "./conversation-queue-manager.js";
@@ -105,10 +101,11 @@ import type {
 import {
   applyRuntimeInjections,
   buildUnifiedTurnContextBlock,
+  findLastInjectedNowContent,
   inboundActorContextFromTrust,
   inboundActorContextFromTrustContext,
   readNowScratchpad,
-  stripInjectedContext,
+  stripInjectionsForCompaction,
 } from "./conversation-runtime-assembly.js";
 import type { SkillProjectionCache } from "./conversation-skill-tools.js";
 import { resolveTrustClass } from "./conversation-tool-setup.js";
@@ -777,6 +774,14 @@ export async function runAgentLoopImpl(
     const isInteractiveResolved =
       options?.isInteractive ?? (!ctx.hasNoClient && !ctx.headlessLock);
 
+    // Only inject NOW.md if it changed since the last injection in the
+    // conversation.  Keeping the previous injection in place avoids mutating
+    // historical user messages and preserves the cached prefix.
+    const currentNowContent = readNowScratchpad();
+    const lastInjectedNow = findLastInjectedNowContent(ctx.messages);
+    const nowScratchpad =
+      currentNowContent !== lastInjectedNow ? currentNowContent : null;
+
     // Shared injection options — reused whenever we need to re-inject after reduction.
     const injectionOpts = {
       activeSurface,
@@ -786,7 +791,7 @@ export async function runAgentLoopImpl(
       channelCapabilities: ctx.channelCapabilities ?? null,
       channelCommandContext: ctx.commandIntent ?? null,
       unifiedTurnContext: unifiedTurnContextStr,
-      nowScratchpad: readNowScratchpad(),
+      nowScratchpad,
       voiceCallControlPrompt: ctx.voiceCallControlPrompt ?? null,
       transportHints: ctx.transportHints ?? null,
       isNonInteractive: !isInteractiveResolved,
@@ -1040,7 +1045,7 @@ export async function runAgentLoopImpl(
 
       // Strip injected context from updated history before compacting,
       // so we compact the "raw" persistent messages.
-      const rawHistory = stripInjectedContext(updatedHistory);
+      const rawHistory = stripInjectionsForCompaction(updatedHistory);
       ctx.messages = rawHistory;
 
       ctx.emitActivityState(
@@ -1182,7 +1187,7 @@ export async function runAgentLoopImpl(
     // convergence loop operates on the full (larger) history.
     if (state.contextTooLargeDetected) {
       if (updatedHistory.length > preRunHistoryLength) {
-        ctx.messages = stripInjectedContext(updatedHistory);
+        ctx.messages = stripInjectionsForCompaction(updatedHistory);
         preRepairMessages = updatedHistory;
         preRunHistoryLength = updatedHistory.length;
       }
@@ -1347,7 +1352,7 @@ export async function runAgentLoopImpl(
           // tier operates on up-to-date history instead of stale
           // pre-rerun messages.
           if (updatedHistory.length > preRunHistoryLength) {
-            ctx.messages = stripInjectedContext(updatedHistory);
+            ctx.messages = stripInjectionsForCompaction(updatedHistory);
             preRepairMessages = updatedHistory;
             preRunHistoryLength = updatedHistory.length;
           }
@@ -1687,7 +1692,11 @@ export async function runAgentLoopImpl(
       { providerName: ctx.provider.name, toolTokenBudget },
     );
 
-    ctx.messages = stripInjectedContext(restoredHistory);
+    // Persist injections in history: runtime-injected context stays on
+    // historical user messages so the conversation prefix is stable for
+    // Anthropic's prefix caching.  Stripping only happens during
+    // compaction/overflow recovery (where a cache miss is expected).
+    ctx.messages = restoredHistory;
 
     emitUsage(
       ctx,
@@ -1938,15 +1947,10 @@ export async function runAgentLoopImpl(
     // Clear at turn end so they never leak into subsequent unrelated messages.
     ctx.commandIntent = undefined;
 
-    if (userMessageId) {
-      const didMutateHistory = consolidateAssistantMessages(
-        ctx.conversationId,
-        userMessageId,
-      );
-      if (didMutateHistory) {
-        rebuildConversationDiskViewFromDbState(ctx.conversationId);
-      }
-    }
+    // Consolidation deferred to compaction: keeping assistant + tool_result
+    // messages unconsolidated preserves the exact message structure sent to
+    // the API, enabling stable prefix caching across turns.  Compaction
+    // consolidates when it summarizes old messages (cache miss is expected).
 
     ctx.drainQueue(yieldedForHandoff ? "checkpoint_handoff" : "loop_complete");
 

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -831,7 +831,7 @@ export function buildUnifiedTurnContextBlock(
  * the message itself is dropped.
  *
  * This is the shared primitive behind the individual strip* functions and
- * the `stripInjectedContext` pipeline.
+ * the `stripInjectionsForCompaction` pipeline.
  */
 export function stripUserTextBlocksByPrefix(
   messages: Message[],
@@ -945,13 +945,35 @@ const RUNTIME_INJECTION_PREFIXES = [
 /**
  * Strip all runtime-injected context from message history in a single pass.
  *
- * All injections (memory context, channel capabilities, workspace top-level,
- * temporal context, active surface context, etc.) are text blocks prepended
- * to user messages with known XML tag prefixes. A single prefix-based pass
- * removes them all.
+ * Used only during compaction and overflow recovery — not on normal turns.
+ * Runtime injections persist in history to keep the conversation prefix
+ * stable for Anthropic's prefix caching. Stripping is only needed when
+ * compaction rewrites the message array (cache miss is expected anyway).
  */
-export function stripInjectedContext(messages: Message[]): Message[] {
+export function stripInjectionsForCompaction(messages: Message[]): Message[] {
   return stripUserTextBlocksByPrefix(messages, RUNTIME_INJECTION_PREFIXES);
+}
+
+/**
+ * Extract the most recently injected NOW.md content from the message history.
+ * Returns null if no NOW.md injection is found.
+ */
+export function findLastInjectedNowContent(
+  messages: Message[],
+): string | null {
+  const prefix = "<NOW.md Always keep this up to date>\n";
+  const suffix = "\n</NOW.md>";
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.role !== "user") continue;
+    for (const block of msg.content) {
+      if (block.type === "text" && block.text.startsWith(prefix)) {
+        const end = block.text.lastIndexOf(suffix);
+        if (end > prefix.length) return block.text.slice(prefix.length, end);
+      }
+    }
+  }
+  return null;
 }
 
 /**

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -57,8 +57,8 @@ import {
   migrateContactsRolePrincipal,
   migrateContactsUserFileColumn,
   migrateConversationForkLineage,
-  migrateConversationsThreadTypeIndex,
   migrateConversationsLastMessageAt,
+  migrateConversationsThreadTypeIndex,
   migrateCreateConversationGraphMemoryState,
   migrateCreateMemoryGraphNodeEdits,
   migrateCreateMemoryGraphTables,
@@ -133,6 +133,7 @@ import {
   migrateSchemaIndexesAndColumns,
   migrateScrubCorruptedImageAttachments,
   migrateStripIntegrationPrefixFromProviderKeys,
+  migrateStripThinkingFromConsolidated,
   migrateUsageDashboardIndexes,
   migrateUsageLlmCallCount,
   migrateVoiceInviteColumns,
@@ -593,6 +594,11 @@ export function initializeDb(): void {
 
   // 107. Add last_message_at denormalized column for message-based sorting
   migrateConversationsLastMessageAt(database);
+
+  // 108. Strip thinking/redacted_thinking from consolidated assistant messages
+  // so the Anthropic provider no longer needs to mutate historical messages,
+  // enabling append-only conversation history for prefix caching.
+  migrateStripThinkingFromConsolidated(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/209-strip-thinking-from-consolidated.ts
+++ b/assistant/src/memory/migrations/209-strip-thinking-from-consolidated.ts
@@ -1,0 +1,85 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+/**
+ * Strip thinking and redacted_thinking blocks from all assistant messages.
+ *
+ * Consolidated messages merge thinking blocks from different API responses,
+ * making their cryptographic signatures invalid. Previously the Anthropic
+ * provider stripped these on every request, mutating the conversation prefix
+ * and defeating prompt caching. This migration cleans them at rest so the
+ * provider no longer needs to strip, enabling append-only conversation
+ * history and stable prefix caching.
+ *
+ * Idempotent — safe to re-run.
+ */
+export function migrateStripThinkingFromConsolidated(
+  database: DrizzleDb,
+): void {
+  withCrashRecovery(
+    database,
+    "migration_strip_thinking_from_consolidated_v1",
+    () => {
+      const raw = getSqliteFrom(database);
+
+      const BATCH_SIZE = 100;
+      let lastRowid = 0;
+
+      for (;;) {
+        const rows = raw
+          .query(
+            `SELECT rowid, id, content FROM messages
+             WHERE role = 'assistant'
+               AND rowid > ?
+             ORDER BY rowid
+             LIMIT ?`,
+          )
+          .all(lastRowid, BATCH_SIZE) as Array<{
+          rowid: number;
+          id: string;
+          content: string;
+        }>;
+
+        if (rows.length === 0) break;
+
+        for (const row of rows) {
+          lastRowid = row.rowid;
+
+          let blocks: Array<{ type: string }>;
+          try {
+            const parsed = JSON.parse(row.content);
+            if (!Array.isArray(parsed)) continue;
+            blocks = parsed;
+          } catch {
+            continue;
+          }
+
+          const hasThinking = blocks.some(
+            (b) => b.type === "thinking" || b.type === "redacted_thinking",
+          );
+          if (!hasThinking) continue;
+
+          const stripped = blocks.filter(
+            (b) => b.type !== "thinking" && b.type !== "redacted_thinking",
+          );
+
+          // Preserve at least one block so the message isn't empty.
+          const finalContent =
+            stripped.length > 0
+              ? stripped
+              : [
+                  {
+                    type: "text" as const,
+                    text: "\x00__PLACEHOLDER__[internal blocks omitted]",
+                  },
+                ];
+
+          raw
+            .query(`UPDATE messages SET content = ? WHERE id = ?`)
+            .run(JSON.stringify(finalContent), row.id);
+        }
+      }
+    },
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -150,6 +150,7 @@ export { migrateCreateMemoryGraphNodeEdits } from "./206-memory-graph-node-edits
 export { migrateScrubCorruptedImageAttachments } from "./206-scrub-corrupted-image-attachments.js";
 export { migrateCreateConversationGraphMemoryState } from "./207-conversation-graph-memory-state.js";
 export { migrateConversationsLastMessageAt } from "./208-conversations-last-message-at.js";
+export { migrateStripThinkingFromConsolidated } from "./209-strip-thinking-from-consolidated.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -206,143 +206,6 @@ function hasOrderedToolResultPrefix(
  * regular content — they are self-paired within the assistant message and must
  * not be separated by the cross-message pairing logic.
  */
-
-/**
- * Expand collapsed multi-turn assistant messages. During agentic tool use, the
- * daemon stores multiple thinking→tool_use→tool_result cycles in a single
- * assistant message. The Anthropic API rejects thinking blocks between
- * tool_use blocks ("tool_use without tool_result immediately after") and
- * requires thinking blocks in the latest assistant message to remain exactly
- * as generated.
- *
- * This function splits collapsed messages at each "thinking/redacted_thinking
- * after tool_use" boundary, recreating the original multi-turn structure.
- * It also distributes tool_result blocks from the following user message to
- * match each segment's tool_use blocks, creating proper assistant→user pairs.
- */
-function expandCollapsedAssistantTurns(
-  messages: Anthropic.MessageParam[],
-): Anthropic.MessageParam[] {
-  const result: Anthropic.MessageParam[] = [];
-
-  for (let mi = 0; mi < messages.length; mi++) {
-    const msg = messages[mi];
-    if (msg.role !== "assistant") {
-      result.push(msg);
-      continue;
-    }
-
-    const content = Array.isArray(msg.content) ? msg.content : [];
-
-    // Check if this message has thinking blocks between tool_use blocks
-    let hasThinkingAfterToolUse = false;
-    let seenToolUse = false;
-    for (const block of content) {
-      if (isToolUseBlock(block)) {
-        seenToolUse = true;
-      } else if (seenToolUse) {
-        const type = (block as { type: string }).type;
-        if (type === "thinking" || type === "redacted_thinking") {
-          hasThinkingAfterToolUse = true;
-          break;
-        }
-      }
-    }
-
-    if (!hasThinkingAfterToolUse) {
-      result.push(msg);
-      continue;
-    }
-
-    // Split at each "thinking after tool_use" boundary into separate segments
-    const segments: Anthropic.ContentBlockParam[][] = [];
-    let current: Anthropic.ContentBlockParam[] = [];
-    let segmentHasToolUse = false;
-
-    for (const block of content) {
-      const type = (block as { type: string }).type;
-      const isThinking = type === "thinking" || type === "redacted_thinking";
-
-      if (isThinking && segmentHasToolUse) {
-        segments.push(current);
-        current = [block];
-        segmentHasToolUse = false;
-      } else {
-        current.push(block);
-        if (isToolUseBlock(block)) {
-          segmentHasToolUse = true;
-        }
-      }
-    }
-    if (current.length > 0) {
-      segments.push(current);
-    }
-
-    // Build a map of tool_results from the following user message (if any)
-    const nextMsg = messages[mi + 1];
-    const nextIsUser = nextMsg && nextMsg.role === "user";
-    const nextContent =
-      nextIsUser && Array.isArray(nextMsg.content) ? nextMsg.content : [];
-    const toolResultMap = new Map<string, Anthropic.ContentBlockParam>();
-    const nonToolResultContent: Anthropic.ContentBlockParam[] = [];
-    for (const block of nextContent) {
-      if (isToolResultBlock(block)) {
-        toolResultMap.set(block.tool_use_id, block);
-      } else {
-        nonToolResultContent.push(block);
-      }
-    }
-
-    // Emit each segment as assistant→user pairs, distributing tool_results
-    for (let si = 0; si < segments.length; si++) {
-      const segment = segments[si];
-      const segToolUseIds = getOrderedToolUseIds(segment);
-      const isLastSegment = si === segments.length - 1;
-
-      result.push({ role: "assistant" as const, content: segment });
-
-      if (segToolUseIds.length > 0 && !isLastSegment) {
-        // Intermediate segment: pair with matching tool_results
-        const segResults = segToolUseIds.map(
-          (id) => toolResultMap.get(id) ?? buildSyntheticToolResult(id),
-        );
-        // Remove matched results from the map
-        for (const id of segToolUseIds) toolResultMap.delete(id);
-        result.push({ role: "user" as const, content: segResults });
-      }
-    }
-
-    // For the last segment, let ensureToolPairing handle pairing with the
-    // (now reduced) user message. Rebuild the user message without the
-    // tool_results that were already distributed to intermediate segments.
-    if (nextIsUser) {
-      const remainingResults = Array.from(toolResultMap.values());
-      const rebuiltUserContent = [...remainingResults, ...nonToolResultContent];
-      // Replace the original user message with the rebuilt one. When all
-      // tool_results were distributed to intermediate segments (empty rebuilt
-      // content), skip the synthetic placeholder if the next message is already
-      // a user turn — ensureToolPairing will pair the last assistant segment
-      // with that next user message naturally.
-      if (rebuiltUserContent.length > 0) {
-        result.push({ role: "user" as const, content: rebuiltUserContent });
-      } else {
-        const nextAfterUser = messages[mi + 2];
-        if (!nextAfterUser || nextAfterUser.role !== "user") {
-          result.push({
-            role: "user" as const,
-            content: [
-              { type: "text" as const, text: SYNTHETIC_CONTINUATION_TEXT },
-            ],
-          });
-        }
-      }
-      mi++; // skip the original user message
-    }
-  }
-
-  return result;
-}
-
 function splitAssistantForToolPairing(content: Anthropic.ContentBlockParam[]): {
   pairedContent: Anthropic.ContentBlockParam[];
   carryoverContent: Anthropic.ContentBlockParam[];
@@ -819,57 +682,12 @@ export class AnthropicProvider implements Provider {
         }
       }
 
-      // Strip thinking/redacted_thinking blocks from historical assistant
-      // messages. These blocks carry cryptographic signatures tied to their
-      // original API response. Consolidated messages (from multi-step tool use)
-      // combine thinking blocks from different responses, making signature
-      // validation fail with "thinking blocks cannot be modified". Stripping is
-      // safe: the API allows it for all historical messages, and new responses
-      // generate fresh thinking blocks.
-      //
-      // The latest assistant turn is preserved: the API requires the most recent
-      // assistant message's thinking blocks to be passed back unmodified when
-      // sending tool results during in-progress tool-use loops.
-      let lastAssistantIdx = -1;
-      for (let i = formatted.length - 1; i >= 0; i--) {
-        if (formatted[i].role === "assistant") {
-          lastAssistantIdx = i;
-          break;
-        }
-      }
-      for (let i = 0; i < formatted.length; i++) {
-        const msg = formatted[i];
-        if (msg.role !== "assistant" || !Array.isArray(msg.content)) continue;
-        if (i === lastAssistantIdx) continue;
-        const stripped = msg.content.filter(
-          (b) =>
-            (b as { type: string }).type !== "thinking" &&
-            (b as { type: string }).type !== "redacted_thinking",
-        );
-        if (stripped.length < msg.content.length) {
-          // Ensure the message isn't empty after stripping
-          msg.content =
-            stripped.length > 0
-              ? stripped
-              : [
-                  {
-                    type: "text" as const,
-                    text: PLACEHOLDER_BLOCKS_OMITTED,
-                  },
-                ];
-        }
-      }
+      // Thinking blocks are stripped at persistence time (consolidation and
+      // DB migration 208) so historical messages are clean when loaded.
+      // Within a turn, assistant messages have original thinking with valid
+      // signatures — the API accepts them. No provider-side stripping needed.
 
-      // Expand collapsed multi-turn assistant messages. When agentic tool use
-      // produces multiple thinking→tool_use cycles in a single stored message,
-      // the API rejects thinking blocks between tool_use blocks. Split such
-      // messages at each "thinking after tool_use" boundary to recreate the
-      // original multi-turn structure. With thinking blocks stripped above, the
-      // expansion is typically a no-op, but is kept as a safety net for edge
-      // cases where stripping is incomplete.
-      const expanded = expandCollapsedAssistantTurns(formatted);
-
-      sentMessages = ensureToolPairing(repairOrphanedServerToolUse(expanded));
+      sentMessages = ensureToolPairing(repairOrphanedServerToolUse(formatted));
       const { effort, speed, output_config, ...restConfig } = (config ??
         {}) as Record<string, unknown> & {
         effort?: Anthropic.OutputConfig["effort"];
@@ -965,34 +783,13 @@ export class AnthropicProvider implements Provider {
         }
       }
 
-      // Place a cache breakpoint on the second-to-last user turn so the
-      // conversation prefix is cached between agent-loop iterations.
-      //
-      // Why second-to-last, not last?  The last user message is always new
-      // (either the initial message with fresh temporal context, or a tool
-      // result appended by the agent loop) so its breakpoint never produces
-      // a cache hit.  The second-to-last user turn is stable between
-      // iterations and caching up to it saves re-processing the full
-      // conversation prefix.
-      //
-      // We use only 1 user-turn breakpoint to stay within the Anthropic
-      // API limit of 4 cache_control blocks total:
-      //   system-static (1) + system-dynamic (2) + last-tool (3) + user (4)
-      const userIndices: number[] = [];
-      for (let i = 0; i < params.messages.length; i++) {
-        if (params.messages[i].role === "user") userIndices.push(i);
-      }
-      // slice(-2, -1) gives the second-to-last; empty array if < 2 user turns.
-      for (const idx of userIndices.slice(-2, -1)) {
-        const content = params.messages[idx].content;
-        if (Array.isArray(content) && content.length > 0) {
-          (
-            content[content.length - 1] as unknown as {
-              cache_control?: { type: string; ttl?: string };
-            }
-          ).cache_control = { type: "ephemeral", ttl: "1h" };
-        }
-      }
+      // Automatic caching: the API places a cache breakpoint on the last
+      // cacheable block and advances it as the conversation grows. With
+      // append-only history, the prefix is stable across turns and tool-use
+      // iterations, so the automatic breakpoint achieves near-optimal cache
+      // hit rates. Combined with manual breakpoints (2 system + 1 tools = 3),
+      // this uses all 4 available cache slots.
+      params.cache_control = { type: "ephemeral" as const, ttl: "1h" as const };
 
       const { signal: timeoutSignal, cleanup: cleanupTimeout } =
         createStreamTimeout(this.streamTimeoutMs, signal);


### PR DESCRIPTION
## Summary

- **Persist runtime injections** — stop stripping injected context at turn end so the conversation prefix is stable for Anthropic's prefix caching. Only strip during compaction/overflow recovery. Add NOW.md change detection to skip re-injection when unchanged.
- **Remove thinking block mutations** — DB migration strips thinking from existing consolidated messages. Remove provider-side stripping and `expandCollapsedAssistantTurns`. Within a turn, thinking blocks have valid signatures and the API accepts them.
- **Defer consolidation + enable automatic caching** — stop merging messages at turn end to preserve the exact API message structure. Enable request-level `cache_control` with 1h TTL; remove manual second-to-last user turn breakpoint.

## Test plan

- [x] `bunx tsc --noEmit` — clean (no new errors)
- [x] `bun test anthropic-provider.test.ts` — 41 pass, 0 fail
- [x] `bun test conversation-runtime-assembly.test.ts` — 86 pass, 0 fail
- [x] `bun test conversation-agent-loop.test.ts` — 35 pass, 0 fail
- [x] `bun test conversation-agent-loop-overflow.test.ts` — 3 pass, 7 todo, 0 fail
- [x] `bun test conversation-history-web-search.test.ts` — 8 pass, 0 fail
- [ ] Manual: monitor `cache_read_input_tokens` in usage events across multi-turn conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
