### PR TITLE
fix: lint error — unused 'kind' variable in memory-recall-log-store

### DIFF
--- a/assistant/src/memory/memory-recall-log-store.ts
+++ b/assistant/src/memory/memory-recall-log-store.ts
@@ -104,7 +104,7 @@ export function normalizeTopCandidates(raw: unknown): unknown {
     if (!entry || typeof entry !== "object") return entry;
 
     // Start with a shallow copy, then apply field renames
-    const { key, finalScore, semantic, recency, kind, ...rest } = entry;
+    const { key, finalScore, semantic, recency, kind: _kind, ...rest } = entry;
 
     // nodeId: prefer existing nodeId, fall back to key
     if (rest.nodeId === undefined && key !== undefined) {


### PR DESCRIPTION
## Summary
- Rename destructured `kind` to `_kind` in `normalizeTopCandidates()` to fix `@typescript-eslint/no-unused-vars` lint error

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23942108030/job/69830475873