### PR TITLE
Add BackgroundToolManager for tracking deferred tool executions

### DIFF
--- a/assistant/src/__tests__/background-tool-manager.test.ts
+++ b/assistant/src/__tests__/background-tool-manager.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, test } from "bun:test";
+
+import type { BackgroundExecution } from "../agent/background-tool-manager.js";
+import { BackgroundToolManager } from "../agent/background-tool-manager.js";
+import type { ToolExecutionResult } from "../tools/types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeResult(content: string): ToolExecutionResult {
+  return { content, isError: false };
+}
+
+/** Create a deferred promise that can be resolved/rejected externally. */
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function makeExecution(
+  overrides: Partial<Omit<BackgroundExecution, "status" | "result">> & {
+    promise: Promise<ToolExecutionResult>;
+  },
+): Omit<BackgroundExecution, "status" | "result"> {
+  return {
+    executionId: overrides.executionId ?? "exec-1",
+    toolName: overrides.toolName ?? "test_tool",
+    toolUseId: overrides.toolUseId ?? "tu-1",
+    conversationId: overrides.conversationId ?? "conv-1",
+    startedAt: overrides.startedAt ?? Date.now(),
+    promise: overrides.promise,
+    abortController: overrides.abortController,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("BackgroundToolManager", () => {
+  test("register + getStatus returns 'running' for an unresolved promise", () => {
+    const mgr = new BackgroundToolManager();
+    const { promise } = deferred<ToolExecutionResult>();
+    mgr.register(makeExecution({ promise }));
+
+    const status = mgr.getStatus("exec-1");
+    expect(status).not.toBeNull();
+    expect(status!.status).toBe("running");
+    expect(status!.elapsedMs).toBeGreaterThanOrEqual(0);
+    expect(status!.result).toBeUndefined();
+  });
+
+  test("resolving the promise transitions status to 'completed' with the result", async () => {
+    const mgr = new BackgroundToolManager();
+    const { promise, resolve } = deferred<ToolExecutionResult>();
+    mgr.register(makeExecution({ promise }));
+
+    const result = makeResult("done");
+    resolve(result);
+
+    // Allow microtask queue to flush so the .then handler runs
+    await promise;
+
+    const status = mgr.getStatus("exec-1");
+    expect(status).not.toBeNull();
+    expect(status!.status).toBe("completed");
+    expect(status!.result).toEqual(result);
+  });
+
+  test("waitFor with a promise that resolves within timeout returns completed: true", async () => {
+    const mgr = new BackgroundToolManager();
+    const { promise, resolve } = deferred<ToolExecutionResult>();
+    mgr.register(makeExecution({ promise }));
+
+    const result = makeResult("quick result");
+
+    // Resolve after a short delay (well within the timeout)
+    setTimeout(() => resolve(result), 10);
+
+    const outcome = await mgr.waitFor("exec-1", 5000);
+    expect(outcome.completed).toBe(true);
+    expect(outcome.result).toEqual(result);
+  });
+
+  test("waitFor with a promise that does not resolve within timeout returns completed: false", async () => {
+    const mgr = new BackgroundToolManager();
+    const { promise } = deferred<ToolExecutionResult>();
+    mgr.register(makeExecution({ promise }));
+
+    const outcome = await mgr.waitFor("exec-1", 50);
+    expect(outcome.completed).toBe(false);
+  });
+
+  test("waitFor with unknown executionId returns completed: false", async () => {
+    const mgr = new BackgroundToolManager();
+    const outcome = await mgr.waitFor("nonexistent", 100);
+    expect(outcome.completed).toBe(false);
+  });
+
+  test("cancel sets status to 'cancelled' and fires the abort controller", () => {
+    const mgr = new BackgroundToolManager();
+    const { promise } = deferred<ToolExecutionResult>();
+    const abortController = new AbortController();
+
+    mgr.register(makeExecution({ promise, abortController }));
+
+    expect(abortController.signal.aborted).toBe(false);
+
+    const cancelResult = mgr.cancel("exec-1");
+    expect(cancelResult.cancelled).toBe(true);
+    expect(cancelResult.message).toContain("cancelled");
+    expect(abortController.signal.aborted).toBe(true);
+
+    const status = mgr.getStatus("exec-1");
+    expect(status!.status).toBe("cancelled");
+  });
+
+  test("cancel returns false for already-completed executions", async () => {
+    const mgr = new BackgroundToolManager();
+    const { promise, resolve } = deferred<ToolExecutionResult>();
+    mgr.register(makeExecution({ promise }));
+
+    resolve(makeResult("done"));
+    await promise;
+
+    const cancelResult = mgr.cancel("exec-1");
+    expect(cancelResult.cancelled).toBe(false);
+    expect(cancelResult.message).toContain("already completed");
+  });
+
+  test("cancel returns false for unknown executionId", () => {
+    const mgr = new BackgroundToolManager();
+    const cancelResult = mgr.cancel("nonexistent");
+    expect(cancelResult.cancelled).toBe(false);
+    expect(cancelResult.message).toContain("No execution found");
+  });
+
+  test("drainCompleted returns completed entries and removes them, leaving running ones", async () => {
+    const mgr = new BackgroundToolManager();
+
+    // Execution 1: will complete
+    const d1 = deferred<ToolExecutionResult>();
+    mgr.register(
+      makeExecution({
+        executionId: "exec-1",
+        conversationId: "conv-1",
+        promise: d1.promise,
+      }),
+    );
+
+    // Execution 2: will stay running
+    const d2 = deferred<ToolExecutionResult>();
+    mgr.register(
+      makeExecution({
+        executionId: "exec-2",
+        conversationId: "conv-1",
+        promise: d2.promise,
+      }),
+    );
+
+    // Execution 3: completed but different conversation
+    const d3 = deferred<ToolExecutionResult>();
+    mgr.register(
+      makeExecution({
+        executionId: "exec-3",
+        conversationId: "conv-2",
+        promise: d3.promise,
+      }),
+    );
+
+    const result1 = makeResult("result-1");
+    d1.resolve(result1);
+    await d1.promise;
+
+    const result3 = makeResult("result-3");
+    d3.resolve(result3);
+    await d3.promise;
+
+    // Drain conv-1 — should get exec-1, not exec-2 (running) or exec-3 (different conv)
+    const drained = mgr.drainCompleted("conv-1");
+    expect(drained).toHaveLength(1);
+    expect(drained[0].executionId).toBe("exec-1");
+    expect(drained[0].result).toEqual(result1);
+
+    // Second drain is idempotent — returns empty
+    const drainedAgain = mgr.drainCompleted("conv-1");
+    expect(drainedAgain).toHaveLength(0);
+
+    // exec-2 should still be tracked
+    expect(mgr.getActiveCount("conv-1")).toBe(1);
+
+    // exec-3 should still be in conv-2
+    const drainedConv2 = mgr.drainCompleted("conv-2");
+    expect(drainedConv2).toHaveLength(1);
+    expect(drainedConv2[0].executionId).toBe("exec-3");
+  });
+
+  test("getActiveCount returns count of running executions for a conversation", () => {
+    const mgr = new BackgroundToolManager();
+
+    const d1 = deferred<ToolExecutionResult>();
+    mgr.register(
+      makeExecution({
+        executionId: "exec-1",
+        conversationId: "conv-1",
+        promise: d1.promise,
+      }),
+    );
+
+    const d2 = deferred<ToolExecutionResult>();
+    mgr.register(
+      makeExecution({
+        executionId: "exec-2",
+        conversationId: "conv-1",
+        promise: d2.promise,
+      }),
+    );
+
+    const d3 = deferred<ToolExecutionResult>();
+    mgr.register(
+      makeExecution({
+        executionId: "exec-3",
+        conversationId: "conv-2",
+        promise: d3.promise,
+      }),
+    );
+
+    expect(mgr.getActiveCount("conv-1")).toBe(2);
+    expect(mgr.getActiveCount("conv-2")).toBe(1);
+    expect(mgr.getActiveCount("conv-unknown")).toBe(0);
+  });
+
+  test("cleanup removes all entries for a conversation", () => {
+    const mgr = new BackgroundToolManager();
+
+    const d1 = deferred<ToolExecutionResult>();
+    mgr.register(
+      makeExecution({
+        executionId: "exec-1",
+        conversationId: "conv-1",
+        promise: d1.promise,
+      }),
+    );
+
+    const d2 = deferred<ToolExecutionResult>();
+    mgr.register(
+      makeExecution({
+        executionId: "exec-2",
+        conversationId: "conv-1",
+        promise: d2.promise,
+      }),
+    );
+
+    const d3 = deferred<ToolExecutionResult>();
+    mgr.register(
+      makeExecution({
+        executionId: "exec-3",
+        conversationId: "conv-2",
+        promise: d3.promise,
+      }),
+    );
+
+    mgr.cleanup("conv-1");
+
+    // conv-1 entries should be gone
+    expect(mgr.getStatus("exec-1")).toBeNull();
+    expect(mgr.getStatus("exec-2")).toBeNull();
+    expect(mgr.getActiveCount("conv-1")).toBe(0);
+
+    // conv-2 should be unaffected
+    expect(mgr.getStatus("exec-3")).not.toBeNull();
+    expect(mgr.getActiveCount("conv-2")).toBe(1);
+  });
+
+  test("rejected promise transitions to completed with error result", async () => {
+    const mgr = new BackgroundToolManager();
+    const { promise, reject } = deferred<ToolExecutionResult>();
+    mgr.register(makeExecution({ promise }));
+
+    reject(new Error("tool exploded"));
+
+    // Allow microtask queue to flush
+    try {
+      await promise;
+    } catch {
+      // expected
+    }
+
+    const status = mgr.getStatus("exec-1");
+    expect(status).not.toBeNull();
+    expect(status!.status).toBe("completed");
+    expect(status!.result).toBeDefined();
+    expect(status!.result!.isError).toBe(true);
+    expect(status!.result!.content).toContain("tool exploded");
+  });
+});

--- a/assistant/src/agent/background-tool-manager.ts
+++ b/assistant/src/agent/background-tool-manager.ts
@@ -1,0 +1,167 @@
+import type { ToolExecutionResult } from "../tools/types.js";
+
+export interface BackgroundExecution {
+  executionId: string;
+  toolName: string;
+  toolUseId: string;
+  conversationId: string;
+  startedAt: number;
+  promise: Promise<ToolExecutionResult>;
+  result?: ToolExecutionResult;
+  status: "running" | "completed" | "cancelled";
+  abortController?: AbortController;
+}
+
+export class BackgroundToolManager {
+  private executions = new Map<string, BackgroundExecution>();
+
+  register(exec: Omit<BackgroundExecution, "status" | "result">): void {
+    const entry: BackgroundExecution = {
+      ...exec,
+      status: "running",
+    };
+    this.executions.set(exec.executionId, entry);
+
+    // Attach completion handler — when the promise resolves, update status
+    // and store the result. Guard against the entry being cancelled or
+    // removed before the promise settles.
+    exec.promise.then(
+      (result) => {
+        const current = this.executions.get(exec.executionId);
+        if (current && current.status === "running") {
+          current.status = "completed";
+          current.result = result;
+        }
+      },
+      (_err) => {
+        // If the promise rejects (e.g. tool threw), treat as completed with
+        // an error result so drainCompleted can pick it up.
+        const current = this.executions.get(exec.executionId);
+        if (current && current.status === "running") {
+          current.status = "completed";
+          current.result = {
+            content: _err instanceof Error ? _err.message : String(_err),
+            isError: true,
+          };
+        }
+      },
+    );
+  }
+
+  getStatus(executionId: string): {
+    status: "running" | "completed" | "cancelled";
+    elapsedMs: number;
+    result?: ToolExecutionResult;
+  } | null {
+    const entry = this.executions.get(executionId);
+    if (!entry) return null;
+    return {
+      status: entry.status,
+      elapsedMs: Date.now() - entry.startedAt,
+      result: entry.result,
+    };
+  }
+
+  async waitFor(
+    executionId: string,
+    timeoutMs: number,
+  ): Promise<{ completed: boolean; result?: ToolExecutionResult }> {
+    const entry = this.executions.get(executionId);
+    if (!entry) return { completed: false };
+
+    // Already done — return immediately
+    if (entry.status === "completed") {
+      return { completed: true, result: entry.result };
+    }
+    if (entry.status === "cancelled") {
+      return { completed: false };
+    }
+
+    // Race the execution promise against a timeout
+    return new Promise<{ completed: boolean; result?: ToolExecutionResult }>(
+      (resolve) => {
+        const timer = setTimeout(() => {
+          resolve({ completed: false });
+        }, timeoutMs);
+
+        entry.promise
+          .then((result) => {
+            clearTimeout(timer);
+            resolve({ completed: true, result });
+          })
+          .catch(() => {
+            clearTimeout(timer);
+            // Re-read the entry — the .then handler in register() may have
+            // already populated the error result.
+            const current = this.executions.get(executionId);
+            resolve({
+              completed: true,
+              result: current?.result,
+            });
+          });
+      },
+    );
+  }
+
+  cancel(executionId: string): { cancelled: boolean; message: string } {
+    const entry = this.executions.get(executionId);
+    if (!entry) {
+      return {
+        cancelled: false,
+        message: `No execution found with ID ${executionId}`,
+      };
+    }
+    if (entry.status !== "running") {
+      return {
+        cancelled: false,
+        message: `Execution ${executionId} is already ${entry.status}`,
+      };
+    }
+
+    entry.status = "cancelled";
+    if (entry.abortController) {
+      entry.abortController.abort();
+    }
+    return {
+      cancelled: true,
+      message: `Execution ${executionId} (${entry.toolName}) cancelled`,
+    };
+  }
+
+  drainCompleted(conversationId: string): BackgroundExecution[] {
+    const completed: BackgroundExecution[] = [];
+    for (const [id, entry] of this.executions) {
+      if (
+        entry.conversationId === conversationId &&
+        entry.status === "completed"
+      ) {
+        completed.push(entry);
+        this.executions.delete(id);
+      }
+    }
+    return completed;
+  }
+
+  getActiveCount(conversationId: string): number {
+    let count = 0;
+    for (const entry of this.executions.values()) {
+      if (
+        entry.conversationId === conversationId &&
+        entry.status === "running"
+      ) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  cleanup(conversationId: string): void {
+    for (const [id, entry] of this.executions) {
+      if (entry.conversationId === conversationId) {
+        this.executions.delete(id);
+      }
+    }
+  }
+}
+
+export const backgroundToolManager = new BackgroundToolManager();


### PR DESCRIPTION
## Summary
- Create `BackgroundToolManager` class with register, getStatus, waitFor, cancel, drainCompleted, getActiveCount, and cleanup methods
- Export singleton instance for use by agent loop and background_tool_control tool
- Add comprehensive tests for all manager methods

Part of plan: tool-deferral-background-execution.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
