### PR TITLE
Add Integrations tab to IntelligencePanel with placeholder content

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -18,9 +18,11 @@ struct IntelligencePanel: View {
     @State private var selectedTab: IntelligenceTab
     @State private var cachedAssistantName: String = "Your Assistant"
     @State private var isEmailEnabled: Bool = false
+    @State private var isIntegrationsTabEnabled: Bool = false
     @Binding var pendingSkillId: String?
     @State private var pendingFilePath: String?
     private static let emailFeatureFlagKey = "email-channel"
+    private static let integrationsFeatureFlagKey = "intelligence-integrations"
 
     init(onClose: @escaping () -> Void, onInvokeSkill: ((SkillInfo) -> Void)? = nil, onCreateSkill: (() -> Void)? = nil, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient? = nil, store: SettingsStore? = nil, conversationManager: ConversationManager? = nil, showToast: ((String, ToastInfo.Style) -> Void)? = nil, initialTab: String? = nil, pendingMemoryId: Binding<String?> = .constant(nil), pendingSkillId: Binding<String?> = .constant(nil)) {
         self.onClose = onClose
@@ -40,6 +42,7 @@ struct IntelligencePanel: View {
     private enum IntelligenceTab: String, CaseIterable {
         case identity = "Identity"
         case installedSkills = "Skills"
+        case integrations = "Integrations"
         case workspace = "Workspace"
         case contacts = "Contacts"
         case memories = "Memories"
@@ -75,12 +78,18 @@ struct IntelligencePanel: View {
                 if key == Self.emailFeatureFlagKey {
                     isEmailEnabled = enabled
                 }
+                if key == Self.integrationsFeatureFlagKey {
+                    isIntegrationsTabEnabled = enabled
+                }
             }
         }
     }
 
     private var visibleTabs: [IntelligenceTab] {
-        IntelligenceTab.allCases
+        IntelligenceTab.allCases.filter { tab in
+            if tab == .integrations { return isIntegrationsTabEnabled }
+            return true
+        }
     }
 
     private func loadFeatureFlags() async {
@@ -90,6 +99,9 @@ struct IntelligencePanel: View {
             if let emailFlag = flags.first(where: { $0.key == Self.emailFeatureFlagKey }) {
                 isEmailEnabled = emailFlag.enabled
             }
+            if let integrationsFlag = flags.first(where: { $0.key == Self.integrationsFeatureFlagKey }) {
+                isIntegrationsTabEnabled = integrationsFlag.enabled
+            }
         } catch {
             // Fall through to local file fallback
             let resolved = AssistantFeatureFlagResolver.resolvedFlags(
@@ -97,6 +109,9 @@ struct IntelligencePanel: View {
             )
             if let emailEnabled = resolved[Self.emailFeatureFlagKey] {
                 isEmailEnabled = emailEnabled
+            }
+            if let integrationsEnabled = resolved[Self.integrationsFeatureFlagKey] {
+                isIntegrationsTabEnabled = integrationsEnabled
             }
         }
     }
@@ -123,6 +138,11 @@ struct IntelligencePanel: View {
             .padding(.top, VSpacing.sm)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
             .clipped()
+
+        case .integrations:
+            VEmptyState(title: "Integrations", subtitle: "Coming soon", icon: VIcon.puzzle.rawValue)
+                .padding(.top, VSpacing.sm)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
 
         case .installedSkills:
             AgentPanelContent(


### PR DESCRIPTION
## Summary
- Add new 'Integrations' case to IntelligenceTab enum
- Render VEmptyState placeholder when tab is selected
- Feature-gate behind 'intelligence-integrations' flag

Part of plan: move-integrations-branch.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
