### PR TITLE
Reduce default auditLimit from 10,000 to match daemon default of 1,000

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -562,7 +562,7 @@ enum LogExporter {
     /// are handled consistently for both local and managed assistants.
     @discardableResult
     private nonisolated static func fetchDaemonExports(into directory: URL, scope: LogExportScope) async -> Bool {
-        var body: [String: Any] = ["auditLimit": 10000]
+        var body: [String: Any] = ["auditLimit": 1000]
         if case .conversation(let conversationId, _, let startTime, let endTime) = scope {
             body["conversationId"] = conversationId
             if let startTime {


### PR DESCRIPTION
## Summary
- Change auditLimit from 10,000 to 1,000 in the daemon export request to reduce payload size
- The daemon's own default is 1,000; the client was unnecessarily overriding it to 10x

Part of plan: respect-log-time-filter.md (PR 8 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
