### PR TITLE
fix: remove always-empty orphanedItemIds and unsupersededItemIds dead code

### DIFF
--- a/assistant/src/__tests__/conversation-history-web-search.test.ts
+++ b/assistant/src/__tests__/conversation-history-web-search.test.ts
@@ -41,7 +41,7 @@ mock.module("../memory/conversation-crud.js", () => ({
   deleteMessageById: (messageId: string) => {
     deletedMessageIds.push(messageId);
     dbMessages = dbMessages.filter((m) => m.id !== messageId);
-    return { segmentIds: [], orphanedItemIds: [] };
+    return { segmentIds: [], deletedSummaryIds: [] };
   },
   updateMessageContent: (messageId: string, content: string) => {
     updatedMessages.push({ id: messageId, content });

--- a/assistant/src/__tests__/conversation-wipe.test.ts
+++ b/assistant/src/__tests__/conversation-wipe.test.ts
@@ -135,8 +135,6 @@ describe("wipeConversation", () => {
 
     expect(getConversation(conv.id)).toBeNull();
     expect(result.segmentIds).toEqual([]);
-    expect(result.orphanedItemIds).toEqual([]);
-    expect(result.unsupersededItemIds).toEqual([]);
     expect(result.deletedSummaryIds).toEqual([]);
     expect(result.cancelledJobCount).toBe(0);
   });

--- a/assistant/src/__tests__/conversation-workspace-cache-state.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-cache-state.test.ts
@@ -91,7 +91,7 @@ mock.module("../memory/conversation-crud.js", () => ({
   updateConversationUsage: () => {},
   updateConversationTitle: () => {},
   updateConversationContextWindow: () => {},
-  deleteMessageById: () => ({ segmentIds: [], orphanedItemIds: [] }),
+  deleteMessageById: () => ({ segmentIds: [], deletedSummaryIds: [] }),
   deleteLastExchange: () => 0,
 }));
 

--- a/assistant/src/__tests__/conversation-workspace-injection.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-injection.test.ts
@@ -123,7 +123,7 @@ mock.module("../memory/conversation-crud.js", () => ({
   updateConversationUsage: () => {},
   updateConversationTitle: () => {},
   updateConversationContextWindow: () => {},
-  deleteMessageById: () => ({ segmentIds: [], orphanedItemIds: [] }),
+  deleteMessageById: () => ({ segmentIds: [], deletedSummaryIds: [] }),
   deleteLastExchange: () => 0,
 }));
 

--- a/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
@@ -120,7 +120,7 @@ mock.module("../memory/conversation-crud.js", () => ({
   updateConversationUsage: () => {},
   updateConversationTitle: () => {},
   updateConversationContextWindow: () => {},
-  deleteMessageById: () => ({ segmentIds: [], orphanedItemIds: [] }),
+  deleteMessageById: () => ({ segmentIds: [], deletedSummaryIds: [] }),
   deleteLastExchange: () => 0,
 }));
 

--- a/assistant/src/cli/commands/conversations.ts
+++ b/assistant/src/cli/commands/conversations.ts
@@ -375,12 +375,6 @@ Examples:
           targetId: segId,
         });
       }
-      for (const itemId of result.orphanedItemIds) {
-        enqueueMemoryJob("delete_qdrant_vectors", {
-          targetType: "item",
-          targetId: itemId,
-        });
-      }
       for (const summaryId of result.deletedSummaryIds) {
         enqueueMemoryJob("delete_qdrant_vectors", {
           targetType: "summary",
@@ -390,8 +384,7 @@ Examples:
 
       log.info(
         `Wiped conversation "${conversation.title ?? "Untitled"}". ` +
-          `Restored ${result.unsupersededItemIds.length} memory items, ` +
-          `deleted ${result.deletedSummaryIds.length} summaries, ` +
+          `Deleted ${result.deletedSummaryIds.length} summaries, ` +
           `cancelled ${result.cancelledJobCount} jobs.`,
       );
     });

--- a/assistant/src/daemon/conversation-history.ts
+++ b/assistant/src/daemon/conversation-history.ts
@@ -68,14 +68,13 @@ export function findLastUndoableUserMessageIndex(messages: Message[]): number {
 // ── Qdrant Vector Cleanup ────────────────────────────────────────────
 
 /**
- * Delete Qdrant vector entries for the given segment and item IDs.
+ * Delete Qdrant vector entries for the given segment IDs.
  * Individual deletion failures are logged and enqueued as retry jobs
  * to prevent silently orphaned vectors.
  */
 export async function cleanupQdrantVectors(
   conversationId: string,
   segmentIds: string[],
-  orphanedItemIds: string[],
 ): Promise<void> {
   let qdrant: ReturnType<typeof getQdrantClient>;
   try {
@@ -84,14 +83,11 @@ export async function cleanupQdrantVectors(
     return; // Qdrant not initialized — nothing to clean up.
   }
 
-  if (segmentIds.length === 0 && orphanedItemIds.length === 0) return;
+  if (segmentIds.length === 0) return;
 
   const targets: Array<{ targetType: string; targetId: string }> = [];
   for (const segId of segmentIds) {
     targets.push({ targetType: "segment", targetId: segId });
-  }
-  for (const itemId of orphanedItemIds) {
-    targets.push({ targetType: "item", targetId: itemId });
   }
 
   const results = await Promise.allSettled(
@@ -124,7 +120,6 @@ export async function cleanupQdrantVectors(
         succeeded,
         failed,
         segments: segmentIds.length,
-        items: orphanedItemIds.length,
       },
       "Cleaned up Qdrant vectors after regenerate",
     );
@@ -187,20 +182,17 @@ export function consolidateAssistantMessages(
     // Still delete internal tool_result messages even if only one assistant message,
     // and collect IDs for vector cleanup
     const allSegmentIds: string[] = [];
-    const allOrphanedItemIds: string[] = [];
     for (const id of messagesToDelete) {
       const deleted = deleteMessageById(id);
       didMutate = true;
       allSegmentIds.push(...deleted.segmentIds);
-      allOrphanedItemIds.push(...deleted.orphanedItemIds);
     }
 
     // Clean up Qdrant vectors (fire-and-forget)
-    if (allSegmentIds.length > 0 || allOrphanedItemIds.length > 0) {
+    if (allSegmentIds.length > 0) {
       cleanupQdrantVectors(
         conversationId,
         allSegmentIds,
-        allOrphanedItemIds,
       ).catch((err) => {
         log.warn(
           { err, conversationId },
@@ -322,24 +314,20 @@ export function consolidateAssistantMessages(
   // Delete the other assistant messages and internal tool_result messages,
   // and collect IDs for vector cleanup
   const allSegmentIds: string[] = [];
-  const allOrphanedItemIds: string[] = [];
   for (let i = 1; i < messagesToConsolidate.length; i++) {
     const deleted = deleteMessageById(messagesToConsolidate[i].id);
     allSegmentIds.push(...deleted.segmentIds);
-    allOrphanedItemIds.push(...deleted.orphanedItemIds);
   }
   for (const id of messagesToDelete) {
     const deleted = deleteMessageById(id);
     allSegmentIds.push(...deleted.segmentIds);
-    allOrphanedItemIds.push(...deleted.orphanedItemIds);
   }
 
   // Clean up Qdrant vectors (fire-and-forget)
-  if (allSegmentIds.length > 0 || allOrphanedItemIds.length > 0) {
+  if (allSegmentIds.length > 0) {
     cleanupQdrantVectors(
       conversationId,
       allSegmentIds,
-      allOrphanedItemIds,
     ).catch((err) => {
       log.warn(
         { err, conversationId },
@@ -539,18 +527,15 @@ export async function regenerate(
 
   // Delete each message via deleteMessageById and collect IDs for Qdrant cleanup.
   const allSegmentIds: string[] = [];
-  const allOrphanedItemIds: string[] = [];
   for (const msg of messagesToDelete) {
     const deleted = deleteMessageById(msg.id);
     allSegmentIds.push(...deleted.segmentIds);
-    allOrphanedItemIds.push(...deleted.orphanedItemIds);
   }
 
   // Clean up Qdrant vectors (fire-and-forget).
   cleanupQdrantVectors(
     conversation.conversationId,
     allSegmentIds,
-    allOrphanedItemIds,
   ).catch((err) => {
     log.warn(
       { err, conversationId: conversation.conversationId },

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -355,12 +355,6 @@ export async function runDaemon(): Promise<void> {
           targetId: segId,
         });
       }
-      for (const itemId of deletedMemory.orphanedItemIds) {
-        enqueueMemoryJob("delete_qdrant_vectors", {
-          targetType: "item",
-          targetId: itemId,
-        });
-      }
       for (const summaryId of deletedMemory.deletedSummaryIds) {
         enqueueMemoryJob("delete_qdrant_vectors", {
           targetType: "summary",
@@ -369,13 +363,11 @@ export async function runDaemon(): Promise<void> {
       }
       if (
         deletedMemory.segmentIds.length > 0 ||
-        deletedMemory.orphanedItemIds.length > 0 ||
         deletedMemory.deletedSummaryIds.length > 0
       ) {
         log.info(
           {
             segments: deletedMemory.segmentIds.length,
-            orphanedItems: deletedMemory.orphanedItemIds.length,
             deletedSummaries: deletedMemory.deletedSummaryIds.length,
           },
           "Enqueued Qdrant vector cleanup jobs for purged private conversations",

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -612,14 +612,13 @@ export function forkConversation(params: {
 
 /**
  * Delete a conversation and all its messages, cleaning up orphaned memory
- * artifacts (items, embeddings). Returns segment and orphaned item IDs so
- * callers can clean up the corresponding Qdrant vector entries.
+ * artifacts (embeddings). Returns segment IDs so callers can clean up
+ * the corresponding Qdrant vector entries.
  */
 export function deleteConversation(id: string): DeletedMemoryIds {
   const db = getDb();
   const result: DeletedMemoryIds = {
     segmentIds: [],
-    orphanedItemIds: [],
     deletedSummaryIds: [],
   };
 
@@ -729,7 +728,6 @@ export function deleteConversation(id: string): DeletedMemoryIds {
  */
 export function wipeConversation(id: string): WipeConversationResult {
   const db = getDb();
-  const unsupersededItemIds: string[] = [];
   const deletedSummaryIds: string[] = [];
 
   // Step A — Cancel pending memory jobs (before deleting messages, since
@@ -771,7 +769,6 @@ export function wipeConversation(id: string): WipeConversationResult {
   // Step E — Return the combined result.
   return {
     ...deletedMemoryIds,
-    unsupersededItemIds,
     deletedSummaryIds: [
       ...deletedSummaryIds,
       ...deletedMemoryIds.deletedSummaryIds,
@@ -801,20 +798,17 @@ export function purgePrivateConversations(): {
       count: 0,
       deletedMemory: {
         segmentIds: [],
-        orphanedItemIds: [],
         deletedSummaryIds: [],
       },
     };
   }
 
   const allSegmentIds: string[] = [];
-  const allOrphanedItemIds: string[] = [];
   const allDeletedSummaryIds: string[] = [];
 
   for (const conv of privateConvs) {
     const deleted = deleteConversation(conv.id);
     allSegmentIds.push(...deleted.segmentIds);
-    allOrphanedItemIds.push(...deleted.orphanedItemIds);
     allDeletedSummaryIds.push(...deleted.deletedSummaryIds);
   }
 
@@ -822,7 +816,6 @@ export function purgePrivateConversations(): {
     count: privateConvs.length,
     deletedMemory: {
       segmentIds: allSegmentIds,
-      orphanedItemIds: allOrphanedItemIds,
       deletedSummaryIds: allDeletedSummaryIds,
     },
   };
@@ -1282,12 +1275,10 @@ export function deleteLastExchange(conversationId: string): number {
  */
 export interface DeletedMemoryIds {
   segmentIds: string[];
-  orphanedItemIds: string[];
   deletedSummaryIds: string[];
 }
 
 export interface WipeConversationResult extends DeletedMemoryIds {
-  unsupersededItemIds: string[];
   cancelledJobCount: number;
 }
 
@@ -1369,7 +1360,6 @@ export function deleteMessageById(messageId: string): DeletedMemoryIds {
   const db = getDb();
   const result: DeletedMemoryIds = {
     segmentIds: [],
-    orphanedItemIds: [],
     deletedSummaryIds: [],
   };
 

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -344,12 +344,6 @@ export function conversationManagementRouteDefinitions(
             targetId: segId,
           });
         }
-        for (const itemId of result.orphanedItemIds) {
-          enqueueMemoryJob("delete_qdrant_vectors", {
-            targetType: "item",
-            targetId: itemId,
-          });
-        }
         for (const summaryId of result.deletedSummaryIds) {
           enqueueMemoryJob("delete_qdrant_vectors", {
             targetType: "summary",
@@ -359,7 +353,6 @@ export function conversationManagementRouteDefinitions(
         log.info(
           {
             conversationId: resolvedId,
-            unsuperseded: result.unsupersededItemIds.length,
             summariesDeleted: result.deletedSummaryIds.length,
             jobsCancelled: result.cancelledJobCount,
           },
@@ -367,7 +360,6 @@ export function conversationManagementRouteDefinitions(
         );
         return Response.json({
           wiped: true,
-          unsupersededItems: result.unsupersededItemIds.length,
           deletedSummaries: result.deletedSummaryIds.length,
           cancelledJobs: result.cancelledJobCount,
         });
@@ -415,12 +407,6 @@ export function conversationManagementRouteDefinitions(
           enqueueMemoryJob("delete_qdrant_vectors", {
             targetType: "segment",
             targetId: segId,
-          });
-        }
-        for (const itemId of deleted.orphanedItemIds) {
-          enqueueMemoryJob("delete_qdrant_vectors", {
-            targetType: "item",
-            targetId: itemId,
           });
         }
         for (const summaryId of deleted.deletedSummaryIds) {


### PR DESCRIPTION
## Summary
- Remove orphanedItemIds from DeletedMemoryIds interface and all consumers
- Remove unsupersededItemIds from WipeConversationResult and all consumers
- Both were always empty arrays since migration 203 dropped the memory_items table

Part of plan: rip-old-memory-system.md (review fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
