### PR TITLE
Enable gateway file logging to ~/.vellum/logs/ by default

### DIFF
--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 
 import { getLogger, type LogFileConfig } from "./logger.js";
@@ -148,7 +149,7 @@ export function loadConfig(): GatewayConfig {
   }
 
   const logFile: LogFileConfig = {
-    dir: undefined,
+    dir: process.env.GATEWAY_LOG_DIR ?? join(homedir(), ".vellum", "logs"),
     retentionDays: 30,
   };
 

--- a/gateway/src/logger.ts
+++ b/gateway/src/logger.ts
@@ -17,7 +17,7 @@ export type LogFileConfig = {
 
 const LOG_FILE_PREFIX = "gateway-";
 const LOG_FILE_SUFFIX = ".log";
-const LOG_FILE_PATTERN = /^gateway-(\d{4}-\d{2}-\d{2})\.log$/;
+export const LOG_FILE_PATTERN = /^gateway-(\d{4}-\d{2}-\d{2})\.log$/;
 
 function formatDate(date: Date): string {
   const y = date.getUTCFullYear();


### PR DESCRIPTION
## Summary
- Set default gateway log directory to ~/.vellum/logs/ (overridable via GATEWAY_LOG_DIR)
- Export LOG_FILE_PATTERN from logger.ts for reuse by log collection route

Part of plan: gateway-log-collection-api.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
