### PR TITLE
fix: verify SHA-256 during pass 2 to detect content changes between passes

### DIFF
--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -64,6 +64,8 @@ interface FileMetadata {
   archivePath: string;
   diskPath: string;
   size: number;
+  /** SHA-256 hex digest computed during pass 1; verified during pass 2. */
+  expectedSha256?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -692,12 +694,15 @@ async function* generateTarStream(
   for (const file of files) {
     yield createPaxAndHeaderBlocks(file.archivePath, file.size);
 
-    // Stream file data from disk, tracking bytes to detect TOCTOU races
+    // Stream file data from disk, tracking bytes and computing SHA-256
+    // to detect TOCTOU races (size or content changes between passes)
     let bytesWritten = 0;
+    const verifyHash = file.expectedSha256 ? createHash("sha256") : null;
     const stream = createReadStream(file.diskPath);
     for await (const chunk of stream) {
       const data = chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk);
       bytesWritten += data.length;
+      verifyHash?.update(data);
       yield data;
     }
 
@@ -705,6 +710,15 @@ async function* generateTarStream(
       throw new Error(
         `File size changed during export: ${file.archivePath} (expected ${file.size}, got ${bytesWritten})`,
       );
+    }
+
+    if (verifyHash && file.expectedSha256) {
+      const actualSha256 = verifyHash.digest("hex");
+      if (actualSha256 !== file.expectedSha256) {
+        throw new Error(
+          `File content changed during export: ${file.archivePath} (checksum mismatch)`,
+        );
+      }
     }
 
     yield tarPaddingBytes(file.size);
@@ -787,6 +801,7 @@ export async function streamExportVBundle(
   const fileEntries: ManifestFileEntryType[] = [];
   for (const file of allFileMetadata) {
     const sha256 = await computeFileSha256(file.diskPath);
+    file.expectedSha256 = sha256;
     fileEntries.push({
       path: file.archivePath,
       sha256,


### PR DESCRIPTION
## Summary
Addresses TOCTOU checksum drift feedback from Codex and Devin reviewers.

- Compute SHA-256 of each file during pass 2 (tar streaming) and compare against the pass-1 digest
- If content changed between passes (even without size change), the export aborts with a clear error
- This ensures the bytes archived are exactly the bytes that were hashed for the manifest
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
