### PR TITLE
feat: use 5m prompt cache TTL for subagent conversations

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -31,6 +31,8 @@ export interface AgentLoopConfig {
     | { type: "tool"; name: string };
   /** Minimum interval (ms) between consecutive LLM calls to prevent spin when tools return instantly */
   minTurnIntervalMs?: number;
+  /** Override the default prompt cache TTL sent to the provider (e.g. "5m" for short-lived subagents). */
+  cacheTtl?: "5m" | "1h";
 }
 
 export interface CheckpointInfo {
@@ -250,6 +252,10 @@ export class AgentLoop {
 
         if (this.config.toolChoice) {
           providerConfig.tool_choice = this.config.toolChoice;
+        }
+
+        if (this.config.cacheTtl) {
+          providerConfig.cacheTtl = this.config.cacheTtl;
         }
 
         const preLlmResult = await getHookManager().trigger("pre-llm-call", {

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -280,6 +280,7 @@ export class Conversation {
     memoryPolicy?: ConversationMemoryPolicy,
     sharedCesClient?: CesClient,
     speedOverride?: Speed,
+    cacheTtl?: "5m" | "1h",
   ) {
     this.conversationId = conversationId;
     this.systemPrompt = systemPrompt;
@@ -418,6 +419,7 @@ export class Conversation {
         ...(fastModeEnabled && resolvedSpeed === "fast"
           ? { speed: resolvedSpeed }
           : {}),
+        ...(cacheTtl ? { cacheTtl } : {}),
       },
       toolDefs.length > 0 ? toolDefs : undefined,
       toolDefs.length > 0 ? toolExecutor : undefined,

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -579,6 +579,7 @@ export class AnthropicProvider implements Provider {
     options?: SendMessageOptions,
   ): Promise<ProviderResponse> {
     const { config, onEvent, signal } = options ?? {};
+    const cacheTtl: "5m" | "1h" = ((config as Record<string, unknown> | undefined)?.cacheTtl as "5m" | "1h") ?? "1h";
     let sentMessages: Anthropic.MessageParam[] | undefined;
     try {
       const formatted = messages
@@ -732,12 +733,12 @@ export class AnthropicProvider implements Provider {
             {
               type: "text" as const,
               text: staticBlock,
-              cache_control: { type: "ephemeral" as const, ttl: "1h" as const },
+              cache_control: { type: "ephemeral" as const, ttl: cacheTtl },
             },
             {
               type: "text" as const,
               text: dynamicBlock,
-              cache_control: { type: "ephemeral" as const, ttl: "1h" as const },
+              cache_control: { type: "ephemeral" as const, ttl: cacheTtl },
             },
           ];
         } else {
@@ -745,7 +746,7 @@ export class AnthropicProvider implements Provider {
             {
               type: "text" as const,
               text: systemPrompt,
-              cache_control: { type: "ephemeral" as const, ttl: "1h" as const },
+              cache_control: { type: "ephemeral" as const, ttl: cacheTtl },
             },
           ];
         }
@@ -765,7 +766,7 @@ export class AnthropicProvider implements Provider {
               ? {
                   cache_control: {
                     type: "ephemeral" as const,
-                    ttl: "1h" as const,
+                    ttl: cacheTtl,
                   },
                 }
               : {}),
@@ -785,7 +786,7 @@ export class AnthropicProvider implements Provider {
               ? {
                   cache_control: {
                     type: "ephemeral" as const,
-                    ttl: "1h" as const,
+                    ttl: cacheTtl,
                   },
                 }
               : {}),
@@ -814,7 +815,7 @@ export class AnthropicProvider implements Provider {
         if (typeof lastBlock !== "string") {
           (lastBlock as unknown as Record<string, unknown>).cache_control = {
             type: "ephemeral",
-            ttl: "1h",
+            ttl: cacheTtl,
           };
         }
         turnStartIdx = i;

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -218,6 +218,9 @@ export class SubagentManager {
       workingDir,
       this.broadcastToAllClients, // forward parent's broadcast so tool side-effects (e.g. app_files_changed) reach all clients
       memoryPolicy,
+      undefined, // sharedCesClient
+      undefined, // speedOverride
+      "5m", // cacheTtl — subagents run tight tool-use loops, 5m is always hot
     );
 
     // Mark conversation as having no direct client — it routes through parent.


### PR DESCRIPTION
## Summary
- Thread `cacheTtl` option through `AgentLoopConfig` → `Conversation` → Anthropic provider
- Subagents pass `cacheTtl: "5m"` — their cache is always hot during execution, so 1h is wasteful
- Main conversations retain the default 1h TTL; advancing tail stays at 5m regardless

## Original prompt
it (plan: subagent prompt cache TTL optimization)