### PR TITLE
feat(settings): add spinner, toast, masked placeholder to image gen key save

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
@@ -61,13 +61,7 @@ struct ImageGenerationServiceCard: View {
             yourOwnContent: {
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     // API Key field
-                    VTextField(
-                        "API Key",
-                        placeholder: "Enter your API key",
-                        text: $apiKeyText,
-                        isSecure: true,
-                        errorMessage: store.imageGenKeySaveError
-                    )
+                    apiKeyField
 
                     // Model picker
                     modelPicker
@@ -75,7 +69,9 @@ struct ImageGenerationServiceCard: View {
                     // Action buttons
                     ServiceCardActions(
                         hasChanges: hasChanges,
+                        isSaving: store.imageGenKeySaving,
                         onSave: { save() },
+                        savingLabel: "Validating...",
                         onReset: {
                             store.clearImageGenKey()
                             apiKeyText = ""
@@ -124,6 +120,25 @@ struct ImageGenerationServiceCard: View {
         }
     }
 
+    // MARK: - API Key Field
+
+    private var apiKeyField: some View {
+        let placeholder: String = {
+            if isConnected {
+                return "••••••••••••••••"
+            }
+            return "Enter your Gemini API key"
+        }()
+        return VTextField(
+            "API Key",
+            placeholder: placeholder,
+            text: $apiKeyText,
+            isSecure: true,
+            errorMessage: store.imageGenKeySaveError
+        )
+        .disabled(store.imageGenKeySaving)
+    }
+
     // MARK: - Model Picker
 
     private var modelPicker: some View {
@@ -144,11 +159,16 @@ struct ImageGenerationServiceCard: View {
     // MARK: - Save
 
     private func save() {
-        // Persist API key if entered and in your-own mode
+        // Persist API key if entered and in your-own mode.
+        // saveImageGenKey is async (validates with the provider before storing).
+        // The key text is kept until validation succeeds so the user can retry.
         let trimmedKey = apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
         if draftMode == "your-own" && !trimmedKey.isEmpty {
-            store.saveImageGenKey(trimmedKey)
-            apiKeyText = ""
+            let keyTextBinding = $apiKeyText
+            store.saveImageGenKey(trimmedKey, onSuccess: {
+                keyTextBinding.wrappedValue = ""
+                showToast("Gemini API key saved", .success)
+            })
         }
 
         let modeChanged = draftMode != store.imageGenMode


### PR DESCRIPTION
## Summary
- Replace hardcoded VTextField with computed `apiKeyField` that shows masked dots when a key is saved
- Pass `imageGenKeySaving` to ServiceCardActions for Validating... spinner and button disable
- Defer text field clear to onSuccess callback with a toast confirmation
- Disable text field during async validation

Part of plan: image-gen-key-save-ux.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
