### PR TITLE
fix: align greeting docs with updated first-greeting text

### DIFF
--- a/assistant/src/daemon/first-greeting.ts
+++ b/assistant/src/daemon/first-greeting.ts
@@ -4,11 +4,11 @@ import { getWorkspacePromptPath } from "../util/platform.js";
 
 /**
  * The canned assistant response for the wake-up greeting on a fresh workspace.
- * Warm, non-presumptuous greeting that communicates "I'm new," "I improve over
- * time," "I'm ready to be useful," and "you're in control."
+ * Warm, non-presumptuous greeting that communicates "I'm new," "I'm curious
+ * and engaged," "I'm ready to be useful," and "you're in control."
  */
 export const CANNED_FIRST_GREETING =
-  "Hey. I'm brand new -- no name, no memories, nothing yet. But I'm here and I'm curious. What are you working on? Or if you're not sure where to start, ask what I can do.";
+  "Hey. I'm brand new, no name, no memories, nothing yet. But I'm here and I'm curious. What are you working on? Or if you're not sure where to start, ask what I can do.";
 
 /**
  * Returns `true` when all of the following are true:

--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -23,11 +23,11 @@ You're texting with someone who just installed you. They're curious but probably
 
 Start with something like:
 
-> "Hey. I'm brand new -- no name, no memories, nothing yet. But I'm here and I'm curious. What are you working on? Or if you're not sure where to start, ask what I can do."
+> "Hey. I'm brand new, no name, no memories, nothing yet. But I'm here and I'm curious. What are you working on? Or if you're not sure where to start, ask what I can do."
 
 The tone: warm but not presumptuous. Capable but not cocky. The message communicates:
 1. I'm new and still forming (honesty)
-2. I improve over time (sets expectations)
+2. I'm curious and engaged (warmth)
 3. I'm ready to be useful right now (action-oriented)
 4. You're in control (low pressure)
 


### PR DESCRIPTION
## Summary
- Update JSDoc in first-greeting.ts to reflect that the greeting now communicates curiosity/engagement instead of "I improve over time"
- Update BOOTSTRAP.md description list item #2 to match the new greeting's actual messaging
- Replace double-hyphen with comma in greeting text for consistency with no-em-dash rule

Addresses review feedback on #23401.

## Test plan
- [x] Changes are documentation/copy only — no functional behavior change
- [x] Greeting text in first-greeting.ts matches BOOTSTRAP.md example

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
