### PR TITLE
fix: record re-engagement timestamp after successful delivery

### DIFF
--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -496,10 +496,11 @@ describe("HeartbeatService", () => {
       writeFileSync(join(testWorkspaceDir, "USER.md"), USER_TEMPLATE);
 
       const service = createService();
-      const prompt = service.buildPrompt("- Check things");
+      const { prompt, includedReengagement } = service.buildPrompt("- Check things");
 
       expect(prompt).toContain("<relationship-depth>");
       expect(prompt).toContain("profile is still sparse");
+      expect(includedReengagement).toBe(true);
     });
 
     test("omits <relationship-depth> when profile is not shallow", () => {
@@ -510,9 +511,10 @@ describe("HeartbeatService", () => {
       writeFileSync(join(testWorkspaceDir, "USER.md"), USER_TEMPLATE);
 
       const service = createService();
-      const prompt = service.buildPrompt("- Check things");
+      const { prompt, includedReengagement } = service.buildPrompt("- Check things");
 
       expect(prompt).not.toContain("<relationship-depth>");
+      expect(includedReengagement).toBe(false);
     });
 
     test("omits <relationship-depth> when cooldown has not elapsed", () => {
@@ -525,9 +527,10 @@ describe("HeartbeatService", () => {
       );
 
       const service = createService();
-      const prompt = service.buildPrompt("- Check things");
+      const { prompt, includedReengagement } = service.buildPrompt("- Check things");
 
       expect(prompt).not.toContain("<relationship-depth>");
+      expect(includedReengagement).toBe(false);
     });
 
     test("includes <relationship-depth> when cooldown has elapsed", () => {
@@ -541,9 +544,39 @@ describe("HeartbeatService", () => {
       );
 
       const service = createService();
-      const prompt = service.buildPrompt("- Check things");
+      const { prompt, includedReengagement } = service.buildPrompt("- Check things");
 
       expect(prompt).toContain("<relationship-depth>");
+      expect(includedReengagement).toBe(true);
+    });
+
+    test("does not record timestamp when processMessage fails", async () => {
+      writeFileSync(join(testWorkspaceDir, "IDENTITY.md"), IDENTITY_TEMPLATE);
+      writeFileSync(join(testWorkspaceDir, "USER.md"), USER_TEMPLATE);
+
+      const service = createService({
+        processMessage: async () => {
+          throw new Error("LLM timeout");
+        },
+      });
+
+      await service.runOnce();
+
+      // The reengagement timestamp file should NOT exist since delivery failed
+      const tsPath = join(testWorkspaceDir, ".reengagement-ts");
+      expect(existsSync(tsPath)).toBe(false);
+    });
+
+    test("records timestamp after successful delivery", async () => {
+      writeFileSync(join(testWorkspaceDir, "IDENTITY.md"), IDENTITY_TEMPLATE);
+      writeFileSync(join(testWorkspaceDir, "USER.md"), USER_TEMPLATE);
+
+      const service = createService();
+      await service.runOnce();
+
+      // The reengagement timestamp file should exist after successful delivery
+      const tsPath = join(testWorkspaceDir, ".reengagement-ts");
+      expect(existsSync(tsPath)).toBe(true);
     });
   });
 });

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -223,7 +223,7 @@ export class HeartbeatService {
     try {
       const config = getConfig().heartbeat;
       const checklist = this.readChecklist();
-      const prompt = this.buildPrompt(checklist);
+      const { prompt, includedReengagement } = this.buildPrompt(checklist);
 
       const conversation = bootstrapConversation({
         conversationType: "background",
@@ -241,6 +241,11 @@ export class HeartbeatService {
       await this.deps.processMessage(conversation.id, prompt, {
         speed: config.speed,
       });
+
+      if (includedReengagement) {
+        recordReengagementTimestamp();
+      }
+
       log.info({ conversationId: conversation.id }, "Heartbeat completed");
     } catch (err) {
       log.error({ err }, "Heartbeat failed");
@@ -264,7 +269,7 @@ export class HeartbeatService {
   }
 
   /** @internal Exposed for testing. */
-  buildPrompt(checklist: string): string {
+  buildPrompt(checklist: string): { prompt: string; includedReengagement: boolean } {
     let prompt = `You are running a periodic heartbeat check. Review the following checklist and take any necessary actions.
 
 <heartbeat-checklist>
@@ -277,12 +282,13 @@ After completing your review, end your response with one of:
 - HEARTBEAT_ALERT — if you found issues that need attention (describe them before this marker)
 </heartbeat-disposition>`;
 
+    let includedReengagement = false;
     if (isShallowProfile() && isReengagementCooldownElapsed()) {
-      recordReengagementTimestamp();
+      includedReengagement = true;
       prompt += `\n\n<relationship-depth>\nYou don't know much about this person yet — their profile is still sparse. If the moment feels right during this beat, gently invite them to share something about themselves. Not an interrogation — something natural like "I realized I don't actually know much about what you do. Fill me in sometime?" Only do this occasionally, not every beat. If they engage, save what you learn.\n</relationship-depth>`;
     }
 
-    return prompt;
+    return { prompt, includedReengagement };
   }
 }
 

--- a/meta/bun.lock
+++ b/meta/bun.lock
@@ -5,10 +5,10 @@
     "": {
       "name": "vellum",
       "dependencies": {
-        "@vellumai/assistant": "0.5.10",
-        "@vellumai/cli": "0.5.10",
-        "@vellumai/credential-executor": "0.5.10",
-        "@vellumai/vellum-gateway": "0.5.10",
+        "@vellumai/assistant": "0.6.0",
+        "@vellumai/cli": "0.6.0",
+        "@vellumai/credential-executor": "0.6.0",
+        "@vellumai/vellum-gateway": "0.6.0",
       },
       "devDependencies": {
         "@types/bun": "^1.2.4",
@@ -184,13 +184,13 @@
 
     "@types/tedious": ["@types/tedious@4.0.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw=="],
 
-    "@vellumai/assistant": ["@vellumai/assistant@0.5.10", "", { "dependencies": { "@agentclientprotocol/sdk": "^0.16.1", "@anthropic-ai/sdk": "^0.78.0", "@google/genai": "^1.40.0", "@modelcontextprotocol/sdk": "^1.15.1", "@qdrant/js-client-rest": "^1.16.2", "@resvg/resvg-js": "^2.6.2", "@sentry/node": "^10.38.0", "@vellumai/ces-contracts": "file:../packages/ces-contracts", "@vellumai/credential-storage": "file:../packages/credential-storage", "@vellumai/egress-proxy": "file:../packages/egress-proxy", "agentmail": "^0.1.0", "archiver": "^7.0.1", "commander": "^13.1.0", "croner": "^10.0.1", "dotenv": "^17.3.1", "drizzle-orm": "^0.38.4", "jszip": "^3.10.1", "minimatch": "^10.2.4", "openai": "^6.18.0", "pino": "^9.6.0", "pino-pretty": "^13.1.3", "playwright": "^1.58.2", "postgres": "^3.4.8", "qrcode": "^1.5.4", "react": "^19.2.4", "rrule": "^2.8.1", "tldts": "^7.0.23", "tree-sitter-bash": "0.25.1", "uuid": "^11.1.0", "web-tree-sitter": "0.26.5", "yaml": "^2.7.1", "zod": "^4.3.6" }, "bin": { "assistant": "src/index.ts" } }, "sha512-zwh19/ZZViNLh9IUgvCY3/8eZ3ryhxDQFXtwekEtZirrdDg3OUBr38UUjABC6uXABDHonl3m4zQQuncD5US/uw=="],
+    "@vellumai/assistant": ["@vellumai/assistant@0.6.0", "", { "dependencies": { "@agentclientprotocol/sdk": "^0.16.1", "@anthropic-ai/sdk": "^0.78.0", "@google/genai": "^1.40.0", "@modelcontextprotocol/sdk": "^1.15.1", "@qdrant/js-client-rest": "^1.16.2", "@resvg/resvg-js": "^2.6.2", "@sentry/node": "^10.38.0", "@vellumai/ces-contracts": "file:../packages/ces-contracts", "@vellumai/credential-storage": "file:../packages/credential-storage", "@vellumai/egress-proxy": "file:../packages/egress-proxy", "agentmail": "^0.1.0", "archiver": "^7.0.1", "commander": "^13.1.0", "croner": "^10.0.1", "dotenv": "^17.3.1", "drizzle-orm": "^0.38.4", "jszip": "^3.10.1", "minimatch": "^10.2.4", "openai": "^6.18.0", "pino": "^9.6.0", "pino-pretty": "^13.1.3", "playwright": "^1.58.2", "postgres": "^3.4.8", "qrcode": "^1.5.4", "react": "^19.2.4", "rrule": "^2.8.1", "tldts": "^7.0.23", "tree-sitter-bash": "0.25.1", "uuid": "^11.1.0", "web-tree-sitter": "0.26.5", "yaml": "^2.7.1", "zod": "^4.3.6" }, "bin": { "assistant": "src/index.ts" } }, "sha512-Iycrcr3bFVlZ9gQTVvmqQu3pSvyhcR+UtoyEIeZgwCwf2xScVlYtkTgn8LJggVzTYroXTZzy14j5QFJMndvAmg=="],
 
-    "@vellumai/cli": ["@vellumai/cli@0.5.10", "", { "dependencies": { "chalk": "^5.6.0", "ink": "^6.7.0", "jsqr": "^1.4.0", "nanoid": "^5.1.7", "pngjs": "^7.0.0", "qrcode-terminal": "^0.12.0", "react": "^19.2.4", "react-devtools-core": "^6.1.2" }, "bin": { "vellum": "src/index.ts" } }, "sha512-tbvBMOnDL+w4/eDhBJa+5G20c6/jWY1Nem8KAqoDVv2BERbUu19LF5VL+fOilVRqfOUwfmf2TYo3YV1NzYf1DQ=="],
+    "@vellumai/cli": ["@vellumai/cli@0.6.0", "", { "dependencies": { "chalk": "^5.6.0", "ink": "^6.7.0", "jsqr": "^1.4.0", "nanoid": "^5.1.7", "pngjs": "^7.0.0", "qrcode-terminal": "^0.12.0", "react": "^19.2.4", "react-devtools-core": "^6.1.2" }, "bin": { "vellum": "src/index.ts" } }, "sha512-Ei0J7UHTqBgBdBrcfsYowfDewwwzOND21KHvshkw1teYz+Zhxc992yYtuUAgXgO6PVN69BDA0TNNe9zLT2xwXw=="],
 
-    "@vellumai/credential-executor": ["@vellumai/credential-executor@0.5.10", "", { "dependencies": { "@vellumai/ces-contracts": "file:../packages/ces-contracts", "@vellumai/credential-storage": "file:../packages/credential-storage", "@vellumai/egress-proxy": "file:../packages/egress-proxy" }, "bin": { "credential-executor": "src/main.ts", "credential-executor-managed": "src/managed-main.ts" } }, "sha512-xVzxt87dF3VSxf1TvRFtO/nWFK3euEfQ6md/WRl6a1NtINv/GZ7RSG+cvSO+V52nK1JXKm64VeU0B2bUL7oikQ=="],
+    "@vellumai/credential-executor": ["@vellumai/credential-executor@0.6.0", "", { "dependencies": { "@vellumai/ces-contracts": "file:../packages/ces-contracts", "@vellumai/credential-storage": "file:../packages/credential-storage", "@vellumai/egress-proxy": "file:../packages/egress-proxy" }, "bin": { "credential-executor": "src/main.ts", "credential-executor-managed": "src/managed-main.ts" } }, "sha512-ZunoSHleDupcHuEImCkQ5NgjVPeu0K+sDrjYvFKoou1WrnG9wqjamW7F3GV7TZpt0BDSKR+cCbcbcKCposCv0A=="],
 
-    "@vellumai/vellum-gateway": ["@vellumai/vellum-gateway@0.5.10", "", { "dependencies": { "file-type": "^21.3.0", "minimatch": "^10.2.4", "pino": "^9.6.0", "pino-pretty": "^13.1.3", "uuid": "^13.0.0" } }, "sha512-6lxZEHPtzq3G1Qt9ByKlpZAHR7/XhJKdV4QWviBhy6DEGm5zji0Q/3ThJM7UxQkutq72W03xfugz1UOGOuRGNg=="],
+    "@vellumai/vellum-gateway": ["@vellumai/vellum-gateway@0.6.0", "", { "dependencies": { "file-type": "^21.3.0", "minimatch": "^10.2.4", "pino": "^9.6.0", "pino-pretty": "^13.1.3", "uuid": "^13.0.0" } }, "sha512-7EdWuP33/fKVzExlNrlYoPLwLfQuf4OKfHaJ6d2C9rVMUbHz+K+CBublPAcXY/JkfQEasubXDKEr0jqpAQOtTg=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 


### PR DESCRIPTION
## Summary
- Move recordReengagementTimestamp() from buildPrompt() to executeRun() after processMessage() succeeds
- Prevents 18-hour cooldown from being consumed when heartbeat delivery fails
- Ensures shallow-profile re-engagement nudge is retried on next beat if delivery fails

Addresses review feedback on #23405.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
