### PR TITLE
fix: clean up stale pending-interactions on prompt timeout, abort, and disposal

### DIFF
--- a/assistant/src/__tests__/approval-routes-http.test.ts
+++ b/assistant/src/__tests__/approval-routes-http.test.ts
@@ -919,7 +919,7 @@ describe("standalone approval endpoints — HTTP layer", () => {
       await stopServer();
     });
 
-    test("removes all entries including host-tools when includeHostTools is true", async () => {
+    test("removes host-tool entries when includeHostTools is true but preserves acp_confirmation", async () => {
       const session = makeIdleSession();
       await startServer(() => session);
 
@@ -943,6 +943,12 @@ describe("standalone approval endpoints — HTTP layer", () => {
         conversationId: "conv-dispose",
         kind: "host_cu",
       });
+      pendingInteractions.register("req-acp-2", {
+        conversation: null,
+        conversationId: "conv-dispose",
+        kind: "acp_confirmation",
+        directResolve: () => {},
+      });
 
       pendingInteractions.dropByConversationId("conv-dispose", {
         includeHostTools: true,
@@ -952,6 +958,8 @@ describe("standalone approval endpoints — HTTP layer", () => {
       expect(pendingInteractions.get("req-bash-2")).toBeUndefined();
       expect(pendingInteractions.get("req-file-2")).toBeUndefined();
       expect(pendingInteractions.get("req-cu-2")).toBeUndefined();
+      // ACP confirmations are always preserved for the session manager
+      expect(pendingInteractions.get("req-acp-2")).toBeDefined();
 
       await stopServer();
     });

--- a/assistant/src/__tests__/approval-routes-http.test.ts
+++ b/assistant/src/__tests__/approval-routes-http.test.ts
@@ -839,4 +839,146 @@ describe("standalone approval endpoints — HTTP layer", () => {
       await stopServer();
     });
   });
+
+  // ── drop ──────────────────────────────────────────────────────────────
+
+  describe("drop", () => {
+    test("removes a single interaction by requestId", async () => {
+      const session = makeIdleSession();
+      await startServer(() => session);
+
+      pendingInteractions.register("req-drop-1", {
+        conversation: session,
+        conversationId: "conv-d",
+        kind: "confirmation",
+      });
+      expect(pendingInteractions.get("req-drop-1")).toBeDefined();
+
+      pendingInteractions.drop("req-drop-1");
+      expect(pendingInteractions.get("req-drop-1")).toBeUndefined();
+
+      await stopServer();
+    });
+
+    test("is idempotent — dropping a nonexistent requestId does not throw", async () => {
+      const session = makeIdleSession();
+      await startServer(() => session);
+
+      // Should not throw
+      pendingInteractions.drop("nonexistent-id");
+      pendingInteractions.drop("nonexistent-id");
+
+      await stopServer();
+    });
+  });
+
+  // ── dropByConversationId ──────────────────────────────────────────────
+
+  describe("dropByConversationId", () => {
+    test("removes confirmation and secret entries but skips host-tool entries by default", async () => {
+      const session = makeIdleSession();
+      await startServer(() => session);
+
+      pendingInteractions.register("req-conf", {
+        conversation: session,
+        conversationId: "conv-cleanup",
+        kind: "confirmation",
+      });
+      pendingInteractions.register("req-sec", {
+        conversation: session,
+        conversationId: "conv-cleanup",
+        kind: "secret",
+      });
+      pendingInteractions.register("req-bash", {
+        conversation: session,
+        conversationId: "conv-cleanup",
+        kind: "host_bash",
+      });
+      pendingInteractions.register("req-file", {
+        conversation: session,
+        conversationId: "conv-cleanup",
+        kind: "host_file",
+      });
+      pendingInteractions.register("req-cu", {
+        conversation: session,
+        conversationId: "conv-cleanup",
+        kind: "host_cu",
+      });
+
+      pendingInteractions.dropByConversationId("conv-cleanup");
+
+      // Confirmation and secret should be gone
+      expect(pendingInteractions.get("req-conf")).toBeUndefined();
+      expect(pendingInteractions.get("req-sec")).toBeUndefined();
+
+      // Host-tool entries should remain
+      expect(pendingInteractions.get("req-bash")).toBeDefined();
+      expect(pendingInteractions.get("req-file")).toBeDefined();
+      expect(pendingInteractions.get("req-cu")).toBeDefined();
+
+      await stopServer();
+    });
+
+    test("removes all entries including host-tools when includeHostTools is true", async () => {
+      const session = makeIdleSession();
+      await startServer(() => session);
+
+      pendingInteractions.register("req-conf-2", {
+        conversation: session,
+        conversationId: "conv-dispose",
+        kind: "confirmation",
+      });
+      pendingInteractions.register("req-bash-2", {
+        conversation: session,
+        conversationId: "conv-dispose",
+        kind: "host_bash",
+      });
+      pendingInteractions.register("req-file-2", {
+        conversation: session,
+        conversationId: "conv-dispose",
+        kind: "host_file",
+      });
+      pendingInteractions.register("req-cu-2", {
+        conversation: session,
+        conversationId: "conv-dispose",
+        kind: "host_cu",
+      });
+
+      pendingInteractions.dropByConversationId("conv-dispose", {
+        includeHostTools: true,
+      });
+
+      expect(pendingInteractions.get("req-conf-2")).toBeUndefined();
+      expect(pendingInteractions.get("req-bash-2")).toBeUndefined();
+      expect(pendingInteractions.get("req-file-2")).toBeUndefined();
+      expect(pendingInteractions.get("req-cu-2")).toBeUndefined();
+
+      await stopServer();
+    });
+
+    test("does not affect entries for other conversations", async () => {
+      const session = makeIdleSession();
+      await startServer(() => session);
+
+      pendingInteractions.register("req-other-conv", {
+        conversation: session,
+        conversationId: "conv-other",
+        kind: "confirmation",
+      });
+      pendingInteractions.register("req-target-conv", {
+        conversation: session,
+        conversationId: "conv-target",
+        kind: "confirmation",
+      });
+
+      pendingInteractions.dropByConversationId("conv-target", {
+        includeHostTools: true,
+      });
+
+      expect(pendingInteractions.get("req-other-conv")).toBeDefined();
+      expect(pendingInteractions.get("req-target-conv")).toBeUndefined();
+
+      await stopServer();
+    });
+  });
 });

--- a/assistant/src/__tests__/pending-interaction-cleanup.test.ts
+++ b/assistant/src/__tests__/pending-interaction-cleanup.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Tests that pending-interactions entries are cleaned up when a prompt
+ * finishes (timeout, abort, resolve, dispose) via the onPromptReleased
+ * callback, and that conversation disposal drops all entries including
+ * host-tool interactions.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    timeouts: { permissionTimeoutSec: 0.1 },
+    secretDetection: { enabled: false, allowOneTimeSend: false },
+  }),
+}));
+
+mock.module("../security/redaction.js", () => ({
+  redactSensitiveFields: (input: Record<string, unknown>) => input,
+}));
+
+import { PermissionPrompter } from "../permissions/prompter.js";
+import { SecretPrompter } from "../permissions/secret-prompter.js";
+import * as pendingInteractions from "../runtime/pending-interactions.js";
+
+beforeEach(() => {
+  pendingInteractions.clear();
+});
+
+afterEach(() => {
+  pendingInteractions.clear();
+});
+
+// ---------------------------------------------------------------------------
+// PermissionPrompter cleanup
+// ---------------------------------------------------------------------------
+
+describe("PermissionPrompter + pending-interactions cleanup", () => {
+  test("confirmation timeout removes the pending interaction entry", async () => {
+    let capturedRequestId = "";
+    const prompter = new PermissionPrompter((msg: any) => {
+      if (msg.requestId) capturedRequestId = msg.requestId;
+    });
+    prompter.setOnPromptReleased((requestId) => {
+      pendingInteractions.drop(requestId);
+    });
+
+    // Start the prompt (this will time out after 100ms from our mock config)
+    const resultPromise = prompter.prompt(
+      "test_tool",
+      { cmd: "ls" },
+      "low",
+      [],
+      [],
+    );
+
+    // Register in pending-interactions as the server would
+    await new Promise((r) => setTimeout(r, 10));
+    expect(capturedRequestId).not.toBe("");
+    pendingInteractions.register(capturedRequestId, {
+      conversation: null,
+      conversationId: "conv-test",
+      kind: "confirmation",
+    });
+    expect(pendingInteractions.get(capturedRequestId)).toBeDefined();
+
+    // Wait for timeout
+    const result = await resultPromise;
+    expect(result.decision).toBe("deny");
+
+    // The onPromptReleased callback should have dropped the entry
+    expect(pendingInteractions.get(capturedRequestId)).toBeUndefined();
+  });
+
+  test("abort signal removes the pending interaction entry", async () => {
+    let capturedRequestId = "";
+    const prompter = new PermissionPrompter((msg: any) => {
+      if (msg.requestId) capturedRequestId = msg.requestId;
+    });
+    prompter.setOnPromptReleased((requestId) => {
+      pendingInteractions.drop(requestId);
+    });
+
+    const controller = new AbortController();
+
+    const resultPromise = prompter.prompt(
+      "test_tool",
+      { cmd: "ls" },
+      "low",
+      [],
+      [],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      controller.signal,
+    );
+
+    await new Promise((r) => setTimeout(r, 10));
+    pendingInteractions.register(capturedRequestId, {
+      conversation: null,
+      conversationId: "conv-test",
+      kind: "confirmation",
+    });
+    expect(pendingInteractions.get(capturedRequestId)).toBeDefined();
+
+    controller.abort();
+    const result = await resultPromise;
+    expect(result.decision).toBe("deny");
+    expect(pendingInteractions.get(capturedRequestId)).toBeUndefined();
+  });
+
+  test("resolveConfirmation removes the pending interaction entry", async () => {
+    let capturedRequestId = "";
+    const prompter = new PermissionPrompter((msg: any) => {
+      if (msg.requestId) capturedRequestId = msg.requestId;
+    });
+    prompter.setOnPromptReleased((requestId) => {
+      pendingInteractions.drop(requestId);
+    });
+
+    const resultPromise = prompter.prompt(
+      "test_tool",
+      { cmd: "ls" },
+      "low",
+      [],
+      [],
+    );
+
+    await new Promise((r) => setTimeout(r, 10));
+    pendingInteractions.register(capturedRequestId, {
+      conversation: null,
+      conversationId: "conv-test",
+      kind: "confirmation",
+    });
+
+    prompter.resolveConfirmation(capturedRequestId, "allow");
+    const result = await resultPromise;
+    expect(result.decision).toBe("allow");
+    expect(pendingInteractions.get(capturedRequestId)).toBeUndefined();
+  });
+
+  test("dispose removes all pending interaction entries", async () => {
+    const capturedIds: string[] = [];
+    const prompter = new PermissionPrompter((msg: any) => {
+      if (msg.requestId) capturedIds.push(msg.requestId);
+    });
+    prompter.setOnPromptReleased((requestId) => {
+      pendingInteractions.drop(requestId);
+    });
+
+    // Start two prompts
+    const p1 = prompter
+      .prompt("tool1", {}, "low", [], [])
+      .catch(() => ({ decision: "deny" as const }));
+    const p2 = prompter
+      .prompt("tool2", {}, "low", [], [])
+      .catch(() => ({ decision: "deny" as const }));
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(capturedIds).toHaveLength(2);
+
+    for (const id of capturedIds) {
+      pendingInteractions.register(id, {
+        conversation: null,
+        conversationId: "conv-test",
+        kind: "confirmation",
+      });
+    }
+
+    prompter.dispose();
+    await Promise.allSettled([p1, p2]);
+
+    for (const id of capturedIds) {
+      expect(pendingInteractions.get(id)).toBeUndefined();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SecretPrompter cleanup
+// ---------------------------------------------------------------------------
+
+describe("SecretPrompter + pending-interactions cleanup", () => {
+  test("secret timeout removes the pending interaction entry", async () => {
+    let capturedRequestId = "";
+    const prompter = new SecretPrompter((msg: any) => {
+      if (msg.requestId) capturedRequestId = msg.requestId;
+    });
+    prompter.setOnPromptReleased((requestId) => {
+      pendingInteractions.drop(requestId);
+    });
+
+    const resultPromise = prompter.prompt("api", "key", "API Key");
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(capturedRequestId).not.toBe("");
+    pendingInteractions.register(capturedRequestId, {
+      conversation: null,
+      conversationId: "conv-test",
+      kind: "secret",
+    });
+
+    const result = await resultPromise;
+    expect(result.value).toBeNull();
+    expect(pendingInteractions.get(capturedRequestId)).toBeUndefined();
+  });
+
+  test("resolveSecret removes the pending interaction entry", async () => {
+    let capturedRequestId = "";
+    const prompter = new SecretPrompter((msg: any) => {
+      if (msg.requestId) capturedRequestId = msg.requestId;
+    });
+    prompter.setOnPromptReleased((requestId) => {
+      pendingInteractions.drop(requestId);
+    });
+
+    const resultPromise = prompter.prompt("api", "key", "API Key");
+
+    await new Promise((r) => setTimeout(r, 10));
+    pendingInteractions.register(capturedRequestId, {
+      conversation: null,
+      conversationId: "conv-test",
+      kind: "secret",
+    });
+
+    prompter.resolveSecret(capturedRequestId, "the-secret", "store");
+    const result = await resultPromise;
+    expect(result.value).toBe("the-secret");
+    expect(pendingInteractions.get(capturedRequestId)).toBeUndefined();
+  });
+
+  test("dispose removes all pending secret interaction entries", async () => {
+    const capturedIds: string[] = [];
+    const prompter = new SecretPrompter((msg: any) => {
+      if (msg.requestId) capturedIds.push(msg.requestId);
+    });
+    prompter.setOnPromptReleased((requestId) => {
+      pendingInteractions.drop(requestId);
+    });
+
+    const p1 = prompter
+      .prompt("api", "key1", "Key 1")
+      .catch(() => ({ value: null, delivery: "store" as const }));
+    const p2 = prompter
+      .prompt("api", "key2", "Key 2")
+      .catch(() => ({ value: null, delivery: "store" as const }));
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    for (const id of capturedIds) {
+      pendingInteractions.register(id, {
+        conversation: null,
+        conversationId: "conv-test",
+        kind: "secret",
+      });
+    }
+
+    prompter.dispose();
+    await Promise.allSettled([p1, p2]);
+
+    for (const id of capturedIds) {
+      expect(pendingInteractions.get(id)).toBeUndefined();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dropByConversationId with host-tool entries
+// ---------------------------------------------------------------------------
+
+describe("dropByConversationId for conversation disposal", () => {
+  test("drops host_bash, host_file, host_cu, and confirmation entries when includeHostTools is true", () => {
+    pendingInteractions.register("req-conf", {
+      conversation: null,
+      conversationId: "conv-dispose",
+      kind: "confirmation",
+    });
+    pendingInteractions.register("req-secret", {
+      conversation: null,
+      conversationId: "conv-dispose",
+      kind: "secret",
+    });
+    pendingInteractions.register("req-bash", {
+      conversation: null,
+      conversationId: "conv-dispose",
+      kind: "host_bash",
+    });
+    pendingInteractions.register("req-file", {
+      conversation: null,
+      conversationId: "conv-dispose",
+      kind: "host_file",
+    });
+    pendingInteractions.register("req-cu", {
+      conversation: null,
+      conversationId: "conv-dispose",
+      kind: "host_cu",
+    });
+
+    pendingInteractions.dropByConversationId("conv-dispose", {
+      includeHostTools: true,
+    });
+
+    expect(pendingInteractions.get("req-conf")).toBeUndefined();
+    expect(pendingInteractions.get("req-secret")).toBeUndefined();
+    expect(pendingInteractions.get("req-bash")).toBeUndefined();
+    expect(pendingInteractions.get("req-file")).toBeUndefined();
+    expect(pendingInteractions.get("req-cu")).toBeUndefined();
+  });
+
+  test("does not affect entries for other conversations", () => {
+    pendingInteractions.register("req-keep", {
+      conversation: null,
+      conversationId: "conv-keep",
+      kind: "host_bash",
+    });
+    pendingInteractions.register("req-drop", {
+      conversation: null,
+      conversationId: "conv-dispose",
+      kind: "host_bash",
+    });
+
+    pendingInteractions.dropByConversationId("conv-dispose", {
+      includeHostTools: true,
+    });
+
+    expect(pendingInteractions.get("req-keep")).toBeDefined();
+    expect(pendingInteractions.get("req-drop")).toBeUndefined();
+  });
+});

--- a/assistant/src/__tests__/pending-interaction-cleanup.test.ts
+++ b/assistant/src/__tests__/pending-interaction-cleanup.test.ts
@@ -275,7 +275,7 @@ describe("SecretPrompter + pending-interactions cleanup", () => {
 // ---------------------------------------------------------------------------
 
 describe("dropByConversationId for conversation disposal", () => {
-  test("drops host_bash, host_file, host_cu, and confirmation entries when includeHostTools is true", () => {
+  test("drops host_bash, host_file, host_cu, and confirmation entries when includeHostTools is true but preserves acp_confirmation", () => {
     pendingInteractions.register("req-conf", {
       conversation: null,
       conversationId: "conv-dispose",
@@ -301,6 +301,12 @@ describe("dropByConversationId for conversation disposal", () => {
       conversationId: "conv-dispose",
       kind: "host_cu",
     });
+    pendingInteractions.register("req-acp", {
+      conversation: null,
+      conversationId: "conv-dispose",
+      kind: "acp_confirmation",
+      directResolve: () => {},
+    });
 
     pendingInteractions.dropByConversationId("conv-dispose", {
       includeHostTools: true,
@@ -311,6 +317,8 @@ describe("dropByConversationId for conversation disposal", () => {
     expect(pendingInteractions.get("req-bash")).toBeUndefined();
     expect(pendingInteractions.get("req-file")).toBeUndefined();
     expect(pendingInteractions.get("req-cu")).toBeUndefined();
+    // ACP confirmations are always preserved for the session manager
+    expect(pendingInteractions.get("req-acp")).toBeDefined();
   });
 
   test("does not affect entries for other conversations", () => {

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -23,6 +23,7 @@ import {
   isUntrustedTrustClass,
   type TrustClass,
 } from "../runtime/actor-trust-resolver.js";
+import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { unregisterConversationSender } from "../tools/browser/browser-screencast.js";
 import { getLogger } from "../util/logger.js";
 import {
@@ -324,6 +325,14 @@ export function disposeConversation(ctx: DisposeContext): void {
   }
 
   ctx.abort();
+
+  // Drop all remaining pending interactions for this conversation, including
+  // host-tool entries. After disposal the conversation can no longer receive
+  // results, so keeping them would leak the Conversation reference.
+  pendingInteractions.dropByConversationId(ctx.conversationId, {
+    includeHostTools: true,
+  });
+
   unregisterCallNotifiers(ctx.conversationId);
   unregisterConversationSender(ctx.conversationId);
   resetSkillToolProjection(ctx.skillProjectionState);

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -296,6 +296,9 @@ export class Conversation {
     );
     this.traceEmitter = new TraceEmitter(conversationId, sendToClient);
     this.prompter = new PermissionPrompter(sendToClient);
+    this.prompter.setOnPromptReleased((requestId) => {
+      pendingInteractions.drop(requestId);
+    });
     this.prompter.setOnStateChanged((requestId, state, source, toolUseId) => {
       // Route through emitConfirmationStateChanged so the event reaches
       // the client via sendToClient (wired to the SSE hub for HTTP conversations).
@@ -327,6 +330,9 @@ export class Conversation {
       }
     });
     this.secretPrompter = new SecretPrompter(sendToClient);
+    this.secretPrompter.setOnPromptReleased((requestId) => {
+      pendingInteractions.drop(requestId);
+    });
 
     // Register watch/call notifiers (reads ctx properties lazily)
     registerConversationNotifiers(conversationId, this);

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -33,6 +33,7 @@ export class PermissionPrompter {
   private pending = new Map<string, PendingPrompt>();
   private sendToClient: (msg: ServerMessage) => void;
   private onStateChanged?: ConfirmationStateCallback;
+  private onPromptReleased?: (requestId: string) => void;
 
   constructor(sendToClient: (msg: ServerMessage) => void) {
     this.sendToClient = sendToClient;
@@ -40,6 +41,15 @@ export class PermissionPrompter {
 
   setOnStateChanged(cb: ConfirmationStateCallback): void {
     this.onStateChanged = cb;
+  }
+
+  /**
+   * Register a callback invoked whenever a prompt is removed from this
+   * prompter (timeout, resolution, abort, or dispose). Callers use this
+   * to keep external trackers (e.g. pending-interactions) in sync.
+   */
+  setOnPromptReleased(cb: (requestId: string) => void): void {
+    this.onPromptReleased = cb;
   }
 
   updateSender(sendToClient: (msg: ServerMessage) => void): void {
@@ -79,6 +89,7 @@ export class PermissionPrompter {
       const timeoutMs = getConfig().timeouts.permissionTimeoutSec * 1000;
       const timer = setTimeout(() => {
         this.pending.delete(requestId);
+        this.onPromptReleased?.(requestId);
         log.warn(
           { requestId, toolName },
           "Permission prompt timed out, defaulting to deny",
@@ -97,6 +108,7 @@ export class PermissionPrompter {
           if (this.pending.has(requestId)) {
             clearTimeout(timer);
             this.pending.delete(requestId);
+            this.onPromptReleased?.(requestId);
             resolve({ decision: "deny" });
           }
         };
@@ -159,6 +171,7 @@ export class PermissionPrompter {
     }
     clearTimeout(pending.timer);
     this.pending.delete(requestId);
+    this.onPromptReleased?.(requestId);
     pending.resolve({
       decision,
       selectedPattern,
@@ -176,6 +189,7 @@ export class PermissionPrompter {
     for (const [requestId, pending] of this.pending) {
       clearTimeout(pending.timer);
       this.pending.delete(requestId);
+      this.onPromptReleased?.(requestId);
       pending.resolve({
         decision: "deny",
         decisionContext:
@@ -189,8 +203,9 @@ export class PermissionPrompter {
   }
 
   dispose(): void {
-    for (const [, pending] of this.pending) {
+    for (const [requestId, pending] of this.pending) {
       clearTimeout(pending.timer);
+      this.onPromptReleased?.(requestId);
       pending.reject(
         new AssistantError("Prompter disposed", ErrorCode.INTERNAL_ERROR),
       );

--- a/assistant/src/permissions/secret-prompter.ts
+++ b/assistant/src/permissions/secret-prompter.ts
@@ -25,9 +25,19 @@ interface PendingSecretPrompt {
 export class SecretPrompter {
   private pending = new Map<string, PendingSecretPrompt>();
   private sendToClient: (msg: ServerMessage) => void;
+  private onPromptReleased?: (requestId: string) => void;
 
   constructor(sendToClient: (msg: ServerMessage) => void) {
     this.sendToClient = sendToClient;
+  }
+
+  /**
+   * Register a callback invoked whenever a secret prompt is removed from this
+   * prompter (timeout, resolution, or dispose). Callers use this to keep
+   * external trackers (e.g. pending-interactions) in sync.
+   */
+  setOnPromptReleased(cb: (requestId: string) => void): void {
+    this.onPromptReleased = cb;
   }
 
   updateSender(sendToClient: (msg: ServerMessage) => void): void {
@@ -58,6 +68,7 @@ export class SecretPrompter {
       const timeoutMs = getConfig().timeouts.permissionTimeoutSec * 1000;
       const timer = setTimeout(() => {
         this.pending.delete(requestId);
+        this.onPromptReleased?.(requestId);
         log.warn({ requestId, service, field }, "Secret prompt timed out");
         resolve({ value: null, delivery: "store" });
       }, timeoutMs);
@@ -106,12 +117,14 @@ export class SecretPrompter {
     }
     clearTimeout(pending.timer);
     this.pending.delete(requestId);
+    this.onPromptReleased?.(requestId);
     pending.resolve({ value: value ?? null, delivery: delivery ?? "store" });
   }
 
   dispose(): void {
-    for (const [, pending] of this.pending) {
+    for (const [requestId, pending] of this.pending) {
       clearTimeout(pending.timer);
+      this.onPromptReleased?.(requestId);
       pending.reject(
         new AssistantError("Prompter disposed", ErrorCode.INTERNAL_ERROR),
       );

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -134,8 +134,11 @@ export function drop(requestId: string): void {
  *
  * By default, host_bash, host_file, host_cu, and acp_confirmation interactions
  * are skipped (same as `removeByConversation`). Pass `{ includeHostTools: true }`
- * to drop everything — use this only when the conversation is being disposed
- * and the host-tool results can no longer be delivered.
+ * to also drop host_bash, host_file, and host_cu entries — use this when the
+ * conversation is being disposed and host-tool results can no longer be delivered.
+ *
+ * acp_confirmation entries are always skipped because they store a `directResolve`
+ * callback that the ACP session manager needs during its own teardown.
  */
 export function dropByConversationId(
   conversationId: string,
@@ -144,12 +147,14 @@ export function dropByConversationId(
   const includeHostTools = options?.includeHostTools ?? false;
   for (const [requestId, interaction] of pending) {
     if (interaction.conversationId !== conversationId) continue;
+    // ACP confirmations are always preserved — the session manager handles
+    // their lifecycle via teardownSession.
+    if (interaction.kind === "acp_confirmation") continue;
     if (
       !includeHostTools &&
       (interaction.kind === "host_bash" ||
         interaction.kind === "host_file" ||
-        interaction.kind === "host_cu" ||
-        interaction.kind === "acp_confirmation")
+        interaction.kind === "host_cu")
     ) {
       continue;
     }

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -121,6 +121,42 @@ export function removeByConversation(conversation: Conversation): void {
   }
 }
 
+/**
+ * Remove a single pending interaction by requestId. Idempotent — safe to call
+ * even if the request has already been resolved or dropped elsewhere.
+ */
+export function drop(requestId: string): void {
+  pending.delete(requestId);
+}
+
+/**
+ * Remove all pending interactions for a conversation by conversationId.
+ *
+ * By default, host_bash, host_file, host_cu, and acp_confirmation interactions
+ * are skipped (same as `removeByConversation`). Pass `{ includeHostTools: true }`
+ * to drop everything — use this only when the conversation is being disposed
+ * and the host-tool results can no longer be delivered.
+ */
+export function dropByConversationId(
+  conversationId: string,
+  options?: { includeHostTools?: boolean },
+): void {
+  const includeHostTools = options?.includeHostTools ?? false;
+  for (const [requestId, interaction] of pending) {
+    if (interaction.conversationId !== conversationId) continue;
+    if (
+      !includeHostTools &&
+      (interaction.kind === "host_bash" ||
+        interaction.kind === "host_file" ||
+        interaction.kind === "host_cu" ||
+        interaction.kind === "acp_confirmation")
+    ) {
+      continue;
+    }
+    pending.delete(requestId);
+  }
+}
+
 /** Clear all pending interactions. Useful for testing. */
 export function clear(): void {
   pending.clear();


### PR DESCRIPTION
## Summary
- Add `drop(requestId)` and `dropByConversationId(conversationId, options)` to `pending-interactions.ts` for explicit, idempotent cleanup of stale entries
- Wire `onPromptReleased` callbacks in both `PermissionPrompter` and `SecretPrompter` so that timed-out, aborted, resolved, or disposed prompts automatically remove their global pending-interaction entries
- Call `dropByConversationId` with `includeHostTools: true` during conversation disposal to drop all remaining entries (including host_bash, host_file, host_cu) since the conversation can no longer receive results

## Original prompt
--safe implement this assistant-daemon-pending-interaction-cleanup.md do not break existing stuff please
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
