### PR TITLE
Add referral code response model and BillingService API methods

### DIFF
--- a/clients/shared/App/Auth/AuthModels.swift
+++ b/clients/shared/App/Auth/AuthModels.swift
@@ -207,6 +207,7 @@ public enum PlatformAPIError: LocalizedError, Sendable {
     case serverError(statusCode: Int, detail: String?)
     case authenticationRequired
     case accessDenied(detail: String)
+    case notFound
 
     public var errorDescription: String? {
         switch self {
@@ -222,6 +223,8 @@ public enum PlatformAPIError: LocalizedError, Sendable {
             return "Authentication required"
         case .accessDenied(let detail):
             return detail
+        case .notFound:
+            return "Not found"
         }
     }
 }
@@ -322,4 +325,11 @@ public struct TopUpCheckoutRequest: Codable, Sendable {
 
 public struct TopUpCheckoutResponse: Codable, Sendable {
     public let checkout_url: String
+}
+
+public struct ReferralCodeResponse: Codable, Sendable {
+    public let referral_url: String
+    public let referred_count: Int
+    public let total_earned_usd: String
+    public let earning_cap_usd: String
 }

--- a/clients/shared/App/Auth/BillingService.swift
+++ b/clients/shared/App/Auth/BillingService.swift
@@ -161,6 +161,115 @@ public final class BillingService {
         }
     }
 
+    /// Fetch the current user's referral code.
+    /// Throws `PlatformAPIError.notFound` if the user has no referral code yet.
+    public func getReferralCode() async throws -> ReferralCodeResponse {
+        let urlString = "\(AuthService.shared.baseURL)/v1/referral-codes/me/"
+        guard let url = URL(string: urlString) else {
+            throw PlatformAPIError.invalidURL
+        }
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "GET"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        if let token = await SessionTokenManager.getTokenAsync() {
+            urlRequest.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        } else {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        guard let organizationId = UserDefaults.standard.string(forKey: "connectedOrganizationId") else {
+            throw PlatformAPIError.authenticationRequired
+        }
+        urlRequest.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: urlRequest)
+        } catch {
+            throw PlatformAPIError.networkError(error.localizedDescription)
+        }
+
+        let httpResponse = response as? HTTPURLResponse
+        let statusCode = httpResponse?.statusCode ?? 0
+
+        log.debug("Platform request GET referral-codes/me/ -> \(statusCode)")
+
+        if statusCode == 401 || statusCode == 403 {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        if statusCode == 404 {
+            throw PlatformAPIError.notFound
+        }
+
+        guard (200..<300).contains(statusCode) else {
+            let detail = String(data: data, encoding: .utf8)
+            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
+        }
+
+        do {
+            return try JSONDecoder().decode(ReferralCodeResponse.self, from: data)
+        } catch {
+            throw PlatformAPIError.decodingError(error.localizedDescription)
+        }
+    }
+
+    /// Create a referral code for the current user.
+    public func createReferralCode() async throws -> ReferralCodeResponse {
+        let urlString = "\(AuthService.shared.baseURL)/v1/referral-codes/me/"
+        guard let url = URL(string: urlString) else {
+            throw PlatformAPIError.invalidURL
+        }
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.httpBody = "{}".data(using: .utf8)
+
+        if let token = await SessionTokenManager.getTokenAsync() {
+            urlRequest.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        } else {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        guard let organizationId = UserDefaults.standard.string(forKey: "connectedOrganizationId") else {
+            throw PlatformAPIError.authenticationRequired
+        }
+        urlRequest.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: urlRequest)
+        } catch {
+            throw PlatformAPIError.networkError(error.localizedDescription)
+        }
+
+        let httpResponse = response as? HTTPURLResponse
+        let statusCode = httpResponse?.statusCode ?? 0
+
+        log.debug("Platform request POST referral-codes/me/ -> \(statusCode)")
+
+        if statusCode == 401 || statusCode == 403 {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        guard (200..<300).contains(statusCode) else {
+            let detail = String(data: data, encoding: .utf8)
+            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
+        }
+
+        do {
+            return try JSONDecoder().decode(ReferralCodeResponse.self, from: data)
+        } catch {
+            throw PlatformAPIError.decodingError(error.localizedDescription)
+        }
+    }
+
     /// Create a top-up checkout session and return the Stripe checkout URL.
     public func createTopUpCheckout(amountUsd: String) async throws -> URL {
         let urlString = "\(AuthService.shared.baseURL)/v1/organizations/billing/top-ups/checkout-session/"

--- a/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
@@ -209,6 +209,8 @@ public final class ManagedAssistantBootstrapService {
             return .serverError(statusCode: 0, detail: "Invalid URL configuration")
         case .decodingError(let message):
             return .unexpectedResponse(message)
+        case .notFound:
+            return .serverError(statusCode: 404, detail: "Not found")
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add ReferralCodeResponse model to AuthModels.swift with referral_url, referred_count, total_earned_usd, earning_cap_usd fields
- Add PlatformAPIError.notFound case for clean 404 handling
- Add getReferralCode() and createReferralCode() methods to BillingService following existing auth/error patterns
- Handle exhaustive switch in ManagedAssistantBootstrapService for new .notFound case

Part of plan: referral-billing-ui.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
