### PR TITLE
Skills tab: source-based filter redesign & UX polish

### DIFF
--- a/clients/ios/Views/Intelligence/SkillDetailView.swift
+++ b/clients/ios/Views/Intelligence/SkillDetailView.swift
@@ -156,7 +156,7 @@ struct SkillDetailView: View {
                     .multilineTextAlignment(.center)
             }
 
-            VSkillTypePill(origin: skill.origin, status: skill.status)
+            VSkillTypePill(origin: skill.origin)
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, VSpacing.sm)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -297,7 +297,7 @@ struct SkillItemRow: View {
                             .lineLimit(1)
                             .truncationMode(.tail)
 
-                        VSkillTypePill(origin: skill.origin, status: skill.status)
+                        VSkillTypePill(origin: skill.origin)
 
                         Spacer()
                     }
@@ -352,7 +352,7 @@ struct AvailableSkillItemRow: View {
                             .foregroundStyle(VColor.contentEmphasized)
                             .lineLimit(1)
                             .truncationMode(.tail)
-                        VSkillTypePill(origin: skill.origin, status: skill.status)
+                        VSkillTypePill(origin: skill.origin)
                         Spacer()
                     }
                     Text(skill.description)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -175,7 +175,7 @@ struct AgentPanelContent: View {
         case .available: return "No Skills Available"
         case .vellum: return "No Vellum Skills"
         case .community: return "No Community Skills"
-        case .custom: return "No Created Skills"
+        case .custom: return "No Custom Skills"
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -163,6 +163,50 @@ struct AgentPanelContent: View {
         .accessibilityAddTraits(skillsManager.selectedCategory == category ? .isSelected : [])
     }
 
+    // MARK: - Empty State
+
+    private var emptyStateTitle: String {
+        if let category = skillsManager.selectedCategory {
+            return "No \(category.displayName) Skills"
+        }
+        switch skillsManager.skillFilter {
+        case .all: return "No Skills Available"
+        case .installed: return "No Skills Installed"
+        case .available: return "No Skills Available"
+        case .vellum: return "No Vellum Skills"
+        case .community: return "No Community Skills"
+        case .custom: return "No Custom Skills"
+        }
+    }
+
+    private var emptyStateSubtitle: String {
+        if skillsManager.selectedCategory != nil {
+            return "Try selecting a different category or clearing the filter."
+        }
+        switch skillsManager.skillFilter {
+        case .all: return "Check your connection to the Vellum catalog."
+        case .installed: return "Ask your assistant in chat to search for and install new skills."
+        case .available: return "All available skills have been installed."
+        case .vellum: return "No bundled Vellum skills found."
+        case .community: return "No Community skills found. Try installing some from the catalog."
+        case .custom: return "Create a custom skill by describing what you want in chat."
+        }
+    }
+
+    private var emptyStateIcon: String {
+        if skillsManager.selectedCategory != nil {
+            return VIcon.layoutGrid.rawValue
+        }
+        switch skillsManager.skillFilter {
+        case .all: return VIcon.cloudOff.rawValue
+        case .installed: return VIcon.zap.rawValue
+        case .available: return VIcon.circleCheck.rawValue
+        case .vellum: return VIcon.package.rawValue
+        case .community: return VIcon.globe.rawValue
+        case .custom: return VIcon.user.rawValue
+        }
+    }
+
     // MARK: - Content View
 
     @ViewBuilder
@@ -190,15 +234,9 @@ struct AgentPanelContent: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if skillsManager.filteredSkills.isEmpty {
             VEmptyState(
-                title: skillsManager.skillFilter == .all
-                    ? "No Skills Available"
-                    : (skillsManager.selectedCategory == nil ? "No Skills Installed" : "No \(skillsManager.selectedCategory!.displayName) Skills"),
-                subtitle: skillsManager.skillFilter == .all
-                    ? "Check your connection to the Vellum catalog."
-                    : (skillsManager.selectedCategory == nil
-                        ? "Ask your assistant in chat to search for and install new skills."
-                        : "Try selecting a different category or clearing the filter."),
-                icon: skillsManager.skillFilter == .all ? VIcon.cloudOff.rawValue : VIcon.zap.rawValue
+                title: emptyStateTitle,
+                subtitle: emptyStateSubtitle,
+                icon: emptyStateIcon
             )
         } else {
             ScrollView {
@@ -259,7 +297,7 @@ struct SkillItemRow: View {
                             .lineLimit(1)
                             .truncationMode(.tail)
 
-                        skillTag(for: skill.origin, status: skill.status)
+                        VSkillTypePill(origin: skill.origin, status: skill.status)
 
                         Spacer()
                     }
@@ -271,19 +309,23 @@ struct SkillItemRow: View {
                         .truncationMode(.tail)
                 }
 
-                if isRemovable {
-                    VButton(
-                        label: "Delete",
-                        iconOnly: VIcon.trash.rawValue,
-                        style: .dangerGhost,
-                        action: onDelete
-                    )
-                    .accessibilityLabel("Uninstall skill")
-                }
+                VButton(
+                    label: "Remove",
+                    leftIcon: VIcon.trash.rawValue,
+                    style: .dangerGhost,
+                    size: .compact,
+                    action: onDelete
+                )
+                .disabled(!isRemovable)
+                .opacity(isRemovable ? 1.0 : 0.3)
+                .if(!isRemovable) { $0.vTooltip("Bundled skills cannot be removed") }
+                .accessibilityLabel(isRemovable ? "Uninstall skill" : "Core skill cannot be removed")
             }
         }
-        .contextMenu {
-            Button("Remove", role: .destructive, action: onDelete)
+        .if(isRemovable) { view in
+            view.contextMenu {
+                Button("Remove", role: .destructive, action: onDelete)
+            }
         }
         .accessibilityElement(children: .combine)
     }
@@ -297,66 +339,40 @@ struct AvailableSkillItemRow: View {
     var isInstalling: Bool = false
 
     var body: some View {
-        HStack(alignment: .center, spacing: VSpacing.lg) {
-            if let emoji = skill.emoji, !emoji.isEmpty {
-                Text(emoji)
-                    .font(.system(size: 32))
-                    .opacity(0.5)
-            }
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                HStack(alignment: .center, spacing: VSpacing.sm) {
-                    Text(skill.name)
-                        .font(VFont.titleSmall)
+        VCard {
+            HStack(alignment: .center, spacing: VSpacing.lg) {
+                if let emoji = skill.emoji, !emoji.isEmpty {
+                    Text(emoji)
+                        .font(.system(size: 32))
+                }
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    HStack(alignment: .center, spacing: VSpacing.sm) {
+                        Text(skill.name)
+                            .font(VFont.titleSmall)
+                            .foregroundStyle(VColor.contentEmphasized)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                        VSkillTypePill(origin: skill.origin, status: skill.status)
+                        Spacer()
+                    }
+                    Text(skill.description)
+                        .font(VFont.bodyMediumDefault)
                         .foregroundStyle(VColor.contentSecondary)
                         .lineLimit(1)
                         .truncationMode(.tail)
-                    skillTag(for: skill.origin, status: skill.status)
-                    Spacer()
                 }
-                Text(skill.description)
-                    .font(VFont.bodyMediumDefault)
-                    .foregroundStyle(VColor.contentTertiary)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-            }
-            if isInstalling {
-                VLoadingIndicator()
-            } else {
-                VButton(
-                    label: "Install",
-                    style: .outlined,
-                    action: onInstall
-                )
+                if isInstalling {
+                    VLoadingIndicator()
+                } else {
+                    VButton(
+                        label: "Install",
+                        leftIcon: VIcon.arrowDownToLine.rawValue,
+                        style: .ghost,
+                        size: .compact,
+                        action: onInstall
+                    )
+                }
             }
         }
-        .padding(VSpacing.lg)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.xl)
-                .strokeBorder(
-                    VColor.borderDisabled,
-                    style: StrokeStyle(lineWidth: 2, dash: [6, 4])
-                )
-        )
-    }
-}
-
-// MARK: - Skill Tag Helper
-
-private func skillTag(for origin: String, status: String? = nil) -> VTag {
-    if status == "available" {
-        return VTag("Available", color: VColor.funTeal, icon: .arrowDownToLine)
-    }
-    switch origin {
-    case "vellum":
-        return VTag("Core", color: VColor.contentDefault, icon: .package)
-    case "clawhub":
-        return VTag("Community", color: VColor.funPurple, icon: .globe)
-    case "skillssh":
-        return VTag("Community", color: VColor.funTeal, icon: .globe)
-    case "custom":
-        return VTag("Created", color: VColor.contentSecondary, icon: .sparkles)
-    default:
-        return VTag(origin.capitalized, color: VColor.contentTertiary, icon: .puzzle)
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -175,7 +175,7 @@ struct AgentPanelContent: View {
         case .available: return "No Skills Available"
         case .vellum: return "No Vellum Skills"
         case .community: return "No Community Skills"
-        case .custom: return "No Custom Skills"
+        case .custom: return "No Created Skills"
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
@@ -215,7 +215,7 @@ struct SkillDetailTitleRow: View {
 
             Spacer()
 
-            VSkillTypePill(origin: skill.origin, status: skill.status)
+            VSkillTypePill(origin: skill.origin)
 
             if skill.kind == "installed" {
                 VButton(label: "Remove", style: .dangerOutline) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
@@ -211,10 +211,11 @@ struct SkillDetailTitleRow: View {
                         .lineLimit(1)
                 }
 
-                VSkillTypePill(origin: skill.origin, status: skill.status)
             }
 
             Spacer()
+
+            VSkillTypePill(origin: skill.origin, status: skill.status)
 
             if skill.kind == "installed" {
                 VButton(label: "Remove", style: .dangerOutline) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -2,17 +2,28 @@ import SwiftUI
 import Combine
 import VellumAssistantShared
 
-/// Filter for showing all skills or only installed ones.
+/// Filter for showing skills by status or source.
 enum SkillFilter: String, CaseIterable {
     case all = "All"
     case installed = "Installed"
+    case available = "Available"
+    case vellum = "Vellum"
+    case community = "Community"
+    case custom = "Custom"
 
     var icon: VIcon {
         switch self {
-        case .all: return .circle
+        case .all: return .layoutGrid
         case .installed: return .circleCheck
+        case .available: return .arrowDownToLine
+        case .vellum: return .package
+        case .community: return .globe
+        case .custom: return .user
         }
     }
+
+    static var statusFilters: [SkillFilter] { [.all, .installed, .available] }
+    static var sourceFilters: [SkillFilter] { [.vellum, .community, .custom] }
 }
 
 @MainActor
@@ -127,10 +138,19 @@ final class SkillsManager {
         let hasSearch = !query.isEmpty
 
         let baseSkills: [SkillInfo]
-        if skillFilter == .all {
+        switch skillFilter {
+        case .all:
             baseSkills = skills
-        } else {
+        case .installed:
             baseSkills = skills.filter { $0.isInstalled }
+        case .available:
+            baseSkills = skills.filter { $0.isAvailable }
+        case .vellum:
+            baseSkills = skills.filter { $0.origin == "vellum" }
+        case .community:
+            baseSkills = skills.filter { $0.origin == "clawhub" || $0.origin == "skillssh" }
+        case .custom:
+            baseSkills = skills.filter { $0.origin == "custom" }
         }
 
         let searchFiltered: [SkillInfo]

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -196,7 +196,7 @@ final class SkillsManager {
     static func sourceLabel(_ origin: String) -> String {
         switch origin {
         case "vellum":
-            return "Core"
+            return "Vellum"
         case "clawhub":
             return "Community"
         case "skillssh":

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -9,7 +9,7 @@ enum SkillFilter: String, CaseIterable {
     case available = "Available"
     case vellum = "Vellum"
     case community = "Community"
-    case custom = "Custom"
+    case custom = "Created"
 
     var icon: VIcon {
         switch self {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -9,7 +9,7 @@ enum SkillFilter: String, CaseIterable {
     case available = "Available"
     case vellum = "Vellum"
     case community = "Community"
-    case custom = "Created"
+    case custom = "Custom"
 
     var icon: VIcon {
         switch self {
@@ -202,7 +202,7 @@ final class SkillsManager {
         case "skillssh":
             return "Community"
         case "custom":
-            return "Created"
+            return "Custom"
         default:
             return origin.replacingOccurrences(of: "-", with: " ").capitalized
         }

--- a/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
@@ -12,7 +12,7 @@ public struct VSkillTypePill: View {
 
         var label: String {
             switch self {
-            case .vellum: return "Core"
+            case .vellum: return "Vellum"
             case .clawhub: return "Community"
             case .skillssh: return "Community"
             case .custom: return "Created"
@@ -26,7 +26,7 @@ public struct VSkillTypePill: View {
             case .vellum: return .package
             case .clawhub: return .globe
             case .skillssh: return .globe
-            case .custom: return .sparkles
+            case .custom: return .user
             case .available: return .arrowDownToLine
             case .other(_, let icon, _, _): return .resolve(icon)
             }

--- a/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
@@ -30,7 +30,7 @@ public struct VSkillTypePill: View {
             switch self {
             case .vellum: return VColor.primaryBase
             case .community: return VColor.funTeal
-            case .custom: return VColor.funCoral
+            case .custom: return VColor.funPurple
             case .other(_, _, let fg, _): return fg
             }
         }
@@ -39,7 +39,7 @@ public struct VSkillTypePill: View {
             switch self {
             case .vellum: return VColor.primaryBase.opacity(0.12)
             case .community: return VColor.funTeal.opacity(0.12)
-            case .custom: return VColor.funCoral.opacity(0.12)
+            case .custom: return VColor.funPurple.opacity(0.12)
             case .other(_, _, _, let bg): return bg
             }
         }

--- a/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
@@ -1,22 +1,18 @@
 import SwiftUI
 
-/// A pill badge indicating the type/source of a skill based on its origin.
+/// A pill badge indicating the source of a skill.
 public struct VSkillTypePill: View {
     public enum SkillType {
         case vellum
-        case clawhub
-        case skillssh
+        case community
         case custom
-        case available
         case other(label: String, icon: String, foreground: Color, background: Color)
 
         var label: String {
             switch self {
             case .vellum: return "Vellum"
-            case .clawhub: return "Community"
-            case .skillssh: return "Community"
+            case .community: return "Community"
             case .custom: return "Created"
-            case .available: return "Available"
             case .other(let label, _, _, _): return label
             }
         }
@@ -24,32 +20,26 @@ public struct VSkillTypePill: View {
         var vIcon: VIcon {
             switch self {
             case .vellum: return .package
-            case .clawhub: return .globe
-            case .skillssh: return .globe
+            case .community: return .globe
             case .custom: return .user
-            case .available: return .arrowDownToLine
             case .other(_, let icon, _, _): return .resolve(icon)
             }
         }
 
         var foregroundColor: Color {
             switch self {
-            case .vellum: return VColor.contentDefault
-            case .clawhub: return VColor.funPurple
-            case .skillssh: return VColor.funTeal
-            case .custom: return VColor.contentSecondary
-            case .available: return VColor.funTeal
+            case .vellum: return VColor.primaryBase
+            case .community: return VColor.funTeal
+            case .custom: return VColor.funCoral
             case .other(_, _, let fg, _): return fg
             }
         }
 
         var backgroundColor: Color {
             switch self {
-            case .vellum: return VColor.surfaceBase
-            case .clawhub: return VColor.funPurple.opacity(0.12)
-            case .skillssh: return VColor.funTeal.opacity(0.12)
-            case .custom: return VColor.surfaceBase
-            case .available: return VColor.funTeal.opacity(0.12)
+            case .vellum: return VColor.primaryBase.opacity(0.12)
+            case .community: return VColor.funTeal.opacity(0.12)
+            case .custom: return VColor.funCoral.opacity(0.12)
             case .other(_, _, _, let bg): return bg
             }
         }
@@ -61,28 +51,22 @@ public struct VSkillTypePill: View {
         self.type = type
     }
 
-    /// Convenience initializer from a skill origin string and optional kind/status.
-    public init(origin: String, status: String? = nil) {
-        if status == "available" {
-            self.type = .available
-        } else {
-            switch origin {
-            case "vellum":
-                self.type = .vellum
-            case "clawhub":
-                self.type = .clawhub
-            case "skillssh":
-                self.type = .skillssh
-            case "custom":
-                self.type = .custom
-            default:
-                self.type = .other(
-                    label: origin.replacingOccurrences(of: "-", with: " ").capitalized,
-                    icon: VIcon.puzzle.rawValue,
-                    foreground: VColor.contentTertiary,
-                    background: VColor.surfaceOverlay
-                )
-            }
+    /// Convenience initializer from a skill origin string.
+    public init(origin: String) {
+        switch origin {
+        case "vellum":
+            self.type = .vellum
+        case "clawhub", "skillssh":
+            self.type = .community
+        case "custom":
+            self.type = .custom
+        default:
+            self.type = .other(
+                label: origin.replacingOccurrences(of: "-", with: " ").capitalized,
+                icon: VIcon.puzzle.rawValue,
+                foreground: VColor.contentTertiary,
+                background: VColor.surfaceOverlay
+            )
         }
     }
 

--- a/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VSkillTypePill.swift
@@ -12,7 +12,7 @@ public struct VSkillTypePill: View {
             switch self {
             case .vellum: return "Vellum"
             case .community: return "Community"
-            case .custom: return "Created"
+            case .custom: return "Custom"
             case .other(let label, _, _, _): return label
             }
         }

--- a/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/FeedbackGallerySection.swift
@@ -458,10 +458,8 @@ struct FeedbackGallerySection: View {
                 VCard {
                     HStack(spacing: VSpacing.lg) {
                         VSkillTypePill(type: .vellum)
-                        VSkillTypePill(type: .clawhub)
-                        VSkillTypePill(type: .skillssh)
+                        VSkillTypePill(type: .community)
                         VSkillTypePill(type: .custom)
-                        VSkillTypePill(type: .available)
                     }
                 }
             }


### PR DESCRIPTION

<img width="1325" height="1244" alt="Screenshot 2026-04-03 at 9 34 32 AM" src="https://github.com/user-attachments/assets/76c3fc41-0b71-4b2a-a137-708c7a307936" />
## Summary
- Added source-based filter options (Vellum, Community, Custom) alongside status filters (All, Installed, Available) in the skills tab dropdown
- Improved empty state messaging per filter type with contextual titles, subtitles, and icons
- Redesigned SkillItemRow with always-visible (but disabled for bundled) delete button and tooltip, replaced VTag with VSkillTypePill
- Wrapped AvailableSkillItemRow in VCard for consistent styling, added install icon, improved text contrast
- Moved VSkillTypePill in detail view to the right side of the title row for better visual hierarchy

## Original prompt
Noa made some changes to platform and vellum-assistant that are adding properly meta information about skills, we want only to keep UI changes and take source categories the way it is right now. sync with latest main and copy UI/UX from here https://github.com/vellum-ai/vellum-assistant/pull/22611, then close that old pr
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

Closes LUM-425