### PR TITLE
fix: remove dividers between settings service cards

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -501,10 +501,6 @@ struct SettingsPanel: View {
             // OAUTH PROVIDERS (dynamic from API)
             if !isIntegrationsGridEnabled {
                 ForEach(store.managedOAuthProviders, id: \.provider_key) { provider in
-                    Divider()
-                        .background(VColor.borderBase)
-                        .padding(.vertical, VSpacing.sm)
-
                     OAuthProviderServiceCard(
                         store: store,
                         authManager: authManager,
@@ -513,10 +509,6 @@ struct SettingsPanel: View {
                     )
                 }
             } else {
-                Divider()
-                    .background(VColor.borderBase)
-                    .padding(.vertical, VSpacing.sm)
-
                 IntegrationsGridView(
                     store: store,
                     authManager: authManager,


### PR DESCRIPTION
## Summary
- Remove dividers between OAuth provider cards and integrations grid in Models & Services settings
- Cards are separated by VStack spacing, not additional dividers

## Test plan
- [ ] Models & Services tab shows cards separated by spacing only, no dividers between them

🤖 Generated with [Claude Code](https://claude.com/claude-code)