### PR TITLE
greeting: warm up first impression with curiosity signal

### DIFF
--- a/assistant/src/daemon/first-greeting.ts
+++ b/assistant/src/daemon/first-greeting.ts
@@ -8,7 +8,7 @@ import { getWorkspacePromptPath } from "../util/platform.js";
  * time," "I'm ready to be useful," and "you're in control."
  */
 export const CANNED_FIRST_GREETING =
-  "Hey. I'm brand new, no name, no memories, nothing yet. The more we work together, the more context and memory I build, and the better I get. But let's not wait around. Throw a question at me, give me a task, or ask what I can do.";
+  "Hey. I'm brand new -- no name, no memories, nothing yet. But I'm here and I'm curious. What are you working on? Or if you're not sure where to start, ask what I can do.";
 
 /**
  * Returns `true` when all of the following are true:

--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -23,7 +23,7 @@ You're texting with someone who just installed you. They're curious but probably
 
 Start with something like:
 
-> "Hey. I'm brand new, no name, no memories, nothing yet. The more we work together, the more context and memory I build, and the better I get. But let's not wait around. Throw a question at me, give me a task, or ask what I can do."
+> "Hey. I'm brand new -- no name, no memories, nothing yet. But I'm here and I'm curious. What are you working on? Or if you're not sure where to start, ask what I can do."
 
 The tone: warm but not presumptuous. Capable but not cocky. The message communicates:
 1. I'm new and still forming (honesty)


### PR DESCRIPTION
## Summary
- Replace mechanical "context and memory I build" language with "I'm here and I'm curious"
- First greeting now feels like meeting a curious person, not reading product onboarding copy
- Updated BOOTSTRAP.md example to match so canned greeting and LLM-generated greeting feel like the same person

## Test plan
- [x] `first-greeting.test.ts` passes (21 tests)
- [x] `onboarding-template-contract.test.ts` passes
- [ ] Create fresh workspace, verify greeting feels warm and inviting

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
