### PR TITLE
feat(settings): image gen key save UX + service card copy updates

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
@@ -44,7 +44,7 @@ struct ImageGenerationServiceCard: View {
     var body: some View {
         ServiceModeCard(
             title: "Image Generation",
-            subtitle: "Configure which provider and model to use for AI image generation",
+            subtitle: "Configure which model your assistant uses to generate images",
             draftMode: $draftMode,
             managedContent: {
                 if isLoggedIn {

--- a/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
@@ -61,13 +61,7 @@ struct ImageGenerationServiceCard: View {
             yourOwnContent: {
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     // API Key field
-                    VTextField(
-                        "API Key",
-                        placeholder: "Enter your API key",
-                        text: $apiKeyText,
-                        isSecure: true,
-                        errorMessage: store.imageGenKeySaveError
-                    )
+                    apiKeyField
 
                     // Model picker
                     modelPicker
@@ -75,7 +69,9 @@ struct ImageGenerationServiceCard: View {
                     // Action buttons
                     ServiceCardActions(
                         hasChanges: hasChanges,
+                        isSaving: store.imageGenKeySaving,
                         onSave: { save() },
+                        savingLabel: "Validating...",
                         onReset: {
                             store.clearImageGenKey()
                             apiKeyText = ""
@@ -124,6 +120,25 @@ struct ImageGenerationServiceCard: View {
         }
     }
 
+    // MARK: - API Key Field
+
+    private var apiKeyField: some View {
+        let placeholder: String = {
+            if isConnected {
+                return "••••••••••••••••"
+            }
+            return "Enter your Gemini API key"
+        }()
+        return VTextField(
+            "API Key",
+            placeholder: placeholder,
+            text: $apiKeyText,
+            isSecure: true,
+            errorMessage: store.imageGenKeySaveError
+        )
+        .disabled(store.imageGenKeySaving)
+    }
+
     // MARK: - Model Picker
 
     private var modelPicker: some View {
@@ -144,11 +159,16 @@ struct ImageGenerationServiceCard: View {
     // MARK: - Save
 
     private func save() {
-        // Persist API key if entered and in your-own mode
+        // Persist API key if entered and in your-own mode.
+        // saveImageGenKey is async (validates with the provider before storing).
+        // The key text is kept until validation succeeds so the user can retry.
         let trimmedKey = apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
         if draftMode == "your-own" && !trimmedKey.isEmpty {
-            store.saveImageGenKey(trimmedKey)
-            apiKeyText = ""
+            let keyTextBinding = $apiKeyText
+            store.saveImageGenKey(trimmedKey, onSuccess: {
+                keyTextBinding.wrappedValue = ""
+                showToast("Gemini API key saved", .success)
+            })
         }
 
         let modeChanged = draftMode != store.imageGenMode

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -92,7 +92,9 @@ struct InferenceServiceCard: View {
     var body: some View {
         ServiceModeCard(
             title: "Inference",
-            subtitle: "Configure which LLM provider and model to use to power your assistant",
+            subtitle: draftMode == "managed"
+                ? "Configure which model to use to power your assistant"
+                : "Configure which LLM provider and model to use to power your assistant",
             draftMode: $draftMode,
             managedContent: {
                 if isLoggedIn {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -46,6 +46,7 @@ public final class SettingsStore: ObservableObject {
     @Published var braveKeySaveError: String?
     @Published var perplexityKeySaveError: String?
     @Published var imageGenKeySaveError: String?
+    @Published var imageGenKeySaving: Bool = false
     @Published var maskedBraveKey: String = ""
     @Published var maskedPerplexityKey: String = ""
     @Published var maskedImageGenKey: String = ""
@@ -887,10 +888,11 @@ public final class SettingsStore: ObservableObject {
         scheduleRoutingSourceRefresh()
     }
 
-    func saveImageGenKey(_ raw: String) {
+    func saveImageGenKey(_ raw: String, onSuccess: (() -> Void)? = nil) {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         imageGenKeySaveError = nil
+        imageGenKeySaving = true
         APIKeyManager.setKey(trimmed, for: "gemini")
         // Remove any stale deletion tombstone eagerly — the user's intent is to
         // save a new key, so any prior clear is superseded.
@@ -899,8 +901,10 @@ public final class SettingsStore: ObservableObject {
         maskedImageGenKey = Self.maskKey(trimmed)
         Task {
             let result = await syncKeyToDaemonWithValidation(provider: "gemini", value: trimmed)
+            imageGenKeySaving = false
             if result.success {
                 scheduleRoutingSourceRefresh()
+                onSuccess?()
             } else if let error = result.error {
                 imageGenKeySaveError = error
                 if !result.isTransient {

--- a/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
@@ -80,7 +80,7 @@ struct WebSearchServiceCard: View {
     var body: some View {
         ServiceModeCard(
             title: "Web Search",
-            subtitle: "Configure which web search provider to use for online research",
+            subtitle: "Configure how your assistant should search the web",
             draftMode: $draftMode,
             managedContent: {
                 if store.inferenceMode == "your-own" {


### PR DESCRIPTION
## Summary
- Add saving spinner state (`imageGenKeySaving`) and `onSuccess` callback to `saveImageGenKey` in SettingsStore, matching the `saveInferenceAPIKey` pattern
- Update ImageGenerationServiceCard with masked placeholder when key exists, "Validating..." spinner, deferred text clear on success, and toast confirmation
- Update subtitle copy across Inference, Web Search, and Image Generation service cards for clarity

## PRs merged into feature branch
- #23393: feat(settings): add saving spinner state and success callback to saveImageGenKey
- #23392: copy(settings): update service card subtitles for clarity
- #23396: feat(settings): add spinner, toast, masked placeholder to image gen key save

Part of plan: image-gen-key-save-ux.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23397" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
