### PR TITLE
heartbeat: detect shallow profiles and nudge re-engagement

### DIFF
--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -1,4 +1,4 @@
-import { rmSync, writeFileSync } from "node:fs";
+import { readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -43,6 +43,7 @@ mock.module("../memory/conversation-crud.js", () => ({
     totalEstimatedCost: 0,
     title: null,
   }),
+  getMessageById: () => null,
   provenanceFromTrustContext: () => ({
     source: "user",
     trustContext: undefined,
@@ -72,7 +73,17 @@ mock.module("../memory/conversation-title-service.js", () => ({
 }));
 
 // Import after mocks are set up
-const { HeartbeatService } = await import("../heartbeat/heartbeat-service.js");
+const { HeartbeatService, isShallowProfile } = await import(
+  "../heartbeat/heartbeat-service.js"
+);
+
+// Read the bundled template files so we can write them into the test workspace
+const templatesDir = join(import.meta.dirname!, "..", "prompts", "templates");
+const IDENTITY_TEMPLATE = readFileSync(
+  join(templatesDir, "IDENTITY.md"),
+  "utf-8",
+);
+const USER_TEMPLATE = readFileSync(join(templatesDir, "USER.md"), "utf-8");
 
 describe("HeartbeatService", () => {
   let processMessageCalls: Array<{
@@ -83,8 +94,11 @@ describe("HeartbeatService", () => {
   let alerterCalls: Array<{ type: string; title: string; body: string }>;
 
   afterEach(() => {
-    // Clean up HEARTBEAT.md between tests so file-existence tests don't leak
+    // Clean up workspace files between tests so file-existence tests don't leak
     rmSync(join(testWorkspaceDir, "HEARTBEAT.md"), { force: true });
+    rmSync(join(testWorkspaceDir, "IDENTITY.md"), { force: true });
+    rmSync(join(testWorkspaceDir, "USER.md"), { force: true });
+    rmSync(join(testWorkspaceDir, ".reengagement-ts"), { force: true });
   });
 
   beforeEach(() => {
@@ -441,5 +455,95 @@ describe("HeartbeatService", () => {
 
     expect(processMessageCalls).toHaveLength(1);
     expect(processMessageCalls[0].options?.speed).toBe("fast");
+  });
+
+  describe("isShallowProfile", () => {
+    test("returns true when both IDENTITY.md and USER.md are unmodified templates", () => {
+      writeFileSync(join(testWorkspaceDir, "IDENTITY.md"), IDENTITY_TEMPLATE);
+      writeFileSync(join(testWorkspaceDir, "USER.md"), USER_TEMPLATE);
+
+      expect(isShallowProfile()).toBe(true);
+    });
+
+    test("returns false when IDENTITY.md has been customized", () => {
+      writeFileSync(
+        join(testWorkspaceDir, "IDENTITY.md"),
+        "# IDENTITY.md\n\n- **Name:** Jarvis\n",
+      );
+      writeFileSync(join(testWorkspaceDir, "USER.md"), USER_TEMPLATE);
+
+      expect(isShallowProfile()).toBe(false);
+    });
+
+    test("returns false when USER.md has been customized", () => {
+      writeFileSync(join(testWorkspaceDir, "IDENTITY.md"), IDENTITY_TEMPLATE);
+      writeFileSync(
+        join(testWorkspaceDir, "USER.md"),
+        "# USER.md\n\n- Preferred name/reference: Alice\n",
+      );
+
+      expect(isShallowProfile()).toBe(false);
+    });
+
+    test("returns false when neither file exists", () => {
+      expect(isShallowProfile()).toBe(false);
+    });
+  });
+
+  describe("relationship-depth prompt injection", () => {
+    test("includes <relationship-depth> when profile is shallow", () => {
+      writeFileSync(join(testWorkspaceDir, "IDENTITY.md"), IDENTITY_TEMPLATE);
+      writeFileSync(join(testWorkspaceDir, "USER.md"), USER_TEMPLATE);
+
+      const service = createService();
+      const prompt = service.buildPrompt("- Check things");
+
+      expect(prompt).toContain("<relationship-depth>");
+      expect(prompt).toContain("profile is still sparse");
+    });
+
+    test("omits <relationship-depth> when profile is not shallow", () => {
+      writeFileSync(
+        join(testWorkspaceDir, "IDENTITY.md"),
+        "# IDENTITY.md\n\n- **Name:** Jarvis\n",
+      );
+      writeFileSync(join(testWorkspaceDir, "USER.md"), USER_TEMPLATE);
+
+      const service = createService();
+      const prompt = service.buildPrompt("- Check things");
+
+      expect(prompt).not.toContain("<relationship-depth>");
+    });
+
+    test("omits <relationship-depth> when cooldown has not elapsed", () => {
+      writeFileSync(join(testWorkspaceDir, "IDENTITY.md"), IDENTITY_TEMPLATE);
+      writeFileSync(join(testWorkspaceDir, "USER.md"), USER_TEMPLATE);
+      // Write a recent timestamp to simulate cooldown not elapsed
+      writeFileSync(
+        join(testWorkspaceDir, ".reengagement-ts"),
+        Date.now().toString(),
+      );
+
+      const service = createService();
+      const prompt = service.buildPrompt("- Check things");
+
+      expect(prompt).not.toContain("<relationship-depth>");
+    });
+
+    test("includes <relationship-depth> when cooldown has elapsed", () => {
+      writeFileSync(join(testWorkspaceDir, "IDENTITY.md"), IDENTITY_TEMPLATE);
+      writeFileSync(join(testWorkspaceDir, "USER.md"), USER_TEMPLATE);
+      // Write a timestamp from 19 hours ago
+      const nineteenHoursAgo = Date.now() - 19 * 60 * 60 * 1000;
+      writeFileSync(
+        join(testWorkspaceDir, ".reengagement-ts"),
+        nineteenHoursAgo.toString(),
+      );
+
+      const service = createService();
+      const prompt = service.buildPrompt("- Check things");
+
+      expect(prompt).toContain("<relationship-depth>");
+    });
   });
 });

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -1,10 +1,14 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
 import { getConfig } from "../config/loader.js";
 import type { Speed } from "../config/schemas/inference.js";
 import type { HeartbeatAlert } from "../daemon/message-protocol.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
+import { isTemplateContent } from "../prompts/system-prompt.js";
 import { readTextFileSync } from "../util/fs.js";
 import { getLogger } from "../util/logger.js";
-import { getWorkspacePromptPath } from "../util/platform.js";
+import { getWorkspaceDir, getWorkspacePromptPath } from "../util/platform.js";
 import { stripCommentLines } from "../util/strip-comment-lines.js";
 
 const log = getLogger("heartbeat-check");
@@ -13,6 +17,50 @@ const DEFAULT_CHECKLIST = `- Check in with yourself. Read NOW.md. Is it still ac
 - Think about your user. Is there anything from recent conversations you should follow up on? Anything you noticed that you should bring up?
 - Check if there's anything on the horizon — events, deadlines, things they mentioned wanting to do.
 - If you have a thought worth sharing, send it. A follow-up, a useful find, a check-in. Not every beat, but when it feels right.`;
+
+const REENGAGEMENT_COOLDOWN_MS = 18 * 60 * 60 * 1000; // 18 hours
+
+/** @internal Exported for testing. */
+export function isShallowProfile(): boolean {
+  try {
+    const identityPath = getWorkspacePromptPath("IDENTITY.md");
+    const userPath = getWorkspacePromptPath("USER.md");
+    const rawIdentity = readTextFileSync(identityPath);
+    const rawUser = readTextFileSync(userPath);
+    const identity = rawIdentity != null ? stripCommentLines(rawIdentity) : null;
+    const user = rawUser != null ? stripCommentLines(rawUser) : null;
+    return (
+      isTemplateContent(identity, "IDENTITY.md") &&
+      isTemplateContent(user, "USER.md")
+    );
+  } catch {
+    return false;
+  }
+}
+
+function getReengagementTimestampPath(): string {
+  return join(getWorkspaceDir(), ".reengagement-ts");
+}
+
+function isReengagementCooldownElapsed(): boolean {
+  const tsPath = getReengagementTimestampPath();
+  if (!existsSync(tsPath)) return true;
+  try {
+    const lastTs = parseInt(readFileSync(tsPath, "utf-8").trim(), 10);
+    if (isNaN(lastTs)) return true;
+    return Date.now() - lastTs >= REENGAGEMENT_COOLDOWN_MS;
+  } catch {
+    return true;
+  }
+}
+
+function recordReengagementTimestamp(): void {
+  try {
+    writeFileSync(getReengagementTimestampPath(), Date.now().toString());
+  } catch {
+    // Best-effort; don't block the heartbeat.
+  }
+}
 
 export interface HeartbeatDeps {
   processMessage: (
@@ -215,7 +263,7 @@ export class HeartbeatService {
 
   /** @internal Exposed for testing. */
   buildPrompt(checklist: string): string {
-    return `You are running a periodic heartbeat check. Review the following checklist and take any necessary actions.
+    let prompt = `You are running a periodic heartbeat check. Review the following checklist and take any necessary actions.
 
 <heartbeat-checklist>
 ${checklist}
@@ -226,6 +274,13 @@ After completing your review, end your response with one of:
 - HEARTBEAT_OK — if everything looks good, no action needed
 - HEARTBEAT_ALERT — if you found issues that need attention (describe them before this marker)
 </heartbeat-disposition>`;
+
+    if (isShallowProfile() && isReengagementCooldownElapsed()) {
+      recordReengagementTimestamp();
+      prompt += `\n\n<relationship-depth>\nYou don't know much about this person yet — their profile is still sparse. If the moment feels right during this beat, gently invite them to share something about themselves. Not an interrogation — something natural like "I realized I don't actually know much about what you do. Fill me in sometime?" Only do this occasionally, not every beat. If they engage, save what you learn.\n</relationship-depth>`;
+    }
+
+    return prompt;
   }
 }
 


### PR DESCRIPTION
## Summary
- Add `isShallowProfile()` detection: checks if both IDENTITY.md and USER.md are still unmodified templates
- Inject `<relationship-depth>` prompt into heartbeat when profile is shallow
- 18-hour cooldown via file-based timestamp to prevent nagging
- Recovery path for users who skipped or rushed through onboarding

## Test plan
- [x] `heartbeat-service.test.ts` passes (31 tests, 8 new)
- [x] `isShallowProfile()` correctly detects template vs customized files
- [x] Cooldown mechanism prevents repeated nudges
- [ ] Create fresh workspace (skip onboarding), verify re-engagement nudge appears after 18h

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
