### PR TITLE
fix: remove dead cleanup command, rewrite re-extract to use graph_extract

### DIFF
--- a/assistant/src/cli/commands/memory.ts
+++ b/assistant/src/cli/commands/memory.ts
@@ -7,7 +7,6 @@ import {
   getMemorySystemStatus,
   queryMemory,
   requestMemoryBackfill,
-  requestMemoryCleanup,
   requestMemoryRebuildIndex,
   requestReextract,
 } from "../../memory/admin.js";
@@ -104,38 +103,6 @@ Examples:
       initializeDb();
       const jobId = requestMemoryBackfill(Boolean(opts?.force));
       log.info(`Queued backfill job: ${jobId}`);
-    });
-
-  memory
-    .command("cleanup")
-    .description("Queue cleanup jobs for stale superseded items")
-    .option(
-      "--retention-ms <ms>",
-      "Optional retention threshold in milliseconds"
-    )
-    .addHelpText(
-      "after",
-      `
-Queues a background cleanup job to remove memory items that have been
-superseded by newer, corrected facts past the retention threshold.
-
-The optional --retention-ms flag sets the minimum age (in milliseconds) a
-record must have before it is eligible for cleanup. If omitted, the system
-default retention period is used.
-
-Examples:
-  $ assistant memory cleanup
-  $ assistant memory cleanup --retention-ms 86400000`
-    )
-    .action((opts: { retentionMs?: string }) => {
-      initializeDb();
-      const retentionMs = opts.retentionMs
-        ? Number.parseInt(opts.retentionMs, 10)
-        : undefined;
-      requestMemoryCleanup(
-        Number.isFinite(retentionMs) ? retentionMs : undefined
-      );
-      log.info("Memory cleanup requested (legacy items table dropped)");
     });
 
   memory
@@ -270,7 +237,7 @@ extraction prompt. This is useful after updating the extraction prompt
 (e.g. importance scoring rework) to re-score and re-extract memories
 from historically important conversations.
 
-The command resets extraction checkpoints so the batch extraction handler
+The command resets extraction checkpoints so the graph extraction handler
 re-processes all messages. Existing memories are provided as supersession
 context — the new extraction can supersede old flat-fact memories with
 richer, properly-scored replacements.

--- a/assistant/src/memory/admin.ts
+++ b/assistant/src/memory/admin.ts
@@ -69,10 +69,6 @@ export function requestMemoryRebuildIndex(): string {
   return id;
 }
 
-export function requestMemoryCleanup(_retentionMs?: number): void {
-  log.info("Memory cleanup requested (legacy items table dropped — no-op)");
-}
-
 export async function queryMemory(
   query: string,
   _conversationId: string,
@@ -204,7 +200,7 @@ export function findReextractTarget(
 /**
  * Queue re-extraction for a set of conversations.
  * Resets extraction checkpoints and clears extraction summaries so the
- * batch extraction handler processes all messages from scratch with
+ * graph extraction handler processes all messages from scratch with
  * expanded supersession context.
  */
 export function requestReextract(
@@ -216,12 +212,12 @@ export function requestReextract(
   for (const target of targets) {
     const { conversationId } = target;
 
-    // Reset batch extraction checkpoints
+    // Reset graph extraction checkpoints
     deleteMemoryCheckpoint(
-      `batch_extract:${conversationId}:last_message_id`,
+      `graph_extract:${conversationId}:last_ts`,
     );
     deleteMemoryCheckpoint(
-      `batch_extract:${conversationId}:pending_count`,
+      `graph_extract:${conversationId}:pending_count`,
     );
 
     // Clear the extraction summary so it starts fresh
@@ -236,7 +232,7 @@ export function requestReextract(
 
     // Resolve scope and enqueue with fullReextract flag
     const scopeId = getConversationMemoryScopeId(conversationId);
-    const jobId = enqueueMemoryJob("batch_extract", {
+    const jobId = enqueueMemoryJob("graph_extract", {
       conversationId,
       scopeId,
       fullReextract: true,


### PR DESCRIPTION
## Summary
- Remove the no-op requestMemoryCleanup() and CLI memory cleanup command
- Rewrite requestReextract() to enqueue graph_extract instead of dead batch_extract

Part of plan: rip-old-memory-system.md (PR 5 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
