### PR TITLE
test: add queryContext coverage to memory-recall-log-store test

### DIFF
--- a/assistant/src/__tests__/memory-recall-log-store.test.ts
+++ b/assistant/src/__tests__/memory-recall-log-store.test.ts
@@ -62,6 +62,7 @@ describe("memory-recall-log-store", () => {
       topCandidatesJson: [{ id: "c1", score: 0.9 }],
       injectedText: "some memory context",
       reason: "user query matched memories",
+      queryContext: "what is the weather like",
     });
 
     backfillMemoryRecallLogMessageId(conversationId, messageId);
@@ -85,6 +86,34 @@ describe("memory-recall-log-store", () => {
     expect(result!.topCandidates).toEqual([{ id: "c1", score: 0.9 }]);
     expect(result!.injectedText).toBe("some memory context");
     expect(result!.reason).toBe("user query matched memories");
+    expect(result!.queryContext).toBe("what is the weather like");
+  });
+
+  test("queryContext defaults to null when omitted", () => {
+    const conversationId = "conv-no-query-ctx";
+    const messageId = "msg-no-query-ctx";
+
+    recordMemoryRecallLog({
+      conversationId,
+      enabled: true,
+      degraded: false,
+      semanticHits: 1,
+      mergedCount: 1,
+      selectedCount: 1,
+      tier1Count: 1,
+      tier2Count: 0,
+      hybridSearchLatencyMs: 50,
+      sparseVectorUsed: false,
+      injectedTokens: 100,
+      latencyMs: 80,
+      topCandidatesJson: [],
+    });
+
+    backfillMemoryRecallLogMessageId(conversationId, messageId);
+
+    const result = getMemoryRecallLogByMessageIds([messageId]);
+    expect(result).not.toBeNull();
+    expect(result!.queryContext).toBeNull();
   });
 
   test("returns null when no log exists for a messageId", () => {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for memory-recall-query-context.md.

**Gap:** No test coverage for queryContext in memory-recall-log-store.test.ts
**What was expected:** Round-trip test should verify queryContext persistence
**What was found:** Test didn't include queryContext in params or assertions
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23527" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
