### PR TITLE
Update skill card buttons to standard size and proper styles

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -329,7 +329,7 @@ struct SkillItemRow: View {
                 VButton(
                     label: "Remove",
                     leftIcon: VIcon.trash.rawValue,
-                    style: .outlined,
+                    style: .dangerOutline,
                     action: onDelete
                 )
                 .disabled(!isRemovable)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -329,8 +329,7 @@ struct SkillItemRow: View {
                 VButton(
                     label: "Remove",
                     leftIcon: VIcon.trash.rawValue,
-                    style: .dangerGhost,
-                    size: .compact,
+                    style: .outlined,
                     action: onDelete
                 )
                 .disabled(!isRemovable)
@@ -384,8 +383,7 @@ struct AvailableSkillItemRow: View {
                     VButton(
                         label: "Install",
                         leftIcon: VIcon.arrowDownToLine.rawValue,
-                        style: .ghost,
-                        size: .compact,
+                        style: .primary,
                         action: onInstall
                     )
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -91,7 +91,7 @@ struct FileContentView: View {
                 if modes.count > 1 {
                     VSegmentControl(
                         items: modes.map { (label: viewModeLabel($0), tag: $0) },
-                        selection: $viewMode,
+                        selection: $viewMode
                     )
                     .fixedSize()
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
@@ -218,7 +218,7 @@ struct SkillDetailTitleRow: View {
             VSkillTypePill(origin: skill.origin)
 
             if skill.kind == "installed" {
-                VButton(label: "Remove", style: .dangerOutline) {
+                VButton(label: "Remove", leftIcon: VIcon.trash.rawValue, style: .dangerOutline) {
                     onDelete()
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Settings/IntegrationDetailModal.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/IntegrationDetailModal.swift
@@ -80,7 +80,7 @@ struct IntegrationDetailModal: View {
                         (label: "Managed", tag: "managed"),
                         (label: "Your Own", tag: "your-own"),
                     ],
-                    selection: $draftMode,
+                    selection: $draftMode
                 )
                 .frame(maxWidth: .infinity)
 

--- a/clients/macos/vellum-assistant/Features/Settings/ServiceModeCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ServiceModeCard.swift
@@ -55,7 +55,7 @@ struct ServiceModeCard<ManagedContent: View, YourOwnContent: View>: View {
                         (label: "Managed", tag: "managed"),
                         (label: "Your Own", tag: "your-own"),
                     ],
-                    selection: $draftMode,
+                    selection: $draftMode
                 )
                 .frame(width: 220)
             }

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
@@ -35,7 +35,7 @@ struct RecordingSourcePickerView: View {
             // Scope picker (Display / Window)
             VSegmentControl(
                 items: CaptureScope.allCases.map { (label: $0.rawValue, tag: $0) },
-                selection: $viewModel.captureScope,
+                selection: $viewModel.captureScope
             )
             .padding(.horizontal, VSpacing.lg)
             .padding(.bottom, VSpacing.sm)

--- a/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
@@ -32,7 +32,7 @@ struct ButtonsGallerySection: View {
                                     (label: "Ghost", tag: VButton.Style.ghost),
                                     (label: "Contrast", tag: VButton.Style.contrast),
                                 ],
-                                selection: $selectedStyle,
+                                selection: $selectedStyle
                             )
                             .frame(maxWidth: 600)
 


### PR DESCRIPTION
## Summary
- Changed the Remove button in installed skill cards from `dangerGhost`/`compact` to `outlined`/`regular` (standard size)
- Changed the Install button in available skill cards from `ghost`/`compact` to `primary`/`regular` (solid primary, standard size)
- Fixed trailing comma build errors across several Swift files

## Original prompt
make button in skill card standard size and outlined both for remove and solid primary for install
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
