### PR TITLE
fix: enable text selection in code blocks on macOS

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -584,6 +584,7 @@ private struct CodeBlockView: View, Equatable {
                 Text(code)
                     .font(.custom("DMMono-Regular", size: 13))
                     .foregroundStyle(textColor)
+                    .textSelection(.enabled)
                     .fixedSize(horizontal: true, vertical: true)
                     .padding(VSpacing.sm)
             }


### PR DESCRIPTION
## Summary
- Add `.textSelection(.enabled)` to the `Text(code)` view in `CodeBlockView` so users can drag to select text inside code blocks
- The shared `MarkdownRenderer.swift` already had this modifier — the macOS-specific `MarkdownSegmentView.swift` was missing it

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23413" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
