### PR TITLE
fix: drawer divider logic and group title styling

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
@@ -97,24 +97,22 @@ struct ConversationSwitcherDrawer: View {
 
             ScrollView(.vertical, showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 0) {
-                    ForEach(drawerEntries.indices, id: \.self) { index in
-                        let entry = drawerEntries[index]
+                    let nonEmptyEntries = drawerEntries.filter { !$0.conversations.isEmpty }
+                    ForEach(nonEmptyEntries.indices, id: \.self) { index in
+                        let entry = nonEmptyEntries[index]
                         let sectionId = entry.group?.id ?? "ungrouped"
-                        let conversations = entry.conversations
                         let isExpanded = expandedSections.contains(sectionId)
 
-                        if !conversations.isEmpty {
-                            if index > 0 {
-                                VMenuDivider()
-                            }
-                            sectionContent(
-                                sectionId: sectionId,
-                                group: entry.group,
-                                title: entry.group?.name ?? "Conversations",
-                                conversations: conversations,
-                                isExpanded: isExpanded
-                            )
+                        if index > 0 {
+                            VMenuDivider()
                         }
+                        sectionContent(
+                            sectionId: sectionId,
+                            group: entry.group,
+                            title: entry.group?.name ?? "Conversations",
+                            conversations: entry.conversations,
+                            isExpanded: isExpanded
+                        )
                     }
                 }
                 .background(GeometryReader { contentGeo in
@@ -160,15 +158,16 @@ struct ConversationSwitcherDrawer: View {
     ) -> some View {
         HStack {
             Text(title)
-                .font(VFont.labelDefault)
+                .font(VFont.bodySmallDefault)
                 .foregroundStyle(VColor.contentTertiary)
             Spacer()
             Text("\(conversations.count)")
-                .font(VFont.labelDefault)
+                .font(VFont.bodySmallDefault)
                 .foregroundStyle(VColor.contentTertiary)
         }
         .padding(.horizontal, VSpacing.sm)
         .padding(.top, VSpacing.xs)
+        .padding(.bottom, VSpacing.xs)
 
         let isScheduled = group?.id == ConversationGroup.scheduled.id
         let isBackground = group?.id == ConversationGroup.background.id


### PR DESCRIPTION
## Summary
- Fix extra divider showing above first section in collapsed sidebar drawer by filtering empty entries before rendering
- Use `bodySmallDefault` (12px) for group titles instead of `labelDefault` (11px)
- Add `VSpacing.xs` (4pt) padding below group title

## Test plan
- [ ] Collapse sidebar, open conversation switcher — no extra divider above first section
- [ ] Group titles use 12px font
- [ ] Proper spacing between group title and first conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
