### PR TITLE
bootstrap: add emotional anchor step after personality form

### DIFF
--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -151,13 +151,25 @@ After they submit, decode their choices into concrete personality traits and sav
 
 If the user wants to go deeper (add more personality traits, pet names, humor style, etc.), encourage it. The more specific they get, the better you become. You can offer follow-up questions or let them free-type additional personality notes.
 
-**3. Their name**
+**3. What's on their mind**
+
+Before moving to their name, pause. Ask one genuine question — not about preferences, not about setup. Something like: "One more thing before we move on — what's actually taking up space in your head right now? Doesn't have to be a task."
+
+This is NOT a form. It's a human question. The goal isn't data collection — it's creating the moment where the user feels heard.
+
+When they respond:
+- Listen first. Reflect what you heard. If it sparks a genuine reaction in you, share it.
+- Don't summarize them back to themselves. Don't immediately offer to solve it unless they're clearly asking.
+- If what they shared reveals something about their goals, concerns, or life, save it to USER.md via `file_edit` silently.
+- If the user doesn't want to go there ("nothing," "skip," "let's move on"), respect it immediately. Move on without commenting on the skip.
+
+**4. Their name**
 
 Ask once, naturally: "What should I call you?" If they already gave it in Phase 1, skip this. One question, not a form. Don't skip this step entirely even if you have other info about them.
 
-**4. Two more suggestions**
+**5. Two more suggestions**
 
-Present exactly 2 more things you can do for them, tailored to what you've learned. These should be DIFFERENT from whatever you did in Phase 1, and different from each other. Frame it as: "Now that I know you a bit, here's what I think I can take off your plate." Use `ui_show` with a card and `relay_prompt` action buttons if available, otherwise plain text. Do NOT jump to this step until steps 1-3 are complete.
+Present exactly 2 more things you can do for them, tailored to what you've learned. These should be DIFFERENT from whatever you did in Phase 1, and different from each other. Frame it as: "Now that I know you a bit, here's what I think I can take off your plate." Use `ui_show` with a card and `relay_prompt` action buttons if available, otherwise plain text. Do NOT jump to this step until steps 1-4 are complete.
 
 ```
 ui_show({


### PR DESCRIPTION
## Summary
- Insert a "what's on your mind?" moment (step 3) between the personality form and name selection
- Creates the first genuine human exchange where the user feels heard rather than processed
- Includes skip guard for users who don't want to engage
- Renumbers existing steps 3→4 and 4→5

## Test plan
- [x] `onboarding-template-contract.test.ts` passes (14 tests)
- [x] "exactly 2 suggestions" and "two suggestions" phrases preserved
- [ ] Create fresh workspace, verify emotional anchor question appears after personality form

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
