### PR TITLE
Respect log time filter throughout feedback export pipeline

### DIFF
--- a/assistant/src/__tests__/log-export-workspace.test.ts
+++ b/assistant/src/__tests__/log-export-workspace.test.ts
@@ -52,11 +52,13 @@ initializeDb();
 const routes = logExportRouteDefinitions();
 const exportRoute = routes.find((r) => r.endpoint === "export")!;
 
-async function callExport(): Promise<Response> {
+async function callExport(
+  body: Record<string, unknown> = {},
+): Promise<Response> {
   const req = new Request("http://localhost/v1/export", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({}),
+    body: JSON.stringify(body),
   });
   const url = new URL(req.url);
   return exportRoute.handler({
@@ -162,6 +164,28 @@ try {
 } catch {
   // Symlink creation may fail on some platforms; tests will still pass
 }
+
+// Daemon log files — used for date filtering tests
+const logsDir = join(testWorkspaceDir, "data", "logs");
+mkdirSync(logsDir, { recursive: true });
+writeFileSync(
+  join(logsDir, "assistant-2025-01-10.log"),
+  "log entry from Jan 10\n",
+);
+writeFileSync(
+  join(logsDir, "assistant-2025-01-15.log"),
+  "log entry from Jan 15\n",
+);
+writeFileSync(
+  join(logsDir, "assistant-2025-01-20.log"),
+  "log entry from Jan 20\n",
+);
+writeFileSync(
+  join(logsDir, "assistant-2025-01-25.log"),
+  "log entry from Jan 25\n",
+);
+// Non-dated log file — should always be included regardless of time filter
+writeFileSync(join(logsDir, "vellum.log"), "non-dated log content\n");
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -304,6 +328,85 @@ describe("POST /v1/export — tar.gz archive", () => {
       );
       const parsed = JSON.parse(configContent);
       expect(parsed.provider).toBe("anthropic");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("POST /v1/export — daemon log date filtering", () => {
+  test("excludes log files before startTime", async () => {
+    // startTime = Jan 14 — should exclude assistant-2025-01-10.log
+    const startTime = new Date("2025-01-14T00:00:00.000Z").getTime();
+    const res = await callExport({ startTime });
+    const dir = await extractArchive(res);
+    try {
+      const logFiles = readdirSync(join(dir, "daemon-logs"));
+      expect(logFiles).not.toContain("assistant-2025-01-10.log");
+      expect(logFiles).toContain("assistant-2025-01-15.log");
+      expect(logFiles).toContain("assistant-2025-01-20.log");
+      expect(logFiles).toContain("assistant-2025-01-25.log");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("excludes log files after endTime", async () => {
+    // endTime = Jan 22 — should exclude assistant-2025-01-25.log
+    const endTime = new Date("2025-01-22T00:00:00.000Z").getTime();
+    const res = await callExport({ endTime });
+    const dir = await extractArchive(res);
+    try {
+      const logFiles = readdirSync(join(dir, "daemon-logs"));
+      expect(logFiles).toContain("assistant-2025-01-10.log");
+      expect(logFiles).toContain("assistant-2025-01-15.log");
+      expect(logFiles).toContain("assistant-2025-01-20.log");
+      expect(logFiles).not.toContain("assistant-2025-01-25.log");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("filters log files by both startTime and endTime", async () => {
+    // startTime = Jan 14, endTime = Jan 22 — should only include Jan 15 and Jan 20
+    const startTime = new Date("2025-01-14T00:00:00.000Z").getTime();
+    const endTime = new Date("2025-01-22T00:00:00.000Z").getTime();
+    const res = await callExport({ startTime, endTime });
+    const dir = await extractArchive(res);
+    try {
+      const logFiles = readdirSync(join(dir, "daemon-logs"));
+      expect(logFiles).not.toContain("assistant-2025-01-10.log");
+      expect(logFiles).toContain("assistant-2025-01-15.log");
+      expect(logFiles).toContain("assistant-2025-01-20.log");
+      expect(logFiles).not.toContain("assistant-2025-01-25.log");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("always includes non-dated log files regardless of time filter", async () => {
+    const startTime = new Date("2025-01-14T00:00:00.000Z").getTime();
+    const endTime = new Date("2025-01-22T00:00:00.000Z").getTime();
+    const res = await callExport({ startTime, endTime });
+    const dir = await extractArchive(res);
+    try {
+      const logFiles = readdirSync(join(dir, "daemon-logs"));
+      expect(logFiles).toContain("vellum.log");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("includes all log files when no time filter is specified", async () => {
+    const res = await callExport();
+    const dir = await extractArchive(res);
+    try {
+      const logFiles = readdirSync(join(dir, "daemon-logs"));
+      expect(logFiles).toContain("assistant-2025-01-10.log");
+      expect(logFiles).toContain("assistant-2025-01-15.log");
+      expect(logFiles).toContain("assistant-2025-01-20.log");
+      expect(logFiles).toContain("assistant-2025-01-25.log");
+      expect(logFiles).toContain("vellum.log");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -31,7 +31,7 @@ import {
   messages,
   toolInvocations,
 } from "../../memory/schema.js";
-import { getLogger } from "../../util/logger.js";
+import { getLogger, LOG_FILE_PATTERN } from "../../util/logger.js";
 import {
   getDaemonStderrLogPath,
   getDataDir,
@@ -167,9 +167,19 @@ async function handleExport(body: ExportRequestBody): Promise<Response> {
 
     const logsDir = join(getDataDir(), "logs");
     const collectedLogFiles: string[] = [];
+    const startDate = startTime ? new Date(startTime) : undefined;
+    const endDate = endTime ? new Date(endTime) : undefined;
     if (existsSync(logsDir)) {
       const entries = readdirSync(logsDir);
       for (const entry of entries) {
+        // Filter dated log files by time range
+        const dateMatch = entry.match(LOG_FILE_PATTERN);
+        if (dateMatch && (startDate || endDate)) {
+          const fileDate = new Date(dateMatch[1] + "T23:59:59.999Z"); // end of day
+          const fileDateStart = new Date(dateMatch[1] + "T00:00:00.000Z");
+          if (startDate && fileDate < startDate) continue; // entire day is before range
+          if (endDate && fileDateStart > endDate) continue; // entire day is after range
+        }
         const filePath = join(logsDir, entry);
         try {
           const stat = statSync(filePath);

--- a/assistant/src/util/logger.ts
+++ b/assistant/src/util/logger.ts
@@ -36,7 +36,7 @@ export type LogFileConfig = {
 
 const LOG_FILE_PREFIX = "assistant-";
 const LOG_FILE_SUFFIX = ".log";
-const LOG_FILE_PATTERN = /^assistant-(\d{4}-\d{2}-\d{2})\.log$/;
+export const LOG_FILE_PATTERN = /^assistant-(\d{4}-\d{2}-\d{2})\.log$/;
 
 function formatDate(date: Date): string {
   const y = date.getUTCFullYear();

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -292,7 +292,7 @@ enum LogExporter {
             // 1-2. Client artifacts — session logs, debug-state, hang-context, hang-sample files
             if let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
                 let appSupportDir = appSupport.appendingPathComponent("vellum-assistant", isDirectory: true)
-                collectClientArtifacts(from: appSupportDir, into: tempDir, fileManager: fileManager)
+                collectClientArtifacts(from: appSupportDir, into: tempDir, cutoffDate: cutoffDate, fileManager: fileManager)
             }
 
             // 3. Assistant logs — platform API for managed, local gateway for self-hosted
@@ -481,15 +481,46 @@ enum LogExporter {
     nonisolated static func collectClientArtifacts(
         from sourceDir: URL,
         into destDir: URL,
+        cutoffDate: Date? = nil,
         fileManager: FileManager = .default
     ) {
-        // Session logs
+        // Session logs — filter by modification date when cutoffDate is set
         let sessionLogDir = sourceDir.appendingPathComponent("logs", isDirectory: true)
-        copyDirectoryContents(
-            from: sessionLogDir,
-            to: destDir.appendingPathComponent("session-logs", isDirectory: true),
-            fileManager: fileManager
-        )
+        if let cutoffDate {
+            // Enumerate files and include only those modified at or after the cutoff
+            if fileManager.fileExists(atPath: sessionLogDir.path),
+               let files = try? fileManager.contentsOfDirectory(
+                   at: sessionLogDir,
+                   includingPropertiesForKeys: [.contentModificationDateKey],
+                   options: [.skipsHiddenFiles]
+               ) {
+                let filtered = files.filter { url in
+                    guard let values = try? url.resourceValues(forKeys: [.contentModificationDateKey]),
+                          let modDate = values.contentModificationDate else {
+                        return false
+                    }
+                    return modDate >= cutoffDate
+                }
+
+                if !filtered.isEmpty {
+                    let sessionLogDest = destDir.appendingPathComponent("session-logs", isDirectory: true)
+                    try? fileManager.createDirectory(at: sessionLogDest, withIntermediateDirectories: true)
+                    for file in filtered {
+                        try? fileManager.copyItem(
+                            at: file,
+                            to: sessionLogDest.appendingPathComponent(file.lastPathComponent)
+                        )
+                    }
+                }
+            }
+        } else {
+            // No cutoff — copy all session logs (existing behavior)
+            copyDirectoryContents(
+                from: sessionLogDir,
+                to: destDir.appendingPathComponent("session-logs", isDirectory: true),
+                fileManager: fileManager
+            )
+        }
 
         // Debug state snapshot
         let debugState = sourceDir.appendingPathComponent("debug-state.json")

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -348,7 +348,8 @@ enum LogExporter {
             // 9. macOS crash/hang reports — recent .ips/.crash/.spin files for assistant-related processes
             collectCrashReports(
                 into: tempDir.appendingPathComponent("crash-reports", isDirectory: true),
-                fileManager: fileManager
+                fileManager: fileManager,
+                cutoffDate: cutoffDate
             )
         }
 
@@ -689,7 +690,8 @@ enum LogExporter {
     /// included, capped at 5 MB total (newest first).
     private nonisolated static func collectCrashReports(
         into dest: URL,
-        fileManager: FileManager
+        fileManager: FileManager,
+        cutoffDate: Date? = nil
     ) {
         let home = NSHomeDirectory()
         let reportsDir = URL(fileURLWithPath: home)
@@ -702,7 +704,7 @@ enum LogExporter {
             options: [.skipsHiddenFiles]
         ) else { return }
 
-        let cutoff = Date().addingTimeInterval(-7 * 24 * 60 * 60)
+        let cutoff = cutoffDate ?? Date().addingTimeInterval(-7 * 24 * 60 * 60)
 
         // Filter to matching files, then sort newest-first
         let matching = contents

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -316,7 +316,8 @@ enum LogExporter {
             copyDirectoryContents(
                 from: xdgLogDir,
                 to: tempDir.appendingPathComponent("xdg-logs", isDirectory: true),
-                fileManager: fileManager
+                fileManager: fileManager,
+                cutoffDate: cutoffDate
             )
 
             // 5. Lockfile — ~/.vellum.lock.json (sanitized to strip credentials)
@@ -559,20 +560,40 @@ enum LogExporter {
 
     /// Copies all files from `source` into `dest`, creating `dest` if needed.
     /// Silently skips if `source` doesn't exist or is empty.
+    ///
+    /// When `cutoffDate` is non-nil, only files whose content modification date
+    /// is on or after the cutoff are copied. Files without a readable modification
+    /// date are included to avoid silently dropping data.
     private nonisolated static func copyDirectoryContents(
         from source: URL,
         to dest: URL,
-        fileManager: FileManager
+        fileManager: FileManager,
+        cutoffDate: Date? = nil
     ) {
         guard fileManager.fileExists(atPath: source.path) else { return }
         guard let items = try? fileManager.contentsOfDirectory(
             at: source,
-            includingPropertiesForKeys: nil,
+            includingPropertiesForKeys: [.contentModificationDateKey],
             options: [.skipsHiddenFiles]
         ), !items.isEmpty else { return }
 
+        let filtered: [URL]
+        if let cutoff = cutoffDate {
+            filtered = items.filter { url in
+                guard let values = try? url.resourceValues(forKeys: [.contentModificationDateKey]),
+                      let modDate = values.contentModificationDate else {
+                    // Include files whose modification date can't be read
+                    return true
+                }
+                return modDate >= cutoff
+            }
+        } else {
+            filtered = items
+        }
+
+        guard !filtered.isEmpty else { return }
         try? fileManager.createDirectory(at: dest, withIntermediateDirectories: true)
-        for item in items {
+        for item in filtered {
             try? fileManager.copyItem(
                 at: item,
                 to: dest.appendingPathComponent(item.lastPathComponent)

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -300,6 +300,8 @@ enum LogExporter {
 
             if isManagedAssistant, let assistantId = connectedId,
                let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") {
+                // TODO: fetchPlatformLogs does not yet support time-range filtering.
+                // The platform export API would need a startTime parameter to respect cutoffDate here.
                 await fetchPlatformLogs(into: tempDir, assistantId: assistantId, organizationId: orgId)
             } else {
                 let success = await fetchDaemonExports(into: tempDir, scope: formData?.scope ?? .global, cutoffDate: cutoffDate)
@@ -500,7 +502,8 @@ enum LogExporter {
                 let filtered = files.filter { url in
                     guard let values = try? url.resourceValues(forKeys: [.contentModificationDateKey]),
                           let modDate = values.contentModificationDate else {
-                        return false
+                        // Include files whose modification date can't be read to avoid data loss
+                        return true
                     }
                     return modDate >= cutoffDate
                 }

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -302,7 +302,7 @@ enum LogExporter {
                let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") {
                 await fetchPlatformLogs(into: tempDir, assistantId: assistantId, organizationId: orgId)
             } else {
-                let success = await fetchDaemonExports(into: tempDir, scope: formData?.scope ?? .global)
+                let success = await fetchDaemonExports(into: tempDir, scope: formData?.scope ?? .global, cutoffDate: cutoffDate)
                 if !success {
                     daemonUnreachable = true
                 }
@@ -617,7 +617,7 @@ enum LogExporter {
     /// Routes through ``GatewayHTTPClient`` so auth and connection resolution
     /// are handled consistently for both local and managed assistants.
     @discardableResult
-    private nonisolated static func fetchDaemonExports(into directory: URL, scope: LogExportScope) async -> Bool {
+    private nonisolated static func fetchDaemonExports(into directory: URL, scope: LogExportScope, cutoffDate: Date? = nil) async -> Bool {
         var body: [String: Any] = ["auditLimit": 1000]
         if case .conversation(let conversationId, _, let startTime, let endTime) = scope {
             body["conversationId"] = conversationId
@@ -627,6 +627,8 @@ enum LogExporter {
             if let endTime {
                 body["endTime"] = Int(endTime.timeIntervalSince1970 * 1000)
             }
+        } else if let cutoffDate {
+            body["startTime"] = Int(cutoffDate.timeIntervalSince1970 * 1000)
         }
 
         do {

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -409,7 +409,8 @@ enum LogExporter {
         if shouldCollectLogs {
             // 11. macOS unified log — recent os.Logger entries for this app's subsystem.
             collectUnifiedLog(
-                to: tempDir.appendingPathComponent("os-log.txt")
+                to: tempDir.appendingPathComponent("os-log.txt"),
+                cutoffDate: cutoffDate
             )
 
             // 12. Sanitized workspace config — client-side fallback if daemon export didn't include it.
@@ -772,16 +773,18 @@ enum LogExporter {
     /// for this app's subsystem. Includes CLI audit trail, lifecycle events,
     /// and any other structured log output not written to files on disk.
     ///
-    /// Uses `OSLogStore` to read entries from the last 24 hours. Falls back
-    /// silently if the API is unavailable or the subsystem has no entries.
-    private nonisolated static func collectUnifiedLog(to destination: URL) {
+    /// Uses `OSLogStore` to read entries starting from `cutoffDate`, or the
+    /// last 24 hours when no cutoff is provided. Falls back silently if the
+    /// API is unavailable or the subsystem has no entries.
+    private nonisolated static func collectUnifiedLog(to destination: URL, cutoffDate: Date? = nil) {
         do {
             let store = try OSLogStore(scope: .currentProcessIdentifier)
-            let oneDayAgo = store.position(date: Date().addingTimeInterval(-86400))
+            let logCutoff = cutoffDate ?? Date().addingTimeInterval(-86400)
+            let position = store.position(date: logCutoff)
             let subsystem = Bundle.appBundleIdentifier
 
             let entries = try store.getEntries(
-                at: oneDayAgo,
+                at: position,
                 matching: NSPredicate(format: "subsystem == %@", subsystem)
             )
 

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -285,6 +285,8 @@ enum LogExporter {
         let connectedAssistant = connectedId.flatMap { LockfileAssistant.loadByName($0) }
         var daemonUnreachable = false
 
+        let cutoffDate: Date? = formData?.logTimeRange.cutoffDate
+
         let shouldCollectLogs = formData?.includeLogs ?? true
         if shouldCollectLogs {
             // 1-2. Client artifacts — session logs, debug-state, hang-context, hang-sample files

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -626,6 +626,8 @@ enum LogExporter {
             body["conversationId"] = conversationId
             if let startTime {
                 body["startTime"] = Int(startTime.timeIntervalSince1970 * 1000)
+            } else if let cutoffDate {
+                body["startTime"] = Int(cutoffDate.timeIntervalSince1970 * 1000)
             }
             if let endTime {
                 body["endTime"] = Int(endTime.timeIntervalSince1970 * 1000)

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -564,7 +564,7 @@ enum LogExporter {
     /// are handled consistently for both local and managed assistants.
     @discardableResult
     private nonisolated static func fetchDaemonExports(into directory: URL, scope: LogExportScope) async -> Bool {
-        var body: [String: Any] = ["auditLimit": 10000]
+        var body: [String: Any] = ["auditLimit": 1000]
         if case .conversation(let conversationId, _, let startTime, let endTime) = scope {
             body["conversationId"] = conversationId
             if let startTime {

--- a/clients/macos/vellum-assistant/Logging/LogReportReason.swift
+++ b/clients/macos/vellum-assistant/Logging/LogReportReason.swift
@@ -70,6 +70,15 @@ enum LogTimeRange: String, CaseIterable, Identifiable, Sendable {
         case .allTime: return "All time"
         }
     }
+
+    /// Returns the earliest `Date` that should be included, or `nil` for `.allTime`.
+    var cutoffDate: Date? {
+        switch self {
+        case .pastHour: return Date().addingTimeInterval(-3600)
+        case .past24Hours: return Date().addingTimeInterval(-86400)
+        case .allTime: return nil
+        }
+    }
 }
 
 /// Aggregated form data collected from the feedback sheet.

--- a/clients/macos/vellum-assistantTests/LogExporterClientArtifactsTests.swift
+++ b/clients/macos/vellum-assistantTests/LogExporterClientArtifactsTests.swift
@@ -314,4 +314,136 @@ struct LogExporterClientArtifactsTests {
         )
         #expect(copiedSample == sampleContent)
     }
+
+    // MARK: - Session Log Cutoff Date Filtering
+
+    @Test
+    func filtersSessionLogsByCutoffDate() throws {
+        let (source, dest) = try makeTempDirs()
+        defer { cleanup(source) }
+        let fm = FileManager.default
+
+        let logsDir = source.appendingPathComponent("logs", isDirectory: true)
+        try fm.createDirectory(at: logsDir, withIntermediateDirectories: true)
+
+        // Create three session log files
+        let oldFile = logsDir.appendingPathComponent("chat-diagnostics-old.jsonl")
+        let recentFile = logsDir.appendingPathComponent("chat-diagnostics-recent.jsonl")
+        let newestFile = logsDir.appendingPathComponent("chat-diagnostics-newest.jsonl")
+
+        try "old event\n".write(to: oldFile, atomically: true, encoding: .utf8)
+        try "recent event\n".write(to: recentFile, atomically: true, encoding: .utf8)
+        try "newest event\n".write(to: newestFile, atomically: true, encoding: .utf8)
+
+        // Set modification dates: old = 2 hours ago, recent = 30 min ago, newest = now
+        let twoHoursAgo = Date().addingTimeInterval(-7200)
+        let thirtyMinAgo = Date().addingTimeInterval(-1800)
+        let now = Date()
+
+        try fm.setAttributes([.modificationDate: twoHoursAgo], ofItemAtPath: oldFile.path)
+        try fm.setAttributes([.modificationDate: thirtyMinAgo], ofItemAtPath: recentFile.path)
+        try fm.setAttributes([.modificationDate: now], ofItemAtPath: newestFile.path)
+
+        // Use a cutoff of 1 hour ago — should exclude the old file
+        let cutoff = Date().addingTimeInterval(-3600)
+        LogExporter.collectClientArtifacts(from: source, into: dest, cutoffDate: cutoff, fileManager: fm)
+
+        let sessionLogsDir = dest.appendingPathComponent("session-logs", isDirectory: true)
+        #expect(fm.fileExists(atPath: sessionLogsDir.path))
+
+        let copiedFiles = try fm.contentsOfDirectory(at: sessionLogsDir, includingPropertiesForKeys: nil)
+        let copiedNames = Set(copiedFiles.map(\.lastPathComponent))
+
+        #expect(copiedNames.count == 2)
+        #expect(copiedNames.contains("chat-diagnostics-recent.jsonl"))
+        #expect(copiedNames.contains("chat-diagnostics-newest.jsonl"))
+        #expect(!copiedNames.contains("chat-diagnostics-old.jsonl"))
+    }
+
+    @Test
+    func cutoffDateNilCollectsAllSessionLogs() throws {
+        let (source, dest) = try makeTempDirs()
+        defer { cleanup(source) }
+        let fm = FileManager.default
+
+        let logsDir = source.appendingPathComponent("logs", isDirectory: true)
+        try fm.createDirectory(at: logsDir, withIntermediateDirectories: true)
+
+        // Create session log files with varied modification dates
+        let oldFile = logsDir.appendingPathComponent("chat-diagnostics-old.jsonl")
+        let recentFile = logsDir.appendingPathComponent("chat-diagnostics-recent.jsonl")
+
+        try "old event\n".write(to: oldFile, atomically: true, encoding: .utf8)
+        try "recent event\n".write(to: recentFile, atomically: true, encoding: .utf8)
+
+        let oneWeekAgo = Date().addingTimeInterval(-7 * 24 * 3600)
+        try fm.setAttributes([.modificationDate: oneWeekAgo], ofItemAtPath: oldFile.path)
+
+        // cutoffDate: nil should collect all files (backward compat / allTime)
+        LogExporter.collectClientArtifacts(from: source, into: dest, cutoffDate: nil, fileManager: fm)
+
+        let sessionLogsDir = dest.appendingPathComponent("session-logs", isDirectory: true)
+        #expect(fm.fileExists(atPath: sessionLogsDir.path))
+
+        let copiedFiles = try fm.contentsOfDirectory(at: sessionLogsDir, includingPropertiesForKeys: nil)
+        #expect(copiedFiles.count == 2)
+    }
+
+    @Test
+    func cutoffDateExcludesAllSessionLogsWhenAllOld() throws {
+        let (source, dest) = try makeTempDirs()
+        defer { cleanup(source) }
+        let fm = FileManager.default
+
+        let logsDir = source.appendingPathComponent("logs", isDirectory: true)
+        try fm.createDirectory(at: logsDir, withIntermediateDirectories: true)
+
+        // Create session logs that are all older than the cutoff
+        let file1 = logsDir.appendingPathComponent("chat-diagnostics-1.jsonl")
+        let file2 = logsDir.appendingPathComponent("chat-diagnostics-2.jsonl")
+
+        try "event1\n".write(to: file1, atomically: true, encoding: .utf8)
+        try "event2\n".write(to: file2, atomically: true, encoding: .utf8)
+
+        let twoDaysAgo = Date().addingTimeInterval(-2 * 24 * 3600)
+        try fm.setAttributes([.modificationDate: twoDaysAgo], ofItemAtPath: file1.path)
+        try fm.setAttributes([.modificationDate: twoDaysAgo], ofItemAtPath: file2.path)
+
+        // Cutoff = 1 hour ago — both files are older
+        let cutoff = Date().addingTimeInterval(-3600)
+        LogExporter.collectClientArtifacts(from: source, into: dest, cutoffDate: cutoff, fileManager: fm)
+
+        // session-logs directory should not be created since no files pass the filter
+        let sessionLogsDir = dest.appendingPathComponent("session-logs", isDirectory: true)
+        #expect(!fm.fileExists(atPath: sessionLogsDir.path))
+    }
+
+    @Test
+    func cutoffDateStillCollectsNonSessionArtifacts() throws {
+        let (source, dest) = try makeTempDirs()
+        defer { cleanup(source) }
+        let fm = FileManager.default
+
+        // Create debug-state.json and hang-context.json (these should always be collected)
+        try "{\"debug\":true}".write(
+            to: source.appendingPathComponent("debug-state.json"),
+            atomically: true, encoding: .utf8
+        )
+        try "{\"stall\":1.0}".write(
+            to: source.appendingPathComponent("hang-context.json"),
+            atomically: true, encoding: .utf8
+        )
+        try "sample data".write(
+            to: source.appendingPathComponent("hang-sample.txt"),
+            atomically: true, encoding: .utf8
+        )
+
+        // Use a cutoff — non-session artifacts should still be collected regardless
+        let cutoff = Date().addingTimeInterval(-3600)
+        LogExporter.collectClientArtifacts(from: source, into: dest, cutoffDate: cutoff, fileManager: fm)
+
+        #expect(fm.fileExists(atPath: dest.appendingPathComponent("debug-state.json").path))
+        #expect(fm.fileExists(atPath: dest.appendingPathComponent("hang-context.json").path))
+        #expect(fm.fileExists(atPath: dest.appendingPathComponent("hang-sample.txt").path))
+    }
 }


### PR DESCRIPTION
## Summary
The feedback form exposes a LogTimeRange picker ("Past hour", "Past 24 hours", "All time") but the selected value was only written to metadata — it never actually filtered any collected log sources. This PR threads the time filter through every log source that can reasonably be filtered, significantly reducing payload sizes and improving upload reliability.

## Changes
- Add `cutoffDate` computed property to `LogTimeRange` and thread it through `populateStagingDirectory`
- Filter macOS session logs by file modification date
- Filter XDG CLI logs by file modification date  
- Use feedback time range for crash report cutoff (instead of hardcoded 7 days)
- Use feedback time range for unified OS log collection (instead of hardcoded 24h)
- Pass `startTime` from feedback time range to daemon export API for global exports
- Filter daemon log files by filename date pattern (`assistant-YYYY-MM-DD.log`) server-side
- Reduce default `auditLimit` from 10,000 to 1,000 to match daemon default

## PRs merged into feature branch
- #23422: Add cutoffDate helper to LogTimeRange and thread it through log collection
- #23426: Filter session log files by cutoff date during feedback export
- #23428: Filter XDG CLI log files by cutoff date during feedback export
- #23425: Use feedback time range for crash report cutoff instead of hardcoded 7 days
- #23424: Use feedback time range for unified OS log collection instead of hardcoded 24h
- #23427: Pass startTime from feedback time range to daemon export API
- #23423: Filter daemon log files by startTime/endTime in export handler
- #23420: Reduce default auditLimit from 10,000 to match daemon default of 1,000

Part of plan: respect-log-time-filter.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
