### PR TITLE
fix: add skill_execute to role allowlists so skill tools are reachable

### DIFF
--- a/assistant/src/__tests__/subagent-role-registry.test.ts
+++ b/assistant/src/__tests__/subagent-role-registry.test.ts
@@ -43,6 +43,14 @@ describe("SUBAGENT_ROLE_REGISTRY", () => {
     }
   });
 
+  test('every role with allowedTools includes "skill_execute"', () => {
+    for (const [_role, config] of Object.entries(SUBAGENT_ROLE_REGISTRY)) {
+      if (config.allowedTools !== undefined) {
+        expect(config.allowedTools).toContain("skill_execute");
+      }
+    }
+  });
+
   test('every role pre-activates the "subagent" skill', () => {
     for (const [_role, config] of Object.entries(SUBAGENT_ROLE_REGISTRY)) {
       expect(config.skillIds).toContain("subagent");

--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -95,6 +95,7 @@ export const SUBAGENT_ROLE_REGISTRY: Record<SubagentRole, SubagentRoleConfig> =
     },
     researcher: {
       allowedTools: [
+        "skill_execute",
         "web_search",
         "web_fetch",
         "file_read",
@@ -107,6 +108,7 @@ export const SUBAGENT_ROLE_REGISTRY: Record<SubagentRole, SubagentRoleConfig> =
     },
     coder: {
       allowedTools: [
+        "skill_execute",
         "bash",
         "file_read",
         "file_write",
@@ -120,6 +122,7 @@ export const SUBAGENT_ROLE_REGISTRY: Record<SubagentRole, SubagentRoleConfig> =
     },
     planner: {
       allowedTools: [
+        "skill_execute",
         "file_read",
         "web_search",
         "web_fetch",


### PR DESCRIPTION
## Summary
Add skill_execute to the allowedTools array for all non-general roles (researcher, coder, planner). Without this, skill-based tools like notify_parent are in the allowlist but unreachable because the LLM never sees skill_execute in its tool definitions.