### PR TITLE
fix: consistent date-filter fallback and document platform log gap

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -300,6 +300,8 @@ enum LogExporter {
 
             if isManagedAssistant, let assistantId = connectedId,
                let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") {
+                // TODO: fetchPlatformLogs does not yet support time-range filtering.
+                // The platform export API would need a startTime parameter to respect cutoffDate here.
                 await fetchPlatformLogs(into: tempDir, assistantId: assistantId, organizationId: orgId)
             } else {
                 let success = await fetchDaemonExports(into: tempDir, scope: formData?.scope ?? .global, cutoffDate: cutoffDate)
@@ -500,7 +502,8 @@ enum LogExporter {
                 let filtered = files.filter { url in
                     guard let values = try? url.resourceValues(forKeys: [.contentModificationDateKey]),
                           let modDate = values.contentModificationDate else {
-                        return false
+                        // Include files whose modification date can't be read to avoid data loss
+                        return true
                     }
                     return modDate >= cutoffDate
                 }


### PR DESCRIPTION
## Summary
Fixes two gaps identified during plan review for respect-log-time-filter.md:
- Change session log filtering to include (not drop) files with unreadable modification dates, matching copyDirectoryContents behavior
- Add TODO comment documenting that fetchPlatformLogs does not yet support time-range filtering
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
