### PR TITLE
fix: update color tokens and VCard component to match Figma designs

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsCard.swift
@@ -49,7 +49,7 @@ private struct ConditionalCardModifier: ViewModifier {
     let showBorder: Bool
     func body(content: Content) -> some View {
         if showBorder {
-            content.vCard(background: VColor.surfaceOverlay)
+            content.vCard(background: VColor.surfaceLift)
         } else {
             content
         }
@@ -60,7 +60,7 @@ private struct ConditionalCardModifier: ViewModifier {
 struct SettingsDivider: View {
     var body: some View {
         Rectangle()
-            .fill(VColor.borderDisabled)
+            .fill(VColor.borderHover)
             .frame(height: 1)
     }
 }

--- a/clients/shared/DesignSystem/Components/Display/VCard.swift
+++ b/clients/shared/DesignSystem/Components/Display/VCard.swift
@@ -23,7 +23,7 @@ public struct VCard<Content: View>: View {
     private var backgroundColor: Color {
         if isActive { return VColor.surfaceActive }
         if isHovered && action != nil { return VColor.surfaceBase }
-        return VColor.surfaceOverlay
+        return VColor.surfaceLift
     }
 
     public var body: some View {
@@ -33,7 +33,7 @@ public struct VCard<Content: View>: View {
             .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
             .overlay(
                 RoundedRectangle(cornerRadius: VRadius.xl)
-                    .strokeBorder(VColor.borderDisabled, lineWidth: 2)
+                    .strokeBorder(VColor.borderHover, lineWidth: 1)
             )
             .contentShape(RoundedRectangle(cornerRadius: VRadius.xl))
             .onTapGesture { action?() }

--- a/clients/shared/DesignSystem/Modifiers/CardModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/CardModifier.swift
@@ -2,9 +2,9 @@ import SwiftUI
 
 public struct CardModifier: ViewModifier {
     public var radius: CGFloat = VRadius.lg
-    public var background: Color = VColor.surfaceBase
+    public var background: Color = VColor.surfaceLift
 
-    public init(radius: CGFloat = VRadius.lg, background: Color = VColor.surfaceBase) {
+    public init(radius: CGFloat = VRadius.lg, background: Color = VColor.surfaceLift) {
         self.radius = radius
         self.background = background
     }
@@ -17,14 +17,14 @@ public struct CardModifier: ViewModifier {
             )
             .overlay(
                 RoundedRectangle(cornerRadius: radius)
-                    .strokeBorder(VColor.borderDisabled, lineWidth: 2)
+                    .strokeBorder(VColor.borderHover, lineWidth: 1)
                     .allowsHitTesting(false)
             )
     }
 }
 
 public extension View {
-    func vCard(radius: CGFloat = VRadius.lg, background: Color = VColor.surfaceBase) -> some View {
+    func vCard(radius: CGFloat = VRadius.lg, background: Color = VColor.surfaceLift) -> some View {
         modifier(CardModifier(radius: radius, background: background))
     }
 }

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -132,7 +132,7 @@ private enum FigmaRawColor {
     static let borderDarkHover = Color(hex: 0x2D3339)
     static let borderLightActive = Color(hex: 0x2D3339)
     static let borderDarkActive = Color(hex: 0xF6F5F4)
-    static let borderLightElement = Color(hex: 0xD3CCC5)
+    static let borderLightElement = Color(hex: 0xCFCCC9)
     static let borderDarkElement = Color(hex: 0x5A6672)
 
     // Content
@@ -144,7 +144,7 @@ private enum FigmaRawColor {
     static let contentDarkSecondary = Color(hex: 0xA9B2BB)
     static let contentLightTertiary = Color(hex: 0x71808E)
     static let contentDarkTertiary = Color(hex: 0x8D99A5)
-    static let contentLightDisabled = Color(hex: 0xA9B2BB)
+    static let contentLightDisabled = Color(hex: 0xCFCCC9)
     static let contentDarkDisabled = Color(hex: 0x5A6672)
     static let contentLightBackground = Color(hex: 0xF2F0EE)
     static let contentDarkBackground = Color(hex: 0x2D3339)
@@ -186,13 +186,13 @@ public enum VColor {
         .borderBase: .init(lightHex: "#F2F0EE", darkHex: "#24292E"),
         .borderHover: .init(lightHex: "#F6F5F4", darkHex: "#2D3339"),
         .borderActive: .init(lightHex: "#2D3339", darkHex: "#F6F5F4"),
-        .borderElement: .init(lightHex: "#D3CCC5", darkHex: "#5A6672"),
+        .borderElement: .init(lightHex: "#CFCCC9", darkHex: "#5A6672"),
 
         .contentEmphasized: .init(lightHex: "#161616", darkHex: "#FDFDFC"),
         .contentDefault: .init(lightHex: "#24292E", darkHex: "#F6F5F4"),
         .contentSecondary: .init(lightHex: "#5A6672", darkHex: "#A9B2BB"),
         .contentTertiary: .init(lightHex: "#71808E", darkHex: "#8D99A5"),
-        .contentDisabled: .init(lightHex: "#A9B2BB", darkHex: "#5A6672"),
+        .contentDisabled: .init(lightHex: "#CFCCC9", darkHex: "#5A6672"),
         .contentBackground: .init(lightHex: "#F2F0EE", darkHex: "#2D3339"),
         .contentInset: .init(lightHex: "#FDFDFC", darkHex: "#17191C"),
 


### PR DESCRIPTION
## Summary
- Update borderElement light (#D3CCC5 → #CFCCC9) and contentDisabled light (#A9B2BB → #CFCCC9) color tokens to match Figma
- Update VCard and CardModifier to use surfaceLift background, borderHover border color, and 1pt border width
- Update SettingsCard to use surfaceLift background and borderHover divider color

Part of plan: settings-colors-update.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
