### PR TITLE
fix: extract mergeSkillIds helper and add unit tests for skill dedup

### DIFF
--- a/assistant/src/__tests__/subagent-role-registry.test.ts
+++ b/assistant/src/__tests__/subagent-role-registry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  mergeSkillIds,
   SUBAGENT_ROLE_REGISTRY,
   type SubagentRole,
 } from "../subagent/index.js";
@@ -46,5 +47,26 @@ describe("SUBAGENT_ROLE_REGISTRY", () => {
     for (const [_role, config] of Object.entries(SUBAGENT_ROLE_REGISTRY)) {
       expect(config.skillIds).toContain("subagent");
     }
+  });
+});
+
+describe("mergeSkillIds", () => {
+  test("removes duplicates between role and config skill IDs", () => {
+    expect(mergeSkillIds(["a", "b"], ["b", "c"])).toEqual(["a", "b", "c"]);
+  });
+
+  test("returns only role skills when config is undefined", () => {
+    expect(mergeSkillIds(["subagent"], undefined)).toEqual(["subagent"]);
+  });
+
+  test("includes caller-provided extras alongside role skills", () => {
+    expect(mergeSkillIds(["subagent"], ["custom-skill"])).toEqual([
+      "subagent",
+      "custom-skill",
+    ]);
+  });
+
+  test("returns empty array when both inputs are empty", () => {
+    expect(mergeSkillIds([], undefined)).toEqual([]);
   });
 });

--- a/assistant/src/subagent/index.ts
+++ b/assistant/src/subagent/index.ts
@@ -1,4 +1,4 @@
-export { SubagentManager } from "./manager.js";
+export { mergeSkillIds, SubagentManager } from "./manager.js";
 export type {
   SubagentConfig,
   SubagentRole,

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -33,6 +33,16 @@ import {
 
 const log = getLogger("subagent-manager");
 
+// ── Skill ID merge helper ──────────────────────────────────────────────
+
+/**
+ * Merge role-defined skill IDs with caller-provided skill IDs, deduplicating.
+ * Exported for direct unit testing.
+ */
+export function mergeSkillIds(roleSkillIds: string[], configSkillIds?: string[]): string[] {
+  return [...new Set([...roleSkillIds, ...(configSkillIds ?? [])])];
+}
+
 // ── Default subagent system prompt ──────────────────────────────────────
 
 function buildSubagentSystemPrompt(config: SubagentConfig, role: SubagentRole): string {
@@ -220,7 +230,7 @@ export class SubagentManager {
     }
 
     // Pre-activate skills defined by the role config, merged with any caller-provided skill IDs.
-    const mergedSkillIds = [...new Set([...roleConfig.skillIds, ...(config.preactivatedSkillIds ?? [])])];
+    const mergedSkillIds = mergeSkillIds(roleConfig.skillIds, config.preactivatedSkillIds);
     if (mergedSkillIds.length > 0) {
       conversation.setPreactivatedSkillIds(mergedSkillIds);
     }


### PR DESCRIPTION
## Summary
Extract skill ID merge/dedup logic from SubagentManager.spawn() into a testable mergeSkillIds helper and add 4 unit tests covering dedup, empty config, extras, and empty-both cases.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
