### PR TITLE
fix: correct comment listing graph_extract as messageId-keyed

### DIFF
--- a/assistant/src/memory/task-memory-cleanup.ts
+++ b/assistant/src/memory/task-memory-cleanup.ts
@@ -100,9 +100,9 @@ export function invalidateAssistantInferredItemsForConversation(
 
 /**
  * Cancel all pending/running memory jobs referencing the given conversation.
- * Covers every job type: `graph_extract`, `embed_attachment` (keyed by messageId),
+ * Covers every job type: `embed_attachment` (keyed by messageId),
  * `embed_segment` (keyed by segmentId via memory_segments),
- * `build_conversation_summary` (keyed by conversationId),
+ * `graph_extract`, `build_conversation_summary` (keyed by conversationId),
  * and `embed_graph_node` (keyed by nodeId sourced from the conversation).
  */
 export function cancelPendingJobsForConversation(
@@ -112,7 +112,7 @@ export function cancelPendingJobsForConversation(
   const now = Date.now();
   let total = 0;
 
-  // Jobs keyed by messageId: graph_extract, embed_attachment
+  // Jobs keyed by messageId: embed_attachment
   total += rawRun(
     `UPDATE memory_jobs
         SET status = 'failed',
@@ -127,7 +127,7 @@ export function cancelPendingJobsForConversation(
     conversationId,
   );
 
-  // Jobs keyed by conversationId: build_conversation_summary
+  // Jobs keyed by conversationId: graph_extract, build_conversation_summary
   total += rawRun(
     `UPDATE memory_jobs
         SET status = 'failed',


### PR DESCRIPTION
## Summary
Fixes stale comment in cancelPendingJobsForConversation that incorrectly listed graph_extract as messageId-keyed. graph_extract jobs use conversationId in their payload.

Part of plan: rip-old-memory-system.md (review fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
