### PR TITLE
fix: filter out invalid entries in normalizeTopCandidates

### DIFF
--- a/assistant/src/memory/memory-recall-log-store.ts
+++ b/assistant/src/memory/memory-recall-log-store.ts
@@ -100,8 +100,8 @@ export interface MemoryRecallLog {
  */
 export function normalizeTopCandidates(raw: unknown): unknown {
   if (!Array.isArray(raw)) return raw;
-  return raw.map((entry: Record<string, unknown>) => {
-    if (!entry || typeof entry !== "object") return entry;
+  return raw.flatMap((entry: Record<string, unknown>) => {
+    if (!entry || typeof entry !== "object") return [];
 
     // Start with a shallow copy, then apply field renames
     const { key, finalScore, semantic, recency, kind: _kind, ...rest } = entry;


### PR DESCRIPTION
Address review feedback on #23330. The guard returned non-object entries unchanged, propagating malformed data. Now filters them out via flatMap so downstream decoding succeeds.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
