### PR TITLE
feat: add generic Oura Ring skills to first-party catalog

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -423,6 +423,18 @@
       "compatibility": "Designed for Vellum personal assistants"
     },
     {
+      "id": "watch-together",
+      "name": "watch-together",
+      "description": "Watch TV shows and movies with the user in real time by processing screen captures into frames and audio analysis",
+      "metadata": {
+        "emoji": "📺",
+        "vellum": {
+          "display-name": "Watch Together"
+        }
+      },
+      "compatibility": "Designed for Vellum personal assistants"
+    },
+    {
       "id": "weather",
       "name": "weather",
       "description": "Get current weather conditions and forecasts for any location",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -196,6 +196,31 @@
       "compatibility": "Designed for Vellum personal assistants"
     },
     {
+      "id": "oura",
+      "name": "oura",
+      "description": "Pull sleep, activity, readiness, heart rate, and other health data from a connected Oura Ring via the Oura Cloud API V2",
+      "metadata": {
+        "emoji": "💍",
+        "vellum": {
+          "display-name": "Oura Ring",
+          "includes": ["oura-setup"]
+        }
+      },
+      "compatibility": "Designed for Vellum personal assistants"
+    },
+    {
+      "id": "oura-setup",
+      "name": "oura-setup",
+      "description": "Connect an Oura Ring via OAuth2 — app registration, token exchange, and credential storage",
+      "metadata": {
+        "emoji": "💍",
+        "vellum": {
+          "display-name": "Oura Ring Setup"
+        }
+      },
+      "compatibility": "Designed for Vellum personal assistants"
+    },
+    {
       "id": "public-ingress",
       "name": "public-ingress",
       "description": "Set up and manage ngrok-based public ingress for local assistants; do not use this in managed mode when platform callback routing is available",

--- a/skills/oura-setup/SKILL.md
+++ b/skills/oura-setup/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: oura-setup
+description: Connect an Oura Ring via OAuth2 — app registration, token exchange, and credential storage
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "💍"
+  vellum:
+    display-name: "Oura Ring Setup"
+---
+
+# Oura Ring Integration
+
+Connect the user's Oura Ring to pull sleep, heart rate, readiness, activity, and other health data via the Oura Cloud API V2.
+
+## Prerequisites
+
+- An Oura Ring (Gen 3 or Ring 4) with an active Oura Membership ($6/mo required for API access)
+- The Oura app installed and paired with the ring
+- An Oura Cloud account at https://cloud.ouraring.com
+
+## Setup
+
+### 1. Register a Developer Application
+
+Have the user go to https://developer.ouraring.com/applications and create a new application:
+
+- **Display Name:** The user's preferred name for the integration
+- **Description:** Brief description of the integration
+- **Contact Email:** User's email
+- **Website:** Any valid URL (e.g. a personal website)
+- **Privacy Policy / Terms of Service:** Any valid URLs (required fields, not enforced for personal apps)
+- **Redirect URIs:** `http://localhost:3000/callback`
+- **Scopes:** Enable all scopes needed. Recommended: `personal`, `daily`, `heartrate`, `sleep`, `workout`, `spo2`, `stress`, `heart_health`, `session`, `ring_configuration`
+
+Save the **Client ID** and **Client Secret**.
+
+### 2. Run the OAuth Flow
+
+Store the client secret securely using `credential_store`, then write and run the OAuth helper script on the user's machine:
+
+```python
+#!/usr/bin/env python3
+"""Oura Ring OAuth2 helper — catches auth code and exchanges for tokens instantly."""
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from urllib.parse import urlparse, parse_qs, urlencode
+import urllib.request, json, webbrowser, ssl
+
+CLIENT_ID = 'YOUR_CLIENT_ID'
+CLIENT_SECRET = 'YOUR_CLIENT_SECRET'
+REDIRECT_URI = 'http://localhost:3000/callback'
+SCOPES = 'email personal daily heartrate workout tag session spo2 ring_configuration stress heart_health'
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        if parsed.path == '/':
+            params = urlencode({
+                'response_type': 'code', 'client_id': CLIENT_ID,
+                'redirect_uri': REDIRECT_URI, 'scope': SCOPES, 'state': 'assistant'
+            })
+            self.send_response(302)
+            self.send_header('Location', f'https://cloud.ouraring.com/oauth/authorize?{params}')
+            self.end_headers()
+        elif parsed.path == '/callback':
+            code = parse_qs(parsed.query).get('code', [''])[0]
+            if code:
+                token_data = urlencode({
+                    'grant_type': 'authorization_code', 'code': code,
+                    'redirect_uri': REDIRECT_URI, 'client_id': CLIENT_ID,
+                    'client_secret': CLIENT_SECRET,
+                }).encode()
+                try:
+                    req = urllib.request.Request('https://api.ouraring.com/oauth/token',
+                        data=token_data,
+                        headers={'Content-Type': 'application/x-www-form-urlencoded'},
+                        method='POST')
+                    resp = urllib.request.urlopen(req, context=ssl.create_default_context())
+                    result = json.loads(resp.read())
+                    with open('/tmp/oura_tokens.json', 'w') as f:
+                        json.dump(result, f, indent=2)
+                    self.send_response(200)
+                    self.send_header('Content-Type', 'text/html')
+                    self.end_headers()
+                    self.wfile.write(b'<html><body><h1>Connected! You can close this tab.</h1></body></html>')
+                    print(f'\nTokens saved to /tmp/oura_tokens.json')
+                except Exception as e:
+                    self.send_response(500)
+                    self.end_headers()
+                    self.wfile.write(f'Token exchange failed: {e}'.encode())
+    def log_message(self, *a): pass
+
+print('Opening browser for Oura authorization...')
+webbrowser.open('http://localhost:3000')
+HTTPServer(('localhost', 3000), Handler).serve_forever()
+```
+
+Run with `python3 /path/to/script.py` on the user's machine (`host_bash`). The user authorizes in their browser, the script catches the code and exchanges it for tokens in under a second.
+
+**Important:** Auth codes expire in ~30 seconds. Do NOT have the user paste codes manually — use this script to catch and exchange them automatically.
+
+### 3. Store Tokens
+
+After the OAuth flow, read tokens from `/tmp/oura_tokens.json` and store them:
+- `access_token` — store in credential vault with injection template for `api.ouraring.com` Authorization header (Bearer prefix)
+- `refresh_token` — store in credential vault for token refresh
+- Tokens expire in ~30 days. Set a reminder to refresh before expiry.
+
+### 4. Verify Connection
+
+Test with the personal info endpoint:
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" "https://api.ouraring.com/v2/usercollection/personal_info"
+```
+
+## Available Endpoints
+
+All endpoints use `GET https://api.ouraring.com/v2/usercollection/{type}` with query params `start_date` and `end_date` (YYYY-MM-DD format).
+
+| Endpoint | Data | Notes |
+|----------|------|-------|
+| `/v2/usercollection/daily_sleep` | Sleep score, duration, efficiency, stages | Best checked after user's typical wake time |
+| `/v2/usercollection/sleep` | Detailed sleep periods with HR, HRV, movement | Raw sleep period data |
+| `/v2/usercollection/daily_readiness` | Readiness score, HRV balance, recovery | Good morning check-in metric |
+| `/v2/usercollection/daily_activity` | Steps, calories, movement, inactivity | Activity summary |
+| `/v2/usercollection/heartrate` | Continuous HR (use `start_datetime`/`end_datetime` in ISO format) | Can be large — limit date range |
+| `/v2/usercollection/daily_spo2` | Blood oxygen levels | Nightly average |
+| `/v2/usercollection/daily_stress` | Stress score and recovery | Daytime stress tracking |
+| `/v2/usercollection/workout` | Detected workouts with HR, calories | Auto-detected or manual |
+| `/v2/usercollection/personal_info` | Age, weight, height, email | Good connection test |
+
+## Token Refresh
+
+Tokens expire after 30 days. Refresh with:
+```bash
+curl -s -X POST "https://api.ouraring.com/oauth/token" \
+  -d "grant_type=refresh_token&refresh_token=$REFRESH_TOKEN&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET"
+```
+
+Store the new access_token and refresh_token from the response.
+
+## Tips
+
+- New rings need 1-2 nights to calibrate before data is meaningful
+- Sleep data typically appears a few hours after the user wakes up
+- Heart rate data during workouts appears after the workout syncs via the Oura app
+- Rate limit: 5000 requests per 5 minutes
+- Ring 4 and Gen 3 users MUST have an active Oura Membership for API access

--- a/skills/oura/SKILL.md
+++ b/skills/oura/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: oura
+description: Pull sleep, activity, readiness, heart rate, and other health data from a connected Oura Ring via the Oura Cloud API V2
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "💍"
+  vellum:
+    display-name: "Oura Ring"
+    includes:
+      - oura-setup
+---
+
+# Oura Ring — Data Access
+
+Pull sleep, activity, readiness, heart rate, and other health data from a connected Oura Ring via the Oura Cloud API V2.
+
+**For initial setup (OAuth, app registration, token exchange), see the `oura-setup` skill.**
+
+## Prerequisites
+
+- Oura Ring already connected via OAuth (see `oura-setup` skill)
+- Credential stored: `oura` / `access_token` with injection template for `api.ouraring.com` (Authorization header, Bearer prefix)
+- Credential ID can be found via `credential_store` list action, filtering for service `oura`, field `access_token`
+
+## Making Requests
+
+All requests go through the credential proxy — no need to manually attach tokens.
+
+```bash
+curl -s "https://api.ouraring.com/v2/usercollection/{endpoint}?start_date=YYYY-MM-DD&end_date=YYYY-MM-DD"
+```
+
+Run via `bash` with:
+- `network_mode: "proxied"`
+- `credential_ids: ["<oura access_token credential_id>"]`
+
+## Endpoints
+
+| Endpoint | What It Returns | Best For |
+|----------|----------------|----------|
+| `personal_info` | Age, weight, height, email | Connection test |
+| `daily_sleep` | Sleep score, duration, efficiency, stages | Morning check-in |
+| `sleep` | Detailed sleep periods — HR, HRV, movement, timestamps | Deep sleep analysis |
+| `daily_readiness` | Readiness score, HRV balance, recovery index | Morning readiness |
+| `daily_activity` | Steps, calories, movement, MET data, activity score | Daily activity summary |
+| `heartrate` | Continuous HR readings (uses `start_datetime`/`end_datetime` ISO format) | Workout HR, resting HR |
+| `workout` | Detected workouts — HR, calories, duration, type | Exercise tracking |
+| `daily_spo2` | Blood oxygen (SpO2) nightly average | Breathing/oxygen |
+| `daily_stress` | Stress score, recovery periods | Stress monitoring |
+| `ring_configuration` | Ring model, firmware, color, design | Ring info |
+
+## Query Parameters
+
+- **Most endpoints:** `start_date` and `end_date` in `YYYY-MM-DD` format
+- **Heart rate:** Uses `start_datetime` and `end_datetime` in ISO 8601 format (e.g. `2025-01-15T00:00:00-05:00`)
+- **Personal info / ring config:** No date params needed
+- Omitting dates usually returns recent data (last 1-7 days depending on endpoint)
+
+## Common Patterns
+
+### Morning health check
+Pull sleep + readiness + activity for today:
+```bash
+DATE=$(date +%Y-%m-%d)
+curl -s "https://api.ouraring.com/v2/usercollection/daily_sleep?start_date=$DATE&end_date=$DATE"
+curl -s "https://api.ouraring.com/v2/usercollection/daily_readiness?start_date=$DATE&end_date=$DATE"
+```
+
+### Workout details with HR
+```bash
+YESTERDAY=$(date -v-1d +%Y-%m-%d)
+TODAY=$(date +%Y-%m-%d)
+curl -s "https://api.ouraring.com/v2/usercollection/workout?start_date=$YESTERDAY&end_date=$TODAY"
+```
+
+### Heart rate during a specific window
+```bash
+# Adjust the datetime range as needed (ISO 8601 with timezone offset)
+curl -s "https://api.ouraring.com/v2/usercollection/heartrate?start_datetime=YYYY-MM-DDT23:00:00-05:00&end_datetime=YYYY-MM-DDT01:00:00-05:00"
+```
+
+## Notes
+
+- New rings need **1-2 nights** to calibrate before sleep/readiness scores are meaningful
+- Sleep data appears a few hours after waking
+- Short workouts (<15 min) may not be auto-detected — check raw heart rate instead
+- Heart rate endpoint can return large datasets — keep time windows tight
+- Rate limit: 5,000 requests per 5 minutes
+- Tokens expire after ~30 days. Refresh using the `oura-setup` skill's token refresh instructions.
+
+## Token Refresh
+
+When the access token expires, use the refresh token via the `oura-setup` skill:
+
+```bash
+curl -s -X POST "https://api.ouraring.com/oauth/token" \
+  -d "grant_type=refresh_token&refresh_token=REFRESH_TOKEN&client_id=CLIENT_ID&client_secret=CLIENT_SECRET"
+```
+
+Store the new access_token and refresh_token. See `oura-setup` for full details.

--- a/skills/watch-together/SKILL.md
+++ b/skills/watch-together/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: "Watch Together"
+description: "Watch TV shows and movies with the user in real time by processing screen captures into frames and audio analysis."
+metadata:
+  vellum:
+    emoji: 📺
+---
+
+# Watch Together
+
+Real-time TV/movie watching pipeline. Chunks arrive automatically via signal files — no polling, no timer, no manual triggering.
+
+## How It Works
+
+1. The user runs `capture-live.sh` in their terminal with the current conversation ID
+2. ffmpeg records screen + audio in 30-second segments
+3. Each segment is auto-processed (frame extraction + audio extraction)
+4. A signal file pushes the chunk into the active conversation
+5. The assistant receives it as a `[WATCH-CHUNK]` message with key frames attached as images
+6. The assistant sees the frames, reacts, updates the episode state
+
+## When You Receive a [WATCH-CHUNK] Message
+
+This is the core loop. When a message arrives starting with `[WATCH-CHUNK]`:
+
+1. **Read episode-state.md** from the session dir to remember where you are
+2. **Look at the frames** — 6 key frames are attached as images. LOOK at them with your own vision. Have opinions. Use `file_read` on additional frames from the processed dir if you want more detail.
+3. **Read audio analysis** — if audio exists, send the audio file to Gemini for dialogue transcription, speaker tone, music mood, and sound design description. If no audio, rely on the user's descriptions.
+4. **React to the user** — share what you noticed. Cinematography, expressions, theories, callbacks. Be engaged.
+5. **Update episode-state.md** — write observations to the relevant sections (characters, plot, theories, visual motifs, audio, emotional arc)
+6. **Rewind if needed** — if something caught your eye, use the rewind tool for dense 720p frames
+
+### Reaction Calibration
+
+- **Intense scene**: go all in. Multiple messages. Caps lock. Theories flying.
+- **Quiet moment**: brief observation or comfortable silence. Don't force it.
+- **Plot twist**: lose your mind. Strong reactions are the point.
+- **Beautiful cinematography**: geek out. Notice framing, lighting, color.
+- **Character moment**: connect it to your theories. Whatever feels true.
+
+## Starting a Session
+
+When the user says they want to watch something:
+
+1. Create the session directory and episode state file
+2. Give them the capture command with the current conversation ID:
+   ```
+   bash ~/.vellum/workspace/watch-together/scripts/capture-live.sh \
+     ~/.vellum/workspace/watch-together/sessions/<session-id> \
+     <conversation_id> \
+     30
+   ```
+3. Tell them to start the show. Chunks will arrive automatically.
+
+The conversation ID is the bare UUID from the conversation's DB record (e.g. `191a7dcc-3e4d-4825-a5b6-97876525f56c`), NOT the full folder name with the timestamp prefix. Using the folder name will create a new conversation instead of routing to the existing one.
+
+## Tools
+
+### start_watch
+Initialize a watch session and provide the user the capture command.
+
+Parameters:
+- `show_name` (string, required) — Name of the show
+- `season` (number, required) — Season number  
+- `episode` (number, required) — Episode number
+
+Implementation: Create session dir, copy episode state template, output the capture command for the user to run.
+
+```bash
+SESSION_ID=$(echo "${show_name}" | tr ' ' '-' | tr '[:upper:]' '[:lower:]')-s${season}e${episode}
+SESSION_DIR="$HOME/.vellum/workspace/watch-together/sessions/$SESSION_ID"
+mkdir -p "$SESSION_DIR/chunks" "$SESSION_DIR/processed"
+cp "$HOME/.vellum/workspace/watch-together/episode-state-template.md" "$SESSION_DIR/episode-state.md"
+echo "$SESSION_DIR"
+```
+
+### process_chunk
+Process a single video file through the frame extraction pipeline.
+
+Parameters:
+- `chunk_path` (string, required) — Path to the .mp4 file
+- `output_dir` (string, required) — Directory to write extracted frames and audio
+
+```bash
+bash "$HOME/.vellum/workspace/watch-together/scripts/process-chunk.sh" "$chunk_path" "$output_dir"
+```
+
+### rewind
+Dense 720p frame extraction for a specific time range. Use when something catches your eye.
+
+Parameters:
+- `chunk_path` (string, required) — Path to the original .mp4 chunk
+- `output_dir` (string, required) — Where to save the dense frames  
+- `start_time` (number, required) — Start time in seconds
+- `end_time` (number, required) — End time in seconds
+
+```bash
+bash "$HOME/.vellum/workspace/watch-together/scripts/process-chunk.sh" "$chunk_path" "$output_dir" --rewind "$start_time" "$end_time"
+```
+
+## Environment Variables
+
+- `GEMINI_API_KEY` — Required for audio analysis. Without it, chunks arrive with no audio description and the assistant has no audio context (the user provides verbal descriptions instead). Set it in the shell before running `capture-live.sh`.
+- `GEMINI_MODEL` — Optional, defaults to `gemini-3-flash-preview`.
+
+## File Locations
+
+- Scripts: `~/.vellum/workspace/watch-together/scripts/`
+- Sessions: `~/.vellum/workspace/watch-together/sessions/`
+- Episode state template: `~/.vellum/workspace/watch-together/episode-state-template.md`
+- Signal format: JSON to `~/.vellum/workspace/signals/user-message.<requestId>` (supports `attachments` array with `{path, filename, mimeType}` for inline images)
+
+## Episode State Template Sections
+
+- **Characters** — who you've met, visual details, mannerisms
+- **What's happened** — plot beats in order (your understanding, not a transcript)
+- **My theories** — predictions, suspicions, setups
+- **Visual motifs** — recurring shots, lighting patterns, color choices, framing
+- **Audio landscape** — musical themes, silence usage, sound design patterns
+- **Emotional arc** — how the episode feels
+- **Last chunk** — freshest observations
+- **User notes** — real-time context from the user that couldn't be derived from frames/audio

--- a/skills/watch-together/episode-state-template.md
+++ b/skills/watch-together/episode-state-template.md
@@ -1,0 +1,25 @@
+# [Show Name] — S_E_
+
+## Characters
+<!-- Who have I met? What do I know about them? Visual details, mannerisms, voice notes from Gemini -->
+
+## What's happened
+<!-- Plot beats in order. Not a transcript — my understanding of the story -->
+
+## My theories
+<!-- Predictions, suspicions, things that feel like setups -->
+
+## Visual motifs
+<!-- Recurring shots, lighting patterns, color choices, framing decisions -->
+
+## Audio landscape  
+<!-- Musical themes, silence usage, sound design patterns (from Gemini) -->
+
+## Emotional arc
+<!-- How does this episode FEEL? What's the emotional throughline? -->
+
+## Last chunk
+<!-- What just happened — my freshest observations before the next chunk arrives -->
+
+## User notes
+<!-- Real-time context from the user that couldn't be derived from frames/audio -->

--- a/skills/watch-together/scripts/analyze-audio.sh
+++ b/skills/watch-together/scripts/analyze-audio.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# analyze-audio.sh — Send audio to Gemini for description
+# Usage: ./analyze-audio.sh <audio_file> <output.json> [prompt_file]
+#
+# If prompt_file is provided, uses that as the analysis prompt.
+# Otherwise uses a default comprehensive audio description prompt.
+#
+# Requires: GEMINI_API_KEY environment variable
+
+set -euo pipefail
+
+AUDIO_FILE="${1:?Usage: analyze-audio.sh <audio_file> <output.json> [prompt_file]}"
+OUTPUT_FILE="${2:?Missing output file path}"
+PROMPT_FILE="${3:-}"
+
+MODEL="${GEMINI_MODEL:-gemini-3-flash-preview}"
+
+if [[ -z "${GEMINI_API_KEY:-}" ]]; then
+    echo "❌ GEMINI_API_KEY not set"
+    exit 1
+fi
+
+API_URL="https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateContent?key=${GEMINI_API_KEY}"
+
+# Detect MIME type
+case "${AUDIO_FILE##*.}" in
+    mp3) MIME_TYPE="audio/mpeg" ;;
+    wav) MIME_TYPE="audio/wav" ;;
+    m4a) MIME_TYPE="audio/mp4" ;;
+    aac) MIME_TYPE="audio/aac" ;;
+    ogg) MIME_TYPE="audio/ogg" ;;
+    mp4) MIME_TYPE="video/mp4" ;;
+    *)   MIME_TYPE="audio/mpeg" ;;
+esac
+
+# Load prompt
+if [[ -n "$PROMPT_FILE" ]] && [[ -f "$PROMPT_FILE" ]]; then
+    PROMPT=$(cat "$PROMPT_FILE")
+else
+    PROMPT="Analyze this audio clip and describe everything you hear:
+
+1. **Dialogue**: Transcribe all spoken lines with approximate timestamps (e.g. [0:05]). For each line, describe the speaker's voice (pitch, age, quality) and delivery (tone, emotion, volume, pacing — e.g. whispering, shouting, trembling, sarcastic, flat, tender, desperate).
+
+2. **Music**: Describe any music — mood, instruments, intensity, tempo, key feeling. How does it change across the clip? Note if there is NO music — silence is a deliberate choice.
+
+3. **Sound Design**: Non-speech, non-music audio. Ambient sounds, foley, environmental atmosphere — footsteps, doors, wind, rain, glass, fabric, breathing, crowd noise, mechanical sounds, anything.
+
+4. **Emotional Arc**: How does the audio feel across the full duration? Where are the peaks and valleys? What is the sound trying to make the listener feel?
+
+5. **Silence & Pauses**: Note any significant silence or pauses. Duration, what surrounds them, what they communicate.
+
+Be specific and vivid. Describe what you hear as if translating sound for someone who cannot hear it."
+fi
+
+# Build request with python (handles base64 encoding cleanly)
+python3 -c "
+import json, base64, sys
+
+with open('$AUDIO_FILE', 'rb') as f:
+    audio_b64 = base64.b64encode(f.read()).decode()
+
+prompt = open('$PROMPT_FILE', 'r').read() if '$PROMPT_FILE' and '$PROMPT_FILE' != '' else '''$(echo "$PROMPT" | sed "s/'/\\\\'/g")'''
+
+request = {
+    'contents': [{
+        'parts': [
+            {
+                'inlineData': {
+                    'mimeType': '$MIME_TYPE',
+                    'data': audio_b64
+                }
+            },
+            {'text': prompt}
+        ]
+    }],
+    'generationConfig': {
+        'temperature': 0.7,
+        'maxOutputTokens': 2048
+    }
+}
+
+json.dump(request, sys.stdout)
+" > /tmp/gemini-audio-request.json
+
+echo "🎧 Analyzing audio with $MODEL..."
+
+HTTP_CODE=$(curl -s -w "%{http_code}" -o "$OUTPUT_FILE.raw" \
+    -X POST "$API_URL" \
+    -H "Content-Type: application/json" \
+    -d @/tmp/gemini-audio-request.json)
+
+rm -f /tmp/gemini-audio-request.json
+
+if [[ "$HTTP_CODE" != "200" ]]; then
+    echo "❌ Gemini API error (HTTP $HTTP_CODE)"
+    cat "$OUTPUT_FILE.raw" 2>/dev/null | head -5
+    rm -f "$OUTPUT_FILE.raw"
+    exit 1
+fi
+
+python3 -c "
+import json
+with open('$OUTPUT_FILE.raw') as f:
+    resp = json.loads(f.read())
+text = resp['candidates'][0]['content']['parts'][0]['text']
+with open('$OUTPUT_FILE', 'w') as f:
+    json.dump({'audio_analysis': text, 'model': '$MODEL'}, f, indent=2)
+print(text)
+"
+
+rm -f "$OUTPUT_FILE.raw"
+echo "✅ Audio analysis saved to $OUTPUT_FILE"

--- a/skills/watch-together/scripts/capture-live.sh
+++ b/skills/watch-together/scripts/capture-live.sh
@@ -1,0 +1,335 @@
+#!/bin/bash
+# capture-live.sh — Record, process, and push chunks to the assistant in real time
+#
+# This script:
+# 1. Records screen + audio in T-second segments
+# 2. Automatically processes each segment (frame extraction + audio)
+# 3. Sends a signal to the assistant's conversation so it sees each chunk
+#
+# Usage: ./capture-live.sh <session_dir> <conversation_key> [chunk_seconds] [screen_device] [audio_device]
+#
+# conversation_key: the conversation ID where the assistant is watching
+#                   (e.g. "2026-03-30T06-08-25.628Z_191a7dcc-...")
+
+set -euo pipefail
+
+SESSION_DIR="${1:?Usage: capture-live.sh <session_dir> <conversation_key> [chunk_seconds] [screen_device] [audio_device]}"
+CONVERSATION_KEY="${2:?Missing conversation_key — the assistant needs to know where to send reactions}"
+CHUNK_SECONDS="${3:-30}"
+SCREEN_DEVICE="${4:-2}"
+AUDIO_DEVICE="${5:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORKSPACE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SIGNALS_DIR="$HOME/.vellum/workspace/signals"
+CHUNKS_DIR="$SESSION_DIR/chunks"
+PROCESSED_DIR="$SESSION_DIR/processed"
+
+# Clean previous recording data so the watcher doesn't skip stale chunks
+rm -rf "$CHUNKS_DIR" "$PROCESSED_DIR"
+mkdir -p "$CHUNKS_DIR" "$PROCESSED_DIR" "$SIGNALS_DIR"
+
+# Auto-detect audio device
+if [[ -z "$AUDIO_DEVICE" ]]; then
+    DEVICES=$(ffmpeg -f avfoundation -list_devices true -i "" 2>&1 || true)
+    if echo "$DEVICES" | grep -qi "BlackHole"; then
+        AUDIO_DEVICE=$(echo "$DEVICES" | grep -i "BlackHole" | head -1 | grep -o '\[[0-9]*\]' | tr -d '[]')
+        echo "🔊 Audio: BlackHole (system audio capture)"
+    else
+        echo "⚠️  No BlackHole — video-only mode. The user will describe audio."
+        AUDIO_DEVICE="none"
+    fi
+fi
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "🎬 Watch Together — Live Capture"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "   Session:      $SESSION_DIR"
+echo "   Conversation: ${CONVERSATION_KEY:0:40}..."
+echo "   Chunks:       ${CHUNK_SECONDS}s each"
+echo "   Audio:        $AUDIO_DEVICE"
+echo ""
+echo "   Press Ctrl+C to stop"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# Function to process a chunk and signal the assistant
+process_and_signal() {
+    local CHUNK_FILE="$1"
+    local CHUNK_NAME=$(basename "$CHUNK_FILE" .mp4)
+    local OUT_DIR="$PROCESSED_DIR/$CHUNK_NAME"
+
+    echo "⚙️  Processing $CHUNK_NAME..."
+    "$SCRIPT_DIR/process-chunk.sh" "$CHUNK_FILE" "$OUT_DIR" 2>&1
+
+    if [[ ! -f "$OUT_DIR/manifest.json" ]]; then
+        echo "❌ Processing failed for $CHUNK_NAME"
+        return
+    fi
+
+    # Count frames
+    local FRAME_COUNT=$(ls "$OUT_DIR/frames"/f_*.jpg 2>/dev/null | wc -l | tr -d ' ')
+    local HAS_AUDIO="false"
+    [[ -f "$OUT_DIR/audio/audio.mp3" ]] && HAS_AUDIO="true"
+
+    # Build frame list (select ~6 evenly spaced frames for the assistant to look at)
+    local FRAME_FILES=($(ls "$OUT_DIR/frames"/f_*.jpg 2>/dev/null | sort))
+    local TOTAL_FRAMES=${#FRAME_FILES[@]}
+    local SELECTED_FRAMES=""
+
+    if [[ $TOTAL_FRAMES -le 6 ]]; then
+        SELECTED_FRAMES=$(printf '%s\n' "${FRAME_FILES[@]}" | tr '\n' '|')
+    else
+        local STEP=$((TOTAL_FRAMES / 6))
+        for i in 0 1 2 3 4 5; do
+            local IDX=$((i * STEP))
+            SELECTED_FRAMES+="${FRAME_FILES[$IDX]}|"
+        done
+    fi
+
+    # Run Gemini audio analysis before building signal content
+    if [[ -f "$OUT_DIR/audio/audio.mp3" ]] && [[ -n "${GEMINI_API_KEY:-}" ]]; then
+        echo "🎧 Analyzing audio with Gemini..."
+
+        # Build context-aware prompt with previous chunk's analysis
+        local PROMPT_FILE=""
+        local PREV_CHUNK_NUM=$((10#${CHUNK_NAME##*-} - 1))
+        local PREV_ANALYSIS="$PROCESSED_DIR/$(printf "chunk-%03d" $PREV_CHUNK_NUM)/audio/gemini-analysis.json"
+        if [[ $PREV_CHUNK_NUM -ge 0 ]] && [[ -f "$PREV_ANALYSIS" ]]; then
+            PROMPT_FILE="$OUT_DIR/audio/prompt.txt"
+            local PREV_TEXT
+            PREV_TEXT=$(python3 -c "
+import json
+with open('$PREV_ANALYSIS') as f:
+    print(json.load(f).get('audio_analysis', ''))
+" 2>/dev/null || true)
+            if [[ -n "$PREV_TEXT" ]]; then
+                cat > "$PROMPT_FILE" << PROMPT_EOF
+You are analyzing consecutive audio clips from the SAME source (a TV show or music video being watched in real time). Maintain consistency with your previous analysis unless the audio clearly contradicts it.
+
+PREVIOUS CHUNK ANALYSIS:
+$PREV_TEXT
+
+---
+
+Now analyze this next audio clip. Describe everything you hear:
+
+1. **Dialogue**: Transcribe all spoken lines with approximate timestamps (e.g. [0:05]). For each line, describe the speaker's voice (pitch, age, quality) and delivery (tone, emotion, volume, pacing).
+
+2. **Music**: Describe any music — mood, instruments, intensity, tempo, key feeling. How does it change across the clip? Note if there is NO music.
+
+3. **Sound Design**: Non-speech, non-music audio. Ambient sounds, foley, environmental atmosphere.
+
+4. **Emotional Arc**: How does the audio feel across the full duration? Where are the peaks and valleys?
+
+5. **Silence & Pauses**: Note any significant silence or pauses.
+
+Be specific and vivid. Describe what you hear as if translating sound for someone who cannot hear it.
+PROMPT_EOF
+            fi
+        fi
+
+        "$SCRIPT_DIR/analyze-audio.sh" "$OUT_DIR/audio/audio.mp3" "$OUT_DIR/audio/gemini-analysis.json" ${PROMPT_FILE:+"$PROMPT_FILE"} 2>&1 || echo "⚠️  Audio analysis failed (non-fatal)"
+    fi
+
+    # Read Gemini audio analysis if available (from a previous chunk's background run)
+    local AUDIO_ANALYSIS=""
+    if [[ -f "$OUT_DIR/audio/gemini-analysis.json" ]]; then
+        AUDIO_ANALYSIS=$(python3 -c "
+import json
+with open('$OUT_DIR/audio/gemini-analysis.json') as f:
+    data = json.loads(f.read())
+print(data.get('audio_analysis', 'No analysis available'))
+" 2>/dev/null || echo "Could not read audio analysis")
+    fi
+
+    # Read volume info
+    local VOLUME_INFO=""
+    if [[ -f "$OUT_DIR/audio/volume.txt" ]] && [[ -s "$OUT_DIR/audio/volume.txt" ]]; then
+        VOLUME_INFO=$(cat "$OUT_DIR/audio/volume.txt")
+    fi
+
+    # Build content with all info embedded
+    local CONTENT="[WATCH-CHUNK] ${CHUNK_NAME}
+Session: ${SESSION_DIR}
+Processed: ${OUT_DIR}
+Frames: ${FRAME_COUNT} total, 6 key frames attached
+
+Spectrogram: ${OUT_DIR}/audio/spectrogram.png
+Raw chunk: ${CHUNKS_DIR}/${CHUNK_NAME}.mp4"
+
+    if [[ -n "$AUDIO_ANALYSIS" ]]; then
+        CONTENT="${CONTENT}
+
+🎧 AUDIO ANALYSIS (Gemini):
+${AUDIO_ANALYSIS}"
+    fi
+
+    if [[ -n "$VOLUME_INFO" ]]; then
+        CONTENT="${CONTENT}
+
+📊 Volume: ${VOLUME_INFO}"
+    fi
+
+    CONTENT="${CONTENT}
+
+The key frames are attached as images — you can see them directly. The audio analysis above describes what was heard. React, update episode-state.md, enjoy the show. 🔔"
+
+    # Write signal to wake the assistant
+    local REQUEST_ID="watch-${CHUNK_NAME}-$(date +%s)"
+    local SIGNAL_FILE="$SIGNALS_DIR/user-message.${REQUEST_ID}"
+
+    SIG_CONTENT="$CONTENT" \
+    SIG_FRAMES="$SELECTED_FRAMES" \
+    SIG_OUT_DIR="$OUT_DIR" \
+    SIG_CONV_KEY="$CONVERSATION_KEY" \
+    SIG_REQ_ID="$REQUEST_ID" \
+    SIG_FILE="$SIGNAL_FILE" \
+    python3 << 'PYEOF'
+import json, os
+
+content = os.environ["SIG_CONTENT"]
+selected_frames = os.environ["SIG_FRAMES"]
+out_dir = os.environ["SIG_OUT_DIR"]
+conversation_key = os.environ["SIG_CONV_KEY"]
+request_id = os.environ["SIG_REQ_ID"]
+signal_file = os.environ["SIG_FILE"]
+
+# Build attachments from selected frames
+attachments = []
+for f in selected_frames.rstrip("|").split("|"):
+    f = f.strip()
+    if f and os.path.isfile(f):
+        attachments.append({
+            "path": f,
+            "filename": os.path.basename(f),
+            "mimeType": "image/jpeg"
+        })
+
+# Attach spectrogram if it exists
+spec = os.path.join(out_dir, "audio", "spectrogram.png")
+if os.path.isfile(spec):
+    attachments.append({
+        "path": spec,
+        "filename": "spectrogram.png",
+        "mimeType": "image/png"
+    })
+
+signal = {
+    "conversationKey": conversation_key,
+    "content": content,
+    "sourceChannel": "vellum",
+    "interface": "cli",
+    "requestId": request_id,
+    "bypassSecretCheck": True,
+    "attachments": attachments
+}
+with open(signal_file, "w") as f:
+    json.dump(signal, f)
+PYEOF
+
+    echo "📨 Signaled assistant: $CHUNK_NAME ($FRAME_COUNT frames, audio: $HAS_AUDIO)"
+}
+
+# Background watcher: process new chunks as they appear
+# Strategy: process chunk N when chunk N+1 appears (proves N is fully written)
+watch_for_chunks() {
+    local LAST_PROCESSED=-1
+
+    while true; do
+        # Glob may match nothing; disable nounset temporarily for safe array building
+        local CHUNKS=()
+        while IFS= read -r f; do
+            CHUNKS+=("$f")
+        done < <(ls "$CHUNKS_DIR"/chunk-*.mp4 2>/dev/null | sort)
+        local CURRENT_COUNT=${#CHUNKS[@]}
+
+        local idx=$((LAST_PROCESSED + 1))
+        while [[ $idx -lt $CURRENT_COUNT ]]; do
+            local CHUNK="${CHUNKS[$idx]}"
+            local CHUNK_NAME=$(basename "$CHUNK" .mp4)
+
+            # Skip if already processed
+            if [[ -f "$PROCESSED_DIR/$CHUNK_NAME/manifest.json" ]]; then
+                LAST_PROCESSED=$idx
+                idx=$((idx + 1))
+                continue
+            fi
+
+            # Only process if the file has a valid moov atom (fully written)
+            if ! ffprobe -v error -show_entries format=duration "$CHUNK" >/dev/null 2>&1; then
+                break
+            fi
+
+            process_and_signal "$CHUNK"
+            LAST_PROCESSED=$idx
+            idx=$((idx + 1))
+        done
+
+        sleep 3
+    done
+}
+
+# Start the chunk watcher in the background
+watch_for_chunks &
+WATCHER_PID=$!
+
+# Cleanup on exit
+cleanup() {
+    echo ""
+    echo "🛑 Stopping capture..."
+    kill $WATCHER_PID 2>/dev/null || true
+    wait $WATCHER_PID 2>/dev/null || true
+
+    # Process any remaining unprocessed chunks
+    echo "⚙️  Processing remaining chunks..."
+    local CHUNKS=($(ls "$CHUNKS_DIR"/chunk-*.mp4 2>/dev/null | sort))
+    for CHUNK in "${CHUNKS[@]}"; do
+        local CHUNK_NAME=$(basename "$CHUNK" .mp4)
+        if [[ ! -f "$PROCESSED_DIR/$CHUNK_NAME/manifest.json" ]]; then
+            process_and_signal "$CHUNK"
+        fi
+    done
+
+    echo ""
+    echo "✅ Session complete!"
+    echo "   Chunks: $CHUNKS_DIR"
+    echo "   Processed: $PROCESSED_DIR"
+}
+trap cleanup EXIT INT TERM
+
+# Build ffmpeg command
+# Notes on macOS screen capture:
+# - AVFoundation screen capture outputs uyvy422/nv12, not yuv420p
+# - We let ffmpeg auto-select the input pixel format and convert during encoding
+# - probesize helps with initial stream detection
+# - r 30 on OUTPUT side controls encoding framerate (not capture)
+FFMPEG_CMD=(ffmpeg -v warning -stats)
+FFMPEG_CMD+=(-f avfoundation -capture_cursor 0 -probesize 20M -framerate 30)
+
+if [[ "$AUDIO_DEVICE" == "none" ]]; then
+    FFMPEG_CMD+=(-i "${SCREEN_DEVICE}:none")
+else
+    FFMPEG_CMD+=(-i "${SCREEN_DEVICE}:${AUDIO_DEVICE}")
+fi
+
+# Video: let x264 handle pixel format conversion internally
+FFMPEG_CMD+=(-c:v libx264 -preset ultrafast -crf 28 -r 30)
+
+if [[ "$AUDIO_DEVICE" != "none" ]]; then
+    # Record at native 96kHz from BlackHole — resampling during live capture
+    # drops audio frames. Extraction in process-chunk.sh handles the downsample.
+    FFMPEG_CMD+=(-c:a aac -b:a 128k)
+fi
+
+FFMPEG_CMD+=(
+    -f segment
+    -segment_time "$CHUNK_SECONDS"
+    -reset_timestamps 1
+    -segment_format mp4
+    "$CHUNKS_DIR/chunk-%03d.mp4"
+)
+
+echo "🔴 Recording... chunks will be sent to the assistant automatically"
+echo ""
+"${FFMPEG_CMD[@]}"

--- a/skills/watch-together/scripts/capture.sh
+++ b/skills/watch-together/scripts/capture.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# capture.sh — Record screen + system audio in T-second chunks
+# Usage: ./capture.sh <session_dir> [chunk_seconds] [screen_device] [audio_device]
+#
+# Prerequisites:
+#   - ffmpeg installed (brew install ffmpeg)
+#   - Screen recording permission granted
+#   - For system audio: BlackHole installed (brew install blackhole-2ch)
+#     Then set up a Multi-Output Device in Audio MIDI Setup that includes
+#     both your speakers/headphones AND BlackHole 2ch
+#
+# The script records until you press 'q' or Ctrl+C.
+
+set -euo pipefail
+
+SESSION_DIR="${1:?Usage: capture.sh <session_dir> [chunk_seconds] [screen_device] [audio_device]}"
+CHUNK_SECONDS="${2:-30}"
+SCREEN_DEVICE="${3:-2}"  # "Capture screen 0" on most Macs
+AUDIO_DEVICE="${4:-}"    # Auto-detect if not specified
+
+# Auto-detect audio device: prefer BlackHole, fall back to mic
+if [[ -z "$AUDIO_DEVICE" ]]; then
+    DEVICES=$(ffmpeg -f avfoundation -list_devices true -i "" 2>&1 || true)
+    if echo "$DEVICES" | grep -qi "BlackHole"; then
+        AUDIO_DEVICE=$(echo "$DEVICES" | grep -i "BlackHole" | head -1 | grep -o '\[[0-9]*\]' | tr -d '[]')
+        echo "🔊 Audio: BlackHole (system audio capture)"
+    else
+        echo "⚠️  BlackHole not found — no system audio capture available"
+        echo "   Install with: brew install blackhole-2ch"
+        echo "   Then set up Multi-Output Device in Audio MIDI Setup"
+        echo ""
+        echo "   Continuing WITHOUT audio capture (video-only mode)"
+        echo "   The user will describe audio verbally 👂"
+        AUDIO_DEVICE="none"
+    fi
+fi
+
+CHUNKS_DIR="$SESSION_DIR/chunks"
+mkdir -p "$CHUNKS_DIR"
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "🎬 Watch Together — Capture"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "   Session:  $SESSION_DIR"
+echo "   Chunks:   ${CHUNK_SECONDS}s each"
+echo "   Screen:   device $SCREEN_DEVICE"
+echo "   Audio:    ${AUDIO_DEVICE}"
+echo ""
+echo "   Press 'q' to stop recording"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# Build ffmpeg command
+FFMPEG_CMD=(ffmpeg -v warning -stats)
+
+# Input: screen
+FFMPEG_CMD+=(-f avfoundation -capture_cursor 0 -framerate 30)
+
+if [[ "$AUDIO_DEVICE" == "none" ]]; then
+    FFMPEG_CMD+=(-i "${SCREEN_DEVICE}:none")
+else
+    FFMPEG_CMD+=(-i "${SCREEN_DEVICE}:${AUDIO_DEVICE}")
+fi
+
+# Video encoding: fast, reasonable quality
+FFMPEG_CMD+=(-c:v libx264 -preset ultrafast -crf 23 -pix_fmt yuv420p)
+
+# Audio encoding (if available)
+if [[ "$AUDIO_DEVICE" != "none" ]]; then
+    FFMPEG_CMD+=(-c:a aac -b:a 128k)
+fi
+
+# Segment into chunks
+FFMPEG_CMD+=(
+    -f segment
+    -segment_time "$CHUNK_SECONDS"
+    -reset_timestamps 1
+    -segment_format mp4
+    "$CHUNKS_DIR/chunk-%03d.mp4"
+)
+
+echo "🔴 Recording..."
+"${FFMPEG_CMD[@]}"
+echo ""
+echo "✅ Recording stopped. Chunks saved to: $CHUNKS_DIR"
+echo "   Process chunks with: ./process-chunk.sh <chunk.mp4> <output_dir>"

--- a/skills/watch-together/scripts/process-chunk.sh
+++ b/skills/watch-together/scripts/process-chunk.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# process-chunk.sh — Extract frames + audio from a video chunk
+# Usage: ./process-chunk.sh <chunk.mp4> <output_dir> [--rewind START END]
+
+set -euo pipefail
+
+CHUNK="$1"
+OUTPUT_DIR="$2"
+SHORT_EDGE="${SHORT_EDGE:-480}"
+SCENE_THRESHOLD="${SCENE_THRESHOLD:-0.3}"
+FPS=$(ffprobe -v error -select_streams v:0 -show_entries stream=r_frame_rate -of csv=p=0 "$CHUNK" | head -1)
+# Convert fractional fps (e.g. "30000/1001") to integer
+FPS_INT=$(python3 -c "print(int(round(eval('$FPS'))))")
+
+mkdir -p "$OUTPUT_DIR/frames" "$OUTPUT_DIR/audio"
+
+# --- REWIND MODE: dense extraction for a specific time range ---
+if [[ "${3:-}" == "--rewind" ]]; then
+    START="${4:?rewind needs START time}"
+    END="${5:?rewind needs END time}"
+    REWIND_DIR="$OUTPUT_DIR/rewind_${START}_${END}"
+    mkdir -p "$REWIND_DIR"
+
+    echo "🔍 Rewind mode: pulling 10fps from ${START}s to ${END}s"
+    ffmpeg -v warning -ss "$START" -to "$END" -i "$CHUNK" \
+        -vf "scale=-1:720" \
+        -r 10 \
+        -q:v 2 \
+        "$REWIND_DIR/r_%04d.jpg"
+
+    # Count output frames
+    RCOUNT=$(ls "$REWIND_DIR"/r_*.jpg 2>/dev/null | wc -l | tr -d ' ')
+    echo "✅ Rewind complete: $RCOUNT frames at 720p"
+    exit 0
+fi
+
+# --- NORMAL MODE: scene detection + 1fps baseline ---
+echo "🎬 Processing: $(basename "$CHUNK")"
+echo "   FPS: $FPS_INT | Scene threshold: $SCENE_THRESHOLD | Scale: ${SHORT_EDGE}p"
+
+# Extract frames: 1fps baseline + scene change detection
+# Pipe showinfo to capture timestamps for each output frame
+# Extract frames — showinfo goes to stderr, frames to files
+ffmpeg -v warning -i "$CHUNK" \
+    -vf "scale=-1:${SHORT_EDGE},select='not(mod(n\,${FPS_INT}))+gt(scene\,${SCENE_THRESHOLD})',showinfo" \
+    -vsync vfr \
+    -q:v 3 \
+    "$OUTPUT_DIR/frames/f_%04d.jpg" \
+    2> "$OUTPUT_DIR/frames/showinfo_raw.txt" || true
+
+# Parse timestamps from showinfo output
+grep "pts_time" "$OUTPUT_DIR/frames/showinfo_raw.txt" | \
+    sed 's/.*pts_time:\([0-9.]*\).*/\1/' > "$OUTPUT_DIR/frames/timestamps.txt" 2>/dev/null || true
+
+# Extract audio as separate file for Gemini analysis
+# aresample=async=1 fills gaps in audio packets from AVFoundation/BlackHole capture,
+# which delivers sparse audio frames spread across the full video timeline.
+ffmpeg -v warning -i "$CHUNK" \
+    -vn -af "aresample=async=1" -acodec libmp3lame -q:a 4 \
+    "$OUTPUT_DIR/audio/audio.mp3" 2>/dev/null || echo "⚠️  No audio track found"
+
+# Extract spectrogram image
+ffmpeg -v warning -i "$CHUNK" \
+    -lavfi "showspectrumpic=s=800x200:mode=combined:color=intensity" \
+    "$OUTPUT_DIR/audio/spectrogram.png" 2>/dev/null || echo "⚠️  Could not generate spectrogram"
+
+# Extract volume levels
+ffmpeg -v warning -i "$CHUNK" \
+    -af "volumedetect" -f null /dev/null 2>&1 | \
+    grep -E "mean_volume|max_volume|histogram" > "$OUTPUT_DIR/audio/volume.txt" 2>/dev/null || true
+
+# Generate summary
+FRAME_COUNT=$(ls "$OUTPUT_DIR/frames"/f_*.jpg 2>/dev/null | wc -l | tr -d ' ')
+DURATION=$(ffprobe -v error -show_entries format=duration -of csv=p=0 "$CHUNK" | head -1)
+HAS_AUDIO="no"
+[[ -f "$OUTPUT_DIR/audio/audio.mp3" ]] && HAS_AUDIO="yes"
+
+cat > "$OUTPUT_DIR/manifest.json" << EOF
+{
+  "source": "$(basename "$CHUNK")",
+  "duration_seconds": $DURATION,
+  "fps": $FPS_INT,
+  "frame_count": $FRAME_COUNT,
+  "scene_threshold": $SCENE_THRESHOLD,
+  "short_edge": $SHORT_EDGE,
+  "has_audio": $HAS_AUDIO,
+  "frames_dir": "frames/",
+  "timestamps_file": "frames/timestamps.txt",
+  "audio_file": "audio/audio.mp3",
+  "spectrogram": "audio/spectrogram.png"
+}
+EOF
+
+echo "✅ Done: $FRAME_COUNT frames extracted | audio: $HAS_AUDIO | duration: ${DURATION}s"

--- a/skills/watch-together/scripts/process-session.sh
+++ b/skills/watch-together/scripts/process-session.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# process-session.sh — Process all chunks in a session directory
+# Usage: ./process-session.sh <session_dir> [start_chunk]
+#
+# Processes each chunk through the frame extraction + audio pipeline.
+# Can resume from a specific chunk number if interrupted.
+
+set -euo pipefail
+
+SESSION_DIR="${1:?Usage: process-session.sh <session_dir> [start_chunk]}"
+START="${2:-0}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+CHUNKS_DIR="$SESSION_DIR/chunks"
+PROCESSED_DIR="$SESSION_DIR/processed"
+mkdir -p "$PROCESSED_DIR"
+
+# Find all chunks
+CHUNKS=($(ls "$CHUNKS_DIR"/chunk-*.mp4 2>/dev/null | sort))
+TOTAL=${#CHUNKS[@]}
+
+if [[ $TOTAL -eq 0 ]]; then
+    echo "❌ No chunks found in $CHUNKS_DIR"
+    exit 1
+fi
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "🎬 Processing $TOTAL chunks (starting at $START)"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+for i in $(seq "$START" $((TOTAL - 1))); do
+    CHUNK="${CHUNKS[$i]}"
+    CHUNK_NAME=$(basename "$CHUNK" .mp4)
+    OUT="$PROCESSED_DIR/$CHUNK_NAME"
+
+    if [[ -f "$OUT/manifest.json" ]]; then
+        echo "⏭️  Skipping $CHUNK_NAME (already processed)"
+        continue
+    fi
+
+    echo ""
+    echo "[$((i+1))/$TOTAL] $CHUNK_NAME"
+    "$SCRIPT_DIR/process-chunk.sh" "$CHUNK" "$OUT"
+done
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "✅ All chunks processed!"
+echo "   Processed data: $PROCESSED_DIR"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
## Summary
- Add `oura-setup` skill: OAuth2 flow with Python helper script, app registration guide, token storage, endpoint reference, and refresh instructions
- Add `oura` skill: data access patterns for all Oura Cloud API V2 endpoints (sleep, readiness, activity, HR, stress, SpO2, workouts) with credential proxy integration
- Register both in `catalog.json` with proper metadata and `oura` including `oura-setup` as a dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)