### PR TITLE
fix: non-interactive guardian sessions respect v2 hostAccess gate

### DIFF
--- a/assistant/src/__tests__/permission-checker-host-gate.test.ts
+++ b/assistant/src/__tests__/permission-checker-host-gate.test.ts
@@ -293,6 +293,40 @@ describe("permission-checker host-access gate (v2)", () => {
       });
     });
 
+    describe("non-interactive guardian session with hostAccess=false", () => {
+      beforeEach(() => {
+        setHostAccess(false);
+      });
+
+      test("host tool is NOT auto-approved (denies instead of guardian_auto_approve)", async () => {
+        const promptSpy = mock(() =>
+          Promise.resolve({ decision: "allow" as const }),
+        );
+        const prompter = {
+          prompt: promptSpy,
+        } as unknown as PermissionPrompter;
+        const checker = new PermissionChecker(prompter);
+        const result = await checker.checkPermission(
+          "host_bash",
+          {},
+          makeTool("host_bash"),
+          makeContext({ isInteractive: false, trustClass: "guardian" }),
+          executionTarget,
+          noopEmit,
+          noopSanitize,
+          Date.now(),
+          noopDiff,
+        );
+
+        // v2ForcePrompt is true (hostAccess=false), so the non-interactive
+        // guardian auto-approve must NOT fire. Since there is no interactive
+        // client, the tool should be denied.
+        expect(promptSpy).not.toHaveBeenCalled();
+        expect(result.allowed).toBe(false);
+        expect(result.decision).toBe("denied");
+      });
+    });
+
     describe("forcePromptSideEffects bypasses v2 auto-allow for side-effect tools", () => {
       beforeEach(() => {
         setHostAccess(true);

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -215,6 +215,7 @@ export class PermissionChecker {
           context.trustClass === "guardian" &&
           !context.requireFreshApproval &&
           !isDynamicSkillLoad &&
+          !v2ForcePrompt &&
           riskLevel !== RiskLevel.High
         ) {
           log.info(


### PR DESCRIPTION
## Summary
Non-interactive guardian sessions (scheduled jobs, reminders) now respect the v2 hostAccess=false gate instead of auto-approving host tools.

Part of plan: permission-system-redesign.md (fix round 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23468" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
