### PR TITLE
fix: handle deleted/rotated files during pass-2 streaming

### DIFF
--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -707,15 +707,20 @@ async function* generateTarStream(
     // consistency mechanism for the database.
     let bytesWritten = 0;
     if (file.size > 0) {
-      const stream = createReadStream(file.diskPath, {
-        start: 0,
-        end: file.size - 1,
-      });
-      for await (const chunk of stream) {
-        const data =
-          chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk);
-        bytesWritten += data.length;
-        yield data;
+      try {
+        const stream = createReadStream(file.diskPath, {
+          start: 0,
+          end: file.size - 1,
+        });
+        for await (const chunk of stream) {
+          const data =
+            chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk);
+          bytesWritten += data.length;
+          yield data;
+        }
+      } catch {
+        // File was deleted or rotated between passes — emit zeros for
+        // the full declared size so the tar structure stays valid
       }
     }
 


### PR DESCRIPTION
## Summary
If a file is deleted or rotated between pass 1 and pass 2, catch the error and emit zeros for the full declared size so the tar structure stays valid and the export completes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
