### PR TITLE
fix: update gallery examples to use default card background

### DIFF
--- a/clients/shared/DesignSystem/Gallery/Sections/DisplayGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/DisplayGallerySection.swift
@@ -166,7 +166,7 @@ struct DisplayGallerySection: View {
                         .foregroundStyle(VColor.contentSecondary)
                 }
                 .padding(VSpacing.lg)
-                .vCard(background: VColor.surfaceOverlay)
+                .vCard()
 
                 VDisclosureSection(
                     title: "With Subtitle",
@@ -178,7 +178,7 @@ struct DisplayGallerySection: View {
                         .foregroundStyle(VColor.contentSecondary)
                 }
                 .padding(VSpacing.lg)
-                .vCard(background: VColor.surfaceOverlay)
+                .vCard()
 
             }
 


### PR DESCRIPTION
## Summary
Update DisplayGallerySection to use default .vCard() background instead of explicit surfaceOverlay.

Part of plan: settings-colors-update.md (fix round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
