### PR TITLE
fix: log raw Anthropic API errors before converting to ProviderError

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -1042,7 +1042,7 @@ export class AnthropicProvider implements Provider {
           {
             status: error.status,
             message: error.message,
-            headers: error.headers,
+            headers: Object.fromEntries(error.headers?.entries() ?? []),
           },
           `Anthropic API error (${error.status})`,
         );

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -762,7 +762,12 @@ export class AnthropicProvider implements Provider {
             description: t.description,
             input_schema: t.input_schema as Anthropic.Tool["input_schema"],
             ...(i === otherTools.length - 1
-              ? { cache_control: { type: "ephemeral" as const, ttl: "1h" as const } }
+              ? {
+                  cache_control: {
+                    type: "ephemeral" as const,
+                    ttl: "1h" as const,
+                  },
+                }
               : {}),
           }));
           const webSearchTool: Anthropic.WebSearchTool20250305 = {
@@ -777,7 +782,12 @@ export class AnthropicProvider implements Provider {
             description: t.description,
             input_schema: t.input_schema as Anthropic.Tool["input_schema"],
             ...(i === tools.length - 1
-              ? { cache_control: { type: "ephemeral" as const, ttl: "1h" as const } }
+              ? {
+                  cache_control: {
+                    type: "ephemeral" as const,
+                    ttl: "1h" as const,
+                  },
+                }
               : {}),
           }));
         }
@@ -841,8 +851,7 @@ export class AnthropicProvider implements Provider {
       }
 
       // Fast mode: use the beta endpoint with speed: "fast" for Opus 4.6
-      const useFastMode =
-        speed === "fast" && effectiveModel.includes("opus");
+      const useFastMode = speed === "fast" && effectiveModel.includes("opus");
 
       // Collect required betas: extended cache TTL for 1h system prompt caching,
       // 1M context window, and fast-mode when applicable.
@@ -1029,6 +1038,14 @@ export class AnthropicProvider implements Provider {
             "Anthropic 400: tool_use/tool_result pairing error — dumping message structure",
           );
         }
+        log.error(
+          {
+            status: error.status,
+            message: error.message,
+            headers: error.headers,
+          },
+          `Anthropic API error (${error.status})`,
+        );
         const retryAfterMs = extractRetryAfterMs(error.headers);
         throw new ProviderError(
           `Anthropic API error (${error.status}): ${error.message}`,


### PR DESCRIPTION
## Summary
- When the Anthropic API returns a 4xx, the daemon converts it to a generic "The AI provider rejected the request" message, losing the raw status code and error details
- Adds a `log.error()` call with the status, message, and headers before throwing `ProviderError`
- Companion to vellum-ai/vellum-assistant-platform#3756 which captures per-test daemon logs in E2E artifacts

## Test plan
- [ ] Trigger an Anthropic API error (e.g., invalid API key) and verify the raw error appears in daemon logs
- [ ] Verify existing error handling behavior is unchanged (same ProviderError is thrown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
