### PR TITLE
fix: unwrap double-nested response in conversation analysis endpoint

### DIFF
--- a/assistant/src/runtime/routes/conversation-analysis-routes.ts
+++ b/assistant/src/runtime/routes/conversation-analysis-routes.ts
@@ -154,9 +154,15 @@ If you identify insights worth remembering for future conversations, use your me
           });
 
         // l. Return the new conversation detail
-        return Response.json({
-          conversation: deps.buildConversationDetailResponse(newConv.id),
-        });
+        const detail = deps.buildConversationDetailResponse(newConv.id);
+        if (!detail) {
+          return httpError(
+            "NOT_FOUND",
+            `Analysis conversation ${newConv.id} could not be loaded`,
+            404,
+          );
+        }
+        return Response.json(detail);
       },
     },
   ];


### PR DESCRIPTION
## Summary
- `buildConversationDetailResponse()` returns `{ conversation: { ...serialized... } }`, but the analyze route was wrapping it in another `{ conversation: ... }`, producing a double-nested response
- The Swift client decodes this as `ForkConversationResponse` which expects a flat `{ conversation: { ... } }` — the double nesting caused JSON decode failures, surfacing as "Failed to create conversation analysis."
- Returns the detail object directly and adds a null guard, matching the fork endpoint pattern

## Original prompt
Fix double-nested response causing "Failed to create conversation analysis." error