### PR TITLE
fix: add missing config loader mock exports and regenerate OpenAPI spec

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4943,6 +4943,63 @@ paths:
           schema:
             type: string
           description: Conversation ID
+  /v1/permission-mode:
+    get:
+      operationId: permissionmode_get
+      summary: Get permission mode
+      description: Return the current two-axis permission mode (askBeforeActing, hostAccess).
+      tags:
+        - settings
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  askBeforeActing:
+                    type: boolean
+                  hostAccess:
+                    type: boolean
+                required:
+                  - askBeforeActing
+                  - hostAccess
+                additionalProperties: false
+    put:
+      operationId: permissionmode_put
+      summary: Update permission mode
+      description: Update the two-axis permission mode. Requires the permission-controls-v2 feature flag.
+      tags:
+        - settings
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  askBeforeActing:
+                    type: boolean
+                  hostAccess:
+                    type: boolean
+                required:
+                  - askBeforeActing
+                  - hostAccess
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                askBeforeActing:
+                  type: boolean
+                hostAccess:
+                  type: boolean
+              additionalProperties: false
   /v1/recordings/pause:
     post:
       operationId: recordings_pause_post

--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -18,6 +18,9 @@ let mockConfig = {
 mock.module("../config/loader.js", () => ({
   getConfig: () => mockConfig,
   loadConfig: () => mockConfig,
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
 }));
 
 // Mock conversation store
@@ -73,9 +76,8 @@ mock.module("../memory/conversation-title-service.js", () => ({
 }));
 
 // Import after mocks are set up
-const { HeartbeatService, isShallowProfile } = await import(
-  "../heartbeat/heartbeat-service.js"
-);
+const { HeartbeatService, isShallowProfile } =
+  await import("../heartbeat/heartbeat-service.js");
 
 // Read the bundled template files so we can write them into the test workspace
 const templatesDir = join(import.meta.dirname!, "..", "prompts", "templates");
@@ -496,7 +498,8 @@ describe("HeartbeatService", () => {
       writeFileSync(join(testWorkspaceDir, "USER.md"), USER_TEMPLATE);
 
       const service = createService();
-      const { prompt, includedReengagement } = service.buildPrompt("- Check things");
+      const { prompt, includedReengagement } =
+        service.buildPrompt("- Check things");
 
       expect(prompt).toContain("<relationship-depth>");
       expect(prompt).toContain("profile is still sparse");
@@ -511,7 +514,8 @@ describe("HeartbeatService", () => {
       writeFileSync(join(testWorkspaceDir, "USER.md"), USER_TEMPLATE);
 
       const service = createService();
-      const { prompt, includedReengagement } = service.buildPrompt("- Check things");
+      const { prompt, includedReengagement } =
+        service.buildPrompt("- Check things");
 
       expect(prompt).not.toContain("<relationship-depth>");
       expect(includedReengagement).toBe(false);
@@ -527,7 +531,8 @@ describe("HeartbeatService", () => {
       );
 
       const service = createService();
-      const { prompt, includedReengagement } = service.buildPrompt("- Check things");
+      const { prompt, includedReengagement } =
+        service.buildPrompt("- Check things");
 
       expect(prompt).not.toContain("<relationship-depth>");
       expect(includedReengagement).toBe(false);
@@ -544,7 +549,8 @@ describe("HeartbeatService", () => {
       );
 
       const service = createService();
-      const { prompt, includedReengagement } = service.buildPrompt("- Check things");
+      const { prompt, includedReengagement } =
+        service.buildPrompt("- Check things");
 
       expect(prompt).toContain("<relationship-depth>");
       expect(includedReengagement).toBe(true);


### PR DESCRIPTION
## Summary
- Add `loadRawConfig`, `saveRawConfig`, and `invalidateConfigCache` to the `config/loader.js` mock in `heartbeat-service.test.ts`. The new `permission-mode-store` module (imported transitively via `system-prompt.ts`) requires these exports, which the incomplete mock was missing.
- Regenerate `openapi.yaml` to include the new `GET /v1/permission-mode` and `PUT /v1/permission-mode` endpoints.

Part of plan: permission-system-redesign.md (CI fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
