### PR TITLE
heartbeat: default to enabled, 6h interval, active hours 8–22

### DIFF
--- a/assistant/src/config/schemas/heartbeat.ts
+++ b/assistant/src/config/schemas/heartbeat.ts
@@ -12,7 +12,7 @@ export const HeartbeatConfigSchema = z
       .number({ error: "heartbeat.intervalMs must be a number" })
       .int("heartbeat.intervalMs must be an integer")
       .positive("heartbeat.intervalMs must be a positive integer")
-      .default(3_600_000)
+      .default(6 * 3_600_000)
       .describe("Time between heartbeat checks in milliseconds"),
     speed: SpeedSchema.default("standard").describe(
       "Inference speed mode for heartbeat conversations — defaults to standard to avoid inheriting the global fast mode multiplier",
@@ -22,37 +22,19 @@ export const HeartbeatConfigSchema = z
       .int("heartbeat.activeHoursStart must be an integer")
       .min(0, "heartbeat.activeHoursStart must be >= 0")
       .max(23, "heartbeat.activeHoursStart must be <= 23")
-      .optional()
-      .describe(
-        "Hour of the day (0-23) when heartbeat checks begin — must be set together with activeHoursEnd",
-      ),
+      .default(8)
+      .describe("Hour of the day (0-23) when heartbeat checks begin"),
     activeHoursEnd: z
       .number({ error: "heartbeat.activeHoursEnd must be a number" })
       .int("heartbeat.activeHoursEnd must be an integer")
       .min(0, "heartbeat.activeHoursEnd must be >= 0")
       .max(23, "heartbeat.activeHoursEnd must be <= 23")
-      .optional()
-      .describe(
-        "Hour of the day (0-23) when heartbeat checks stop — must be set together with activeHoursStart",
-      ),
+      .default(22)
+      .describe("Hour of the day (0-23) when heartbeat checks stop"),
   })
   .describe("Periodic heartbeat configuration for health monitoring")
   .superRefine((config, ctx) => {
-    const hasStart = config.activeHoursStart != null;
-    const hasEnd = config.activeHoursEnd != null;
-    if (hasStart !== hasEnd) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: [hasStart ? "activeHoursEnd" : "activeHoursStart"],
-        message:
-          "heartbeat.activeHoursStart and heartbeat.activeHoursEnd must both be set or both be omitted",
-      });
-    }
-    if (
-      hasStart &&
-      hasEnd &&
-      config.activeHoursStart === config.activeHoursEnd
-    ) {
+    if (config.activeHoursStart === config.activeHoursEnd) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["activeHoursEnd"],

--- a/assistant/src/runtime/routes/heartbeat-routes.ts
+++ b/assistant/src/runtime/routes/heartbeat-routes.ts
@@ -47,16 +47,10 @@ function handleUpdateConfig(
   if (typeof body.enabled === "boolean") heartbeat.enabled = body.enabled;
   if (typeof body.intervalMs === "number")
     heartbeat.intervalMs = body.intervalMs;
-  if ("activeHoursStart" in body) {
-    heartbeat.activeHoursStart =
-      typeof body.activeHoursStart === "number"
-        ? body.activeHoursStart
-        : undefined;
-  }
-  if ("activeHoursEnd" in body) {
-    heartbeat.activeHoursEnd =
-      typeof body.activeHoursEnd === "number" ? body.activeHoursEnd : undefined;
-  }
+  if (typeof body.activeHoursStart === "number")
+    heartbeat.activeHoursStart = body.activeHoursStart;
+  if (typeof body.activeHoursEnd === "number")
+    heartbeat.activeHoursEnd = body.activeHoursEnd;
 
   try {
     saveConfig({ ...config, heartbeat });


### PR DESCRIPTION
## Summary

- Enable heartbeat by default (`enabled: true`)
- Change default interval from 1h → 6h
- Add default active hours: 8am–10pm (local time), so heartbeats don't fire overnight
- Simplify `superRefine` — active hours are now required fields with defaults rather than optional, so the "must both be set or omitted" check is no longer needed

## Behavior change note

Existing users with heartbeat explicitly disabled (`heartbeat.enabled: false` in config) are unaffected. Users who had heartbeat enabled with no active hours constraint will now get the 8–22 window applied — they can override by setting `activeHoursStart`/`activeHoursEnd` explicitly in config.

## Test plan

- [ ] Fresh install: heartbeat fires at 6h intervals, skips outside 8am–10pm
- [ ] Explicit `heartbeat.enabled: false` in config still disables it
- [ ] Setting custom `activeHoursStart`/`activeHoursEnd` overrides the defaults
- [ ] `PUT /v1/heartbeat/config` still updates active hours correctly; passing a non-number is a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23391" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
