### PR TITLE
fix: make subagent skill discoverable in catalog

### DIFF
--- a/assistant/src/config/bundled-skills/subagent/SKILL.md
+++ b/assistant/src/config/bundled-skills/subagent/SKILL.md
@@ -6,6 +6,9 @@ metadata:
   emoji: "🤖"
   vellum:
     display-name: "Subagent"
+    activation-hints:
+      - "Run tasks in parallel, delegate work to background agents, or do multiple things at once"
+      - "Spawn a researcher, coder, or planner agent for independent work"
 ---
 
 Subagent orchestration -- spawn background agents to work on tasks in parallel.

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -427,7 +427,7 @@ export function createProxyApprovalCallback(
  * history or explicit preactivation. Without this, their tools are
  * unavailable in fresh conversations until `skill_load` is called.
  */
-const DEFAULT_PREACTIVATED_SKILL_IDS = ["tasks", "notifications"];
+const DEFAULT_PREACTIVATED_SKILL_IDS = ["tasks", "notifications", "subagent"];
 
 /**
  * Subset of Conversation state that the resolveTools callback reads at each


### PR DESCRIPTION
## Summary

- Add `activation-hints` to the subagent SKILL.md frontmatter so the memory graph node matches queries about parallel work, delegation, and background agents
- Add `"subagent"` to `DEFAULT_PREACTIVATED_SKILL_IDS` alongside `tasks` and `notifications` so subagent tools are always registered without needing `skill_load`

## Original prompt

it (subagent skill not showing up in catalog, Velissa can't find it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)