### PR TITLE
feat: persist and return queryContext in memory recall logs

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -654,6 +654,7 @@ export async function runAgentLoopImpl(
           })),
           injectedText: graphResult.injectedBlockText ?? undefined,
           reason: `graph:${graphResult.mode}`,
+          queryContext: m?.queryContext ?? undefined,
         });
       } catch (err) {
         log.warn({ err }, "Failed to persist memory recall log (non-fatal)");

--- a/assistant/src/memory/memory-recall-log-store.ts
+++ b/assistant/src/memory/memory-recall-log-store.ts
@@ -23,6 +23,7 @@ export interface RecordMemoryRecallLogParams {
   topCandidatesJson: unknown;
   injectedText?: string;
   reason?: string;
+  queryContext?: string;
 }
 
 export function recordMemoryRecallLog(
@@ -53,6 +54,7 @@ export function recordMemoryRecallLog(
       topCandidatesJson: JSON.stringify(params.topCandidatesJson),
       injectedText: params.injectedText ?? null,
       reason: params.reason ?? null,
+      queryContext: params.queryContext ?? null,
       createdAt: Date.now(),
     })
     .run();
@@ -92,6 +94,7 @@ export interface MemoryRecallLog {
   topCandidates: unknown;
   injectedText: string | null;
   reason: string | null;
+  queryContext: string | null;
 }
 
 /**
@@ -164,5 +167,6 @@ export function getMemoryRecallLogByMessageIds(
     topCandidates: normalizeTopCandidates(JSON.parse(row.topCandidatesJson)),
     injectedText: row.injectedText,
     reason: row.reason,
+    queryContext: row.queryContext,
   };
 }


### PR DESCRIPTION
## Summary
- Add queryContext to RecordMemoryRecallLogParams and MemoryRecallLog interfaces
- Persist queryContext in recordMemoryRecallLog insert
- Return queryContext from getMemoryRecallLogByMessageIds
- Thread queryContext from retrieval metrics through conversation-agent-loop

Part of plan: memory-recall-query-context.md (PR 4 of 5)