### PR TITLE
fix: add runtime validation for invalid subagent role values

### DIFF
--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -1297,6 +1297,23 @@ describe("Subagent role-based spawn", () => {
     }
   });
 
+  test("spawn with invalid role returns clear error message", async () => {
+    const result = await executeSubagentSpawn(
+      {
+        label: "Bad role task",
+        objective: "Should fail",
+        role: "nonexistent-role",
+      },
+      makeContext("sess-role-invalid", { sendToClient: () => {} }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Invalid subagent role");
+    expect(result.content).toContain("nonexistent-role");
+    expect(result.content).toContain("Must be one of");
+    expect(result.content).toContain("general");
+    expect(result.content).toContain("researcher");
+  });
+
   test("spawn tool definition includes role property", () => {
     const def = findTool("subagent_spawn");
     expect(def).toBeDefined();

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -132,6 +132,9 @@ export class SubagentManager {
 
     // ── Resolve role ─────────────────────────────────────────────────
     const role: SubagentRole = (config.role as SubagentRole) ?? "general";
+    if (!SUBAGENT_ROLE_REGISTRY[role]) {
+      throw new Error(`Invalid subagent role "${config.role}". Must be one of: ${Object.keys(SUBAGENT_ROLE_REGISTRY).join(", ")}`);
+    }
     const roleConfig = SUBAGENT_ROLE_REGISTRY[role];
 
     // ── Create conversation ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
Add runtime guard in SubagentManager.spawn() for invalid role values, producing a clear error message instead of an unhelpful TypeError.

- Validates role against SUBAGENT_ROLE_REGISTRY before use, throwing a descriptive error listing valid roles
- Adds test verifying spawn with invalid role returns clear error