### PR TITLE
fix: remove stale trailing undefined from proxy approval test assertion

### DIFF
--- a/assistant/src/__tests__/proxy-approval-callback.test.ts
+++ b/assistant/src/__tests__/proxy-approval-callback.test.ts
@@ -310,7 +310,6 @@ describe("createProxyApprovalCallback", () => {
       "/tmp/test-project",
       "allow",
       100,
-      undefined,
     );
   });
 


### PR DESCRIPTION
## Summary
- Remove trailing `undefined` from `addRuleMock` assertion in `proxy-approval-callback.test.ts` — the implementation only passes 5 args, not 6

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23964615278/job/69901873097
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
