### PR TITLE
feat: add last_n parameter to subagent_read for scoped output retrieval

### DIFF
--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -790,6 +790,111 @@ describe("Subagent read tool", () => {
     }
   });
 
+  test("read with last_n: 1 returns only the last message", async () => {
+    const manager = getSubagentManager();
+    const subagentId = "read-last-n-1";
+    injectSubagent(manager, subagentId, ownerConversation, "completed");
+
+    mockGetMessages = (convId: string) => {
+      if (convId !== `conv-${subagentId}`) return null;
+      return [
+        { role: "assistant", content: "First message" },
+        { role: "assistant", content: "Second message" },
+        { role: "assistant", content: "Third message" },
+      ];
+    };
+
+    try {
+      const result = await executeSubagentRead(
+        { subagent_id: subagentId, last_n: 1 },
+        makeContext(ownerConversation),
+      );
+      expect(result.isError).toBe(false);
+      expect(result.content).toBe("Third message");
+    } finally {
+      mockGetMessages = () => null;
+    }
+  });
+
+  test("read with last_n: 2 returns last 2 messages joined", async () => {
+    const manager = getSubagentManager();
+    const subagentId = "read-last-n-2";
+    injectSubagent(manager, subagentId, ownerConversation, "completed");
+
+    mockGetMessages = (convId: string) => {
+      if (convId !== `conv-${subagentId}`) return null;
+      return [
+        { role: "assistant", content: "First message" },
+        { role: "assistant", content: "Second message" },
+        { role: "assistant", content: "Third message" },
+      ];
+    };
+
+    try {
+      const result = await executeSubagentRead(
+        { subagent_id: subagentId, last_n: 2 },
+        makeContext(ownerConversation),
+      );
+      expect(result.isError).toBe(false);
+      expect(result.content).toBe("Second message\n\nThird message");
+    } finally {
+      mockGetMessages = () => null;
+    }
+  });
+
+  test("read with last_n omitted returns all messages", async () => {
+    const manager = getSubagentManager();
+    const subagentId = "read-last-n-omit";
+    injectSubagent(manager, subagentId, ownerConversation, "completed");
+
+    mockGetMessages = (convId: string) => {
+      if (convId !== `conv-${subagentId}`) return null;
+      return [
+        { role: "assistant", content: "First message" },
+        { role: "assistant", content: "Second message" },
+        { role: "assistant", content: "Third message" },
+      ];
+    };
+
+    try {
+      const result = await executeSubagentRead(
+        { subagent_id: subagentId },
+        makeContext(ownerConversation),
+      );
+      expect(result.isError).toBe(false);
+      expect(result.content).toBe(
+        "First message\n\nSecond message\n\nThird message",
+      );
+    } finally {
+      mockGetMessages = () => null;
+    }
+  });
+
+  test("read with last_n larger than available returns all messages", async () => {
+    const manager = getSubagentManager();
+    const subagentId = "read-last-n-large";
+    injectSubagent(manager, subagentId, ownerConversation, "completed");
+
+    mockGetMessages = (convId: string) => {
+      if (convId !== `conv-${subagentId}`) return null;
+      return [
+        { role: "assistant", content: "First message" },
+        { role: "assistant", content: "Second message" },
+      ];
+    };
+
+    try {
+      const result = await executeSubagentRead(
+        { subagent_id: subagentId, last_n: 100 },
+        makeContext(ownerConversation),
+      );
+      expect(result.isError).toBe(false);
+      expect(result.content).toBe("First message\n\nSecond message");
+    } finally {
+      mockGetMessages = () => null;
+    }
+  });
+
   test("read concatenates multiple assistant messages", async () => {
     const manager = getSubagentManager();
     const subagentId = "read-multi-1";

--- a/assistant/src/config/bundled-skills/subagent/TOOLS.json
+++ b/assistant/src/config/bundled-skills/subagent/TOOLS.json
@@ -117,6 +117,10 @@
             "type": "string",
             "description": "The ID of the subagent whose output to read."
           },
+          "last_n": {
+            "type": "integer",
+            "description": "Number of recent assistant messages to return. Omit to return all messages (current behavior)."
+          },
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"

--- a/assistant/src/tools/subagent/read.ts
+++ b/assistant/src/tools/subagent/read.ts
@@ -69,8 +69,12 @@ export async function executeSubagentRead(
     return { content: "Subagent produced no text output.", isError: false };
   }
 
+  const lastN =
+    typeof input.last_n === "number" && input.last_n > 0 ? input.last_n : 0;
+  const sliced = lastN ? output.slice(-lastN) : output;
+
   return {
-    content: output.join("\n\n"),
+    content: sliced.join("\n\n"),
     isError: false,
   };
 }


### PR DESCRIPTION
## Summary
- Add optional last_n parameter to subagent_read tool
- When set, returns only the last N assistant messages instead of all
- Backwards compatible — omitting last_n preserves current behavior

Part of plan: subagent-delegation-system.md (PR 4 of 7)