### PR TITLE
fix: recompute prompt model when selected inspector entry changes

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorPromptTab.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorPromptTab.swift
@@ -29,7 +29,7 @@ struct MessageInspectorPromptTab: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(VColor.surfaceBase)
-        .task {
+        .task(id: entry.id) {
             model = MessageInspectorPromptTabModel(entry: entry)
         }
     }


### PR DESCRIPTION
Address review feedback on #23347. The .task modifier without id only ran on first appear, causing stale model when switching entries. Adds entry.id to trigger refresh.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23485" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
