### PR TITLE
feat(macos): show streaming thinking blocks in real time

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
@@ -47,6 +47,14 @@ struct ThinkingBlockView: View {
         }
         .background(VColor.surfaceOverlay)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .onAppear {
+            if isStreaming { isExpanded = true }
+        }
+        .onChange(of: isStreaming) { _, newValue in
+            withAnimation(VAnimation.fast) {
+                isExpanded = newValue
+            }
+        }
     }
 
     // MARK: - Header

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -199,7 +199,7 @@
       "key": "show-thinking-blocks",
       "label": "Show Thinking Blocks",
       "description": "Display the assistant's thinking/reasoning inline in chat messages as collapsible blocks",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "inline-skill-commands",


### PR DESCRIPTION
## Summary
- Enable `show-thinking-blocks` feature flag by default so thinking content is rendered inline in chat
- Auto-expand `ThinkingBlockView` during streaming and auto-collapse on completion, giving real-time visibility into the model's reasoning
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
