### PR TITLE
fix: use correct tool names (recall/remember) in role allowlists

### DIFF
--- a/assistant/src/__tests__/subagent-role-registry.test.ts
+++ b/assistant/src/__tests__/subagent-role-registry.test.ts
@@ -51,6 +51,28 @@ describe("SUBAGENT_ROLE_REGISTRY", () => {
     }
   });
 
+  test('researcher includes "recall" and "remember" for memory access', () => {
+    const tools = SUBAGENT_ROLE_REGISTRY.researcher.allowedTools!;
+    expect(tools).toContain("recall");
+    expect(tools).toContain("remember");
+  });
+
+  test('coder includes "recall" for memory access', () => {
+    expect(SUBAGENT_ROLE_REGISTRY.coder.allowedTools!).toContain("recall");
+  });
+
+  test('planner includes "recall" for memory access', () => {
+    expect(SUBAGENT_ROLE_REGISTRY.planner.allowedTools!).toContain("recall");
+  });
+
+  test("no role references the old memory_recall tool name", () => {
+    for (const [_role, config] of Object.entries(SUBAGENT_ROLE_REGISTRY)) {
+      if (config.allowedTools !== undefined) {
+        expect(config.allowedTools).not.toContain("memory_recall");
+      }
+    }
+  });
+
   test('every role pre-activates the "subagent" skill', () => {
     for (const [_role, config] of Object.entries(SUBAGENT_ROLE_REGISTRY)) {
       expect(config.skillIds).toContain("subagent");

--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -95,26 +95,28 @@ export const SUBAGENT_ROLE_REGISTRY: Record<SubagentRole, SubagentRoleConfig> =
     },
     researcher: {
       allowedTools: [
-        "skill_execute",
         "web_search",
         "web_fetch",
         "file_read",
-        "memory_recall",
+        "recall",
+        "remember",
         "notify_parent",
+        "skill_execute",
       ],
       skillIds: ["subagent"],
       systemPromptPreamble:
-        "You are a research-focused subagent with read-only access. Search the web, read files, and recall memories. You cannot write files or run shell commands.",
+        "You are a research-focused subagent with read-only access. Search the web, read files, and recall and store memories. You cannot write files or run shell commands.",
     },
     coder: {
       allowedTools: [
-        "skill_execute",
         "bash",
         "file_read",
         "file_write",
         "file_edit",
         "web_search",
+        "recall",
         "notify_parent",
+        "skill_execute",
       ],
       skillIds: ["subagent"],
       systemPromptPreamble:
@@ -122,12 +124,12 @@ export const SUBAGENT_ROLE_REGISTRY: Record<SubagentRole, SubagentRoleConfig> =
     },
     planner: {
       allowedTools: [
-        "skill_execute",
         "file_read",
         "web_search",
         "web_fetch",
-        "memory_recall",
+        "recall",
         "notify_parent",
+        "skill_execute",
       ],
       skillIds: ["subagent"],
       systemPromptPreamble:


### PR DESCRIPTION
## Summary
Fix role allowlists to use the actual registered tool names: 'recall' (not 'memory_recall') and 'remember'. Add 'recall' to coder role and 'remember' to researcher role.