### PR TITLE
feat: add PermissionModeStore for runtime permission mode state

### DIFF
--- a/assistant/src/__tests__/permission-mode-store.test.ts
+++ b/assistant/src/__tests__/permission-mode-store.test.ts
@@ -1,0 +1,277 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before imports that depend on platform/logger
+// ---------------------------------------------------------------------------
+
+const WORKSPACE_DIR = process.env.VELLUM_WORKSPACE_DIR!;
+const CONFIG_PATH = join(WORKSPACE_DIR, "config.json");
+
+function ensureTestDir(): void {
+  const dirs = [
+    WORKSPACE_DIR,
+    join(WORKSPACE_DIR, "data"),
+    join(WORKSPACE_DIR, "data", "logs"),
+  ];
+  for (const dir of dirs) {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  }
+}
+
+function makeLoggerStub(): Record<string, unknown> {
+  const stub: Record<string, unknown> = {};
+  for (const m of [
+    "info",
+    "warn",
+    "error",
+    "debug",
+    "trace",
+    "fatal",
+    "silent",
+    "child",
+  ]) {
+    stub[m] = m === "child" ? () => makeLoggerStub() : () => {};
+  }
+  return stub;
+}
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeLoggerStub(),
+}));
+
+afterAll(() => {
+  mock.restore();
+});
+
+import { invalidateConfigCache } from "../config/loader.js";
+import {
+  getMode,
+  initPermissionModeStore,
+  onModeChanged,
+  resetForTesting,
+  setAskBeforeActing,
+  setHostAccess,
+} from "../permissions/permission-mode-store.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function writeConfig(obj: unknown): void {
+  ensureTestDir();
+  writeFileSync(CONFIG_PATH, JSON.stringify(obj, null, 2) + "\n");
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  ensureTestDir();
+  resetForTesting();
+  invalidateConfigCache();
+  // Remove config file to start clean
+  try {
+    rmSync(CONFIG_PATH, { force: true });
+  } catch {
+    /* noop */
+  }
+});
+
+afterEach(() => {
+  resetForTesting();
+  invalidateConfigCache();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PermissionModeStore", () => {
+  describe("getMode", () => {
+    test("returns defaults when no config exists", () => {
+      const mode = getMode();
+      expect(mode.askBeforeActing).toBe(true);
+      expect(mode.hostAccess).toBe(false);
+    });
+
+    test("reads initial state from config", () => {
+      writeConfig({
+        permissions: {
+          askBeforeActing: false,
+          hostAccess: true,
+        },
+      });
+
+      initPermissionModeStore();
+      const mode = getMode();
+      expect(mode.askBeforeActing).toBe(false);
+      expect(mode.hostAccess).toBe(true);
+    });
+
+    test("returns a defensive copy (mutations do not affect store)", () => {
+      const mode = getMode();
+      mode.askBeforeActing = false;
+      mode.hostAccess = true;
+
+      const fresh = getMode();
+      expect(fresh.askBeforeActing).toBe(true);
+      expect(fresh.hostAccess).toBe(false);
+    });
+  });
+
+  describe("setAskBeforeActing", () => {
+    test("updates in-memory state", () => {
+      expect(getMode().askBeforeActing).toBe(true);
+
+      setAskBeforeActing(false);
+      expect(getMode().askBeforeActing).toBe(false);
+    });
+
+    test("persists to config.json", () => {
+      setAskBeforeActing(false);
+
+      const raw = readConfig();
+      const permissions = raw.permissions as Record<string, unknown>;
+      expect(permissions.askBeforeActing).toBe(false);
+    });
+
+    test("no-op when value is unchanged", () => {
+      const calls: unknown[] = [];
+      onModeChanged((mode) => calls.push(mode));
+
+      // Default is true; setting to true should not fire
+      setAskBeforeActing(true);
+      expect(calls).toHaveLength(0);
+    });
+  });
+
+  describe("setHostAccess", () => {
+    test("updates in-memory state", () => {
+      expect(getMode().hostAccess).toBe(false);
+
+      setHostAccess(true);
+      expect(getMode().hostAccess).toBe(true);
+    });
+
+    test("persists to config.json", () => {
+      setHostAccess(true);
+
+      const raw = readConfig();
+      const permissions = raw.permissions as Record<string, unknown>;
+      expect(permissions.hostAccess).toBe(true);
+    });
+
+    test("no-op when value is unchanged", () => {
+      const calls: unknown[] = [];
+      onModeChanged((mode) => calls.push(mode));
+
+      // Default is false; setting to false should not fire
+      setHostAccess(false);
+      expect(calls).toHaveLength(0);
+    });
+  });
+
+  describe("onModeChanged", () => {
+    test("fires on askBeforeActing change", () => {
+      const received: Array<{ askBeforeActing: boolean; hostAccess: boolean }> =
+        [];
+      onModeChanged((mode) => received.push(mode));
+
+      setAskBeforeActing(false);
+      expect(received).toHaveLength(1);
+      expect(received[0].askBeforeActing).toBe(false);
+      expect(received[0].hostAccess).toBe(false);
+    });
+
+    test("fires on hostAccess change", () => {
+      const received: Array<{ askBeforeActing: boolean; hostAccess: boolean }> =
+        [];
+      onModeChanged((mode) => received.push(mode));
+
+      setHostAccess(true);
+      expect(received).toHaveLength(1);
+      expect(received[0].askBeforeActing).toBe(true);
+      expect(received[0].hostAccess).toBe(true);
+    });
+
+    test("unsubscribe stops notifications", () => {
+      const received: unknown[] = [];
+      const unsubscribe = onModeChanged((mode) => received.push(mode));
+
+      setAskBeforeActing(false);
+      expect(received).toHaveLength(1);
+
+      unsubscribe();
+      setHostAccess(true);
+      expect(received).toHaveLength(1); // no new notification
+    });
+
+    test("listener errors do not break other listeners", () => {
+      const received: unknown[] = [];
+      onModeChanged(() => {
+        throw new Error("boom");
+      });
+      onModeChanged((mode) => received.push(mode));
+
+      setAskBeforeActing(false);
+      expect(received).toHaveLength(1);
+    });
+  });
+
+  describe("persistence round-trip", () => {
+    test("state survives store reset and re-initialization", () => {
+      setAskBeforeActing(false);
+      setHostAccess(true);
+
+      // Simulate daemon restart: reset store and re-init from config
+      resetForTesting();
+      invalidateConfigCache();
+      initPermissionModeStore();
+
+      const mode = getMode();
+      expect(mode.askBeforeActing).toBe(false);
+      expect(mode.hostAccess).toBe(true);
+    });
+
+    test("preserves other config fields when persisting", () => {
+      writeConfig({
+        maxTokens: 8000,
+        permissions: {
+          mode: "strict",
+          askBeforeActing: true,
+          hostAccess: false,
+        },
+      });
+
+      initPermissionModeStore();
+      setHostAccess(true);
+
+      const raw = readConfig();
+      expect(raw.maxTokens).toBe(8000);
+      const permissions = raw.permissions as Record<string, unknown>;
+      expect(permissions.mode).toBe("strict");
+      expect(permissions.hostAccess).toBe(true);
+    });
+  });
+});

--- a/assistant/src/permissions/permission-mode-store.ts
+++ b/assistant/src/permissions/permission-mode-store.ts
@@ -1,0 +1,180 @@
+/**
+ * Singleton runtime store for the two-axis permission mode.
+ *
+ * Reads initial state from the `permissions` section of config.json on
+ * initialization and persists mutations back to the config file via the
+ * raw-config read/write helpers so env-var–derived keys are never leaked
+ * to disk.
+ *
+ * Downstream consumers (e.g. SSE broadcast) register change listeners
+ * via `onModeChanged()`.
+ */
+
+import {
+  invalidateConfigCache,
+  loadConfig,
+  loadRawConfig,
+  saveRawConfig,
+} from "../config/loader.js";
+import { getLogger } from "../util/logger.js";
+import type { PermissionMode } from "./permission-mode.js";
+import { DEFAULT_PERMISSION_MODE } from "./permission-mode.js";
+
+const log = getLogger("permission-mode-store");
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ModeChangeListener = (mode: PermissionMode) => void;
+
+// ---------------------------------------------------------------------------
+// Module-level state
+// ---------------------------------------------------------------------------
+
+let currentMode: PermissionMode = { ...DEFAULT_PERMISSION_MODE };
+let initialized = false;
+const listeners: ModeChangeListener[] = [];
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function notifyListeners(): void {
+  const snapshot = { ...currentMode };
+  for (const listener of listeners) {
+    try {
+      listener(snapshot);
+    } catch (err) {
+      log.error({ err }, "Error in permission mode change listener");
+    }
+  }
+}
+
+/**
+ * Persist the current in-memory permission mode to config.json.
+ *
+ * Uses the raw-config pattern (loadRawConfig → mutate → saveRawConfig) so
+ * that env-var–derived fields (API keys, dataDir) are never written to disk.
+ */
+function persistToConfig(): void {
+  try {
+    const raw = loadRawConfig();
+
+    // Ensure the permissions object exists
+    if (
+      raw.permissions == null ||
+      typeof raw.permissions !== "object" ||
+      Array.isArray(raw.permissions)
+    ) {
+      raw.permissions = {};
+    }
+
+    const permissions = raw.permissions as Record<string, unknown>;
+    permissions.askBeforeActing = currentMode.askBeforeActing;
+    permissions.hostAccess = currentMode.hostAccess;
+
+    saveRawConfig(raw);
+
+    // Invalidate the cached config so the next loadConfig() picks up the
+    // persisted values rather than returning stale in-memory state.
+    invalidateConfigCache();
+  } catch (err) {
+    log.error({ err }, "Failed to persist permission mode to config");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Initialize the store from the current config. Safe to call multiple times;
+ * subsequent calls are no-ops unless `resetForTesting()` has been called.
+ */
+export function initPermissionModeStore(): void {
+  if (initialized) return;
+
+  try {
+    const config = loadConfig();
+    currentMode = {
+      askBeforeActing: config.permissions.askBeforeActing,
+      hostAccess: config.permissions.hostAccess,
+    };
+  } catch (err) {
+    log.warn(
+      { err },
+      "Failed to load permission mode from config; using defaults",
+    );
+    currentMode = { ...DEFAULT_PERMISSION_MODE };
+  }
+
+  initialized = true;
+}
+
+/**
+ * Return the current permission mode. Initializes from config on first call
+ * if `initPermissionModeStore()` hasn't been called yet.
+ */
+export function getMode(): PermissionMode {
+  if (!initialized) {
+    initPermissionModeStore();
+  }
+  return { ...currentMode };
+}
+
+/**
+ * Update the `askBeforeActing` axis. Persists to config.json and notifies
+ * change listeners.
+ */
+export function setAskBeforeActing(value: boolean): void {
+  if (!initialized) {
+    initPermissionModeStore();
+  }
+
+  if (currentMode.askBeforeActing === value) return;
+
+  currentMode.askBeforeActing = value;
+  persistToConfig();
+  notifyListeners();
+}
+
+/**
+ * Update the `hostAccess` axis. Persists to config.json and notifies
+ * change listeners.
+ */
+export function setHostAccess(value: boolean): void {
+  if (!initialized) {
+    initPermissionModeStore();
+  }
+
+  if (currentMode.hostAccess === value) return;
+
+  currentMode.hostAccess = value;
+  persistToConfig();
+  notifyListeners();
+}
+
+/**
+ * Register a callback that fires whenever the permission mode changes.
+ * Returns an unsubscribe function.
+ */
+export function onModeChanged(callback: ModeChangeListener): () => void {
+  listeners.push(callback);
+  return () => {
+    const idx = listeners.indexOf(callback);
+    if (idx >= 0) {
+      listeners.splice(idx, 1);
+    }
+  };
+}
+
+/**
+ * Reset the store to uninitialized state. **Test-only** — production code
+ * should never call this.
+ */
+export function resetForTesting(): void {
+  currentMode = { ...DEFAULT_PERMISSION_MODE };
+  initialized = false;
+  listeners.length = 0;
+}


### PR DESCRIPTION
## Summary
- Add singleton PermissionModeStore that manages askBeforeActing and hostAccess state
- Initialize from config on startup, persist changes back to config.json
- Support change listeners for downstream consumers (SSE broadcast, etc.)
- Add tests for get/set, persistence, and change listener behavior

Part of plan: permission-system-redesign.md (PR 3 of 17)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
