### PR TITLE
chore: remove stale comments referencing old memory_items system

### DIFF
--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -725,10 +725,7 @@ export function deleteConversation(id: string): DeletedMemoryIds {
  *
  * Extends `deleteConversation` with:
  * - Cancelling pending memory jobs before deletion
- * - Restoring memory items that were explicitly superseded by items from this conversation
- * - Restoring orphaned subject-match superseded items after deletion
  * - Deleting conversation-scoped memory summaries and their embeddings
- * - Enqueuing `embed_item` jobs for all restored items
  */
 export function wipeConversation(id: string): WipeConversationResult {
   const db = getDb();

--- a/assistant/src/memory/graph/extraction-job.ts
+++ b/assistant/src/memory/graph/extraction-job.ts
@@ -22,10 +22,10 @@ const log = getLogger("graph-extraction-job");
  * Checkpoint key: `graph_extract:<conversationId>:last_ts`
  * Value: epoch ms of the most recent message processed.
  *
- * This mirrors the old batch_extract pattern:
- * - Triggered by indexer after batchSize messages (default 10)
- * - Also triggered by indexer idle debounce (default 300s)
- * - Also triggered by conversation dispose (end of conversation)
+ * Trigger sources:
+ * - Indexer after batchSize messages (default 10)
+ * - Indexer idle debounce (default 300s)
+ * - Conversation dispose (end of conversation)
  */
 export async function graphExtractJob(
   job: MemoryJob,


### PR DESCRIPTION
## Summary
- Remove JSDoc references to old supersession, embed_item, and memory_items from wipeConversation()
- Remove 'mirrors old batch_extract' comment from graph extraction job

Part of plan: rip-old-memory-system.md (PR 2 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
