### PR TITLE
fix: resolve 'Unknown' tool call chips on conversation reload

### DIFF
--- a/assistant/src/__tests__/list-messages-tool-merge.test.ts
+++ b/assistant/src/__tests__/list-messages-tool-merge.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Tests for handleListMessages tool_result merging.
+ *
+ * Verifies that tool_result blocks from user messages are merged into the
+ * preceding assistant message so they render with proper tool names instead
+ * of "Unknown" after a conversation reload.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+  }),
+}));
+
+import { addMessage, createConversation } from "../memory/conversation-crud.js";
+import { getDb, initializeDb } from "../memory/db.js";
+import { handleListMessages } from "../runtime/routes/conversation-routes.js";
+
+initializeDb();
+
+function resetTables() {
+  const db = getDb();
+  db.run("DELETE FROM message_attachments");
+  db.run("DELETE FROM attachments");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+function createTestUrl(conversationId: string): URL {
+  return new URL(
+    `http://localhost/v1/messages?conversationId=${conversationId}`,
+  );
+}
+
+interface ToolCallPayload {
+  name: string;
+  input: Record<string, unknown>;
+  result?: string;
+  isError?: boolean;
+}
+
+interface MessagePayload {
+  role: string;
+  content: string;
+  toolCalls?: ToolCallPayload[];
+  textSegments?: string[];
+}
+
+describe("handleListMessages tool_result merging", () => {
+  beforeEach(resetTables);
+
+  test("merges tool_result from user message into preceding assistant", async () => {
+    const conv = createConversation();
+    // User prompt
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "run ls" }]),
+    );
+    // Assistant with tool_use
+    await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([
+        { type: "text", text: "Running command." },
+        { type: "tool_use", id: "tu1", name: "bash", input: { command: "ls" } },
+      ]),
+    );
+    // Tool result (separate user message)
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([
+        { type: "tool_result", tool_use_id: "tu1", content: "file1.txt\nfile2.txt" },
+      ]),
+    );
+
+    const response = handleListMessages(createTestUrl(conv.id), null);
+    const body = (await response.json()) as { messages: MessagePayload[] };
+
+    // Should be 2 messages: user prompt + assistant (tool_result user msg suppressed)
+    expect(body.messages).toHaveLength(2);
+    expect(body.messages[0].role).toBe("user");
+    expect(body.messages[1].role).toBe("assistant");
+
+    // Assistant tool call should have proper name AND result
+    const toolCalls = body.messages[1].toolCalls;
+    expect(toolCalls).toBeDefined();
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls![0].name).toBe("bash");
+    expect(toolCalls![0].result).toBe("file1.txt\nfile2.txt");
+  });
+
+  test("merges multiple tool_results into matching tool_uses", async () => {
+    const conv = createConversation();
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "do stuff" }]),
+    );
+    await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([
+        { type: "tool_use", id: "tu1", name: "bash", input: { command: "ls" } },
+        { type: "text", text: "and also" },
+        { type: "tool_use", id: "tu2", name: "file_read", input: { path: "/tmp/a" } },
+      ]),
+    );
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([
+        { type: "tool_result", tool_use_id: "tu1", content: "dir listing" },
+        { type: "tool_result", tool_use_id: "tu2", content: "file contents" },
+      ]),
+    );
+
+    const response = handleListMessages(createTestUrl(conv.id), null);
+    const body = (await response.json()) as { messages: MessagePayload[] };
+
+    expect(body.messages).toHaveLength(2);
+    const toolCalls = body.messages[1].toolCalls!;
+    expect(toolCalls).toHaveLength(2);
+    expect(toolCalls[0].name).toBe("bash");
+    expect(toolCalls[0].result).toBe("dir listing");
+    expect(toolCalls[1].name).toBe("file_read");
+    expect(toolCalls[1].result).toBe("file contents");
+  });
+
+  test("plain user message passes through unchanged", async () => {
+    const conv = createConversation();
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "hello" }]),
+    );
+    await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([{ type: "text", text: "hi there" }]),
+    );
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "how are you?" }]),
+    );
+
+    const response = handleListMessages(createTestUrl(conv.id), null);
+    const body = (await response.json()) as { messages: MessagePayload[] };
+
+    expect(body.messages).toHaveLength(3);
+    expect(body.messages[2].role).toBe("user");
+    expect(body.messages[2].content).toBe("how are you?");
+  });
+
+  test("tool_result at start of array (no preceding assistant) is suppressed", async () => {
+    const conv = createConversation();
+    // Orphan tool_result with no preceding assistant (pagination boundary)
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([
+        { type: "tool_result", tool_use_id: "tu_orphan", content: "stale result" },
+      ]),
+    );
+    await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([{ type: "text", text: "response" }]),
+    );
+
+    const response = handleListMessages(createTestUrl(conv.id), null);
+    const body = (await response.json()) as { messages: MessagePayload[] };
+
+    // Orphan tool_result user message should be suppressed
+    expect(body.messages).toHaveLength(1);
+    expect(body.messages[0].role).toBe("assistant");
+    expect(body.messages[0].content).toBe("response");
+  });
+
+  test("multi-turn: each tool_result merges into correct assistant", async () => {
+    const conv = createConversation();
+    // Turn 1
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "list files" }]),
+    );
+    await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([
+        { type: "tool_use", id: "tu1", name: "bash", input: { command: "ls" } },
+      ]),
+    );
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([
+        { type: "tool_result", tool_use_id: "tu1", content: "files" },
+      ]),
+    );
+    // Turn 2
+    await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([
+        { type: "text", text: "Now reading:" },
+        { type: "tool_use", id: "tu2", name: "file_read", input: { path: "/x" } },
+      ]),
+    );
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([
+        { type: "tool_result", tool_use_id: "tu2", content: "file data" },
+      ]),
+    );
+    // Turn 3: real user message
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "thanks" }]),
+    );
+
+    const response = handleListMessages(createTestUrl(conv.id), null);
+    const body = (await response.json()) as { messages: MessagePayload[] };
+
+    // user("list files"), assistant(bash), assistant(file_read), user("thanks")
+    expect(body.messages).toHaveLength(4);
+    expect(body.messages[0].role).toBe("user");
+    expect(body.messages[1].role).toBe("assistant");
+    expect(body.messages[1].toolCalls![0].name).toBe("bash");
+    expect(body.messages[1].toolCalls![0].result).toBe("files");
+    expect(body.messages[2].role).toBe("assistant");
+    expect(body.messages[2].toolCalls![0].name).toBe("file_read");
+    expect(body.messages[2].toolCalls![0].result).toBe("file data");
+    expect(body.messages[3].role).toBe("user");
+    expect(body.messages[3].content).toBe("thanks");
+  });
+
+  test("tool_result with is_error propagates error status", async () => {
+    const conv = createConversation();
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "do it" }]),
+    );
+    await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([
+        { type: "tool_use", id: "tu1", name: "bash", input: { command: "fail" } },
+      ]),
+    );
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([
+        {
+          type: "tool_result",
+          tool_use_id: "tu1",
+          content: "command not found",
+          is_error: true,
+        },
+      ]),
+    );
+
+    const response = handleListMessages(createTestUrl(conv.id), null);
+    const body = (await response.json()) as { messages: MessagePayload[] };
+
+    expect(body.messages).toHaveLength(2);
+    const tc = body.messages[1].toolCalls![0];
+    expect(tc.name).toBe("bash");
+    expect(tc.result).toBe("command not found");
+    expect(tc.isError).toBe(true);
+  });
+});

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -410,8 +410,15 @@ export function handleListMessages(
     rawMessages = getMessages(resolvedConversationId);
   }
 
+  // During streaming, tool_use (assistant) and tool_result (user) events are
+  // assembled client-side into a single assistant ChatMessage. On reload, they
+  // are separate DB rows. Merge tool_result blocks from user messages into the
+  // preceding assistant message so renderHistoryContent can pair them via its
+  // pendingToolUses map — otherwise they render as "Unknown" tool calls.
+  const mergedMessages = mergeToolResultsIntoAssistantMessages(rawMessages);
+
   // Parse content blocks and extract text + tool calls
-  const parsed = rawMessages.map((msg) => {
+  const parsed = mergedMessages.map((msg) => {
     let content: unknown;
     try {
       content = JSON.parse(msg.content);
@@ -597,6 +604,135 @@ export function handleListMessages(
   }
 
   return Response.json({ messages });
+}
+
+// ── Tool-result merging ─────────────────────────────────────────────
+
+function isToolResultType(type: string): boolean {
+  return type === "tool_result" || type === "web_search_tool_result";
+}
+
+function isSystemNoticeText(block: Record<string, unknown>): boolean {
+  if (block.type !== "text") return false;
+  const text = typeof block.text === "string" ? block.text : "";
+  return text.startsWith("<system_notice>") && text.endsWith("</system_notice>");
+}
+
+/**
+ * Merge tool_result blocks from user messages into the preceding assistant
+ * message's content array. This lets renderHistoryContent's pendingToolUses
+ * map pair tool_use and tool_result blocks, preventing "unknown" tool names.
+ *
+ * User messages that consist entirely of tool_result blocks (and optional
+ * system_notice text) are removed from the output. Mixed messages (tool_result
+ * + real user text) keep only the non-tool-result blocks.
+ */
+function mergeToolResultsIntoAssistantMessages(
+  messages: MessageRow[],
+): MessageRow[] {
+  // Index of the most recent assistant message in the output array.
+  let lastAssistantIdx = -1;
+  // Parsed content caches — lazily populated per assistant message.
+  const parsedAssistantContent = new Map<number, unknown[]>();
+
+  const result: MessageRow[] = [];
+
+  for (const msg of messages) {
+    if (msg.role === "assistant") {
+      lastAssistantIdx = result.length;
+      result.push(msg);
+      continue;
+    }
+
+    // Only process user messages — other roles pass through.
+    if (msg.role !== "user") {
+      result.push(msg);
+      continue;
+    }
+
+    let blocks: unknown[];
+    try {
+      const parsed = JSON.parse(msg.content);
+      if (!Array.isArray(parsed)) {
+        result.push(msg);
+        continue;
+      }
+      blocks = parsed;
+    } catch {
+      result.push(msg);
+      continue;
+    }
+
+    // Separate tool-result blocks from real user content.
+    const toolResultBlocks: unknown[] = [];
+    const otherBlocks: unknown[] = [];
+    for (const block of blocks) {
+      if (
+        typeof block === "object" &&
+        block !== null &&
+        typeof (block as Record<string, unknown>).type === "string"
+      ) {
+        const rec = block as Record<string, unknown>;
+        if (isToolResultType(rec.type as string)) {
+          toolResultBlocks.push(block);
+        } else if (isSystemNoticeText(rec)) {
+          // System notices don't count as user content — drop them when
+          // the message is otherwise tool-result-only.
+          otherBlocks.push(block);
+        } else {
+          otherBlocks.push(block);
+        }
+      } else {
+        otherBlocks.push(block);
+      }
+    }
+
+    // No tool results → pass through unchanged.
+    if (toolResultBlocks.length === 0) {
+      result.push(msg);
+      continue;
+    }
+
+    // Append tool_result blocks to the preceding assistant message's content.
+    if (lastAssistantIdx >= 0) {
+      const assistant = result[lastAssistantIdx];
+      let assistantContent = parsedAssistantContent.get(lastAssistantIdx);
+      if (!assistantContent) {
+        try {
+          const parsed = JSON.parse(assistant.content);
+          assistantContent = Array.isArray(parsed) ? parsed : [parsed];
+        } catch {
+          assistantContent = [];
+        }
+        parsedAssistantContent.set(lastAssistantIdx, assistantContent);
+      }
+      assistantContent.push(...toolResultBlocks);
+    }
+    // else: no preceding assistant message (pagination boundary) — drop the
+    // tool_result blocks to avoid rendering "unknown" chips.
+
+    // If the user message had only tool_result (+ system_notice) blocks,
+    // suppress it entirely. Otherwise keep the non-tool-result content.
+    const realUserContent = otherBlocks.filter(
+      (b) =>
+        !(
+          typeof b === "object" &&
+          b !== null &&
+          isSystemNoticeText(b as Record<string, unknown>)
+        ),
+    );
+    if (realUserContent.length > 0) {
+      result.push({ ...msg, content: JSON.stringify(otherBlocks) });
+    }
+    // else: tool-result-only → suppressed
+  }
+
+  // Write back any modified assistant message content.
+  for (const [idx, content] of parsedAssistantContent) {
+    result[idx] = { ...result[idx], content: JSON.stringify(content) };
+  }
+
+  return result;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Tool calls were showing as "Unknown" when reloading conversations from the database after restart
- Root cause: `renderHistoryContent()` processes each DB message independently — user messages with `tool_result` blocks can't match them to `tool_use` blocks in the preceding assistant message, producing `{name: "unknown"}` entries
- Added `mergeToolResultsIntoAssistantMessages()` to pre-merge tool_result blocks into the preceding assistant message before rendering, matching the client's streaming behavior

## Original prompt
Fix "Unknown" tool call chips appearing in the app when reloading a conversation from the DB on restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
