### PR TITLE
fix: add tab-fallback guard when integrations flag is disabled

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -82,6 +82,9 @@ struct IntelligencePanel: View {
                 }
                 if key == Self.integrationsFeatureFlagKey {
                     isIntegrationsTabEnabled = enabled
+                    if !enabled && selectedTab == .integrations {
+                        selectedTab = .identity
+                    }
                 }
             }
         }
@@ -103,6 +106,9 @@ struct IntelligencePanel: View {
             }
             if let integrationsFlag = flags.first(where: { $0.key == Self.integrationsFeatureFlagKey }) {
                 isIntegrationsTabEnabled = integrationsFlag.enabled
+                if !integrationsFlag.enabled && selectedTab == .integrations {
+                    selectedTab = .identity
+                }
             }
         } catch {
             // Fall through to local file fallback
@@ -114,6 +120,9 @@ struct IntelligencePanel: View {
             }
             if let integrationsEnabled = resolved[Self.integrationsFeatureFlagKey] {
                 isIntegrationsTabEnabled = integrationsEnabled
+                if !integrationsEnabled && selectedTab == .integrations {
+                    selectedTab = .identity
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for move-integrations-branch.md.

**Gap:** Missing tab-fallback when integrations flag is disabled at runtime
**What was expected:** selectedTab resets to .identity when flag is disabled (matching SettingsPanel pattern)
**What was found:** No guard existed — tab stayed on .integrations even when hidden
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
