### PR TITLE
fix: migrate remaining surfaceOverlay card backgrounds to surfaceLift

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -591,7 +591,7 @@ struct SettingsPanel: View {
             }
             .padding(VSpacing.lg)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .vCard(background: VColor.surfaceOverlay)
+            .vCard()
 
             // TRUST RULES section
             if connectionManager != nil {
@@ -612,7 +612,7 @@ struct SettingsPanel: View {
                 }
                 .padding(VSpacing.lg)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .vCard(background: VColor.surfaceOverlay)
+                .vCard()
             }
 
             // PRIVACY section

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
@@ -75,7 +75,7 @@ struct AssistantBackupsSection: View {
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .vCard(background: VColor.surfaceOverlay)
+        .vCard()
         .frame(maxWidth: .infinity, alignment: .leading)
         .task {
             if assistant.isManaged || (assistant.isRemote && !assistant.isDocker) {

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -58,7 +58,7 @@ struct AssistantTransferSection: View {
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .vCard(background: VColor.surfaceOverlay)
+        .vCard()
         .alert("Transfer to Cloud", isPresented: $showingConfirmation) {
             Button("Cancel", role: .cancel) {}
             Button("Transfer", role: .destructive) {

--- a/clients/macos/vellum-assistant/Features/Settings/EmbeddingServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/EmbeddingServiceCard.swift
@@ -115,7 +115,7 @@ struct EmbeddingServiceCard: View {
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .vCard(radius: VRadius.xl, background: VColor.surfaceOverlay)
+        .vCard(radius: VRadius.xl)
         .onAppear {
             draftProvider = store.embeddingProvider
             draftModel = store.embeddingModel ?? ""

--- a/clients/macos/vellum-assistant/Features/Settings/ServiceModeCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ServiceModeCard.swift
@@ -33,7 +33,7 @@ struct ServiceModeCard<ManagedContent: View, YourOwnContent: View>: View {
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .vCard(radius: VRadius.xl, background: VColor.surfaceOverlay)
+        .vCard(radius: VRadius.xl)
     }
 
     // MARK: - Header

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsArchivedConversationsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsArchivedConversationsTab.swift
@@ -29,7 +29,7 @@ struct SettingsArchivedConversationsTab: View {
                 }
                 .padding(VSpacing.lg)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .vCard(background: VColor.surfaceOverlay)
+                .vCard()
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
## Summary
Migrate 7 remaining .vCard(background: VColor.surfaceOverlay) call sites to use the new surfaceLift default, ensuring visual consistency across all settings cards.

Part of plan: settings-colors-update.md (fix round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23364" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
