### PR TITLE
fix: cast TextBlockParam through unknown to fix TS2352

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -854,7 +854,7 @@ export class AnthropicProvider implements Provider {
         params.tools &&
         params.tools.length > 0
       ) {
-        delete (params.system[0] as Record<string, unknown>).cache_control;
+        delete (params.system[0] as unknown as Record<string, unknown>).cache_control;
       }
 
       const { signal: timeoutSignal, cleanup: cleanupTimeout } =


### PR DESCRIPTION
## Summary
- Fix TypeScript error TS2352 in `assistant/src/providers/anthropic/client.ts:857` where `TextBlockParam` couldn't be directly cast to `Record<string, unknown>`
- Added intermediate `unknown` cast (`as unknown as Record<string, unknown>`) as recommended by TypeScript

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23965590566/job/69904745994
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23510" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
