### PR TITLE
feat: add POST conversations/:id/analyze endpoint

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -127,6 +127,7 @@ import {
   contactCatchAllRouteDefinitions,
   contactRouteDefinitions,
 } from "./routes/contact-routes.js";
+import { conversationAnalysisRouteDefinitions } from "./routes/conversation-analysis-routes.js";
 import { conversationAttentionRouteDefinitions } from "./routes/conversation-attention-routes.js";
 import {
   type ConversationManagementDeps,
@@ -1082,6 +1083,14 @@ export class RuntimeHttpServer {
 
       ...(conversationManagementDeps
         ? conversationManagementRouteDefinitions(conversationManagementDeps)
+        : []),
+
+      ...(this.sendMessageDeps
+        ? conversationAnalysisRouteDefinitions({
+            sendMessageDeps: this.sendMessageDeps,
+            buildConversationDetailResponse: (id) =>
+              this.buildConversationDetailResponse(id),
+          })
         : []),
 
       ...groupRouteDefinitions(),

--- a/assistant/src/runtime/routes/conversation-analysis-routes.ts
+++ b/assistant/src/runtime/routes/conversation-analysis-routes.ts
@@ -1,0 +1,163 @@
+/**
+ * Route handler for conversation analysis.
+ *
+ * POST /v1/conversations/:id/analyze — analyze a conversation via a new
+ * agent loop that produces a structured self-assessment.
+ */
+
+import {
+  addMessage,
+  createConversation,
+  getConversation,
+  getMessages,
+} from "../../memory/conversation-crud.js";
+import { resolveConversationId } from "../../memory/conversation-key-store.js";
+import type { ServerMessage } from "../../daemon/message-protocol.js";
+import { getLogger } from "../../util/logger.js";
+import { buildAssistantEvent } from "../assistant-event.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+import type { SendMessageDeps } from "../http-types.js";
+
+const log = getLogger("conversation-analysis-routes");
+
+// ---------------------------------------------------------------------------
+// Dependency types — injected by the daemon at wiring time
+// ---------------------------------------------------------------------------
+
+export interface ConversationAnalysisDeps {
+  sendMessageDeps: SendMessageDeps;
+  buildConversationDetailResponse: (
+    id: string,
+  ) => Record<string, unknown> | null;
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function conversationAnalysisRouteDefinitions(
+  deps: ConversationAnalysisDeps,
+): RouteDefinition[] {
+  return [
+    {
+      endpoint: "conversations/:id/analyze",
+      method: "POST",
+      policyKey: "conversations/analyze",
+      summary: "Analyze a conversation",
+      description:
+        "Create a new conversation with a structured self-assessment of an existing conversation.",
+      tags: ["conversations"],
+      handler: async ({ params }) => {
+        // a. Resolve conversation ID
+        const resolvedId = resolveConversationId(params.id);
+        if (!resolvedId) {
+          return httpError(
+            "NOT_FOUND",
+            `Conversation ${params.id} not found`,
+            404,
+          );
+        }
+
+        // b. Load the conversation
+        const conversation = getConversation(resolvedId);
+        if (!conversation) {
+          return httpError(
+            "NOT_FOUND",
+            `Conversation ${resolvedId} not found`,
+            404,
+          );
+        }
+
+        // c. Reject private conversations
+        if (conversation.conversationType === "private") {
+          return httpError(
+            "FORBIDDEN",
+            "Private conversations cannot be analyzed",
+            403,
+          );
+        }
+
+        // d. Check for messages
+        const existingMessages = getMessages(resolvedId);
+        if (existingMessages.length === 0) {
+          return httpError(
+            "BAD_REQUEST",
+            "Conversation has no messages to analyze",
+            400,
+          );
+        }
+
+        // e. Build the analysis transcript
+        const { buildAnalysisTranscript } = await import(
+          "../../export/transcript-formatter.js"
+        );
+        const transcript = buildAnalysisTranscript(resolvedId);
+
+        // f. Create a new conversation for the analysis
+        const newConv = createConversation({
+          title: `Analysis: ${conversation.title ?? "Untitled"}`,
+        });
+
+        // g. Build the analysis prompt
+        const prompt = `<transcript>
+${transcript}
+</transcript>
+
+Analyze the conversation above. Provide a structured self-assessment:
+
+1. **Summary**: What was the user trying to accomplish? What was the outcome?
+2. **What went well**: Effective tool usage, good reasoning, helpful responses, problem-solving patterns.
+3. **What went wrong**: Errors, unnecessary tool calls, incorrect assumptions, wasted turns, misunderstandings.
+4. **Root causes**: Why did failures happen? Missing context? Wrong approach? Tool limitations?
+5. **Recommendations**: Specific, actionable improvements for similar conversations next time.
+
+Be honest and specific. Reference particular moments in the transcript. Focus on patterns that generalize beyond this specific conversation.
+
+If you identify insights worth remembering for future conversations, use your memory tools to save them.`;
+
+        // h. Persist the user message
+        const message = await addMessage(
+          newConv.id,
+          "user",
+          JSON.stringify([{ type: "text", text: prompt }]),
+        );
+        const messageId = message.id;
+
+        // i. Load the conversation into memory
+        const analysisConversation =
+          await deps.sendMessageDeps.getOrCreateConversation(newConv.id);
+
+        // j. Build onEvent using inline hub publisher
+        const onEvent = (msg: ServerMessage) => {
+          deps.sendMessageDeps.assistantEventHub.publish(
+            buildAssistantEvent(
+              DAEMON_INTERNAL_ASSISTANT_ID,
+              msg,
+              newConv.id,
+            ),
+          );
+        };
+
+        // k. Fire-and-forget the agent loop
+        analysisConversation
+          .runAgentLoop(prompt, messageId, onEvent, {
+            isInteractive: false,
+            isUserMessage: true,
+          })
+          .catch((err) => {
+            log.error(
+              { err, conversationId: newConv.id },
+              "Analysis agent loop failed",
+            );
+          });
+
+        // l. Return the new conversation detail
+        return Response.json({
+          conversation: deps.buildConversationDetailResponse(newConv.id),
+        });
+      },
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Add conversation-analysis-routes.ts with POST conversations/:id/analyze endpoint
- Gathers full transcript via buildAnalysisTranscript, creates new conversation, persists analysis prompt, fires agent loop
- Returns new conversation detail (same shape as fork endpoint)
- Register route in http-server.ts gated on sendMessageDeps

Part of plan: conversation-analysis.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23551" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
