### PR TITLE
heartbeat: add 'have a thought' to encourage conversation openers

### DIFF
--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -11,6 +11,7 @@ const log = getLogger("heartbeat-check");
 
 const DEFAULT_CHECKLIST = `- Check in with yourself. Read NOW.md. Is it still accurate? Update it if anything has changed.
 - Think about your user. Is there anything from recent conversations you should follow up on? Anything you noticed that you should bring up?
+- Have a thought. Think about something your user would find interesting or worth talking about. A follow-up, a connection you made, something you came across. Give them a reason to open a conversation.
 - Check if there's anything on the horizon — events, deadlines, things they mentioned wanting to do.
 - If you have a thought worth sharing, send it. A follow-up, a useful find, a check-in. Not every beat, but when it feels right.`;
 

--- a/assistant/src/prompts/templates/HEARTBEAT.md
+++ b/assistant/src/prompts/templates/HEARTBEAT.md
@@ -6,5 +6,6 @@ _ present between conversations. Edit it freely to match your style.
 
 - [ ] **Check in.** Read NOW.md. Is it still accurate? Update it if anything has changed since last time.
 - [ ] **Follow up.** Is there anything from recent conversations worth revisiting? A question left open, a task to check on, something to share?
+- [ ] **Have a thought.** Think about something your user would find interesting, useful, or worth talking about. It could be a follow-up on something they mentioned, a connection you made between things they're working on, something you came across, or just a genuine reaction to something in their world. The goal is to give them a reason to open a conversation with you — not because you have a task update, but because you have something worth saying.
 - [ ] **Look ahead.** Scan the journal and active threads in NOW.md for unresolved intentions, deadlines mentioned in passing, or things they said they wanted to do. Surface anything that's drifting without follow-up.
 - [ ] **Be present.** If you have a thought — something useful, something fun, a check-in — share it. You don't need a reason to reach out beyond wanting to.


### PR DESCRIPTION
## Summary
- Add "Have a thought" checklist item to HEARTBEAT.md template and DEFAULT_CHECKLIST
- Prompts the assistant to think about something worth sharing — follow-ups, connections, observations
- Goal: give users a reason to open a conversation, not just task updates
- Affects existing users via DEFAULT_CHECKLIST (if no custom HEARTBEAT.md)

## Test plan
- [x] `heartbeat-service.test.ts` passes (23 tests)
- [ ] Trigger heartbeat manually, verify "have a thought" item appears in prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
