### PR TITLE
fix: exclude host_bash from proxied network risk downgrade

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -689,7 +689,7 @@ export async function classifyRisk(
   // per-request approval separately. Cap the bash tool's own risk at Medium
   // so trust rules can auto-allow the command execution.
   if (
-    (toolName === "bash" || toolName === "host_bash") &&
+    toolName === "bash" &&
     input.network_mode === "proxied" &&
     result === RiskLevel.High
   ) {


### PR DESCRIPTION
Address review feedback on #23343. host_bash doesn't implement proxied mode, so the risk downgrade was a security bypass. Now only sandboxed bash tools get the medium-risk cap.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
