### PR TITLE
fix: skip synthetic user placeholders when selecting cache anchor

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -797,14 +797,17 @@ export class AnthropicProvider implements Provider {
       // This is the stable anchor for the current turn — everything up to
       // and including it won't change during tool-use iterations, so a long
       // TTL is appropriate. Walk backwards to find the last user message
-      // with a text block (skipping tool_result-only messages from tool
-      // loops).
+      // with a real text block (skipping tool_result-only messages and
+      // synthetic continuation placeholders injected by ensureToolPairing).
       let turnStartIdx = -1;
       for (let i = sentMessages.length - 1; i >= 0; i--) {
         const msg = sentMessages[i];
         if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
         const hasText = msg.content.some(
-          (b) => typeof b !== "string" && b.type === "text",
+          (b) =>
+            typeof b !== "string" &&
+            b.type === "text" &&
+            b.text !== SYNTHETIC_CONTINUATION_TEXT,
         );
         if (!hasText) continue;
         const lastBlock = msg.content[msg.content.length - 1];


### PR DESCRIPTION
Address review feedback on #23358. The backward scan could anchor cache_control on a synthetic continuation placeholder instead of the real turn-starting user message, causing cache misses during tool loops.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
