### PR TITLE
feat: inject "ask before acting" instruction into system prompt

### DIFF
--- a/assistant/src/__tests__/system-prompt-ask-mode.test.ts
+++ b/assistant/src/__tests__/system-prompt-ask-mode.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for the "Action Confirmation Mode" system prompt injection.
+ *
+ * Verifies:
+ *   - Prompt includes the section when `permission-controls-v2` flag is enabled
+ *     AND `askBeforeActing` is `true`.
+ *   - Prompt excludes the section when the flag is disabled.
+ *   - Prompt excludes the section when `askBeforeActing` is `false`.
+ */
+import { mkdirSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Mock platform to use a temp directory
+const TEST_DIR = process.env.VELLUM_WORKSPACE_DIR!;
+
+const noopLogger: Record<string, unknown> = new Proxy(
+  {} as Record<string, unknown>,
+  {
+    get: (_target, prop) => (prop === "child" ? () => noopLogger : () => {}),
+  },
+);
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const realLogger = require("../util/logger.js");
+mock.module("../util/logger.js", () => ({
+  ...realLogger,
+  getLogger: () => noopLogger,
+  getCliLogger: () => noopLogger,
+  truncateForLog: (v: string) => v,
+  initLogger: () => {},
+  pruneOldLogFiles: () => 0,
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-3.1-flash-image-preview",
+      },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
+    },
+  }),
+  loadConfig: () => ({}),
+  loadRawConfig: () => ({}),
+  saveConfig: () => {},
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const realUserReference = require("../prompts/user-reference.js");
+mock.module("../prompts/user-reference.js", () => ({
+  ...realUserReference,
+  resolveUserReference: () => "John",
+  resolveUserPronouns: () => null,
+}));
+
+// ---------------------------------------------------------------------------
+// Controllable mocks for feature flags and permission mode
+// ---------------------------------------------------------------------------
+
+let flagEnabled = false;
+let askBeforeActing = true;
+
+mock.module("../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: (key: string) => {
+    if (key === "permission-controls-v2") return flagEnabled;
+    return true;
+  },
+  _setOverridesForTesting: () => {},
+  clearFeatureFlagOverridesCache: () => {},
+  getAssistantFeatureFlagDefaults: () => ({}),
+}));
+
+mock.module("../permissions/permission-mode-store.js", () => ({
+  getMode: () => ({ askBeforeActing, hostAccess: false }),
+  initPermissionModeStore: () => {},
+  setAskBeforeActing: () => {},
+  setHostAccess: () => {},
+  onModeChanged: () => () => {},
+  resetForTesting: () => {},
+}));
+
+// Import after mocks
+const { buildSystemPrompt } = await import("../prompts/system-prompt.js");
+
+const ACTION_CONFIRMATION_HEADING = "## Action Confirmation Mode";
+
+describe("Action Confirmation Mode system prompt injection", () => {
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    flagEnabled = false;
+    askBeforeActing = true;
+  });
+
+  afterEach(() => {
+    flagEnabled = false;
+    askBeforeActing = true;
+  });
+
+  test("includes section when flag enabled and askBeforeActing is true", () => {
+    flagEnabled = true;
+    askBeforeActing = true;
+    const result = buildSystemPrompt();
+    expect(result).toContain(ACTION_CONFIRMATION_HEADING);
+    expect(result).toContain('"Ask before acting" mode');
+  });
+
+  test("excludes section when flag is disabled", () => {
+    flagEnabled = false;
+    askBeforeActing = true;
+    const result = buildSystemPrompt();
+    expect(result).not.toContain(ACTION_CONFIRMATION_HEADING);
+  });
+
+  test("excludes section when askBeforeActing is false", () => {
+    flagEnabled = true;
+    askBeforeActing = false;
+    const result = buildSystemPrompt();
+    expect(result).not.toContain(ACTION_CONFIRMATION_HEADING);
+  });
+
+  test("excludes section when both flag disabled and askBeforeActing false", () => {
+    flagEnabled = false;
+    askBeforeActing = false;
+    const result = buildSystemPrompt();
+    expect(result).not.toContain(ACTION_CONFIRMATION_HEADING);
+  });
+});

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -8,8 +8,11 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getIsContainerized } from "../config/env-registry.js";
+import { loadConfig } from "../config/loader.js";
 import { listConnections } from "../oauth/oauth-store.js";
+import { getMode } from "../permissions/permission-mode-store.js";
 import { resolveBundledDir } from "../util/bundled-asset.js";
 import { getLogger } from "../util/logger.js";
 import {
@@ -277,6 +280,9 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   // Journal entries are extracted into graph nodes by the memory pipeline.
   // Journal files remain writable on disk.
 
+  const askBeforeActingSection = buildAskBeforeActingSection();
+  if (askBeforeActingSection) dynamicParts.push(askBeforeActingSection);
+
   const dynamic = dynamicParts.join("\n\n");
 
   return staticParts.join("\n\n") + SYSTEM_PROMPT_CACHE_BOUNDARY + dynamic;
@@ -356,6 +362,25 @@ function buildIntegrationSection(): string {
   }
 
   return lines.join("\n");
+}
+
+function buildAskBeforeActingSection(): string | null {
+  try {
+    const config = loadConfig();
+    if (!isAssistantFeatureFlagEnabled("permission-controls-v2", config)) {
+      return null;
+    }
+    const mode = getMode();
+    if (!mode.askBeforeActing) return null;
+
+    return [
+      "## Action Confirmation Mode",
+      "",
+      'You are in "Ask before acting" mode. Use your judgment about when to check in with the user before proceeding. You should ask for confirmation before actions that are costly, time-consuming, or hard to reverse — for example: sending emails or messages, deleting files or data, making purchases, posting publicly, modifying permissions, or taking actions with significant real-world consequences. You do NOT need to ask before routine low-stakes actions like reading files, searching, running safe shell commands, or making code edits — just do those.',
+    ].join("\n");
+  } catch {
+    return null;
+  }
 }
 
 function buildContainerizedSection(): string {


### PR DESCRIPTION
## Summary
- Inject Action Confirmation Mode section into system prompt when flag on + askBeforeActing=true
- LLM uses judgment to check in before costly/irreversible actions (not every tool call)
- No prompt change when flag off or askBeforeActing=false
- Add tests for all three scenarios

Part of plan: permission-system-redesign.md (PR 7 of 17)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
