### PR TITLE
fix: guard label index against duplicate labels and stale dispose

### DIFF
--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -1191,6 +1191,54 @@ describe("Label-based subagent lookup", () => {
   });
 });
 
+// ── Label collision & dispose guard ─────────────────────────────────
+
+describe("Label collision and dispose guard", () => {
+  test("disposing second subagent with same label keeps first reachable by label", () => {
+    const manager = getSubagentManager();
+    const parentConversation = "label-collision-sess";
+    const firstId = "collision-sub-1";
+    const secondId = "collision-sub-2";
+    const sharedLabel = "Shared Worker";
+
+    // Inject two subagents with the same label — second overwrites label index.
+    injectSubagent(manager, firstId, parentConversation, "running", {
+      config: {
+        id: firstId,
+        parentConversationId: parentConversation,
+        label: sharedLabel,
+        objective: "first task",
+      },
+    });
+    injectSubagent(manager, secondId, parentConversation, "completed", {
+      config: {
+        id: secondId,
+        parentConversationId: parentConversation,
+        label: sharedLabel,
+        objective: "second task",
+      },
+    });
+
+    // Label should currently resolve to the second subagent.
+    expect(manager.getByLabel(sharedLabel, parentConversation)?.config.id).toBe(
+      secondId,
+    );
+
+    // Dispose the FIRST subagent — its label was already overwritten,
+    // so the label index entry (pointing to second) must survive.
+    manager.dispose(firstId);
+
+    const afterDispose = manager.getByLabel(sharedLabel, parentConversation);
+    expect(afterDispose).toBeDefined();
+    expect(afterDispose!.config.id).toBe(secondId);
+
+    // The second subagent should still be directly accessible too.
+    expect(manager.getState(secondId)).toBeDefined();
+    // And the first should be gone.
+    expect(manager.getState(firstId)).toBeUndefined();
+  });
+});
+
 // ── Role-based spawn ──────────────────────────────────────────────
 
 describe("Subagent role-based spawn", () => {

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -223,10 +223,19 @@ export class SubagentManager {
 
     managed.conversation = conversation;
     this.subagents.set(subagentId, managed);
-    this.labelIndex.set(
-      `${config.parentConversationId}:${config.label.toLowerCase().trim()}`,
-      subagentId,
-    );
+    const labelKey = `${config.parentConversationId}:${config.label.toLowerCase().trim()}`;
+    if (this.labelIndex.has(labelKey)) {
+      log.warn(
+        {
+          label: config.label,
+          parentConversationId: config.parentConversationId,
+          existingSubagentId: this.labelIndex.get(labelKey),
+          newSubagentId: subagentId,
+        },
+        "Label collision: new subagent overwrites label index entry (previous subagent still accessible by UUID)",
+      );
+    }
+    this.labelIndex.set(labelKey, subagentId);
 
     // Track parent → child relationship.
     if (!this.parentToChildren.has(config.parentConversationId)) {
@@ -518,12 +527,14 @@ export class SubagentManager {
     managed.conversation.dispose();
     this.subagents.delete(subagentId);
 
-    // Remove from label index.
+    // Remove from label index only if it still maps to this subagent
+    // (guards against stale delete when a newer subagent reused the label).
     const label = managed.state.config.label;
     const parentConvId = managed.state.config.parentConversationId;
-    this.labelIndex.delete(
-      `${parentConvId}:${label.toLowerCase().trim()}`,
-    );
+    const labelKey = `${parentConvId}:${label.toLowerCase().trim()}`;
+    if (this.labelIndex.get(labelKey) === subagentId) {
+      this.labelIndex.delete(labelKey);
+    }
 
     // Remove from parent tracking.
     const parentId = managed.state.config.parentConversationId;


### PR DESCRIPTION
## Summary
Fixes label index issues when multiple subagents share the same label:
- Add log warning on label collision in spawn
- Guard dispose to only delete label entry if it still maps to the disposed subagent
- Add test for label collision + dispose behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23501" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
