### PR TITLE
fix: pre-activate subagent skill so notify_parent is available to subagents

### DIFF
--- a/assistant/src/__tests__/subagent-role-registry.test.ts
+++ b/assistant/src/__tests__/subagent-role-registry.test.ts
@@ -41,4 +41,10 @@ describe("SUBAGENT_ROLE_REGISTRY", () => {
       }
     }
   });
+
+  test('every role pre-activates the "subagent" skill', () => {
+    for (const [_role, config] of Object.entries(SUBAGENT_ROLE_REGISTRY)) {
+      expect(config.skillIds).toContain("subagent");
+    }
+  });
 });

--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -89,7 +89,7 @@ export const SUBAGENT_ROLE_REGISTRY: Record<SubagentRole, SubagentRoleConfig> =
   {
     general: {
       allowedTools: undefined,
-      skillIds: [],
+      skillIds: ["subagent"],
       systemPromptPreamble:
         "You are a general-purpose subagent. Complete the delegated task thoroughly and concisely.",
     },
@@ -101,7 +101,7 @@ export const SUBAGENT_ROLE_REGISTRY: Record<SubagentRole, SubagentRoleConfig> =
         "memory_recall",
         "notify_parent",
       ],
-      skillIds: [],
+      skillIds: ["subagent"],
       systemPromptPreamble:
         "You are a research-focused subagent with read-only access. Search the web, read files, and recall memories. You cannot write files or run shell commands.",
     },
@@ -114,7 +114,7 @@ export const SUBAGENT_ROLE_REGISTRY: Record<SubagentRole, SubagentRoleConfig> =
         "web_search",
         "notify_parent",
       ],
-      skillIds: [],
+      skillIds: ["subagent"],
       systemPromptPreamble:
         "You are a code-focused subagent with file and shell access. Read, write, and edit files, and run shell commands.",
     },
@@ -126,7 +126,7 @@ export const SUBAGENT_ROLE_REGISTRY: Record<SubagentRole, SubagentRoleConfig> =
         "memory_recall",
         "notify_parent",
       ],
-      skillIds: [],
+      skillIds: ["subagent"],
       systemPromptPreamble:
         "You are an analysis-focused subagent with read-only access. Read files, search the web, and synthesize findings. You cannot write files or run shell commands.",
     },


### PR DESCRIPTION
## Summary
Fixes gap where notify_parent tool was in role allowlists but the subagent bundled skill providing it was never pre-activated on subagent conversations.

- Set skillIds: ["subagent"] on all roles in SUBAGENT_ROLE_REGISTRY
- Update registry tests to verify skillIds