### PR TITLE
feat: file-backed audio spool with unified eviction budget

### DIFF
--- a/assistant/src/calls/audio-store.test.ts
+++ b/assistant/src/calls/audio-store.test.ts
@@ -1,21 +1,32 @@
-import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { afterAll, describe, expect, test } from "bun:test";
 
-import { getAudio, storeAudio } from "./audio-store.js";
+import {
+  cleanupAudioSpool,
+  createStreamingEntry,
+  getAudio,
+  storeAudio,
+} from "./audio-store.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Reset module-level state between tests by re-importing.
- * Since the store uses module-level variables, we isolate via fresh imports
- * where needed, but for most tests the shared module state is fine as long
- * as we account for it.
- */
-
 function makeBuffer(sizeBytes: number): Buffer {
   return Buffer.alloc(sizeBytes, 0x42);
 }
+
+function readFileResult(
+  result: NonNullable<ReturnType<typeof getAudio>>,
+): Buffer {
+  if (result.type !== "file")
+    throw new Error(`Expected file result, got ${result.type}`);
+  return readFileSync(result.filePath);
+}
+
+afterAll(() => {
+  cleanupAudioSpool();
+});
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -28,10 +39,8 @@ describe("audio-store", () => {
       const id = storeAudio(buf, "mp3");
       const result = getAudio(id);
       expect(result).not.toBeNull();
-      expect(result!.type).toBe("buffer");
-      if (result!.type === "buffer") {
-        expect(result!.buffer).toEqual(buf);
-      }
+      expect(result!.type).toBe("file");
+      expect(readFileResult(result!)).toEqual(buf);
       expect(result!.contentType).toBe("audio/mpeg");
     });
 
@@ -54,16 +63,20 @@ describe("audio-store", () => {
   });
 
   describe("TTL expiration", () => {
-    test("expired entries return null", () => {
+    test("expired entries return null and delete temp file", () => {
       const buf = makeBuffer(128);
       const id = storeAudio(buf, "wav");
+      const filePath =
+        getAudio(id)!.type === "file" ? (getAudio(id) as any).filePath : null;
+      expect(filePath).toBeTruthy();
 
-      // Fast-forward time past TTL (60s)
       const originalNow = Date.now;
       Date.now = () => originalNow() + 61_000;
       try {
         const result = getAudio(id);
         expect(result).toBeNull();
+        // Temp file should be cleaned up
+        expect(existsSync(filePath!)).toBe(false);
       } finally {
         Date.now = originalNow;
       }
@@ -72,8 +85,6 @@ describe("audio-store", () => {
 
   describe("capacity eviction", () => {
     test("evicts oldest entries when capacity is exceeded", () => {
-      // The store has a 50MB cap. Fill it with entries, then add one more
-      // that would exceed the cap. The oldest should be evicted.
       const chunkSize = 10 * 1024 * 1024; // 10MB per chunk
       const ids: string[] = [];
 
@@ -82,7 +93,6 @@ describe("audio-store", () => {
         ids.push(storeAudio(makeBuffer(chunkSize), "opus"));
       }
 
-      // All 5 should be retrievable
       for (const id of ids) {
         expect(getAudio(id)).not.toBeNull();
       }
@@ -90,8 +100,95 @@ describe("audio-store", () => {
       // Add one more 10MB entry — should evict the oldest
       const newId = storeAudio(makeBuffer(chunkSize), "mp3");
       expect(getAudio(newId)).not.toBeNull();
-      // The first entry should have been evicted
       expect(getAudio(ids[0]!)).toBeNull();
+    });
+  });
+
+  describe("streaming entries", () => {
+    test("streaming entries count toward the same byte cap as stored audio", () => {
+      const handle = createStreamingEntry("mp3");
+      const chunk = makeBuffer(10 * 1024 * 1024); // 10MB
+
+      // Push 40MB of streaming data
+      for (let i = 0; i < 4; i++) {
+        handle.push(new Uint8Array(chunk));
+      }
+      handle.finalize();
+
+      // Store another 10MB — should fit at 50MB total
+      const storedId = storeAudio(makeBuffer(10 * 1024 * 1024), "wav");
+      expect(getAudio(storedId)).not.toBeNull();
+
+      // One more should trigger eviction
+      const extraId = storeAudio(makeBuffer(10 * 1024 * 1024), "mp3");
+      expect(getAudio(extraId)).not.toBeNull();
+      // The streaming entry or the stored entry should have been evicted
+      const streamResult = getAudio(handle.audioId);
+      const storedResult = getAudio(storedId);
+      // At least one was evicted to make room
+      expect(!streamResult || !storedResult).toBe(true);
+    });
+
+    test("completed streaming audio can be fetched as a file", () => {
+      const handle = createStreamingEntry("opus");
+      const chunk1 = new Uint8Array([1, 2, 3]);
+      const chunk2 = new Uint8Array([4, 5, 6]);
+      handle.push(chunk1);
+      handle.push(chunk2);
+      handle.finalize();
+
+      const result = getAudio(handle.audioId);
+      expect(result).not.toBeNull();
+      expect(result!.type).toBe("file");
+      const content = readFileResult(result!);
+      expect(new Uint8Array(content)).toEqual(
+        new Uint8Array([1, 2, 3, 4, 5, 6]),
+      );
+      expect(result!.contentType).toBe("audio/opus");
+    });
+
+    test("in-progress streaming returns a ReadableStream", async () => {
+      const handle = createStreamingEntry("mp3");
+      handle.push(new Uint8Array([10, 20]));
+
+      const result = getAudio(handle.audioId);
+      expect(result).not.toBeNull();
+      expect(result!.type).toBe("stream");
+
+      if (result!.type === "stream") {
+        const reader = result!.stream.getReader();
+
+        // Read the replayed existing bytes
+        const { value: first } = await reader.read();
+        expect(first).toEqual(new Uint8Array([10, 20]));
+
+        // Push more while reading
+        handle.push(new Uint8Array([30, 40]));
+        const { value: second } = await reader.read();
+        expect(second).toEqual(new Uint8Array([30, 40]));
+
+        handle.finalize();
+        const { done } = await reader.read();
+        expect(done).toBe(true);
+      }
+    });
+
+    test("oversized or abandoned streams are evicted on expiry", () => {
+      const handle = createStreamingEntry("wav");
+      handle.push(new Uint8Array(makeBuffer(1024)));
+      // Don't finalize — simulate abandoned stream
+
+      // Confirm it exists before expiry
+      expect(getAudio(handle.audioId)).not.toBeNull();
+
+      const originalNow = Date.now;
+      Date.now = () => originalNow() + 61_000;
+      try {
+        // Any eviction-triggering call should clean it up
+        expect(getAudio(handle.audioId)).toBeNull();
+      } finally {
+        Date.now = originalNow;
+      }
     });
   });
 });

--- a/assistant/src/calls/audio-store.ts
+++ b/assistant/src/calls/audio-store.ts
@@ -3,6 +3,7 @@ import {
   appendFileSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   rmSync,
   unlinkSync,
@@ -36,6 +37,19 @@ function getSpoolDir(): string {
   if (!spoolDir) {
     spoolDir = join(getDataDir(), "audio-spool");
     mkdirSync(spoolDir, { recursive: true });
+    // Purge leftover files from prior unclean exits so stale audio
+    // does not accumulate outside of the tracked eviction budget.
+    try {
+      for (const name of readdirSync(spoolDir)) {
+        try {
+          unlinkSync(join(spoolDir, name));
+        } catch {
+          // best-effort
+        }
+      }
+    } catch {
+      // best-effort
+    }
   }
   return spoolDir;
 }
@@ -102,6 +116,11 @@ export function createStreamingEntry(
   return {
     audioId: id,
     push(chunk: Uint8Array) {
+      // Guard: entry may have been evicted (TTL/capacity) while the
+      // producer is still pushing. Silently drop the chunk so we don't
+      // write to an untracked file or corrupt currentBytes accounting.
+      if (!entries.has(id)) return;
+
       appendFileSync(filePath, chunk);
       entry.sizeBytes += chunk.byteLength;
       currentBytes += chunk.byteLength;
@@ -115,6 +134,8 @@ export function createStreamingEntry(
       }
     },
     finalize() {
+      if (!entries.has(id)) return;
+
       entry.complete = true;
       for (const controller of entry.subscribers) {
         try {

--- a/assistant/src/calls/audio-store.ts
+++ b/assistant/src/calls/audio-store.ts
@@ -1,40 +1,69 @@
 import { randomUUID } from "node:crypto";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
 
-interface AudioEntry {
-  buffer: Buffer;
-  contentType: string;
-  expiresAt: number;
-}
+import { getDataDir } from "../util/platform.js";
 
-interface StreamingAudioEntry {
+// ---------------------------------------------------------------------------
+// Unified metadata — both stored and streaming entries share one map
+// ---------------------------------------------------------------------------
+
+interface AudioEntryMeta {
+  filePath: string;
   contentType: string;
+  sizeBytes: number;
   expiresAt: number;
-  chunks: Uint8Array[];
-  totalBytes: number;
   complete: boolean;
   subscribers: Set<ReadableStreamDefaultController<Uint8Array>>;
 }
 
-const store = new Map<string, AudioEntry>();
-const streamingStore = new Map<string, StreamingAudioEntry>();
+const entries = new Map<string, AudioEntryMeta>();
 const MAX_STORE_BYTES = 50 * 1024 * 1024; // 50MB cap
 const TTL_MS = 60_000; // 60 seconds
 
 let currentBytes = 0;
+let spoolDir: string | null = null;
+
+function getSpoolDir(): string {
+  if (!spoolDir) {
+    spoolDir = join(getDataDir(), "audio-spool");
+    mkdirSync(spoolDir, { recursive: true });
+  }
+  return spoolDir;
+}
+
+// ---------------------------------------------------------------------------
+// Store complete audio — writes buffer to disk immediately
+// ---------------------------------------------------------------------------
 
 export function storeAudio(
   buffer: Buffer,
   format: "mp3" | "wav" | "opus",
 ): string {
   evictExpired();
-  // Evict oldest if over capacity
-  while (currentBytes + buffer.length > MAX_STORE_BYTES && store.size > 0) {
-    const oldest = store.keys().next().value;
-    if (oldest) removeEntry(oldest);
-  }
+  evictForCapacity(buffer.length);
+
   const id = randomUUID();
   const contentType = contentTypeForFormat(format);
-  store.set(id, { buffer, contentType, expiresAt: Date.now() + TTL_MS });
+  const filePath = join(getSpoolDir(), id);
+  writeFileSync(filePath, buffer);
+
+  entries.set(id, {
+    filePath,
+    contentType,
+    sizeBytes: buffer.length,
+    expiresAt: Date.now() + TTL_MS,
+    complete: true,
+    subscribers: new Set(),
+  });
   currentBytes += buffer.length;
   return id;
 }
@@ -55,21 +84,28 @@ export function createStreamingEntry(
   evictExpired();
   const id = randomUUID();
   const contentType = contentTypeForFormat(format);
-  const entry: StreamingAudioEntry = {
+  const filePath = join(getSpoolDir(), id);
+
+  // Create an empty file for appending
+  writeFileSync(filePath, Buffer.alloc(0));
+
+  const entry: AudioEntryMeta = {
+    filePath,
     contentType,
+    sizeBytes: 0,
     expiresAt: Date.now() + TTL_MS,
-    chunks: [],
-    totalBytes: 0,
     complete: false,
     subscribers: new Set(),
   };
-  streamingStore.set(id, entry);
+  entries.set(id, entry);
 
   return {
     audioId: id,
     push(chunk: Uint8Array) {
-      entry.chunks.push(chunk);
-      entry.totalBytes += chunk.byteLength;
+      appendFileSync(filePath, chunk);
+      entry.sizeBytes += chunk.byteLength;
+      currentBytes += chunk.byteLength;
+
       for (const controller of entry.subscribers) {
         try {
           controller.enqueue(chunk);
@@ -97,61 +133,66 @@ export function createStreamingEntry(
 // ---------------------------------------------------------------------------
 
 export type AudioResult =
-  | { type: "buffer"; buffer: Buffer; contentType: string }
+  | { type: "file"; filePath: string; sizeBytes: number; contentType: string }
   | { type: "stream"; stream: ReadableStream<Uint8Array>; contentType: string };
 
 export function getAudio(id: string): AudioResult | null {
   evictExpired();
 
-  // Check streaming store first
-  const streamingEntry = streamingStore.get(id);
-  if (streamingEntry) {
-    if (Date.now() > streamingEntry.expiresAt) {
-      streamingStore.delete(id);
-      return null;
-    }
-
-    if (streamingEntry.complete) {
-      // Synthesis finished — serve the complete buffer
-      const merged = mergeChunks(streamingEntry.chunks);
-      return {
-        type: "buffer",
-        buffer: Buffer.from(merged),
-        contentType: streamingEntry.contentType,
-      };
-    }
-
-    // Still streaming — return a ReadableStream that replays existing
-    // chunks and subscribes for future ones.
-    let ctrl: ReadableStreamDefaultController<Uint8Array>;
-    const stream = new ReadableStream<Uint8Array>({
-      start(controller) {
-        ctrl = controller;
-        for (const chunk of streamingEntry.chunks) {
-          controller.enqueue(chunk);
-        }
-        if (streamingEntry.complete) {
-          controller.close();
-        } else {
-          streamingEntry.subscribers.add(controller);
-        }
-      },
-      cancel() {
-        streamingEntry.subscribers.delete(ctrl);
-      },
-    });
-
-    return { type: "stream", stream, contentType: streamingEntry.contentType };
-  }
-
-  // Check regular store
-  const entry = store.get(id);
+  const entry = entries.get(id);
   if (!entry) return null;
   if (Date.now() > entry.expiresAt) {
     removeEntry(id);
     return null;
   }
-  return { type: "buffer", buffer: entry.buffer, contentType: entry.contentType };
+
+  if (entry.complete) {
+    return {
+      type: "file",
+      filePath: entry.filePath,
+      sizeBytes: entry.sizeBytes,
+      contentType: entry.contentType,
+    };
+  }
+
+  // Still streaming — return a ReadableStream that replays existing bytes
+  // from disk then subscribes for future chunks.
+  let ctrl: ReadableStreamDefaultController<Uint8Array>;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      ctrl = controller;
+      // Sync read ensures no chunks are missed between read and subscribe
+      const existing = readFileSync(entry.filePath);
+      if (existing.length > 0) {
+        controller.enqueue(new Uint8Array(existing));
+      }
+      if (entry.complete) {
+        controller.close();
+      } else {
+        entry.subscribers.add(controller);
+      }
+    },
+    cancel() {
+      entry.subscribers.delete(ctrl);
+    },
+  });
+
+  return { type: "stream", stream, contentType: entry.contentType };
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup — call on daemon shutdown to remove all temp files
+// ---------------------------------------------------------------------------
+
+export function cleanupAudioSpool(): void {
+  for (const [id] of entries) {
+    removeEntry(id);
+  }
+  const dir = spoolDir;
+  if (dir && existsSync(dir)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  spoolDir = null;
 }
 
 // ---------------------------------------------------------------------------
@@ -166,40 +207,48 @@ function contentTypeForFormat(format: "mp3" | "wav" | "opus"): string {
       : "audio/opus";
 }
 
-function mergeChunks(chunks: Uint8Array[]): Uint8Array {
-  const totalLength = chunks.reduce((sum, c) => sum + c.byteLength, 0);
-  const merged = new Uint8Array(totalLength);
-  let offset = 0;
-  for (const chunk of chunks) {
-    merged.set(chunk, offset);
-    offset += chunk.byteLength;
+function removeEntry(id: string): void {
+  const entry = entries.get(id);
+  if (entry) {
+    for (const controller of entry.subscribers) {
+      try {
+        controller.close();
+      } catch {
+        // noop
+      }
+    }
+    entry.subscribers.clear();
+    currentBytes -= entry.sizeBytes;
+    try {
+      unlinkSync(entry.filePath);
+    } catch {
+      // File may already be gone
+    }
+    entries.delete(id);
   }
-  return merged;
 }
 
-function removeEntry(id: string): void {
-  const entry = store.get(id);
-  if (entry) {
-    currentBytes -= entry.buffer.length;
-    store.delete(id);
+function evictForCapacity(incomingBytes: number): void {
+  while (currentBytes + incomingBytes > MAX_STORE_BYTES && entries.size > 0) {
+    // Evict oldest completed entry first; fall back to oldest overall
+    let oldestCompleted: string | null = null;
+    let oldestAny: string | null = null;
+    for (const [id, e] of entries) {
+      if (!oldestAny) oldestAny = id;
+      if (e.complete && !oldestCompleted) {
+        oldestCompleted = id;
+        break;
+      }
+    }
+    const victim = oldestCompleted ?? oldestAny;
+    if (victim) removeEntry(victim);
+    else break;
   }
 }
 
 function evictExpired(): void {
   const now = Date.now();
-  for (const [id, entry] of store) {
+  for (const [id, entry] of entries) {
     if (now > entry.expiresAt) removeEntry(id);
-  }
-  for (const [id, entry] of streamingStore) {
-    if (now > entry.expiresAt) {
-      for (const controller of entry.subscribers) {
-        try {
-          controller.close();
-        } catch {
-          // noop
-        }
-      }
-      streamingStore.delete(id);
-    }
   }
 }

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/node";
 
+import { cleanupAudioSpool } from "../calls/audio-store.js";
 import type { HeartbeatService } from "../heartbeat/heartbeat-service.js";
 import type { HookManager } from "../hooks/manager.js";
 import type { McpServerManager } from "../mcp/manager.js";
@@ -107,6 +108,7 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     if (deps.runtimeHttp) await deps.runtimeHttp.stop();
     await browserManager.closeAllPages();
     cleanupShellOutputTempFiles();
+    cleanupAudioSpool();
     deps.scheduler.stop();
     deps.getMemoryWorker()?.stop();
 

--- a/assistant/src/runtime/routes/audio-routes.ts
+++ b/assistant/src/runtime/routes/audio-routes.ts
@@ -23,12 +23,12 @@ export function handleGetAudio(audioId: string): Response {
   if (!entry) {
     return httpError("NOT_FOUND", "Audio not found", 404);
   }
-  if (entry.type === "buffer") {
-    return new Response(new Uint8Array(entry.buffer), {
+  if (entry.type === "file") {
+    return new Response(Bun.file(entry.filePath), {
       status: 200,
       headers: {
         "Content-Type": entry.contentType,
-        "Content-Length": entry.buffer.length.toString(),
+        "Content-Length": entry.sizeBytes.toString(),
       },
     });
   }

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -382,6 +382,7 @@ export function ensureDataDir(): void {
     join(wsData, "apps"),
     join(wsData, "interfaces"),
     join(wsData, "sounds"),
+    join(wsData, "audio-spool"),
   ];
   for (const dir of dirs) {
     if (!existsSync(dir)) {


### PR DESCRIPTION
## Summary
- Replace in-memory audio `Buffer`/`Uint8Array[]` retention with file-backed entries under `~/.vellum/workspace/data/audio-spool`, keeping only lightweight metadata in memory
- Unify streaming and non-streaming entries into a single `Map` with shared 50MB eviction budget — streaming chunks now count toward the same cap
- Serve completed audio via `Bun.file()` (zero-copy sendfile) and clean up temp files on expiry, removal, and daemon shutdown

## Original prompt
--safe implement this please plans/assistant-daemon-streaming-audio-spool.md avoid breaking existing stuff
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
