### PR TITLE
refactor: standardize nav items and remove menuCompact font

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/DynamicWorkspaceWrapper.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DynamicWorkspaceWrapper.swift
@@ -328,11 +328,11 @@ private struct ShareDrawer: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            ShareDrawerRow(icon: .share, label: "Share", action: onShare)
+            VNavItem(icon: VIcon.share.rawValue, label: "Share") { onShare() }
             if isDeployToVercelEnabled {
                 VColor.borderBase.frame(height: 1)
                     .padding(.horizontal, VSpacing.xs)
-                ShareDrawerRow(icon: .arrowUpRight, label: "Publish to Vercel", action: onPublish)
+                VNavItem(icon: VIcon.arrowUpRight.rawValue, label: "Publish to Vercel") { onPublish() }
             }
         }
         .padding(.vertical, VSpacing.xs)
@@ -347,32 +347,3 @@ private struct ShareDrawer: View {
     }
 }
 
-private struct ShareDrawerRow: View {
-    let icon: VIcon
-    let label: String
-    let action: () -> Void
-    @State private var isHovered = false
-
-    var body: some View {
-        Button(action: action) {
-            HStack(spacing: VSpacing.sm) {
-                VIconView(icon, size: 12)
-                    .foregroundStyle(isHovered ? VColor.contentDefault : VColor.contentSecondary)
-                    .frame(width: 18)
-                Text(label)
-                    .font(VFont.bodyMediumLighter)
-                    .foregroundStyle(VColor.contentDefault)
-                Spacer()
-            }
-            .padding(.horizontal, VSpacing.md)
-            .padding(.vertical, VSpacing.sm)
-            .background(VColor.surfaceBase.opacity(isHovered ? 1 : 0))
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .onHover { hovering in
-            isHovered = hovering
-        }
-        .pointerCursor()
-    }
-}

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -12,6 +12,20 @@ enum SettingsTab: String {
     case schedules = "Schedules"
     case developer = "Developer"
 
+    var icon: VIcon {
+        switch self {
+        case .general: return .slidersHorizontal
+        case .modelsAndServices: return .cpu
+        case .voice: return .mic
+        case .sounds: return .volume2
+        case .permissionsAndPrivacy: return .shieldCheck
+        case .billing: return .creditCard
+        case .archivedConversations: return .archive
+        case .schedules: return .calendar
+        case .developer: return .terminal
+        }
+    }
+
     /// Primary tabs shown in the main nav list (excludes feature-flagged bottom tabs).
     static func primaryTabs(billingEnabled: Bool = false, soundsEnabled: Bool = true, schedulesEnabled: Bool = false) -> [SettingsTab] {
         var tabs: [SettingsTab] = [.general, .modelsAndServices, .voice]
@@ -348,7 +362,7 @@ struct SettingsPanel: View {
     private var settingsNav: some View {
         VStack(alignment: .leading, spacing: VSpacing.xs) {
             ForEach(SettingsTab.primaryTabs(billingEnabled: billingVisible, soundsEnabled: isSoundsEnabled, schedulesEnabled: isSchedulesEnabled), id: \.self) { tab in
-                SettingsNavRow(tab: tab, isSelected: selectedTab == tab) {
+                VNavItem(icon: tab.icon.rawValue, label: tab.rawValue, isActive: selectedTab == tab) {
                     selectedTab = tab
                 }
             }
@@ -358,7 +372,7 @@ struct SettingsPanel: View {
                     .frame(height: 1)
                     .padding(.vertical, SidebarLayoutMetrics.dividerVerticalPadding)
                     .padding(.trailing, VSpacing.md)
-                SettingsNavRow(tab: .developer, isSelected: selectedTab == .developer) {
+                VNavItem(icon: SettingsTab.developer.icon.rawValue, label: "Developer", isActive: selectedTab == .developer) {
                     selectedTab = .developer
                 }
             }
@@ -726,45 +740,6 @@ struct SettingsPanel: View {
 
 }
 
-// MARK: - Settings Nav Row
-
-private struct SettingsNavRow: View {
-    let tab: SettingsTab
-    let isSelected: Bool
-    let action: () -> Void
-
-    @State private var isHovered = false
-
-    var body: some View {
-        Button(action: action) {
-            HStack {
-                Text(tab.rawValue)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                    .font(VFont.bodyMediumLighter)
-                    .foregroundStyle(isSelected ? VColor.contentEmphasized : VColor.contentSecondary)
-                Spacer()
-            }
-            .padding(.leading, VSpacing.sm)
-            .padding(.trailing, VSpacing.sm)
-            .padding(.vertical, SidebarLayoutMetrics.rowVerticalPadding)
-            .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-                (isSelected ? VColor.surfaceActive : VColor.surfaceBase.opacity(isHovered ? 1 : 0))
-                    .animation(VAnimation.fast, value: isHovered)
-            )
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .padding(.trailing, VSpacing.md)
-        .onHover { hovering in
-            isHovered = hovering
-        }
-        .pointerCursor()
-    }
-}
 
 // MARK: - Environment Variables Sheet
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
@@ -254,7 +254,7 @@ struct ConversationSwitcherDrawer: View {
                     .frame(width: 20, height: 20)
 
                 Text(subGroup.label)
-                    .font(VFont.menuCompact)
+                    .font(VFont.bodyMediumDefault)
                     .foregroundStyle(VColor.contentDefault)
                     .lineLimit(1)
                     .truncationMode(.tail)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
@@ -68,7 +68,7 @@ struct SidebarSectionHeader: View {
                 TextField("Group name", text: $renamingName, onCommit: {
                     onCommitRename?(renamingName)
                 })
-                .font(VFont.menuCompact)
+                .font(VFont.bodyMediumDefault)
                 .textFieldStyle(.plain)
                 .focused($isRenameFocused)
                 .onAppear { isRenameFocused = true }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -243,7 +243,7 @@ struct SidebarSectionView: View {
                     .frame(width: 20, height: 20)
 
                 Text(subGroup.label)
-                    .font(VFont.menuCompact)
+                    .font(VFont.bodyMediumDefault)
                     .foregroundStyle(VColor.contentDefault)
                     .lineLimit(1)
                     .truncationMode(.tail)

--- a/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
@@ -295,7 +295,7 @@ public enum VMenuItemSize {
     /// Regular menu item — delegates to `VNavItem` (14pt `VFont.bodyMediumDefault`).
     case regular
 
-    fileprivate var font: Font { self == .compact ? VFont.menuCompact : VFont.bodyMediumDefault }
+    fileprivate var font: Font { VFont.bodyMediumDefault }
 }
 
 // MARK: - VMenuItem
@@ -565,7 +565,7 @@ public struct VSubMenuItem<Content: View>: View {
                     .frame(width: VSize.iconSlot, height: VSize.iconSlot)
             }
             Text(label)
-                .font(VFont.menuCompact)
+                .font(VFont.bodyMediumDefault)
                 .foregroundStyle(isEnabled ? VColor.contentSecondary : VColor.contentDisabled)
                 .lineLimit(1)
                 .truncationMode(.tail)


### PR DESCRIPTION
## Summary
- Settings sidebar: replace custom `SettingsNavRow` with `VNavItem` + icons for each tab (General, Models & Services, Voice, Sounds, Permissions & Privacy, Billing, Archived, Schedules, Developer)
- Share drawer: replace custom `ShareDrawerRow` with `VNavItem`
- Replace all `menuCompact` (Inter 300, 13px) with `bodyMediumDefault` (Inter 400, 14px) across VMenu, sidebar subgroups, section headers, and rename fields
- Delete `SettingsNavRow` and `ShareDrawerRow` dead code

## Test plan
- [ ] Settings sidebar shows icons for all tabs
- [ ] Settings nav hover/active states work
- [ ] Share drawer renders correctly with VNavItem
- [ ] Menu items use consistent 14px font
- [ ] Sidebar subgroup labels use consistent font

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23372" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
