### PR TITLE
fix: remove dead MemoryJobType members, schema exports, and worker cases

### DIFF
--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -14,16 +14,8 @@ const log = getLogger("memory-jobs-store");
 
 export type MemoryJobType =
   | "embed_segment"
-  | "embed_item"
   | "embed_summary"
-  | "extract_items"
-  | "extract_entities"
-  | "batch_extract"
-  | "cleanup_stale_superseded_items" // legacy compat — silently dropped by worker (memory_items table dropped)
   | "prune_old_conversations"
-  | "backfill_entity_relations"
-  | "refresh_weekly_summary"
-  | "refresh_monthly_summary"
   | "build_conversation_summary"
   | "backfill"
   | "rebuild_index"
@@ -32,7 +24,6 @@ export type MemoryJobType =
   | "embed_media"
   | "embed_attachment"
   | "generate_conversation_starters"
-  | "journal_carry_forward"
   | "embed_graph_node"
   | "graph_extract"
   | "graph_decay"
@@ -40,13 +31,10 @@ export type MemoryJobType =
   | "graph_pattern_scan"
   | "graph_narrative_refine"
   | "graph_trigger_embed"
-  | "graph_bootstrap"
-  | "generate_capability_cards" // legacy compat — silently dropped by worker (capability cards removed)
-  | "generate_thread_starters"; // legacy compat — silently dropped by worker (renamed to generate_conversation_starters)
+  | "graph_bootstrap";
 
 const EMBED_JOB_TYPES: MemoryJobType[] = [
   "embed_segment",
-  "embed_item",
   "embed_summary",
   "embed_media",
   "embed_attachment",
@@ -136,32 +124,6 @@ export function upsertDebouncedJob(
   } else {
     enqueueMemoryJob(type, payload, runAfter, dbOverride);
   }
-}
-
-/**
- * Check whether a pending or running `journal_carry_forward` job already
- * exists for the given filename + userSlug.  Used to prevent duplicate
- * enqueues while a carry-forward job is still in flight.
- */
-export function hasActiveCarryForwardJob(
-  filename: string,
-  userSlug: string
-): boolean {
-  const db = getDb();
-  return (
-    db
-      .select({ id: memoryJobs.id })
-      .from(memoryJobs)
-      .where(
-        and(
-          eq(memoryJobs.type, "journal_carry_forward"),
-          inArray(memoryJobs.status, ["pending", "running"]),
-          sql`json_extract(${memoryJobs.payload}, '$.filename') = ${filename}`,
-          sql`json_extract(${memoryJobs.payload}, '$.userSlug') = ${userSlug}`
-        )
-      )
-      .get() != null
-  );
 }
 
 /**

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -355,13 +355,6 @@ async function processJob(
     case "embed_segment":
       await embedSegmentJob(job, config);
       return;
-    case "embed_item":
-    case "extract_items":
-    case "batch_extract":
-    case "extract_entities":
-    case "cleanup_stale_superseded_items":
-      // Old extraction pipeline replaced by memory graph — silently drop
-      return;
     case "embed_summary":
       await embedSummaryJob(job, config);
       return;
@@ -373,13 +366,6 @@ async function processJob(
       return;
     case "backfill":
       await backfillJob(job, config);
-      return;
-    case "backfill_entity_relations":
-      // Entity relation backfill has been removed — silently drop legacy jobs
-      return;
-    case "refresh_weekly_summary":
-    case "refresh_monthly_summary":
-      // Global summary rollups have been removed — silently drop legacy jobs
       return;
     case "rebuild_index":
       await rebuildIndexJob();
@@ -395,9 +381,6 @@ async function processJob(
       return;
     case "embed_attachment":
       await embedAttachmentJob(job, config);
-      return;
-    case "journal_carry_forward":
-      // Journal carry-forward replaced by graph extraction — silently drop
       return;
     case "embed_graph_node":
       await embedGraphNodeJob(job, config);
@@ -422,12 +405,6 @@ async function processJob(
       return;
     case "generate_conversation_starters":
       await generateConversationStartersJob(job);
-      return;
-    case "generate_capability_cards":
-      // Capability cards were removed — silently drop legacy jobs.
-      return;
-    case "generate_thread_starters":
-      // Thread starters renamed to conversation starters — silently drop legacy jobs
       return;
     default:
       throw new Error(

--- a/assistant/src/memory/schema/memory-core.ts
+++ b/assistant/src/memory/schema/memory-core.ts
@@ -2,7 +2,6 @@ import {
   blob,
   index,
   integer,
-  real,
   sqliteTable,
   text,
   uniqueIndex,
@@ -30,56 +29,6 @@ export const memorySegments = sqliteTable(
     updatedAt: integer("updated_at").notNull(),
   },
   (table) => [index("idx_memory_segments_scope_id").on(table.scopeId)],
-);
-
-export const memoryItems = sqliteTable(
-  "memory_items",
-  {
-    id: text("id").primaryKey(),
-    kind: text("kind").notNull(),
-    subject: text("subject").notNull(),
-    statement: text("statement").notNull(),
-    status: text("status").notNull(),
-    confidence: real("confidence").notNull(),
-    importance: real("importance"),
-    accessCount: integer("access_count").notNull().default(0),
-    fingerprint: text("fingerprint").notNull(),
-    verificationState: text("verification_state")
-      .notNull()
-      .default("assistant_inferred"),
-    scopeId: text("scope_id").notNull().default("default"),
-    firstSeenAt: integer("first_seen_at").notNull(),
-    lastSeenAt: integer("last_seen_at").notNull(),
-    lastUsedAt: integer("last_used_at"),
-    validFrom: integer("valid_from"),
-    invalidAt: integer("invalid_at"),
-    supersedes: text("supersedes"),
-    supersededBy: text("superseded_by"),
-    overrideConfidence: text("override_confidence").default("inferred"),
-    sourceType: text("source_type").notNull().default("extraction"),
-    sourceMessageRole: text("source_message_role"),
-  },
-  (table) => [
-    index("idx_memory_items_scope_id").on(table.scopeId),
-    index("idx_memory_items_fingerprint").on(table.fingerprint),
-  ],
-);
-
-export const memoryItemSources = sqliteTable(
-  "memory_item_sources",
-  {
-    memoryItemId: text("memory_item_id")
-      .notNull()
-      .references(() => memoryItems.id, { onDelete: "cascade" }),
-    messageId: text("message_id")
-      .notNull()
-      .references(() => messages.id, { onDelete: "cascade" }),
-    evidence: text("evidence"),
-    createdAt: integer("created_at").notNull(),
-  },
-  (table) => [
-    index("idx_memory_item_sources_memory_item_id").on(table.memoryItemId),
-  ],
 );
 
 export const memorySummaries = sqliteTable(


### PR DESCRIPTION
## Summary
- Remove memoryItems and memoryItemSources dead schema exports from memory-core.ts
- Remove 11 dead MemoryJobType union members that were silently dropped by the worker
- Remove all silently-dropped case blocks from the worker dispatch

Part of plan: rip-old-memory-system.md (PR 8 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
