### PR TITLE
fix: type errors in subagent-notify-parent test

### DIFF
--- a/assistant/src/__tests__/subagent-notify-parent.test.ts
+++ b/assistant/src/__tests__/subagent-notify-parent.test.ts
@@ -113,9 +113,13 @@ function makeContext(
 describe("notify_parent tool definition", () => {
   test("has correct core tool definition", () => {
     const def = notifyParentTool.getDefinition();
+    const schema = def.input_schema as Record<string, unknown>;
     expect(def.name).toBe("notify_parent");
-    expect(def.input_schema.required).toContain("message");
-    expect(def.input_schema.properties.urgency.enum).toEqual([
+    expect(schema.required).toContain("message");
+    expect(
+      (schema.properties as Record<string, Record<string, unknown>>).urgency
+        .enum,
+    ).toEqual([
       "info",
       "important",
       "blocked",


### PR DESCRIPTION
## Summary
- Cast `input_schema` to `Record<string, unknown>` in the notify_parent test to fix TS2339 errors (`Property 'required'/'properties' does not exist on type 'object'`)
- The `ToolDefinition.input_schema` field is typed as `object`, which is correct for the interface but requires assertions when accessing JSON schema properties in tests

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23969463928/job/69915803444