### PR TITLE
Add cutoffDate helper to LogTimeRange and thread it through log collection

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -285,6 +285,8 @@ enum LogExporter {
         let connectedAssistant = connectedId.flatMap { LockfileAssistant.loadByName($0) }
         var daemonUnreachable = false
 
+        let cutoffDate: Date? = formData?.logTimeRange.cutoffDate
+
         let shouldCollectLogs = formData?.includeLogs ?? true
         if shouldCollectLogs {
             // 1-2. Client artifacts — session logs, debug-state, hang-context, hang-sample files

--- a/clients/macos/vellum-assistant/Logging/LogReportReason.swift
+++ b/clients/macos/vellum-assistant/Logging/LogReportReason.swift
@@ -70,6 +70,15 @@ enum LogTimeRange: String, CaseIterable, Identifiable, Sendable {
         case .allTime: return "All time"
         }
     }
+
+    /// Returns the earliest `Date` that should be included, or `nil` for `.allTime`.
+    var cutoffDate: Date? {
+        switch self {
+        case .pastHour: return Date().addingTimeInterval(-3600)
+        case .past24Hours: return Date().addingTimeInterval(-86400)
+        case .allTime: return nil
+        }
+    }
 }
 
 /// Aggregated form data collected from the feedback sheet.


### PR DESCRIPTION
## Summary
- Add `cutoffDate` computed property to `LogTimeRange` that converts the enum to a `Date?`
- Thread the cutoff date into `populateStagingDirectory` for use by subsequent PRs

Part of plan: respect-log-time-filter.md (PR 1 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
