### PR TITLE
Add tool-deferral feature flag and toolDeferralThresholdSec config setting

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -105,6 +105,7 @@ describe("AssistantConfigSchema", () => {
       shellMaxTimeoutSec: 600,
       permissionTimeoutSec: 300,
       toolExecutionTimeoutSec: 120,
+      toolDeferralThresholdSec: 10,
       providerStreamTimeoutSec: 1800,
     });
     expect(result.sandbox).toEqual({
@@ -230,6 +231,45 @@ describe("AssistantConfigSchema", () => {
     if (!result.success) {
       expect(result.error.issues.length).toBeGreaterThanOrEqual(3);
     }
+  });
+
+  // ── toolDeferralThresholdSec ───────────────────────────────────────
+
+  test("toolDeferralThresholdSec defaults to 10", () => {
+    const result = AssistantConfigSchema.parse({});
+    expect(result.timeouts.toolDeferralThresholdSec).toBe(10);
+  });
+
+  test("accepts custom toolDeferralThresholdSec", () => {
+    const result = AssistantConfigSchema.parse({
+      timeouts: { toolDeferralThresholdSec: 5 },
+    });
+    expect(result.timeouts.toolDeferralThresholdSec).toBe(5);
+  });
+
+  test("rejects non-positive toolDeferralThresholdSec", () => {
+    for (const bad of [0, -1, -10]) {
+      const result = AssistantConfigSchema.safeParse({
+        timeouts: { toolDeferralThresholdSec: bad },
+      });
+      expect(result.success).toBe(false);
+    }
+  });
+
+  test("rejects non-finite toolDeferralThresholdSec", () => {
+    for (const bad of [Infinity, -Infinity, NaN]) {
+      const result = AssistantConfigSchema.safeParse({
+        timeouts: { toolDeferralThresholdSec: bad },
+      });
+      expect(result.success).toBe(false);
+    }
+  });
+
+  test("rejects non-number toolDeferralThresholdSec", () => {
+    const result = AssistantConfigSchema.safeParse({
+      timeouts: { toolDeferralThresholdSec: "fast" },
+    });
+    expect(result.success).toBe(false);
   });
 
   test("rejects invalid thinking config", () => {

--- a/assistant/src/config/schemas/timeouts.ts
+++ b/assistant/src/config/schemas/timeouts.ts
@@ -32,6 +32,14 @@ export const TimeoutConfigSchema = z
       .positive("timeouts.toolExecutionTimeoutSec must be a positive number")
       .default(120)
       .describe("Default timeout for tool execution in seconds"),
+    toolDeferralThresholdSec: z
+      .number({ error: "timeouts.toolDeferralThresholdSec must be a number" })
+      .finite("timeouts.toolDeferralThresholdSec must be finite")
+      .positive("timeouts.toolDeferralThresholdSec must be a positive number")
+      .default(10)
+      .describe(
+        "If a tool execution exceeds this threshold (seconds), the agent loop defers it to the background and continues the assistant turn with a placeholder result. Only effective when the tool-deferral feature flag is enabled.",
+      ),
     providerStreamTimeoutSec: z
       .number({ error: "timeouts.providerStreamTimeoutSec must be a number" })
       .finite("timeouts.providerStreamTimeoutSec must be finite")

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -272,6 +272,14 @@
       "label": "Teleport",
       "description": "Enable teleport UI in General settings for moving assistants between hosting environments",
       "defaultEnabled": false
+    },
+    {
+      "id": "tool-deferral",
+      "scope": "assistant",
+      "key": "tool-deferral",
+      "label": "Tool Deferral",
+      "description": "When enabled, tool executions that exceed a configurable threshold are deferred to the background. The assistant can continue its turn and manage background executions via background_tool_control.",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Register `tool-deferral` feature flag in the registry with `defaultEnabled: false`
- Add `toolDeferralThresholdSec` to the timeout config schema (default 10s)
- Update config-schema tests for the new field

Part of plan: tool-deferral-background-execution.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23583" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
