### PR TITLE
Filter daemon log files by startTime/endTime in export handler

### DIFF
--- a/assistant/src/__tests__/log-export-workspace.test.ts
+++ b/assistant/src/__tests__/log-export-workspace.test.ts
@@ -52,11 +52,13 @@ initializeDb();
 const routes = logExportRouteDefinitions();
 const exportRoute = routes.find((r) => r.endpoint === "export")!;
 
-async function callExport(): Promise<Response> {
+async function callExport(
+  body: Record<string, unknown> = {},
+): Promise<Response> {
   const req = new Request("http://localhost/v1/export", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({}),
+    body: JSON.stringify(body),
   });
   const url = new URL(req.url);
   return exportRoute.handler({
@@ -162,6 +164,28 @@ try {
 } catch {
   // Symlink creation may fail on some platforms; tests will still pass
 }
+
+// Daemon log files — used for date filtering tests
+const logsDir = join(testWorkspaceDir, "data", "logs");
+mkdirSync(logsDir, { recursive: true });
+writeFileSync(
+  join(logsDir, "assistant-2025-01-10.log"),
+  "log entry from Jan 10\n",
+);
+writeFileSync(
+  join(logsDir, "assistant-2025-01-15.log"),
+  "log entry from Jan 15\n",
+);
+writeFileSync(
+  join(logsDir, "assistant-2025-01-20.log"),
+  "log entry from Jan 20\n",
+);
+writeFileSync(
+  join(logsDir, "assistant-2025-01-25.log"),
+  "log entry from Jan 25\n",
+);
+// Non-dated log file — should always be included regardless of time filter
+writeFileSync(join(logsDir, "vellum.log"), "non-dated log content\n");
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -304,6 +328,85 @@ describe("POST /v1/export — tar.gz archive", () => {
       );
       const parsed = JSON.parse(configContent);
       expect(parsed.provider).toBe("anthropic");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("POST /v1/export — daemon log date filtering", () => {
+  test("excludes log files before startTime", async () => {
+    // startTime = Jan 14 — should exclude assistant-2025-01-10.log
+    const startTime = new Date("2025-01-14T00:00:00.000Z").getTime();
+    const res = await callExport({ startTime });
+    const dir = await extractArchive(res);
+    try {
+      const logFiles = readdirSync(join(dir, "daemon-logs"));
+      expect(logFiles).not.toContain("assistant-2025-01-10.log");
+      expect(logFiles).toContain("assistant-2025-01-15.log");
+      expect(logFiles).toContain("assistant-2025-01-20.log");
+      expect(logFiles).toContain("assistant-2025-01-25.log");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("excludes log files after endTime", async () => {
+    // endTime = Jan 22 — should exclude assistant-2025-01-25.log
+    const endTime = new Date("2025-01-22T00:00:00.000Z").getTime();
+    const res = await callExport({ endTime });
+    const dir = await extractArchive(res);
+    try {
+      const logFiles = readdirSync(join(dir, "daemon-logs"));
+      expect(logFiles).toContain("assistant-2025-01-10.log");
+      expect(logFiles).toContain("assistant-2025-01-15.log");
+      expect(logFiles).toContain("assistant-2025-01-20.log");
+      expect(logFiles).not.toContain("assistant-2025-01-25.log");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("filters log files by both startTime and endTime", async () => {
+    // startTime = Jan 14, endTime = Jan 22 — should only include Jan 15 and Jan 20
+    const startTime = new Date("2025-01-14T00:00:00.000Z").getTime();
+    const endTime = new Date("2025-01-22T00:00:00.000Z").getTime();
+    const res = await callExport({ startTime, endTime });
+    const dir = await extractArchive(res);
+    try {
+      const logFiles = readdirSync(join(dir, "daemon-logs"));
+      expect(logFiles).not.toContain("assistant-2025-01-10.log");
+      expect(logFiles).toContain("assistant-2025-01-15.log");
+      expect(logFiles).toContain("assistant-2025-01-20.log");
+      expect(logFiles).not.toContain("assistant-2025-01-25.log");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("always includes non-dated log files regardless of time filter", async () => {
+    const startTime = new Date("2025-01-14T00:00:00.000Z").getTime();
+    const endTime = new Date("2025-01-22T00:00:00.000Z").getTime();
+    const res = await callExport({ startTime, endTime });
+    const dir = await extractArchive(res);
+    try {
+      const logFiles = readdirSync(join(dir, "daemon-logs"));
+      expect(logFiles).toContain("vellum.log");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("includes all log files when no time filter is specified", async () => {
+    const res = await callExport();
+    const dir = await extractArchive(res);
+    try {
+      const logFiles = readdirSync(join(dir, "daemon-logs"));
+      expect(logFiles).toContain("assistant-2025-01-10.log");
+      expect(logFiles).toContain("assistant-2025-01-15.log");
+      expect(logFiles).toContain("assistant-2025-01-20.log");
+      expect(logFiles).toContain("assistant-2025-01-25.log");
+      expect(logFiles).toContain("vellum.log");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -31,7 +31,7 @@ import {
   messages,
   toolInvocations,
 } from "../../memory/schema.js";
-import { getLogger } from "../../util/logger.js";
+import { getLogger, LOG_FILE_PATTERN } from "../../util/logger.js";
 import {
   getDaemonStderrLogPath,
   getDataDir,
@@ -167,9 +167,19 @@ async function handleExport(body: ExportRequestBody): Promise<Response> {
 
     const logsDir = join(getDataDir(), "logs");
     const collectedLogFiles: string[] = [];
+    const startDate = startTime ? new Date(startTime) : undefined;
+    const endDate = endTime ? new Date(endTime) : undefined;
     if (existsSync(logsDir)) {
       const entries = readdirSync(logsDir);
       for (const entry of entries) {
+        // Filter dated log files by time range
+        const dateMatch = entry.match(LOG_FILE_PATTERN);
+        if (dateMatch && (startDate || endDate)) {
+          const fileDate = new Date(dateMatch[1] + "T23:59:59.999Z"); // end of day
+          const fileDateStart = new Date(dateMatch[1] + "T00:00:00.000Z");
+          if (startDate && fileDate < startDate) continue; // entire day is before range
+          if (endDate && fileDateStart > endDate) continue; // entire day is after range
+        }
         const filePath = join(logsDir, entry);
         try {
           const stat = statSync(filePath);

--- a/assistant/src/util/logger.ts
+++ b/assistant/src/util/logger.ts
@@ -36,7 +36,7 @@ export type LogFileConfig = {
 
 const LOG_FILE_PREFIX = "assistant-";
 const LOG_FILE_SUFFIX = ".log";
-const LOG_FILE_PATTERN = /^assistant-(\d{4}-\d{2}-\d{2})\.log$/;
+export const LOG_FILE_PATTERN = /^assistant-(\d{4}-\d{2}-\d{2})\.log$/;
 
 function formatDate(date: Date): string {
   const y = date.getUTCFullYear();


### PR DESCRIPTION
## Summary
- Filter daemon log files by filename date pattern (`assistant-YYYY-MM-DD.log`) against startTime/endTime
- Non-dated log files (e.g. `daemon-stderr.log`, `vellum.log`) are always included
- Add tests verifying date-based file filtering

Part of plan: respect-log-time-filter.md (PR 7 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
