### PR TITLE
fix: remove dead high-risk proxy code after risk downgrade

### DIFF
--- a/assistant/src/__tests__/proxy-approval-callback.test.ts
+++ b/assistant/src/__tests__/proxy-approval-callback.test.ts
@@ -486,40 +486,6 @@ describe("createProxyApprovalCallback", () => {
   // in contrast to the proxied bash activation path which CANNOT (tested
   // in tool-executor.test.ts).
 
-  test("always_allow_high_risk persists rule with allowHighRisk flag", async () => {
-    const ctx = makeContext();
-    const prompterSendToClient = mock(() => {});
-    const prompter = new PermissionPrompter(prompterSendToClient);
-
-    const originalPrompt = prompter.prompt.bind(prompter);
-    prompter.prompt = async (...args) => {
-      const p = originalPrompt(...args);
-      await new Promise((r) => setTimeout(r, 10));
-      const call = (prompterSendToClient.mock.calls as unknown[][])[0];
-      const msg = call[0] as { requestId: string };
-      prompter.resolveConfirmation(
-        msg.requestId,
-        "always_allow_high_risk",
-        "network_request:https://api.fal.ai:443/*",
-        "/tmp/test-project",
-      );
-      return p;
-    };
-
-    const callback = createProxyApprovalCallback(prompter, ctx);
-    const result = await callback(makeAskMissingCredentialRequest());
-
-    expect(result).toBe(true);
-    expect(addRuleMock).toHaveBeenCalledWith(
-      "network_request",
-      "network_request:https://api.fal.ai:443/*",
-      "/tmp/test-project",
-      "allow",
-      100,
-      { allowHighRisk: true },
-    );
-  });
-
   test("one-time allow does NOT persist any rule", async () => {
     const ctx = makeContext();
     const prompterSendToClient = mock(() => {});

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -375,8 +375,7 @@ export function createProxyApprovalCallback(
 
     // Persist trust rule if the user chose "always allow" or "always deny"
     if (
-      (response.decision === "always_allow" ||
-        response.decision === "always_allow_high_risk") &&
+      response.decision === "always_allow" &&
       response.selectedPattern &&
       response.selectedScope
     ) {
@@ -385,7 +384,6 @@ export function createProxyApprovalCallback(
           toolName,
           pattern: response.selectedPattern,
           scope: response.selectedScope,
-          highRisk: response.decision === "always_allow_high_risk",
         },
         "Persisting always-allow trust rule (proxy)",
       );
@@ -395,9 +393,6 @@ export function createProxyApprovalCallback(
         response.selectedScope,
         "allow",
         100,
-        response.decision === "always_allow_high_risk"
-          ? { allowHighRisk: true }
-          : undefined,
       );
     }
     if (


### PR DESCRIPTION
Address review feedback on #23339. Cleans up unreachable `always_allow_high_risk` branches and stale `allowHighRisk` flag handling left behind when proxied network request risk was hardcoded to medium.

Since the Swift client only sends `always_allow_high_risk` when `riskLevel` is `"high"` (ToolConfirmationBubble.swift:61), and proxy requests hardcode `riskLevel: "medium"`, the high-risk branches were dead code.

Changes:
- Remove `always_allow_high_risk` condition from proxy trust-rule persistence
- Remove `allowHighRisk` flag from `addRule` call
- Remove `highRisk` field from log output
- Remove corresponding dead-code test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
