### PR TITLE
fix: register notify_parent executor in bundled-tool-registry

### DIFF
--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -165,6 +165,7 @@ import * as scaffoldManaged from "./bundled-skills/skill-management/tools/scaffo
 // ── subagent ───────────────────────────────────────────────────────────────────
 import * as subagentAbort from "./bundled-skills/subagent/tools/subagent-abort.js";
 import * as subagentMessage from "./bundled-skills/subagent/tools/subagent-message.js";
+import * as subagentNotifyParent from "./bundled-skills/subagent/tools/subagent-notify-parent.js";
 import * as subagentRead from "./bundled-skills/subagent/tools/subagent-read.js";
 import * as subagentSpawn from "./bundled-skills/subagent/tools/subagent-spawn.js";
 import * as subagentStatus from "./bundled-skills/subagent/tools/subagent-status.js";
@@ -391,6 +392,7 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["subagent:tools/subagent-abort.ts", subagentAbort],
   ["subagent:tools/subagent-message.ts", subagentMessage],
   ["subagent:tools/subagent-read.ts", subagentRead],
+  ["subagent:tools/subagent-notify-parent.ts", subagentNotifyParent],
 
   // tasks
   ["tasks:tools/task-save.ts", taskSave],


### PR DESCRIPTION
## Summary
Register the notify_parent skill tool executor in bundled-tool-registry.ts so it loads correctly in compiled binaries (not just dev mode dynamic import fallback).