### PR TITLE
fix: add missing queryContext param in MessageInspectorViewTests

### DIFF
--- a/clients/macos/vellum-assistantTests/MessageInspectorViewTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageInspectorViewTests.swift
@@ -71,7 +71,8 @@ final class MessageInspectorViewTests: XCTestCase {
             latencyMs: 42,
             reason: nil,
             topCandidates: [],
-            injectedText: nil
+            injectedText: nil,
+            queryContext: nil
         )
         state.finishLoading(with: .loaded(makeResponse(logs: [
             makeLog(id: "a", createdAt: 1_000)
@@ -103,7 +104,8 @@ final class MessageInspectorViewTests: XCTestCase {
             latencyMs: 5,
             reason: nil,
             topCandidates: [],
-            injectedText: nil
+            injectedText: nil,
+            queryContext: nil
         )
         state.finishLoading(with: .loaded(makeResponse(logs: [
             makeLog(id: "a", createdAt: 1_000)


### PR DESCRIPTION
## Summary
- Add `queryContext: nil` to both `MemoryRecallData` init call sites in `MessageInspectorViewTests.swift` to match the new parameter added in #23525

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23968143776/job/69912186761