### PR TITLE
feat: add set_permission_mode guardian tool for deterministic mode switching

### DIFF
--- a/assistant/src/__tests__/set-permission-mode.test.ts
+++ b/assistant/src/__tests__/set-permission-mode.test.ts
@@ -245,7 +245,8 @@ describe("set_permission_mode tool", () => {
 
     test("definition includes both properties", () => {
       const def = setPermissionModeTool.getDefinition();
-      const props = def.input_schema.properties as Record<string, unknown>;
+      const schema = def.input_schema as { properties?: Record<string, unknown> };
+      const props = schema.properties as Record<string, unknown>;
       expect(props).toHaveProperty("askBeforeActing");
       expect(props).toHaveProperty("hostAccess");
     });

--- a/assistant/src/__tests__/set-permission-mode.test.ts
+++ b/assistant/src/__tests__/set-permission-mode.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Tests for the set_permission_mode system tool.
+ *
+ * Verifies:
+ *   - Mode transitions via askBeforeActing and hostAccess
+ *   - Partial updates (only provided fields change)
+ *   - Idempotent calls (setting same value is safe)
+ *   - Error when no fields provided
+ *   - Tool is not registered when permission-controls-v2 flag is off
+ *   - Tool is registered when permission-controls-v2 flag is on
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before imports that depend on platform/logger
+// ---------------------------------------------------------------------------
+
+const WORKSPACE_DIR = process.env.VELLUM_WORKSPACE_DIR!;
+const CONFIG_PATH = join(WORKSPACE_DIR, "config.json");
+
+function ensureTestDir(): void {
+  const dirs = [
+    WORKSPACE_DIR,
+    join(WORKSPACE_DIR, "data"),
+    join(WORKSPACE_DIR, "data", "logs"),
+  ];
+  for (const dir of dirs) {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  }
+}
+
+function makeLoggerStub(): Record<string, unknown> {
+  const stub: Record<string, unknown> = {};
+  for (const m of [
+    "info",
+    "warn",
+    "error",
+    "debug",
+    "trace",
+    "fatal",
+    "silent",
+    "child",
+  ]) {
+    stub[m] = m === "child" ? () => makeLoggerStub() : () => {};
+  }
+  return stub;
+}
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeLoggerStub(),
+}));
+
+afterAll(() => {
+  mock.restore();
+});
+
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
+import { invalidateConfigCache } from "../config/loader.js";
+import {
+  getMode,
+  resetForTesting,
+} from "../permissions/permission-mode-store.js";
+import { __clearRegistryForTesting, getTool } from "../tools/registry.js";
+import { registerSystemTools } from "../tools/system/register.js";
+import { setPermissionModeTool } from "../tools/system/set-permission-mode.js";
+import type { ToolContext } from "../tools/types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function writeConfig(obj: unknown): void {
+  ensureTestDir();
+  writeFileSync(CONFIG_PATH, JSON.stringify(obj, null, 2) + "\n");
+}
+
+function makeContext(): ToolContext {
+  return {
+    workingDir: WORKSPACE_DIR,
+    conversationId: "test-conversation",
+    trustClass: "guardian",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  ensureTestDir();
+  resetForTesting();
+  invalidateConfigCache();
+  _setOverridesForTesting({});
+  __clearRegistryForTesting();
+  // Write a minimal config so the store initializes cleanly
+  writeConfig({});
+});
+
+afterEach(() => {
+  resetForTesting();
+  invalidateConfigCache();
+  _setOverridesForTesting({});
+  __clearRegistryForTesting();
+});
+
+// ---------------------------------------------------------------------------
+// Tests — tool execution
+// ---------------------------------------------------------------------------
+
+describe("set_permission_mode tool", () => {
+  describe("mode transitions", () => {
+    test("sets askBeforeActing to false", async () => {
+      const result = await setPermissionModeTool.execute(
+        { askBeforeActing: false },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("askBeforeActing: false");
+
+      const mode = getMode();
+      expect(mode.askBeforeActing).toBe(false);
+    });
+
+    test("sets hostAccess to true", async () => {
+      const result = await setPermissionModeTool.execute(
+        { hostAccess: true },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("hostAccess: true");
+
+      const mode = getMode();
+      expect(mode.hostAccess).toBe(true);
+    });
+
+    test("sets both fields at once", async () => {
+      const result = await setPermissionModeTool.execute(
+        { askBeforeActing: false, hostAccess: true },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("askBeforeActing: false");
+      expect(result.content).toContain("hostAccess: true");
+
+      const mode = getMode();
+      expect(mode.askBeforeActing).toBe(false);
+      expect(mode.hostAccess).toBe(true);
+    });
+  });
+
+  describe("partial updates", () => {
+    test("only askBeforeActing changes, hostAccess unchanged", async () => {
+      await setPermissionModeTool.execute(
+        { askBeforeActing: false },
+        makeContext(),
+      );
+
+      const mode = getMode();
+      expect(mode.askBeforeActing).toBe(false);
+      // hostAccess should remain at default (false)
+      expect(mode.hostAccess).toBe(false);
+    });
+
+    test("only hostAccess changes, askBeforeActing unchanged", async () => {
+      await setPermissionModeTool.execute({ hostAccess: true }, makeContext());
+
+      const mode = getMode();
+      // askBeforeActing should remain at default (true)
+      expect(mode.askBeforeActing).toBe(true);
+      expect(mode.hostAccess).toBe(true);
+    });
+  });
+
+  describe("idempotent calls", () => {
+    test("setting askBeforeActing to current value is safe", async () => {
+      // Default is true
+      const result = await setPermissionModeTool.execute(
+        { askBeforeActing: true },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(getMode().askBeforeActing).toBe(true);
+    });
+
+    test("setting hostAccess to current value is safe", async () => {
+      // Default is false
+      const result = await setPermissionModeTool.execute(
+        { hostAccess: false },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(getMode().hostAccess).toBe(false);
+    });
+
+    test("repeated calls produce same result", async () => {
+      await setPermissionModeTool.execute(
+        { askBeforeActing: false, hostAccess: true },
+        makeContext(),
+      );
+      const result = await setPermissionModeTool.execute(
+        { askBeforeActing: false, hostAccess: true },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      const mode = getMode();
+      expect(mode.askBeforeActing).toBe(false);
+      expect(mode.hostAccess).toBe(true);
+    });
+  });
+
+  describe("validation", () => {
+    test("returns error when no fields provided", async () => {
+      const result = await setPermissionModeTool.execute({}, makeContext());
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("at least one");
+    });
+  });
+
+  describe("tool definition", () => {
+    test("has correct name", () => {
+      expect(setPermissionModeTool.name).toBe("set_permission_mode");
+    });
+
+    test("has correct category", () => {
+      expect(setPermissionModeTool.category).toBe("system");
+    });
+
+    test("definition includes both properties", () => {
+      const def = setPermissionModeTool.getDefinition();
+      const props = def.input_schema.properties as Record<string, unknown>;
+      expect(props).toHaveProperty("askBeforeActing");
+      expect(props).toHaveProperty("hostAccess");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — feature flag gating
+// ---------------------------------------------------------------------------
+
+describe("set_permission_mode registration", () => {
+  test("tool is NOT registered when permission-controls-v2 flag is off", () => {
+    _setOverridesForTesting({ "permission-controls-v2": false });
+    registerSystemTools();
+
+    expect(getTool("set_permission_mode")).toBeUndefined();
+  });
+
+  test("tool IS registered when permission-controls-v2 flag is on", () => {
+    _setOverridesForTesting({ "permission-controls-v2": true });
+    registerSystemTools();
+
+    expect(getTool("set_permission_mode")).toBeDefined();
+  });
+});

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -7,6 +7,8 @@ import { hostFileEditTool } from "./host-filesystem/edit.js";
 import { hostFileReadTool } from "./host-filesystem/read.js";
 import { hostFileWriteTool } from "./host-filesystem/write.js";
 import { hostShellTool } from "./host-terminal/host-shell.js";
+import { registerSystemTools } from "./system/register.js";
+import { setPermissionModeTool } from "./system/set-permission-mode.js";
 import type { Tool } from "./types.js";
 import { allUiSurfaceTools } from "./ui-surface/definitions.js";
 import { registerUiSurfaceTools } from "./ui-surface/registry.js";
@@ -264,6 +266,7 @@ export async function initializeTools(): Promise<void> {
 
   registerUiSurfaceTools();
   registerAppTools();
+  registerSystemTools();
 
   // Snapshot core tools for __resetRegistryForTesting().  We include every
   // non-skill tool that was registered by the manifest, while excluding
@@ -282,6 +285,7 @@ export async function initializeTools(): Promise<void> {
       ...allComputerUseTools.map((t: Tool) => t.name),
       ...allUiSurfaceTools.map((t: Tool) => t.name),
       ...coreAppProxyTools.map((t: Tool) => t.name),
+      setPermissionModeTool.name,
     ]);
 
     coreToolsSnapshot = new Map<string, Tool>();

--- a/assistant/src/tools/system/register.ts
+++ b/assistant/src/tools/system/register.ts
@@ -1,0 +1,23 @@
+/**
+ * Registers feature-flag-gated system tools with the daemon's tool registry.
+ *
+ * Called once at daemon startup via initializeTools(). Tools that are always
+ * registered (e.g. request_system_permission) are handled via the tool
+ * manifest's explicit tools list; this module handles conditional registration.
+ */
+
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
+import { getConfig } from "../../config/loader.js";
+import { registerTool } from "../registry.js";
+import { setPermissionModeTool } from "./set-permission-mode.js";
+
+export function registerSystemTools(): void {
+  try {
+    const config = getConfig();
+    if (isAssistantFeatureFlagEnabled("permission-controls-v2", config)) {
+      registerTool(setPermissionModeTool);
+    }
+  } catch {
+    // Config not yet loaded (e.g. during test setup) — permission mode tool stays off.
+  }
+}

--- a/assistant/src/tools/system/set-permission-mode.ts
+++ b/assistant/src/tools/system/set-permission-mode.ts
@@ -64,6 +64,20 @@ class SetPermissionModeTool implements Tool {
       };
     }
 
+    // Validate types of provided fields
+    if (askBeforeActing !== undefined && typeof askBeforeActing !== "boolean") {
+      return {
+        content: `Error: askBeforeActing must be a boolean, got ${typeof askBeforeActing}.`,
+        isError: true,
+      };
+    }
+    if (hostAccess !== undefined && typeof hostAccess !== "boolean") {
+      return {
+        content: `Error: hostAccess must be a boolean, got ${typeof hostAccess}.`,
+        isError: true,
+      };
+    }
+
     // Apply changes for provided fields
     if (typeof askBeforeActing === "boolean") {
       setAskBeforeActing(askBeforeActing);

--- a/assistant/src/tools/system/set-permission-mode.ts
+++ b/assistant/src/tools/system/set-permission-mode.ts
@@ -1,0 +1,89 @@
+/**
+ * System tool: set_permission_mode
+ *
+ * Allows the LLM to deterministically switch permission mode axes via the
+ * PermissionModeStore rather than relying on model-generated text.
+ *
+ * This tool is always available (no permission check required) when the
+ * `permission-controls-v2` feature flag is enabled — it IS the permission
+ * mechanism.
+ */
+
+import {
+  getMode,
+  setAskBeforeActing,
+  setHostAccess,
+} from "../../permissions/permission-mode-store.js";
+import { RiskLevel } from "../../permissions/types.js";
+import type { ToolDefinition } from "../../providers/types.js";
+import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
+
+class SetPermissionModeTool implements Tool {
+  name = "set_permission_mode";
+  description =
+    "Change the assistant's permission mode. Supports partial updates — " +
+    "only the provided fields are changed. Use this to toggle whether the " +
+    "assistant asks before acting or whether host access is enabled.";
+  category = "system";
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: "object",
+        properties: {
+          askBeforeActing: {
+            type: "boolean",
+            description:
+              "When true, the assistant checks in with the user before taking actions.",
+          },
+          hostAccess: {
+            type: "boolean",
+            description:
+              "When true, the assistant can execute commands on the host machine without prompting.",
+          },
+        },
+      },
+    };
+  }
+
+  async execute(
+    input: Record<string, unknown>,
+    _context: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    const { askBeforeActing, hostAccess } = input;
+
+    // Validate that at least one field is provided
+    if (askBeforeActing === undefined && hostAccess === undefined) {
+      return {
+        content:
+          "Error: at least one of askBeforeActing or hostAccess must be provided.",
+        isError: true,
+      };
+    }
+
+    // Apply changes for provided fields
+    if (typeof askBeforeActing === "boolean") {
+      setAskBeforeActing(askBeforeActing);
+    }
+
+    if (typeof hostAccess === "boolean") {
+      setHostAccess(hostAccess);
+    }
+
+    // Return confirmation with the new state
+    const mode = getMode();
+    return {
+      content: [
+        "Permission mode updated.",
+        `  askBeforeActing: ${mode.askBeforeActing}`,
+        `  hostAccess: ${mode.hostAccess}`,
+      ].join("\n"),
+      isError: false,
+    };
+  }
+}
+
+export const setPermissionModeTool = new SetPermissionModeTool();


### PR DESCRIPTION
## Summary
- Add `set_permission_mode` system tool for LLM-driven mode switching via `PermissionModeStore`
- Gate tool registration on `permission-controls-v2` feature flag via new `registerSystemTools()` function
- Add tests for mode transitions, partial updates, idempotent calls, validation, and flag gating

Part of plan: permission-system-redesign.md (PR 4 of 17)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
