### PR TITLE
Use feedback time range for crash report cutoff instead of hardcoded 7 days

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -347,7 +347,8 @@ enum LogExporter {
             // 9. macOS crash/hang reports — recent .ips/.crash/.spin files for assistant-related processes
             collectCrashReports(
                 into: tempDir.appendingPathComponent("crash-reports", isDirectory: true),
-                fileManager: fileManager
+                fileManager: fileManager,
+                cutoffDate: cutoffDate
             )
         }
 
@@ -637,7 +638,8 @@ enum LogExporter {
     /// included, capped at 5 MB total (newest first).
     private nonisolated static func collectCrashReports(
         into dest: URL,
-        fileManager: FileManager
+        fileManager: FileManager,
+        cutoffDate: Date? = nil
     ) {
         let home = NSHomeDirectory()
         let reportsDir = URL(fileURLWithPath: home)
@@ -650,7 +652,7 @@ enum LogExporter {
             options: [.skipsHiddenFiles]
         ) else { return }
 
-        let cutoff = Date().addingTimeInterval(-7 * 24 * 60 * 60)
+        let cutoff = cutoffDate ?? Date().addingTimeInterval(-7 * 24 * 60 * 60)
 
         // Filter to matching files, then sort newest-first
         let matching = contents


### PR DESCRIPTION
## Summary
- Accept optional cutoffDate in collectCrashReports
- Use cutoffDate when provided, fall back to existing 7-day default
- Pass cutoffDate from populateStagingDirectory

Part of plan: respect-log-time-filter.md (PR 4 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
