### PR TITLE
fix: clean up sidebar group styling

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -168,7 +168,7 @@ struct SidebarConversationItem: View, Equatable {
                     .accessibilityLabel("Private conversation")
             }
             Text(conversation.title)
-                .font(VFont.menuCompact)
+                .font(VFont.bodyMediumDefault)
                 .foregroundStyle(isSelected ? VColor.contentEmphasized : VColor.contentSecondary)
                 .lineLimit(1)
                 .truncationMode(.tail)
@@ -255,7 +255,7 @@ struct SidebarConversationItem: View, Equatable {
             HStack(spacing: VSpacing.xs) {
                 Color.clear.frame(width: 20, height: 20)
                 Text(conversation.title)
-                    .font(VFont.menuCompact)
+                    .font(VFont.bodyMediumDefault)
                     .foregroundStyle(VColor.contentDefault)
                     .lineLimit(1)
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
@@ -78,7 +78,7 @@ struct SidebarSectionHeader: View {
                 }
             } else {
                 Text(group.name)
-                    .font(VFont.menuCompact)
+                    .font(VFont.bodySmallDefault)
                     .foregroundStyle(VColor.contentTertiary)
             }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -129,10 +129,10 @@ struct SidebarSectionView: View {
                 VStack(spacing: 0) {
                     sectionContent
                 }
-                .padding(.vertical, VSpacing.xxs)
+                .padding(.bottom, VSpacing.xxs)
                 .background(
                     RoundedRectangle(cornerRadius: VRadius.md)
-                        .fill(isDropTarget ? VColor.systemPositiveWeak : VColor.contentTertiary.opacity(0.06))
+                        .fill(isDropTarget ? VColor.systemPositiveWeak : .clear)
                 )
                 .modifier(SectionBodyDropModifier(
                     groupId: group.id,
@@ -312,10 +312,6 @@ struct SidebarSectionView: View {
                 }
             }
             .padding(.vertical, VSpacing.xxs)
-            .background(
-                RoundedRectangle(cornerRadius: VRadius.md)
-                    .fill(VColor.contentTertiary.opacity(0.03))
-            )
             .overlay(alignment: .leading) {
                 UnevenRoundedRectangle(
                     topLeadingRadius: VRadius.md,


### PR DESCRIPTION
## Summary
- Remove background fill from expanded sidebar groups (interfered with thread hover states)
- Use `bodySmallDefault` (Inter 12px) for group titles (Pinned, Scheduled, Background)
- Use `bodyMediumDefault` (Inter 14px) for thread titles to match VNavItem
- Remove top padding between group header and first thread

## Test plan
- [ ] Expanded groups have no background fill
- [ ] Group titles use smaller text
- [ ] Thread titles match nav item text style
- [ ] Hover states work cleanly on threads
- [ ] Drop target highlight still works when dragging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
