### PR TITLE
fix: clear permission mode on disconnect and add route policy entries

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -480,6 +480,10 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   // Tools
   { endpoint: "tools", scopes: ["settings.read"] },
   { endpoint: "tools/simulate-permission", scopes: ["settings.read"] },
+
+  // Permission mode
+  { endpoint: "permission-mode:GET", scopes: ["settings.read"] },
+  { endpoint: "permission-mode", scopes: ["settings.write"] },
 ];
 
 for (const { endpoint, scopes } of ACTOR_ENDPOINTS) {

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -275,6 +275,8 @@ public final class GatewayConnectionManager: ObservableObject {
         keyFingerprint = nil
         latestMemoryStatus = nil
         currentModel = nil
+        latestModelInfo = nil
+        permissionMode = nil
     }
 
     /// Clears the last update outcome after the UI has consumed it.


### PR DESCRIPTION
## Summary
- Clear permissionMode on assistant switch/disconnect to prevent stale state
- Add route policy entries for GET/PUT /v1/permission-mode endpoints

Part of plan: permission-system-redesign.md (fix round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23466" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
