### PR TITLE
fix: close leaked ngrok log fd in parent after spawn

### DIFF
--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -1,5 +1,6 @@
 import { execFileSync, spawn, type ChildProcess } from "node:child_process";
 import {
+  closeSync,
   existsSync,
   mkdirSync,
   openSync,
@@ -130,10 +131,11 @@ export function startNgrokProcess(
   logFilePath?: string,
 ): ChildProcess {
   let stdio: ("ignore" | "pipe" | number)[] = ["ignore", "pipe", "pipe"];
+  let fd: number | undefined;
   if (logFilePath) {
     const dir = dirname(logFilePath);
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-    const fd = openSync(logFilePath, "a");
+    fd = openSync(logFilePath, "a");
     stdio = ["ignore", fd, fd];
   }
 
@@ -141,6 +143,14 @@ export function startNgrokProcess(
     detached: true,
     stdio,
   });
+
+  // The child process inherits a duplicate of the fd via dup2, so the
+  // parent's copy is no longer needed. Close it to avoid leaking the
+  // file descriptor for the lifetime of the parent process.
+  if (fd !== undefined) {
+    closeSync(fd);
+  }
+
   return child;
 }
 


### PR DESCRIPTION
## Summary
- Addresses review feedback from #18712
- After spawning the ngrok child process with file-based stdio, the parent's copy of the log file descriptor was never closed
- The child inherits its own copy via dup2, so the parent's fd is unnecessary and leaked for the lifetime of the CLI process — especially relevant with `--keep-alive` where the process runs indefinitely

## Test plan
- [x] `bunx tsc --noEmit` passes in `cli/`
- [ ] Manual: verify ngrok tunnel still works correctly after the fd is closed in the parent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
