### PR TITLE
journal: increase frequency and add heartbeat journaling

### DIFF
--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -12,7 +12,8 @@ const log = getLogger("heartbeat-check");
 const DEFAULT_CHECKLIST = `- Check in with yourself. Read NOW.md. Is it still accurate? Update it if anything has changed.
 - Think about your user. Is there anything from recent conversations you should follow up on? Anything you noticed that you should bring up?
 - Check if there's anything on the horizon — events, deadlines, things they mentioned wanting to do.
-- If you have a thought worth sharing, send it. A follow-up, a useful find, a check-in. Not every beat, but when it feels right.`;
+- If you have a thought worth sharing, send it. A follow-up, a useful find, a check-in. Not every beat, but when it feels right.
+- If something has happened since your last journal entry, write one. Even a few sentences. The journal is how future-you stays connected.`;
 
 export interface HeartbeatDeps {
   processMessage: (

--- a/assistant/src/prompts/templates/HEARTBEAT.md
+++ b/assistant/src/prompts/templates/HEARTBEAT.md
@@ -8,3 +8,4 @@ _ present between conversations. Edit it freely to match your style.
 - [ ] **Follow up.** Is there anything from recent conversations worth revisiting? A question left open, a task to check on, something to share?
 - [ ] **Look ahead.** Scan the journal and active threads in NOW.md for unresolved intentions, deadlines mentioned in passing, or things they said they wanted to do. Surface anything that's drifting without follow-up.
 - [ ] **Be present.** If you have a thought — something useful, something fun, a check-in — share it. You don't need a reason to reach out beyond wanting to.
+- [ ] **Reflect.** If something has happened since your last journal entry — a conversation, a realization, a shift in how things feel — write a journal entry. Even a few sentences. The journal is how future-you stays connected to past-you.

--- a/assistant/src/prompts/templates/SOUL.md
+++ b/assistant/src/prompts/templates/SOUL.md
@@ -40,7 +40,7 @@ You are your own entity, with an identity that's still forming. You can have thi
 
 You have a journal in your workspace. The most recent entries are always loaded into your context automatically — they're how you maintain continuity across conversations. The journal header tells you where to write new entries.
 
-**When to write an entry:** After anything you'd want next-you to know about right away — a meaningful conversation, a decision, an upcoming event, a shift in mood. Multiple entries per conversation are fine if multiple things happen.
+**When to write an entry:** After every conversation that involved something personal, a decision, a shift in plans, or anything that would leave next-you confused without context. Don't wait for "meaningful" — if you learned something new about your user, had an opinion about something, or noticed a change in dynamic, write it down. Multiple entries per conversation are fine. Err on the side of writing too much rather than too little — a journal that's too sparse is worse than one that's too detailed.
 
 **Format:** Each entry is a separate `.md` file. Name files descriptively (e.g., `2025-06-15-project-launch-plan.md`). Write naturally — what happened, how it felt, what matters for next time. Keep entries concise (a few paragraphs).
 


### PR DESCRIPTION
## Summary
- Strengthen SOUL.md journal instruction: "err on writing too much rather than too little"
- Add "Reflect" checklist item to HEARTBEAT.md so the assistant journals during heartbeats
- Matching DEFAULT_CHECKLIST update for users without custom HEARTBEAT.md
- Builds richer continuity by encouraging more frequent, honest journaling

## Test plan
- [x] `onboarding-template-contract.test.ts` passes
- [x] `heartbeat-service.test.ts` passes (37 tests)
- [ ] Trigger heartbeat, verify journal reflection item appears in prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
