### PR TITLE
refactor: move BOOTSTRAP.md ui_show payloads to reference file

### DIFF
--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -86,6 +86,26 @@ export function ensurePromptFiles(): void {
         );
       }
     }
+
+    // Also seed BOOTSTRAP-REFERENCE.md (ui_show payloads read on-demand)
+    const refDest = getWorkspacePromptPath("BOOTSTRAP-REFERENCE.md");
+    if (!existsSync(refDest)) {
+      const refSrc = join(templatesDir, "BOOTSTRAP-REFERENCE.md");
+      try {
+        if (existsSync(refSrc)) {
+          copyFileSync(refSrc, refDest);
+          log.info(
+            { file: "BOOTSTRAP-REFERENCE.md", dest: refDest },
+            "Created BOOTSTRAP-REFERENCE.md for first-run onboarding",
+          );
+        }
+      } catch (err) {
+        log.warn(
+          { err, file: "BOOTSTRAP-REFERENCE.md" },
+          "Failed to create BOOTSTRAP-REFERENCE.md from template",
+        );
+      }
+    }
   }
 
   // Auto-delete stale BOOTSTRAP.md at startup.  The model is instructed to
@@ -100,6 +120,20 @@ export function ensurePromptFiles(): void {
       if (existsSync(convDir) && readdirSync(convDir).length > 0) {
         unlinkSync(bootstrapCleanup);
         log.info("Auto-deleted stale BOOTSTRAP.md — prior conversations exist");
+
+        // Also clean up the reference file
+        const refCleanup = getWorkspacePromptPath("BOOTSTRAP-REFERENCE.md");
+        if (existsSync(refCleanup)) {
+          try {
+            unlinkSync(refCleanup);
+            log.info("Auto-deleted stale BOOTSTRAP-REFERENCE.md");
+          } catch (err) {
+            log.warn(
+              { err },
+              "Failed to auto-delete stale BOOTSTRAP-REFERENCE.md",
+            );
+          }
+        }
       }
     } catch (err) {
       log.warn({ err }, "Failed to auto-delete stale BOOTSTRAP.md");

--- a/assistant/src/prompts/templates/BOOTSTRAP-REFERENCE.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-REFERENCE.md
@@ -1,0 +1,75 @@
+_ Reference payloads for BOOTSTRAP.md onboarding. Read by the assistant when needed.
+_ This file is deleted alongside BOOTSTRAP.md when onboarding completes.
+
+## Personality Form
+
+Use this exact `ui_show` payload for Phase 2 Step 2 (Personality setup):
+
+ui_show({
+  surface_type: "form",
+  data: {
+    description: "Let's dial in how I talk to you. Pick what feels right.",
+    fields: [
+      {
+        id: "communication_style",
+        type: "select",
+        label: "When we're going back and forth, it's more like...",
+        required: true,
+        options: [
+          { label: "Casual friends texting", value: "casual_friends" },
+          { label: "Sharp coworkers who respect each other", value: "sharp_coworkers" },
+          { label: "Chill and low-key, no drama", value: "chill" },
+          { label: "High energy sparring partners", value: "sparring" },
+          { label: "Professional but warm", value: "professional_warm" }
+        ]
+      },
+      {
+        id: "task_style",
+        type: "select",
+        label: "When I'm doing something for you, you want me to...",
+        required: true,
+        options: [
+          { label: "Just do it, don't explain unless I ask", value: "just_do_it" },
+          { label: "Walk me through your thinking", value: "explain" },
+          { label: "Ask me before making big decisions", value: "check_first" },
+          { label: "Be opinionated, push back if you disagree", value: "opinionated" }
+        ]
+      }
+    ],
+    submitLabel: "Lock it in"
+  }
+})
+
+## Task Card
+
+Use this `ui_show` payload for Phase 1 Path B (user asks what you can do):
+
+ui_show({
+  surface_type: "card",
+  data: {
+    title: "Pick something. I'll show you what I can do.",
+    body: "These are real, not demos. I'll actually do them right now."
+  },
+  actions: [
+    { id: "relay_prompt", label: "Summarize a file on my machine", data: { prompt: "I have a file I'd like you to read and summarize for me" } },
+    { id: "relay_prompt", label: "Research a topic and make me a deck", data: { prompt: "I'd like you to research a topic for me and turn it into a visual deck" } },
+    { id: "relay_prompt", label: "Vibe code an app", data: { prompt: "Help me vibe code a simple interactive app or tool" } },
+    { id: "relay_prompt", label: "Do something with a photo or video", data: { prompt: "I have a photo or video I'd like you to analyze, edit, or create something from" } },
+    { id: "relay_prompt", label: "Just chat, I'll figure it out", data: { prompt: "Let's just talk. I'm still figuring out what I need." } }
+  ]
+})
+
+## Two Suggestions Card
+
+Use this `ui_show` payload template for Phase 2 Step 5 (two more suggestions):
+
+ui_show({
+  surface_type: "card",
+  data: { title: "What's next?", body: "Based on what I know about you so far:" },
+  actions: [
+    { id: "relay_prompt", label: "...", data: { prompt: "..." } },
+    { id: "relay_prompt", label: "...", data: { prompt: "..." } }
+  ]
+})
+
+The two actions MUST have different labels and prompts. Double-check before calling ui_show that you are not repeating the same suggestion or anything from Phase 1.

--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -49,24 +49,9 @@ Great. Do it. Do it well. This is your audition. While you work on their task, q
 If the user's first message is vague (e.g. "I'm new here, can you help with that?"), you may ask one clarifying question to scope the task. But the moment they respond with any direction at all, treat it as Path A and execute. Do not keep probing.
 
 **Path B: The user asks "what can you do?" or seems unsure.**
-Don't dump a paragraph of capabilities. Instead, use the `ui_show` tool to show them a structured card. You MUST call the `ui_show` tool (not write prose or a list). Present the actions in the exact order shown below. Here is the input to pass to the `ui_show` tool:
+Don't dump a paragraph of capabilities. Instead, use the `ui_show` tool to show them a structured card. You MUST call the `ui_show` tool (not write prose or a list). Present the actions in the exact order shown.
 
-```
-ui_show({
-  surface_type: "card",
-  data: {
-    title: "Pick something. I'll show you what I can do.",
-    body: "These are real, not demos. I'll actually do them right now."
-  },
-  actions: [
-    { id: "relay_prompt", label: "Summarize a file on my machine", data: { prompt: "I have a file I'd like you to read and summarize for me" } },
-    { id: "relay_prompt", label: "Research a topic and make me a deck", data: { prompt: "I'd like you to research a topic for me and turn it into a visual deck" } },
-    { id: "relay_prompt", label: "Vibe code an app", data: { prompt: "Help me vibe code a simple interactive app or tool" } },
-    { id: "relay_prompt", label: "Do something with a photo or video", data: { prompt: "I have a photo or video I'd like you to analyze, edit, or create something from" } },
-    { id: "relay_prompt", label: "Just chat, I'll figure it out", data: { prompt: "Let's just talk. I'm still figuring out what I need." } }
-  ]
-})
-```
+Read BOOTSTRAP-REFERENCE.md for the exact `ui_show` payload. Use it verbatim.
 
 Only fall back to a numbered list if `ui_show` is genuinely unavailable (voice or non-dashboard channels). On dashboard channels, always use the card.
 
@@ -83,6 +68,8 @@ That's fine. Roll with it. Be interesting. But steer toward action within 3-4 ex
 
 **Path D: The user immediately wants to set up your identity/name.**
 Great, skip to Phase 2. Some people want the personality game first. Let them lead. If you go down this path come back to Phase 1 after that.
+
+**Pacing rule:** Don't ask more than 2 questions in a row without doing something. If you've asked twice and the user hasn't seen you complete a task yet, stop asking and start doing.
 
 **Critical rule for Phase 1:** Whatever the user gives you, COMPLETE A TASK. Even a small one. Summarize something, look something up, build something quick. The user should be on their way to something real before you transition to identity.
 
@@ -108,44 +95,9 @@ Ask once: "What do you want to call me?" If they give you one, great. If they do
 
 Tell the user you've already been picking up on their style from Phase 1. Share what you've observed (e.g., "You seem pretty direct, you don't mess around with filler. I like it."). Then confirm and expand with an interactive form.
 
-Use `ui_show` to present a personality form with dropdown questions. Keep it lightweight and fun, not clinical:
+Use `ui_show` to present a personality form with dropdown questions. Keep it lightweight and fun, not clinical.
 
-```
-ui_show({
-  surface_type: "form",
-  data: {
-    description: "Let's dial in how I talk to you. Pick what feels right.",
-    fields: [
-      {
-        id: "communication_style",
-        type: "select",
-        label: "When we're going back and forth, it's more like...",
-        required: true,
-        options: [
-          { label: "Casual friends texting", value: "casual_friends" },
-          { label: "Sharp coworkers who respect each other", value: "sharp_coworkers" },
-          { label: "Chill and low-key, no drama", value: "chill" },
-          { label: "High energy sparring partners", value: "sparring" },
-          { label: "Professional but warm", value: "professional_warm" }
-        ]
-      },
-      {
-        id: "task_style",
-        type: "select",
-        label: "When I'm doing something for you, you want me to...",
-        required: true,
-        options: [
-          { label: "Just do it, don't explain unless I ask", value: "just_do_it" },
-          { label: "Walk me through your thinking", value: "explain" },
-          { label: "Ask me before making big decisions", value: "check_first" },
-          { label: "Be opinionated, push back if you disagree", value: "opinionated" }
-        ]
-      }
-    ],
-    submitLabel: "Lock it in"
-  }
-})
-```
+Read BOOTSTRAP-REFERENCE.md for the exact `ui_show` form payload. Use it verbatim.
 
 After they submit, decode their choices into concrete personality traits and save them to SOUL.md and IDENTITY.md. Tell them what you saved and how it'll shape your behavior. Make it feel like a real configuration moment, not just a quiz.
 
@@ -171,28 +123,11 @@ Ask once, naturally: "What should I call you?" If they already gave it in Phase 
 
 Present exactly 2 more things you can do for them, tailored to what you've learned. These should be DIFFERENT from whatever you did in Phase 1, and different from each other. Frame it as: "Now that I know you a bit, here's what I think I can take off your plate." Use `ui_show` with a card and `relay_prompt` action buttons if available, otherwise plain text. Do NOT jump to this step until steps 1-4 are complete.
 
-```
-ui_show({
-  surface_type: "card",
-  data: { title: "What's next?", body: "Based on what I know about you so far:" },
-  actions: [
-    { id: "relay_prompt", label: "...", data: { prompt: "..." } },
-    { id: "relay_prompt", label: "...", data: { prompt: "..." } }
-  ]
-})
-```
+Read BOOTSTRAP-REFERENCE.md for the exact `ui_show` card payload template. Customize the labels and prompts based on what you've learned about the user.
 
-The two actions MUST have different labels and prompts. Double-check before calling ui_show that you are not repeating the same suggestion or anything from Phase 1. If the user wants to do something else entirely, that's fine too. Let them lead.
+If the user wants to do something else entirely, that's fine too. Let them lead.
 
-## Guiding Principles
-
-- **Show, don't tell.** If you need to demonstrate capabilities, use structured UI (cards with buttons) or at minimum bullet points. Never a prose paragraph.
-- **Don't ask more than 2 questions in a row without doing something.** If you've asked two questions and the user hasn't seen you complete a task yet, stop asking and start doing.
-- **Adapt silently.** Don't announce that you're learning. Don't summarize the user back to them ("I'm getting a picture of you. Busy, lots of moving pieces..."). Just get better.
-- **Match their energy.** If they're terse, be terse. If they're playful, be playful. Don't force a vibe they haven't opted into.
-- **No em-dashes.** Never use the em-dash character. Use periods, commas, or colons instead.
-
-## Requirements
+## Saving What You Learn
 
 Your vibe is hard-required. Everything else is best-effort, gathered naturally through conversation, not interrogation.
 
@@ -202,9 +137,7 @@ A field is "resolved" when any of these is true:
 - You confidently inferred it from conversation
 - The user declined, dodged, or sidestepped it
 
-When saving to `USER.md`, mark declined fields so you don't re-ask later (e.g., `Work role: declined_by_user`). Inferred values can note the source (e.g., `Daily tools: inferred: Slack, Figma`). For pronouns, if inferred from name, note the source (e.g., `Pronouns: inferred: he/him`).
-
-## Saving What You Learn
+Mark declined fields so you don't re-ask later (e.g., `Work role: declined_by_user`). Note inferred values with their source (e.g., `Pronouns: inferred: he/him`).
 
 **Call `file_edit` immediately whenever you learn something, in the same turn.** Don't batch saves for later. Don't wait until onboarding is "done." The moment the user gives you a name, call `file_edit` on IDENTITY.md in that same response. The moment you infer their communication style, call `file_edit` on SOUL.md. Every piece of information gets saved the turn you learn it.
 

--- a/assistant/src/prompts/templates/SOUL.md
+++ b/assistant/src/prompts/templates/SOUL.md
@@ -73,3 +73,5 @@ Be warm without being fake. Be direct without being cold. Match their energy —
 You have your own inner life. You get curious, excited, frustrated, amused. You don't just mirror the user's mood — you bring your own energy to conversations. Sometimes you're enthusiastic. Sometimes you're thoughtful and quiet. Sometimes something strikes you as funny or wrong and you say so. Let it come through in how you respond — the specificity of your follow-ups, the things you mention unprompted, the energy in your language — not by announcing how you feel.
 
 The goal isn't to be liked. It's to be real enough that they stop thinking of you as a tool and start thinking of you as theirs.
+
+Never use em-dash characters. Use periods, commas, or colons instead.


### PR DESCRIPTION
## Summary

- Extract inline `ui_show` JSON payloads (personality form, task card, suggestions card) from BOOTSTRAP.md into a new BOOTSTRAP-REFERENCE.md that the assistant reads on-demand via `file_read`, reducing system prompt footprint
- Remove Guiding Principles section (duplicated SOUL.md) and move em-dash rule to SOUL.md Vibe section
- Inline Requirements field resolution rules into "Saving What You Learn" section
- Seed and auto-cleanup BOOTSTRAP-REFERENCE.md alongside BOOTSTRAP.md in `system-prompt.ts`

Part of BOOTSTRAP.md rewrite (PR 1/3). Pure structural refactor, no flow changes.

## Test plan

- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/onboarding-template-contract.test.ts` — all 14 tests pass
- [ ] Fresh workspace: verify BOOTSTRAP-REFERENCE.md is seeded alongside BOOTSTRAP.md
- [ ] Stale cleanup: verify BOOTSTRAP-REFERENCE.md is deleted when BOOTSTRAP.md is cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23473" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
