### PR TITLE
fix: update extraction job cancellation to target graph_extract

### DIFF
--- a/assistant/src/__tests__/task-memory-cleanup.test.ts
+++ b/assistant/src/__tests__/task-memory-cleanup.test.ts
@@ -736,24 +736,24 @@ describe("invalidateAssistantInferredItemsForConversation", () => {
     expect(isConversationFailed(otherConvId)).toBe(false);
   });
 
-  test("cancels pending extract_items jobs for the failed conversation", () => {
+  test("cancels pending graph_extract jobs for the failed conversation", () => {
     seedConversations();
     seedMessages();
 
     const db = getDb();
 
-    // Enqueue extract_items jobs for messages in the target conversation
-    enqueueMemoryJob("extract_items", {
-      messageId: "msg-task-1",
+    // Enqueue graph_extract jobs for the target conversation
+    enqueueMemoryJob("graph_extract", {
+      conversationId: convId,
       scopeId: "default",
     });
-    enqueueMemoryJob("extract_items", {
-      messageId: "msg-task-2",
+    enqueueMemoryJob("graph_extract", {
+      conversationId: convId,
       scopeId: "default",
     });
-    // Enqueue an extract_items job for a message in a different conversation
-    enqueueMemoryJob("extract_items", {
-      messageId: "msg-other",
+    // Enqueue a graph_extract job for a different conversation
+    enqueueMemoryJob("graph_extract", {
+      conversationId: otherConvId,
       scopeId: "default",
     });
 
@@ -761,7 +761,7 @@ describe("invalidateAssistantInferredItemsForConversation", () => {
     const pendingBefore = db
       .select()
       .from(memoryJobs)
-      .where(eq(memoryJobs.type, "extract_items"))
+      .where(eq(memoryJobs.type, "graph_extract"))
       .all();
     expect(pendingBefore.filter((j) => j.status === "pending")).toHaveLength(3);
 
@@ -771,7 +771,7 @@ describe("invalidateAssistantInferredItemsForConversation", () => {
     const allJobs = db
       .select()
       .from(memoryJobs)
-      .where(eq(memoryJobs.type, "extract_items"))
+      .where(eq(memoryJobs.type, "graph_extract"))
       .all();
     const failedJobs = allJobs.filter((j) => j.status === "failed");
     const pendingJobs = allJobs.filter((j) => j.status === "pending");
@@ -785,6 +785,6 @@ describe("invalidateAssistantInferredItemsForConversation", () => {
     // The job for the other conversation should remain pending
     expect(pendingJobs).toHaveLength(1);
     const payload = JSON.parse(pendingJobs[0].payload);
-    expect(payload.messageId).toBe("msg-other");
+    expect(payload.conversationId).toBe(otherConvId);
   });
 });

--- a/assistant/src/memory/task-memory-cleanup.ts
+++ b/assistant/src/memory/task-memory-cleanup.ts
@@ -100,7 +100,7 @@ export function invalidateAssistantInferredItemsForConversation(
 
 /**
  * Cancel all pending/running memory jobs referencing the given conversation.
- * Covers every job type: `extract_items`, `embed_attachment` (keyed by messageId),
+ * Covers every job type: `graph_extract`, `embed_attachment` (keyed by messageId),
  * `embed_segment` (keyed by segmentId via memory_segments),
  * `build_conversation_summary` (keyed by conversationId),
  * and `embed_graph_node` (keyed by nodeId sourced from the conversation).
@@ -112,7 +112,7 @@ export function cancelPendingJobsForConversation(
   const now = Date.now();
   let total = 0;
 
-  // Jobs keyed by messageId: extract_items, embed_attachment
+  // Jobs keyed by messageId: graph_extract, embed_attachment
   total += rawRun(
     `UPDATE memory_jobs
         SET status = 'failed',
@@ -183,8 +183,8 @@ export function cancelPendingJobsForConversation(
 }
 
 /**
- * Cancel only pending/running `extract_items` jobs for messages in the
- * given conversation. Used by the task-failure path where we want to
+ * Cancel only pending/running `graph_extract` jobs for the given
+ * conversation. Used by the task-failure path where we want to
  * stop new extractions but must NOT cancel `embed_graph_node` jobs —
  * those nodes may be multi-sourced and still valid.
  */
@@ -198,10 +198,8 @@ function cancelPendingExtractionJobsForConversation(
             last_error = 'conversation_failed',
             updated_at = ?
       WHERE status IN ('pending', 'running')
-        AND type = 'extract_items'
-        AND json_extract(payload, '$.messageId') IN (
-          SELECT id FROM messages WHERE conversation_id = ?
-        )`,
+        AND type = 'graph_extract'
+        AND json_extract(payload, '$.conversationId') = ?`,
     now,
     conversationId,
   );


### PR DESCRIPTION
## Summary
- Rewrite cancelPendingExtractionJobsForConversation() to cancel graph_extract jobs instead of extract_items
- Update corresponding test to use graph_extract job type and conversationId-based filtering

Part of plan: rip-old-memory-system.md (PR 4 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
