### PR TITLE
fix: handle array-format tool_result content in subagent detail

### DIFF
--- a/assistant/src/__tests__/subagent-detail.test.ts
+++ b/assistant/src/__tests__/subagent-detail.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for parseSubagentMessages — verifies that tool result content is
+ * correctly extracted from both string and array formats.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { parseSubagentMessages } from "../runtime/routes/subagents-routes.js";
+
+function msg(role: string, content: unknown[]) {
+  return { role, content: JSON.stringify(content) };
+}
+
+describe("parseSubagentMessages", () => {
+  test("extracts string tool_result content", () => {
+    const messages = [
+      msg("user", [{ type: "text", text: "Do something" }]),
+      msg("assistant", [
+        { type: "tool_use", id: "t1", name: "web_search", input: { query: "test" } },
+      ]),
+      msg("user", [
+        { type: "tool_result", tool_use_id: "t1", content: "Search results here" },
+      ]),
+    ];
+
+    const result = parseSubagentMessages("sub-1", messages);
+    const toolResult = result.events.find((e) => e.type === "tool_result");
+    expect(toolResult).toBeDefined();
+    expect(toolResult!.content).toBe("Search results here");
+    expect(toolResult!.toolName).toBe("web_search");
+  });
+
+  test("extracts array-format tool_result content", () => {
+    const messages = [
+      msg("user", [{ type: "text", text: "Do something" }]),
+      msg("assistant", [
+        { type: "tool_use", id: "t2", name: "file_read", input: { file_path: "/tmp/test.txt" } },
+      ]),
+      msg("user", [
+        {
+          type: "tool_result",
+          tool_use_id: "t2",
+          content: [
+            { type: "text", text: "Line 1 of file" },
+            { type: "text", text: "Line 2 of file" },
+          ],
+        },
+      ]),
+    ];
+
+    const result = parseSubagentMessages("sub-1", messages);
+    const toolResult = result.events.find((e) => e.type === "tool_result");
+    expect(toolResult).toBeDefined();
+    expect(toolResult!.content).toBe("Line 1 of file\nLine 2 of file");
+    expect(toolResult!.toolName).toBe("file_read");
+  });
+
+  test("handles null tool_result content gracefully", () => {
+    const messages = [
+      msg("user", [{ type: "text", text: "Do something" }]),
+      msg("assistant", [
+        { type: "tool_use", id: "t3", name: "bash", input: { command: "echo hi" } },
+      ]),
+      msg("user", [
+        { type: "tool_result", tool_use_id: "t3", content: null },
+      ]),
+    ];
+
+    const result = parseSubagentMessages("sub-1", messages);
+    const toolResult = result.events.find((e) => e.type === "tool_result");
+    expect(toolResult).toBeDefined();
+    expect(toolResult!.content).toBe("");
+  });
+
+  test("extracts objective from first user message", () => {
+    const messages = [
+      msg("user", [{ type: "text", text: "Research vampire lore" }]),
+      msg("assistant", [{ type: "text", text: "On it." }]),
+    ];
+
+    const result = parseSubagentMessages("sub-1", messages);
+    expect(result.objective).toBe("Research vampire lore");
+  });
+});

--- a/assistant/src/runtime/routes/subagents-routes.ts
+++ b/assistant/src/runtime/routes/subagents-routes.ts
@@ -34,15 +34,17 @@ export interface SubagentDetailResult {
   }>;
 }
 
-export function getSubagentDetail(
+/**
+ * Parse raw message rows into subagent detail events. Extracted as a pure
+ * function so it can be unit-tested without a database.
+ */
+export function parseSubagentMessages(
   subagentId: string,
-  conversationId: string,
+  messages: Array<{ role: string; content: string }>,
 ): SubagentDetailResult {
-  const subagentMsgs = getMessages(conversationId);
-
   // Extract objective from the first user message
   let objective: string | undefined;
-  const firstUser = subagentMsgs.find((m) => m.role === "user");
+  const firstUser = messages.find((m) => m.role === "user");
   if (firstUser) {
     try {
       const parsed = JSON.parse(firstUser.content);
@@ -67,7 +69,7 @@ export function getSubagentDetail(
     isError?: boolean;
   }> = [];
   const pendingTools = new Map<string, string>();
-  for (const m of subagentMsgs) {
+  for (const m of messages) {
     if (m.role !== "assistant" && m.role !== "user") continue;
     let content: unknown[];
     try {
@@ -101,7 +103,19 @@ export function getSubagentDetail(
         const toolUseId =
           typeof block.tool_use_id === "string" ? block.tool_use_id : "";
         const resultContent =
-          typeof block.content === "string" ? block.content : "";
+          typeof block.content === "string"
+            ? block.content
+            : Array.isArray(block.content)
+              ? (block.content as unknown[])
+                  .filter(
+                    (b): b is Record<string, unknown> =>
+                      isRecord(b) &&
+                      (b as Record<string, unknown>).type === "text" &&
+                      typeof (b as Record<string, unknown>).text === "string",
+                  )
+                  .map((b) => b.text as string)
+                  .join("\n")
+              : "";
         const isError = block.is_error === true;
         const toolName = toolUseId ? pendingTools.get(toolUseId) : undefined;
         events.push({
@@ -115,6 +129,13 @@ export function getSubagentDetail(
   }
 
   return { subagentId, objective, events };
+}
+
+export function getSubagentDetail(
+  subagentId: string,
+  conversationId: string,
+): SubagentDetailResult {
+  return parseSubagentMessages(subagentId, getMessages(conversationId));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fix `getSubagentDetail()` to handle array-format `tool_result` content blocks (e.g. `[{ type: "text", text: "..." }]`) in addition to plain strings — previously returned empty string for array content
- Extract `parseSubagentMessages()` as a pure function for testability
- Add 4 tests covering string content, array content, null content, and objective extraction

## Original prompt
PR 2 from the plan: Fix empty tool result content in detail response.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
