### PR TITLE
fix: auto-load remaining conversations for pinned section when beyond page size

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -191,6 +191,20 @@ struct SidebarSectionView: View {
         }
 
         showMoreLessButton
+
+        // When all loaded conversations fit within maxCollapsed (e.g. pinned
+        // sections use .max) the show-more button never appears, yet more
+        // conversations may exist on the server beyond the initial page.
+        // Auto-trigger a full load so those items become visible.
+        if conversations.count <= maxCollapsed,
+           let conversationManager,
+           conversationManager.hasMoreConversations {
+            Color.clear
+                .frame(height: 0)
+                .onAppear {
+                    conversationManager.loadAllRemainingConversations()
+                }
+        }
     }
 
     // MARK: - Schedule Sub-Groups


### PR DESCRIPTION
## Summary
- Address review feedback on #23338
- The `maxCollapsed: .max` change for pinned conversations inadvertently removed the "Show More" button since `conversations.count > Int.max` is never true
- The initial restore only fetches 50 conversations, so workspaces with >50 pinned conversations could never load older pinned items
- Adds an auto-load trigger in `SidebarSectionView.flatContent` that fires `loadAllRemainingConversations()` when all loaded items fit within `maxCollapsed` but more exist on the server

## Test plan
- [ ] Verify pinned section still shows all loaded conversations without truncation
- [ ] Verify that with >50 pinned conversations, remaining items auto-load when the section appears
- [ ] Verify the "Show more" button still works for non-pinned sections with >5 conversations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
