### PR TITLE
fix: replace force-unwraps with safe optional binding in integrations tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -142,13 +142,17 @@ struct IntelligencePanel: View {
             .clipped()
 
         case .integrations:
-            IntegrationsPanelContent(
-                store: store!,
-                authManager: authManager!,
-                showToast: showToast ?? { _, _ in }
-            )
-            .padding(.top, VSpacing.sm)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+            if let store, let authManager {
+                IntegrationsPanelContent(
+                    store: store,
+                    authManager: authManager,
+                    showToast: showToast ?? { _, _ in }
+                )
+                .padding(.top, VSpacing.sm)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+            } else {
+                VEmptyState(message: "Integrations are unavailable.")
+            }
 
         case .installedSkills:
             AgentPanelContent(


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for move-integrations-branch.md.

**Gap:** Force-unwrap of optional store and authManager in integrations tab case
**What was expected:** Defensive optional handling matching other tab patterns
**What was found:** store! and authManager! force-unwraps could crash if nil
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
