### PR TITLE
fix: update test fixtures to use live job types

### DIFF
--- a/assistant/src/__tests__/conversation-wipe.test.ts
+++ b/assistant/src/__tests__/conversation-wipe.test.ts
@@ -102,7 +102,7 @@ describe("wipeConversation", () => {
     const db = getDb();
     db.run(`DELETE FROM memory_jobs`);
 
-    enqueueMemoryJob("extract_items", { messageId: msg.id });
+    enqueueMemoryJob("graph_extract", { conversationId: conv.id });
     enqueueMemoryJob("build_conversation_summary", {
       conversationId: conv.id,
     });
@@ -121,8 +121,6 @@ describe("wipeConversation", () => {
       .all() as Array<{ status: string; last_error: string | null }>;
 
     for (const job of jobs) {
-      // Skip embed_item jobs enqueued by wipeConversation's unsupersede logic
-      if (job.status === "pending") continue;
       expect(job.status).toBe("failed");
       expect(job.last_error).toContain("conversation_wiped");
     }

--- a/assistant/src/__tests__/jobs-store-qdrant-breaker.test.ts
+++ b/assistant/src/__tests__/jobs-store-qdrant-breaker.test.ts
@@ -37,15 +37,15 @@ describe("claimMemoryJobs with Qdrant circuit breaker", () => {
 
   test("claims embed jobs when circuit breaker is closed (healthy)", () => {
     enqueueMemoryJob("embed_segment", { segmentId: "seg-1" });
-    enqueueMemoryJob("embed_item", { itemId: "item-1" });
-    enqueueMemoryJob("extract_items", { conversationId: "conv-1" });
+    enqueueMemoryJob("embed_graph_node", { nodeId: "node-1" });
+    enqueueMemoryJob("graph_extract", { conversationId: "conv-1" });
 
     const claimed = claimMemoryJobs(10);
     const types = claimed.map((j) => j.type);
 
     expect(types).toContain("embed_segment");
-    expect(types).toContain("embed_item");
-    expect(types).toContain("extract_items");
+    expect(types).toContain("embed_graph_node");
+    expect(types).toContain("graph_extract");
     expect(claimed).toHaveLength(3);
   });
 
@@ -62,9 +62,9 @@ describe("claimMemoryJobs with Qdrant circuit breaker", () => {
     }
 
     enqueueMemoryJob("embed_segment", { segmentId: "seg-1" });
-    enqueueMemoryJob("embed_item", { itemId: "item-1" });
+    enqueueMemoryJob("embed_graph_node", { nodeId: "node-1" });
     enqueueMemoryJob("embed_summary", { summaryId: "sum-1" });
-    enqueueMemoryJob("extract_items", { conversationId: "conv-1" });
+    enqueueMemoryJob("graph_extract", { conversationId: "conv-1" });
     enqueueMemoryJob("build_conversation_summary", {
       conversationId: "conv-1",
     });
@@ -73,10 +73,10 @@ describe("claimMemoryJobs with Qdrant circuit breaker", () => {
     const types = claimed.map((j) => j.type);
 
     // Only non-embed jobs should be claimed
-    expect(types).toContain("extract_items");
+    expect(types).toContain("graph_extract");
     expect(types).toContain("build_conversation_summary");
     expect(types).not.toContain("embed_segment");
-    expect(types).not.toContain("embed_item");
+    expect(types).not.toContain("embed_graph_node");
     expect(types).not.toContain("embed_summary");
     expect(claimed).toHaveLength(2);
   });
@@ -95,7 +95,7 @@ describe("claimMemoryJobs with Qdrant circuit breaker", () => {
 
     // Verify embed jobs are skipped while open
     enqueueMemoryJob("embed_segment", { segmentId: "seg-1" });
-    enqueueMemoryJob("extract_items", { conversationId: "conv-1" });
+    enqueueMemoryJob("graph_extract", { conversationId: "conv-1" });
 
     const claimedWhileOpen = claimMemoryJobs(10);
     expect(claimedWhileOpen.map((j) => j.type)).not.toContain("embed_segment");
@@ -104,21 +104,22 @@ describe("claimMemoryJobs with Qdrant circuit breaker", () => {
     _resetQdrantBreaker();
 
     // Re-enqueue an embed job (the previous one is now "running")
-    enqueueMemoryJob("embed_item", { itemId: "item-2" });
+    enqueueMemoryJob("embed_graph_node", { nodeId: "node-2" });
 
     const claimedAfterClose = claimMemoryJobs(10);
     const types = claimedAfterClose.map((j) => j.type);
 
-    expect(types).toContain("embed_item");
+    expect(types).toContain("embed_graph_node");
   });
 
   test("all embed job types are skipped when breaker is open", async () => {
     const embedTypes: MemoryJobType[] = [
       "embed_segment",
-      "embed_item",
       "embed_summary",
       "embed_media",
       "embed_attachment",
+      "embed_graph_node",
+      "graph_trigger_embed",
     ];
 
     // Trip the circuit breaker
@@ -137,13 +138,13 @@ describe("claimMemoryJobs with Qdrant circuit breaker", () => {
       enqueueMemoryJob(type, { id: `test-${type}` });
     }
     // Also enqueue a non-embed job
-    enqueueMemoryJob("extract_entities", { conversationId: "conv-1" });
+    enqueueMemoryJob("graph_consolidate", { conversationId: "conv-1" });
 
     const claimed = claimMemoryJobs(20);
     const types = claimed.map((j) => j.type);
 
     // Only the non-embed job should be claimed
     expect(claimed).toHaveLength(1);
-    expect(types).toEqual(["extract_entities"]);
+    expect(types).toEqual(["graph_consolidate"]);
   });
 });


### PR DESCRIPTION
## Summary
- Replace embed_item/extract_items/extract_entities with live job types in conversation-wipe and jobs-store-qdrant-breaker tests
- Update embed types array to match current EMBED_JOB_TYPES

Part of plan: rip-old-memory-system.md (PR 7 of 8)