### PR TITLE
Remove OAuth integrations section from Models & Services settings tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -128,7 +128,6 @@ struct SettingsPanel: View {
     @State private var isDeveloperEnabled: Bool = false
     @State private var isSoundsEnabled: Bool = true
     @State private var isEmbeddingProviderEnabled: Bool = false
-    @State private var isIntegrationsGridEnabled: Bool = false
     @State private var showingDevUnlock: Bool = false
     @State private var devUnlockText: String = ""
     @State private var devUnlockMonitor: Any?
@@ -139,7 +138,6 @@ struct SettingsPanel: View {
     private static let developerFeatureFlagKey = "settings-developer-nav"
     private static let embeddingProviderFeatureFlagKey = "settings-embedding-provider"
     private static let soundsFeatureFlagKey = "sounds"
-    private static let integrationsGridFeatureFlagKey = "settings-integrations-grid"
 
     var body: some View {
         VStack(spacing: 0) {
@@ -197,7 +195,6 @@ struct SettingsPanel: View {
             isBillingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.billingFeatureFlagKey)
             isSoundsEnabled = assistantFeatureFlagStore.isEnabled(Self.soundsFeatureFlagKey)
             isSchedulesEnabled = assistantFeatureFlagStore.isEnabled(Self.schedulesFeatureFlagKey)
-            isIntegrationsGridEnabled = assistantFeatureFlagStore.isEnabled(Self.integrationsGridFeatureFlagKey)
             // The init already consumed pendingSettingsTab into selectedTab.
             // Clear the store value so it doesn't leak into future navigations.
             if store.pendingSettingsTab != nil {
@@ -261,8 +258,6 @@ struct SettingsPanel: View {
                     if !enabled && selectedTab == .schedules {
                         selectedTab = .general
                     }
-                } else if key == Self.integrationsGridFeatureFlagKey {
-                    isIntegrationsGridEnabled = enabled
                 }
             }
         }
@@ -410,7 +405,7 @@ struct SettingsPanel: View {
                 }
             })
         case .modelsAndServices:
-            integrationsContent
+            modelsAndServicesContent
         case .voice:
             VoiceSettingsView(store: store)
         case .sounds:
@@ -428,9 +423,9 @@ struct SettingsPanel: View {
         }
     }
 
-    // MARK: - Integrations Tab
+    // MARK: - Models & Services Tab
 
-    private var integrationsContent: some View {
+    private var modelsAndServicesContent: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             // Managed services billing info banner
             HStack(spacing: VSpacing.sm) {
@@ -498,23 +493,6 @@ struct SettingsPanel: View {
                 )
             }
 
-            // OAUTH PROVIDERS (dynamic from API)
-            if !isIntegrationsGridEnabled {
-                ForEach(store.managedOAuthProviders, id: \.provider_key) { provider in
-                    OAuthProviderServiceCard(
-                        store: store,
-                        authManager: authManager,
-                        showToast: showToast,
-                        providerKey: provider.provider_key
-                    )
-                }
-            } else {
-                IntegrationsGridView(
-                    store: store,
-                    authManager: authManager,
-                    showToast: showToast
-                )
-            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .onAppear {
@@ -523,7 +501,6 @@ struct SettingsPanel: View {
             store.refreshModelInfo()
             store.loadProviderRoutingSources()
             store.refreshEmbeddingConfig()
-            store.fetchManagedOAuthProviders()
         }
     }
 
@@ -666,9 +643,6 @@ struct SettingsPanel: View {
                 if let schedulesFlag = flags.first(where: { $0.key == Self.schedulesFeatureFlagKey }) {
                     isSchedulesEnabled = schedulesFlag.enabled
                 }
-                if let integrationsGridFlag = flags.first(where: { $0.key == Self.integrationsGridFeatureFlagKey }) {
-                    isIntegrationsGridEnabled = integrationsGridFlag.enabled
-                }
                 consumeDeferredDeepLinkIfVisible()
                 return
             } catch {
@@ -692,10 +666,6 @@ struct SettingsPanel: View {
         if let schedulesEnabled = resolved[Self.schedulesFeatureFlagKey] {
             isSchedulesEnabled = schedulesEnabled
         }
-        if let integrationsGridEnabled = resolved[Self.integrationsGridFeatureFlagKey] {
-            isIntegrationsGridEnabled = integrationsGridEnabled
-        }
-
         consumeDeferredDeepLinkIfVisible()
     }
 


### PR DESCRIPTION
## Summary
- Remove OAuthProviderServiceCard and IntegrationsGridView from Models & Services tab
- Remove settings-integrations-grid feature flag handling from SettingsPanel
- Remove store.fetchManagedOAuthProviders() call from settings onAppear
- Rename integrationsContent to modelsAndServicesContent

Part of plan: move-integrations-branch.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
