### PR TITLE
fix: stabilize pagination offsets when injecting pinned conversations

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -1049,6 +1049,7 @@ export class RuntimeHttpServer {
           const attentionStates =
             getAttentionStateByConversationIds(conversationIds);
           const parentCache = new Map<string, ConversationRow | null>();
+          const nextOffset = offset + limit;
           const response: Record<string, unknown> = {
             conversations: rows.map((conversation) =>
               this.serializeConversationSummary({
@@ -1059,7 +1060,8 @@ export class RuntimeHttpServer {
                 parentCache,
               }),
             ),
-            hasMore: offset + rows.length < totalCount,
+            nextOffset,
+            hasMore: nextOffset < totalCount,
           };
           // Include groups array on first page only
           if (offset === 0) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationListStore.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationListStore.swift
@@ -594,9 +594,13 @@ final class ConversationListStore {
 
     /// Handle appended conversations from a "load more" response.
     func appendConversations(from response: ConversationListResponseMessage) {
-        // Increment offset by the unfiltered count so pagination stays aligned
-        // with the daemon's row numbering regardless of client-side filtering.
-        serverOffset += response.conversations.count
+        // Use the server-provided nextOffset (DB-level pagination) so injected
+        // pinned conversations don't inflate the offset and skip rows.
+        if let nextOffset = response.nextOffset {
+            serverOffset = nextOffset
+        } else {
+            serverOffset += response.conversations.count
+        }
 
         // Merge groups if provided (first page only from server).
         if let responseGroups = response.groups, !responseGroups.isEmpty {

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -3457,13 +3457,17 @@ public struct ConversationListResponse: Codable, Sendable {
     public let conversations: [ConversationListResponseItem]
     /// Whether more conversations exist beyond the returned page.
     public let hasMore: Bool?
+    /// The offset to use for the next page request. Based on DB-level
+    /// pagination so injected pinned conversations don't inflate the value.
+    public let nextOffset: Int?
     /// Available conversation groups. Sent with the first page only.
     public let groups: [ConversationGroupResponse]?
 
-    public init(type: String, conversations: [ConversationListResponseItem], hasMore: Bool? = nil, groups: [ConversationGroupResponse]? = nil) {
+    public init(type: String, conversations: [ConversationListResponseItem], hasMore: Bool? = nil, nextOffset: Int? = nil, groups: [ConversationGroupResponse]? = nil) {
         self.type = type
         self.conversations = conversations
         self.hasMore = hasMore
+        self.nextOffset = nextOffset
         self.groups = groups
     }
 }


### PR DESCRIPTION
Address review feedback on #23340. Injected pinned conversations inflated response size, breaking offset-based pagination. Returns pinned items separately so the client doesn't count them toward offset.

## Changes

- **Server**: Add `nextOffset` field (= `offset + limit`) to conversations list response, fix `hasMore` to use DB-level offset instead of inflated `rows.length`
- **Swift types**: Add `nextOffset: Int?` to `ConversationListResponse`
- **macOS client**: Use `response.nextOffset` when available instead of `response.conversations.count` for offset advancement (backwards-compatible fallback retained)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23491" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
