### PR TITLE
fix: lint error in subagent-role-registry test

### DIFF
--- a/assistant/src/__tests__/subagent-role-registry.test.ts
+++ b/assistant/src/__tests__/subagent-role-registry.test.ts
@@ -21,7 +21,7 @@ describe("SUBAGENT_ROLE_REGISTRY", () => {
   });
 
   test("every role has a non-empty systemPromptPreamble", () => {
-    for (const [role, config] of Object.entries(SUBAGENT_ROLE_REGISTRY)) {
+    for (const [_role, config] of Object.entries(SUBAGENT_ROLE_REGISTRY)) {
       expect(config.systemPromptPreamble.length).toBeGreaterThan(0);
     }
   });
@@ -40,7 +40,7 @@ describe("SUBAGENT_ROLE_REGISTRY", () => {
   });
 
   test('every role with allowedTools includes "notify_parent"', () => {
-    for (const [role, config] of Object.entries(SUBAGENT_ROLE_REGISTRY)) {
+    for (const [_role, config] of Object.entries(SUBAGENT_ROLE_REGISTRY)) {
       if (config.allowedTools !== undefined) {
         expect(config.allowedTools).toContain("notify_parent");
       }


### PR DESCRIPTION
## Summary
- Prefix unused `role` variables with `_` in `subagent-role-registry.test.ts` to satisfy the `@typescript-eslint/no-unused-vars` lint rule

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23964426873/job/69901303886