### PR TITLE
fix: update VFileBrowser and WorkspacePanel to new card styling

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -412,11 +412,11 @@ private struct WorkspaceTreeSidebar: View {
             handleDrop(providers: providers, targetDir: "", state: state, workspaceClient: workspaceClient)
             return true
         }
-        .background(VColor.surfaceOverlay)
+        .background(VColor.surfaceLift)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
         .overlay(
             RoundedRectangle(cornerRadius: VRadius.xl)
-                .strokeBorder(VColor.borderDisabled, lineWidth: 2)
+                .strokeBorder(VColor.borderHover, lineWidth: 1)
                 .allowsHitTesting(false)
         )
         .alert("New File", isPresented: $state.showingNewFileAlert) {

--- a/clients/shared/DesignSystem/Components/Display/VFileBrowser.swift
+++ b/clients/shared/DesignSystem/Components/Display/VFileBrowser.swift
@@ -100,11 +100,11 @@ public struct VFileBrowser<ContentPane: View>: View {
         }
         .padding(VSpacing.md)
         .frame(width: sidebarWidth)
-        .background(VColor.surfaceOverlay)
+        .background(VColor.surfaceLift)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
         .overlay(
             RoundedRectangle(cornerRadius: VRadius.xl)
-                .strokeBorder(VColor.borderDisabled, lineWidth: 2)
+                .strokeBorder(VColor.borderHover, lineWidth: 1)
         )
     }
 
@@ -113,11 +113,11 @@ public struct VFileBrowser<ContentPane: View>: View {
     private var rightPane: some View {
         contentPane(selectedFile)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(VColor.surfaceOverlay)
+            .background(VColor.surfaceLift)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
             .overlay(
                 RoundedRectangle(cornerRadius: VRadius.xl)
-                    .strokeBorder(VColor.borderDisabled, lineWidth: 2)
+                    .strokeBorder(VColor.borderHover, lineWidth: 1)
             )
     }
 }


### PR DESCRIPTION
## Summary
Update VFileBrowser and WorkspacePanel to use borderHover/1pt/surfaceLift card styling, matching the updated VCard and CardModifier patterns.

Part of plan: settings-colors-update.md (fix round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23363" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
