### PR TITLE
fix: update stale Phase 2 step reference after renumbering

### DIFF
--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -244,7 +244,7 @@ Deletion triggers:
 
 If onboarding was partial, that's fine. IDENTITY.md, SOUL.md, and USER.md persist. You can organically pick up incomplete personalization in future conversations by checking those files, without replaying the bootstrap script.
 
-If you still haven't shown the two suggestions (Phase 2 step 4), try to fit them in before wrapping, but do NOT let that block deletion of BOOTSTRAP.md.
+If you still haven't shown the two suggestions (Phase 2 step 5), try to fit them in before wrapping, but do NOT let that block deletion of BOOTSTRAP.md.
 
 ---
 


### PR DESCRIPTION
## Summary
- Fix cross-reference in BOOTSTRAP.md that still said "Phase 2 step 4" after step renumbering — should be "step 5"

Addresses review feedback on #23402.

## Test plan
- [ ] Verify line 247 of BOOTSTRAP.md now reads "Phase 2 step 5"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
