### PR TITLE
feat: register permission-controls-v2 feature flag

### DIFF
--- a/assistant/src/__tests__/permission-controls-v2-flag.test.ts
+++ b/assistant/src/__tests__/permission-controls-v2-flag.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for the `permission-controls-v2` feature flag.
+ *
+ * Verifies:
+ *   - The flag defaults to disabled (not enabled)
+ *   - The flag can be enabled via `_setOverridesForTesting`
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  _setOverridesForTesting,
+  isAssistantFeatureFlagEnabled,
+} from "../config/assistant-feature-flags.js";
+import type { AssistantConfig } from "../config/schema.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeConfig(): AssistantConfig {
+  return {} as AssistantConfig;
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  _setOverridesForTesting({});
+});
+
+afterEach(() => {
+  _setOverridesForTesting({});
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("permission-controls-v2 feature flag", () => {
+  test("defaults to disabled", () => {
+    const config = makeConfig();
+    expect(
+      isAssistantFeatureFlagEnabled("permission-controls-v2", config),
+    ).toBe(false);
+  });
+
+  test("can be enabled via overrides", () => {
+    _setOverridesForTesting({ "permission-controls-v2": true });
+    const config = makeConfig();
+    expect(
+      isAssistantFeatureFlagEnabled("permission-controls-v2", config),
+    ).toBe(true);
+  });
+});

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -272,6 +272,14 @@
       "label": "Teleport",
       "description": "Enable teleport UI in General settings for moving assistants between hosting environments",
       "defaultEnabled": false
+    },
+    {
+      "id": "permission-controls-v2",
+      "scope": "assistant",
+      "key": "permission-controls-v2",
+      "label": "Permission Controls V2",
+      "description": "Replace risk-level permission system with two independent controls: 'Ask before acting' (LLM behavior toggle) and 'Host access' (system-enforced gate)",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Register permission-controls-v2 feature flag in the registry (default: disabled)
- Copy updated registry to bundled assistant config
- Add test verifying flag defaults and override behavior

Part of plan: permission-system-redesign.md (PR 1 of 17)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23433" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
