### PR TITLE
feat: add subagentAllowedTools filter to tool resolution pipeline

### DIFF
--- a/assistant/src/__tests__/subagent-tool-filtering.test.ts
+++ b/assistant/src/__tests__/subagent-tool-filtering.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for the subagentAllowedTools mechanism in createResolveToolsCallback.
+ *
+ * Covers:
+ * - Resolver filters core tools to only those in the subagent allowlist
+ * - Resolver filters skill tool names through the subagent allowlist
+ * - Resolver passes all tools through when subagentAllowedTools is undefined
+ * - allowedToolNames on ctx is also filtered (defense in depth at executor level)
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import type { SkillProjectionCache } from "../daemon/conversation-skill-tools.js";
+import type { Message, ToolDefinition } from "../providers/types.js";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be set up before importing the module under test
+// ---------------------------------------------------------------------------
+
+const mockProjectSkillTools = mock(
+  (_history: Message[], _opts: unknown) => ({
+    allowedToolNames: new Set<string>(),
+    toolDefinitions: [] as ToolDefinition[],
+  }),
+);
+
+mock.module("../daemon/conversation-skill-tools.js", () => ({
+  projectSkillTools: mockProjectSkillTools,
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import {
+  createResolveToolsCallback,
+  type SkillProjectionContext,
+} from "../daemon/conversation-tool-setup.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeToolDef(name: string): ToolDefinition {
+  return { name, description: `${name} tool`, input_schema: {} };
+}
+
+function makeCtx(
+  overrides: Partial<SkillProjectionContext> = {},
+): SkillProjectionContext {
+  return {
+    skillProjectionState: new Map(),
+    skillProjectionCache: {} as SkillProjectionCache,
+    coreToolNames: new Set(["file_read", "web_search", "bash", "file_write"]),
+    toolsDisabledDepth: 0,
+    ...overrides,
+  };
+}
+
+const EMPTY_HISTORY: Message[] = [];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createResolveToolsCallback — subagentAllowedTools", () => {
+  test("filters core tools to only those in the subagent allowlist", () => {
+    const toolDefs = [
+      makeToolDef("file_read"),
+      makeToolDef("web_search"),
+      makeToolDef("bash"),
+      makeToolDef("file_write"),
+    ];
+    const ctx = makeCtx({
+      subagentAllowedTools: new Set(["file_read", "web_search"]),
+    });
+    const resolve = createResolveToolsCallback(toolDefs, ctx)!;
+
+    const tools = resolve(EMPTY_HISTORY);
+    const names = tools.map((t) => t.name);
+    expect(names).toContain("file_read");
+    expect(names).toContain("web_search");
+    expect(names).not.toContain("bash");
+    expect(names).not.toContain("file_write");
+  });
+
+  test("passes all tools through when subagentAllowedTools is undefined", () => {
+    const toolDefs = [
+      makeToolDef("file_read"),
+      makeToolDef("web_search"),
+      makeToolDef("bash"),
+      makeToolDef("file_write"),
+    ];
+    const ctx = makeCtx({ subagentAllowedTools: undefined });
+    const resolve = createResolveToolsCallback(toolDefs, ctx)!;
+
+    const tools = resolve(EMPTY_HISTORY);
+    const names = tools.map((t) => t.name);
+    expect(names).toContain("file_read");
+    expect(names).toContain("web_search");
+    expect(names).toContain("bash");
+    expect(names).toContain("file_write");
+  });
+
+  test("filters skill tool names through the subagent allowlist", () => {
+    // Configure mock to return skill tools
+    mockProjectSkillTools.mockReturnValueOnce({
+      allowedToolNames: new Set(["skill_a", "skill_b", "skill_c"]),
+      toolDefinitions: [],
+    });
+
+    const toolDefs = [makeToolDef("file_read")];
+    const ctx = makeCtx({
+      subagentAllowedTools: new Set(["file_read", "skill_b"]),
+    });
+    const resolve = createResolveToolsCallback(toolDefs, ctx)!;
+
+    resolve(EMPTY_HISTORY);
+
+    // allowedToolNames should include file_read and skill_b but not skill_a or skill_c
+    expect(ctx.allowedToolNames!.has("file_read")).toBe(true);
+    expect(ctx.allowedToolNames!.has("skill_b")).toBe(true);
+    expect(ctx.allowedToolNames!.has("skill_a")).toBe(false);
+    expect(ctx.allowedToolNames!.has("skill_c")).toBe(false);
+  });
+
+  test("allowedToolNames on ctx is filtered when subagentAllowedTools is set", () => {
+    const toolDefs = [
+      makeToolDef("file_read"),
+      makeToolDef("web_search"),
+      makeToolDef("bash"),
+    ];
+    const ctx = makeCtx({
+      subagentAllowedTools: new Set(["file_read", "web_search"]),
+    });
+    const resolve = createResolveToolsCallback(toolDefs, ctx)!;
+
+    resolve(EMPTY_HISTORY);
+
+    // Defense in depth: the allowedToolNames gate on ctx must also be scoped
+    expect(ctx.allowedToolNames!.has("file_read")).toBe(true);
+    expect(ctx.allowedToolNames!.has("web_search")).toBe(true);
+    expect(ctx.allowedToolNames!.has("bash")).toBe(false);
+  });
+
+  test("includes all skill tools in allowedToolNames when subagentAllowedTools is undefined", () => {
+    mockProjectSkillTools.mockReturnValueOnce({
+      allowedToolNames: new Set(["skill_a", "skill_b"]),
+      toolDefinitions: [],
+    });
+
+    const toolDefs = [makeToolDef("file_read")];
+    const ctx = makeCtx({ subagentAllowedTools: undefined });
+    const resolve = createResolveToolsCallback(toolDefs, ctx)!;
+
+    resolve(EMPTY_HISTORY);
+
+    expect(ctx.allowedToolNames!.has("file_read")).toBe(true);
+    expect(ctx.allowedToolNames!.has("skill_a")).toBe(true);
+    expect(ctx.allowedToolNames!.has("skill_b")).toBe(true);
+  });
+});

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -453,6 +453,8 @@ export interface SkillProjectionContext {
   };
   /** True when no client is connected (HTTP-only). */
   readonly hasNoClient?: boolean;
+  /** When set, only tools in this set are included in the resolved tool list (subagent delegation). */
+  subagentAllowedTools?: Set<string>;
 }
 
 // ── Conditional tool sets ────────────────────────────────────────────
@@ -544,18 +546,24 @@ export function createResolveToolsCallback(
       isToolActiveForContext(d.name, ctx),
     );
 
+    // When the conversation is acting as a subagent, restrict core tools to
+    // only those explicitly allowed by the parent orchestrator.
+    const scopedCoreDefs = ctx.subagentAllowedTools
+      ? filteredCoreDefs.filter((d) => ctx.subagentAllowedTools!.has(d.name))
+      : filteredCoreDefs;
+
     // Re-read MCP tool definitions from the registry each turn so conversations
     // automatically pick up tools added/removed by `vellum mcp reload`.
     const currentMcpDefs = getMcpToolDefinitions();
     log.debug(
       {
-        coreCount: filteredCoreDefs.length,
+        coreCount: scopedCoreDefs.length,
         mcpCount: currentMcpDefs.length,
         mcpTools: currentMcpDefs.map((d) => d.name),
       },
       "MCP tools resolved for turn",
     );
-    const allBaseDefs = [...filteredCoreDefs, ...currentMcpDefs];
+    const allBaseDefs = [...scopedCoreDefs, ...currentMcpDefs];
 
     const effectivePreactivated = [
       ...DEFAULT_PREACTIVATED_SKILL_IDS,
@@ -568,6 +576,10 @@ export function createResolveToolsCallback(
     });
     const turnAllowed = new Set(allBaseDefs.map((d) => d.name));
     for (const name of projection.allowedToolNames) {
+      // When a subagent allowlist is active, exclude skill tools not on it.
+      if (ctx.subagentAllowedTools && !ctx.subagentAllowedTools.has(name)) {
+        continue;
+      }
       turnAllowed.add(name);
     }
     ctx.allowedToolNames = turnAllowed;

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -160,6 +160,7 @@ export class Conversation {
   /** @internal */ allowedToolNames?: Set<string>;
   /** @internal */ toolsDisabledDepth = 0;
   /** @internal */ preactivatedSkillIds?: string[];
+  /** @internal */ subagentAllowedTools?: Set<string>;
   /** @internal */ coreToolNames: Set<string>;
   /** @internal */ readonly skillProjectionState = new Map<string, string>();
   /** @internal */ readonly skillProjectionCache: SkillProjectionCache = {};
@@ -538,6 +539,10 @@ export class Conversation {
 
   setSandboxOverride(enabled: boolean | undefined): void {
     this.sandboxOverride = enabled;
+  }
+
+  setSubagentAllowedTools(tools: Set<string> | undefined): void {
+    this.subagentAllowedTools = tools;
   }
 
   isProcessing(): boolean {


### PR DESCRIPTION
## Summary
- Add subagentAllowedTools field to SkillProjectionContext interface
- Apply allowlist filter in createResolveToolsCallback for both core and skill tools
- Add setSubagentAllowedTools setter on Conversation class

Part of plan: subagent-delegation-system.md (PR 2 of 7)