### PR TITLE
fix: sort imports in conversation-analysis-routes.ts

### DIFF
--- a/assistant/src/runtime/routes/conversation-analysis-routes.ts
+++ b/assistant/src/runtime/routes/conversation-analysis-routes.ts
@@ -5,6 +5,7 @@
  * agent loop that produces a structured self-assessment.
  */
 
+import type { ServerMessage } from "../../daemon/message-protocol.js";
 import {
   addMessage,
   createConversation,
@@ -12,7 +13,6 @@ import {
   getMessages,
 } from "../../memory/conversation-crud.js";
 import { resolveConversationId } from "../../memory/conversation-key-store.js";
-import type { ServerMessage } from "../../daemon/message-protocol.js";
 import { getLogger } from "../../util/logger.js";
 import { buildAssistantEvent } from "../assistant-event.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error in `conversation-analysis-routes.ts` by moving the `../../daemon/message-protocol.js` import before `../../memory/` imports (alphabetical order)

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23969134924/job/69914936834
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23555" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
