### PR TITLE
fix: emit shrink padding in bounded 64KB chunks to avoid OOM

### DIFF
--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -719,9 +719,13 @@ async function* generateTarStream(
       }
     }
 
-    // If the file shrank, pad with zeros to reach the declared size
-    if (bytesWritten < file.size) {
-      yield new Uint8Array(file.size - bytesWritten);
+    // If the file shrank, pad with zeros in bounded chunks to reach
+    // the declared size without a large single allocation
+    let remaining = file.size - bytesWritten;
+    while (remaining > 0) {
+      const chunkSize = Math.min(remaining, 65536);
+      yield new Uint8Array(chunkSize);
+      remaining -= chunkSize;
     }
 
     yield tarPaddingBytes(file.size);


### PR DESCRIPTION
## Summary
Addresses Codex feedback: if a large file is truncated during export, the single-allocation zero padding could itself cause OOM. Now emits padding in 64KB chunks.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23457" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
