### PR TITLE
feat: add `file_list` to role allowlists, remove unused `skill_execute` and skill preactivation

### DIFF
--- a/assistant/src/__tests__/subagent-role-registry.test.ts
+++ b/assistant/src/__tests__/subagent-role-registry.test.ts
@@ -43,10 +43,10 @@ describe("SUBAGENT_ROLE_REGISTRY", () => {
     }
   });
 
-  test('every role with allowedTools includes "skill_execute"', () => {
+  test('no role includes "skill_execute" (replaced by core tools)', () => {
     for (const [_role, config] of Object.entries(SUBAGENT_ROLE_REGISTRY)) {
       if (config.allowedTools !== undefined) {
-        expect(config.allowedTools).toContain("skill_execute");
+        expect(config.allowedTools).not.toContain("skill_execute");
       }
     }
   });
@@ -73,10 +73,17 @@ describe("SUBAGENT_ROLE_REGISTRY", () => {
     }
   });
 
-  test('every role pre-activates the "subagent" skill', () => {
+  test("every role has empty skillIds (no skill preactivation)", () => {
     for (const [_role, config] of Object.entries(SUBAGENT_ROLE_REGISTRY)) {
-      expect(config.skillIds).toContain("subagent");
+      expect(config.skillIds).toEqual([]);
     }
+  });
+
+  test('researcher and planner include "file_list"', () => {
+    expect(SUBAGENT_ROLE_REGISTRY.researcher.allowedTools).toContain(
+      "file_list",
+    );
+    expect(SUBAGENT_ROLE_REGISTRY.planner.allowedTools).toContain("file_list");
   });
 });
 

--- a/assistant/src/config/bundled-skills/subagent/SKILL.md
+++ b/assistant/src/config/bundled-skills/subagent/SKILL.md
@@ -29,9 +29,9 @@ Each subagent is spawned with a role that determines its tool access. Choose the
 | Role | Tools | When to use |
 |---|---|---|
 | `general` | Full tool access | Task genuinely needs unrestricted capabilities (rare -- prefer a specialized role) |
-| `researcher` | `web_search`, `web_fetch`, `file_read`, `recall`, `remember`, `notify_parent`, `skill_execute` | Information gathering, web research, codebase exploration, reading documentation |
-| `coder` | `bash`, `file_read`, `file_write`, `file_edit`, `web_search`, `recall`, `notify_parent`, `skill_execute` | Code changes, file editing, running commands, build/test tasks |
-| `planner` | `file_read`, `web_search`, `web_fetch`, `recall`, `notify_parent`, `skill_execute` | Analysis, planning, synthesizing information, reviewing approaches |
+| `researcher` | `web_search`, `web_fetch`, `file_read`, `file_list`, `recall`, `remember`, `notify_parent` | Information gathering, web research, codebase exploration, reading documentation |
+| `coder` | `bash`, `file_read`, `file_write`, `file_edit`, `web_search`, `recall`, `notify_parent` | Code changes, file editing, running commands, build/test tasks |
+| `planner` | `file_read`, `file_list`, `web_search`, `web_fetch`, `recall`, `notify_parent` | Analysis, planning, synthesizing information, reviewing approaches |
 
 All specialized roles (`researcher`, `coder`, `planner`) include `notify_parent` for mid-run communication with the parent.
 

--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -89,7 +89,7 @@ export const SUBAGENT_ROLE_REGISTRY: Record<SubagentRole, SubagentRoleConfig> =
   {
     general: {
       allowedTools: undefined,
-      skillIds: ["subagent"],
+      skillIds: [],
       systemPromptPreamble:
         "You are a general-purpose subagent. Complete the delegated task thoroughly and concisely.",
     },
@@ -98,12 +98,12 @@ export const SUBAGENT_ROLE_REGISTRY: Record<SubagentRole, SubagentRoleConfig> =
         "web_search",
         "web_fetch",
         "file_read",
+        "file_list",
         "recall",
         "remember",
         "notify_parent",
-        "skill_execute",
       ],
-      skillIds: ["subagent"],
+      skillIds: [],
       systemPromptPreamble:
         "You are a research-focused subagent with read-only access. Search the web, read files, and recall and store memories. You cannot write files or run shell commands.",
     },
@@ -116,22 +116,21 @@ export const SUBAGENT_ROLE_REGISTRY: Record<SubagentRole, SubagentRoleConfig> =
         "web_search",
         "recall",
         "notify_parent",
-        "skill_execute",
       ],
-      skillIds: ["subagent"],
+      skillIds: [],
       systemPromptPreamble:
         "You are a code-focused subagent with file and shell access. Read, write, and edit files, and run shell commands.",
     },
     planner: {
       allowedTools: [
         "file_read",
+        "file_list",
         "web_search",
         "web_fetch",
         "recall",
         "notify_parent",
-        "skill_execute",
       ],
-      skillIds: ["subagent"],
+      skillIds: [],
       systemPromptPreamble:
         "You are an analysis-focused subagent with read-only access. Read files, search the web, and synthesize findings. You cannot write files or run shell commands.",
     },


### PR DESCRIPTION
## Summary
- Add `file_list` to researcher and planner role allowlists
- Remove `skill_execute` from all role allowlists (no longer needed)
- Clear `skillIds` on all roles (subagent skill only has parent-facing tools)
- Update SKILL.md role table and remove `notify_parent` from Available Tools section
- Update registry guard tests

Part of plan: subagent-tool-scoping.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
