### PR TITLE
Add ToolDeferredToBackground and BackgroundToolCompleted client event types

### DIFF
--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -308,6 +308,28 @@ export interface AssistantActivityState {
   statusText?: string;
 }
 
+/** Sent when a long-running tool is deferred to background execution. */
+export interface ToolDeferredToBackground {
+  type: "tool_deferred_to_background";
+  executionId: string;
+  toolName: string;
+  toolUseId: string;
+  elapsedMs: number;
+  conversationId?: string;
+}
+
+/** Sent when a background tool finishes execution. */
+export interface BackgroundToolCompleted {
+  type: "background_tool_completed";
+  executionId: string;
+  toolName: string;
+  toolUseId: string;
+  result: string;
+  isError: boolean;
+  durationMs: number;
+  conversationId?: string;
+}
+
 export type TraceEventKind =
   | "request_received"
   | "request_queued"
@@ -369,4 +391,6 @@ export type _MessagesServerMessages =
   | SuggestionResponse
   | TraceEvent
   | ConfirmationStateChanged
-  | AssistantActivityState;
+  | AssistantActivityState
+  | ToolDeferredToBackground
+  | BackgroundToolCompleted;


### PR DESCRIPTION
## Summary
- Add `ToolDeferredToBackground` and `BackgroundToolCompleted` interfaces to message types
- Add both to the `ServerMessage` union type for WebSocket serialization

Part of plan: tool-deferral-background-execution.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
