### PR TITLE
Filter session log files by cutoff date during feedback export

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -292,7 +292,7 @@ enum LogExporter {
             // 1-2. Client artifacts — session logs, debug-state, hang-context, hang-sample files
             if let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
                 let appSupportDir = appSupport.appendingPathComponent("vellum-assistant", isDirectory: true)
-                collectClientArtifacts(from: appSupportDir, into: tempDir, fileManager: fileManager)
+                collectClientArtifacts(from: appSupportDir, into: tempDir, cutoffDate: cutoffDate, fileManager: fileManager)
             }
 
             // 3. Assistant logs — platform API for managed, local gateway for self-hosted
@@ -481,15 +481,46 @@ enum LogExporter {
     nonisolated static func collectClientArtifacts(
         from sourceDir: URL,
         into destDir: URL,
+        cutoffDate: Date? = nil,
         fileManager: FileManager = .default
     ) {
-        // Session logs
+        // Session logs — filter by modification date when cutoffDate is set
         let sessionLogDir = sourceDir.appendingPathComponent("logs", isDirectory: true)
-        copyDirectoryContents(
-            from: sessionLogDir,
-            to: destDir.appendingPathComponent("session-logs", isDirectory: true),
-            fileManager: fileManager
-        )
+        if let cutoffDate {
+            // Enumerate files and include only those modified at or after the cutoff
+            if fileManager.fileExists(atPath: sessionLogDir.path),
+               let files = try? fileManager.contentsOfDirectory(
+                   at: sessionLogDir,
+                   includingPropertiesForKeys: [.contentModificationDateKey],
+                   options: [.skipsHiddenFiles]
+               ) {
+                let filtered = files.filter { url in
+                    guard let values = try? url.resourceValues(forKeys: [.contentModificationDateKey]),
+                          let modDate = values.contentModificationDate else {
+                        return false
+                    }
+                    return modDate >= cutoffDate
+                }
+
+                if !filtered.isEmpty {
+                    let sessionLogDest = destDir.appendingPathComponent("session-logs", isDirectory: true)
+                    try? fileManager.createDirectory(at: sessionLogDest, withIntermediateDirectories: true)
+                    for file in filtered {
+                        try? fileManager.copyItem(
+                            at: file,
+                            to: sessionLogDest.appendingPathComponent(file.lastPathComponent)
+                        )
+                    }
+                }
+            }
+        } else {
+            // No cutoff — copy all session logs (existing behavior)
+            copyDirectoryContents(
+                from: sessionLogDir,
+                to: destDir.appendingPathComponent("session-logs", isDirectory: true),
+                fileManager: fileManager
+            )
+        }
 
         // Debug state snapshot
         let debugState = sourceDir.appendingPathComponent("debug-state.json")

--- a/clients/macos/vellum-assistantTests/LogExporterClientArtifactsTests.swift
+++ b/clients/macos/vellum-assistantTests/LogExporterClientArtifactsTests.swift
@@ -314,4 +314,136 @@ struct LogExporterClientArtifactsTests {
         )
         #expect(copiedSample == sampleContent)
     }
+
+    // MARK: - Session Log Cutoff Date Filtering
+
+    @Test
+    func filtersSessionLogsByCutoffDate() throws {
+        let (source, dest) = try makeTempDirs()
+        defer { cleanup(source) }
+        let fm = FileManager.default
+
+        let logsDir = source.appendingPathComponent("logs", isDirectory: true)
+        try fm.createDirectory(at: logsDir, withIntermediateDirectories: true)
+
+        // Create three session log files
+        let oldFile = logsDir.appendingPathComponent("chat-diagnostics-old.jsonl")
+        let recentFile = logsDir.appendingPathComponent("chat-diagnostics-recent.jsonl")
+        let newestFile = logsDir.appendingPathComponent("chat-diagnostics-newest.jsonl")
+
+        try "old event\n".write(to: oldFile, atomically: true, encoding: .utf8)
+        try "recent event\n".write(to: recentFile, atomically: true, encoding: .utf8)
+        try "newest event\n".write(to: newestFile, atomically: true, encoding: .utf8)
+
+        // Set modification dates: old = 2 hours ago, recent = 30 min ago, newest = now
+        let twoHoursAgo = Date().addingTimeInterval(-7200)
+        let thirtyMinAgo = Date().addingTimeInterval(-1800)
+        let now = Date()
+
+        try fm.setAttributes([.modificationDate: twoHoursAgo], ofItemAtPath: oldFile.path)
+        try fm.setAttributes([.modificationDate: thirtyMinAgo], ofItemAtPath: recentFile.path)
+        try fm.setAttributes([.modificationDate: now], ofItemAtPath: newestFile.path)
+
+        // Use a cutoff of 1 hour ago — should exclude the old file
+        let cutoff = Date().addingTimeInterval(-3600)
+        LogExporter.collectClientArtifacts(from: source, into: dest, cutoffDate: cutoff, fileManager: fm)
+
+        let sessionLogsDir = dest.appendingPathComponent("session-logs", isDirectory: true)
+        #expect(fm.fileExists(atPath: sessionLogsDir.path))
+
+        let copiedFiles = try fm.contentsOfDirectory(at: sessionLogsDir, includingPropertiesForKeys: nil)
+        let copiedNames = Set(copiedFiles.map(\.lastPathComponent))
+
+        #expect(copiedNames.count == 2)
+        #expect(copiedNames.contains("chat-diagnostics-recent.jsonl"))
+        #expect(copiedNames.contains("chat-diagnostics-newest.jsonl"))
+        #expect(!copiedNames.contains("chat-diagnostics-old.jsonl"))
+    }
+
+    @Test
+    func cutoffDateNilCollectsAllSessionLogs() throws {
+        let (source, dest) = try makeTempDirs()
+        defer { cleanup(source) }
+        let fm = FileManager.default
+
+        let logsDir = source.appendingPathComponent("logs", isDirectory: true)
+        try fm.createDirectory(at: logsDir, withIntermediateDirectories: true)
+
+        // Create session log files with varied modification dates
+        let oldFile = logsDir.appendingPathComponent("chat-diagnostics-old.jsonl")
+        let recentFile = logsDir.appendingPathComponent("chat-diagnostics-recent.jsonl")
+
+        try "old event\n".write(to: oldFile, atomically: true, encoding: .utf8)
+        try "recent event\n".write(to: recentFile, atomically: true, encoding: .utf8)
+
+        let oneWeekAgo = Date().addingTimeInterval(-7 * 24 * 3600)
+        try fm.setAttributes([.modificationDate: oneWeekAgo], ofItemAtPath: oldFile.path)
+
+        // cutoffDate: nil should collect all files (backward compat / allTime)
+        LogExporter.collectClientArtifacts(from: source, into: dest, cutoffDate: nil, fileManager: fm)
+
+        let sessionLogsDir = dest.appendingPathComponent("session-logs", isDirectory: true)
+        #expect(fm.fileExists(atPath: sessionLogsDir.path))
+
+        let copiedFiles = try fm.contentsOfDirectory(at: sessionLogsDir, includingPropertiesForKeys: nil)
+        #expect(copiedFiles.count == 2)
+    }
+
+    @Test
+    func cutoffDateExcludesAllSessionLogsWhenAllOld() throws {
+        let (source, dest) = try makeTempDirs()
+        defer { cleanup(source) }
+        let fm = FileManager.default
+
+        let logsDir = source.appendingPathComponent("logs", isDirectory: true)
+        try fm.createDirectory(at: logsDir, withIntermediateDirectories: true)
+
+        // Create session logs that are all older than the cutoff
+        let file1 = logsDir.appendingPathComponent("chat-diagnostics-1.jsonl")
+        let file2 = logsDir.appendingPathComponent("chat-diagnostics-2.jsonl")
+
+        try "event1\n".write(to: file1, atomically: true, encoding: .utf8)
+        try "event2\n".write(to: file2, atomically: true, encoding: .utf8)
+
+        let twoDaysAgo = Date().addingTimeInterval(-2 * 24 * 3600)
+        try fm.setAttributes([.modificationDate: twoDaysAgo], ofItemAtPath: file1.path)
+        try fm.setAttributes([.modificationDate: twoDaysAgo], ofItemAtPath: file2.path)
+
+        // Cutoff = 1 hour ago — both files are older
+        let cutoff = Date().addingTimeInterval(-3600)
+        LogExporter.collectClientArtifacts(from: source, into: dest, cutoffDate: cutoff, fileManager: fm)
+
+        // session-logs directory should not be created since no files pass the filter
+        let sessionLogsDir = dest.appendingPathComponent("session-logs", isDirectory: true)
+        #expect(!fm.fileExists(atPath: sessionLogsDir.path))
+    }
+
+    @Test
+    func cutoffDateStillCollectsNonSessionArtifacts() throws {
+        let (source, dest) = try makeTempDirs()
+        defer { cleanup(source) }
+        let fm = FileManager.default
+
+        // Create debug-state.json and hang-context.json (these should always be collected)
+        try "{\"debug\":true}".write(
+            to: source.appendingPathComponent("debug-state.json"),
+            atomically: true, encoding: .utf8
+        )
+        try "{\"stall\":1.0}".write(
+            to: source.appendingPathComponent("hang-context.json"),
+            atomically: true, encoding: .utf8
+        )
+        try "sample data".write(
+            to: source.appendingPathComponent("hang-sample.txt"),
+            atomically: true, encoding: .utf8
+        )
+
+        // Use a cutoff — non-session artifacts should still be collected regardless
+        let cutoff = Date().addingTimeInterval(-3600)
+        LogExporter.collectClientArtifacts(from: source, into: dest, cutoffDate: cutoff, fileManager: fm)
+
+        #expect(fm.fileExists(atPath: dest.appendingPathComponent("debug-state.json").path))
+        #expect(fm.fileExists(atPath: dest.appendingPathComponent("hang-context.json").path))
+        #expect(fm.fileExists(atPath: dest.appendingPathComponent("hang-sample.txt").path))
+    }
 }


### PR DESCRIPTION
## Summary
- Update collectClientArtifacts to accept optional cutoffDate parameter
- Filter session log files by modification date when cutoffDate is non-nil
- Add tests for filtered and unfiltered session log collection

Part of plan: respect-log-time-filter.md (PR 2 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
