### PR TITLE
fix: restore subagent UI on conversation history reload

### DIFF
--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -274,4 +274,11 @@ export interface RuntimeMessagePayload {
   textSegments?: string[];
   thinkingSegments?: string[];
   contentOrder?: string[];
+  subagentNotification?: {
+    subagentId: string;
+    label: string;
+    status: string;
+    error?: string;
+    conversationId?: string;
+  };
 }

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -431,10 +431,33 @@ export function handleListMessages(
     // was queued or its persistence was delayed (long assistant generation),
     // sentAt captures the actual event time. Falls back to createdAt.
     let sentAt: number | undefined;
+    let subagentNotification:
+      | {
+          subagentId: string;
+          label: string;
+          status: string;
+          error?: string;
+          conversationId?: string;
+        }
+      | undefined;
     if (msg.metadata) {
       try {
         const meta = JSON.parse(msg.metadata);
         if (typeof meta.sentAt === "number") sentAt = meta.sentAt;
+        if (meta.subagentNotification) {
+          const n = meta.subagentNotification;
+          if (typeof n.subagentId === "string" && typeof n.label === "string") {
+            subagentNotification = {
+              subagentId: n.subagentId,
+              label: n.label,
+              status: typeof n.status === "string" ? n.status : "completed",
+              ...(typeof n.error === "string" ? { error: n.error } : {}),
+              ...(typeof n.conversationId === "string"
+                ? { conversationId: n.conversationId }
+                : {}),
+            };
+          }
+        }
       } catch {
         // Ignore malformed metadata
       }
@@ -482,6 +505,7 @@ export function handleListMessages(
           ? { thinkingSegments: rendered.thinkingSegments }
           : {}),
         id: msg.id,
+        subagentNotification,
       };
     }
 
@@ -499,6 +523,7 @@ export function handleListMessages(
         ? { thinkingSegments: rendered.thinkingSegments }
         : {}),
       id: msg.id,
+      subagentNotification,
     };
   });
 
@@ -587,6 +612,9 @@ export function handleListMessages(
         ? { thinkingSegments: m.thinkingSegments }
         : {}),
       ...(m.contentOrder.length > 0 ? { contentOrder: m.contentOrder } : {}),
+      ...(m.subagentNotification
+        ? { subagentNotification: m.subagentNotification }
+        : {}),
     };
   });
 


### PR DESCRIPTION
## Summary
- Extract `subagentNotification` from message metadata in the `/messages` history endpoint — it was stored in the DB but never included in the response
- Add `subagentNotification` field to `RuntimeMessagePayload` type
- The Swift client already has `HistoryReconstructionService` wired to reconstruct `activeSubagents` from this field — it just was never receiving the data

## Original prompt
After reloading from the db the nice UI to see subagents is gone — the interactive clickable subagent rows disappear and only the markdown table remains.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23552" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
