### PR TITLE
feat: expand personality form + add email/calendar task options

### DIFF
--- a/assistant/src/__tests__/onboarding-template-contract.test.ts
+++ b/assistant/src/__tests__/onboarding-template-contract.test.ts
@@ -98,6 +98,12 @@ describe("onboarding template contracts", () => {
       expect(bootstrap).toContain("new colleague");
     });
 
+    test("instructs checking Connected Services for email task variant", () => {
+      expect(bootstrap).toContain("Connected Services");
+      expect(bootstrap).toContain("Connect my email");
+      expect(bootstrap).toContain("Check my email");
+    });
+
     test("includes daily briefing and channel suggestions in getting set up", () => {
       const lower = bootstrap.toLowerCase();
       expect(lower).toContain("daily briefing");
@@ -107,15 +113,23 @@ describe("onboarding template contracts", () => {
   });
 
   describe("BOOTSTRAP-REFERENCE.md", () => {
-    test("contains personality form ui_show payload", () => {
+    test("contains personality form with 4 dropdowns", () => {
       expect(bootstrapRef).toContain("surface_type: \"form\"");
       expect(bootstrapRef).toContain("communication_style");
       expect(bootstrapRef).toContain("task_style");
+      expect(bootstrapRef).toContain("humor");
+      expect(bootstrapRef).toContain("depth");
     });
 
-    test("contains task card ui_show payload with relay_prompt actions", () => {
-      expect(bootstrapRef).toContain("surface_type: \"card\"");
+    test("contains email-not-connected task card variant", () => {
+      expect(bootstrapRef).toContain("Email Not Connected");
+      expect(bootstrapRef).toContain("Connect my email");
       expect(bootstrapRef).toContain("relay_prompt");
+    });
+
+    test("contains email-already-connected task card variant", () => {
+      expect(bootstrapRef).toContain("Email Already Connected");
+      expect(bootstrapRef).toContain("Check my email");
     });
   });
 

--- a/assistant/src/prompts/templates/BOOTSTRAP-REFERENCE.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-REFERENCE.md
@@ -3,12 +3,12 @@ _ This file is deleted alongside BOOTSTRAP.md when onboarding completes.
 
 ## Personality Form
 
-Use this exact `ui_show` payload for Phase 2 Step 2 (Personality setup):
+Use this exact `ui_show` payload for Step 2 (Personality Quiz):
 
 ui_show({
   surface_type: "form",
   data: {
-    description: "Let's dial in how I talk to you. Pick what feels right.",
+    description: "Let's figure out how we work together. Pick what feels right.",
     fields: [
       {
         id: "communication_style",
@@ -34,42 +34,67 @@ ui_show({
           { label: "Ask me before making big decisions", value: "check_first" },
           { label: "Be opinionated, push back if you disagree", value: "opinionated" }
         ]
+      },
+      {
+        id: "humor",
+        type: "select",
+        label: "When it comes to humor...",
+        required: true,
+        options: [
+          { label: "Dry and deadpan", value: "dry" },
+          { label: "Playful and light", value: "playful" },
+          { label: "Keep it professional", value: "professional" },
+          { label: "Match my energy", value: "match" }
+        ]
+      },
+      {
+        id: "depth",
+        type: "select",
+        label: "When explaining things...",
+        required: true,
+        options: [
+          { label: "Keep it simple", value: "simple" },
+          { label: "I like details", value: "detailed" },
+          { label: "Depends on the topic", value: "adaptive" }
+        ]
       }
     ],
     submitLabel: "Lock it in"
   }
 })
 
-## Task Card
+## Task Card (Email Not Connected)
 
-Use this `ui_show` payload for Phase 1 Path B (user asks what you can do):
+Use this `ui_show` payload for Step 4 when Gmail/Outlook is NOT in the Connected Services section:
 
 ui_show({
   surface_type: "card",
   data: {
-    title: "Pick something. I'll show you what I can do.",
-    body: "These are real, not demos. I'll actually do them right now."
+    title: "Pick something. I'll do it right now.",
+    body: "These are real, not demos."
   },
   actions: [
-    { id: "relay_prompt", label: "Summarize a file on my machine", data: { prompt: "I have a file I'd like you to read and summarize for me" } },
+    { id: "relay_prompt", label: "Connect my email", data: { prompt: "I'd like to connect my Gmail or Outlook so you can help me manage my email and calendar" } },
     { id: "relay_prompt", label: "Research a topic and make me a deck", data: { prompt: "I'd like you to research a topic for me and turn it into a visual deck" } },
-    { id: "relay_prompt", label: "Vibe code an app", data: { prompt: "Help me vibe code a simple interactive app or tool" } },
-    { id: "relay_prompt", label: "Do something with a photo or video", data: { prompt: "I have a photo or video I'd like you to analyze, edit, or create something from" } },
-    { id: "relay_prompt", label: "Just chat, I'll figure it out", data: { prompt: "Let's just talk. I'm still figuring out what I need." } }
+    { id: "relay_prompt", label: "Build me something", data: { prompt: "Help me build a simple interactive app or tool" } },
+    { id: "relay_prompt", label: "Do something with a photo", data: { prompt: "I have a photo I'd like you to analyze, edit, or create something from" } }
   ]
 })
 
-## Two Suggestions Card
+## Task Card (Email Already Connected)
 
-Use this `ui_show` payload template for Phase 2 Step 5 (two more suggestions):
+Use this `ui_show` payload for Step 4 when Google or Outlook IS in the Connected Services section:
 
 ui_show({
   surface_type: "card",
-  data: { title: "What's next?", body: "Based on what I know about you so far:" },
+  data: {
+    title: "Pick something. I'll do it right now.",
+    body: "These are real, not demos."
+  },
   actions: [
-    { id: "relay_prompt", label: "...", data: { prompt: "..." } },
-    { id: "relay_prompt", label: "...", data: { prompt: "..." } }
+    { id: "relay_prompt", label: "Check my email", data: { prompt: "Check my email and calendar and give me a summary of what's going on" } },
+    { id: "relay_prompt", label: "Research a topic and make me a deck", data: { prompt: "I'd like you to research a topic for me and turn it into a visual deck" } },
+    { id: "relay_prompt", label: "Build me something", data: { prompt: "Help me build a simple interactive app or tool" } },
+    { id: "relay_prompt", label: "Do something with a photo", data: { prompt: "I have a photo I'd like you to analyze, edit, or create something from" } }
   ]
 })
-
-The two actions MUST have different labels and prompts. Double-check before calling ui_show that you are not repeating the same suggestion or anything from Phase 1.

--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -44,7 +44,7 @@ Save both names to IDENTITY.md and USER.md immediately via `file_edit`.
 
 Frame this as figuring out your working style together. Make it feel like character creation, not a survey.
 
-Say something like: "Nice to meet you, [name]. Let's figure out how we click." Then show the personality form.
+Say something like: "Nice to meet you, [name]. Let's figure out how we click." Then show the personality form (4 dropdowns: communication style, task style, humor, and depth).
 
 Read BOOTSTRAP-REFERENCE.md for the exact `ui_show` form payload. Use it verbatim.
 
@@ -70,10 +70,14 @@ When they respond:
 
 Transition naturally: "Alright, [name]. Let's put this to work. What do you want to tackle first?"
 
-Show a task card. Read BOOTSTRAP-REFERENCE.md for the exact `ui_show` card payload.
+Show a task card. **Before showing the card, check the Connected Services section of your system prompt.** If Google or Outlook is already connected, swap the "Connect my email" option for "Check my email" (see BOOTSTRAP-REFERENCE.md for both variants).
+
+Read BOOTSTRAP-REFERENCE.md for the exact `ui_show` card payload.
 
 **When the user picks an option:**
 
+- **Connect my email:** Guide them through one-click Gmail or Outlook OAuth setup. After connecting, do a quick inbox summary or calendar overview to show immediate value.
+- **Check my email:** They're already connected. Summarize their inbox or today's calendar. Show you can be useful right now.
 - **Research a topic and make me a deck:** Focused web search, 3-5 key points, build a polished interactive deck. Keep it tight, not exhaustive.
 - **Build me something:** Ask what kind of tool or app. Build it using the app builder. Make it look great.
 - **Do something with a photo:** Use media processing or image studio skills. Ask what they have and what they want.


### PR DESCRIPTION
## Summary

- Expand personality quiz from 2 to 4 dropdowns: add humor (dry/playful/professional/match) and depth (simple/detailed/adaptive)
- Add integration-aware task card variants: "Connect my email" when no email connected, "Check my email" when Google/Outlook already connected
- BOOTSTRAP.md instructs checking Connected Services section before showing the task card
- Remove old single task card and two-suggestions card templates from reference file
- Update onboarding tests for new form fields and email task variants

Closes the BOOTSTRAP.md rewrite (PR 3/3). Depends on PR #23474.

## Test plan

- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/__tests__/onboarding-template-contract.test.ts` — all 21 tests pass
- [ ] Test with connected Gmail: verify "Check my email" card variant is shown
- [ ] Test with no email connected: verify "Connect my email" card variant is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23475" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
