### PR TITLE
feat: emoji selector uses substring matching instead of prefix matching

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerEmojiPicker.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerEmojiPicker.swift
@@ -54,7 +54,7 @@ extension ComposerView {
             return
         }
         if let trigger = emojiTriggerRange() {
-            let results = EmojiCatalog.search(prefix: trigger.filter)
+            let results = EmojiCatalog.search(query: trigger.filter)
             if !results.isEmpty {
                 withAnimation(VAnimation.fast) { showEmojiMenu = true }
                 if emojiFilter != trigger.filter {
@@ -70,7 +70,7 @@ extension ComposerView {
     }
 
     func filteredEmoji(_ filter: String) -> [EmojiEntry] {
-        EmojiCatalog.search(prefix: filter, limit: 8)
+        EmojiCatalog.search(query: filter, limit: 8)
     }
 
     func selectEmoji(_ entry: EmojiEntry) {

--- a/clients/macos/vellum-assistantTests/ComposerEmojiPickerTests.swift
+++ b/clients/macos/vellum-assistantTests/ComposerEmojiPickerTests.swift
@@ -5,19 +5,19 @@ import VellumAssistantShared
 
 final class ComposerEmojiPickerTests: XCTestCase {
 
-    func testEmojiCatalogSearchReturnsResultsForCommonPrefixes() {
-        let results = EmojiCatalog.search(prefix: "thu")
-        XCTAssertFalse(results.isEmpty, "Expected results for prefix 'thu'")
+    func testEmojiCatalogSearchReturnsSubstringMatches() {
+        let results = EmojiCatalog.search(query: "eart")
+        XCTAssertFalse(results.isEmpty, "Expected results for substring 'eart'")
         for entry in results {
             XCTAssertTrue(
-                entry.shortcode.hasPrefix("thu"),
-                "Expected shortcode '\(entry.shortcode)' to start with 'thu'"
+                entry.shortcode.contains("eart"),
+                "Expected shortcode '\(entry.shortcode)' to contain 'eart'"
             )
         }
     }
 
     func testEmojiCatalogSearchCapsAtEightByDefault() {
-        let results = EmojiCatalog.search(prefix: "s")
+        let results = EmojiCatalog.search(query: "s")
         XCTAssertLessThanOrEqual(results.count, 8, "Default limit should cap results at 8")
     }
 

--- a/clients/shared/Features/Chat/EmojiCatalog.swift
+++ b/clients/shared/Features/Chat/EmojiCatalog.swift
@@ -1000,18 +1000,21 @@ public enum EmojiCatalog {
         EmojiEntry(shortcode: "zzz", emoji: "\u{1F4A4}"),
     ]
 
-    public static func search(prefix: String, limit: Int = 8) -> [EmojiEntry] {
-        let lowered = prefix.lowercased()
+    public static func search(query: String, limit: Int = 8) -> [EmojiEntry] {
+        let lowered = query.lowercased()
         if lowered.isEmpty {
             return Array(all.prefix(limit))
         }
-        var results: [EmojiEntry] = []
+        var prefixMatches: [EmojiEntry] = []
+        var substringMatches: [EmojiEntry] = []
         for entry in all {
             if entry.shortcode.hasPrefix(lowered) {
-                results.append(entry)
-                if results.count >= limit { break }
+                prefixMatches.append(entry)
+            } else if entry.shortcode.contains(lowered) {
+                substringMatches.append(entry)
             }
+            if prefixMatches.count + substringMatches.count >= limit { break }
         }
-        return results
+        return Array((prefixMatches + substringMatches).prefix(limit))
     }
 }

--- a/clients/shared/Tests/EmojiCatalogTests.swift
+++ b/clients/shared/Tests/EmojiCatalogTests.swift
@@ -28,25 +28,44 @@ final class EmojiCatalogTests: XCTestCase {
         }
     }
 
-    func testSearchPrefixMatch() {
-        let results = EmojiCatalog.search(prefix: "thu")
-        XCTAssertFalse(results.isEmpty, "Expected results for prefix 'thu'")
+    func testSearchSubstringMatch() {
+        let results = EmojiCatalog.search(query: "eart")
+        XCTAssertFalse(results.isEmpty, "Expected results for substring 'eart'")
         for entry in results {
             XCTAssertTrue(
-                entry.shortcode.hasPrefix("thu"),
-                "Entry '\(entry.shortcode)' does not start with 'thu'"
+                entry.shortcode.contains("eart"),
+                "Entry '\(entry.shortcode)' does not contain 'eart'"
             )
         }
     }
 
+    func testSearchPrefixMatchesRankedFirst() {
+        let results = EmojiCatalog.search(query: "hear", limit: 20)
+        // "heart" variants start with "hear" and should appear before substring-only matches like "hear_no_evil" is actually a prefix too
+        // Find first non-prefix match index
+        var lastPrefixIndex = -1
+        var firstSubstringIndex = Int.max
+        for (i, entry) in results.enumerated() {
+            if entry.shortcode.hasPrefix("hear") {
+                lastPrefixIndex = i
+            } else if entry.shortcode.contains("hear") && firstSubstringIndex == Int.max {
+                firstSubstringIndex = i
+            }
+        }
+        if lastPrefixIndex >= 0 && firstSubstringIndex < Int.max {
+            XCTAssertLessThan(lastPrefixIndex, firstSubstringIndex,
+                "Prefix matches should appear before substring-only matches")
+        }
+    }
+
     func testSearchIsCaseInsensitive() {
-        let lower = EmojiCatalog.search(prefix: "thu")
-        let upper = EmojiCatalog.search(prefix: "THU")
+        let lower = EmojiCatalog.search(query: "thu")
+        let upper = EmojiCatalog.search(query: "THU")
         XCTAssertEqual(lower, upper, "Case-insensitive search should return identical results")
     }
 
     func testSearchRespectsLimit() {
-        let results = EmojiCatalog.search(prefix: "", limit: 3)
+        let results = EmojiCatalog.search(query: "", limit: 3)
         XCTAssertLessThanOrEqual(results.count, 3)
     }
 


### PR DESCRIPTION
## Summary
- Changed emoji search from prefix-only matching to substring matching, so typing `:eart` now shows `:heart:` in addition to `:earth_americas:` etc.
- Prefix matches are ranked before substring-only matches for better relevance.
- Renamed the `prefix:` parameter to `query:` to reflect the new behavior.

## Original prompt
the emoji selector should show all emojis that include the substring instead of doing a prefix match