### PR TITLE
feat: add queryContext field to RetrievalMetrics type

### DIFF
--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -768,6 +768,7 @@ export async function loadContextMemory(
       sparseVectorUsed: false,
       embeddingProvider,
       embeddingModel,
+      queryContext: null,
       topCandidates,
     },
   };
@@ -830,6 +831,7 @@ export async function retrieveForTurn(
     sparseVectorUsed: false,
     embeddingProvider: null,
     embeddingModel: null,
+    queryContext: null,
     topCandidates: [],
   };
 
@@ -1187,6 +1189,7 @@ export async function retrieveForTurn(
       sparseVectorUsed: false,
       embeddingProvider,
       embeddingModel,
+      queryContext: null,
       topCandidates,
     },
   };

--- a/assistant/src/memory/graph/types.ts
+++ b/assistant/src/memory/graph/types.ts
@@ -267,6 +267,7 @@ export interface RetrievalMetrics {
   sparseVectorUsed: boolean;
   embeddingProvider: string | null;
   embeddingModel: string | null;
+  queryContext: string | null;
   topCandidates: Array<{
     nodeId: string;
     type: string;


### PR DESCRIPTION
## Summary
- Add queryContext: string | null to RetrievalMetrics interface in types.ts
- Add queryContext: null to all RetrievalMetrics object literals in retriever.ts to satisfy the type

Part of plan: memory-recall-query-context.md (PR 1 of 5)