### PR TITLE
feat: add SubagentRole type and role config registry

### DIFF
--- a/assistant/src/__tests__/subagent-role-registry.test.ts
+++ b/assistant/src/__tests__/subagent-role-registry.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  SUBAGENT_ROLE_REGISTRY,
+  type SubagentRole,
+} from "../subagent/index.js";
+
+/** All roles defined in the SubagentRole union. */
+const ALL_ROLES: SubagentRole[] = [
+  "general",
+  "researcher",
+  "coder",
+  "planner",
+];
+
+describe("SUBAGENT_ROLE_REGISTRY", () => {
+  test("covers all values in the SubagentRole union", () => {
+    const registryKeys = Object.keys(SUBAGENT_ROLE_REGISTRY);
+    expect(registryKeys.sort()).toEqual([...ALL_ROLES].sort());
+    expect(registryKeys).toHaveLength(ALL_ROLES.length);
+  });
+
+  test("every role has a non-empty systemPromptPreamble", () => {
+    for (const [role, config] of Object.entries(SUBAGENT_ROLE_REGISTRY)) {
+      expect(config.systemPromptPreamble.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("general has allowedTools: undefined", () => {
+    expect(SUBAGENT_ROLE_REGISTRY.general.allowedTools).toBeUndefined();
+  });
+
+  test("all non-general roles have allowedTools as a non-empty array", () => {
+    for (const role of ALL_ROLES) {
+      if (role === "general") continue;
+      const config = SUBAGENT_ROLE_REGISTRY[role];
+      expect(Array.isArray(config.allowedTools)).toBe(true);
+      expect(config.allowedTools!.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('every role with allowedTools includes "notify_parent"', () => {
+    for (const [role, config] of Object.entries(SUBAGENT_ROLE_REGISTRY)) {
+      if (config.allowedTools !== undefined) {
+        expect(config.allowedTools).toContain("notify_parent");
+      }
+    }
+  });
+});

--- a/assistant/src/subagent/index.ts
+++ b/assistant/src/subagent/index.ts
@@ -1,6 +1,16 @@
 export { SubagentManager } from "./manager.js";
-export type { SubagentConfig, SubagentState, SubagentStatus } from "./types.js";
-export { SUBAGENT_LIMITS, TERMINAL_STATUSES } from "./types.js";
+export type {
+  SubagentConfig,
+  SubagentRole,
+  SubagentRoleConfig,
+  SubagentState,
+  SubagentStatus,
+} from "./types.js";
+export {
+  SUBAGENT_LIMITS,
+  SUBAGENT_ROLE_REGISTRY,
+  TERMINAL_STATUSES,
+} from "./types.js";
 
 import { SubagentManager } from "./manager.js";
 

--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -41,6 +41,8 @@ export interface SubagentConfig {
   preactivatedSkillIds?: string[];
   /** Whether the parent should present the result to the user. Defaults to true. */
   sendResultToUser?: boolean;
+  /** Optional role for the subagent. Defaults handled by consumers. */
+  role?: SubagentRole;
 }
 
 // ── State (runtime) ─────────────────────────────────────────────────────
@@ -66,3 +68,65 @@ export const SUBAGENT_LIMITS = {
   /** Max nesting depth (1 = no nested subagents). */
   maxDepth: 1,
 } as const;
+
+// ── Roles ───────────────────────────────────────────────────────────────
+
+export type SubagentRole = "general" | "researcher" | "coder" | "planner";
+
+export interface SubagentRoleConfig {
+  /**
+   * When defined, only these tools are visible to the subagent.
+   * `undefined` means no filter (all tools available).
+   */
+  allowedTools?: string[];
+  /** Skill IDs to pre-activate on the subagent conversation. */
+  skillIds: string[];
+  /** Role-specific text prepended to the subagent system prompt. */
+  systemPromptPreamble: string;
+}
+
+export const SUBAGENT_ROLE_REGISTRY: Record<SubagentRole, SubagentRoleConfig> = {
+  general: {
+    allowedTools: undefined,
+    skillIds: [],
+    systemPromptPreamble:
+      "You are a general-purpose subagent. Complete the delegated task thoroughly and concisely.",
+  },
+  researcher: {
+    allowedTools: [
+      "web_search",
+      "web_fetch",
+      "file_read",
+      "memory_recall",
+      "notify_parent",
+    ],
+    skillIds: [],
+    systemPromptPreamble:
+      "You are a research-focused subagent with read-only access. Search the web, read files, and recall memories. You cannot write files or run shell commands.",
+  },
+  coder: {
+    allowedTools: [
+      "bash",
+      "file_read",
+      "file_write",
+      "file_edit",
+      "web_search",
+      "notify_parent",
+    ],
+    skillIds: [],
+    systemPromptPreamble:
+      "You are a code-focused subagent with file and shell access. Read, write, and edit files, and run shell commands.",
+  },
+  planner: {
+    allowedTools: [
+      "file_read",
+      "web_search",
+      "web_fetch",
+      "memory_recall",
+      "notify_parent",
+    ],
+    skillIds: [],
+    systemPromptPreamble:
+      "You are an analysis-focused subagent with read-only access. Read files, search the web, and synthesize findings. You cannot write files or run shell commands.",
+  },
+};


### PR DESCRIPTION
## Summary
- Add SubagentRole type (general | researcher | coder | planner)
- Add SubagentRoleConfig interface and SUBAGENT_ROLE_REGISTRY with tool allowlists and system prompt preambles per role
- Add optional role field to SubagentConfig

Part of plan: subagent-delegation-system.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
