### PR TITLE
fix: remove dead batch_extract enqueue from conversation disposal

### DIFF
--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -9,7 +9,6 @@ import type { EventBus } from "../events/bus.js";
 import type { AssistantDomainEvents } from "../events/domain-events.js";
 import type { ToolProfiler } from "../events/tool-profiling-listener.js";
 import { getHookManager } from "../hooks/manager.js";
-import { getMemoryCheckpoint } from "../memory/checkpoints.js";
 import {
   getConversation,
   getMessages,
@@ -292,19 +291,6 @@ export function disposeConversation(ctx: DisposeContext): void {
   void getHookManager().trigger("conversation-end", {
     conversationId: ctx.conversationId,
   });
-
-  // Trigger batch extraction for any remaining unextracted messages
-  try {
-    const pendingKey = `batch_extract:${ctx.conversationId}:pending_count`;
-    const pending = getMemoryCheckpoint(pendingKey);
-    if (pending && parseInt(pending, 10) > 0) {
-      enqueueMemoryJob("batch_extract", {
-        conversationId: ctx.conversationId,
-      });
-    }
-  } catch {
-    // Best-effort — don't block conversation disposal
-  }
 
   // Trigger graph extraction for end-of-conversation sweep.
   // Only extract from guardian conversations to preserve the memory trust


### PR DESCRIPTION
## Summary
- Remove dead batch_extract checkpoint check and job enqueue from disposeConversation()
- The graph_extract enqueue already handles end-of-conversation extraction

Part of plan: rip-old-memory-system.md (PR 1 of 8)