### PR TITLE
fix: prevent platform blanket-deny from disabling GA feature flags

### DIFF
--- a/gateway/src/__tests__/remote-feature-flag-sync.test.ts
+++ b/gateway/src/__tests__/remote-feature-flag-sync.test.ts
@@ -428,6 +428,43 @@ describe("RemoteFeatureFlagSync", () => {
     );
   });
 
+  test("ignores remote false for GA flags (defaultEnabled: true in registry)", async () => {
+    // The platform sends false for all flags it knows about (blanket-deny).
+    // GA flags (defaultEnabled: true in the registry) should not be disabled
+    // by remote overrides — only local persisted overrides can do that.
+    fetchMock = mock(async () =>
+      Response.json({
+        flags: {
+          // GA flag (defaultEnabled: true) — remote false should be dropped
+          "conversation-starters": false,
+          // Gated flag (defaultEnabled: false) — remote false is kept
+          "email-channel": false,
+          // GA flag set to true — should be kept (redundant but harmless)
+          browser: true,
+          // Unknown flag — remote false is kept (not in registry)
+          "unknown-flag": false,
+        },
+      }),
+    );
+
+    const sync = new RemoteFeatureFlagSync({
+      credentials: fakeCredentialCache(defaultCredentials()),
+    });
+    await sync.start();
+    sync.stop();
+
+    clearRemoteFeatureFlagStoreCache();
+    const cached = readRemoteFeatureFlags();
+    // conversation-starters (GA, remote false) should be absent
+    expect(cached["conversation-starters"]).toBeUndefined();
+    // email-channel (gated, remote false) should be present
+    expect(cached["email-channel"]).toBe(false);
+    // browser (GA, remote true) should be present
+    expect(cached.browser).toBe(true);
+    // unknown-flag (not in registry, remote false) should be present
+    expect(cached["unknown-flag"]).toBe(false);
+  });
+
   test("trims whitespace from credential values", async () => {
     fetchMock = mock(async () => Response.json({ flags: {} }));
 

--- a/gateway/src/remote-feature-flag-sync.ts
+++ b/gateway/src/remote-feature-flag-sync.ts
@@ -1,6 +1,7 @@
 import type { CredentialCache } from "./credential-cache.js";
 import { credentialKey } from "./credential-key.js";
 import { fetchImpl } from "./fetch.js";
+import { loadFeatureFlagDefaults } from "./feature-flag-defaults.js";
 import { writeRemoteFeatureFlags } from "./feature-flag-remote-store.js";
 import { getLogger } from "./logger.js";
 
@@ -153,12 +154,23 @@ export class RemoteFeatureFlagSync {
       return null;
     }
 
-    // Filter to boolean values only (defensive)
+    // Filter to boolean values only (defensive), and prevent the platform
+    // from disabling flags that are already GA (defaultEnabled: true in the
+    // registry). The platform uses a blanket-deny posture, sending false for
+    // every flag it knows about. Without this filter, shipped features get
+    // silently turned off for all users.
+    const registry = loadFeatureFlagDefaults();
     const result: Record<string, boolean> = {};
     for (const [key, value] of Object.entries(body.flags)) {
-      if (typeof value === "boolean") {
-        result[key] = value;
+      if (typeof value !== "boolean") continue;
+      if (!value && registry[key]?.defaultEnabled) {
+        log.debug(
+          { key },
+          "Ignoring remote false for GA flag (defaultEnabled: true)",
+        );
+        continue;
       }
+      result[key] = value;
     }
 
     return result;


### PR DESCRIPTION
## Summary
- Filters remote feature flag overrides so that GA flags (defaultEnabled: true in registry) cannot be disabled by the platform's blanket-deny posture
- Adds test verifying GA flags ignore remote false while gated/unknown flags still respect it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23496" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
