### PR TITLE
fix: sort imports in subagent-tool-filtering test

### DIFF
--- a/assistant/src/__tests__/subagent-tool-filtering.test.ts
+++ b/assistant/src/__tests__/subagent-tool-filtering.test.ts
@@ -2,8 +2,8 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import {
   isToolActiveForContext,
-  SUBAGENT_ONLY_TOOL_NAMES,
   type SkillProjectionContext,
+  SUBAGENT_ONLY_TOOL_NAMES,
 } from "../daemon/conversation-tool-setup.js";
 
 const TEST_TOOL_NAME = "__test_subagent_only_tool__";


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error in `assistant/src/__tests__/subagent-tool-filtering.test.ts` by sorting named exports alphabetically (types before values)

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23969359063/job/69915525732
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23571" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
