### PR TITLE
fix: hide subagent conversations from sidebar listing

### DIFF
--- a/assistant/src/memory/conversation-queries.ts
+++ b/assistant/src/memory/conversation-queries.ts
@@ -50,7 +50,7 @@ export function listConversations(
   ensureGroupMigration();
   const db = getDb();
   const where = backgroundOnly
-    ? sql`${conversations.conversationType} = 'background'`
+    ? sql`${conversations.conversationType} = 'background' AND ${conversations.source} != 'subagent'`
     : sql`${conversations.conversationType} NOT IN ('background', 'private')`;
   const query = db
     .select()
@@ -82,7 +82,7 @@ export function listPinnedConversations(): ConversationRow[] {
 export function countConversations(backgroundOnly = false): number {
   const db = getDb();
   const where = backgroundOnly
-    ? sql`${conversations.conversationType} = 'background'`
+    ? sql`${conversations.conversationType} = 'background' AND ${conversations.source} != 'subagent'`
     : sql`${conversations.conversationType} NOT IN ('background', 'private')`;
   const [{ total }] = db
     .select({ total: count() })

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -151,6 +151,7 @@ export class SubagentManager {
     const subagentId = uuid();
     const conversationRecord = bootstrapConversation({
       conversationType: "background",
+      source: "subagent",
       origin: "subagent",
       systemHint: `Subagent: ${config.label}`,
     });


### PR DESCRIPTION
## Summary
- Set `source: "subagent"` in `SubagentManager.spawn()` so subagent conversations are properly tagged in the DB
- Add `AND source != 'subagent'` to `listConversations` and `countConversations` background queries so subagent conversations no longer appear in the sidebar's Background group

🤖 Generated with [Claude Code](https://claude.com/claude-code)