### PR TITLE
fix: update settings colors and VCard component to match Figma

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -591,7 +591,7 @@ struct SettingsPanel: View {
             }
             .padding(VSpacing.lg)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .vCard(background: VColor.surfaceOverlay)
+            .vCard()
 
             // TRUST RULES section
             if connectionManager != nil {
@@ -612,7 +612,7 @@ struct SettingsPanel: View {
                 }
                 .padding(VSpacing.lg)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .vCard(background: VColor.surfaceOverlay)
+                .vCard()
             }
 
             // PRIVACY section

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -412,11 +412,11 @@ private struct WorkspaceTreeSidebar: View {
             handleDrop(providers: providers, targetDir: "", state: state, workspaceClient: workspaceClient)
             return true
         }
-        .background(VColor.surfaceOverlay)
+        .background(VColor.surfaceLift)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
         .overlay(
             RoundedRectangle(cornerRadius: VRadius.xl)
-                .strokeBorder(VColor.borderDisabled, lineWidth: 2)
+                .strokeBorder(VColor.borderHover, lineWidth: 1)
                 .allowsHitTesting(false)
         )
         .alert("New File", isPresented: $state.showingNewFileAlert) {

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
@@ -75,7 +75,7 @@ struct AssistantBackupsSection: View {
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .vCard(background: VColor.surfaceOverlay)
+        .vCard()
         .frame(maxWidth: .infinity, alignment: .leading)
         .task {
             if assistant.isManaged || (assistant.isRemote && !assistant.isDocker) {

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -58,7 +58,7 @@ struct AssistantTransferSection: View {
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .vCard(background: VColor.surfaceOverlay)
+        .vCard()
         .alert("Transfer to Cloud", isPresented: $showingConfirmation) {
             Button("Cancel", role: .cancel) {}
             Button("Transfer", role: .destructive) {

--- a/clients/macos/vellum-assistant/Features/Settings/EmbeddingServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/EmbeddingServiceCard.swift
@@ -115,7 +115,7 @@ struct EmbeddingServiceCard: View {
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .vCard(radius: VRadius.xl, background: VColor.surfaceOverlay)
+        .vCard(radius: VRadius.xl)
         .onAppear {
             draftProvider = store.embeddingProvider
             draftModel = store.embeddingModel ?? ""

--- a/clients/macos/vellum-assistant/Features/Settings/ServiceModeCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ServiceModeCard.swift
@@ -33,7 +33,7 @@ struct ServiceModeCard<ManagedContent: View, YourOwnContent: View>: View {
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .vCard(radius: VRadius.xl, background: VColor.surfaceOverlay)
+        .vCard(radius: VRadius.xl)
     }
 
     // MARK: - Header

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsArchivedConversationsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsArchivedConversationsTab.swift
@@ -29,7 +29,7 @@ struct SettingsArchivedConversationsTab: View {
                 }
                 .padding(VSpacing.lg)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .vCard(background: VColor.surfaceOverlay)
+                .vCard()
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsCard.swift
@@ -49,7 +49,7 @@ private struct ConditionalCardModifier: ViewModifier {
     let showBorder: Bool
     func body(content: Content) -> some View {
         if showBorder {
-            content.vCard(background: VColor.surfaceOverlay)
+            content.vCard(background: VColor.surfaceLift)
         } else {
             content
         }
@@ -60,7 +60,7 @@ private struct ConditionalCardModifier: ViewModifier {
 struct SettingsDivider: View {
     var body: some View {
         Rectangle()
-            .fill(VColor.borderDisabled)
+            .fill(VColor.borderHover)
             .frame(height: 1)
     }
 }

--- a/clients/shared/DesignSystem/Components/Display/VCard.swift
+++ b/clients/shared/DesignSystem/Components/Display/VCard.swift
@@ -23,7 +23,7 @@ public struct VCard<Content: View>: View {
     private var backgroundColor: Color {
         if isActive { return VColor.surfaceActive }
         if isHovered && action != nil { return VColor.surfaceBase }
-        return VColor.surfaceOverlay
+        return VColor.surfaceLift
     }
 
     public var body: some View {
@@ -33,7 +33,7 @@ public struct VCard<Content: View>: View {
             .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
             .overlay(
                 RoundedRectangle(cornerRadius: VRadius.xl)
-                    .strokeBorder(VColor.borderDisabled, lineWidth: 2)
+                    .strokeBorder(VColor.borderHover, lineWidth: 1)
             )
             .contentShape(RoundedRectangle(cornerRadius: VRadius.xl))
             .onTapGesture { action?() }

--- a/clients/shared/DesignSystem/Components/Display/VFileBrowser.swift
+++ b/clients/shared/DesignSystem/Components/Display/VFileBrowser.swift
@@ -100,11 +100,11 @@ public struct VFileBrowser<ContentPane: View>: View {
         }
         .padding(VSpacing.md)
         .frame(width: sidebarWidth)
-        .background(VColor.surfaceOverlay)
+        .background(VColor.surfaceLift)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
         .overlay(
             RoundedRectangle(cornerRadius: VRadius.xl)
-                .strokeBorder(VColor.borderDisabled, lineWidth: 2)
+                .strokeBorder(VColor.borderHover, lineWidth: 1)
         )
     }
 
@@ -113,11 +113,11 @@ public struct VFileBrowser<ContentPane: View>: View {
     private var rightPane: some View {
         contentPane(selectedFile)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(VColor.surfaceOverlay)
+            .background(VColor.surfaceLift)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
             .overlay(
                 RoundedRectangle(cornerRadius: VRadius.xl)
-                    .strokeBorder(VColor.borderDisabled, lineWidth: 2)
+                    .strokeBorder(VColor.borderHover, lineWidth: 1)
             )
     }
 }

--- a/clients/shared/DesignSystem/Gallery/Sections/DisplayGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/DisplayGallerySection.swift
@@ -166,7 +166,7 @@ struct DisplayGallerySection: View {
                         .foregroundStyle(VColor.contentSecondary)
                 }
                 .padding(VSpacing.lg)
-                .vCard(background: VColor.surfaceOverlay)
+                .vCard()
 
                 VDisclosureSection(
                     title: "With Subtitle",
@@ -178,7 +178,7 @@ struct DisplayGallerySection: View {
                         .foregroundStyle(VColor.contentSecondary)
                 }
                 .padding(VSpacing.lg)
-                .vCard(background: VColor.surfaceOverlay)
+                .vCard()
 
             }
 

--- a/clients/shared/DesignSystem/Modifiers/CardModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/CardModifier.swift
@@ -2,9 +2,9 @@ import SwiftUI
 
 public struct CardModifier: ViewModifier {
     public var radius: CGFloat = VRadius.lg
-    public var background: Color = VColor.surfaceBase
+    public var background: Color = VColor.surfaceLift
 
-    public init(radius: CGFloat = VRadius.lg, background: Color = VColor.surfaceBase) {
+    public init(radius: CGFloat = VRadius.lg, background: Color = VColor.surfaceLift) {
         self.radius = radius
         self.background = background
     }
@@ -17,14 +17,14 @@ public struct CardModifier: ViewModifier {
             )
             .overlay(
                 RoundedRectangle(cornerRadius: radius)
-                    .strokeBorder(VColor.borderDisabled, lineWidth: 2)
+                    .strokeBorder(VColor.borderHover, lineWidth: 1)
                     .allowsHitTesting(false)
             )
     }
 }
 
 public extension View {
-    func vCard(radius: CGFloat = VRadius.lg, background: Color = VColor.surfaceBase) -> some View {
+    func vCard(radius: CGFloat = VRadius.lg, background: Color = VColor.surfaceLift) -> some View {
         modifier(CardModifier(radius: radius, background: background))
     }
 }

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -132,7 +132,7 @@ private enum FigmaRawColor {
     static let borderDarkHover = Color(hex: 0x2D3339)
     static let borderLightActive = Color(hex: 0x2D3339)
     static let borderDarkActive = Color(hex: 0xF6F5F4)
-    static let borderLightElement = Color(hex: 0xD3CCC5)
+    static let borderLightElement = Color(hex: 0xCFCCC9)
     static let borderDarkElement = Color(hex: 0x5A6672)
 
     // Content
@@ -144,7 +144,7 @@ private enum FigmaRawColor {
     static let contentDarkSecondary = Color(hex: 0xA9B2BB)
     static let contentLightTertiary = Color(hex: 0x71808E)
     static let contentDarkTertiary = Color(hex: 0x8D99A5)
-    static let contentLightDisabled = Color(hex: 0xA9B2BB)
+    static let contentLightDisabled = Color(hex: 0xCFCCC9)
     static let contentDarkDisabled = Color(hex: 0x5A6672)
     static let contentLightBackground = Color(hex: 0xF2F0EE)
     static let contentDarkBackground = Color(hex: 0x2D3339)
@@ -186,13 +186,13 @@ public enum VColor {
         .borderBase: .init(lightHex: "#F2F0EE", darkHex: "#24292E"),
         .borderHover: .init(lightHex: "#F6F5F4", darkHex: "#2D3339"),
         .borderActive: .init(lightHex: "#2D3339", darkHex: "#F6F5F4"),
-        .borderElement: .init(lightHex: "#D3CCC5", darkHex: "#5A6672"),
+        .borderElement: .init(lightHex: "#CFCCC9", darkHex: "#5A6672"),
 
         .contentEmphasized: .init(lightHex: "#161616", darkHex: "#FDFDFC"),
         .contentDefault: .init(lightHex: "#24292E", darkHex: "#F6F5F4"),
         .contentSecondary: .init(lightHex: "#5A6672", darkHex: "#A9B2BB"),
         .contentTertiary: .init(lightHex: "#71808E", darkHex: "#8D99A5"),
-        .contentDisabled: .init(lightHex: "#A9B2BB", darkHex: "#5A6672"),
+        .contentDisabled: .init(lightHex: "#CFCCC9", darkHex: "#5A6672"),
         .contentBackground: .init(lightHex: "#F2F0EE", darkHex: "#2D3339"),
         .contentInset: .init(lightHex: "#FDFDFC", darkHex: "#17191C"),
 


### PR DESCRIPTION
## Summary
Update color tokens and VCard component to match latest Figma designs for Settings page in both light and dark mode.

- Align `borderElement` light and `contentDisabled` light color tokens with Figma
- Update VCard/CardModifier to use `surfaceLift` background, `borderHover` border, and 1pt border width
- Update SettingsCard background and divider colors

## PRs merged into feature branch
- #23361: fix: update color tokens and VCard component to match Figma designs

Part of plan: settings-colors-update.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23362" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
