### PR TITLE
feat: attachment-backed ref blocks with JIT hydration

### DIFF
--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -145,6 +145,7 @@ mock.module("../memory/conversation-crud.js", () => ({
   },
   updateConversationUsage: () => {},
   updateConversationTitle: () => {},
+  updateMessageContent: () => {},
 }));
 
 mock.module("../memory/conversation-queries.js", () => ({
@@ -189,6 +190,7 @@ mock.module("../memory/attachments-store.js", () => ({
   },
   getFilePathForAttachment: () => null,
   setAttachmentThumbnail: () => {},
+  getAttachmentContent: () => null,
 }));
 
 mock.module("../memory/retriever.js", () => ({
@@ -1838,7 +1840,7 @@ describe("MessageQueue byte budget", () => {
   function makeItem(
     content: string,
     requestId = "r",
-    attachments: { data: string }[] = [],
+    attachments: { data?: string; sizeBytes?: number }[] = [],
   ) {
     return {
       content,
@@ -1846,7 +1848,8 @@ describe("MessageQueue byte budget", () => {
         id: "a",
         filename: "f",
         mimeType: "text/plain",
-        data: a.data,
+        data: a.data ?? "",
+        sizeBytes: a.sizeBytes,
       })),
       requestId,
       onEvent: () => {},
@@ -1916,5 +1919,26 @@ describe("MessageQueue byte budget", () => {
     expect(
       q.push(makeItem("y".repeat(100), "r2", [{ data: "b".repeat(100) }])),
     ).toBe(false);
+  });
+
+  test("file-backed attachments use sizeBytes instead of data.length", () => {
+    // Without sizeBytes accounting, a file-backed attachment (data: "") would
+    // appear to cost 0 bytes and never trigger the budget. With sizeBytes, the
+    // actual decoded size is counted.
+    const q = new MessageQueue(5_000);
+    // First item: base64-only attachment (2000 chars * 2 = 4000 bytes + 512 + content overhead)
+    expect(q.push(makeItem("hi", "r1", [{ data: "a".repeat(2000) }]))).toBe(
+      true,
+    );
+    // Second item: file-backed attachment — sizeBytes triggers the budget limit
+    expect(q.push(makeItem("hi", "r2", [{ sizeBytes: 3000 }]))).toBe(false);
+  });
+
+  test("file-backed attachments with no sizeBytes are treated as zero-cost", () => {
+    // When neither data nor sizeBytes is set (e.g. metadata-only), no memory
+    // cost is counted — the attachment itself doesn't occupy the queue budget.
+    const q = new MessageQueue(1_000);
+    expect(q.push(makeItem("hello", "r1"))).toBe(true);
+    expect(q.push(makeItem("world", "r2", [{}]))).toBe(false); // budget exceeded by content alone
   });
 });

--- a/assistant/src/__tests__/server-history-render.test.ts
+++ b/assistant/src/__tests__/server-history-render.test.ts
@@ -285,6 +285,79 @@ describe("renderHistoryContent", () => {
   });
 });
 
+describe("renderHistoryContent — attachment-backed ref blocks", () => {
+  test("image_ref block is silently skipped (same as inline image)", () => {
+    const output = renderHistoryContent([
+      {
+        type: "image_ref",
+        source: { attachment_id: "att-1", media_type: "image/jpeg" },
+        size_bytes: 12345,
+      },
+    ]);
+    expect(output.text).toBe("");
+    expect(output.toolCalls).toEqual([]);
+  });
+
+  test("file_ref block renders filename, media type and size", () => {
+    const output = renderHistoryContent([
+      {
+        type: "file_ref",
+        source: {
+          attachment_id: "att-2",
+          media_type: "application/pdf",
+          filename: "report.pdf",
+        },
+        size_bytes: 51200,
+      },
+    ]);
+    expect(output.text).toContain("[File attachment] report.pdf");
+    expect(output.text).toContain("type=application/pdf");
+    expect(output.text).toContain("size=50.0 KB");
+  });
+
+  test("file_ref block renders extracted_text when present", () => {
+    const output = renderHistoryContent([
+      {
+        type: "file_ref",
+        source: {
+          attachment_id: "att-3",
+          media_type: "text/plain",
+          filename: "notes.txt",
+        },
+        extracted_text: "Important content here",
+        size_bytes: 100,
+      },
+    ]);
+    expect(output.text).toContain("Attachment text: Important content here");
+  });
+
+  test("file_ref block without size_bytes omits size from summary", () => {
+    const output = renderHistoryContent([
+      {
+        type: "file_ref",
+        source: {
+          attachment_id: "att-4",
+          media_type: "text/plain",
+          filename: "no-size.txt",
+        },
+      },
+    ]);
+    expect(output.text).toContain("[File attachment] no-size.txt");
+    expect(output.text).not.toContain("size=");
+  });
+
+  test("image_ref mixed with text renders only the text", () => {
+    const output = renderHistoryContent([
+      { type: "text", text: "Here is the image" },
+      {
+        type: "image_ref",
+        source: { attachment_id: "att-5", media_type: "image/png" },
+      },
+    ]);
+    expect(output.text).toBe("Here is the image");
+  });
+});
+
 describe("getAttachmentsForMessage", () => {
   beforeEach(() => {
     const db = getDb();

--- a/assistant/src/agent/attachments.ts
+++ b/assistant/src/agent/attachments.ts
@@ -1,4 +1,11 @@
-import type { ContentBlock, Message } from "../providers/types.js";
+import type {
+  AttachmentBackedFileBlock,
+  AttachmentBackedImageBlock,
+  ContentBlock,
+  FileContent,
+  ImageContent,
+  Message,
+} from "../providers/types.js";
 import { optimizeImageForTransport } from "./image-optimize.js";
 
 export interface MessageAttachmentInput {
@@ -65,4 +72,70 @@ export function enrichMessageWithSourcePaths(
     ...message,
     content: [...message.content, { type: "text" as const, text: annotation }],
   };
+}
+
+/** Type guard — returns true for attachment-backed image or file ref blocks. */
+export function isAttachmentBackedBlock(
+  block: ContentBlock,
+): block is AttachmentBackedImageBlock | AttachmentBackedFileBlock {
+  return block.type === "image_ref" || block.type === "file_ref";
+}
+
+/**
+ * Expand any `image_ref` / `file_ref` blocks in the message list to full
+ * `image` / `file` blocks with inline base64 data, ready for a provider call.
+ *
+ * Returns the same array reference unchanged when no attachment-backed blocks
+ * are present (fast path — no allocation).
+ *
+ * @param messages  History to hydrate.
+ * @param getContent  Returns the raw bytes for a given attachment ID, or null
+ *                    if the attachment cannot be read.  A null return leaves
+ *                    the ref block in place so the message remains valid.
+ */
+export function hydrateAttachmentBlocks(
+  messages: Message[],
+  getContent: (attachmentId: string) => Buffer | null,
+): Message[] {
+  const needsHydration = messages.some((m) =>
+    m.content.some(isAttachmentBackedBlock),
+  );
+  if (!needsHydration) return messages;
+
+  return messages.map((msg) => {
+    if (!msg.content.some(isAttachmentBackedBlock)) return msg;
+    return {
+      ...msg,
+      content: msg.content.map((block): ContentBlock => {
+        if (block.type === "image_ref") {
+          const buf = getContent(block.source.attachment_id);
+          if (!buf) return block;
+          const b64 = buf.toString("base64");
+          const { data, mediaType } = optimizeImageForTransport(
+            b64,
+            block.source.media_type,
+          );
+          return {
+            type: "image",
+            source: { type: "base64", media_type: mediaType, data },
+          } satisfies ImageContent;
+        }
+        if (block.type === "file_ref") {
+          const buf = getContent(block.source.attachment_id);
+          if (!buf) return block;
+          return {
+            type: "file",
+            source: {
+              type: "base64",
+              media_type: block.source.media_type,
+              data: buf.toString("base64"),
+              filename: block.source.filename,
+            },
+            extracted_text: block.extracted_text,
+          } satisfies FileContent;
+        }
+        return block;
+      }),
+    };
+  });
 }

--- a/assistant/src/context/token-estimator.ts
+++ b/assistant/src/context/token-estimator.ts
@@ -103,7 +103,9 @@ function estimateAnthropicImageTokens(width: number, height: number): number {
     scaledHeight = Math.round(scaledHeight * mpScale);
   }
 
-  return Math.ceil(scaledWidth * scaledHeight * ANTHROPIC_IMAGE_TOKENS_PER_PIXEL);
+  return Math.ceil(
+    scaledWidth * scaledHeight * ANTHROPIC_IMAGE_TOKENS_PER_PIXEL,
+  );
 }
 
 function estimateImageTokens(
@@ -177,6 +179,23 @@ export function estimateContentBlockTokens(
     case "web_search_tool_result":
       return (
         WEB_SEARCH_RESULT_TOKENS + estimateTextTokens(stableJson(block.content))
+      );
+    case "image_ref":
+      // Estimate from stored size_bytes; treat as a single Anthropic image page.
+      return (
+        IMAGE_BLOCK_OVERHEAD_TOKENS +
+        estimateTextTokens(block.source.media_type) +
+        Math.min(
+          ANTHROPIC_IMAGE_MAX_TOKENS,
+          Math.ceil((block.size_bytes ?? 0) * ANTHROPIC_IMAGE_TOKENS_PER_PIXEL),
+        )
+      );
+    case "file_ref":
+      return (
+        FILE_BLOCK_OVERHEAD_TOKENS +
+        estimateTextTokens(block.source.filename) +
+        estimateTextTokens(block.source.media_type) +
+        estimateTextTokens(block.extracted_text ?? "")
       );
     default:
       return OTHER_BLOCK_TOKENS;

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -605,7 +605,11 @@ export class ContextWindowManager {
     // images to drop. Images are high-cost and their text context (message
     // headers, surrounding tool_use/tool_result serializations) is preserved.
     const result = [...blocks];
-    for (let i = 0; i < result.length && totalTokens > maxTranscriptTokens; i++) {
+    for (
+      let i = 0;
+      i < result.length && totalTokens > maxTranscriptTokens;
+      i++
+    ) {
       if (result[i].type === "image") {
         totalTokens -= estimateBlockTokens(result[i]);
         const stub: ContentBlock = {
@@ -623,7 +627,11 @@ export class ContextWindowManager {
     // than dropping it entirely so the summarizer always has content to work with.
     let dropUntil = 0;
     let droppedTokens = 0;
-    for (let i = 0; i < result.length && totalTokens > maxTranscriptTokens; i++) {
+    for (
+      let i = 0;
+      i < result.length && totalTokens > maxTranscriptTokens;
+      i++
+    ) {
       const blockTokens = estimateBlockTokens(result[i]);
       const excess = totalTokens - maxTranscriptTokens;
       if (blockTokens > excess && result[i].type === "text") {
@@ -716,7 +724,9 @@ export class ContextWindowManager {
 
     // Fallback: extract text-only transcript for local summary generation.
     const textTranscript = transcriptBlocks
-      .filter((b): b is Extract<ContentBlock, { type: "text" }> => b.type === "text")
+      .filter(
+        (b): b is Extract<ContentBlock, { type: "text" }> => b.type === "text",
+      )
       .map((b) => b.text)
       .join("\n\n");
 
@@ -803,7 +813,11 @@ function adjustForToolPairs(
     // Collect tool_use_ids referenced by tool_results in this user message
     const referencedIds = new Set<string>();
     for (const block of msg.content) {
-      if ((block.type === "tool_result" || block.type === "web_search_tool_result") && "tool_use_id" in block) {
+      if (
+        (block.type === "tool_result" ||
+          block.type === "web_search_tool_result") &&
+        "tool_use_id" in block
+      ) {
         referencedIds.add((block as { tool_use_id: string }).tool_use_id);
       }
     }
@@ -919,7 +933,8 @@ function serializeMessagesToContentBlocks(messages: Message[]): ContentBlock[] {
           textLines.length = 0;
         }
         blocks.push(block);
-      } else if (block.type === "tool_result") { // guard:allow-tool-result-only — web_search_tool_result handled by serializeBlock via else branch
+      } else if (block.type === "tool_result") {
+        // guard:allow-tool-result-only — web_search_tool_result handled by serializeBlock via else branch
         // Extract images from tool_result contentBlocks before serializing.
         const collectedImages: ImageContent[] = [];
         textLines.push(serializeToolResultBlock(block, collectedImages));
@@ -1000,6 +1015,19 @@ function serializeBlock(block: ContentBlock): string {
       return `server_tool_use ${block.name}: ${clampText(stableJson(block.input))}`;
     case "web_search_tool_result":
       return `web_search_tool_result ${block.tool_use_id}`;
+    case "image_ref":
+      return `image_ref: ${block.source.media_type}, attachment=${block.source.attachment_id}`;
+    case "file_ref": {
+      const parts = [
+        `file_ref: ${block.source.filename}`,
+        block.source.media_type,
+        `attachment=${block.source.attachment_id}`,
+      ];
+      if (block.extracted_text) {
+        parts.push(`text=${clampText(block.extracted_text)}`);
+      }
+      return parts.join(", ");
+    }
     default:
       return "unknown_block";
   }

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -9,6 +9,7 @@
 
 import { v4 as uuid } from "uuid";
 
+import { hydrateAttachmentBlocks } from "../agent/attachments.js";
 import type {
   AgentEvent,
   AgentLoop,
@@ -33,6 +34,7 @@ import {
 } from "../instrument.js";
 import { commitAppTurnChanges } from "../memory/app-git-service.js";
 import { getApp, listAppFiles, resolveAppDir } from "../memory/app-store.js";
+import { getAttachmentContent } from "../memory/attachments-store.js";
 import {
   addMessage,
   deleteMessageById,
@@ -421,6 +423,13 @@ export async function runAgentLoopImpl(
       ctx.trustContext?.guardianPrincipalId ??
       ctx.trustContext?.requesterExternalUserId,
   });
+
+  // Expand any attachment-backed ref blocks (image_ref / file_ref) to full
+  // base64 blocks before any provider call.  This is a no-op when no refs
+  // are present (fast path).  Hydration happens once per runAgentLoop
+  // invocation; the in-memory history stays hydrated for the rest of the
+  // session and refs are re-read from DB on the next cold-start.
+  ctx.messages = hydrateAttachmentBlocks(ctx.messages, getAttachmentContent);
 
   try {
     // Auto-complete stale interactive surfaces from previous turns.

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -335,6 +335,9 @@ export async function persistUserMessage(
   //     this turn so the LLM sees the image without waiting for storage to complete.
   //     These get replaced with ref blocks after storage (see below).
   const inlineAttachmentInputs: MessageAttachmentInput[] = [];
+  // All attachments (pre-stored or inline) that have a filePath and are images
+  // — needed so enrichMessageWithSourcePaths can add disk-path annotations.
+  const sourcePathInputs: MessageAttachmentInput[] = [];
   const liveAttachmentBlocks: ContentBlock[] = [];
   for (const a of attachments) {
     if (a.id && attachmentExists(a.id)) {
@@ -347,6 +350,15 @@ export async function persistUserMessage(
           a.extractedText,
         ),
       );
+      if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
+        sourcePathInputs.push({
+          id: a.id,
+          filename: a.filename,
+          mimeType: a.mimeType,
+          data: "",
+          filePath: a.filePath,
+        });
+      }
     } else if (a.data) {
       const input: MessageAttachmentInput = {
         id: a.id,
@@ -357,6 +369,7 @@ export async function persistUserMessage(
         filePath: a.filePath,
       };
       inlineAttachmentInputs.push(input);
+      sourcePathInputs.push(input);
       const [block] = attachmentsToContentBlocks([input]);
       liveAttachmentBlocks.push(block);
     }
@@ -372,7 +385,7 @@ export async function persistUserMessage(
   };
   const llmMessage = enrichMessageWithSourcePaths(
     liveMessage,
-    inlineAttachmentInputs,
+    sourcePathInputs,
   );
   log.info(
     {
@@ -457,10 +470,16 @@ export async function persistUserMessage(
       const a = attachments[i];
       try {
         if (a.id && attachmentExists(a.id)) {
-          linkAttachmentToMessage(persistedUserMessage.id, a.id, i);
+          // Use the returned scoped ID — linkAttachmentToMessage may clone the
+          // attachment row when it's already linked to a different conversation.
+          const scopedId = linkAttachmentToMessage(
+            persistedUserMessage.id,
+            a.id,
+            i,
+          );
           storedRefBlocks.push(
             makeAttachmentRefBlock(
-              a.id,
+              scopedId,
               a.mimeType,
               a.filename,
               a.sizeBytes ?? 0,
@@ -529,7 +548,7 @@ export async function persistUserMessage(
     const refMessage: Message = { role: "user", content: persistedContent };
     ctx.messages[ctx.messages.length - 1] = enrichMessageWithSourcePaths(
       refMessage,
-      inlineAttachmentInputs,
+      sourcePathInputs,
     );
 
     // Sync the updated message (with attachment refs) to the disk view.

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -544,8 +544,13 @@ export async function persistUserMessage(
 
     // Replace the live message in ctx.messages with the ref-only version so
     // subsequent context-window passes don't hold base64 bytes in memory.
-    // Source-path annotations are re-added for the LLM's benefit.
-    const refMessage: Message = { role: "user", content: persistedContent };
+    // Use the original `liveTextContent` (built from `content`, not
+    // `displayContent`) so the LLM still sees the full action payload even
+    // when `displayContent` is a UI-friendly summary.
+    const refMessage: Message = {
+      role: "user",
+      content: [...liveTextContent, ...storedRefBlocks],
+    };
     ctx.messages[ctx.messages.length - 1] = enrichMessageWithSourcePaths(
       refMessage,
       sourcePathInputs,

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -7,8 +7,11 @@
 
 import { v4 as uuid } from "uuid";
 
-import { enrichMessageWithSourcePaths } from "../agent/attachments.js";
-import { createUserMessage } from "../agent/message-types.js";
+import {
+  attachmentsToContentBlocks,
+  enrichMessageWithSourcePaths,
+  type MessageAttachmentInput,
+} from "../agent/attachments.js";
 import type {
   TurnChannelContext,
   TurnInterfaceContext,
@@ -27,13 +30,19 @@ import {
   provenanceFromTrustContext,
   setConversationOriginChannelIfUnset,
   setConversationOriginInterfaceIfUnset,
+  updateMessageContent,
 } from "../memory/conversation-crud.js";
 import {
   syncMessageToDisk,
   updateMetaFile,
 } from "../memory/conversation-disk-view.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
-import type { Message } from "../providers/types.js";
+import type {
+  AttachmentBackedFileBlock,
+  AttachmentBackedImageBlock,
+  ContentBlock,
+  Message,
+} from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
 import type { MessageQueue } from "./conversation-queue-manager.js";
 import type { TrustContext } from "./conversation-runtime-assembly.js";
@@ -263,6 +272,33 @@ export function enqueueMessage(
 
 // ── persistUserMessage ───────────────────────────────────────────────
 
+/** Build an attachment-backed ref block for a stored attachment. */
+function makeAttachmentRefBlock(
+  attachmentId: string,
+  mimeType: string,
+  filename: string,
+  sizeBytes: number,
+  extractedText?: string,
+): AttachmentBackedImageBlock | AttachmentBackedFileBlock {
+  if (mimeType.toLowerCase().startsWith("image/")) {
+    return {
+      type: "image_ref",
+      source: { attachment_id: attachmentId, media_type: mimeType },
+      size_bytes: sizeBytes,
+    };
+  }
+  return {
+    type: "file_ref",
+    source: {
+      attachment_id: attachmentId,
+      media_type: mimeType,
+      filename,
+    },
+    extracted_text: extractedText,
+    size_bytes: sizeBytes,
+  };
+}
+
 export async function persistUserMessage(
   ctx: MessagingConversationContext,
   content: string,
@@ -284,24 +320,63 @@ export async function persistUserMessage(
   ctx.processing = true;
   ctx.abortController = new AbortController();
 
-  const attachmentInputs = attachments.map((attachment) => ({
-    id: attachment.id,
-    filename: attachment.filename,
-    mimeType: attachment.mimeType,
-    data: attachment.data,
-    extractedText: attachment.extractedText,
-    filePath: attachment.filePath,
-  }));
-  const cleanMessage = createUserMessage(content, attachmentInputs);
+  // Collect source paths for image annotations (sent to LLM as text context).
+  const imageSourcePaths: Record<string, string> = {};
+  for (let i = 0; i < attachments.length; i++) {
+    const a = attachments[i];
+    if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
+      imageSourcePaths[`${i}:${a.filename}`] = a.filePath;
+    }
+  }
+
+  // Build the live content blocks for ctx.messages:
+  //   - Pre-stored attachments (have an ID in the store): use ref blocks immediately.
+  //   - Inline attachments (raw base64 data, not yet stored): use base64 blocks for
+  //     this turn so the LLM sees the image without waiting for storage to complete.
+  //     These get replaced with ref blocks after storage (see below).
+  const inlineAttachmentInputs: MessageAttachmentInput[] = [];
+  const liveAttachmentBlocks: ContentBlock[] = [];
+  for (const a of attachments) {
+    if (a.id && attachmentExists(a.id)) {
+      liveAttachmentBlocks.push(
+        makeAttachmentRefBlock(
+          a.id,
+          a.mimeType,
+          a.filename,
+          a.sizeBytes ?? 0,
+          a.extractedText,
+        ),
+      );
+    } else if (a.data) {
+      const input: MessageAttachmentInput = {
+        id: a.id,
+        filename: a.filename,
+        mimeType: a.mimeType,
+        data: a.data,
+        extractedText: a.extractedText,
+        filePath: a.filePath,
+      };
+      inlineAttachmentInputs.push(input);
+      const [block] = attachmentsToContentBlocks([input]);
+      liveAttachmentBlocks.push(block);
+    }
+  }
+
+  const liveTextContent: ContentBlock[] = [];
+  if (content.trim().length > 0) {
+    liveTextContent.push({ type: "text", text: content });
+  }
+  const liveMessage: Message = {
+    role: "user",
+    content: [...liveTextContent, ...liveAttachmentBlocks],
+  };
   const llmMessage = enrichMessageWithSourcePaths(
-    cleanMessage,
-    attachmentInputs,
+    liveMessage,
+    inlineAttachmentInputs,
   );
   log.info(
     {
-      contentBlockTypes: Array.isArray(llmMessage.content)
-        ? llmMessage.content.map((b) => b.type)
-        : typeof llmMessage.content,
+      contentBlockTypes: llmMessage.content.map((b) => b.type),
       attachmentCount: attachments.length,
     },
     "persistUserMessage: content blocks being sent to model",
@@ -314,13 +389,6 @@ export async function persistUserMessage(
     const turnIfCtx =
       extractTurnInterfaceContext(metadata) ?? ctx.getTurnInterfaceContext();
     const provenance = provenanceFromTrustContext(ctx.trustContext);
-    const imageSourcePaths: Record<string, string> = {};
-    for (let i = 0; i < attachments.length; i++) {
-      const a = attachments[i];
-      if (a.filePath && a.mimeType.toLowerCase().startsWith("image/")) {
-        imageSourcePaths[`${i}:${a.filename}`] = a.filePath;
-      }
-    }
 
     const mergedMetadata = {
       ...(metadata ?? {}),
@@ -340,19 +408,18 @@ export async function persistUserMessage(
       ...(Object.keys(imageSourcePaths).length > 0 ? { imageSourcePaths } : {}),
     };
 
-    // When displayContent is provided (e.g. original text before recording
-    // intent stripping), persist that to DB so users see the full message
-    // after restart. The in-memory userMessage (sent to the LLM) still uses
-    // the stripped content.
-    const contentToPersist = displayContent
-      ? JSON.stringify(
-          createUserMessage(displayContent, attachmentInputs).content,
-        )
-      : JSON.stringify(cleanMessage.content);
+    // Persist the message to the DB with a placeholder content that includes
+    // only text blocks. Attachment-backed ref blocks are written in a second
+    // pass below, once each attachment has been stored and has a stable ID.
+    const displayText = displayContent ?? content;
+    const textOnlyContent: ContentBlock[] = [];
+    if (displayText.trim().length > 0) {
+      textOnlyContent.push({ type: "text", text: displayText });
+    }
     const persistedUserMessage = await addMessage(
       ctx.conversationId,
       "user",
-      contentToPersist,
+      JSON.stringify(textOnlyContent),
       mergedMetadata,
     );
 
@@ -381,16 +448,25 @@ export async function persistUserMessage(
       throw new Error("Failed to persist user message");
     }
 
-    // Index user attachments in the attachments table for later retrieval.
+    // Store each attachment and collect the resulting ref blocks for the
+    // second-pass content update. Pre-stored attachments are linked directly;
+    // inline attachments are written to disk and linked in one step.
+    const storedRefBlocks: ContentBlock[] = [];
+
     for (let i = 0; i < attachments.length; i++) {
       const a = attachments[i];
       try {
-        // If the attachment already exists in the store (e.g. file-backed
-        // attachments uploaded separately), link it directly without
-        // re-uploading. This handles the case where data is empty because
-        // the attachment content lives on disk.
         if (a.id && attachmentExists(a.id)) {
           linkAttachmentToMessage(persistedUserMessage.id, a.id, i);
+          storedRefBlocks.push(
+            makeAttachmentRefBlock(
+              a.id,
+              a.mimeType,
+              a.filename,
+              a.sizeBytes ?? 0,
+              a.extractedText,
+            ),
+          );
           continue;
         }
 
@@ -404,13 +480,22 @@ export async function persistUserMessage(
           );
           continue;
         }
-        attachInlineAttachmentToMessage(
+        const stored = attachInlineAttachmentToMessage(
           persistedUserMessage.id,
           i,
           a.filename,
           a.mimeType,
           a.data,
           { sourcePath: a.filePath },
+        );
+        storedRefBlocks.push(
+          makeAttachmentRefBlock(
+            stored.id,
+            a.mimeType,
+            a.filename,
+            stored.sizeBytes,
+            a.extractedText,
+          ),
         );
       } catch (err) {
         if (err instanceof AttachmentUploadError) {
@@ -427,7 +512,27 @@ export async function persistUserMessage(
       }
     }
 
-    // Sync the persisted user message (with attachments) to the disk view
+    // Rewrite the persisted message content with attachment-backed ref blocks
+    // so stored messages never contain inline base64 bytes.
+    const persistedContent: ContentBlock[] = [
+      ...textOnlyContent,
+      ...storedRefBlocks,
+    ];
+    updateMessageContent(
+      persistedUserMessage.id,
+      JSON.stringify(persistedContent),
+    );
+
+    // Replace the live message in ctx.messages with the ref-only version so
+    // subsequent context-window passes don't hold base64 bytes in memory.
+    // Source-path annotations are re-added for the LLM's benefit.
+    const refMessage: Message = { role: "user", content: persistedContent };
+    ctx.messages[ctx.messages.length - 1] = enrichMessageWithSourcePaths(
+      refMessage,
+      inlineAttachmentInputs,
+    );
+
+    // Sync the updated message (with attachment refs) to the disk view.
     const conv = getConversation(ctx.conversationId);
     if (conv) {
       syncMessageToDisk(

--- a/assistant/src/daemon/conversation-queue-manager.ts
+++ b/assistant/src/daemon/conversation-queue-manager.ts
@@ -147,12 +147,19 @@ export class MessageQueue {
 
 /**
  * Estimate the in-memory byte cost of a queued message.
- * Dominated by content text and attachment `data` (base64 strings).
+ *
+ * For file-backed attachments the `data` field is empty; use `sizeBytes`
+ * (the actual decoded file size) as the cost estimate instead so the queue
+ * budget reflects the real allocation that will occur at persist time.
  */
 function estimateItemBytes(item: QueuedMessage): number {
   let bytes = item.content.length * 2; // JS strings are UTF-16
   for (const a of item.attachments) {
-    bytes += a.data.length * 2;
+    if (a.data) {
+      bytes += a.data.length * 2; // base64 string (2 bytes per char in V8)
+    } else if (a.sizeBytes) {
+      bytes += a.sizeBytes; // file-backed: count actual decoded bytes
+    }
     if (a.extractedText) bytes += a.extractedText.length * 2;
   }
   // Small fixed overhead for metadata, pointers, etc. (not worth

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -305,10 +305,42 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
       attachmentParts.push(renderFileBlockForHistory(block));
       continue;
     }
+    if (block.type === "file_ref") {
+      // Attachment-backed file block — render using stored metadata.
+      const source = isRecord(block.source) ? block.source : null;
+      const mediaType =
+        source && typeof source.media_type === "string"
+          ? source.media_type
+          : "application/octet-stream";
+      const filename =
+        source && typeof source.filename === "string"
+          ? source.filename
+          : "attachment";
+      const sizeBytes =
+        typeof block.size_bytes === "number" ? block.size_bytes : 0;
+      const summaryParts = [
+        `[File attachment] ${filename}`,
+        `type=${mediaType}`,
+      ];
+      if (sizeBytes > 0) summaryParts.push(`size=${formatBytes(sizeBytes)}`);
+      const extractedText =
+        typeof block.extracted_text === "string"
+          ? block.extracted_text.trim()
+          : "";
+      const summary = extractedText
+        ? `${summaryParts.join(", ")}\nAttachment text: ${clampAttachmentText(extractedText)}`
+        : summaryParts.join(", ");
+      attachmentParts.push(summary);
+      continue;
+    }
     if (block.type === "image") {
       // Image data is sent as a separate attachment — skip the placeholder
       // text so the client doesn't render both "[Image attachment]" and the
       // actual image thumbnail.
+      continue;
+    }
+    if (block.type === "image_ref") {
+      // Attachment-backed image — same treatment as inline image blocks.
       continue;
     }
     if (block.type === "tool_use") {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -23,11 +23,7 @@ import { onContactChange } from "../contacts/contact-events.js";
 import type { CesClient } from "../credential-execution/client.js";
 import type { CesProcessManager } from "../credential-execution/process-manager.js";
 import type { HeartbeatService } from "../heartbeat/heartbeat-service.js";
-import {
-  getApp,
-  getAppDirPath,
-  isMultifileApp,
-} from "../memory/app-store.js";
+import { getApp, getAppDirPath, isMultifileApp } from "../memory/app-store.js";
 import * as attachmentsStore from "../memory/attachments-store.js";
 import {
   createCanonicalGuardianRequest,
@@ -210,13 +206,10 @@ function makePendingInteractionRegistrar(
           guardianPrincipalId: trustContext?.guardianPrincipalId ?? undefined,
           toolName: msg.toolName,
           commandPreview:
-            redactSecrets(
-              summarizeToolInput(msg.toolName, inputRecord),
-            ) || undefined,
+            redactSecrets(summarizeToolInput(msg.toolName, inputRecord)) ||
+            undefined,
           riskLevel: msg.riskLevel,
-          activityText: activityRaw
-            ? redactSecrets(activityRaw)
-            : undefined,
+          activityText: activityRaw ? redactSecrets(activityRaw) : undefined,
           executionTarget: msg.executionTarget,
           status: "pending",
           requestCode: generateCanonicalRequestCode(),
@@ -648,6 +641,7 @@ export class DaemonServer {
               filename: a.filename,
               mimeType: a.mimeType,
               data: "",
+              sizeBytes: size,
               filePath: a.path,
             });
           } catch (err) {
@@ -671,22 +665,11 @@ export class DaemonServer {
       };
 
       if (conversation.isProcessing()) {
-        // Hydrate file data now — the queue path won't re-read from
-        // the attachment store, so base64 content must be inline.
-        for (let i = resolvedAttachments.length - 1; i >= 0; i--) {
-          const att = resolvedAttachments[i];
-          if (att.filePath && !att.data) {
-            try {
-              att.data = readFileSync(att.filePath).toString("base64");
-            } catch (err) {
-              log.warn(
-                { err, path: att.filePath },
-                "Failed to read queued signal attachment, skipping",
-              );
-              resolvedAttachments.splice(i, 1);
-            }
-          }
-        }
+        // File-backed attachments have already been registered in the
+        // attachment store (above) and carry their ID + sizeBytes.
+        // persistUserMessage handles the id-only path, so we do NOT
+        // read from disk here — that would re-introduce the exact
+        // base64-in-queue memory waste this change is designed to remove.
         const requestId = crypto.randomUUID();
         const resolvedChannel = resolveTurnChannel(params.sourceChannel);
         const resolvedInterface = resolveTurnInterface(params.sourceInterface);
@@ -722,9 +705,7 @@ export class DaemonServer {
       () => this.broadcastIdentityChanged(),
     );
 
-    this.appSourceWatcher.start((appId) =>
-      this.handleAppSourceChange(appId),
-    );
+    this.appSourceWatcher.start((appId) => this.handleAppSourceChange(appId));
 
     // Broadcast contacts_changed to all clients when any contact mutation occurs.
     this.unsubscribeContactChange = onContactChange(() => {
@@ -1103,18 +1084,21 @@ export class DaemonServer {
       assistantMessageInterface: resolvedInterface,
     });
 
+    // Attachments are fetched without hydrating base64 data from disk.
+    // persistUserMessage uses the attachment IDs to create ref blocks
+    // (image_ref / file_ref) which are hydrated just-in-time before each
+    // provider call, avoiding redundant disk reads and memory allocation.
     const attachments = attachmentIds
       ? (() => {
-          const resolved = attachmentsStore.getAttachmentsByIds(attachmentIds, {
-            hydrateFileData: true,
-          });
+          const resolved = attachmentsStore.getAttachmentsByIds(attachmentIds);
           const sourcePaths =
             attachmentsStore.getSourcePathsForAttachments(attachmentIds);
           return resolved.map((a) => ({
             id: a.id,
             filename: a.originalFilename,
             mimeType: a.mimeType,
-            data: a.dataBase64,
+            data: "",
+            sizeBytes: a.sizeBytes,
             ...(sourcePaths.has(a.id)
               ? { filePath: sourcePaths.get(a.id) }
               : {}),

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -42,6 +42,7 @@ import {
   migrateBackfillGuardianPrincipalId,
   migrateBackfillInlineAttachmentsToDisk,
   migrateBackfillUsageCacheAccounting,
+  migrateBackfillUserMessageAttachmentRefs,
   migrateCallSessionInviteMetadata,
   migrateCallSessionMode,
   migrateCallSessionSkipDisclosure,
@@ -603,6 +604,9 @@ export function initializeDb(): void {
 
   // 109. Add reuse_conversation flag to schedule jobs
   migrateScheduleReuseConversation(database);
+
+  // 110. Rewrite existing user messages to use attachment-backed ref blocks
+  migrateBackfillUserMessageAttachmentRefs(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/211-backfill-user-message-attachment-refs.ts
+++ b/assistant/src/memory/migrations/211-backfill-user-message-attachment-refs.ts
@@ -1,0 +1,197 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+/**
+ * Rewrite existing user messages so that inline image/file content blocks
+ * backed by message_attachments rows are replaced with attachment-backed
+ * reference blocks (`image_ref` / `file_ref`).
+ *
+ * This removes the redundant base64 payload from persisted message JSON,
+ * keeping only the attachment ID and metadata. The bytes remain in the
+ * attachment store (on-disk file) and are hydrated just-in-time before
+ * each provider call.
+ *
+ * The migration is idempotent: messages that already use ref blocks, or
+ * that have mismatched attachment counts, are left unchanged.
+ */
+
+interface AttachmentRow {
+  attachment_id: string;
+  position: number;
+  mime_type: string;
+  original_filename: string;
+  size_bytes: number;
+}
+
+function isInlineImageBlock(block: Record<string, unknown>): boolean {
+  return (
+    block.type === "image" &&
+    typeof block.source === "object" &&
+    block.source !== null &&
+    (block.source as Record<string, unknown>).type === "base64" &&
+    typeof (block.source as Record<string, unknown>).data === "string" &&
+    ((block.source as Record<string, unknown>).data as string).length > 0
+  );
+}
+
+function isInlineFileBlock(block: Record<string, unknown>): boolean {
+  return (
+    block.type === "file" &&
+    typeof block.source === "object" &&
+    block.source !== null &&
+    (block.source as Record<string, unknown>).type === "base64" &&
+    typeof (block.source as Record<string, unknown>).data === "string" &&
+    ((block.source as Record<string, unknown>).data as string).length > 0
+  );
+}
+
+export function migrateBackfillUserMessageAttachmentRefs(
+  database: DrizzleDb,
+): void {
+  withCrashRecovery(
+    database,
+    "migration_backfill_user_message_attachment_refs_v1",
+    () => {
+      const raw = getSqliteFrom(database);
+      const BATCH_SIZE = 50;
+      let totalRewritten = 0;
+      let lastRowid = 0;
+
+      for (;;) {
+        // Fetch user messages that have message_attachments links, in batches.
+        const rows = raw
+          .query(
+            `SELECT m.rowid, m.id, m.content
+             FROM messages m
+             WHERE m.role = 'user'
+               AND EXISTS (
+                 SELECT 1 FROM message_attachments ma WHERE ma.message_id = m.id
+               )
+               AND m.rowid > ?
+             ORDER BY m.rowid
+             LIMIT ?`,
+          )
+          .all(lastRowid, BATCH_SIZE) as Array<{
+          rowid: number;
+          id: string;
+          content: string;
+        }>;
+
+        if (rows.length === 0) break;
+
+        for (const row of rows) {
+          lastRowid = row.rowid;
+
+          let blocks: unknown[];
+          try {
+            const parsed = JSON.parse(row.content);
+            if (!Array.isArray(parsed)) continue;
+            blocks = parsed;
+          } catch {
+            continue;
+          }
+
+          // Count image/file blocks that contain inline base64 data.
+          const inlineBlocks = blocks.filter(
+            (b) =>
+              typeof b === "object" &&
+              b !== null &&
+              (isInlineImageBlock(b as Record<string, unknown>) ||
+                isInlineFileBlock(b as Record<string, unknown>)),
+          );
+          if (inlineBlocks.length === 0) continue;
+
+          // Load the attachment links ordered by position.
+          const attachmentLinks = raw
+            .query(
+              `SELECT ma.attachment_id, ma.position,
+                      a.mime_type, a.original_filename, a.size_bytes
+               FROM message_attachments ma
+               JOIN attachments a ON a.id = ma.attachment_id
+               WHERE ma.message_id = ?
+               ORDER BY ma.position`,
+            )
+            .all(row.id) as AttachmentRow[];
+
+          // Guard: attachment count must match inline block count for a safe rewrite.
+          if (attachmentLinks.length !== inlineBlocks.length) continue;
+
+          // Replace each inline block with the corresponding attachment ref.
+          let attachIdx = 0;
+          let changed = false;
+          const rewritten = blocks.map((b) => {
+            if (
+              typeof b !== "object" ||
+              b === null ||
+              (!isInlineImageBlock(b as Record<string, unknown>) &&
+                !isInlineFileBlock(b as Record<string, unknown>))
+            ) {
+              return b;
+            }
+
+            const att = attachmentLinks[attachIdx++];
+            if (!att) return b; // safety: bail if index runs out
+
+            changed = true;
+            const block = b as Record<string, unknown>;
+
+            if (block.type === "image") {
+              return {
+                type: "image_ref",
+                source: {
+                  attachment_id: att.attachment_id,
+                  media_type: att.mime_type,
+                },
+                size_bytes: att.size_bytes,
+              };
+            }
+            // file block
+            return {
+              type: "file_ref",
+              source: {
+                attachment_id: att.attachment_id,
+                media_type: att.mime_type,
+                filename: att.original_filename,
+              },
+              extracted_text:
+                typeof block.extracted_text === "string"
+                  ? block.extracted_text
+                  : undefined,
+              size_bytes: att.size_bytes,
+            };
+          });
+
+          if (!changed) continue;
+
+          raw
+            .query(`UPDATE messages SET content = ? WHERE id = ?`)
+            .run(JSON.stringify(rewritten), row.id);
+          totalRewritten++;
+        }
+      }
+
+      if (totalRewritten > 0) {
+        console.log(
+          `[backfill-attachment-refs] Rewrote ${totalRewritten} user messages to use attachment ref blocks`,
+        );
+      }
+    },
+  );
+}
+
+/**
+ * Reverse: no-op.
+ *
+ * The forward migration rewrote persisted message JSON to remove inline
+ * base64 bytes in favour of attachment IDs. Reversing would require
+ * re-reading each attachment file and re-embedding the base64, which is
+ * a destructive expansion (increases DB size) and not worth implementing
+ * since old code can still read image_ref / file_ref blocks gracefully
+ * (they fall through to the default case in all switches).
+ */
+export function migrateBackfillUserMessageAttachmentRefsDown(
+  _database: DrizzleDb,
+): void {
+  // No-op — see comment above.
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -152,6 +152,7 @@ export { migrateCreateConversationGraphMemoryState } from "./207-conversation-gr
 export { migrateConversationsLastMessageAt } from "./208-conversations-last-message-at.js";
 export { migrateStripThinkingFromConsolidated } from "./209-strip-thinking-from-consolidated.js";
 export { migrateScheduleReuseConversation } from "./210-schedule-reuse-conversation.js";
+export { migrateBackfillUserMessageAttachmentRefs } from "./211-backfill-user-message-attachment-refs.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -41,6 +41,7 @@ import { migrateAddSourceTypeColumnsDown } from "./193-add-source-type-columns.j
 import { migrateStripIntegrationPrefixFromProviderKeysDown } from "./196-strip-integration-prefix-from-provider-keys.js";
 import { migrateRenameMemoryGraphTypeValuesDown } from "./204-rename-memory-graph-type-values.js";
 import { migrateScrubCorruptedImageAttachmentsDown } from "./206-scrub-corrupted-image-attachments.js";
+import { migrateBackfillUserMessageAttachmentRefsDown } from "./211-backfill-user-message-attachment-refs.js";
 
 export interface MigrationRegistryEntry {
   /** The checkpoint key written to memory_checkpoints on completion. */
@@ -356,6 +357,14 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Remove image attachments containing HTML error pages instead of image data",
     down: migrateScrubCorruptedImageAttachmentsDown,
+  },
+  {
+    key: "migration_backfill_user_message_attachment_refs_v1",
+    version: 41,
+    dependsOn: ["migration_backfill_inline_attachments_v1"],
+    description:
+      "Rewrite existing user messages to replace inline base64 image/file blocks with attachment-backed ref blocks (image_ref / file_ref)",
+    down: migrateBackfillUserMessageAttachmentRefsDown,
   },
 ];
 

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -23,6 +23,40 @@ export interface FileContent {
   extracted_text?: string;
 }
 
+/**
+ * Persisted form of a user image attachment. The binary payload lives in the
+ * attachment store; only the attachment ID and media type are kept inline.
+ * Hydrated to a full `ImageContent` block (with base64 `data`) right before
+ * each provider call. Must never be sent to a provider as-is.
+ */
+export interface AttachmentBackedImageBlock {
+  type: "image_ref";
+  source: {
+    attachment_id: string;
+    media_type: string;
+  };
+  /** File size in bytes, used for token estimation without reading the file. */
+  size_bytes?: number;
+}
+
+/**
+ * Persisted form of a user file attachment. The binary payload lives in the
+ * attachment store; only the attachment ID and metadata are kept inline.
+ * Hydrated to a full `FileContent` block (with base64 `data`) right before
+ * each provider call. Must never be sent to a provider as-is.
+ */
+export interface AttachmentBackedFileBlock {
+  type: "file_ref";
+  source: {
+    attachment_id: string;
+    media_type: string;
+    filename: string;
+  };
+  extracted_text?: string;
+  /** File size in bytes, used for token estimation without reading the file. */
+  size_bytes?: number;
+}
+
 export interface ToolUseContent {
   type: "tool_use";
   id: string;
@@ -69,6 +103,8 @@ export type ContentBlock =
   | RedactedThinkingContent
   | ImageContent
   | FileContent
+  | AttachmentBackedImageBlock
+  | AttachmentBackedFileBlock
   | ToolUseContent
   | ToolResultContent
   | ServerToolUseContent


### PR DESCRIPTION
## Summary

- Adds `image_ref` / `file_ref` content block types that store only attachment metadata (ID, MIME type, filename) instead of inline base64 in persisted message history, reducing memory pressure from large attachments
- Rewrites `persistUserMessage` to write ref blocks into the DB after attachment storage, then calls `hydrateAttachmentBlocks` in `runAgentLoopImpl` to expand refs to full base64 just before any provider call
- Removes the eager `readFileSync` hydration from `server.ts`, fixes queue byte-budget accounting to use `sizeBytes` for file-backed entries, and adds a DB migration (211) to backfill existing inline base64 attachments to on-disk refs

## Original prompt
--safe implement this please
plans/assistant-daemon-attachment-hydration.md avoid breaking
existing stuff
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
