### PR TITLE
feat: add PermissionMode type and host-access config schema

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -421,6 +421,8 @@ describe("AssistantConfigSchema", () => {
     const result = AssistantConfigSchema.parse({});
     expect(result.permissions).toEqual({
       mode: "workspace",
+      askBeforeActing: true,
+      hostAccess: false,
     });
   });
 
@@ -1128,6 +1130,8 @@ describe("loadConfig with schema validation", () => {
     const config = loadConfig();
     expect(config.permissions).toEqual({
       mode: "workspace",
+      askBeforeActing: true,
+      hostAccess: false,
     });
   });
 

--- a/assistant/src/__tests__/permission-mode.test.ts
+++ b/assistant/src/__tests__/permission-mode.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+
+import { PermissionsConfigSchema } from "../config/schemas/security.js";
+import {
+  DEFAULT_PERMISSION_MODE,
+  PermissionModeSchema,
+} from "../permissions/permission-mode.js";
+
+// ---------------------------------------------------------------------------
+// Tests: PermissionModeSchema
+// ---------------------------------------------------------------------------
+
+describe("PermissionModeSchema", () => {
+  test("parses empty object with correct defaults", () => {
+    const result = PermissionModeSchema.parse({});
+    expect(result.askBeforeActing).toBe(true);
+    expect(result.hostAccess).toBe(false);
+  });
+
+  test("DEFAULT_PERMISSION_MODE matches schema defaults", () => {
+    const parsed = PermissionModeSchema.parse({});
+    expect(parsed).toEqual(DEFAULT_PERMISSION_MODE);
+  });
+
+  test("accepts explicit true/true", () => {
+    const result = PermissionModeSchema.parse({
+      askBeforeActing: true,
+      hostAccess: true,
+    });
+    expect(result.askBeforeActing).toBe(true);
+    expect(result.hostAccess).toBe(true);
+  });
+
+  test("accepts explicit false/false", () => {
+    const result = PermissionModeSchema.parse({
+      askBeforeActing: false,
+      hostAccess: false,
+    });
+    expect(result.askBeforeActing).toBe(false);
+    expect(result.hostAccess).toBe(false);
+  });
+
+  test("round-trips through JSON serialization", () => {
+    const original = { askBeforeActing: false, hostAccess: true };
+    const json = JSON.stringify(original);
+    const parsed = PermissionModeSchema.parse(JSON.parse(json));
+    expect(parsed).toEqual(original);
+  });
+
+  test("rejects non-boolean askBeforeActing", () => {
+    expect(() =>
+      PermissionModeSchema.parse({ askBeforeActing: "yes" }),
+    ).toThrow();
+  });
+
+  test("rejects non-boolean hostAccess", () => {
+    expect(() => PermissionModeSchema.parse({ hostAccess: "no" })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: PermissionsConfigSchema (permissionMode fields)
+// ---------------------------------------------------------------------------
+
+describe("PermissionsConfigSchema permissionMode fields", () => {
+  test("defaults askBeforeActing to true and hostAccess to false", () => {
+    const result = PermissionsConfigSchema.parse({});
+    expect(result.askBeforeActing).toBe(true);
+    expect(result.hostAccess).toBe(false);
+  });
+
+  test("preserves existing mode field alongside new fields", () => {
+    const result = PermissionsConfigSchema.parse({ mode: "strict" });
+    expect(result.mode).toBe("strict");
+    expect(result.askBeforeActing).toBe(true);
+    expect(result.hostAccess).toBe(false);
+  });
+
+  test("accepts overridden values for new fields", () => {
+    const result = PermissionsConfigSchema.parse({
+      mode: "workspace",
+      askBeforeActing: false,
+      hostAccess: true,
+    });
+    expect(result.mode).toBe("workspace");
+    expect(result.askBeforeActing).toBe(false);
+    expect(result.hostAccess).toBe(true);
+  });
+
+  test("round-trips new fields through JSON serialization", () => {
+    const input = {
+      mode: "workspace" as const,
+      askBeforeActing: false,
+      hostAccess: true,
+    };
+    const json = JSON.stringify(input);
+    const parsed = PermissionsConfigSchema.parse(JSON.parse(json));
+    expect(parsed.askBeforeActing).toBe(false);
+    expect(parsed.hostAccess).toBe(true);
+  });
+});

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -3,6 +3,11 @@ import { z } from "zod";
 import { getDataDir } from "../util/platform.js";
 
 // Re-export all domain schemas
+export type { PermissionMode } from "../permissions/permission-mode.js";
+export {
+  DEFAULT_PERMISSION_MODE,
+  PermissionModeSchema,
+} from "../permissions/permission-mode.js";
 export type { AcpAgentConfig, AcpConfig } from "./acp-schema.js";
 export { AcpAgentConfigSchema, AcpConfigSchema } from "./acp-schema.js";
 export type {
@@ -143,6 +148,7 @@ export type {
 export {
   PermissionsConfigSchema,
   SecretDetectionConfigSchema,
+  VALID_PERMISSIONS_MODES,
 } from "./schemas/security.js";
 export type {
   ImageGenerationService,

--- a/assistant/src/config/schemas/security.ts
+++ b/assistant/src/config/schemas/security.ts
@@ -79,6 +79,20 @@ export const PermissionsConfigSchema = z
       .describe(
         "Permission mode — 'strict' requires explicit approval for all operations, 'workspace' allows operations within the workspace",
       ),
+    askBeforeActing: z
+      .boolean({
+        error: "permissions.askBeforeActing must be a boolean",
+      })
+      .default(true)
+      .describe("Whether the assistant should check in before taking actions"),
+    hostAccess: z
+      .boolean({
+        error: "permissions.hostAccess must be a boolean",
+      })
+      .default(false)
+      .describe(
+        "Whether the assistant can execute commands on the host machine without prompting",
+      ),
   })
   .describe("Permission enforcement mode for tool operations");
 

--- a/assistant/src/permissions/permission-mode.ts
+++ b/assistant/src/permissions/permission-mode.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+/**
+ * Two-axis permission model:
+ * - `askBeforeActing` — LLM behavior toggle: when true the assistant checks in
+ *   with the user before taking actions.
+ * - `hostAccess` — System-enforced gate: when true the assistant can execute
+ *   commands on the host machine without prompting.
+ */
+export type PermissionMode = {
+  askBeforeActing: boolean;
+  hostAccess: boolean;
+};
+
+export const DEFAULT_PERMISSION_MODE: PermissionMode = {
+  askBeforeActing: true,
+  hostAccess: false,
+};
+
+export const PermissionModeSchema = z.object({
+  askBeforeActing: z
+    .boolean({ error: "permissionMode.askBeforeActing must be a boolean" })
+    .default(true)
+    .describe("Whether the assistant should check in before taking actions"),
+  hostAccess: z
+    .boolean({ error: "permissionMode.hostAccess must be a boolean" })
+    .default(false)
+    .describe(
+      "Whether the assistant can execute commands on the host machine without prompting",
+    ),
+});


### PR DESCRIPTION
## Summary
- Add PermissionMode type with askBeforeActing and hostAccess fields
- Add permissionMode field to PermissionsConfigSchema (defaults: askBeforeActing=true, hostAccess=false)
- Re-export new types from config/schema.ts
- Add tests verifying schema defaults and serialization

Part of plan: permission-system-redesign.md (PR 2 of 17)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
