### PR TITLE
feat: permission system redesign — two independent controls (Phase 1)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4943,6 +4943,63 @@ paths:
           schema:
             type: string
           description: Conversation ID
+  /v1/permission-mode:
+    get:
+      operationId: permissionmode_get
+      summary: Get permission mode
+      description: Return the current two-axis permission mode (askBeforeActing, hostAccess).
+      tags:
+        - settings
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  askBeforeActing:
+                    type: boolean
+                  hostAccess:
+                    type: boolean
+                required:
+                  - askBeforeActing
+                  - hostAccess
+                additionalProperties: false
+    put:
+      operationId: permissionmode_put
+      summary: Update permission mode
+      description: Update the two-axis permission mode. Requires the permission-controls-v2 feature flag.
+      tags:
+        - settings
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  askBeforeActing:
+                    type: boolean
+                  hostAccess:
+                    type: boolean
+                required:
+                  - askBeforeActing
+                  - hostAccess
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                askBeforeActing:
+                  type: boolean
+                hostAccess:
+                  type: boolean
+              additionalProperties: false
   /v1/recordings/pause:
     post:
       operationId: recordings_pause_post

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -421,6 +421,8 @@ describe("AssistantConfigSchema", () => {
     const result = AssistantConfigSchema.parse({});
     expect(result.permissions).toEqual({
       mode: "workspace",
+      askBeforeActing: true,
+      hostAccess: false,
     });
   });
 
@@ -1128,6 +1130,8 @@ describe("loadConfig with schema validation", () => {
     const config = loadConfig();
     expect(config.permissions).toEqual({
       mode: "workspace",
+      askBeforeActing: true,
+      hostAccess: false,
     });
   });
 

--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -18,6 +18,9 @@ let mockConfig = {
 mock.module("../config/loader.js", () => ({
   getConfig: () => mockConfig,
   loadConfig: () => mockConfig,
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
 }));
 
 // Mock conversation store
@@ -73,9 +76,8 @@ mock.module("../memory/conversation-title-service.js", () => ({
 }));
 
 // Import after mocks are set up
-const { HeartbeatService, isShallowProfile } = await import(
-  "../heartbeat/heartbeat-service.js"
-);
+const { HeartbeatService, isShallowProfile } =
+  await import("../heartbeat/heartbeat-service.js");
 
 // Read the bundled template files so we can write them into the test workspace
 const templatesDir = join(import.meta.dirname!, "..", "prompts", "templates");
@@ -496,7 +498,8 @@ describe("HeartbeatService", () => {
       writeFileSync(join(testWorkspaceDir, "USER.md"), USER_TEMPLATE);
 
       const service = createService();
-      const { prompt, includedReengagement } = service.buildPrompt("- Check things");
+      const { prompt, includedReengagement } =
+        service.buildPrompt("- Check things");
 
       expect(prompt).toContain("<relationship-depth>");
       expect(prompt).toContain("profile is still sparse");
@@ -511,7 +514,8 @@ describe("HeartbeatService", () => {
       writeFileSync(join(testWorkspaceDir, "USER.md"), USER_TEMPLATE);
 
       const service = createService();
-      const { prompt, includedReengagement } = service.buildPrompt("- Check things");
+      const { prompt, includedReengagement } =
+        service.buildPrompt("- Check things");
 
       expect(prompt).not.toContain("<relationship-depth>");
       expect(includedReengagement).toBe(false);
@@ -527,7 +531,8 @@ describe("HeartbeatService", () => {
       );
 
       const service = createService();
-      const { prompt, includedReengagement } = service.buildPrompt("- Check things");
+      const { prompt, includedReengagement } =
+        service.buildPrompt("- Check things");
 
       expect(prompt).not.toContain("<relationship-depth>");
       expect(includedReengagement).toBe(false);
@@ -544,7 +549,8 @@ describe("HeartbeatService", () => {
       );
 
       const service = createService();
-      const { prompt, includedReengagement } = service.buildPrompt("- Check things");
+      const { prompt, includedReengagement } =
+        service.buildPrompt("- Check things");
 
       expect(prompt).toContain("<relationship-depth>");
       expect(includedReengagement).toBe(true);

--- a/assistant/src/__tests__/permission-checker-host-gate.test.ts
+++ b/assistant/src/__tests__/permission-checker-host-gate.test.ts
@@ -3,9 +3,11 @@
  *
  * When the `permission-controls-v2` feature flag is enabled, the permission
  * checker replaces the risk-classification path with a simple binary check:
- *   - Host tools + hostAccess=false → deterministic prompt (denied)
+ *   - Host tools + hostAccess=false → falls through to interactive prompter
  *   - Host tools + hostAccess=true → auto-allowed
  *   - Non-host tools → auto-allowed (no risk classification)
+ *   - requireFreshApproval → falls through to interactive prompter
+ *   - forcePromptSideEffects + side-effect tool → falls through to prompter
  *
  * When the flag is off, existing risk-level behavior is completely unchanged.
  */
@@ -127,8 +129,14 @@ describe("permission-checker host-access gate (v2)", () => {
       });
 
       for (const toolName of HOST_TOOL_NAMES) {
-        test(`${toolName} returns prompt/denied with host_access_disabled`, async () => {
-          const checker = new PermissionChecker(makePrompter());
+        test(`${toolName} falls through to prompter (interactive prompt)`, async () => {
+          const promptSpy = mock(() =>
+            Promise.resolve({ decision: "allow" as const }),
+          );
+          const prompter = {
+            prompt: promptSpy,
+          } as unknown as PermissionPrompter;
+          const checker = new PermissionChecker(prompter);
           const result = await checker.checkPermission(
             toolName,
             {},
@@ -141,13 +149,38 @@ describe("permission-checker host-access gate (v2)", () => {
             noopDiff,
           );
 
-          expect(result.allowed).toBe(false);
-          expect(result.decision).toBe("prompt");
-          if (!result.allowed) {
-            expect(result.content).toBe("host_access_disabled");
-          }
+          // The prompter should have been called (interactive dialog)
+          expect(promptSpy).toHaveBeenCalled();
+          // Since the mock prompter returns "allow", the result should be allowed
+          expect(result.allowed).toBe(true);
+          expect(result.decision).toBe("allow");
         });
       }
+
+      test("host tool denied by user through prompter returns allowed=false", async () => {
+        const promptSpy = mock(() =>
+          Promise.resolve({ decision: "deny" as const }),
+        );
+        const prompter = {
+          prompt: promptSpy,
+        } as unknown as PermissionPrompter;
+        const checker = new PermissionChecker(prompter);
+        const result = await checker.checkPermission(
+          "host_bash",
+          {},
+          makeTool("host_bash"),
+          makeContext(),
+          executionTarget,
+          noopEmit,
+          noopSanitize,
+          Date.now(),
+          noopDiff,
+        );
+
+        expect(promptSpy).toHaveBeenCalled();
+        expect(result.allowed).toBe(false);
+        expect(result.decision).toBe("deny");
+      });
     });
 
     describe("host tools with hostAccess=true", () => {
@@ -202,6 +235,137 @@ describe("permission-checker host-access gate (v2)", () => {
           expect(result.decision).toBe("allow");
         });
       }
+    });
+
+    describe("requireFreshApproval bypasses v2 auto-allow", () => {
+      beforeEach(() => {
+        setHostAccess(true);
+      });
+
+      test("host tool with requireFreshApproval falls through to prompter", async () => {
+        const promptSpy = mock(() =>
+          Promise.resolve({ decision: "allow" as const }),
+        );
+        const prompter = {
+          prompt: promptSpy,
+        } as unknown as PermissionPrompter;
+        const checker = new PermissionChecker(prompter);
+        const result = await checker.checkPermission(
+          "host_bash",
+          {},
+          makeTool("host_bash"),
+          makeContext({ requireFreshApproval: true }),
+          executionTarget,
+          noopEmit,
+          noopSanitize,
+          Date.now(),
+          noopDiff,
+        );
+
+        expect(promptSpy).toHaveBeenCalled();
+        expect(result.allowed).toBe(true);
+        expect(result.decision).toBe("allow");
+      });
+
+      test("non-host side-effect tool with requireFreshApproval falls through to prompter", async () => {
+        const promptSpy = mock(() =>
+          Promise.resolve({ decision: "allow" as const }),
+        );
+        const prompter = {
+          prompt: promptSpy,
+        } as unknown as PermissionPrompter;
+        const checker = new PermissionChecker(prompter);
+        const result = await checker.checkPermission(
+          "bash",
+          { command: "echo hi" },
+          makeTool("bash"),
+          makeContext({ requireFreshApproval: true }),
+          "sandbox",
+          noopEmit,
+          noopSanitize,
+          Date.now(),
+          noopDiff,
+        );
+
+        expect(promptSpy).toHaveBeenCalled();
+        expect(result.allowed).toBe(true);
+        expect(result.decision).toBe("allow");
+      });
+    });
+
+    describe("forcePromptSideEffects bypasses v2 auto-allow for side-effect tools", () => {
+      beforeEach(() => {
+        setHostAccess(true);
+      });
+
+      test("host side-effect tool with forcePromptSideEffects falls through to prompter", async () => {
+        const promptSpy = mock(() =>
+          Promise.resolve({ decision: "allow" as const }),
+        );
+        const prompter = {
+          prompt: promptSpy,
+        } as unknown as PermissionPrompter;
+        const checker = new PermissionChecker(prompter);
+        const result = await checker.checkPermission(
+          "host_bash",
+          {},
+          makeTool("host_bash"),
+          makeContext({ forcePromptSideEffects: true }),
+          executionTarget,
+          noopEmit,
+          noopSanitize,
+          Date.now(),
+          noopDiff,
+        );
+
+        expect(promptSpy).toHaveBeenCalled();
+        expect(result.allowed).toBe(true);
+        expect(result.decision).toBe("allow");
+      });
+
+      test("non-host side-effect tool with forcePromptSideEffects falls through to prompter", async () => {
+        const promptSpy = mock(() =>
+          Promise.resolve({ decision: "allow" as const }),
+        );
+        const prompter = {
+          prompt: promptSpy,
+        } as unknown as PermissionPrompter;
+        const checker = new PermissionChecker(prompter);
+        const result = await checker.checkPermission(
+          "bash",
+          { command: "echo hi" },
+          makeTool("bash"),
+          makeContext({ forcePromptSideEffects: true }),
+          "sandbox",
+          noopEmit,
+          noopSanitize,
+          Date.now(),
+          noopDiff,
+        );
+
+        expect(promptSpy).toHaveBeenCalled();
+        expect(result.allowed).toBe(true);
+        expect(result.decision).toBe("allow");
+      });
+
+      test("non-host read-only tool with forcePromptSideEffects is still auto-allowed", async () => {
+        const checker = new PermissionChecker(makePrompter());
+        const result = await checker.checkPermission(
+          "file_read",
+          {},
+          makeTool("file_read"),
+          makeContext({ forcePromptSideEffects: true }),
+          "sandbox",
+          noopEmit,
+          noopSanitize,
+          Date.now(),
+          noopDiff,
+        );
+
+        // file_read is not a side-effect tool, so v2 auto-allows it
+        expect(result.allowed).toBe(true);
+        expect(result.decision).toBe("allow");
+      });
     });
   });
 

--- a/assistant/src/__tests__/permission-checker-host-gate.test.ts
+++ b/assistant/src/__tests__/permission-checker-host-gate.test.ts
@@ -293,6 +293,40 @@ describe("permission-checker host-access gate (v2)", () => {
       });
     });
 
+    describe("non-interactive guardian session with hostAccess=false", () => {
+      beforeEach(() => {
+        setHostAccess(false);
+      });
+
+      test("host tool is NOT auto-approved (denies instead of guardian_auto_approve)", async () => {
+        const promptSpy = mock(() =>
+          Promise.resolve({ decision: "allow" as const }),
+        );
+        const prompter = {
+          prompt: promptSpy,
+        } as unknown as PermissionPrompter;
+        const checker = new PermissionChecker(prompter);
+        const result = await checker.checkPermission(
+          "host_bash",
+          {},
+          makeTool("host_bash"),
+          makeContext({ isInteractive: false, trustClass: "guardian" }),
+          executionTarget,
+          noopEmit,
+          noopSanitize,
+          Date.now(),
+          noopDiff,
+        );
+
+        // v2ForcePrompt is true (hostAccess=false), so the non-interactive
+        // guardian auto-approve must NOT fire. Since there is no interactive
+        // client, the tool should be denied.
+        expect(promptSpy).not.toHaveBeenCalled();
+        expect(result.allowed).toBe(false);
+        expect(result.decision).toBe("denied");
+      });
+    });
+
     describe("forcePromptSideEffects bypasses v2 auto-allow for side-effect tools", () => {
       beforeEach(() => {
         setHostAccess(true);

--- a/assistant/src/__tests__/permission-checker-host-gate.test.ts
+++ b/assistant/src/__tests__/permission-checker-host-gate.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Tests for the host-access gate in the permission checker.
+ *
+ * When the `permission-controls-v2` feature flag is enabled, the permission
+ * checker replaces the risk-classification path with a simple binary check:
+ *   - Host tools + hostAccess=false → deterministic prompt (denied)
+ *   - Host tools + hostAccess=true → auto-allowed
+ *   - Non-host tools → auto-allowed (no risk classification)
+ *
+ * When the flag is off, existing risk-level behavior is completely unchanged.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
+import {
+  initPermissionModeStore,
+  resetForTesting as resetPermissionModeStore,
+  setHostAccess,
+} from "../permissions/permission-mode-store.js";
+import type { PermissionPrompter } from "../permissions/prompter.js";
+import { RiskLevel } from "../permissions/types.js";
+import { PermissionChecker } from "../tools/permission-checker.js";
+import type {
+  ExecutionTarget,
+  Tool,
+  ToolContext,
+  ToolLifecycleEvent,
+} from "../tools/types.js";
+
+// ---------------------------------------------------------------------------
+// Mocks — suppress the risk classification / trust-rule subsystem so we can
+// test the v2 early-return gate in isolation.
+// ---------------------------------------------------------------------------
+
+mock.module("../permissions/checker.js", () => ({
+  classifyRisk: async () => RiskLevel.Low,
+  check: async () => ({ decision: "allow", reason: "" }),
+  generateAllowlistOptions: async () => [],
+  generateScopeOptions: () => [],
+}));
+
+mock.module("../hooks/manager.js", () => ({
+  getHookManager: () => ({
+    trigger: async () => {},
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makePrompter(): PermissionPrompter {
+  return {
+    prompt: async () => ({ decision: "allow" as const }),
+  } as unknown as PermissionPrompter;
+}
+
+function makeTool(name: string): Tool {
+  return {
+    name,
+    description: "test tool",
+    category: "test",
+    defaultRiskLevel: RiskLevel.Low,
+    getDefinition: () => ({
+      name,
+      description: "test",
+      input_schema: { type: "object" as const, properties: {} },
+    }),
+    execute: async () => ({ content: "", isError: false }),
+  };
+}
+
+function makeContext(overrides?: Partial<ToolContext>): ToolContext {
+  return {
+    workingDir: "/tmp/test",
+    conversationId: "test-conv",
+    trustClass: "guardian",
+    isInteractive: true,
+    ...overrides,
+  } as ToolContext;
+}
+
+const noopEmit = (_event: ToolLifecycleEvent): void => {};
+const noopSanitize = (
+  _name: string,
+  input: Record<string, unknown>,
+): Record<string, unknown> => input;
+const noopDiff = () => undefined;
+const executionTarget: ExecutionTarget = "host";
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  _setOverridesForTesting({});
+  resetPermissionModeStore();
+  initPermissionModeStore();
+});
+
+afterEach(() => {
+  _setOverridesForTesting({});
+  resetPermissionModeStore();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("permission-checker host-access gate (v2)", () => {
+  describe("when permission-controls-v2 flag is ON", () => {
+    beforeEach(() => {
+      _setOverridesForTesting({ "permission-controls-v2": true });
+    });
+
+    const HOST_TOOL_NAMES = [
+      "host_bash",
+      "host_file_read",
+      "host_file_write",
+      "host_file_edit",
+      "computer_use_run_applescript",
+    ];
+
+    describe("host tools with hostAccess=false", () => {
+      beforeEach(() => {
+        setHostAccess(false);
+      });
+
+      for (const toolName of HOST_TOOL_NAMES) {
+        test(`${toolName} returns prompt/denied with host_access_disabled`, async () => {
+          const checker = new PermissionChecker(makePrompter());
+          const result = await checker.checkPermission(
+            toolName,
+            {},
+            makeTool(toolName),
+            makeContext(),
+            executionTarget,
+            noopEmit,
+            noopSanitize,
+            Date.now(),
+            noopDiff,
+          );
+
+          expect(result.allowed).toBe(false);
+          expect(result.decision).toBe("prompt");
+          if (!result.allowed) {
+            expect(result.content).toBe("host_access_disabled");
+          }
+        });
+      }
+    });
+
+    describe("host tools with hostAccess=true", () => {
+      beforeEach(() => {
+        setHostAccess(true);
+      });
+
+      for (const toolName of HOST_TOOL_NAMES) {
+        test(`${toolName} is auto-allowed`, async () => {
+          const checker = new PermissionChecker(makePrompter());
+          const result = await checker.checkPermission(
+            toolName,
+            {},
+            makeTool(toolName),
+            makeContext(),
+            executionTarget,
+            noopEmit,
+            noopSanitize,
+            Date.now(),
+            noopDiff,
+          );
+
+          expect(result.allowed).toBe(true);
+          expect(result.decision).toBe("allow");
+        });
+      }
+    });
+
+    describe("non-host tools are auto-allowed (no risk classification)", () => {
+      for (const toolName of [
+        "bash",
+        "file_read",
+        "file_write",
+        "web_search",
+      ]) {
+        test(`${toolName} is auto-allowed regardless of hostAccess`, async () => {
+          setHostAccess(false);
+          const checker = new PermissionChecker(makePrompter());
+          const result = await checker.checkPermission(
+            toolName,
+            {},
+            makeTool(toolName),
+            makeContext(),
+            "sandbox",
+            noopEmit,
+            noopSanitize,
+            Date.now(),
+            noopDiff,
+          );
+
+          expect(result.allowed).toBe(true);
+          expect(result.decision).toBe("allow");
+        });
+      }
+    });
+  });
+
+  describe("when permission-controls-v2 flag is OFF", () => {
+    beforeEach(() => {
+      _setOverridesForTesting({ "permission-controls-v2": false });
+    });
+
+    test("host_bash falls through to existing risk classification (returns allow from mocked checker)", async () => {
+      const checker = new PermissionChecker(makePrompter());
+      const result = await checker.checkPermission(
+        "host_bash",
+        {},
+        makeTool("host_bash"),
+        makeContext(),
+        executionTarget,
+        noopEmit,
+        noopSanitize,
+        Date.now(),
+        noopDiff,
+      );
+
+      // The mocked checker returns 'allow', so the result should be
+      // allowed with the old risk-classification path's risk level.
+      expect(result.allowed).toBe(true);
+      expect(result.decision).toBe("allow");
+      // When flag is off, riskLevel comes from classifyRisk (mocked as "low")
+      expect(result.riskLevel).toBe(RiskLevel.Low);
+    });
+
+    test("non-host tools also follow old path", async () => {
+      const checker = new PermissionChecker(makePrompter());
+      const result = await checker.checkPermission(
+        "bash",
+        { command: "echo hello" },
+        makeTool("bash"),
+        makeContext(),
+        "sandbox",
+        noopEmit,
+        noopSanitize,
+        Date.now(),
+        noopDiff,
+      );
+
+      expect(result.allowed).toBe(true);
+      expect(result.decision).toBe("allow");
+      expect(result.riskLevel).toBe(RiskLevel.Low);
+    });
+  });
+});

--- a/assistant/src/__tests__/permission-controls-v2-flag.test.ts
+++ b/assistant/src/__tests__/permission-controls-v2-flag.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for the `permission-controls-v2` feature flag.
+ *
+ * Verifies:
+ *   - The flag defaults to disabled (not enabled)
+ *   - The flag can be enabled via `_setOverridesForTesting`
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  _setOverridesForTesting,
+  isAssistantFeatureFlagEnabled,
+} from "../config/assistant-feature-flags.js";
+import type { AssistantConfig } from "../config/schema.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeConfig(): AssistantConfig {
+  return {} as AssistantConfig;
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  _setOverridesForTesting({});
+});
+
+afterEach(() => {
+  _setOverridesForTesting({});
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("permission-controls-v2 feature flag", () => {
+  test("defaults to disabled", () => {
+    const config = makeConfig();
+    expect(
+      isAssistantFeatureFlagEnabled("permission-controls-v2", config),
+    ).toBe(false);
+  });
+
+  test("can be enabled via overrides", () => {
+    _setOverridesForTesting({ "permission-controls-v2": true });
+    const config = makeConfig();
+    expect(
+      isAssistantFeatureFlagEnabled("permission-controls-v2", config),
+    ).toBe(true);
+  });
+});

--- a/assistant/src/__tests__/permission-mode-sse.test.ts
+++ b/assistant/src/__tests__/permission-mode-sse.test.ts
@@ -1,0 +1,418 @@
+/**
+ * Tests for permission mode SSE broadcast and HTTP endpoints.
+ *
+ * Verifies:
+ *   - SSE `permission_mode_update` event is published on mode change
+ *   - GET /v1/permission-mode returns current state (always available)
+ *   - PUT /v1/permission-mode updates state and broadcasts (flag on)
+ *   - PUT /v1/permission-mode returns 404 when flag is off
+ */
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before imports that depend on platform/logger
+// ---------------------------------------------------------------------------
+
+const WORKSPACE_DIR = process.env.VELLUM_WORKSPACE_DIR!;
+const CONFIG_PATH = join(WORKSPACE_DIR, "config.json");
+
+function ensureTestDir(): void {
+  const dirs = [
+    WORKSPACE_DIR,
+    join(WORKSPACE_DIR, "data"),
+    join(WORKSPACE_DIR, "data", "logs"),
+  ];
+  for (const dir of dirs) {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  }
+}
+
+function makeLoggerStub(): Record<string, unknown> {
+  const stub: Record<string, unknown> = {};
+  for (const m of [
+    "info",
+    "warn",
+    "error",
+    "debug",
+    "trace",
+    "fatal",
+    "silent",
+    "child",
+  ]) {
+    stub[m] = m === "child" ? () => makeLoggerStub() : () => {};
+  }
+  return stub;
+}
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeLoggerStub(),
+}));
+
+let mockFeatureFlagEnabled = false;
+
+mock.module("../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: () => mockFeatureFlagEnabled,
+  _setOverridesForTesting: () => {},
+  clearFeatureFlagOverridesCache: () => {},
+  getAssistantFeatureFlagDefaults: () => ({}),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    secretDetection: { enabled: false },
+    permissions: {
+      askBeforeActing: true,
+      hostAccess: false,
+    },
+  }),
+  loadConfig: () => ({
+    permissions: {
+      askBeforeActing: true,
+      hostAccess: false,
+    },
+  }),
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+// Heavy dependency stubs — prevent settings-routes.ts transitive imports from
+// reaching real OAuth orchestration, secure-key decryption, tool registry, etc.
+// Only the permission-mode GET/PUT handlers are exercised in this file, so these
+// stubs are never called.
+mock.module("../config/skills.js", () => ({
+  loadSkillCatalog: () => [],
+}));
+mock.module("../config/env.js", () => ({
+  getPlatformBaseUrl: () => "http://localhost",
+  setIngressPublicBaseUrl: () => {},
+}));
+mock.module("../daemon/handlers/config-ingress.js", () => ({
+  computeGatewayTarget: () => "",
+  getIngressConfigResult: () => ({}),
+}));
+mock.module("../daemon/handlers/config-voice.js", () => ({
+  normalizeActivationKey: () => ({ ok: true, value: "" }),
+}));
+mock.module("../oauth/connect-orchestrator.js", () => ({
+  orchestrateOAuthConnect: async () => ({ success: false, error: "stub" }),
+}));
+mock.module("../oauth/oauth-store.js", () => ({
+  getApp: () => undefined,
+  getConnectionByProvider: () => undefined,
+  getMostRecentAppByProvider: () => undefined,
+  getProvider: () => undefined,
+}));
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async () => undefined,
+}));
+mock.module("../skills/tool-manifest.js", () => ({
+  parseToolManifestFile: () => ({ tools: [] }),
+}));
+mock.module("../tools/execution-target.js", () => ({
+  resolveExecutionTarget: () => undefined,
+}));
+mock.module("../tools/registry.js", () => ({
+  getAllTools: () => [],
+  getTool: () => undefined,
+}));
+mock.module("../tools/schema-transforms.js", () => ({
+  ACTIVITY_SKIP_SET: new Set(),
+  injectActivityField: (defs: unknown[]) => defs,
+}));
+mock.module("../tools/side-effects.js", () => ({
+  isSideEffectTool: () => false,
+}));
+mock.module("../tools/system/avatar-generator.js", () => ({
+  generateAndSaveAvatar: async () => ({ isError: true, content: "stub" }),
+}));
+mock.module("../permissions/checker.js", () => ({
+  check: async () => ({ decision: "allow", reason: "" }),
+  classifyRisk: async () => "low",
+  generateAllowlistOptions: async () => [],
+  generateScopeOptions: () => [],
+}));
+
+afterAll(() => {
+  mock.restore();
+});
+
+import {
+  getMode,
+  onModeChanged,
+  resetForTesting,
+  setAskBeforeActing,
+  setHostAccess,
+} from "../permissions/permission-mode-store.js";
+import type { AssistantEvent } from "../runtime/assistant-event.js";
+import { AssistantEventHub } from "../runtime/assistant-event-hub.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
+import type { RouteDefinition } from "../runtime/http-router.js";
+import { settingsRouteDefinitions } from "../runtime/routes/settings-routes.js";
+
+// ---------------------------------------------------------------------------
+// Route helpers — call actual route handlers
+// ---------------------------------------------------------------------------
+
+const routes = settingsRouteDefinitions();
+
+function getRoute(method: string, endpoint: string): RouteDefinition {
+  const route = routes.find(
+    (r) => r.method === method && r.endpoint === endpoint,
+  );
+  if (!route) throw new Error(`Route not found: ${method} ${endpoint}`);
+  return route;
+}
+
+function callPut(
+  body: Record<string, unknown>,
+): Promise<Response> | Response {
+  const req = new Request("http://localhost/v1/permission-mode", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return getRoute("PUT", "permission-mode").handler({
+    req,
+    url: new URL(req.url),
+    server: null as never,
+    authContext: null as never,
+    params: {},
+  });
+}
+
+function callGet(): Promise<Response> | Response {
+  const req = new Request("http://localhost/v1/permission-mode");
+  return getRoute("GET", "permission-mode").handler({
+    req,
+    url: new URL(req.url),
+    server: null as never,
+    authContext: null as never,
+    params: {},
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  ensureTestDir();
+  resetForTesting();
+  mockFeatureFlagEnabled = false;
+  // Remove config file to start clean
+  try {
+    rmSync(CONFIG_PATH, { force: true });
+  } catch {
+    /* noop */
+  }
+});
+
+afterEach(() => {
+  resetForTesting();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Permission mode SSE broadcast", () => {
+  test("publishes permission_mode_update event when askBeforeActing changes", async () => {
+    const hub = new AssistantEventHub();
+    const received: AssistantEvent[] = [];
+
+    hub.subscribe({ assistantId: DAEMON_INTERNAL_ASSISTANT_ID }, (event) => {
+      received.push(event);
+    });
+
+    // Wire up a listener that publishes to our test hub
+    const { buildAssistantEvent } =
+      await import("../runtime/assistant-event.js");
+    onModeChanged((mode) => {
+      void hub.publish(
+        buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, {
+          type: "permission_mode_update",
+          askBeforeActing: mode.askBeforeActing,
+          hostAccess: mode.hostAccess,
+        }),
+      );
+    });
+
+    setAskBeforeActing(false);
+
+    // Allow async publish to settle
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(received).toHaveLength(1);
+    expect(received[0].message.type).toBe("permission_mode_update");
+    const payload = received[0].message as {
+      type: "permission_mode_update";
+      askBeforeActing: boolean;
+      hostAccess: boolean;
+    };
+    expect(payload.askBeforeActing).toBe(false);
+    expect(payload.hostAccess).toBe(false);
+  });
+
+  test("publishes permission_mode_update event when hostAccess changes", async () => {
+    const hub = new AssistantEventHub();
+    const received: AssistantEvent[] = [];
+
+    hub.subscribe({ assistantId: DAEMON_INTERNAL_ASSISTANT_ID }, (event) => {
+      received.push(event);
+    });
+
+    const { buildAssistantEvent } =
+      await import("../runtime/assistant-event.js");
+    onModeChanged((mode) => {
+      void hub.publish(
+        buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, {
+          type: "permission_mode_update",
+          askBeforeActing: mode.askBeforeActing,
+          hostAccess: mode.hostAccess,
+        }),
+      );
+    });
+
+    setHostAccess(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(received).toHaveLength(1);
+    expect(received[0].message.type).toBe("permission_mode_update");
+    const payload = received[0].message as {
+      type: "permission_mode_update";
+      askBeforeActing: boolean;
+      hostAccess: boolean;
+    };
+    expect(payload.askBeforeActing).toBe(true);
+    expect(payload.hostAccess).toBe(true);
+  });
+
+  test("does not publish event when value is unchanged", async () => {
+    const hub = new AssistantEventHub();
+    const received: AssistantEvent[] = [];
+
+    hub.subscribe({ assistantId: DAEMON_INTERNAL_ASSISTANT_ID }, (event) => {
+      received.push(event);
+    });
+
+    const { buildAssistantEvent } =
+      await import("../runtime/assistant-event.js");
+    onModeChanged((mode) => {
+      void hub.publish(
+        buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, {
+          type: "permission_mode_update",
+          askBeforeActing: mode.askBeforeActing,
+          hostAccess: mode.hostAccess,
+        }),
+      );
+    });
+
+    // Default is askBeforeActing=true, setting to true is a no-op
+    setAskBeforeActing(true);
+    // Default is hostAccess=false, setting to false is a no-op
+    setHostAccess(false);
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(received).toHaveLength(0);
+  });
+});
+
+describe("GET /v1/permission-mode", () => {
+  test("returns current permission mode state via route handler", async () => {
+    const res = await callGet();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      askBeforeActing: boolean;
+      hostAccess: boolean;
+    };
+    expect(body.askBeforeActing).toBe(true);
+    expect(body.hostAccess).toBe(false);
+  });
+
+  test("returns updated state after mutation via route handler", async () => {
+    setAskBeforeActing(false);
+    setHostAccess(true);
+
+    const res = await callGet();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      askBeforeActing: boolean;
+      hostAccess: boolean;
+    };
+    expect(body.askBeforeActing).toBe(false);
+    expect(body.hostAccess).toBe(true);
+  });
+});
+
+describe("PUT /v1/permission-mode", () => {
+  test("updates askBeforeActing via route handler when flag is enabled", async () => {
+    mockFeatureFlagEnabled = true;
+
+    const res = await callPut({ askBeforeActing: false });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      askBeforeActing: boolean;
+      hostAccess: boolean;
+    };
+    expect(body.askBeforeActing).toBe(false);
+    expect(body.hostAccess).toBe(false);
+  });
+
+  test("updates hostAccess via route handler when flag is enabled", async () => {
+    mockFeatureFlagEnabled = true;
+
+    const res = await callPut({ hostAccess: true });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      askBeforeActing: boolean;
+      hostAccess: boolean;
+    };
+    expect(body.askBeforeActing).toBe(true);
+    expect(body.hostAccess).toBe(true);
+  });
+
+  test("updates both axes independently via route handler", async () => {
+    mockFeatureFlagEnabled = true;
+
+    const res1 = await callPut({ askBeforeActing: false });
+    expect(res1.status).toBe(200);
+
+    const res2 = await callPut({ hostAccess: true });
+    expect(res2.status).toBe(200);
+    const body = (await res2.json()) as {
+      askBeforeActing: boolean;
+      hostAccess: boolean;
+    };
+    expect(body.askBeforeActing).toBe(false);
+    expect(body.hostAccess).toBe(true);
+  });
+
+  test("returns 404 when feature flag is off", async () => {
+    mockFeatureFlagEnabled = false;
+
+    const res = await callPut({ askBeforeActing: false });
+    expect(res.status).toBe(404);
+
+    // Verify the store was NOT mutated — askBeforeActing should remain at default
+    const mode = getMode();
+    expect(mode.askBeforeActing).toBe(true);
+  });
+});

--- a/assistant/src/__tests__/permission-mode-store.test.ts
+++ b/assistant/src/__tests__/permission-mode-store.test.ts
@@ -1,0 +1,277 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before imports that depend on platform/logger
+// ---------------------------------------------------------------------------
+
+const WORKSPACE_DIR = process.env.VELLUM_WORKSPACE_DIR!;
+const CONFIG_PATH = join(WORKSPACE_DIR, "config.json");
+
+function ensureTestDir(): void {
+  const dirs = [
+    WORKSPACE_DIR,
+    join(WORKSPACE_DIR, "data"),
+    join(WORKSPACE_DIR, "data", "logs"),
+  ];
+  for (const dir of dirs) {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  }
+}
+
+function makeLoggerStub(): Record<string, unknown> {
+  const stub: Record<string, unknown> = {};
+  for (const m of [
+    "info",
+    "warn",
+    "error",
+    "debug",
+    "trace",
+    "fatal",
+    "silent",
+    "child",
+  ]) {
+    stub[m] = m === "child" ? () => makeLoggerStub() : () => {};
+  }
+  return stub;
+}
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeLoggerStub(),
+}));
+
+afterAll(() => {
+  mock.restore();
+});
+
+import { invalidateConfigCache } from "../config/loader.js";
+import {
+  getMode,
+  initPermissionModeStore,
+  onModeChanged,
+  resetForTesting,
+  setAskBeforeActing,
+  setHostAccess,
+} from "../permissions/permission-mode-store.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function writeConfig(obj: unknown): void {
+  ensureTestDir();
+  writeFileSync(CONFIG_PATH, JSON.stringify(obj, null, 2) + "\n");
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  ensureTestDir();
+  resetForTesting();
+  invalidateConfigCache();
+  // Remove config file to start clean
+  try {
+    rmSync(CONFIG_PATH, { force: true });
+  } catch {
+    /* noop */
+  }
+});
+
+afterEach(() => {
+  resetForTesting();
+  invalidateConfigCache();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PermissionModeStore", () => {
+  describe("getMode", () => {
+    test("returns defaults when no config exists", () => {
+      const mode = getMode();
+      expect(mode.askBeforeActing).toBe(true);
+      expect(mode.hostAccess).toBe(false);
+    });
+
+    test("reads initial state from config", () => {
+      writeConfig({
+        permissions: {
+          askBeforeActing: false,
+          hostAccess: true,
+        },
+      });
+
+      initPermissionModeStore();
+      const mode = getMode();
+      expect(mode.askBeforeActing).toBe(false);
+      expect(mode.hostAccess).toBe(true);
+    });
+
+    test("returns a defensive copy (mutations do not affect store)", () => {
+      const mode = getMode();
+      mode.askBeforeActing = false;
+      mode.hostAccess = true;
+
+      const fresh = getMode();
+      expect(fresh.askBeforeActing).toBe(true);
+      expect(fresh.hostAccess).toBe(false);
+    });
+  });
+
+  describe("setAskBeforeActing", () => {
+    test("updates in-memory state", () => {
+      expect(getMode().askBeforeActing).toBe(true);
+
+      setAskBeforeActing(false);
+      expect(getMode().askBeforeActing).toBe(false);
+    });
+
+    test("persists to config.json", () => {
+      setAskBeforeActing(false);
+
+      const raw = readConfig();
+      const permissions = raw.permissions as Record<string, unknown>;
+      expect(permissions.askBeforeActing).toBe(false);
+    });
+
+    test("no-op when value is unchanged", () => {
+      const calls: unknown[] = [];
+      onModeChanged((mode) => calls.push(mode));
+
+      // Default is true; setting to true should not fire
+      setAskBeforeActing(true);
+      expect(calls).toHaveLength(0);
+    });
+  });
+
+  describe("setHostAccess", () => {
+    test("updates in-memory state", () => {
+      expect(getMode().hostAccess).toBe(false);
+
+      setHostAccess(true);
+      expect(getMode().hostAccess).toBe(true);
+    });
+
+    test("persists to config.json", () => {
+      setHostAccess(true);
+
+      const raw = readConfig();
+      const permissions = raw.permissions as Record<string, unknown>;
+      expect(permissions.hostAccess).toBe(true);
+    });
+
+    test("no-op when value is unchanged", () => {
+      const calls: unknown[] = [];
+      onModeChanged((mode) => calls.push(mode));
+
+      // Default is false; setting to false should not fire
+      setHostAccess(false);
+      expect(calls).toHaveLength(0);
+    });
+  });
+
+  describe("onModeChanged", () => {
+    test("fires on askBeforeActing change", () => {
+      const received: Array<{ askBeforeActing: boolean; hostAccess: boolean }> =
+        [];
+      onModeChanged((mode) => received.push(mode));
+
+      setAskBeforeActing(false);
+      expect(received).toHaveLength(1);
+      expect(received[0].askBeforeActing).toBe(false);
+      expect(received[0].hostAccess).toBe(false);
+    });
+
+    test("fires on hostAccess change", () => {
+      const received: Array<{ askBeforeActing: boolean; hostAccess: boolean }> =
+        [];
+      onModeChanged((mode) => received.push(mode));
+
+      setHostAccess(true);
+      expect(received).toHaveLength(1);
+      expect(received[0].askBeforeActing).toBe(true);
+      expect(received[0].hostAccess).toBe(true);
+    });
+
+    test("unsubscribe stops notifications", () => {
+      const received: unknown[] = [];
+      const unsubscribe = onModeChanged((mode) => received.push(mode));
+
+      setAskBeforeActing(false);
+      expect(received).toHaveLength(1);
+
+      unsubscribe();
+      setHostAccess(true);
+      expect(received).toHaveLength(1); // no new notification
+    });
+
+    test("listener errors do not break other listeners", () => {
+      const received: unknown[] = [];
+      onModeChanged(() => {
+        throw new Error("boom");
+      });
+      onModeChanged((mode) => received.push(mode));
+
+      setAskBeforeActing(false);
+      expect(received).toHaveLength(1);
+    });
+  });
+
+  describe("persistence round-trip", () => {
+    test("state survives store reset and re-initialization", () => {
+      setAskBeforeActing(false);
+      setHostAccess(true);
+
+      // Simulate daemon restart: reset store and re-init from config
+      resetForTesting();
+      invalidateConfigCache();
+      initPermissionModeStore();
+
+      const mode = getMode();
+      expect(mode.askBeforeActing).toBe(false);
+      expect(mode.hostAccess).toBe(true);
+    });
+
+    test("preserves other config fields when persisting", () => {
+      writeConfig({
+        maxTokens: 8000,
+        permissions: {
+          mode: "strict",
+          askBeforeActing: true,
+          hostAccess: false,
+        },
+      });
+
+      initPermissionModeStore();
+      setHostAccess(true);
+
+      const raw = readConfig();
+      expect(raw.maxTokens).toBe(8000);
+      const permissions = raw.permissions as Record<string, unknown>;
+      expect(permissions.mode).toBe("strict");
+      expect(permissions.hostAccess).toBe(true);
+    });
+  });
+});

--- a/assistant/src/__tests__/permission-mode.test.ts
+++ b/assistant/src/__tests__/permission-mode.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+
+import { PermissionsConfigSchema } from "../config/schemas/security.js";
+import {
+  DEFAULT_PERMISSION_MODE,
+  PermissionModeSchema,
+} from "../permissions/permission-mode.js";
+
+// ---------------------------------------------------------------------------
+// Tests: PermissionModeSchema
+// ---------------------------------------------------------------------------
+
+describe("PermissionModeSchema", () => {
+  test("parses empty object with correct defaults", () => {
+    const result = PermissionModeSchema.parse({});
+    expect(result.askBeforeActing).toBe(true);
+    expect(result.hostAccess).toBe(false);
+  });
+
+  test("DEFAULT_PERMISSION_MODE matches schema defaults", () => {
+    const parsed = PermissionModeSchema.parse({});
+    expect(parsed).toEqual(DEFAULT_PERMISSION_MODE);
+  });
+
+  test("accepts explicit true/true", () => {
+    const result = PermissionModeSchema.parse({
+      askBeforeActing: true,
+      hostAccess: true,
+    });
+    expect(result.askBeforeActing).toBe(true);
+    expect(result.hostAccess).toBe(true);
+  });
+
+  test("accepts explicit false/false", () => {
+    const result = PermissionModeSchema.parse({
+      askBeforeActing: false,
+      hostAccess: false,
+    });
+    expect(result.askBeforeActing).toBe(false);
+    expect(result.hostAccess).toBe(false);
+  });
+
+  test("round-trips through JSON serialization", () => {
+    const original = { askBeforeActing: false, hostAccess: true };
+    const json = JSON.stringify(original);
+    const parsed = PermissionModeSchema.parse(JSON.parse(json));
+    expect(parsed).toEqual(original);
+  });
+
+  test("rejects non-boolean askBeforeActing", () => {
+    expect(() =>
+      PermissionModeSchema.parse({ askBeforeActing: "yes" }),
+    ).toThrow();
+  });
+
+  test("rejects non-boolean hostAccess", () => {
+    expect(() => PermissionModeSchema.parse({ hostAccess: "no" })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: PermissionsConfigSchema (permissionMode fields)
+// ---------------------------------------------------------------------------
+
+describe("PermissionsConfigSchema permissionMode fields", () => {
+  test("defaults askBeforeActing to true and hostAccess to false", () => {
+    const result = PermissionsConfigSchema.parse({});
+    expect(result.askBeforeActing).toBe(true);
+    expect(result.hostAccess).toBe(false);
+  });
+
+  test("preserves existing mode field alongside new fields", () => {
+    const result = PermissionsConfigSchema.parse({ mode: "strict" });
+    expect(result.mode).toBe("strict");
+    expect(result.askBeforeActing).toBe(true);
+    expect(result.hostAccess).toBe(false);
+  });
+
+  test("accepts overridden values for new fields", () => {
+    const result = PermissionsConfigSchema.parse({
+      mode: "workspace",
+      askBeforeActing: false,
+      hostAccess: true,
+    });
+    expect(result.mode).toBe("workspace");
+    expect(result.askBeforeActing).toBe(false);
+    expect(result.hostAccess).toBe(true);
+  });
+
+  test("round-trips new fields through JSON serialization", () => {
+    const input = {
+      mode: "workspace" as const,
+      askBeforeActing: false,
+      hostAccess: true,
+    };
+    const json = JSON.stringify(input);
+    const parsed = PermissionsConfigSchema.parse(JSON.parse(json));
+    expect(parsed.askBeforeActing).toBe(false);
+    expect(parsed.hostAccess).toBe(true);
+  });
+});

--- a/assistant/src/__tests__/set-permission-mode.test.ts
+++ b/assistant/src/__tests__/set-permission-mode.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Tests for the set_permission_mode system tool.
+ *
+ * Verifies:
+ *   - Mode transitions via askBeforeActing and hostAccess
+ *   - Partial updates (only provided fields change)
+ *   - Idempotent calls (setting same value is safe)
+ *   - Error when no fields provided
+ *   - Tool is not registered when permission-controls-v2 flag is off
+ *   - Tool is registered when permission-controls-v2 flag is on
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before imports that depend on platform/logger
+// ---------------------------------------------------------------------------
+
+const WORKSPACE_DIR = process.env.VELLUM_WORKSPACE_DIR!;
+const CONFIG_PATH = join(WORKSPACE_DIR, "config.json");
+
+function ensureTestDir(): void {
+  const dirs = [
+    WORKSPACE_DIR,
+    join(WORKSPACE_DIR, "data"),
+    join(WORKSPACE_DIR, "data", "logs"),
+  ];
+  for (const dir of dirs) {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  }
+}
+
+function makeLoggerStub(): Record<string, unknown> {
+  const stub: Record<string, unknown> = {};
+  for (const m of [
+    "info",
+    "warn",
+    "error",
+    "debug",
+    "trace",
+    "fatal",
+    "silent",
+    "child",
+  ]) {
+    stub[m] = m === "child" ? () => makeLoggerStub() : () => {};
+  }
+  return stub;
+}
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeLoggerStub(),
+}));
+
+afterAll(() => {
+  mock.restore();
+});
+
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
+import { invalidateConfigCache } from "../config/loader.js";
+import {
+  getMode,
+  resetForTesting,
+} from "../permissions/permission-mode-store.js";
+import { __clearRegistryForTesting, getTool } from "../tools/registry.js";
+import { registerSystemTools } from "../tools/system/register.js";
+import { setPermissionModeTool } from "../tools/system/set-permission-mode.js";
+import type { ToolContext } from "../tools/types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function writeConfig(obj: unknown): void {
+  ensureTestDir();
+  writeFileSync(CONFIG_PATH, JSON.stringify(obj, null, 2) + "\n");
+}
+
+function makeContext(): ToolContext {
+  return {
+    workingDir: WORKSPACE_DIR,
+    conversationId: "test-conversation",
+    trustClass: "guardian",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  ensureTestDir();
+  resetForTesting();
+  invalidateConfigCache();
+  _setOverridesForTesting({});
+  __clearRegistryForTesting();
+  // Write a minimal config so the store initializes cleanly
+  writeConfig({});
+});
+
+afterEach(() => {
+  resetForTesting();
+  invalidateConfigCache();
+  _setOverridesForTesting({});
+  __clearRegistryForTesting();
+});
+
+// ---------------------------------------------------------------------------
+// Tests — tool execution
+// ---------------------------------------------------------------------------
+
+describe("set_permission_mode tool", () => {
+  describe("mode transitions", () => {
+    test("sets askBeforeActing to false", async () => {
+      const result = await setPermissionModeTool.execute(
+        { askBeforeActing: false },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("askBeforeActing: false");
+
+      const mode = getMode();
+      expect(mode.askBeforeActing).toBe(false);
+    });
+
+    test("sets hostAccess to true", async () => {
+      const result = await setPermissionModeTool.execute(
+        { hostAccess: true },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("hostAccess: true");
+
+      const mode = getMode();
+      expect(mode.hostAccess).toBe(true);
+    });
+
+    test("sets both fields at once", async () => {
+      const result = await setPermissionModeTool.execute(
+        { askBeforeActing: false, hostAccess: true },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("askBeforeActing: false");
+      expect(result.content).toContain("hostAccess: true");
+
+      const mode = getMode();
+      expect(mode.askBeforeActing).toBe(false);
+      expect(mode.hostAccess).toBe(true);
+    });
+  });
+
+  describe("partial updates", () => {
+    test("only askBeforeActing changes, hostAccess unchanged", async () => {
+      await setPermissionModeTool.execute(
+        { askBeforeActing: false },
+        makeContext(),
+      );
+
+      const mode = getMode();
+      expect(mode.askBeforeActing).toBe(false);
+      // hostAccess should remain at default (false)
+      expect(mode.hostAccess).toBe(false);
+    });
+
+    test("only hostAccess changes, askBeforeActing unchanged", async () => {
+      await setPermissionModeTool.execute({ hostAccess: true }, makeContext());
+
+      const mode = getMode();
+      // askBeforeActing should remain at default (true)
+      expect(mode.askBeforeActing).toBe(true);
+      expect(mode.hostAccess).toBe(true);
+    });
+  });
+
+  describe("idempotent calls", () => {
+    test("setting askBeforeActing to current value is safe", async () => {
+      // Default is true
+      const result = await setPermissionModeTool.execute(
+        { askBeforeActing: true },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(getMode().askBeforeActing).toBe(true);
+    });
+
+    test("setting hostAccess to current value is safe", async () => {
+      // Default is false
+      const result = await setPermissionModeTool.execute(
+        { hostAccess: false },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(getMode().hostAccess).toBe(false);
+    });
+
+    test("repeated calls produce same result", async () => {
+      await setPermissionModeTool.execute(
+        { askBeforeActing: false, hostAccess: true },
+        makeContext(),
+      );
+      const result = await setPermissionModeTool.execute(
+        { askBeforeActing: false, hostAccess: true },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      const mode = getMode();
+      expect(mode.askBeforeActing).toBe(false);
+      expect(mode.hostAccess).toBe(true);
+    });
+  });
+
+  describe("validation", () => {
+    test("returns error when no fields provided", async () => {
+      const result = await setPermissionModeTool.execute({}, makeContext());
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("at least one");
+    });
+  });
+
+  describe("tool definition", () => {
+    test("has correct name", () => {
+      expect(setPermissionModeTool.name).toBe("set_permission_mode");
+    });
+
+    test("has correct category", () => {
+      expect(setPermissionModeTool.category).toBe("system");
+    });
+
+    test("definition includes both properties", () => {
+      const def = setPermissionModeTool.getDefinition();
+      const schema = def.input_schema as { properties?: Record<string, unknown> };
+      const props = schema.properties as Record<string, unknown>;
+      expect(props).toHaveProperty("askBeforeActing");
+      expect(props).toHaveProperty("hostAccess");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — feature flag gating
+// ---------------------------------------------------------------------------
+
+describe("set_permission_mode registration", () => {
+  test("tool is NOT registered when permission-controls-v2 flag is off", () => {
+    _setOverridesForTesting({ "permission-controls-v2": false });
+    registerSystemTools();
+
+    expect(getTool("set_permission_mode")).toBeUndefined();
+  });
+
+  test("tool IS registered when permission-controls-v2 flag is on", () => {
+    _setOverridesForTesting({ "permission-controls-v2": true });
+    registerSystemTools();
+
+    expect(getTool("set_permission_mode")).toBeDefined();
+  });
+});

--- a/assistant/src/__tests__/system-prompt-ask-mode.test.ts
+++ b/assistant/src/__tests__/system-prompt-ask-mode.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for the "Action Confirmation Mode" system prompt injection.
+ *
+ * Verifies:
+ *   - Prompt includes the section when `permission-controls-v2` flag is enabled
+ *     AND `askBeforeActing` is `true`.
+ *   - Prompt excludes the section when the flag is disabled.
+ *   - Prompt excludes the section when `askBeforeActing` is `false`.
+ */
+import { mkdirSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Mock platform to use a temp directory
+const TEST_DIR = process.env.VELLUM_WORKSPACE_DIR!;
+
+const noopLogger: Record<string, unknown> = new Proxy(
+  {} as Record<string, unknown>,
+  {
+    get: (_target, prop) => (prop === "child" ? () => noopLogger : () => {}),
+  },
+);
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const realLogger = require("../util/logger.js");
+mock.module("../util/logger.js", () => ({
+  ...realLogger,
+  getLogger: () => noopLogger,
+  getCliLogger: () => noopLogger,
+  truncateForLog: (v: string) => v,
+  initLogger: () => {},
+  pruneOldLogFiles: () => 0,
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    services: {
+      inference: {
+        mode: "your-own",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+      "image-generation": {
+        mode: "your-own",
+        provider: "gemini",
+        model: "gemini-3.1-flash-image-preview",
+      },
+      "web-search": { mode: "your-own", provider: "inference-provider-native" },
+    },
+  }),
+  loadConfig: () => ({}),
+  loadRawConfig: () => ({}),
+  saveConfig: () => {},
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const realUserReference = require("../prompts/user-reference.js");
+mock.module("../prompts/user-reference.js", () => ({
+  ...realUserReference,
+  resolveUserReference: () => "John",
+  resolveUserPronouns: () => null,
+}));
+
+// ---------------------------------------------------------------------------
+// Controllable mocks for feature flags and permission mode
+// ---------------------------------------------------------------------------
+
+let flagEnabled = false;
+let askBeforeActing = true;
+
+mock.module("../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: (key: string) => {
+    if (key === "permission-controls-v2") return flagEnabled;
+    return true;
+  },
+  _setOverridesForTesting: () => {},
+  clearFeatureFlagOverridesCache: () => {},
+  getAssistantFeatureFlagDefaults: () => ({}),
+}));
+
+mock.module("../permissions/permission-mode-store.js", () => ({
+  getMode: () => ({ askBeforeActing, hostAccess: false }),
+  initPermissionModeStore: () => {},
+  setAskBeforeActing: () => {},
+  setHostAccess: () => {},
+  onModeChanged: () => () => {},
+  resetForTesting: () => {},
+}));
+
+// Import after mocks
+const { buildSystemPrompt } = await import("../prompts/system-prompt.js");
+
+const ACTION_CONFIRMATION_HEADING = "## Action Confirmation Mode";
+
+describe("Action Confirmation Mode system prompt injection", () => {
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    flagEnabled = false;
+    askBeforeActing = true;
+  });
+
+  afterEach(() => {
+    flagEnabled = false;
+    askBeforeActing = true;
+  });
+
+  test("includes section when flag enabled and askBeforeActing is true", () => {
+    flagEnabled = true;
+    askBeforeActing = true;
+    const result = buildSystemPrompt();
+    expect(result).toContain(ACTION_CONFIRMATION_HEADING);
+    expect(result).toContain('"Ask before acting" mode');
+  });
+
+  test("excludes section when flag is disabled", () => {
+    flagEnabled = false;
+    askBeforeActing = true;
+    const result = buildSystemPrompt();
+    expect(result).not.toContain(ACTION_CONFIRMATION_HEADING);
+  });
+
+  test("excludes section when askBeforeActing is false", () => {
+    flagEnabled = true;
+    askBeforeActing = false;
+    const result = buildSystemPrompt();
+    expect(result).not.toContain(ACTION_CONFIRMATION_HEADING);
+  });
+
+  test("excludes section when both flag disabled and askBeforeActing false", () => {
+    flagEnabled = false;
+    askBeforeActing = false;
+    const result = buildSystemPrompt();
+    expect(result).not.toContain(ACTION_CONFIRMATION_HEADING);
+  });
+});

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -3,6 +3,11 @@ import { z } from "zod";
 import { getDataDir } from "../util/platform.js";
 
 // Re-export all domain schemas
+export type { PermissionMode } from "../permissions/permission-mode.js";
+export {
+  DEFAULT_PERMISSION_MODE,
+  PermissionModeSchema,
+} from "../permissions/permission-mode.js";
 export type { AcpAgentConfig, AcpConfig } from "./acp-schema.js";
 export { AcpAgentConfigSchema, AcpConfigSchema } from "./acp-schema.js";
 export type {
@@ -143,6 +148,7 @@ export type {
 export {
   PermissionsConfigSchema,
   SecretDetectionConfigSchema,
+  VALID_PERMISSIONS_MODES,
 } from "./schemas/security.js";
 export type {
   ImageGenerationService,

--- a/assistant/src/config/schemas/security.ts
+++ b/assistant/src/config/schemas/security.ts
@@ -79,6 +79,20 @@ export const PermissionsConfigSchema = z
       .describe(
         "Permission mode — 'strict' requires explicit approval for all operations, 'workspace' allows operations within the workspace",
       ),
+    askBeforeActing: z
+      .boolean({
+        error: "permissions.askBeforeActing must be a boolean",
+      })
+      .default(true)
+      .describe("Whether the assistant should check in before taking actions"),
+    hostAccess: z
+      .boolean({
+        error: "permissions.hostAccess must be a boolean",
+      })
+      .default(false)
+      .describe(
+        "Whether the assistant can execute commands on the host machine without prompting",
+      ),
   })
   .describe("Permission enforcement mode for tool operations");
 

--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -308,6 +308,13 @@ export interface AssistantActivityState {
   statusText?: string;
 }
 
+/** Broadcast to clients when the two-axis permission mode changes. */
+export interface PermissionModeUpdate {
+  type: "permission_mode_update";
+  askBeforeActing: boolean;
+  hostAccess: boolean;
+}
+
 export type TraceEventKind =
   | "request_received"
   | "request_queued"
@@ -369,4 +376,5 @@ export type _MessagesServerMessages =
   | SuggestionResponse
   | TraceEvent
   | ConfirmationStateChanged
-  | AssistantActivityState;
+  | AssistantActivityState
+  | PermissionModeUpdate;

--- a/assistant/src/permissions/permission-mode-store.ts
+++ b/assistant/src/permissions/permission-mode-store.ts
@@ -1,0 +1,180 @@
+/**
+ * Singleton runtime store for the two-axis permission mode.
+ *
+ * Reads initial state from the `permissions` section of config.json on
+ * initialization and persists mutations back to the config file via the
+ * raw-config read/write helpers so env-var–derived keys are never leaked
+ * to disk.
+ *
+ * Downstream consumers (e.g. SSE broadcast) register change listeners
+ * via `onModeChanged()`.
+ */
+
+import {
+  invalidateConfigCache,
+  loadConfig,
+  loadRawConfig,
+  saveRawConfig,
+} from "../config/loader.js";
+import { getLogger } from "../util/logger.js";
+import type { PermissionMode } from "./permission-mode.js";
+import { DEFAULT_PERMISSION_MODE } from "./permission-mode.js";
+
+const log = getLogger("permission-mode-store");
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ModeChangeListener = (mode: PermissionMode) => void;
+
+// ---------------------------------------------------------------------------
+// Module-level state
+// ---------------------------------------------------------------------------
+
+let currentMode: PermissionMode = { ...DEFAULT_PERMISSION_MODE };
+let initialized = false;
+const listeners: ModeChangeListener[] = [];
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function notifyListeners(): void {
+  const snapshot = { ...currentMode };
+  for (const listener of listeners) {
+    try {
+      listener(snapshot);
+    } catch (err) {
+      log.error({ err }, "Error in permission mode change listener");
+    }
+  }
+}
+
+/**
+ * Persist the current in-memory permission mode to config.json.
+ *
+ * Uses the raw-config pattern (loadRawConfig → mutate → saveRawConfig) so
+ * that env-var–derived fields (API keys, dataDir) are never written to disk.
+ */
+function persistToConfig(): void {
+  try {
+    const raw = loadRawConfig();
+
+    // Ensure the permissions object exists
+    if (
+      raw.permissions == null ||
+      typeof raw.permissions !== "object" ||
+      Array.isArray(raw.permissions)
+    ) {
+      raw.permissions = {};
+    }
+
+    const permissions = raw.permissions as Record<string, unknown>;
+    permissions.askBeforeActing = currentMode.askBeforeActing;
+    permissions.hostAccess = currentMode.hostAccess;
+
+    saveRawConfig(raw);
+
+    // Invalidate the cached config so the next loadConfig() picks up the
+    // persisted values rather than returning stale in-memory state.
+    invalidateConfigCache();
+  } catch (err) {
+    log.error({ err }, "Failed to persist permission mode to config");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Initialize the store from the current config. Safe to call multiple times;
+ * subsequent calls are no-ops unless `resetForTesting()` has been called.
+ */
+export function initPermissionModeStore(): void {
+  if (initialized) return;
+
+  try {
+    const config = loadConfig();
+    currentMode = {
+      askBeforeActing: config.permissions.askBeforeActing,
+      hostAccess: config.permissions.hostAccess,
+    };
+  } catch (err) {
+    log.warn(
+      { err },
+      "Failed to load permission mode from config; using defaults",
+    );
+    currentMode = { ...DEFAULT_PERMISSION_MODE };
+  }
+
+  initialized = true;
+}
+
+/**
+ * Return the current permission mode. Initializes from config on first call
+ * if `initPermissionModeStore()` hasn't been called yet.
+ */
+export function getMode(): PermissionMode {
+  if (!initialized) {
+    initPermissionModeStore();
+  }
+  return { ...currentMode };
+}
+
+/**
+ * Update the `askBeforeActing` axis. Persists to config.json and notifies
+ * change listeners.
+ */
+export function setAskBeforeActing(value: boolean): void {
+  if (!initialized) {
+    initPermissionModeStore();
+  }
+
+  if (currentMode.askBeforeActing === value) return;
+
+  currentMode.askBeforeActing = value;
+  persistToConfig();
+  notifyListeners();
+}
+
+/**
+ * Update the `hostAccess` axis. Persists to config.json and notifies
+ * change listeners.
+ */
+export function setHostAccess(value: boolean): void {
+  if (!initialized) {
+    initPermissionModeStore();
+  }
+
+  if (currentMode.hostAccess === value) return;
+
+  currentMode.hostAccess = value;
+  persistToConfig();
+  notifyListeners();
+}
+
+/**
+ * Register a callback that fires whenever the permission mode changes.
+ * Returns an unsubscribe function.
+ */
+export function onModeChanged(callback: ModeChangeListener): () => void {
+  listeners.push(callback);
+  return () => {
+    const idx = listeners.indexOf(callback);
+    if (idx >= 0) {
+      listeners.splice(idx, 1);
+    }
+  };
+}
+
+/**
+ * Reset the store to uninitialized state. **Test-only** — production code
+ * should never call this.
+ */
+export function resetForTesting(): void {
+  currentMode = { ...DEFAULT_PERMISSION_MODE };
+  initialized = false;
+  listeners.length = 0;
+}

--- a/assistant/src/permissions/permission-mode.ts
+++ b/assistant/src/permissions/permission-mode.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+/**
+ * Two-axis permission model:
+ * - `askBeforeActing` — LLM behavior toggle: when true the assistant checks in
+ *   with the user before taking actions.
+ * - `hostAccess` — System-enforced gate: when true the assistant can execute
+ *   commands on the host machine without prompting.
+ */
+export type PermissionMode = {
+  askBeforeActing: boolean;
+  hostAccess: boolean;
+};
+
+export const DEFAULT_PERMISSION_MODE: PermissionMode = {
+  askBeforeActing: true,
+  hostAccess: false,
+};
+
+export const PermissionModeSchema = z.object({
+  askBeforeActing: z
+    .boolean({ error: "permissionMode.askBeforeActing must be a boolean" })
+    .default(true)
+    .describe("Whether the assistant should check in before taking actions"),
+  hostAccess: z
+    .boolean({ error: "permissionMode.hostAccess must be a boolean" })
+    .default(false)
+    .describe(
+      "Whether the assistant can execute commands on the host machine without prompting",
+    ),
+});

--- a/assistant/src/permissions/workspace-policy.ts
+++ b/assistant/src/permissions/workspace-policy.ts
@@ -74,7 +74,16 @@ const HOST_TOOLS = new Set([
   "host_file_write",
   "host_file_edit",
   "host_bash",
+  "computer_use_run_applescript",
 ]);
+
+/**
+ * Check whether a tool name is a host-level tool that requires the
+ * `hostAccess` permission to execute.
+ */
+export function isHostTool(toolName: string): boolean {
+  return HOST_TOOLS.has(toolName);
+}
 
 /** Safe local-only tools that are always workspace-scoped. */
 const ALWAYS_SCOPED_TOOLS = new Set([

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -8,8 +8,11 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getIsContainerized } from "../config/env-registry.js";
+import { loadConfig } from "../config/loader.js";
 import { listConnections } from "../oauth/oauth-store.js";
+import { getMode } from "../permissions/permission-mode-store.js";
 import { resolveBundledDir } from "../util/bundled-asset.js";
 import { getLogger } from "../util/logger.js";
 import {
@@ -277,6 +280,9 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   // Journal entries are extracted into graph nodes by the memory pipeline.
   // Journal files remain writable on disk.
 
+  const askBeforeActingSection = buildAskBeforeActingSection();
+  if (askBeforeActingSection) dynamicParts.push(askBeforeActingSection);
+
   const dynamic = dynamicParts.join("\n\n");
 
   return staticParts.join("\n\n") + SYSTEM_PROMPT_CACHE_BOUNDARY + dynamic;
@@ -356,6 +362,25 @@ function buildIntegrationSection(): string {
   }
 
   return lines.join("\n");
+}
+
+function buildAskBeforeActingSection(): string | null {
+  try {
+    const config = loadConfig();
+    if (!isAssistantFeatureFlagEnabled("permission-controls-v2", config)) {
+      return null;
+    }
+    const mode = getMode();
+    if (!mode.askBeforeActing) return null;
+
+    return [
+      "## Action Confirmation Mode",
+      "",
+      'You are in "Ask before acting" mode. Use your judgment about when to check in with the user before proceeding. You should ask for confirmation before actions that are costly, time-consuming, or hard to reverse — for example: sending emails or messages, deleting files or data, making purchases, posting publicly, modifying permissions, or taking actions with significant real-world consequences. You do NOT need to ask before routine low-stakes actions like reading files, searching, running safe shell commands, or making code edits — just do those.',
+    ].join("\n");
+  } catch {
+    return null;
+  }
 }
 
 function buildContainerizedSection(): string {

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -480,6 +480,10 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   // Tools
   { endpoint: "tools", scopes: ["settings.read"] },
   { endpoint: "tools/simulate-permission", scopes: ["settings.read"] },
+
+  // Permission mode
+  { endpoint: "permission-mode:GET", scopes: ["settings.read"] },
+  { endpoint: "permission-mode", scopes: ["settings.write"] },
 ];
 
 for (const { endpoint, scopes } of ACTOR_ENDPOINTS) {

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -12,11 +12,16 @@ import { join } from "node:path";
 
 import { z } from "zod";
 
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import {
   getPlatformBaseUrl,
   setIngressPublicBaseUrl,
 } from "../../config/env.js";
-import { loadRawConfig, saveRawConfig } from "../../config/loader.js";
+import {
+  getConfig,
+  loadRawConfig,
+  saveRawConfig,
+} from "../../config/loader.js";
 import { loadSkillCatalog } from "../../config/skills.js";
 import {
   computeGatewayTarget,
@@ -36,6 +41,12 @@ import {
   generateAllowlistOptions,
   generateScopeOptions,
 } from "../../permissions/checker.js";
+import {
+  getMode,
+  onModeChanged,
+  setAskBeforeActing,
+  setHostAccess,
+} from "../../permissions/permission-mode-store.js";
 import { getSecureKeyAsync } from "../../security/secure-keys.js";
 import { parseToolManifestFile } from "../../skills/tool-manifest.js";
 import {
@@ -60,6 +71,24 @@ import type { RouteDefinition } from "../http-router.js";
 import { resolveWorkspacePath } from "./workspace-utils.js";
 
 const log = getLogger("settings-routes");
+
+// ---------------------------------------------------------------------------
+// Permission mode SSE broadcast
+// ---------------------------------------------------------------------------
+
+onModeChanged((mode) => {
+  assistantEventHub
+    .publish(
+      buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, {
+        type: "permission_mode_update",
+        askBeforeActing: mode.askBeforeActing,
+        hostAccess: mode.hostAccess,
+      }),
+    )
+    .catch((err) => {
+      log.warn({ err }, "Failed to publish permission_mode_update event");
+    });
+});
 
 // ---------------------------------------------------------------------------
 // Voice config
@@ -895,6 +924,69 @@ export function settingsRouteDefinitions(): RouteDefinition[] {
           log.error({ err }, "Failed to update ingress config via HTTP");
           return httpError("INTERNAL_ERROR", message, 500);
         }
+      },
+    },
+
+    // Permission mode (GET always available; PUT gated on feature flag)
+    {
+      endpoint: "permission-mode",
+      method: "GET",
+      policyKey: "permission-mode:GET",
+      summary: "Get permission mode",
+      description:
+        "Return the current two-axis permission mode (askBeforeActing, hostAccess).",
+      tags: ["settings"],
+      responseBody: z.object({
+        askBeforeActing: z.boolean(),
+        hostAccess: z.boolean(),
+      }),
+      handler: () => {
+        const mode = getMode();
+        return Response.json({
+          askBeforeActing: mode.askBeforeActing,
+          hostAccess: mode.hostAccess,
+        });
+      },
+    },
+    {
+      endpoint: "permission-mode",
+      method: "PUT",
+      policyKey: "permission-mode",
+      summary: "Update permission mode",
+      description:
+        "Update the two-axis permission mode. Requires the permission-controls-v2 feature flag.",
+      tags: ["settings"],
+      requestBody: z.object({
+        askBeforeActing: z.boolean().optional(),
+        hostAccess: z.boolean().optional(),
+      }),
+      responseBody: z.object({
+        askBeforeActing: z.boolean(),
+        hostAccess: z.boolean(),
+      }),
+      handler: async ({ req }) => {
+        const config = getConfig();
+        if (!isAssistantFeatureFlagEnabled("permission-controls-v2", config)) {
+          return httpError("NOT_FOUND", "Not found", 404);
+        }
+
+        const body = (await req.json()) as {
+          askBeforeActing?: boolean;
+          hostAccess?: boolean;
+        };
+
+        if (typeof body.askBeforeActing === "boolean") {
+          setAskBeforeActing(body.askBeforeActing);
+        }
+        if (typeof body.hostAccess === "boolean") {
+          setHostAccess(body.hostAccess);
+        }
+
+        const mode = getMode();
+        return Response.json({
+          askBeforeActing: mode.askBeforeActing,
+          hostAccess: mode.hostAccess,
+        });
       },
     },
   ];

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -71,24 +71,47 @@ export class PermissionChecker {
     // ── permission-controls-v2 early gate ──────────────────────────────
     // When the v2 flag is enabled, replace the entire risk-classification
     // path with a simple binary check: is it a host tool + is host access
-    // enabled?
+    // enabled? Certain security gates (requireFreshApproval,
+    // forcePromptSideEffects, hostAccess=false) fall through to the v1
+    // prompt flow so the interactive prompter is engaged.
     const cfg = getConfig();
+    let v2ForcePrompt = false;
     if (isAssistantFeatureFlagEnabled("permission-controls-v2", cfg)) {
-      if (isHostTool(name)) {
-        const mode = getMode();
-        if (mode.hostAccess) {
-          return { allowed: true, decision: "allow", riskLevel: "none" };
+      // requireFreshApproval demands an interactive prompt every time —
+      // fall through to v1 so the prompter is engaged.
+      const needsFreshApproval = !!context.requireFreshApproval;
+
+      // forcePromptSideEffects (private conversations, untrusted actors)
+      // requires explicit approval for side-effect tools.
+      const needsSideEffectPrompt =
+        !!context.forcePromptSideEffects && isSideEffectTool(name, input);
+
+      if (!needsFreshApproval && !needsSideEffectPrompt) {
+        if (isHostTool(name)) {
+          const mode = getMode();
+          if (mode.hostAccess) {
+            return {
+              allowed: true,
+              decision: "allow",
+              riskLevel: RiskLevel.Low,
+            };
+          }
+          // Host tool with hostAccess disabled — fall through to v1 so the
+          // interactive prompter is engaged (returning allowed:false here
+          // would surface an error string instead of a permission dialog).
+          // The v2ForcePrompt flag ensures check()'s allow decision is
+          // promoted to prompt so the user sees a permission dialog.
+          v2ForcePrompt = true;
+        } else {
+          // Non-host tools are auto-allowed when v2 is on
+          return {
+            allowed: true,
+            decision: "allow",
+            riskLevel: RiskLevel.Low,
+          };
         }
-        // Host tool with hostAccess disabled — deterministic prompt
-        return {
-          allowed: false,
-          decision: "prompt",
-          riskLevel: "none",
-          content: "host_access_disabled",
-        };
       }
-      // Non-host tools are auto-allowed when v2 is on
-      return { allowed: true, decision: "allow", riskLevel: "none" };
+      // Falls through to the v1 risk-classification + prompter path
     }
 
     const risk = await classifyRisk(
@@ -138,6 +161,14 @@ export class PermissionChecker {
         result.decision = "prompt";
         result.reason =
           "Fresh approval required: per-invocation human review enforced";
+      }
+
+      // v2 host-access-disabled: the v2 gate fell through because
+      // hostAccess is off. Promote allow → prompt so the user sees an
+      // interactive permission dialog instead of an error string.
+      if (v2ForcePrompt && result.decision === "allow") {
+        result.decision = "prompt";
+        result.reason = "Host access disabled: requires explicit approval";
       }
 
       if (result.decision === "deny") {

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -1,3 +1,4 @@
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
 import { getHookManager } from "../hooks/manager.js";
 import {
@@ -6,9 +7,11 @@ import {
   generateAllowlistOptions,
   generateScopeOptions,
 } from "../permissions/checker.js";
+import { getMode } from "../permissions/permission-mode-store.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import { addRule } from "../permissions/trust-store.js";
 import { RiskLevel } from "../permissions/types.js";
+import { isHostTool } from "../permissions/workspace-policy.js";
 import {
   getEffectiveMode,
   setConversationMode,
@@ -65,6 +68,29 @@ export class PermissionChecker {
         }
       | undefined,
   ): Promise<PermissionDecision> {
+    // ── permission-controls-v2 early gate ──────────────────────────────
+    // When the v2 flag is enabled, replace the entire risk-classification
+    // path with a simple binary check: is it a host tool + is host access
+    // enabled?
+    const cfg = getConfig();
+    if (isAssistantFeatureFlagEnabled("permission-controls-v2", cfg)) {
+      if (isHostTool(name)) {
+        const mode = getMode();
+        if (mode.hostAccess) {
+          return { allowed: true, decision: "allow", riskLevel: "none" };
+        }
+        // Host tool with hostAccess disabled — deterministic prompt
+        return {
+          allowed: false,
+          decision: "prompt",
+          riskLevel: "none",
+          content: "host_access_disabled",
+        };
+      }
+      // Non-host tools are auto-allowed when v2 is on
+      return { allowed: true, decision: "allow", riskLevel: "none" };
+    }
+
     const risk = await classifyRisk(
       name,
       input,

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -215,6 +215,7 @@ export class PermissionChecker {
           context.trustClass === "guardian" &&
           !context.requireFreshApproval &&
           !isDynamicSkillLoad &&
+          !v2ForcePrompt &&
           riskLevel !== RiskLevel.High
         ) {
           log.info(

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -7,6 +7,8 @@ import { hostFileEditTool } from "./host-filesystem/edit.js";
 import { hostFileReadTool } from "./host-filesystem/read.js";
 import { hostFileWriteTool } from "./host-filesystem/write.js";
 import { hostShellTool } from "./host-terminal/host-shell.js";
+import { registerSystemTools } from "./system/register.js";
+import { setPermissionModeTool } from "./system/set-permission-mode.js";
 import type { Tool } from "./types.js";
 import { allUiSurfaceTools } from "./ui-surface/definitions.js";
 import { registerUiSurfaceTools } from "./ui-surface/registry.js";
@@ -264,6 +266,7 @@ export async function initializeTools(): Promise<void> {
 
   registerUiSurfaceTools();
   registerAppTools();
+  registerSystemTools();
 
   // Snapshot core tools for __resetRegistryForTesting().  We include every
   // non-skill tool that was registered by the manifest, while excluding
@@ -282,6 +285,7 @@ export async function initializeTools(): Promise<void> {
       ...allComputerUseTools.map((t: Tool) => t.name),
       ...allUiSurfaceTools.map((t: Tool) => t.name),
       ...coreAppProxyTools.map((t: Tool) => t.name),
+      setPermissionModeTool.name,
     ]);
 
     coreToolsSnapshot = new Map<string, Tool>();

--- a/assistant/src/tools/system/register.ts
+++ b/assistant/src/tools/system/register.ts
@@ -1,0 +1,23 @@
+/**
+ * Registers feature-flag-gated system tools with the daemon's tool registry.
+ *
+ * Called once at daemon startup via initializeTools(). Tools that are always
+ * registered (e.g. request_system_permission) are handled via the tool
+ * manifest's explicit tools list; this module handles conditional registration.
+ */
+
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
+import { getConfig } from "../../config/loader.js";
+import { registerTool } from "../registry.js";
+import { setPermissionModeTool } from "./set-permission-mode.js";
+
+export function registerSystemTools(): void {
+  try {
+    const config = getConfig();
+    if (isAssistantFeatureFlagEnabled("permission-controls-v2", config)) {
+      registerTool(setPermissionModeTool);
+    }
+  } catch {
+    // Config not yet loaded (e.g. during test setup) — permission mode tool stays off.
+  }
+}

--- a/assistant/src/tools/system/set-permission-mode.ts
+++ b/assistant/src/tools/system/set-permission-mode.ts
@@ -1,0 +1,103 @@
+/**
+ * System tool: set_permission_mode
+ *
+ * Allows the LLM to deterministically switch permission mode axes via the
+ * PermissionModeStore rather than relying on model-generated text.
+ *
+ * This tool is always available (no permission check required) when the
+ * `permission-controls-v2` feature flag is enabled — it IS the permission
+ * mechanism.
+ */
+
+import {
+  getMode,
+  setAskBeforeActing,
+  setHostAccess,
+} from "../../permissions/permission-mode-store.js";
+import { RiskLevel } from "../../permissions/types.js";
+import type { ToolDefinition } from "../../providers/types.js";
+import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
+
+class SetPermissionModeTool implements Tool {
+  name = "set_permission_mode";
+  description =
+    "Change the assistant's permission mode. Supports partial updates — " +
+    "only the provided fields are changed. Use this to toggle whether the " +
+    "assistant asks before acting or whether host access is enabled.";
+  category = "system";
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: this.name,
+      description: this.description,
+      input_schema: {
+        type: "object",
+        properties: {
+          askBeforeActing: {
+            type: "boolean",
+            description:
+              "When true, the assistant checks in with the user before taking actions.",
+          },
+          hostAccess: {
+            type: "boolean",
+            description:
+              "When true, the assistant can execute commands on the host machine without prompting.",
+          },
+        },
+      },
+    };
+  }
+
+  async execute(
+    input: Record<string, unknown>,
+    _context: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    const { askBeforeActing, hostAccess } = input;
+
+    // Validate that at least one field is provided
+    if (askBeforeActing === undefined && hostAccess === undefined) {
+      return {
+        content:
+          "Error: at least one of askBeforeActing or hostAccess must be provided.",
+        isError: true,
+      };
+    }
+
+    // Validate types of provided fields
+    if (askBeforeActing !== undefined && typeof askBeforeActing !== "boolean") {
+      return {
+        content: `Error: askBeforeActing must be a boolean, got ${typeof askBeforeActing}.`,
+        isError: true,
+      };
+    }
+    if (hostAccess !== undefined && typeof hostAccess !== "boolean") {
+      return {
+        content: `Error: hostAccess must be a boolean, got ${typeof hostAccess}.`,
+        isError: true,
+      };
+    }
+
+    // Apply changes for provided fields
+    if (typeof askBeforeActing === "boolean") {
+      setAskBeforeActing(askBeforeActing);
+    }
+
+    if (typeof hostAccess === "boolean") {
+      setHostAccess(hostAccess);
+    }
+
+    // Return confirmation with the new state
+    const mode = getMode();
+    return {
+      content: [
+        "Permission mode updated.",
+        `  askBeforeActing: ${mode.askBeforeActing}`,
+        `  hostAccess: ${mode.hostAccess}`,
+      ].join("\n"),
+      isError: false,
+    };
+  }
+}
+
+export const setPermissionModeTool = new SetPermissionModeTool();

--- a/clients/macos/vellum-assistant/Features/Chat/PermissionModeStatusView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/PermissionModeStatusView.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Popover panel displaying the two-axis permission mode toggles.
+///
+/// - **Ask before acting** — when on the assistant checks in before high-stakes actions.
+/// - **Computer access** — when on the assistant can run commands on the host machine.
+///
+/// Toggles send `PUT /v1/permission-mode` and update immediately on the SSE response.
+/// The view is feature-flag gated on `permission-controls-v2`.
+struct PermissionModeStatusView: View {
+    @ObservedObject var connectionManager: GatewayConnectionManager
+    private let permissionModeClient: any PermissionModeClientProtocol = PermissionModeClient()
+
+    private var askBeforeActing: Bool {
+        connectionManager.permissionMode?.askBeforeActing ?? PermissionModeDefaults.askBeforeActing
+    }
+
+    private var hostAccess: Bool {
+        connectionManager.permissionMode?.hostAccess ?? PermissionModeDefaults.hostAccess
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            Text("Permission Controls")
+                .font(VFont.titleSmall)
+                .foregroundStyle(VColor.contentEmphasized)
+
+            toggleRow(
+                label: "Ask before acting",
+                subtitle: askBeforeActing
+                    ? "Checks in before high-stakes actions"
+                    : "Acts autonomously",
+                isOn: askBeforeActing,
+                icon: askBeforeActing ? .shieldCheck : .shieldOff
+            ) {
+                updateMode(askBeforeActing: !askBeforeActing)
+            }
+
+            toggleRow(
+                label: "Computer access",
+                subtitle: hostAccess
+                    ? "Can run commands on your computer"
+                    : "Cannot access your computer",
+                isOn: hostAccess,
+                icon: hostAccess ? .terminal : .lock
+            ) {
+                updateMode(hostAccess: !hostAccess)
+            }
+        }
+        .padding(VSpacing.lg)
+        .frame(width: 280)
+    }
+
+    // MARK: - Toggle Row
+
+    @ViewBuilder
+    private func toggleRow(
+        label: String,
+        subtitle: String,
+        isOn: Bool,
+        icon: VIcon,
+        onToggle: @escaping () -> Void
+    ) -> some View {
+        HStack(spacing: VSpacing.md) {
+            VIconView(icon, size: 16)
+                .foregroundStyle(isOn ? VColor.systemPositiveStrong : VColor.contentSecondary)
+
+            VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                Text(label)
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentDefault)
+
+                Text(subtitle)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+
+            Spacer()
+
+            Toggle("", isOn: Binding(
+                get: { isOn },
+                set: { _ in onToggle() }
+            ))
+            .toggleStyle(.switch)
+            .labelsHidden()
+            .controlSize(.small)
+            .tint(VColor.systemPositiveStrong)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(label)
+        .accessibilityValue(isOn ? "On" : "Off")
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAction { onToggle() }
+    }
+
+    // MARK: - Network
+
+    private func updateMode(askBeforeActing: Bool? = nil, hostAccess: Bool? = nil) {
+        Task {
+            _ = await permissionModeClient.updatePermissionMode(
+                askBeforeActing: askBeforeActing,
+                hostAccess: hostAccess
+            )
+            // State update arrives via SSE `permission_mode_update` event,
+            // which updates connectionManager.permissionMode automatically.
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -83,6 +83,8 @@ struct MainWindowView: View {
     @State var assistantLoadingTimedOut = false
     /// Whether the main window is in native macOS fullscreen (traffic lights hidden).
     @State var isInFullscreen: Bool = false
+    /// Whether the permission mode popover is shown.
+    @State private var showPermissionModePopover: Bool = false
 
     init(conversationManager: ConversationManager, appListManager: AppListManager, zoomManager: ZoomManager, traceStore: TraceStore, usageDashboardStore: UsageDashboardStore, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, documentManager: DocumentManager, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager, updateManager: UpdateManager, onSendWakeUp: (() -> Void)? = nil) {
         self.conversationManager = conversationManager
@@ -479,6 +481,10 @@ struct MainWindowView: View {
                 .animation(VAnimation.fast, value: updateManager.isServiceGroupUpdateAvailable)
                 .animation(VAnimation.fast, value: updateManager.isDeferredUpdateReady)
             }
+            if assistantFeatureFlagStore.isEnabled("permission-controls-v2"),
+               connectionManager.permissionMode != nil {
+                permissionModeIndicator
+            }
             if windowState.isConversationVisible {
                 TemporaryChatToggleWrapper(
                     activeConversation: conversationManager.activeConversation,
@@ -531,6 +537,50 @@ struct MainWindowView: View {
         }
         .frame(height: 48)
         .background(VColor.surfaceBase)
+    }
+
+    /// Toolbar status indicator for the two-axis permission mode.
+    ///
+    /// Shows a shield icon reflecting the current state:
+    /// - Shield-check when both protections are active (ask + no host access)
+    /// - Shield-alert when host access is granted
+    /// - Shield-off when autonomous mode is active
+    ///
+    /// Tapping opens the `PermissionModeStatusView` popover.
+    private var permissionModeIndicator: some View {
+        let askBeforeActing = connectionManager.permissionMode?.askBeforeActing ?? PermissionModeDefaults.askBeforeActing
+        let hostAccess = connectionManager.permissionMode?.hostAccess ?? PermissionModeDefaults.hostAccess
+
+        let iconName: String
+        let iconColor: Color
+        let tooltip: String
+
+        if askBeforeActing && !hostAccess {
+            iconName = VIcon.shieldCheck.rawValue
+            iconColor = VColor.systemPositiveStrong
+            tooltip = "Protected: asks before acting, no computer access"
+        } else if hostAccess {
+            iconName = VIcon.shieldAlert.rawValue
+            iconColor = VColor.systemMidStrong
+            tooltip = "Computer access enabled"
+        } else {
+            iconName = VIcon.shieldOff.rawValue
+            iconColor = VColor.contentSecondary
+            tooltip = "Autonomous mode: acts without asking"
+        }
+
+        return VButton(
+            label: "Permission controls",
+            iconOnly: iconName,
+            style: .ghost,
+            tooltip: tooltip
+        ) {
+            showPermissionModePopover.toggle()
+        }
+        .foregroundStyle(iconColor)
+        .popover(isPresented: $showPermissionModePopover, arrowEdge: .bottom) {
+            PermissionModeStatusView(connectionManager: connectionManager)
+        }
     }
 
     /// Core layout extracted to break up type-checker complexity.

--- a/clients/macos/vellum-assistant/Models/PermissionMode.swift
+++ b/clients/macos/vellum-assistant/Models/PermissionMode.swift
@@ -1,0 +1,20 @@
+import Foundation
+import VellumAssistantShared
+
+/// Local convenience wrapper around the daemon's two-axis permission mode.
+///
+/// Matches the shape returned by `GET /v1/permission-mode` and broadcast
+/// via `permission_mode_update` SSE events. The canonical Codable type is
+/// `PermissionModeUpdateMessage` in `VellumAssistantShared`; this file
+/// provides domain-specific helpers for the macOS app.
+///
+/// Axes:
+/// - `askBeforeActing` — when true the assistant checks in before taking
+///   high-stakes actions.
+/// - `hostAccess` — when true the assistant can execute commands on the
+///   host machine without prompting.
+enum PermissionModeDefaults {
+    /// Default permission mode: ask before acting, no host access.
+    static let askBeforeActing: Bool = true
+    static let hostAccess: Bool = false
+}

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -275,6 +275,8 @@ public final class GatewayConnectionManager: ObservableObject {
         keyFingerprint = nil
         latestMemoryStatus = nil
         currentModel = nil
+        latestModelInfo = nil
+        permissionMode = nil
     }
 
     /// Clears the last update outcome after the UI has consumed it.

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -46,6 +46,7 @@ public final class GatewayConnectionManager: ObservableObject {
     @Published public var isTrustRulesSheetOpen: Bool = false
     @Published public var currentModel: String?
     @Published public var latestModelInfo: ModelInfoMessage?
+    @Published public var permissionMode: PermissionModeUpdateMessage?
 
     /// Whether the transport has authenticated successfully.
     var isAuthenticated = false
@@ -89,6 +90,7 @@ public final class GatewayConnectionManager: ObservableObject {
     /// Number of consecutive successful health checks. Used to suppress
     /// repetitive "Health check passed" logs after the first three passes.
     private var consecutiveHealthCheckSuccesses = 0
+    private let permissionModeClient: any PermissionModeClientProtocol = PermissionModeClient()
 
     func setUpdateInProgress(_ value: Bool) {
         let wasInProgress = isUpdateInProgress
@@ -480,6 +482,8 @@ public final class GatewayConnectionManager: ObservableObject {
             latestModelInfo = msg
         case .memoryStatus(let msg):
             latestMemoryStatus = msg
+        case .permissionModeUpdate(let msg):
+            permissionMode = msg
         case .authResult(let result):
             isAuthenticated = result.success
         default:
@@ -731,12 +735,26 @@ public final class GatewayConnectionManager: ObservableObject {
             #if os(macOS)
             handlePostSparkleUpdate()
             #endif
+            fetchInitialPermissionMode()
         }
         #if os(macOS)
         if !connected {
             autoWakeIfAssistantDied()
         }
         #endif
+    }
+
+    // MARK: - Permission Mode
+
+    /// Fetches the initial permission mode state from the daemon on connection.
+    private func fetchInitialPermissionMode() {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            if let mode = await permissionModeClient.fetchPermissionMode() {
+                self.permissionMode = mode
+            }
+            // Non-critical — SSE events will sync state once available.
+        }
     }
 
     // MARK: - Errors

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2241,6 +2241,7 @@ public enum ServerMessage: Decodable, Sendable {
     case hostFileCancel(HostFileCancelRequest)
     case hostCuRequest(HostCuRequest)
     case hostCuCancel(HostCuCancelRequest)
+    case permissionModeUpdate(PermissionModeUpdateMessage)
     case usageUpdate(UsageUpdate)
     case serviceGroupUpdateStarting(ServiceGroupUpdateStartingMessage)
     case serviceGroupUpdateProgress(ServiceGroupUpdateProgressMessage)
@@ -2685,6 +2686,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "host_cu_cancel":
             let message = try HostCuCancelRequest(from: decoder)
             self = .hostCuCancel(message)
+        case "permission_mode_update":
+            let message = try PermissionModeUpdateMessage(from: decoder)
+            self = .permissionModeUpdate(message)
         case "usage_update":
             let message = try UsageUpdate(from: decoder)
             self = .usageUpdate(message)
@@ -2705,6 +2709,14 @@ public enum ServerMessage: Decodable, Sendable {
     }
 }
 
+
+// MARK: - Permission Mode
+
+/// Two-axis permission mode state broadcast via SSE or returned by GET /v1/permission-mode.
+public struct PermissionModeUpdateMessage: Decodable, Sendable {
+    public let askBeforeActing: Bool
+    public let hostAccess: Bool
+}
 
 // MARK: - Token Rotation
 

--- a/clients/shared/Network/PermissionModeClient.swift
+++ b/clients/shared/Network/PermissionModeClient.swift
@@ -1,0 +1,64 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "PermissionModeClient")
+
+/// Protocol for the two-axis permission mode endpoints.
+///
+/// - `GET /v1/permission-mode` — always available, returns current state.
+/// - `PUT /v1/permission-mode` — gated on `permission-controls-v2` flag.
+public protocol PermissionModeClientProtocol {
+    func fetchPermissionMode() async -> PermissionModeUpdateMessage?
+    func updatePermissionMode(askBeforeActing: Bool?, hostAccess: Bool?) async -> PermissionModeUpdateMessage?
+}
+
+/// Gateway-backed implementation of ``PermissionModeClientProtocol``.
+public struct PermissionModeClient: PermissionModeClientProtocol {
+    nonisolated public init() {}
+
+    /// Fetches the current permission mode state.
+    ///
+    /// Returns the current state on success, or `nil` on failure.
+    public func fetchPermissionMode() async -> PermissionModeUpdateMessage? {
+        do {
+            let response = try await GatewayHTTPClient.get(path: "permission-mode", quiet: true)
+            guard response.isSuccess else {
+                log.warning("GET /v1/permission-mode failed with status \(response.statusCode)")
+                return nil
+            }
+            return try JSONDecoder().decode(PermissionModeUpdateMessage.self, from: response.data)
+        } catch {
+            log.error("Failed to fetch permission mode: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    /// Updates one or both axes of the permission mode.
+    ///
+    /// Returns the updated state on success, or `nil` on failure (including
+    /// 404 when the `permission-controls-v2` flag is off).
+    public func updatePermissionMode(
+        askBeforeActing: Bool? = nil,
+        hostAccess: Bool? = nil
+    ) async -> PermissionModeUpdateMessage? {
+        var body: [String: Any] = [:]
+        if let askBeforeActing {
+            body["askBeforeActing"] = askBeforeActing
+        }
+        if let hostAccess {
+            body["hostAccess"] = hostAccess
+        }
+
+        do {
+            let response = try await GatewayHTTPClient.put(path: "permission-mode", json: body)
+            guard response.isSuccess else {
+                log.warning("PUT /v1/permission-mode failed with status \(response.statusCode)")
+                return nil
+            }
+            return try JSONDecoder().decode(PermissionModeUpdateMessage.self, from: response.data)
+        } catch {
+            log.error("Failed to update permission mode: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -272,6 +272,14 @@
       "label": "Teleport",
       "description": "Enable teleport UI in General settings for moving assistants between hosting environments",
       "defaultEnabled": false
+    },
+    {
+      "id": "permission-controls-v2",
+      "scope": "assistant",
+      "key": "permission-controls-v2",
+      "label": "Permission Controls V2",
+      "description": "Replace risk-level permission system with two independent controls: 'Ask before acting' (LLM behavior toggle) and 'Host access' (system-enforced gate)",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

Replace the risk-level-based permission system with two independent controls, gated behind the `permission-controls-v2` feature flag (default: disabled):

1. **"Ask before acting"** (default: on) — LLM behavior toggle via system prompt. The assistant uses judgment to check in before high-stakes actions (sending emails, deleting data, posting publicly) while routine operations proceed without friction.

2. **Computer access** (default: off) — System-enforced gate for host tools (`host_bash`, AppleScript, etc.). When off, every host tool call triggers a deterministic approval prompt. When on, host tools run freely.

The old risk-level system remains fully operational when the flag is off. Phase 2 (removing the old system) is deferred until the new system is validated.

## PRs merged into feature branch
- #23433: feat: register permission-controls-v2 feature flag
- #23434: feat: add PermissionMode type and host-access config schema
- #23438: feat: add PermissionModeStore for runtime permission mode state
- #23442: feat: add set_permission_mode guardian tool for deterministic mode switching
- #23441: feat: wire host-access gate into tool permission checking
- #23443: feat: broadcast permission mode changes to clients via SSE
- #23440: feat: inject "ask before acting" instruction into system prompt
- #23455: feat: macOS app — permission mode status indicators and toggle controls

Part of plan: permission-system-redesign.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
