### PR TITLE
fix: cap cache_control blocks at Anthropic API limit of 4

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -187,6 +187,58 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     expect(system[1].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
   });
 
+  test("drops static system block cache_control when total would exceed 4", async () => {
+    const staticBlock = "You are a helpful assistant.";
+    const dynamicBlock = "User workspace files here.";
+    const prompt = staticBlock + SYSTEM_PROMPT_CACHE_BOUNDARY + dynamicBlock;
+
+    // Boundary (2 system) + tools (1) + turn-start (1) + tail (1) = 5 → must cap at 4
+    const messages: Message[] = [
+      userMsg("Do something"),
+      toolUseMsg("tu_1", "bash"),
+      toolResultMsg("tu_1", "output"),
+    ];
+    await provider.sendMessage(messages, sampleTools, prompt);
+
+    const system = lastStreamParams!.system as Array<{
+      type: string;
+      text: string;
+      cache_control?: { type: string; ttl?: string };
+    }>;
+    expect(system).toHaveLength(2);
+    // Static block's cache_control dropped (small, cheap to re-read)
+    expect(system[0].cache_control).toBeUndefined();
+    // Dynamic block keeps its cache_control
+    expect(system[1].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+
+    // Tools breakpoint still present
+    const tools = lastStreamParams!.tools as Array<{
+      cache_control?: { type: string; ttl?: string };
+    }>;
+    expect(tools[tools.length - 1].cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    });
+
+    // Turn-start + tail breakpoints still present
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{
+        type: string;
+        cache_control?: { type: string; ttl?: string };
+      }>;
+    }>;
+    const turnStart = sent[0];
+    expect(
+      turnStart.content[turnStart.content.length - 1].cache_control,
+    ).toEqual({ type: "ephemeral", ttl: "1h" });
+    const lastMsg = sent[sent.length - 1];
+    expect(lastMsg.content[lastMsg.content.length - 1].cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "5m",
+    });
+  });
+
   // -----------------------------------------------------------------------
   // Tool cache control
   // -----------------------------------------------------------------------

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -838,6 +838,25 @@ export class AnthropicProvider implements Provider {
         }
       }
 
+      // Enforce Anthropic API maximum of 4 cache_control blocks.
+      // When the system prompt boundary splits into 2 cached blocks AND
+      // tools + turn-start + advancing-tail breakpoints are all present,
+      // we'd have 5.  Drop the static system block's breakpoint — it's
+      // small (<1K tokens) so the re-read cost is negligible, while the
+      // dynamic block (workspace context) rarely changes mid-session and
+      // benefits more from caching.
+      const hasTailBreakpoint =
+        turnStartIdx >= 0 && turnStartIdx < sentMessages.length - 1;
+      if (
+        hasTailBreakpoint &&
+        Array.isArray(params.system) &&
+        params.system.length === 2 &&
+        params.tools &&
+        params.tools.length > 0
+      ) {
+        delete (params.system[0] as Record<string, unknown>).cache_control;
+      }
+
       const { signal: timeoutSignal, cleanup: cleanupTimeout } =
         createStreamTimeout(this.streamTimeoutMs, signal);
 


### PR DESCRIPTION
## Summary
- Fix 400 errors from Anthropic API when 5 `cache_control` blocks are sent (max is 4)
- When boundary-split system prompt + tools + turn-start + advancing-tail breakpoints all fire, drop the static system block's breakpoint (small, cheap to re-read) to stay within the limit
- Add test covering the 5-breakpoint scenario

## Original prompt
let's actually drop cache breakpoint #1, the static system prompt is quite small (<1000 tokens) and the dynamic section actually rarely changes in practice
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
