### PR TITLE
fix: update VShortcutTag to match Figma design tokens

### DIFF
--- a/clients/shared/DesignSystem/Core/Feedback/VShortcutTag.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VShortcutTag.swift
@@ -9,7 +9,7 @@ public struct VShortcutTag: View {
     @State private var isHovered = false
 
     private let tagColor = VColor.contentSecondary
-    private let borderColor = VColor.borderBase
+    private let borderColor = VColor.borderElement
 
     public init(_ text: String, icon: String? = nil, action: (() -> Void)? = nil) {
         self.text = text
@@ -18,16 +18,16 @@ public struct VShortcutTag: View {
     }
 
     private var tagContent: some View {
-        HStack(spacing: VSpacing.xs) {
+        HStack(spacing: 1) {
             if let icon {
-                VIconView(.resolve(icon), size: 11)
+                VIconView(.resolve(icon), size: 12)
             }
             Text(text)
-                .font(VFont.labelDefault)
+                .font(VFont.bodyMediumDefault)
         }
         .foregroundStyle(tagColor)
-        .padding(.horizontal, VSpacing.sm)
-        .padding(.vertical, VSpacing.xs)
+        .padding(.horizontal, 6)
+        .padding(.vertical, VSpacing.xxs)
         .background(
             Capsule()
                 .strokeBorder(isHovered ? tagColor.opacity(0.5) : borderColor, lineWidth: 1)

--- a/clients/shared/DesignSystem/Core/Feedback/VShortcutTag.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VShortcutTag.swift
@@ -18,16 +18,16 @@ public struct VShortcutTag: View {
     }
 
     private var tagContent: some View {
-        HStack(spacing: 1) {
+        HStack(spacing: VSpacing.xxs) {
             if let icon {
                 VIconView(.resolve(icon), size: 12)
             }
             Text(text)
-                .font(VFont.bodyMediumDefault)
+                .font(VFont.bodySmallDefault)
         }
         .foregroundStyle(tagColor)
-        .padding(.horizontal, 6)
-        .padding(.vertical, VSpacing.xxs)
+        .padding(.horizontal, VSpacing.xs)
+        .padding(.vertical, VSpacing.xs)
         .background(
             Capsule()
                 .strokeBorder(isHovered ? tagColor.opacity(0.5) : borderColor, lineWidth: 1)

--- a/clients/shared/DesignSystem/Core/Feedback/VShortcutTag.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VShortcutTag.swift
@@ -26,7 +26,7 @@ public struct VShortcutTag: View {
                 .font(VFont.bodySmallDefault)
         }
         .foregroundStyle(tagColor)
-        .padding(.horizontal, VSpacing.xs)
+        .padding(.horizontal, VSpacing.sm)
         .padding(.vertical, VSpacing.xs)
         .background(
             Capsule()


### PR DESCRIPTION
## Summary
- Update border color from `borderBase` to `borderElement` to match Figma
- Update font from `labelDefault` (11px) to `bodyMediumDefault` (14px)
- Update icon size from 11pt to 12pt
- Tighten spacing and padding to match Figma spec (gap 1px, h-pad 6px, v-pad 2px)

## Test plan
- [ ] Verify shortcut tags in Settings > Accessibility (keyboard shortcuts)
- [ ] Verify ⌘K search tag in top nav bar
- [ ] Check both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
