### PR TITLE
Add referral-codes feature flag to the macOS flag registry

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -122,6 +122,14 @@
       "defaultEnabled": true
     },
     {
+      "id": "referral-codes",
+      "scope": "macos",
+      "key": "referral-codes",
+      "label": "Referral Codes",
+      "description": "Show the referral invite link and stats panel on the Billing tab in Settings",
+      "defaultEnabled": false
+    },
+    {
       "id": "managed-sign-in",
       "scope": "macos",
       "key": "managed-sign-in",


### PR DESCRIPTION
## Summary
- Add referral-codes flag entry to meta/feature-flags/feature-flag-registry.json with scope macos and defaultEnabled false
- Ships dark by default, can be enabled via VELLUM_FLAG_REFERRAL_CODES=1 env var or UserDefaults

Part of plan: referral-billing-ui.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23580" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
