### PR TITLE
feat: display raw error payload in API error alerts with one-click copy

### DIFF
--- a/clients/shared/Features/Chat/InlineChatErrorAlert.swift
+++ b/clients/shared/Features/Chat/InlineChatErrorAlert.swift
@@ -109,6 +109,34 @@ public struct InlineChatErrorAlert: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
 
+                // Debug details — raw error payload with one-click copy
+                if let details = conversationError?.debugDetails, !details.isEmpty {
+                    VStack(alignment: .leading, spacing: 0) {
+                        HStack {
+                            Text("Details")
+                                .font(VFont.labelDefault)
+                                .foregroundStyle(VColor.contentTertiary)
+                            Spacer()
+                            VCopyButton(text: details, size: .compact, iconSize: 14, accessibilityHint: "Copy error details")
+                        }
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.top, VSpacing.xs)
+
+                        ScrollView {
+                            Text(details)
+                                .font(.system(size: 11, design: .monospaced))
+                                .foregroundStyle(VColor.contentSecondary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .textSelection(.enabled)
+                        }
+                        .frame(maxHeight: 160)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.bottom, VSpacing.sm)
+                    }
+                    .background(RoundedRectangle(cornerRadius: VRadius.sm).fill(VColor.surfaceOverlay))
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                }
+
                 // Retry button
                 if conversationError?.isRetryable == true, let onRetry {
                     Button(action: onRetry) {


### PR DESCRIPTION
## Summary
- Show `debugDetails` in the `InlineChatErrorAlert` as a monospaced, scrollable block with a one-click copy button
- The raw error payload was already sent from the backend to the client but not rendered — this just adds the UI
- Uses existing `VCopyButton` component and `VColor.surfaceOverlay` background pattern

## Original prompt
Whenever I get an API Error, the raw payload of the error should be displayed in the error block and be copyable with one click
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
