### PR TITLE
fix: address TOCTOU race, temp file leak, and name collision in streaming export

### DIFF
--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -9,7 +9,7 @@
  * - trust/trust.json: trust rules (optional, lives in protected/ outside workspace)
  */
 
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import {
   closeSync,
   createReadStream,
@@ -692,10 +692,19 @@ async function* generateTarStream(
   for (const file of files) {
     yield createPaxAndHeaderBlocks(file.archivePath, file.size);
 
-    // Stream file data from disk
+    // Stream file data from disk, tracking bytes to detect TOCTOU races
+    let bytesWritten = 0;
     const stream = createReadStream(file.diskPath);
     for await (const chunk of stream) {
-      yield chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk);
+      const data = chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk);
+      bytesWritten += data.length;
+      yield data;
+    }
+
+    if (bytesWritten !== file.size) {
+      throw new Error(
+        `File size changed during export: ${file.archivePath} (expected ${file.size}, got ${bytesWritten})`,
+      );
     }
 
     yield tarPaddingBytes(file.size);
@@ -805,14 +814,19 @@ export async function streamExportVBundle(
   // Pass 2: Stream tar through gzip into a temp file
   // ------------------------------------------------------------------
 
-  const tempPath = join(tmpdir(), `vbundle-export-${Date.now()}.tmp`);
+  const tempPath = join(tmpdir(), `vbundle-export-${randomUUID()}.tmp`);
 
   const tarGenerator = generateTarStream(manifestData, allFileMetadata);
   const tarReadable = Readable.from(tarGenerator);
   const gzipStream = createGzip();
   const writeStream = createWriteStream(tempPath);
 
-  await pipeline(tarReadable, gzipStream, writeStream);
+  try {
+    await pipeline(tarReadable, gzipStream, writeStream);
+  } catch (error) {
+    await unlink(tempPath).catch(() => {});
+    throw error;
+  }
 
   const tempStat = await stat(tempPath);
 


### PR DESCRIPTION
## Summary
Fixes three gaps identified during plan review:

- **TOCTOU race**: Track bytes written per file in generateTarStream and throw if size mismatches the tar header
- **Temp file leak**: Wrap pipeline call in try/catch to clean up temp file on failure
- **Name collision**: Use randomUUID() instead of Date.now() for temp file names

Fixes gaps from plan review for export-oom-fix.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
