### PR TITLE
feat: show query context card in Memory inspector tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorMemoryTab.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorMemoryTab.swift
@@ -29,6 +29,7 @@ struct MessageInspectorMemoryTabModel: Equatable {
     let searchRows: [Row]
     let candidates: [CandidateRow]
     let injectedText: String?
+    let queryContext: String?
     let degradationReason: String?
     let degradationSemanticUnavailable: Bool
     let degradationFallbackSources: String?
@@ -43,6 +44,7 @@ struct MessageInspectorMemoryTabModel: Equatable {
             searchRows = []
             candidates = []
             injectedText = nil
+            queryContext = nil
             degradationReason = nil
             degradationSemanticUnavailable = false
             degradationFallbackSources = nil
@@ -59,6 +61,7 @@ struct MessageInspectorMemoryTabModel: Equatable {
             searchRows = []
             candidates = []
             injectedText = nil
+            queryContext = nil
             degradationReason = nil
             degradationSemanticUnavailable = false
             degradationFallbackSources = nil
@@ -103,6 +106,7 @@ struct MessageInspectorMemoryTabModel: Equatable {
             }
 
         injectedText = recall.injectedText
+        queryContext = recall.queryContext
 
         if let degradation = recall.degradation {
             degradationReason = degradation.reason
@@ -171,6 +175,10 @@ struct MessageInspectorMemoryTab: View {
                 statusCard
                 funnelCard
                 searchDetailsCard
+
+                if model.queryContext != nil {
+                    queryContextCard
+                }
 
                 if !model.candidates.isEmpty {
                     candidatesCard
@@ -316,6 +324,36 @@ struct MessageInspectorMemoryTab: View {
             .padding(.vertical, VSpacing.xxs)
             .background(VColor.surfaceBase)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+    }
+
+    // MARK: - Query context card
+
+    private var queryContextCard: some View {
+        VCard {
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                HStack(alignment: .firstTextBaseline, spacing: VSpacing.sm) {
+                    cardHeader(title: "Query context", subtitle: "The text embedded as the search vector for semantic retrieval.")
+
+                    Spacer(minLength: VSpacing.md)
+
+                    VCopyButton(
+                        text: model.queryContext ?? "",
+                        size: .compact,
+                        accessibilityHint: "Copy query context"
+                    )
+                }
+
+                HighlightedTextView(
+                    text: .constant(model.queryContext ?? ""),
+                    language: .plain,
+                    isEditable: false,
+                    isActivelyEditing: .constant(false)
+                )
+                .frame(maxWidth: .infinity)
+                .frame(minHeight: 80, maxHeight: 300)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+            }
+        }
     }
 
     // MARK: - Injected text card

--- a/clients/shared/Network/LLMContextClient.swift
+++ b/clients/shared/Network/LLMContextClient.swift
@@ -515,6 +515,7 @@ public struct MemoryRecallData: Codable, Sendable, Equatable {
     public let reason: String?
     public let topCandidates: [MemoryRecallCandidate]
     public let injectedText: String?
+    public let queryContext: String?
 }
 
 /// A single LLM request/response log entry returned by the context endpoint.


### PR DESCRIPTION
## Summary
- Add queryContext to MemoryRecallData Swift struct
- Add Query context card to MessageInspectorMemoryTab with copy button and text view
- Card is hidden when queryContext is nil (backwards-compatible with old recall logs)

Part of plan: memory-recall-query-context.md (PR 5 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)