### PR TITLE
fix: remove dead high-risk guard after proxy risk downgrade

### DIFF
--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -341,10 +341,7 @@ export function createProxyApprovalCallback(
     );
     if (existingRule && existingRule.decision !== "ask") {
       if (existingRule.decision === "deny") return false;
-      // For high-risk proxy decisions, a plain allow rule (without allowHighRisk)
-      // must fall through to prompting — mirroring the checker's behavior.
-      if (riskLevel !== "high" || existingRule.allowHighRisk === true)
-        return true;
+      return true;
     }
 
     // Use the checker's built-in allowlist generation for network_request


### PR DESCRIPTION
## Summary
- Remove dead `riskLevel !== "high"` comparison that caused TS2367 type error in CI
- The previous commit (1a48663) changed `riskLevel` from a conditional expression to always `"medium"`, making the high-risk guard unreachable dead code

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23942108030/job/69830475865
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23357" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
