### PR TITLE
fix: merge SubagentConfig.preactivatedSkillIds with role skillIds in spawn

### DIFF
--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -216,9 +216,10 @@ export class SubagentManager {
       conversation.setSubagentAllowedTools(new Set(roleConfig.allowedTools));
     }
 
-    // Pre-activate skills defined by the role config.
-    if (roleConfig.skillIds.length > 0) {
-      conversation.setPreactivatedSkillIds(roleConfig.skillIds);
+    // Pre-activate skills defined by the role config, merged with any caller-provided skill IDs.
+    const mergedSkillIds = [...new Set([...roleConfig.skillIds, ...(config.preactivatedSkillIds ?? [])])];
+    if (mergedSkillIds.length > 0) {
+      conversation.setPreactivatedSkillIds(mergedSkillIds);
     }
 
     managed.conversation = conversation;


### PR DESCRIPTION
## Summary
Wire up the existing SubagentConfig.preactivatedSkillIds field by merging it with the role's skillIds when pre-activating skills on the subagent conversation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
