### PR TITLE
fix: add private conversation guard to analyze menu item

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
@@ -72,7 +72,7 @@ struct ConversationActionsDrawer: View {
                 VMenuItem(icon: VIcon.gitBranch.rawValue, label: "Fork conversation", action: onForkConversation)
             }
 
-            if !presentation.isChannelConversation {
+            if !presentation.isChannelConversation && !presentation.isPrivateConversation {
                 VMenuItem(
                     icon: VIcon.sparkles.rawValue,
                     label: "Analyze conversation",


### PR DESCRIPTION
## Summary
- Add isPrivateConversation guard to Analyze menu item in ConversationActionsDrawer
- Matches the sidebar context menu visibility guards for consistency

Part of plan: conversation-analysis.md (fix round 1)