### PR TITLE
Filter XDG CLI log files by cutoff date during feedback export

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -316,7 +316,8 @@ enum LogExporter {
             copyDirectoryContents(
                 from: xdgLogDir,
                 to: tempDir.appendingPathComponent("xdg-logs", isDirectory: true),
-                fileManager: fileManager
+                fileManager: fileManager,
+                cutoffDate: cutoffDate
             )
 
             // 5. Lockfile — ~/.vellum.lock.json (sanitized to strip credentials)
@@ -528,20 +529,40 @@ enum LogExporter {
 
     /// Copies all files from `source` into `dest`, creating `dest` if needed.
     /// Silently skips if `source` doesn't exist or is empty.
+    ///
+    /// When `cutoffDate` is non-nil, only files whose content modification date
+    /// is on or after the cutoff are copied. Files without a readable modification
+    /// date are included to avoid silently dropping data.
     private nonisolated static func copyDirectoryContents(
         from source: URL,
         to dest: URL,
-        fileManager: FileManager
+        fileManager: FileManager,
+        cutoffDate: Date? = nil
     ) {
         guard fileManager.fileExists(atPath: source.path) else { return }
         guard let items = try? fileManager.contentsOfDirectory(
             at: source,
-            includingPropertiesForKeys: nil,
+            includingPropertiesForKeys: [.contentModificationDateKey],
             options: [.skipsHiddenFiles]
         ), !items.isEmpty else { return }
 
+        let filtered: [URL]
+        if let cutoff = cutoffDate {
+            filtered = items.filter { url in
+                guard let values = try? url.resourceValues(forKeys: [.contentModificationDateKey]),
+                      let modDate = values.contentModificationDate else {
+                    // Include files whose modification date can't be read
+                    return true
+                }
+                return modDate >= cutoff
+            }
+        } else {
+            filtered = items
+        }
+
+        guard !filtered.isEmpty else { return }
         try? fileManager.createDirectory(at: dest, withIntermediateDirectories: true)
-        for item in items {
+        for item in filtered {
             try? fileManager.copyItem(
                 at: item,
                 to: dest.appendingPathComponent(item.lastPathComponent)


### PR DESCRIPTION
## Summary
- Update copyDirectoryContents to accept optional cutoffDate parameter
- Filter files by modification date when cutoffDate is non-nil
- Pass cutoffDate from populateStagingDirectory to XDG logs collection

Part of plan: respect-log-time-filter.md (PR 3 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
