### PR TITLE
fix: regenerate stale openapi.yaml

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -2521,6 +2521,22 @@ paths:
           required: true
           schema:
             type: string
+  /v1/conversations/{id}/analyze:
+    post:
+      operationId: conversations_by_id_analyze_post
+      summary: Analyze a conversation
+      description: Create a new conversation with a structured self-assessment of an existing conversation.
+      tags:
+        - conversations
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
   /v1/conversations/{id}/cancel:
     post:
       operationId: conversations_by_id_cancel_post


### PR DESCRIPTION
## Summary
- Regenerated `openapi.yaml` to include the new `/v1/conversations/{id}/analyze` endpoint that was added but not reflected in the spec

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23969359063/job/69915525754
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23570" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
