### PR TITLE
feat: wire agent roles into SubagentManager with tool scoping and role prompts

### DIFF
--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -1083,3 +1083,77 @@ describe("Label-based subagent lookup", () => {
     }
   });
 });
+
+// ── Role-based spawn ──────────────────────────────────────────────
+
+describe("Subagent role-based spawn", () => {
+  test("spawn with role 'researcher' passes role to manager", async () => {
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+    let capturedConfig: Record<string, unknown> | undefined;
+
+    manager.spawn = async (config: Record<string, unknown>) => {
+      capturedConfig = config;
+      return "role-researcher-id";
+    };
+
+    try {
+      const result = await executeSubagentSpawn(
+        {
+          label: "Research task",
+          objective: "Find pricing data",
+          role: "researcher",
+        },
+        makeContext("sess-role-1", { sendToClient: () => {} }),
+      );
+      expect(result.isError).toBe(false);
+      const parsed = JSON.parse(result.content);
+      expect(parsed.subagentId).toBe("role-researcher-id");
+      expect(capturedConfig).toBeDefined();
+      expect(capturedConfig!.role).toBe("researcher");
+    } finally {
+      manager.spawn = originalSpawn;
+    }
+  });
+
+  test("spawn without role defaults to general (backwards compat)", async () => {
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+    let capturedConfig: Record<string, unknown> | undefined;
+
+    manager.spawn = async (config: Record<string, unknown>) => {
+      capturedConfig = config;
+      return "role-default-id";
+    };
+
+    try {
+      const result = await executeSubagentSpawn(
+        { label: "General task", objective: "Do something" },
+        makeContext("sess-role-2", { sendToClient: () => {} }),
+      );
+      expect(result.isError).toBe(false);
+      const parsed = JSON.parse(result.content);
+      expect(parsed.subagentId).toBe("role-default-id");
+      expect(capturedConfig).toBeDefined();
+      // When role is not specified, it should not be present in config
+      expect(capturedConfig!.role).toBeUndefined();
+    } finally {
+      manager.spawn = originalSpawn;
+    }
+  });
+
+  test("spawn tool definition includes role property", () => {
+    const def = findTool("subagent_spawn");
+    expect(def).toBeDefined();
+    expect(def.input_schema.properties.role).toBeDefined();
+    expect(def.input_schema.properties.role.type).toBe("string");
+    expect(def.input_schema.properties.role.enum).toEqual([
+      "general",
+      "researcher",
+      "coder",
+      "planner",
+    ]);
+    // role is not required
+    expect(def.input_schema.required).not.toContain("role");
+  });
+});

--- a/assistant/src/config/bundled-skills/subagent/TOOLS.json
+++ b/assistant/src/config/bundled-skills/subagent/TOOLS.json
@@ -25,6 +25,11 @@
             "type": "boolean",
             "description": "Whether to present the subagent's result to the user when it completes. Defaults to true. Set to false for internal/silent processing."
           },
+          "role": {
+            "type": "string",
+            "enum": ["general", "researcher", "coder", "planner"],
+            "description": "Agent specialization that controls tool access. 'researcher': read-only (web, files, memory). 'coder': file and bash access. 'planner': read-only analysis. 'general': full access (default)."
+          },
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -23,7 +23,9 @@ import { getLogger } from "../util/logger.js";
 import { getSandboxWorkingDir } from "../util/platform.js";
 import {
   SUBAGENT_LIMITS,
+  SUBAGENT_ROLE_REGISTRY,
   type SubagentConfig,
+  type SubagentRole,
   type SubagentState,
   type SubagentStatus,
   TERMINAL_STATUSES,
@@ -33,17 +35,24 @@ const log = getLogger("subagent-manager");
 
 // ── Default subagent system prompt ──────────────────────────────────────
 
-function buildSubagentSystemPrompt(config: SubagentConfig): string {
+function buildSubagentSystemPrompt(config: SubagentConfig, role: SubagentRole): string {
+  const roleConfig = SUBAGENT_ROLE_REGISTRY[role];
   const sections: string[] = [
-    "You are a focused subagent working on a specific task delegated by a parent assistant.",
-    "Complete the task thoroughly and concisely.",
+    roleConfig.systemPromptPreamble,
     "",
-    `## Your Task`,
+    "## Your Task",
     config.objective,
   ];
   if (config.context) {
     sections.push("", "## Context from Parent", config.context);
   }
+  sections.push(
+    "",
+    "## Constraints",
+    `- Role: ${role}`,
+    "- You cannot spawn nested subagents.",
+    "- Use notify_parent to report important findings or if you are blocked.",
+  );
   return sections.join("\n");
 }
 
@@ -121,6 +130,10 @@ export class SubagentManager {
       );
     }
 
+    // ── Resolve role ─────────────────────────────────────────────────
+    const role: SubagentRole = (config.role as SubagentRole) ?? "general";
+    const roleConfig = SUBAGENT_ROLE_REGISTRY[role];
+
     // ── Create conversation ─────────────────────────────────────────
     const subagentId = uuid();
     const conversationRecord = bootstrapConversation({
@@ -143,7 +156,7 @@ export class SubagentManager {
 
     const systemPrompt =
       config.systemPromptOverride ??
-      buildSubagentSystemPrompt({ ...config, id: subagentId });
+      buildSubagentSystemPrompt({ ...config, id: subagentId }, role);
     const maxTokens = appConfig.maxTokens;
     const workingDir = getSandboxWorkingDir();
 
@@ -197,6 +210,16 @@ export class SubagentManager {
     // Mark conversation as having no direct client — it routes through parent.
     // This ensures interactive prompts (host attachment reads) fail fast.
     conversation.updateClient(wrappedSendToClient, true);
+
+    // Apply role-based tool filter if the role defines one.
+    if (roleConfig.allowedTools) {
+      conversation.setSubagentAllowedTools(new Set(roleConfig.allowedTools));
+    }
+
+    // Pre-activate skills defined by the role config.
+    if (roleConfig.skillIds.length > 0) {
+      conversation.setPreactivatedSkillIds(roleConfig.skillIds);
+    }
 
     managed.conversation = conversation;
     this.subagents.set(subagentId, managed);

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -9,6 +9,7 @@ export async function executeSubagentSpawn(
   const objective = input.objective as string;
   const extraContext = input.context as string | undefined;
   const sendResultToUser = input.send_result_to_user !== false;
+  const role = (input.role as string | undefined) ?? undefined;
 
   if (!label || !objective) {
     return {
@@ -36,6 +37,7 @@ export async function executeSubagentSpawn(
         objective,
         context: extraContext,
         sendResultToUser,
+        ...(role ? { role: role as import("../../subagent/types.js").SubagentRole } : {}),
       },
       sendToClient as (msg: unknown) => void,
     );


### PR DESCRIPTION
## Summary
- Wire SubagentRole resolution into SubagentManager.spawn()
- Apply role-based tool allowlist via conversation.setSubagentAllowedTools()
- Refactor buildSubagentSystemPrompt to use role-specific preambles and constraints
- Expose role parameter on subagent_spawn tool

Part of plan: subagent-delegation-system.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
