### PR TITLE
fix: use loopback URL for guardian token lease during local hatch

### DIFF
--- a/cli/src/lib/hatch-local.ts
+++ b/cli/src/lib/hatch-local.ts
@@ -308,10 +308,13 @@ export async function hatchLocal(
   }
 
   // Lease a guardian token so the desktop app can import it on first launch
-  // instead of hitting /v1/guardian/init itself.
+  // instead of hitting /v1/guardian/init itself. Use loopback to satisfy
+  // the daemon's local-only check — the mDNS runtimeUrl resolves to a LAN
+  // IP which the daemon rejects as non-loopback.
   emitProgress(6, 7, "Securing connection...");
+  const loopbackUrl = `http://127.0.0.1:${resources.gatewayPort}`;
   try {
-    await leaseGuardianToken(runtimeUrl, instanceName);
+    await leaseGuardianToken(loopbackUrl, instanceName);
   } catch (err) {
     console.error(`⚠️  Guardian token lease failed: ${err}`);
   }


### PR DESCRIPTION
## Summary
- `leaseGuardianToken` was called with the mDNS runtime URL (e.g. `http://iad20-...local:7830`), which resolves to a LAN IP
- The daemon's `/v1/guardian/init` endpoint rejects non-loopback peers with 403 "Bootstrap endpoint is local-only"
- This caused every `desktop-app-hatched` E2E test to fail the assistant export with 401 Unauthorized (no guardian token)
- Fix: use `http://127.0.0.1:<port>` for the lease call since it's always a same-machine operation

## Root cause trace
1. `startGateway()` returns the mDNS public URL (e.g. `http://iad20-...local:7830`)
2. `leaseGuardianToken(runtimeUrl, ...)` calls `/v1/guardian/init` at that URL
3. The TCP connection arrives from the LAN interface, so `server.requestIP()` returns a non-loopback IP
4. The daemon rejects: `{"code":"FORBIDDEN","message":"Bootstrap endpoint is local-only"}`
5. Hatch continues (error swallowed), but no `guardian-token.json` is created
6. Any subsequent authenticated gateway request fails with 401

## Test plan
- [ ] `vellum hatch` on macOS with mDNS hostname succeeds in leasing a guardian token
- [ ] E2E `desktop-app-hatched` tests no longer get 401 on assistant export

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
