### PR TITLE
fix: subagent detail panel dark mode visibility and width

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -47,7 +47,7 @@ struct MainWindowView: View {
     @State private var systemIsDark: Bool = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
     let sidebarExpandedWidth: CGFloat = 240
     let sidebarCollapsedWidth: CGFloat = 52
-    @AppStorage("sidePanelWidth") var sidePanelWidth: Double = 400
+    @AppStorage("sidePanelWidth") var sidePanelWidth: Double = 500
     @AppStorage("appPanelWidth") var appPanelWidth: Double = -1
     @AppStorage("appChatDockWidth") var appChatDockWidth: Double = -1
     let connectionManager: GatewayConnectionManager

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -187,9 +187,9 @@ struct SubagentDetailPanel: View {
     private func eventLabel(for kind: SubagentEventItem.Kind) -> some View {
         switch kind {
         case .text:
-            label(icon: "text.bubble.fill", text: "RESPONSE", color: VColor.systemPositiveWeak)
+            label(icon: "text.bubble.fill", text: "RESPONSE", color: VColor.systemPositiveStrong)
         case .toolUse:
-            label(icon: "wrench.fill", text: "TOOL CALL", color: VColor.systemPositiveWeak)
+            label(icon: "wrench.fill", text: "TOOL CALL", color: VColor.systemPositiveStrong)
         case .toolResult(let isError):
             label(icon: isError ? "xmark.circle.fill" : "checkmark.circle.fill", text: isError ? "TOOL ERROR" : "TOOL RESULT", color: isError ? VColor.systemNegativeStrong : VColor.systemPositiveStrong)
         case .error:
@@ -225,7 +225,7 @@ struct SubagentDetailPanel: View {
             HStack(spacing: VSpacing.xs) {
                 Text(name)
                     .font(VFont.labelDefault)
-                    .foregroundStyle(VColor.systemPositiveWeak)
+                    .foregroundStyle(VColor.systemPositiveStrong)
                 if !event.content.isEmpty {
                     Text(event.content)
                         .font(VFont.bodySmallDefault)
@@ -238,10 +238,10 @@ struct SubagentDetailPanel: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: VRadius.md)
-                    .fill(VColor.primaryActive.opacity(0.06))
+                    .fill(VColor.primaryActive.opacity(0.08))
                     .overlay(
                         RoundedRectangle(cornerRadius: VRadius.md)
-                            .strokeBorder(VColor.primaryActive.opacity(0.12), lineWidth: 1)
+                            .strokeBorder(VColor.primaryActive.opacity(0.16), lineWidth: 1)
                     )
             )
 
@@ -255,7 +255,7 @@ struct SubagentDetailPanel: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(
                     RoundedRectangle(cornerRadius: VRadius.md)
-                        .fill(VColor.surfaceBase.opacity(0.3))
+                        .fill(VColor.surfaceActive.opacity(0.3))
                 )
 
         case .error:


### PR DESCRIPTION
## Summary
- Replace `systemPositiveWeak` with `systemPositiveStrong` for tool call names and event labels — the weak token (#1C251F in dark) was invisible on dark backgrounds
- Bump tool-call card fill/border opacity (0.06→0.08, 0.12→0.16) and switch tool-result background from `surfaceBase` to `surfaceActive` for visible card definition in dark mode
- Increase default side panel width from 400pt to 500pt

## Original prompt
PR 1 from the plan: Fix dark mode colors and panel width in the subagent detail panel. Three changes in SubagentDetailPanel.swift and one in MainWindowView.swift.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
