### PR TITLE
feat: add query_context column to memory_recall_logs table

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -99,6 +99,7 @@ import {
   migrateLlmRequestLogProvider,
   migrateMemoryGraphImageRefs,
   migrateMemoryItemSupersession,
+  migrateMemoryRecallLogsQueryContext,
   migrateMessagesConversationCreatedAtIndex,
   migrateMessagesFtsBackfill,
   migrateNormalizePhoneIdentities,
@@ -603,6 +604,9 @@ export function initializeDb(): void {
 
   // 109. Add reuse_conversation flag to schedule jobs
   migrateScheduleReuseConversation(database);
+
+  // 110. Add query_context column to memory_recall_logs for inspector query display
+  migrateMemoryRecallLogsQueryContext(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/211-memory-recall-logs-query-context.ts
+++ b/assistant/src/memory/migrations/211-memory-recall-logs-query-context.ts
@@ -1,0 +1,18 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+const CHECKPOINT_KEY = "migration_memory_recall_logs_query_context_v1";
+
+/**
+ * Add query_context column to memory_recall_logs to persist the query text
+ * that drove semantic search, enabling the inspector to show what was searched.
+ */
+export function migrateMemoryRecallLogsQueryContext(database: DrizzleDb): void {
+  withCrashRecovery(database, CHECKPOINT_KEY, () => {
+    const raw = getSqliteFrom(database);
+    raw.exec(
+      `ALTER TABLE memory_recall_logs ADD COLUMN query_context TEXT`,
+    );
+  });
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -152,6 +152,7 @@ export { migrateCreateConversationGraphMemoryState } from "./207-conversation-gr
 export { migrateConversationsLastMessageAt } from "./208-conversations-last-message-at.js";
 export { migrateStripThinkingFromConsolidated } from "./209-strip-thinking-from-consolidated.js";
 export { migrateScheduleReuseConversation } from "./210-schedule-reuse-conversation.js";
+export { migrateMemoryRecallLogsQueryContext } from "./211-memory-recall-logs-query-context.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -147,6 +147,7 @@ export const memoryRecallLogs = sqliteTable(
     topCandidatesJson: text("top_candidates_json").notNull(),
     injectedText: text("injected_text"),
     reason: text("reason"),
+    queryContext: text("query_context"),
     createdAt: integer("created_at").notNull(),
   },
   (table) => [


### PR DESCRIPTION
## Summary
- Create migration 211 to add query_context TEXT column to memory_recall_logs
- Register migration in index.ts and db-init.ts
- Update Drizzle schema in infrastructure.ts

Part of plan: memory-recall-query-context.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
