### PR TITLE
fix: add queryContext to MessageInspectorMemoryTabTests makeRecall helper

### DIFF
--- a/clients/macos/vellum-assistantTests/MessageInspectorMemoryTabTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageInspectorMemoryTabTests.swift
@@ -227,7 +227,8 @@ final class MessageInspectorMemoryTabTests: XCTestCase {
         latencyMs: Int = 0,
         reason: String? = nil,
         topCandidates: [MemoryRecallCandidate] = [],
-        injectedText: String? = nil
+        injectedText: String? = nil,
+        queryContext: String? = nil
     ) -> MemoryRecallData {
         MemoryRecallData(
             enabled: enabled,
@@ -246,7 +247,8 @@ final class MessageInspectorMemoryTabTests: XCTestCase {
             latencyMs: latencyMs,
             reason: reason,
             topCandidates: topCandidates,
-            injectedText: injectedText
+            injectedText: injectedText,
+            queryContext: queryContext
         )
     }
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for memory-recall-query-context.md.

**Gap:** Missing queryContext parameter in MessageInspectorMemoryTabTests.swift
**What was expected:** All MemoryRecallData construction sites include queryContext
**What was found:** makeRecall helper in MessageInspectorMemoryTabTests was missed in the earlier fix