### PR TITLE
feat: add notify_parent tool for subagent→parent communication

### DIFF
--- a/assistant/src/__tests__/subagent-notify-parent.test.ts
+++ b/assistant/src/__tests__/subagent-notify-parent.test.ts
@@ -1,0 +1,360 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, mock, test } from "bun:test";
+
+// Mock conversation-crud before importing tool executors that depend on it.
+mock.module("../memory/conversation-crud.js", () => ({
+  getConversationType: () => "default",
+  setConversationOriginChannelIfUnset: () => {},
+  updateConversationContextWindow: () => {},
+  deleteMessageById: () => {},
+  updateConversationTitle: () => {},
+  updateConversationUsage: () => {},
+  addMessage: () => ({ id: "mock-msg-id" }),
+  getConversation: () => ({
+    id: "conv-1",
+    contextSummary: null,
+    contextCompactedMessageCount: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalEstimatedCost: 0,
+    title: null,
+  }),
+  provenanceFromTrustContext: () => ({
+    source: "user",
+    trustContext: undefined,
+  }),
+  getConversationOriginInterface: () => null,
+  getConversationOriginChannel: () => null,
+  getMessages: () => null,
+  createConversation: () => ({ id: "mock-conv" }),
+}));
+
+import { getSubagentManager } from "../subagent/index.js";
+import { SubagentManager } from "../subagent/manager.js";
+import type { SubagentState } from "../subagent/types.js";
+import { executeSubagentNotifyParent } from "../tools/subagent/notify-parent.js";
+
+// Load tool definitions from the bundled skill TOOLS.json
+const toolsJson = JSON.parse(
+  readFileSync(
+    join(import.meta.dirname, "../config/bundled-skills/subagent/TOOLS.json"),
+    "utf-8",
+  ),
+);
+const findTool = (name: string) =>
+  toolsJson.tools.find((t: { name: string }) => t.name === name);
+
+// ── Shared helpers ──────────────────────────────────────────────────
+
+/**
+ * Inject a fake subagent into the singleton manager so tool executors
+ * can find it. Uses the same private-internals trick as the other tests.
+ */
+function injectSubagent(
+  manager: SubagentManager,
+  subagentId: string,
+  parentConversationId: string,
+  status: SubagentState["status"] = "running",
+  overrides: Partial<SubagentState> = {},
+): SubagentState {
+  const internals = manager as unknown as {
+    subagents: Map<
+      string,
+      {
+        conversation: unknown;
+        state: SubagentState;
+        parentSendToClient: () => void;
+      }
+    >;
+    parentToChildren: Map<string, Set<string>>;
+  };
+  const state: SubagentState = {
+    config: {
+      id: subagentId,
+      parentConversationId,
+      label: "Test",
+      objective: "test",
+    },
+    status,
+    conversationId: `conv-${subagentId}`,
+    createdAt: Date.now(),
+    usage: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
+    ...overrides,
+  };
+  const fakeConversation = {
+    abort: () => {},
+    dispose: () => {},
+    messages: [],
+    sendToClient: () => {},
+    usageStats: { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
+    enqueueMessage: () => ({ queued: false }),
+    persistUserMessage: () => "msg-1",
+    runAgentLoop: async () => {},
+  };
+  internals.subagents.set(subagentId, {
+    conversation: fakeConversation,
+    state,
+    parentSendToClient: () => {},
+  });
+  if (!internals.parentToChildren.has(parentConversationId)) {
+    internals.parentToChildren.set(parentConversationId, new Set());
+  }
+  internals.parentToChildren.get(parentConversationId)!.add(subagentId);
+  return state;
+}
+
+function makeContext(
+  conversationId: string,
+  extras: Record<string, unknown> = {},
+) {
+  return {
+    workingDir: "/tmp",
+    conversationId,
+    trustClass: "guardian" as const,
+    ...extras,
+  } as import("../tools/types.js").ToolContext;
+}
+
+// ── Tool definition ────────────────────────────────────────────────
+
+describe("notify_parent tool definition", () => {
+  test("has correct definition in TOOLS.json", () => {
+    const def = findTool("notify_parent");
+    expect(def).toBeDefined();
+    expect(def.input_schema.required).toEqual(["message"]);
+    expect(def.input_schema.properties.urgency.enum).toEqual([
+      "info",
+      "important",
+      "blocked",
+    ]);
+    expect(def.risk).toBe("low");
+    expect(def.execution_target).toBe("host");
+  });
+});
+
+// ── executeSubagentNotifyParent ────────────────────────────────────
+
+describe("executeSubagentNotifyParent", () => {
+  test("rejects calls from non-subagent conversations", async () => {
+    const result = await executeSubagentNotifyParent(
+      { message: "Found something important" },
+      makeContext("not-a-subagent-conv"),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Could not notify parent");
+    expect(result.content).toContain("only available to subagents");
+  });
+
+  test("succeeds when called from a subagent conversation", async () => {
+    const manager = getSubagentManager();
+    const subagentId = "notify-sub-1";
+    const parentConversationId = "notify-parent-1";
+    injectSubagent(manager, subagentId, parentConversationId, "running");
+
+    // Wire up the onSubagentFinished callback.
+    let capturedMessage = "";
+    manager.onSubagentFinished = (
+      _parentId: string,
+      message: string,
+    ) => {
+      capturedMessage = message;
+    };
+
+    try {
+      const result = await executeSubagentNotifyParent(
+        { message: "Found key results", urgency: "important" },
+        makeContext(`conv-${subagentId}`),
+      );
+      expect(result.isError).toBe(false);
+      const parsed = JSON.parse(result.content);
+      expect(parsed.sent).toBe(true);
+      expect(parsed.urgency).toBe("important");
+      expect(capturedMessage).toContain("Found key results");
+    } finally {
+      manager.onSubagentFinished = undefined;
+    }
+  });
+
+  test("formats message with label and urgency", async () => {
+    const manager = getSubagentManager();
+    const subagentId = "notify-format-1";
+    const parentConversationId = "notify-format-parent";
+    injectSubagent(manager, subagentId, parentConversationId, "running", {
+      config: {
+        id: subagentId,
+        parentConversationId,
+        label: "Research Task",
+        objective: "research",
+      },
+    });
+
+    let capturedMessage = "";
+    manager.onSubagentFinished = (
+      _parentId: string,
+      message: string,
+    ) => {
+      capturedMessage = message;
+    };
+
+    try {
+      await executeSubagentNotifyParent(
+        { message: "Preliminary findings ready", urgency: "info" },
+        makeContext(`conv-${subagentId}`),
+      );
+      expect(capturedMessage).toBe(
+        '[Subagent "Research Task" — info] Preliminary findings ready',
+      );
+    } finally {
+      manager.onSubagentFinished = undefined;
+    }
+  });
+
+  test("returns error when message is empty", async () => {
+    const result = await executeSubagentNotifyParent(
+      { message: "" },
+      makeContext("some-conv"),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('"message" is required');
+  });
+
+  test("returns error when message is missing", async () => {
+    const result = await executeSubagentNotifyParent(
+      {},
+      makeContext("some-conv"),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('"message" is required');
+  });
+
+  test("defaults urgency to info when not provided", async () => {
+    const manager = getSubagentManager();
+    const subagentId = "notify-default-urg-1";
+    const parentConversationId = "notify-default-urg-parent";
+    injectSubagent(manager, subagentId, parentConversationId, "running");
+
+    manager.onSubagentFinished = () => {};
+
+    try {
+      const result = await executeSubagentNotifyParent(
+        { message: "Progress update" },
+        makeContext(`conv-${subagentId}`),
+      );
+      expect(result.isError).toBe(false);
+      const parsed = JSON.parse(result.content);
+      expect(parsed.urgency).toBe("info");
+    } finally {
+      manager.onSubagentFinished = undefined;
+    }
+  });
+
+  test("appends guidance hint for blocked urgency", async () => {
+    const manager = getSubagentManager();
+    const subagentId = "notify-blocked-1";
+    const parentConversationId = "notify-blocked-parent";
+    injectSubagent(manager, subagentId, parentConversationId, "running");
+
+    let capturedMessage = "";
+    manager.onSubagentFinished = (
+      _parentId: string,
+      message: string,
+    ) => {
+      capturedMessage = message;
+    };
+
+    try {
+      await executeSubagentNotifyParent(
+        { message: "Need API key to proceed", urgency: "blocked" },
+        makeContext(`conv-${subagentId}`),
+      );
+      expect(capturedMessage).toContain("Need API key to proceed");
+      expect(capturedMessage).toContain(
+        "Use subagent_message to send guidance to this subagent.",
+      );
+    } finally {
+      manager.onSubagentFinished = undefined;
+    }
+  });
+});
+
+// ── Manager-level tests ────────────────────────────────────────────
+
+describe("SubagentManager.notifyParent", () => {
+  test("returns false for terminal subagents", () => {
+    const manager = getSubagentManager();
+
+    for (const terminalStatus of [
+      "completed",
+      "failed",
+      "aborted",
+    ] as const) {
+      const subagentId = `notify-terminal-${terminalStatus}`;
+      const parentConversationId = `notify-terminal-parent-${terminalStatus}`;
+      injectSubagent(
+        manager,
+        subagentId,
+        parentConversationId,
+        terminalStatus,
+      );
+
+      manager.onSubagentFinished = () => {};
+
+      try {
+        const result = manager.notifyParent(
+          `conv-${subagentId}`,
+          "Should not arrive",
+          "info",
+        );
+        expect(result).toBe(false);
+      } finally {
+        manager.onSubagentFinished = undefined;
+      }
+    }
+  });
+
+  test("returns false when onSubagentFinished is not wired", () => {
+    const manager = getSubagentManager();
+    const subagentId = "notify-no-callback-1";
+    const parentConversationId = "notify-no-callback-parent";
+    injectSubagent(manager, subagentId, parentConversationId, "running");
+
+    manager.onSubagentFinished = undefined;
+
+    const result = manager.notifyParent(
+      `conv-${subagentId}`,
+      "Test message",
+      "info",
+    );
+    expect(result).toBe(false);
+  });
+});
+
+describe("SubagentManager.getParentInfo", () => {
+  test("returns undefined for unknown conversationIds", () => {
+    const manager = getSubagentManager();
+    const result = manager.getParentInfo("nonexistent-conversation-id");
+    expect(result).toBeUndefined();
+  });
+
+  test("returns parent info for known subagent conversationId", () => {
+    const manager = getSubagentManager();
+    const subagentId = "parent-info-sub-1";
+    const parentConversationId = "parent-info-parent-1";
+    injectSubagent(manager, subagentId, parentConversationId, "running", {
+      config: {
+        id: subagentId,
+        parentConversationId,
+        label: "Info Lookup",
+        objective: "look things up",
+      },
+    });
+
+    const info = manager.getParentInfo(`conv-${subagentId}`);
+    expect(info).toBeDefined();
+    expect(info!.parentConversationId).toBe(parentConversationId);
+    expect(info!.subagentId).toBe(subagentId);
+    expect(info!.label).toBe("Info Lookup");
+    expect(typeof info!.parentSendToClient).toBe("function");
+  });
+});

--- a/assistant/src/config/bundled-skills/subagent/TOOLS.json
+++ b/assistant/src/config/bundled-skills/subagent/TOOLS.json
@@ -126,6 +126,33 @@
       },
       "executor": "tools/subagent-read.ts",
       "execution_target": "host"
+    },
+    {
+      "name": "notify_parent",
+      "description": "Send a notification to the parent conversation. Use this for important findings, when you're blocked, or when you have preliminary results the parent should know about. Do not overuse — notify for significant findings, not after every tool call.",
+      "category": "orchestration",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "The notification content for the parent."
+          },
+          "urgency": {
+            "type": "string",
+            "enum": ["info", "important", "blocked"],
+            "description": "'info' for progress updates, 'important' for key findings, 'blocked' when you need guidance."
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["message"]
+      },
+      "executor": "tools/subagent-notify-parent.ts",
+      "execution_target": "host"
     }
   ]
 }

--- a/assistant/src/config/bundled-skills/subagent/tools/subagent-notify-parent.ts
+++ b/assistant/src/config/bundled-skills/subagent/tools/subagent-notify-parent.ts
@@ -1,0 +1,12 @@
+import { executeSubagentNotifyParent } from "../../../../tools/subagent/notify-parent.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeSubagentNotifyParent(input, context);
+}

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -59,7 +59,7 @@ interface ManagedSubagent {
 export interface SubagentNotificationInfo {
   subagentId: string;
   label: string;
-  status: "completed" | "failed" | "aborted";
+  status: "running" | "completed" | "failed" | "aborted";
   error?: string;
   conversationId?: string;
 }
@@ -267,7 +267,7 @@ export class SubagentManager {
         log.info({ subagentId }, "Subagent completed");
 
         // Notify the parent conversation so the LLM can call subagent_read.
-        this.notifyParent(managed, "completed", getSender());
+        this.notifyParentTerminal(managed, "completed", getSender());
       }
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
@@ -278,7 +278,7 @@ export class SubagentManager {
       // Only update status if not already terminal (e.g. aborted).
       if (!TERMINAL_STATUSES.has(managed.state.status)) {
         this.setStatus(subagentId, "failed", getSender(), errorMsg);
-        this.notifyParent(managed, "failed", getSender());
+        this.notifyParentTerminal(managed, "failed", getSender());
       }
 
       log.error({ subagentId, err }, "Subagent failed");
@@ -529,11 +529,82 @@ export class SubagentManager {
     } as ServerMessage);
   }
 
+  // ── Child → Parent notification ────────────────────────────────────
+
+  /**
+   * Look up the parent info for a child conversation.
+   * Returns undefined if the conversationId doesn't belong to a subagent.
+   */
+  getParentInfo(childConversationId: string):
+    | {
+        parentConversationId: string;
+        subagentId: string;
+        label: string;
+        parentSendToClient: (msg: ServerMessage) => void;
+      }
+    | undefined {
+    for (const [subagentId, managed] of this.subagents) {
+      if (managed.state.conversationId === childConversationId) {
+        return {
+          parentConversationId: managed.state.config.parentConversationId,
+          subagentId,
+          label: managed.state.config.label,
+          parentSendToClient: managed.parentSendToClient,
+        };
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Send a notification from a running subagent to its parent conversation.
+   * Returns true if the notification was sent, false if the child is not a
+   * subagent, is in a terminal state, or the parent callback is not wired.
+   */
+  notifyParent(
+    childConversationId: string,
+    message: string,
+    urgency: string,
+  ): boolean {
+    const info = this.getParentInfo(childConversationId);
+    if (!info) return false;
+
+    const managed = this.subagents.get(info.subagentId);
+    if (!managed || TERMINAL_STATUSES.has(managed.state.status)) return false;
+    if (!this.onSubagentFinished) return false;
+
+    let notificationString = `[Subagent "${info.label}" — ${urgency}] ${message}`;
+    if (urgency === "blocked") {
+      notificationString +=
+        "\nUse subagent_message to send guidance to this subagent.";
+    }
+
+    try {
+      this.onSubagentFinished(
+        info.parentConversationId,
+        notificationString,
+        info.parentSendToClient,
+        {
+          subagentId: info.subagentId,
+          label: info.label,
+          status: "running",
+        },
+      );
+      return true;
+    } catch (err) {
+      log.error(
+        { subagentId: info.subagentId, err },
+        "Failed to notify parent from subagent",
+      );
+      return false;
+    }
+  }
+
   /**
    * Inject a completion/failure notification into the parent conversation
    * so the LLM automatically informs the user.
    */
-  private notifyParent(
+  private notifyParentTerminal(
     managed: ManagedSubagent,
     outcome: "completed" | "failed",
     parentSendToClient: (msg: ServerMessage) => void,

--- a/assistant/src/tools/subagent/notify-parent.ts
+++ b/assistant/src/tools/subagent/notify-parent.ts
@@ -1,0 +1,30 @@
+import { getSubagentManager } from "../../subagent/index.js";
+import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+export async function executeSubagentNotifyParent(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const message = input.message as string;
+  const urgency = (input.urgency as string) || "info";
+
+  if (!message) {
+    return { content: '"message" is required.', isError: true };
+  }
+
+  const manager = getSubagentManager();
+  const sent = manager.notifyParent(context.conversationId, message, urgency);
+
+  if (!sent) {
+    return {
+      content:
+        "Could not notify parent. This tool is only available to subagents.",
+      isError: true,
+    };
+  }
+
+  return {
+    content: JSON.stringify({ sent: true, urgency }),
+    isError: false,
+  };
+}


### PR DESCRIPTION
## Summary
- Add getParentInfo and notifyParent methods to SubagentManager
- Add notify_parent tool executor and bundled skill wrapper
- Register notify_parent in the subagent bundled skill TOOLS.json

Part of plan: subagent-delegation-system.md (PR 3 of 7)