### PR TITLE
fix: order reasoning sections before response in LLM context inspector

### DIFF
--- a/assistant/src/__tests__/llm-context-normalization.test.ts
+++ b/assistant/src/__tests__/llm-context-normalization.test.ts
@@ -279,12 +279,6 @@ describe("normalizeLlmContextPayloads", () => {
         text: "Find the latest changelog.",
       },
       {
-        kind: "message",
-        label: "Assistant message 2",
-        role: "assistant",
-        text: "Checking sources.",
-      },
-      {
         kind: "reasoning",
         label: "Assistant message 2 reasoning",
         role: "assistant",
@@ -295,6 +289,12 @@ describe("normalizeLlmContextPayloads", () => {
         label: "Assistant message 2 reasoning",
         role: "assistant",
         text: "[redacted thinking]",
+      },
+      {
+        kind: "message",
+        label: "Assistant message 2",
+        role: "assistant",
+        text: "Checking sources.",
       },
       {
         kind: "tool_use",
@@ -332,12 +332,6 @@ describe("normalizeLlmContextPayloads", () => {
     ]);
     expect(normalized.responseSections).toEqual([
       {
-        kind: "message",
-        label: "Assistant response",
-        role: "assistant",
-        text: "I found the changelog.",
-      },
-      {
         kind: "reasoning",
         label: "Assistant response reasoning",
         role: "assistant",
@@ -348,6 +342,12 @@ describe("normalizeLlmContextPayloads", () => {
         label: "Assistant response reasoning",
         role: "assistant",
         text: "[redacted thinking]",
+      },
+      {
+        kind: "message",
+        label: "Assistant response",
+        role: "assistant",
+        text: "I found the changelog.",
       },
       {
         kind: "tool_use",
@@ -413,12 +413,6 @@ describe("normalizeLlmContextPayloads", () => {
     });
     expect(normalized.responseSections).toEqual([
       {
-        kind: "message",
-        label: "Assistant response",
-        role: "assistant",
-        text: "The answer is 42.",
-      },
-      {
         kind: "reasoning",
         label: "Assistant response reasoning",
         role: "assistant",
@@ -429,6 +423,12 @@ describe("normalizeLlmContextPayloads", () => {
         label: "Assistant response reasoning",
         role: "assistant",
         text: "[redacted thinking]",
+      },
+      {
+        kind: "message",
+        label: "Assistant response",
+        role: "assistant",
+        text: "The answer is 42.",
       },
     ]);
   });

--- a/assistant/src/runtime/routes/llm-context-normalization.ts
+++ b/assistant/src/runtime/routes/llm-context-normalization.ts
@@ -570,6 +570,20 @@ function anthropicMessageSections(
   const role = asString(message.role) ?? "unknown";
   const content = message.content;
   const sections: LlmContextSection[] = [];
+
+  // Collect reasoning sections first so they appear before the message text.
+  for (const block of asRecordArray(content) ?? []) {
+    const type = asString(block.type);
+    if (type === "thinking" || type === "redacted_thinking") {
+      sections.push({
+        kind: "reasoning",
+        label: `${label} reasoning`,
+        role,
+        text: collectAnthropicReasoningText(block),
+      });
+    }
+  }
+
   const text = collectAnthropicMessageText(content);
   if (text) {
     sections.push({
@@ -582,16 +596,6 @@ function anthropicMessageSections(
 
   for (const block of asRecordArray(content) ?? []) {
     const type = asString(block.type);
-    if (type === "thinking" || type === "redacted_thinking") {
-      sections.push({
-        kind: "reasoning",
-        label: `${label} reasoning`,
-        role,
-        text: collectAnthropicReasoningText(block),
-      });
-      continue;
-    }
-
     if (isAnthropicToolUseType(type)) {
       sections.push({
         kind: "tool_use",


### PR DESCRIPTION
## Summary
- Reorder `anthropicMessageSections()` to emit reasoning sections (thinking/redacted_thinking) before the message text section, so the LLM context inspector displays reasoning above the corresponding response
- Updated existing test expectations to match the new ordering

## Original prompt
In the LLM context inspector, the reasoning block should come before the corresponding response block
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23354" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
