### PR TITLE
feat(settings): add saving spinner state and success callback to saveImageGenKey

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -46,6 +46,7 @@ public final class SettingsStore: ObservableObject {
     @Published var braveKeySaveError: String?
     @Published var perplexityKeySaveError: String?
     @Published var imageGenKeySaveError: String?
+    @Published var imageGenKeySaving: Bool = false
     @Published var maskedBraveKey: String = ""
     @Published var maskedPerplexityKey: String = ""
     @Published var maskedImageGenKey: String = ""
@@ -887,10 +888,11 @@ public final class SettingsStore: ObservableObject {
         scheduleRoutingSourceRefresh()
     }
 
-    func saveImageGenKey(_ raw: String) {
+    func saveImageGenKey(_ raw: String, onSuccess: (() -> Void)? = nil) {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         imageGenKeySaveError = nil
+        imageGenKeySaving = true
         APIKeyManager.setKey(trimmed, for: "gemini")
         // Remove any stale deletion tombstone eagerly — the user's intent is to
         // save a new key, so any prior clear is superseded.
@@ -899,8 +901,10 @@ public final class SettingsStore: ObservableObject {
         maskedImageGenKey = Self.maskKey(trimmed)
         Task {
             let result = await syncKeyToDaemonWithValidation(provider: "gemini", value: trimmed)
+            imageGenKeySaving = false
             if result.success {
                 scheduleRoutingSourceRefresh()
+                onSuccess?()
             } else if let error = result.error {
                 imageGenKeySaveError = error
                 if !result.isTransient {


### PR DESCRIPTION
## Summary
- Add `@Published var imageGenKeySaving: Bool` to SettingsStore for spinner state during Gemini key validation
- Refactor `saveImageGenKey` to accept an optional `onSuccess` callback, matching the `saveInferenceAPIKey` pattern
- Toggle saving state around the async daemon validation call

Part of plan: image-gen-key-save-ux.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
