### PR TITLE
feat: add `listDirSafe()` to FileSystemOps for directory listing

### DIFF
--- a/assistant/src/__tests__/file-list-tool.test.ts
+++ b/assistant/src/__tests__/file-list-tool.test.ts
@@ -1,0 +1,115 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  FileSystemOps,
+  type PathPolicy,
+} from "../tools/shared/filesystem/file-ops-service.js";
+import { sandboxPolicy } from "../tools/shared/filesystem/path-policy.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const testDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), "file-list-test-")));
+  testDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of testDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/** Build a sandbox-bound PathPolicy for the given directory. */
+function sandboxPolicyFor(boundary: string): PathPolicy {
+  return (rawPath, options) => sandboxPolicy(rawPath, boundary, options);
+}
+
+// ---------------------------------------------------------------------------
+// listDirSafe
+// ---------------------------------------------------------------------------
+
+describe("FileSystemOps.listDirSafe", () => {
+  test("lists directory contents with type indicators (dirs end with /)", () => {
+    const dir = makeTempDir();
+    mkdirSync(join(dir, "subdir-a"));
+    mkdirSync(join(dir, "subdir-b"));
+    writeFileSync(join(dir, "file-a.txt"), "hello");
+    writeFileSync(join(dir, "file-b.md"), "world");
+
+    const ops = new FileSystemOps(sandboxPolicyFor(dir));
+    const result = ops.listDirSafe({ path: dir });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const lines = result.value.listing.split("\n");
+    // Directories first with trailing /
+    expect(lines[0]).toBe("subdir-a/");
+    expect(lines[1]).toBe("subdir-b/");
+    // Files after directories, with size info
+    expect(lines[2]).toMatch(/^file-a\.txt\s+\d+\s*B$/);
+    expect(lines[3]).toMatch(/^file-b\.md\s+\d+\s*B$/);
+  });
+
+  test("glob filtering works (e.g. '*.md' only returns .md files)", () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "readme.md"), "# Title");
+    writeFileSync(join(dir, "notes.md"), "some notes");
+    writeFileSync(join(dir, "app.ts"), "console.log('hi')");
+    writeFileSync(join(dir, "config.json"), "{}");
+
+    const ops = new FileSystemOps(sandboxPolicyFor(dir));
+    const result = ops.listDirSafe({ path: dir, glob: "*.md" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const lines = result.value.listing.split("\n");
+    expect(lines.length).toBe(2);
+    expect(lines[0]).toMatch(/^notes\.md/);
+    expect(lines[1]).toMatch(/^readme\.md/);
+  });
+
+  test("returns NOT_A_DIRECTORY error for file paths", () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "regular-file.txt"), "content");
+
+    const ops = new FileSystemOps(sandboxPolicyFor(dir));
+    const result = ops.listDirSafe({ path: join(dir, "regular-file.txt") });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("NOT_A_DIRECTORY");
+  });
+
+  test("returns NOT_FOUND error for nonexistent paths", () => {
+    const dir = makeTempDir();
+
+    const ops = new FileSystemOps(sandboxPolicyFor(dir));
+    const result = ops.listDirSafe({ path: join(dir, "nonexistent") });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+
+  test("sandbox policy rejects paths outside boundary", () => {
+    const dir = makeTempDir();
+
+    const ops = new FileSystemOps(sandboxPolicyFor(dir));
+    const result = ops.listDirSafe({ path: "../../../etc" });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("PATH_OUT_OF_BOUNDS");
+  });
+});

--- a/assistant/src/tools/shared/filesystem/errors.ts
+++ b/assistant/src/tools/shared/filesystem/errors.ts
@@ -8,6 +8,7 @@ export type FsErrorCode =
   | "PATH_NOT_ABSOLUTE"
   | "NOT_FOUND"
   | "NOT_A_FILE"
+  | "NOT_A_DIRECTORY"
   | "SIZE_LIMIT_EXCEEDED"
   | "MATCH_NOT_FOUND"
   | "MATCH_AMBIGUOUS"
@@ -54,6 +55,10 @@ export function notFound(path: string): FsError {
 
 export function notAFile(path: string): FsError {
   return { code: "NOT_A_FILE", message: `Not a regular file: ${path}`, path };
+}
+
+export function notADirectory(path: string): FsError {
+  return { code: "NOT_A_DIRECTORY", message: `Not a directory: ${path}`, path };
 }
 
 export function sizeLimitExceeded(path: string, detail: string): FsError {

--- a/assistant/src/tools/shared/filesystem/file-ops-service.ts
+++ b/assistant/src/tools/shared/filesystem/file-ops-service.ts
@@ -1,5 +1,7 @@
-import { readFileSync, statSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { minimatch } from "minimatch";
 
 import { ensureDir, pathExists } from "../../../util/fs.js";
 import { applyEdit } from "./edit-engine.js";
@@ -9,6 +11,8 @@ import { checkContentSize, checkFileSizeOnDisk } from "./size-guard.js";
 import type {
   EditInput,
   EditResult,
+  ListInput,
+  ListResult,
   ReadInput,
   ReadResult,
   WriteInput,
@@ -237,4 +241,79 @@ export class FileSystemOps {
       },
     };
   }
+
+  // -------------------------------------------------------------------------
+  // List
+  // -------------------------------------------------------------------------
+
+  listDirSafe(input: ListInput): ListResult {
+    const pathCheck = this.policy(input.path, { mustExist: true });
+    if (!pathCheck.ok) {
+      return {
+        ok: false,
+        error: pathError(input.path, pathCheck.reason, pathCheck.error),
+      };
+    }
+    const resolved = pathCheck.resolved;
+
+    if (!pathExists(resolved)) {
+      return { ok: false, error: Err.notFound(resolved) };
+    }
+
+    const stat = statSync(resolved);
+    if (!stat.isDirectory()) {
+      return { ok: false, error: Err.notADirectory(resolved) };
+    }
+
+    try {
+      let entries = readdirSync(resolved, { withFileTypes: true });
+
+      if (input.glob) {
+        const pattern = input.glob;
+        entries = entries.filter((e) => minimatch(e.name, pattern));
+      }
+
+      // Sort: directories first (alphabetical), then files (alphabetical)
+      const dirs = entries
+        .filter((e) => e.isDirectory())
+        .sort((a, b) => a.name.localeCompare(b.name));
+      const files = entries
+        .filter((e) => !e.isDirectory())
+        .sort((a, b) => a.name.localeCompare(b.name));
+      const sorted = [...dirs, ...files];
+
+      const MAX_ENTRIES = 500;
+      const truncated = sorted.length > MAX_ENTRIES;
+      const visible = sorted.slice(0, MAX_ENTRIES);
+
+      const lines = visible.map((entry) => {
+        if (entry.isDirectory()) {
+          return `${entry.name}/`;
+        }
+        const fileStat = statSync(join(resolved, entry.name));
+        return `${entry.name}  ${formatSize(fileStat.size)}`;
+      });
+
+      if (truncated) {
+        lines.push(
+          `\n... and ${sorted.length - MAX_ENTRIES} more entries (use glob to filter)`,
+        );
+      }
+
+      return { ok: true, value: { listing: lines.join("\n") } };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: Err.ioError(resolved, msg) };
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }

--- a/assistant/src/tools/shared/filesystem/types.ts
+++ b/assistant/src/tools/shared/filesystem/types.ts
@@ -78,3 +78,20 @@ export interface EditOutput {
 export type EditResult =
   | { ok: true; value: EditOutput }
   | { ok: false; error: FsError };
+
+// ---------------------------------------------------------------------------
+// List
+// ---------------------------------------------------------------------------
+
+export interface ListInput {
+  path: string;
+  glob?: string;
+}
+
+export interface ListOutput {
+  listing: string;
+}
+
+export type ListResult =
+  | { ok: true; value: ListOutput }
+  | { ok: false; error: FsError };


### PR DESCRIPTION
## Summary
- Add `NOT_A_DIRECTORY` error code and constructor to filesystem errors
- Add `ListInput`, `ListOutput`, `ListResult` types
- Add `listDirSafe()` method to `FileSystemOps` with glob filtering, sorted output, and 500-entry cap
- Add tests for listing, glob filter, error cases, and sandbox enforcement

Part of plan: subagent-tool-scoping.md (PR 2 of 6)