### PR TITLE
feat: macOS app — permission mode status indicators and toggle controls

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/PermissionModeStatusView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/PermissionModeStatusView.swift
@@ -10,13 +10,14 @@ import VellumAssistantShared
 /// The view is feature-flag gated on `permission-controls-v2`.
 struct PermissionModeStatusView: View {
     @ObservedObject var connectionManager: GatewayConnectionManager
+    private let permissionModeClient: any PermissionModeClientProtocol = PermissionModeClient()
 
     private var askBeforeActing: Bool {
-        connectionManager.permissionMode?.askBeforeActing ?? true
+        connectionManager.permissionMode?.askBeforeActing ?? PermissionModeDefaults.askBeforeActing
     }
 
     private var hostAccess: Bool {
-        connectionManager.permissionMode?.hostAccess ?? false
+        connectionManager.permissionMode?.hostAccess ?? PermissionModeDefaults.hostAccess
     }
 
     var body: some View {
@@ -97,7 +98,7 @@ struct PermissionModeStatusView: View {
 
     private func updateMode(askBeforeActing: Bool? = nil, hostAccess: Bool? = nil) {
         Task {
-            _ = await PermissionModeClient().updatePermissionMode(
+            _ = await permissionModeClient.updatePermissionMode(
                 askBeforeActing: askBeforeActing,
                 hostAccess: hostAccess
             )

--- a/clients/macos/vellum-assistant/Features/Chat/PermissionModeStatusView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/PermissionModeStatusView.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Popover panel displaying the two-axis permission mode toggles.
+///
+/// - **Ask before acting** — when on the assistant checks in before high-stakes actions.
+/// - **Computer access** — when on the assistant can run commands on the host machine.
+///
+/// Toggles send `PUT /v1/permission-mode` and update immediately on the SSE response.
+/// The view is feature-flag gated on `permission-controls-v2`.
+struct PermissionModeStatusView: View {
+    @ObservedObject var connectionManager: GatewayConnectionManager
+
+    private var askBeforeActing: Bool {
+        connectionManager.permissionMode?.askBeforeActing ?? true
+    }
+
+    private var hostAccess: Bool {
+        connectionManager.permissionMode?.hostAccess ?? false
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            Text("Permission Controls")
+                .font(VFont.titleSmall)
+                .foregroundStyle(VColor.contentEmphasized)
+
+            toggleRow(
+                label: "Ask before acting",
+                subtitle: askBeforeActing
+                    ? "Checks in before high-stakes actions"
+                    : "Acts autonomously",
+                isOn: askBeforeActing,
+                icon: askBeforeActing ? .shieldCheck : .shieldOff
+            ) {
+                updateMode(askBeforeActing: !askBeforeActing)
+            }
+
+            toggleRow(
+                label: "Computer access",
+                subtitle: hostAccess
+                    ? "Can run commands on your computer"
+                    : "Cannot access your computer",
+                isOn: hostAccess,
+                icon: hostAccess ? .terminal : .lock
+            ) {
+                updateMode(hostAccess: !hostAccess)
+            }
+        }
+        .padding(VSpacing.lg)
+        .frame(width: 280)
+    }
+
+    // MARK: - Toggle Row
+
+    @ViewBuilder
+    private func toggleRow(
+        label: String,
+        subtitle: String,
+        isOn: Bool,
+        icon: VIcon,
+        onToggle: @escaping () -> Void
+    ) -> some View {
+        HStack(spacing: VSpacing.md) {
+            VIconView(icon, size: 16)
+                .foregroundStyle(isOn ? VColor.systemPositiveStrong : VColor.contentSecondary)
+
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                Text(label)
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentDefault)
+
+                Text(subtitle)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+
+            Spacer()
+
+            Toggle("", isOn: Binding(
+                get: { isOn },
+                set: { _ in onToggle() }
+            ))
+            .toggleStyle(.switch)
+            .labelsHidden()
+            .controlSize(.small)
+            .tint(VColor.systemPositiveStrong)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(label)
+        .accessibilityValue(isOn ? "On" : "Off")
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAction { onToggle() }
+    }
+
+    // MARK: - Network
+
+    private func updateMode(askBeforeActing: Bool? = nil, hostAccess: Bool? = nil) {
+        Task {
+            _ = await PermissionModeClient().updatePermissionMode(
+                askBeforeActing: askBeforeActing,
+                hostAccess: hostAccess
+            )
+            // State update arrives via SSE `permission_mode_update` event,
+            // which updates connectionManager.permissionMode automatically.
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -83,6 +83,8 @@ struct MainWindowView: View {
     @State var assistantLoadingTimedOut = false
     /// Whether the main window is in native macOS fullscreen (traffic lights hidden).
     @State var isInFullscreen: Bool = false
+    /// Whether the permission mode popover is shown.
+    @State private var showPermissionModePopover: Bool = false
 
     init(conversationManager: ConversationManager, appListManager: AppListManager, zoomManager: ZoomManager, traceStore: TraceStore, usageDashboardStore: UsageDashboardStore, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, documentManager: DocumentManager, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager, updateManager: UpdateManager, onSendWakeUp: (() -> Void)? = nil) {
         self.conversationManager = conversationManager
@@ -479,6 +481,10 @@ struct MainWindowView: View {
                 .animation(VAnimation.fast, value: updateManager.isServiceGroupUpdateAvailable)
                 .animation(VAnimation.fast, value: updateManager.isDeferredUpdateReady)
             }
+            if assistantFeatureFlagStore.isEnabled("permission-controls-v2"),
+               connectionManager.permissionMode != nil {
+                permissionModeIndicator
+            }
             if windowState.isConversationVisible {
                 TemporaryChatToggleWrapper(
                     activeConversation: conversationManager.activeConversation,
@@ -531,6 +537,50 @@ struct MainWindowView: View {
         }
         .frame(height: 48)
         .background(VColor.surfaceBase)
+    }
+
+    /// Toolbar status indicator for the two-axis permission mode.
+    ///
+    /// Shows a shield icon reflecting the current state:
+    /// - Shield-check when both protections are active (ask + no host access)
+    /// - Shield-alert when host access is granted
+    /// - Shield-off when autonomous mode is active
+    ///
+    /// Tapping opens the `PermissionModeStatusView` popover.
+    private var permissionModeIndicator: some View {
+        let askBeforeActing = connectionManager.permissionMode?.askBeforeActing ?? true
+        let hostAccess = connectionManager.permissionMode?.hostAccess ?? false
+
+        let iconName: String
+        let iconColor: Color
+        let tooltip: String
+
+        if askBeforeActing && !hostAccess {
+            iconName = VIcon.shieldCheck.rawValue
+            iconColor = VColor.systemPositiveStrong
+            tooltip = "Protected: asks before acting, no computer access"
+        } else if hostAccess {
+            iconName = VIcon.shieldAlert.rawValue
+            iconColor = VColor.systemMidStrong
+            tooltip = "Computer access enabled"
+        } else {
+            iconName = VIcon.shieldOff.rawValue
+            iconColor = VColor.contentSecondary
+            tooltip = "Autonomous mode: acts without asking"
+        }
+
+        return VButton(
+            label: "Permission controls",
+            iconOnly: iconName,
+            style: .ghost,
+            tooltip: tooltip
+        ) {
+            showPermissionModePopover.toggle()
+        }
+        .foregroundStyle(iconColor)
+        .popover(isPresented: $showPermissionModePopover, arrowEdge: .bottom) {
+            PermissionModeStatusView(connectionManager: connectionManager)
+        }
     }
 
     /// Core layout extracted to break up type-checker complexity.

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -548,8 +548,8 @@ struct MainWindowView: View {
     ///
     /// Tapping opens the `PermissionModeStatusView` popover.
     private var permissionModeIndicator: some View {
-        let askBeforeActing = connectionManager.permissionMode?.askBeforeActing ?? true
-        let hostAccess = connectionManager.permissionMode?.hostAccess ?? false
+        let askBeforeActing = connectionManager.permissionMode?.askBeforeActing ?? PermissionModeDefaults.askBeforeActing
+        let hostAccess = connectionManager.permissionMode?.hostAccess ?? PermissionModeDefaults.hostAccess
 
         let iconName: String
         let iconColor: Color

--- a/clients/macos/vellum-assistant/Models/PermissionMode.swift
+++ b/clients/macos/vellum-assistant/Models/PermissionMode.swift
@@ -1,0 +1,20 @@
+import Foundation
+import VellumAssistantShared
+
+/// Local convenience wrapper around the daemon's two-axis permission mode.
+///
+/// Matches the shape returned by `GET /v1/permission-mode` and broadcast
+/// via `permission_mode_update` SSE events. The canonical Codable type is
+/// `PermissionModeUpdateMessage` in `VellumAssistantShared`; this file
+/// provides domain-specific helpers for the macOS app.
+///
+/// Axes:
+/// - `askBeforeActing` — when true the assistant checks in before taking
+///   high-stakes actions.
+/// - `hostAccess` — when true the assistant can execute commands on the
+///   host machine without prompting.
+enum PermissionModeDefaults {
+    /// Default permission mode: ask before acting, no host access.
+    static let askBeforeActing: Bool = true
+    static let hostAccess: Bool = false
+}

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -90,6 +90,7 @@ public final class GatewayConnectionManager: ObservableObject {
     /// Number of consecutive successful health checks. Used to suppress
     /// repetitive "Health check passed" logs after the first three passes.
     private var consecutiveHealthCheckSuccesses = 0
+    private let permissionModeClient: any PermissionModeClientProtocol = PermissionModeClient()
 
     func setUpdateInProgress(_ value: Bool) {
         let wasInProgress = isUpdateInProgress
@@ -749,14 +750,10 @@ public final class GatewayConnectionManager: ObservableObject {
     private func fetchInitialPermissionMode() {
         Task { @MainActor [weak self] in
             guard let self else { return }
-            do {
-                let response = try await GatewayHTTPClient.get(path: "permission-mode", quiet: true)
-                guard response.isSuccess else { return }
-                let decoded = try JSONDecoder().decode(PermissionModeUpdateMessage.self, from: response.data)
-                self.permissionMode = decoded
-            } catch {
-                // Non-critical — SSE events will sync state once available.
+            if let mode = await permissionModeClient.fetchPermissionMode() {
+                self.permissionMode = mode
             }
+            // Non-critical — SSE events will sync state once available.
         }
     }
 

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -46,6 +46,7 @@ public final class GatewayConnectionManager: ObservableObject {
     @Published public var isTrustRulesSheetOpen: Bool = false
     @Published public var currentModel: String?
     @Published public var latestModelInfo: ModelInfoMessage?
+    @Published public var permissionMode: PermissionModeUpdateMessage?
 
     /// Whether the transport has authenticated successfully.
     var isAuthenticated = false
@@ -480,6 +481,8 @@ public final class GatewayConnectionManager: ObservableObject {
             latestModelInfo = msg
         case .memoryStatus(let msg):
             latestMemoryStatus = msg
+        case .permissionModeUpdate(let msg):
+            permissionMode = msg
         case .authResult(let result):
             isAuthenticated = result.success
         default:
@@ -731,12 +734,30 @@ public final class GatewayConnectionManager: ObservableObject {
             #if os(macOS)
             handlePostSparkleUpdate()
             #endif
+            fetchInitialPermissionMode()
         }
         #if os(macOS)
         if !connected {
             autoWakeIfAssistantDied()
         }
         #endif
+    }
+
+    // MARK: - Permission Mode
+
+    /// Fetches the initial permission mode state from the daemon on connection.
+    private func fetchInitialPermissionMode() {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                let response = try await GatewayHTTPClient.get(path: "permission-mode", quiet: true)
+                guard response.isSuccess else { return }
+                let decoded = try JSONDecoder().decode(PermissionModeUpdateMessage.self, from: response.data)
+                self.permissionMode = decoded
+            } catch {
+                // Non-critical — SSE events will sync state once available.
+            }
+        }
     }
 
     // MARK: - Errors

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2241,6 +2241,7 @@ public enum ServerMessage: Decodable, Sendable {
     case hostFileCancel(HostFileCancelRequest)
     case hostCuRequest(HostCuRequest)
     case hostCuCancel(HostCuCancelRequest)
+    case permissionModeUpdate(PermissionModeUpdateMessage)
     case usageUpdate(UsageUpdate)
     case serviceGroupUpdateStarting(ServiceGroupUpdateStartingMessage)
     case serviceGroupUpdateProgress(ServiceGroupUpdateProgressMessage)
@@ -2685,6 +2686,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "host_cu_cancel":
             let message = try HostCuCancelRequest(from: decoder)
             self = .hostCuCancel(message)
+        case "permission_mode_update":
+            let message = try PermissionModeUpdateMessage(from: decoder)
+            self = .permissionModeUpdate(message)
         case "usage_update":
             let message = try UsageUpdate(from: decoder)
             self = .usageUpdate(message)
@@ -2705,6 +2709,14 @@ public enum ServerMessage: Decodable, Sendable {
     }
 }
 
+
+// MARK: - Permission Mode
+
+/// Two-axis permission mode state broadcast via SSE or returned by GET /v1/permission-mode.
+public struct PermissionModeUpdateMessage: Decodable, Sendable {
+    public let askBeforeActing: Bool
+    public let hostAccess: Bool
+}
 
 // MARK: - Token Rotation
 

--- a/clients/shared/Network/PermissionModeClient.swift
+++ b/clients/shared/Network/PermissionModeClient.swift
@@ -3,12 +3,35 @@ import os
 
 private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "PermissionModeClient")
 
-/// HTTP client for the two-axis permission mode endpoints.
+/// Protocol for the two-axis permission mode endpoints.
 ///
 /// - `GET /v1/permission-mode` — always available, returns current state.
 /// - `PUT /v1/permission-mode` — gated on `permission-controls-v2` flag.
-public struct PermissionModeClient {
+public protocol PermissionModeClientProtocol {
+    func fetchPermissionMode() async -> PermissionModeUpdateMessage?
+    func updatePermissionMode(askBeforeActing: Bool?, hostAccess: Bool?) async -> PermissionModeUpdateMessage?
+}
+
+/// Gateway-backed implementation of ``PermissionModeClientProtocol``.
+public struct PermissionModeClient: PermissionModeClientProtocol {
     nonisolated public init() {}
+
+    /// Fetches the current permission mode state.
+    ///
+    /// Returns the current state on success, or `nil` on failure.
+    public func fetchPermissionMode() async -> PermissionModeUpdateMessage? {
+        do {
+            let response = try await GatewayHTTPClient.get(path: "permission-mode", quiet: true)
+            guard response.isSuccess else {
+                log.warning("GET /v1/permission-mode failed with status \(response.statusCode)")
+                return nil
+            }
+            return try JSONDecoder().decode(PermissionModeUpdateMessage.self, from: response.data)
+        } catch {
+            log.error("Failed to fetch permission mode: \(error.localizedDescription)")
+            return nil
+        }
+    }
 
     /// Updates one or both axes of the permission mode.
     ///

--- a/clients/shared/Network/PermissionModeClient.swift
+++ b/clients/shared/Network/PermissionModeClient.swift
@@ -1,0 +1,41 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "PermissionModeClient")
+
+/// HTTP client for the two-axis permission mode endpoints.
+///
+/// - `GET /v1/permission-mode` — always available, returns current state.
+/// - `PUT /v1/permission-mode` — gated on `permission-controls-v2` flag.
+public struct PermissionModeClient {
+    nonisolated public init() {}
+
+    /// Updates one or both axes of the permission mode.
+    ///
+    /// Returns the updated state on success, or `nil` on failure (including
+    /// 404 when the `permission-controls-v2` flag is off).
+    public func updatePermissionMode(
+        askBeforeActing: Bool? = nil,
+        hostAccess: Bool? = nil
+    ) async -> PermissionModeUpdateMessage? {
+        var body: [String: Any] = [:]
+        if let askBeforeActing {
+            body["askBeforeActing"] = askBeforeActing
+        }
+        if let hostAccess {
+            body["hostAccess"] = hostAccess
+        }
+
+        do {
+            let response = try await GatewayHTTPClient.put(path: "permission-mode", json: body)
+            guard response.isSuccess else {
+                log.warning("PUT /v1/permission-mode failed with status \(response.statusCode)")
+                return nil
+            }
+            return try JSONDecoder().decode(PermissionModeUpdateMessage.self, from: response.data)
+        } catch {
+            log.error("Failed to update permission mode: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add PermissionModeUpdateMessage to shared MessageTypes and ServerMessage enum
- Add SSE permission_mode_update event handling in GatewayConnectionManager
- Fetch initial permission mode state via GET /v1/permission-mode on connection
- Add PermissionModeClient for PUT /v1/permission-mode requests
- Add PermissionModeStatusView with Ask before acting and Computer access toggles
- Add persistent shield status indicator in toolbar with popover
- Feature-flag gated on permission-controls-v2
- State syncs via GET on connect + SSE updates

Part of plan: permission-system-redesign.md (PR 8 of 17)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23455" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
