### PR TITLE
feat: populate queryContext in loadContextMemory and retrieveForTurn

### DIFF
--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -377,11 +377,13 @@ export async function loadContextMemory(
   let queryVector: number[] | null = null;
   let embeddingProvider: string | null = null;
   let embeddingModel: string | null = null;
+  let contextQueryText: string | null = null;
   if (opts.recentSummaries.length > 0) {
     try {
       const queryText = opts.recentSummaries.join("\n\n");
       const truncated =
         queryText.length > 3000 ? queryText.slice(0, 3000) : queryText;
+      contextQueryText = truncated;
       const result = await embedWithRetry(opts.config, [truncated], {
         signal: opts.signal,
       });
@@ -768,7 +770,7 @@ export async function loadContextMemory(
       sparseVectorUsed: false,
       embeddingProvider,
       embeddingModel,
-      queryContext: null,
+      queryContext: contextQueryText,
       topCandidates,
     },
   };
@@ -900,6 +902,7 @@ export async function retrieveForTurn(
           imageBlocks.length > 0 ? Date.now() - searchStart : 0,
         embeddingProvider,
         embeddingModel,
+        queryContext: queryText || null,
       },
     };
   }
@@ -971,6 +974,7 @@ export async function retrieveForTurn(
             hybridSearchLatencyMs: Date.now() - searchStart,
             embeddingProvider,
             embeddingModel,
+            queryContext: queryText || null,
           },
         };
       }
@@ -1022,6 +1026,7 @@ export async function retrieveForTurn(
         hybridSearchLatencyMs,
         embeddingProvider,
         embeddingModel,
+        queryContext: queryText || null,
       },
     };
   }
@@ -1189,7 +1194,7 @@ export async function retrieveForTurn(
       sparseVectorUsed: false,
       embeddingProvider,
       embeddingModel,
-      queryContext: null,
+      queryContext: queryText || null,
       topCandidates,
     },
   };


### PR DESCRIPTION
## Summary
- Set queryContext to truncated summary text in loadContextMemory metrics
- Set queryContext to user+assistant message text in retrieveForTurn metrics
- Propagate through all early-return paths

Part of plan: memory-recall-query-context.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
