### PR TITLE
fix: remove unused variable in conversation-wipe test

### DIFF
--- a/assistant/src/__tests__/conversation-wipe.test.ts
+++ b/assistant/src/__tests__/conversation-wipe.test.ts
@@ -94,7 +94,7 @@ describe("wipeConversation", () => {
 
   test("cancels pending memory jobs", async () => {
     const conv = createConversation("test");
-    const msg = await addMessage(conv.id, "user", "hello", undefined, {
+    await addMessage(conv.id, "user", "hello", undefined, {
       skipIndexing: true,
     });
 


### PR DESCRIPTION
## Summary
- Remove unused `msg` variable assignment in `conversation-wipe.test.ts` that caused a lint failure (`@typescript-eslint/no-unused-vars`)

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23968689584/job/69913702513