### PR TITLE
feat: add "Analyze" to sidebar conversation context menu

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -210,6 +210,10 @@ extension MainWindowView {
             onDragStart: {
                 sidebar.beginConversationDrag(conversation.id)
             },
+            onAnalyze: conversation.conversationId != nil && !conversation.isChannelConversation && conversation.kind != .private ? {
+                selectConversation(conversation)
+                Task<Void, Never> { await conversationManager.analyzeActiveConversation() }
+            } : nil,
             onOpenInNewWindow: conversation.conversationId != nil ? {
                 AppDelegate.shared?.threadWindowManager?.openThread(
                     conversationLocalId: conversation.id,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
@@ -78,6 +78,10 @@ struct ConversationSwitcherDrawer: View {
             onDragStart: {
                 sidebar.beginConversationDrag(conversation.id)
             },
+            onAnalyze: conversation.conversationId != nil && !conversation.isChannelConversation && conversation.kind != .private ? {
+                selectConversation(conversation)
+                Task<Void, Never> { await conversationManager.analyzeActiveConversation() }
+            } : nil,
             onOpenInNewWindow: conversation.conversationId != nil ? {
                 AppDelegate.shared?.threadWindowManager?.openThread(
                     conversationLocalId: conversation.id,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -20,6 +20,7 @@ struct SidebarConversationItem: View, Equatable {
     var onStartRename: () -> Void
     var onMarkUnread: () -> Void
     var onDragStart: () -> Void
+    var onAnalyze: (() -> Void)?
     var onOpenInNewWindow: (() -> Void)?
     var onShowFeedback: (() -> Void)?
     /// Available groups for the "Move to" submenu. Excludes the conversation's current group.
@@ -76,6 +77,12 @@ struct SidebarConversationItem: View, Equatable {
                 onMarkUnread()
             }
             .disabled(!canMarkUnread)
+        }
+
+        if !conversation.isChannelConversation && conversation.kind != .private, let onAnalyze {
+            VMenuItem(icon: VIcon.sparkles.rawValue, label: "Analyze") {
+                onAnalyze()
+            }
         }
 
         if !moveToGroups.isEmpty, let onMoveToGroup {


### PR DESCRIPTION
## Summary
- Add onAnalyze callback to SidebarConversationItem
- Add sparkles-icon Analyze menu item in the right-click context menu
- Wire callback through parent views to trigger conversation analysis

Part of plan: conversation-analysis.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
