### PR TITLE
feat: use streaming vbundle export in migration route to prevent OOM

### DIFF
--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -11,6 +11,8 @@
  * results with is_valid flag and detailed error descriptions.
  */
 
+import { createReadStream } from "node:fs";
+import { Readable } from "node:stream";
 import { Database } from "bun:sqlite";
 
 import { z } from "zod";
@@ -27,7 +29,7 @@ import {
 } from "../../util/platform.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
-import { buildExportVBundle } from "../migrations/vbundle-builder.js";
+import { streamExportVBundle } from "../migrations/vbundle-builder.js";
 import {
   analyzeImport,
   DefaultPathResolver,
@@ -141,8 +143,10 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
     }
   }
 
+  let cleanup: (() => Promise<void>) | undefined;
+
   try {
-    const { archive, manifest } = buildExportVBundle({
+    const result = await streamExportVBundle({
       // hooksDir is intentionally omitted — hooks now live under workspace/hooks/
       // and are included in the workspace walk. Passing hooksDir separately would
       // export them twice (once as workspace/hooks/... and again as hooks/...).
@@ -170,25 +174,32 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
       },
     });
 
+    cleanup = result.cleanup;
+    const { tempPath, size, manifest } = result;
+
     const timestamp = manifest.created_at.replace(/[:.]/g, "-");
     const filename = `export-${timestamp}.vbundle`;
 
-    const body = archive.buffer.slice(
-      archive.byteOffset,
-      archive.byteOffset + archive.byteLength,
-    ) as ArrayBuffer;
+    const fileStream = createReadStream(tempPath);
+    fileStream.on("close", () => {
+      cleanup?.();
+      cleanup = undefined;
+    });
+
+    const body = Readable.toWeb(fileStream) as ReadableStream;
 
     return new Response(body, {
       status: 200,
       headers: {
         "Content-Type": "application/octet-stream",
         "Content-Disposition": `attachment; filename="${filename}"`,
-        "Content-Length": String(archive.length),
+        "Content-Length": String(size),
         "X-Vbundle-Schema-Version": manifest.schema_version,
         "X-Vbundle-Manifest-Sha256": manifest.manifest_sha256,
       },
     });
   } catch (err) {
+    await cleanup?.();
     log.error({ err }, "Failed to build export bundle");
     return httpError(
       "INTERNAL_ERROR",

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -186,7 +186,7 @@ export async function handleMigrationExport(req: Request): Promise<Response> {
       cleanup = undefined;
     });
 
-    const body = Readable.toWeb(fileStream) as ReadableStream;
+    const body = Readable.toWeb(fileStream) as unknown as ReadableStream;
 
     return new Response(body, {
       status: 200,


### PR DESCRIPTION
## Summary
- Replace synchronous in-memory buildExportVBundle call with streaming streamExportVBundle
- Stream temp file as HTTP response using Readable.toWeb(createReadStream)
- Clean up temp file on stream close and on error

Part of plan: export-oom-fix.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23378" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
