### PR TITLE
revert(macos): remove auto-expand behavior from thinking blocks

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
@@ -47,14 +47,6 @@ struct ThinkingBlockView: View {
         }
         .background(VColor.surfaceOverlay)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-        .onAppear {
-            if isStreaming { isExpanded = true }
-        }
-        .onChange(of: isStreaming) { _, newValue in
-            withAnimation(VAnimation.fast) {
-                isExpanded = newValue
-            }
-        }
     }
 
     // MARK: - Header


### PR DESCRIPTION
## Summary
- Removes the `.onAppear` and `.onChange(of: isStreaming)` modifiers from `ThinkingBlockView` that auto-expanded thinking blocks during streaming
- Thinking blocks now always start collapsed and require manual tap to expand
- The `show-thinking-blocks` feature flag remains enabled — blocks are still visible, just not auto-opened

## Original prompt
revert the change making thinking blocks open by default