### PR TITLE
feat: add "Analyze conversation" to conversation actions dropdown

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
@@ -12,6 +12,7 @@ struct ConversationTitleActionsControl: View {
     let onArchive: () -> Void
     let onRename: () -> Void
     let onOpenForkParent: () -> Void
+    let onAnalyzeConversation: () -> Void
     @Binding var showDrawer: Bool
 
     var body: some View {
@@ -58,6 +59,7 @@ struct ConversationActionsDrawer: View {
     let onUnpin: () -> Void
     let onArchive: () -> Void
     let onRename: () -> Void
+    let onAnalyzeConversation: () -> Void
     var onOpenInNewWindow: (() -> Void)? = nil
 
     var body: some View {
@@ -68,6 +70,14 @@ struct ConversationActionsDrawer: View {
 
             if presentation.showsForkConversationAction && !presentation.isChannelConversation {
                 VMenuItem(icon: VIcon.gitBranch.rawValue, label: "Fork conversation", action: onForkConversation)
+            }
+
+            if !presentation.isChannelConversation {
+                VMenuItem(
+                    icon: VIcon.sparkles.rawValue,
+                    label: "Analyze conversation",
+                    action: onAnalyzeConversation
+                )
             }
 
             if let onOpenInNewWindow {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Drawers.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Drawers.swift
@@ -57,6 +57,12 @@ extension MainWindowView {
                     dismissConversationDrawer()
                 },
                 onRename: { startRenameActiveConversation(); dismissConversationDrawer() },
+                onAnalyzeConversation: {
+                    Task {
+                        await conversationManager.analyzeActiveConversation()
+                        await MainActor.run { dismissConversationDrawer() }
+                    }
+                },
                 onOpenInNewWindow: conversationManager.activeConversation?.conversationId != nil ? {
                     guard let id = conversationManager.activeConversationId else { return }
                     AppDelegate.shared?.threadWindowManager?.openThread(

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -525,7 +525,13 @@ struct MainWindowView: View {
                         dismissConversationDrawer()
                     },
                     onRename: { startRenameActiveConversation(); dismissConversationDrawer() },
-                    onOpenForkParent: { openForkParentConversation() }
+                    onOpenForkParent: { openForkParentConversation() },
+                    onAnalyzeConversation: {
+                        Task {
+                            await conversationManager.analyzeActiveConversation()
+                            await MainActor.run { dismissConversationDrawer() }
+                        }
+                    }
                 )
             }
         }
@@ -832,6 +838,7 @@ private struct ConversationTitleOverlay: View {
     let onArchive: () -> Void
     let onRename: () -> Void
     let onOpenForkParent: () -> Void
+    let onAnalyzeConversation: () -> Void
 
     private var presentation: ConversationHeaderPresentation {
         ConversationHeaderPresentation(
@@ -851,6 +858,7 @@ private struct ConversationTitleOverlay: View {
             onArchive: onArchive,
             onRename: onRename,
             onOpenForkParent: onOpenForkParent,
+            onAnalyzeConversation: onAnalyzeConversation,
             showDrawer: $showDrawer
         )
         .onGeometryChange(for: CGRect.self) { proxy in


### PR DESCRIPTION
## Summary
- Add onAnalyzeConversation callback to ConversationTitleActionsControl and ConversationActionsDrawer
- Add sparkles-icon menu item in the dropdown for non-channel conversations
- Wire callback through ConversationTitleOverlay and MainWindowView+Drawers to ConversationManager.analyzeActiveConversation()

Part of plan: conversation-analysis.md (PR 5 of 6)