### PR TITLE
fix: re-inject NOW.md after compaction and fix stale comment

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -910,9 +910,12 @@ export async function runAgentLoopImpl(
           shouldInjectWorkspace = true;
         }
 
-        // Re-inject with potentially downgraded injection mode
+        // Re-inject with potentially downgraded injection mode.
+        // Override nowScratchpad: compaction strips existing NOW.md blocks,
+        // so we must re-inject the current content unconditionally.
         runMessages = applyRuntimeInjections(ctx.messages, {
           ...injectionOpts,
+          nowScratchpad: currentNowContent,
           workspaceTopLevelContext: shouldInjectWorkspace
             ? ctx.workspaceTopLevelContext
             : null,
@@ -1103,9 +1106,13 @@ export async function runAgentLoopImpl(
         shouldInjectWorkspace = true;
       }
 
-      // Re-inject runtime context and re-enter the agent loop
+      // Re-inject runtime context and re-enter the agent loop.
+      // After compaction, stripInjectionsForCompaction() removes the existing
+      // NOW.md block from history, so we must re-inject the current content
+      // even if it hasn't changed since the last injection.
       runMessages = applyRuntimeInjections(ctx.messages, {
         ...injectionOpts,
+        nowScratchpad: currentNowContent,
         workspaceTopLevelContext: shouldInjectWorkspace
           ? ctx.workspaceTopLevelContext
           : null,
@@ -1312,6 +1319,7 @@ export async function runAgentLoopImpl(
 
         runMessages = applyRuntimeInjections(ctx.messages, {
           ...injectionOpts,
+          nowScratchpad: currentNowContent,
           workspaceTopLevelContext: shouldInjectWorkspace
             ? ctx.workspaceTopLevelContext
             : null,
@@ -1430,6 +1438,7 @@ export async function runAgentLoopImpl(
 
             runMessages = applyRuntimeInjections(ctx.messages, {
               ...injectionOpts,
+              nowScratchpad: currentNowContent,
               workspaceTopLevelContext: shouldInjectWorkspace
                 ? ctx.workspaceTopLevelContext
                 : null,
@@ -1546,6 +1555,7 @@ export async function runAgentLoopImpl(
 
           runMessages = applyRuntimeInjections(ctx.messages, {
             ...injectionOpts,
+            nowScratchpad: currentNowContent,
             workspaceTopLevelContext: shouldInjectWorkspace
               ? ctx.workspaceTopLevelContext
               : null,

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -682,10 +682,10 @@ export class AnthropicProvider implements Provider {
         }
       }
 
-      // Thinking blocks are stripped at persistence time (consolidation and
-      // DB migration 208) so historical messages are clean when loaded.
-      // Within a turn, assistant messages have original thinking with valid
-      // signatures — the API accepts them. No provider-side stripping needed.
+      // Thinking blocks are stripped at rest by DB migration 209 so
+      // historical messages are clean when loaded. Within a turn,
+      // assistant messages have original thinking with valid signatures
+      // — the API accepts them. No provider-side stripping needed.
 
       sentMessages = ensureToolPairing(repairOrphanedServerToolUse(formatted));
       const { effort, speed, output_config, ...restConfig } = (config ??


### PR DESCRIPTION
Address review feedback on #23353. NOW.md was silently lost after compaction because the pre-computed null value was reused. Now stores current content for re-injection at all 5 post-compaction sites. Also fixes comment referencing removed consolidation code and wrong migration number (208 → 209).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
