### PR TITLE
fix: add 'running' to subagent notification status in Zod schema and API type

### DIFF
--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -310,11 +310,11 @@ export interface HistoryResponse {
     contentOrder?: string[];
     /** UI surfaces (widgets) embedded in the message. */
     surfaces?: HistoryResponseSurface[];
-    /** Present when this message is a subagent lifecycle notification (completed/failed/aborted). */
+    /** Present when this message is a subagent lifecycle notification (running/completed/failed/aborted). */
     subagentNotification?: {
       subagentId: string;
       label: string;
-      status: "completed" | "failed" | "aborted";
+      status: "running" | "completed" | "failed" | "aborted";
       error?: string;
       conversationId?: string;
     };

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -70,7 +70,7 @@ const interfaceIdSchema = z.enum(INTERFACE_IDS);
 const subagentNotificationSchema = z.object({
   subagentId: z.string(),
   label: z.string(),
-  status: z.enum(["completed", "failed", "aborted"]),
+  status: z.enum(["running", "completed", "failed", "aborted"]),
   error: z.string().optional(),
   conversationId: z.string().optional(),
 });


### PR DESCRIPTION
## Summary
Add 'running' to the subagent notification status enum in both the Zod persistence schema and the HistoryResponse TypeScript type, aligning them with the SubagentNotificationInfo type that now includes mid-run notifications from notify_parent.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
