### PR TITLE
fix: remove vestigial fullReextract payload from requestReextract

### DIFF
--- a/assistant/src/memory/admin.ts
+++ b/assistant/src/memory/admin.ts
@@ -230,12 +230,11 @@ export function requestReextract(
       )
       .run();
 
-    // Resolve scope and enqueue with fullReextract flag
+    // Resolve scope and enqueue re-extraction
     const scopeId = getConversationMemoryScopeId(conversationId);
     const jobId = enqueueMemoryJob("graph_extract", {
       conversationId,
       scopeId,
-      fullReextract: true,
     });
     jobIds.push(jobId);
 


### PR DESCRIPTION
## Summary
Removes dead `fullReextract: true` property from `graph_extract` job payload in `requestReextract()`. The property was carried over from the old `batch_extract` handler but is never consumed by `graphExtractJob`.

Part of plan: rip-old-memory-system.md (review fix)