### PR TITLE
fix: move isNull guard to recovery backfill call site only

### DIFF
--- a/assistant/src/memory/llm-request-log-store.ts
+++ b/assistant/src/memory/llm-request-log-store.ts
@@ -99,9 +99,7 @@ export function setMessageIdOnLogs(
   const db = getDb();
   db.update(llmRequestLogs)
     .set({ messageId })
-    .where(
-      and(inArray(llmRequestLogs.id, logIds), isNull(llmRequestLogs.messageId)),
-    )
+    .where(inArray(llmRequestLogs.id, logIds))
     .run();
 }
 
@@ -285,13 +283,24 @@ export function getRequestLogsByMessageId(messageId: string): LogRow[] {
         );
 
         // Opportunistically backfill recovered unlinked logs so future queries
-        // hit the fast indexed-by-messageId path.
+        // hit the fast indexed-by-messageId path.  Guard with isNull so this
+        // recovery path never overwrites a messageId already set by an
+        // authoritative caller (e.g. watch-notifier).
         if (unlinkedLogs.length > 0 && turnMessageIds.length > 0) {
           try {
-            setMessageIdOnLogs(
-              unlinkedLogs.map((l) => l.id),
-              turnMessageIds[turnMessageIds.length - 1]!,
-            );
+            const db = getDb();
+            const ids = unlinkedLogs.map((l) => l.id);
+            const targetMessageId =
+              turnMessageIds[turnMessageIds.length - 1]!;
+            db.update(llmRequestLogs)
+              .set({ messageId: targetMessageId })
+              .where(
+                and(
+                  inArray(llmRequestLogs.id, ids),
+                  isNull(llmRequestLogs.messageId),
+                ),
+              )
+              .run();
           } catch {
             // non-fatal — the recovery already returned the right data
           }


### PR DESCRIPTION
Address review feedback on #23324. The isNull guard on setMessageIdOnLogs blocked authoritative watch-notifier callers from correcting linkage. Moves the guard to the recovery call site only.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23480" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
