### PR TITLE
feat: raise default significance of autoinjected skill memories

### DIFF
--- a/assistant/src/memory/graph/capability-seed.ts
+++ b/assistant/src/memory/graph/capability-seed.ts
@@ -270,7 +270,7 @@ function upsertCapabilityNode(sourceKey: string, content: string): void {
     },
     fidelity: "vivid" as const,
     confidence: 1.0,
-    significance: 0.3,
+    significance: 0.6,
     stability: 1000, // Effectively permanent — never decays
     reinforcementCount: 0,
     lastReinforced: now,


### PR DESCRIPTION
## Summary
- Increased the default `significance` for autoinjected skill/capability memory nodes from `0.3` to `0.6`
- This ensures skills surface more reliably in memory retrieval without dominating over high-significance personal memories

## Original prompt
the default importance of autoinjected skill memories should be higher