### PR TITLE
fix: update test expectations for file_list tool addition

### DIFF
--- a/assistant/src/__tests__/file-list-tool.test.ts
+++ b/assistant/src/__tests__/file-list-tool.test.ts
@@ -151,8 +151,8 @@ describe("FileListTool", () => {
     // Directory first with trailing /
     expect(lines[0]).toBe("src/");
     // Files after, with size info
-    expect(lines[1]).toMatch(/^README\.md\s+\d+\s*B$/);
-    expect(lines[2]).toMatch(/^index\.ts\s+\d+\s*B$/);
+    expect(lines[1]).toMatch(/^index\.ts\s+\d+\s*B$/);
+    expect(lines[2]).toMatch(/^README\.md\s+\d+\s*B$/);
   });
 
   test("execute() returns error for invalid path input", async () => {

--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -109,7 +109,7 @@ describe("tool registry dynamic-tools tools", () => {
 
 describe("tool manifest", () => {
   test("eager module tool names list contains expected count", () => {
-    expect(eagerModuleToolNames.length).toBe(9);
+    expect(eagerModuleToolNames.length).toBe(10);
   });
 
   test("explicit tools list includes memory and credential tools", () => {


### PR DESCRIPTION
## Summary
- Bumps the eager module tool count assertion from 9 to 10 in `registry.test.ts` to account for the new `file_list` tool added in #23568
- Fixes file ordering in `file-list-tool.test.ts` — `localeCompare` sorts `index.ts` before `README.md`, so the assertions were in the wrong order

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23969443335/job/69915749141
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
