### PR TITLE
fix: v2 permission gate respects security gates and triggers interactive prompt

### DIFF
--- a/assistant/src/__tests__/permission-checker-host-gate.test.ts
+++ b/assistant/src/__tests__/permission-checker-host-gate.test.ts
@@ -3,9 +3,11 @@
  *
  * When the `permission-controls-v2` feature flag is enabled, the permission
  * checker replaces the risk-classification path with a simple binary check:
- *   - Host tools + hostAccess=false → deterministic prompt (denied)
+ *   - Host tools + hostAccess=false → falls through to interactive prompter
  *   - Host tools + hostAccess=true → auto-allowed
  *   - Non-host tools → auto-allowed (no risk classification)
+ *   - requireFreshApproval → falls through to interactive prompter
+ *   - forcePromptSideEffects + side-effect tool → falls through to prompter
  *
  * When the flag is off, existing risk-level behavior is completely unchanged.
  */
@@ -127,8 +129,14 @@ describe("permission-checker host-access gate (v2)", () => {
       });
 
       for (const toolName of HOST_TOOL_NAMES) {
-        test(`${toolName} returns prompt/denied with host_access_disabled`, async () => {
-          const checker = new PermissionChecker(makePrompter());
+        test(`${toolName} falls through to prompter (interactive prompt)`, async () => {
+          const promptSpy = mock(() =>
+            Promise.resolve({ decision: "allow" as const }),
+          );
+          const prompter = {
+            prompt: promptSpy,
+          } as unknown as PermissionPrompter;
+          const checker = new PermissionChecker(prompter);
           const result = await checker.checkPermission(
             toolName,
             {},
@@ -141,13 +149,38 @@ describe("permission-checker host-access gate (v2)", () => {
             noopDiff,
           );
 
-          expect(result.allowed).toBe(false);
-          expect(result.decision).toBe("prompt");
-          if (!result.allowed) {
-            expect(result.content).toBe("host_access_disabled");
-          }
+          // The prompter should have been called (interactive dialog)
+          expect(promptSpy).toHaveBeenCalled();
+          // Since the mock prompter returns "allow", the result should be allowed
+          expect(result.allowed).toBe(true);
+          expect(result.decision).toBe("allow");
         });
       }
+
+      test("host tool denied by user through prompter returns allowed=false", async () => {
+        const promptSpy = mock(() =>
+          Promise.resolve({ decision: "deny" as const }),
+        );
+        const prompter = {
+          prompt: promptSpy,
+        } as unknown as PermissionPrompter;
+        const checker = new PermissionChecker(prompter);
+        const result = await checker.checkPermission(
+          "host_bash",
+          {},
+          makeTool("host_bash"),
+          makeContext(),
+          executionTarget,
+          noopEmit,
+          noopSanitize,
+          Date.now(),
+          noopDiff,
+        );
+
+        expect(promptSpy).toHaveBeenCalled();
+        expect(result.allowed).toBe(false);
+        expect(result.decision).toBe("deny");
+      });
     });
 
     describe("host tools with hostAccess=true", () => {
@@ -202,6 +235,137 @@ describe("permission-checker host-access gate (v2)", () => {
           expect(result.decision).toBe("allow");
         });
       }
+    });
+
+    describe("requireFreshApproval bypasses v2 auto-allow", () => {
+      beforeEach(() => {
+        setHostAccess(true);
+      });
+
+      test("host tool with requireFreshApproval falls through to prompter", async () => {
+        const promptSpy = mock(() =>
+          Promise.resolve({ decision: "allow" as const }),
+        );
+        const prompter = {
+          prompt: promptSpy,
+        } as unknown as PermissionPrompter;
+        const checker = new PermissionChecker(prompter);
+        const result = await checker.checkPermission(
+          "host_bash",
+          {},
+          makeTool("host_bash"),
+          makeContext({ requireFreshApproval: true }),
+          executionTarget,
+          noopEmit,
+          noopSanitize,
+          Date.now(),
+          noopDiff,
+        );
+
+        expect(promptSpy).toHaveBeenCalled();
+        expect(result.allowed).toBe(true);
+        expect(result.decision).toBe("allow");
+      });
+
+      test("non-host side-effect tool with requireFreshApproval falls through to prompter", async () => {
+        const promptSpy = mock(() =>
+          Promise.resolve({ decision: "allow" as const }),
+        );
+        const prompter = {
+          prompt: promptSpy,
+        } as unknown as PermissionPrompter;
+        const checker = new PermissionChecker(prompter);
+        const result = await checker.checkPermission(
+          "bash",
+          { command: "echo hi" },
+          makeTool("bash"),
+          makeContext({ requireFreshApproval: true }),
+          "sandbox",
+          noopEmit,
+          noopSanitize,
+          Date.now(),
+          noopDiff,
+        );
+
+        expect(promptSpy).toHaveBeenCalled();
+        expect(result.allowed).toBe(true);
+        expect(result.decision).toBe("allow");
+      });
+    });
+
+    describe("forcePromptSideEffects bypasses v2 auto-allow for side-effect tools", () => {
+      beforeEach(() => {
+        setHostAccess(true);
+      });
+
+      test("host side-effect tool with forcePromptSideEffects falls through to prompter", async () => {
+        const promptSpy = mock(() =>
+          Promise.resolve({ decision: "allow" as const }),
+        );
+        const prompter = {
+          prompt: promptSpy,
+        } as unknown as PermissionPrompter;
+        const checker = new PermissionChecker(prompter);
+        const result = await checker.checkPermission(
+          "host_bash",
+          {},
+          makeTool("host_bash"),
+          makeContext({ forcePromptSideEffects: true }),
+          executionTarget,
+          noopEmit,
+          noopSanitize,
+          Date.now(),
+          noopDiff,
+        );
+
+        expect(promptSpy).toHaveBeenCalled();
+        expect(result.allowed).toBe(true);
+        expect(result.decision).toBe("allow");
+      });
+
+      test("non-host side-effect tool with forcePromptSideEffects falls through to prompter", async () => {
+        const promptSpy = mock(() =>
+          Promise.resolve({ decision: "allow" as const }),
+        );
+        const prompter = {
+          prompt: promptSpy,
+        } as unknown as PermissionPrompter;
+        const checker = new PermissionChecker(prompter);
+        const result = await checker.checkPermission(
+          "bash",
+          { command: "echo hi" },
+          makeTool("bash"),
+          makeContext({ forcePromptSideEffects: true }),
+          "sandbox",
+          noopEmit,
+          noopSanitize,
+          Date.now(),
+          noopDiff,
+        );
+
+        expect(promptSpy).toHaveBeenCalled();
+        expect(result.allowed).toBe(true);
+        expect(result.decision).toBe("allow");
+      });
+
+      test("non-host read-only tool with forcePromptSideEffects is still auto-allowed", async () => {
+        const checker = new PermissionChecker(makePrompter());
+        const result = await checker.checkPermission(
+          "file_read",
+          {},
+          makeTool("file_read"),
+          makeContext({ forcePromptSideEffects: true }),
+          "sandbox",
+          noopEmit,
+          noopSanitize,
+          Date.now(),
+          noopDiff,
+        );
+
+        // file_read is not a side-effect tool, so v2 auto-allows it
+        expect(result.allowed).toBe(true);
+        expect(result.decision).toBe("allow");
+      });
     });
   });
 

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -71,24 +71,47 @@ export class PermissionChecker {
     // ── permission-controls-v2 early gate ──────────────────────────────
     // When the v2 flag is enabled, replace the entire risk-classification
     // path with a simple binary check: is it a host tool + is host access
-    // enabled?
+    // enabled? Certain security gates (requireFreshApproval,
+    // forcePromptSideEffects, hostAccess=false) fall through to the v1
+    // prompt flow so the interactive prompter is engaged.
     const cfg = getConfig();
+    let v2ForcePrompt = false;
     if (isAssistantFeatureFlagEnabled("permission-controls-v2", cfg)) {
-      if (isHostTool(name)) {
-        const mode = getMode();
-        if (mode.hostAccess) {
-          return { allowed: true, decision: "allow", riskLevel: "none" };
+      // requireFreshApproval demands an interactive prompt every time —
+      // fall through to v1 so the prompter is engaged.
+      const needsFreshApproval = !!context.requireFreshApproval;
+
+      // forcePromptSideEffects (private conversations, untrusted actors)
+      // requires explicit approval for side-effect tools.
+      const needsSideEffectPrompt =
+        !!context.forcePromptSideEffects && isSideEffectTool(name, input);
+
+      if (!needsFreshApproval && !needsSideEffectPrompt) {
+        if (isHostTool(name)) {
+          const mode = getMode();
+          if (mode.hostAccess) {
+            return {
+              allowed: true,
+              decision: "allow",
+              riskLevel: RiskLevel.Low,
+            };
+          }
+          // Host tool with hostAccess disabled — fall through to v1 so the
+          // interactive prompter is engaged (returning allowed:false here
+          // would surface an error string instead of a permission dialog).
+          // The v2ForcePrompt flag ensures check()'s allow decision is
+          // promoted to prompt so the user sees a permission dialog.
+          v2ForcePrompt = true;
+        } else {
+          // Non-host tools are auto-allowed when v2 is on
+          return {
+            allowed: true,
+            decision: "allow",
+            riskLevel: RiskLevel.Low,
+          };
         }
-        // Host tool with hostAccess disabled — deterministic prompt
-        return {
-          allowed: false,
-          decision: "prompt",
-          riskLevel: "none",
-          content: "host_access_disabled",
-        };
       }
-      // Non-host tools are auto-allowed when v2 is on
-      return { allowed: true, decision: "allow", riskLevel: "none" };
+      // Falls through to the v1 risk-classification + prompter path
     }
 
     const risk = await classifyRisk(
@@ -138,6 +161,14 @@ export class PermissionChecker {
         result.decision = "prompt";
         result.reason =
           "Fresh approval required: per-invocation human review enforced";
+      }
+
+      // v2 host-access-disabled: the v2 gate fell through because
+      // hostAccess is off. Promote allow → prompt so the user sees an
+      // interactive permission dialog instead of an error string.
+      if (v2ForcePrompt && result.decision === "allow") {
+        result.decision = "prompt";
+        result.reason = "Host access disabled: requires explicit approval";
       }
 
       if (result.decision === "deny") {


### PR DESCRIPTION
## Summary
Fixes 4 gaps in the v2 permission checker gate:
- Respect requireFreshApproval (manage_secure_command_tool)
- Respect forcePromptSideEffects (untrusted actors, private conversations)
- Host-access gate triggers interactive prompt instead of error string
- Use RiskLevel.Low instead of invalid 'none' value

Part of plan: permission-system-redesign.md (fix round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
