### PR TITLE
Pass startTime from feedback time range to daemon export API

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -302,7 +302,7 @@ enum LogExporter {
                let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") {
                 await fetchPlatformLogs(into: tempDir, assistantId: assistantId, organizationId: orgId)
             } else {
-                let success = await fetchDaemonExports(into: tempDir, scope: formData?.scope ?? .global)
+                let success = await fetchDaemonExports(into: tempDir, scope: formData?.scope ?? .global, cutoffDate: cutoffDate)
                 if !success {
                     daemonUnreachable = true
                 }
@@ -563,7 +563,7 @@ enum LogExporter {
     /// Routes through ``GatewayHTTPClient`` so auth and connection resolution
     /// are handled consistently for both local and managed assistants.
     @discardableResult
-    private nonisolated static func fetchDaemonExports(into directory: URL, scope: LogExportScope) async -> Bool {
+    private nonisolated static func fetchDaemonExports(into directory: URL, scope: LogExportScope, cutoffDate: Date? = nil) async -> Bool {
         var body: [String: Any] = ["auditLimit": 1000]
         if case .conversation(let conversationId, _, let startTime, let endTime) = scope {
             body["conversationId"] = conversationId
@@ -573,6 +573,8 @@ enum LogExporter {
             if let endTime {
                 body["endTime"] = Int(endTime.timeIntervalSince1970 * 1000)
             }
+        } else if let cutoffDate {
+            body["startTime"] = Int(cutoffDate.timeIntervalSince1970 * 1000)
         }
 
         do {


### PR DESCRIPTION
## Summary
- Accept optional cutoffDate in fetchDaemonExports
- Send startTime to daemon for global exports when a time range is selected
- Conversation-scoped exports continue using their existing time bounds

Part of plan: respect-log-time-filter.md (PR 6 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
