### PR TITLE
Auto-approve bash tools in platform-hosted mode

### DIFF
--- a/assistant/src/__tests__/platform-bash-auto-approve.test.ts
+++ b/assistant/src/__tests__/platform-bash-auto-approve.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Tests for platform-hosted bash auto-approval.
+ *
+ * Verifies that bash and host_bash tools are auto-approved without prompting
+ * when running in platform-hosted mode (IS_PLATFORM=true) for guardian actors.
+ * Also verifies that deny rules, non-guardian actors, requireFreshApproval,
+ * and non-bash tools are unaffected by this auto-approval path.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import type { ScopeOption } from "../permissions/types.js";
+import type { ToolExecutionResult } from "../tools/types.js";
+
+// ---------------------------------------------------------------------------
+// Mock setup — mirrors require-fresh-approval.test.ts patterns
+// ---------------------------------------------------------------------------
+
+const mockConfig = {
+  provider: "anthropic",
+  model: "test",
+  maxTokens: 4096,
+  dataDir: "/tmp",
+  timeouts: {
+    shellDefaultTimeoutSec: 120,
+    shellMaxTimeoutSec: 600,
+    permissionTimeoutSec: 300,
+  },
+  sandbox: {
+    enabled: false,
+    backend: "native" as const,
+    docker: {
+      image: "vellum-sandbox:latest",
+      cpus: 1,
+      memoryMb: 512,
+      pidsLimit: 256,
+      network: "none" as const,
+    },
+  },
+  rateLimit: { maxRequestsPerMinute: 0 },
+  secretDetection: {
+    enabled: false,
+    action: "warn" as const,
+    entropyThreshold: 4.0,
+  },
+  permissions: {
+    mode: "workspace" as const,
+  },
+};
+
+let fakeToolResult: ToolExecutionResult = { content: "ok", isError: false };
+
+/** Override the check() result for specific tests. */
+let checkResultOverride: { decision: string; reason: string } | undefined;
+
+/** Override the risk level returned by classifyRisk(). Defaults to "medium". */
+let riskOverride: string = "medium";
+
+/** Scope options override. */
+let scopeOptionsOverride: ScopeOption[] | undefined;
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => mockConfig,
+  loadConfig: () => mockConfig,
+  invalidateConfigCache: () => {},
+  saveConfig: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+  truncateForLog: (value: string) => value,
+}));
+
+mock.module("../permissions/checker.js", () => ({
+  classifyRisk: async () => riskOverride,
+  check: async () => {
+    if (checkResultOverride) return checkResultOverride;
+    return { decision: "allow", reason: "allowed" };
+  },
+  generateAllowlistOptions: () => [
+    { label: "exact", description: "exact", pattern: "exact" },
+  ],
+  generateScopeOptions: () =>
+    scopeOptionsOverride ?? [{ label: "/tmp", scope: "/tmp" }],
+}));
+
+mock.module("../memory/tool-usage-store.js", () => ({
+  recordToolInvocation: () => {},
+}));
+
+mock.module("../tools/registry.js", () => ({
+  getTool: (name: string) => {
+    if (name === "unknown_tool") return undefined;
+    return {
+      name,
+      description: "test tool",
+      category: "shell",
+      defaultRiskLevel: "medium",
+      getDefinition: () => ({}),
+      execute: async () => fakeToolResult,
+    };
+  },
+  getAllTools: () => [],
+}));
+
+mock.module("../tools/shared/filesystem/path-policy.js", () => ({
+  sandboxPolicy: () => ({ ok: false }),
+  hostPolicy: () => ({ ok: false }),
+}));
+
+mock.module("../tools/terminal/sandbox.js", () => ({
+  wrapCommand: () => ({ command: "", sandboxed: false }),
+}));
+
+mock.module("../approvals/approval-primitive.js", () => ({
+  consumeGrantForInvocation: async () => ({ ok: false, reason: "no_grant" }),
+}));
+
+import { PermissionPrompter } from "../permissions/prompter.js";
+import { clearAll as clearAllOverrides } from "../runtime/conversation-approval-overrides.js";
+import { ToolExecutor } from "../tools/executor.js";
+import type { ToolContext as TC } from "../tools/types.js";
+
+function makeContext(overrides?: Partial<TC>): TC {
+  return {
+    workingDir: "/tmp/project",
+    conversationId: "conversation-1",
+    trustClass: "guardian",
+    isInteractive: true,
+    ...overrides,
+  };
+}
+
+function makePrompter(): PermissionPrompter {
+  return {
+    prompt: async () => ({ decision: "allow" as const }),
+    resolveConfirmation: () => {},
+    updateSender: () => {},
+    dispose: () => {},
+  } as unknown as PermissionPrompter;
+}
+
+afterAll(() => {
+  mock.restore();
+});
+
+// ---------------------------------------------------------------------------
+// Platform-hosted bash auto-approval
+// ---------------------------------------------------------------------------
+
+describe("platform-hosted bash auto-approval", () => {
+  beforeEach(() => {
+    fakeToolResult = { content: "ok", isError: false };
+    checkResultOverride = undefined;
+    scopeOptionsOverride = undefined;
+    riskOverride = "medium";
+    clearAllOverrides();
+  });
+
+  afterEach(() => {
+    clearAllOverrides();
+  });
+
+  test("bash auto-approved in platform-hosted mode", async () => {
+    checkResultOverride = { decision: "prompt", reason: "Needs approval" };
+
+    let promptCalled = false;
+    const trackingPrompter = {
+      prompt: async () => {
+        promptCalled = true;
+        return { decision: "allow" as const };
+      },
+      resolveConfirmation: () => {},
+      updateSender: () => {},
+      dispose: () => {},
+    } as unknown as PermissionPrompter;
+
+    const executor = new ToolExecutor(trackingPrompter);
+    const result = await executor.execute(
+      "bash",
+      { command: "echo hello" },
+      makeContext({ isPlatformHosted: true, trustClass: "guardian" }),
+    );
+
+    expect(promptCalled).toBe(false);
+    expect(result.isError).toBe(false);
+  });
+
+  test("host_bash auto-approved in platform-hosted mode", async () => {
+    checkResultOverride = { decision: "prompt", reason: "Needs approval" };
+
+    let promptCalled = false;
+    const trackingPrompter = {
+      prompt: async () => {
+        promptCalled = true;
+        return { decision: "allow" as const };
+      },
+      resolveConfirmation: () => {},
+      updateSender: () => {},
+      dispose: () => {},
+    } as unknown as PermissionPrompter;
+
+    const executor = new ToolExecutor(trackingPrompter);
+    const result = await executor.execute(
+      "host_bash",
+      { command: "echo hello" },
+      makeContext({ isPlatformHosted: true, trustClass: "guardian" }),
+    );
+
+    expect(promptCalled).toBe(false);
+    expect(result.isError).toBe(false);
+  });
+
+  test("bash NOT auto-approved when not platform-hosted", async () => {
+    checkResultOverride = { decision: "prompt", reason: "Needs approval" };
+
+    let promptCalled = false;
+    const trackingPrompter = {
+      prompt: async () => {
+        promptCalled = true;
+        return { decision: "allow" as const };
+      },
+      resolveConfirmation: () => {},
+      updateSender: () => {},
+      dispose: () => {},
+    } as unknown as PermissionPrompter;
+
+    const executor = new ToolExecutor(trackingPrompter);
+    await executor.execute(
+      "bash",
+      { command: "echo hello" },
+      makeContext({ isPlatformHosted: false, trustClass: "guardian" }),
+    );
+
+    expect(promptCalled).toBe(true);
+  });
+
+  test("bash NOT auto-approved for non-guardian actors", async () => {
+    checkResultOverride = { decision: "prompt", reason: "Needs approval" };
+
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      "bash",
+      { command: "echo hello" },
+      makeContext({ isPlatformHosted: true, trustClass: "trusted_contact" }),
+    );
+
+    // Non-guardian actors are blocked by the pre-execution guardian approval
+    // gate before reaching the permission checker. The tool must NOT succeed
+    // via platform auto-approve.
+    expect(result.isError).toBe(true);
+  });
+
+  test("bash NOT auto-approved when requireFreshApproval is set", async () => {
+    checkResultOverride = { decision: "prompt", reason: "Needs approval" };
+
+    let promptCalled = false;
+    const trackingPrompter = {
+      prompt: async () => {
+        promptCalled = true;
+        return { decision: "allow" as const };
+      },
+      resolveConfirmation: () => {},
+      updateSender: () => {},
+      dispose: () => {},
+    } as unknown as PermissionPrompter;
+
+    const executor = new ToolExecutor(trackingPrompter);
+    await executor.execute(
+      "bash",
+      { command: "echo hello" },
+      makeContext({
+        isPlatformHosted: true,
+        trustClass: "guardian",
+        requireFreshApproval: true,
+      }),
+    );
+
+    expect(promptCalled).toBe(true);
+  });
+
+  test("deny rules still respected in platform-hosted mode", async () => {
+    checkResultOverride = { decision: "deny", reason: "Explicitly denied" };
+
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      "bash",
+      { command: "rm -rf /" },
+      makeContext({ isPlatformHosted: true, trustClass: "guardian" }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Explicitly denied");
+  });
+
+  test("high-risk bash auto-approved in platform-hosted mode", async () => {
+    riskOverride = "high";
+    checkResultOverride = { decision: "prompt", reason: "High risk command" };
+
+    let promptCalled = false;
+    const trackingPrompter = {
+      prompt: async () => {
+        promptCalled = true;
+        return { decision: "allow" as const };
+      },
+      resolveConfirmation: () => {},
+      updateSender: () => {},
+      dispose: () => {},
+    } as unknown as PermissionPrompter;
+
+    const executor = new ToolExecutor(trackingPrompter);
+    const result = await executor.execute(
+      "bash",
+      { command: "rm -rf /tmp/stuff" },
+      makeContext({ isPlatformHosted: true, trustClass: "guardian" }),
+    );
+
+    expect(promptCalled).toBe(false);
+    expect(result.isError).toBe(false);
+  });
+
+  test("non-bash tools NOT auto-approved in platform-hosted mode", async () => {
+    checkResultOverride = { decision: "prompt", reason: "Needs approval" };
+
+    let promptCalled = false;
+    const trackingPrompter = {
+      prompt: async () => {
+        promptCalled = true;
+        return { decision: "allow" as const };
+      },
+      resolveConfirmation: () => {},
+      updateSender: () => {},
+      dispose: () => {},
+    } as unknown as PermissionPrompter;
+
+    const executor = new ToolExecutor(trackingPrompter);
+    await executor.execute(
+      "file_write",
+      { path: "/tmp/test.txt", content: "hello" },
+      makeContext({ isPlatformHosted: true, trustClass: "guardian" }),
+    );
+
+    expect(promptCalled).toBe(true);
+  });
+});

--- a/assistant/src/__tests__/platform-bash-auto-approve.test.ts
+++ b/assistant/src/__tests__/platform-bash-auto-approve.test.ts
@@ -201,7 +201,7 @@ describe("platform-hosted bash auto-approval", () => {
     expect(result.isError).toBe(false);
   });
 
-  test("host_bash auto-approved in platform-hosted mode", async () => {
+  test("host_bash NOT auto-approved in platform-hosted mode", async () => {
     checkResultOverride = { decision: "prompt", reason: "Needs approval" };
 
     let promptCalled = false;
@@ -216,14 +216,13 @@ describe("platform-hosted bash auto-approval", () => {
     } as unknown as PermissionPrompter;
 
     const executor = new ToolExecutor(trackingPrompter);
-    const result = await executor.execute(
+    await executor.execute(
       "host_bash",
       { command: "echo hello" },
       makeContext({ isPlatformHosted: true, trustClass: "guardian" }),
     );
 
-    expect(promptCalled).toBe(false);
-    expect(result.isError).toBe(false);
+    expect(promptCalled).toBe(true);
   });
 
   test("bash NOT auto-approved when not platform-hosted", async () => {

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -7,6 +7,7 @@
  */
 
 import { isHttpAuthDisabled } from "../config/env.js";
+import { getIsPlatform } from "../config/env-registry.js";
 import type { CesClient } from "../credential-execution/client.js";
 import { getBindingByConversation } from "../memory/external-conversation-store.js";
 import {
@@ -192,6 +193,7 @@ export function createToolExecutor(
       toolUseId,
       hostBashProxy: ctx.hostBashProxy,
       hostFileProxy: ctx.hostFileProxy,
+      isPlatformHosted: getIsPlatform(),
       cesClient: ctx.cesClient,
       onToolLifecycleEvent: handleToolLifecycleEvent,
       sendToClient: (msg) => {

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -137,17 +137,16 @@ export class PermissionChecker {
         };
       }
 
-      // Platform-hosted mode: auto-approve bash and host_bash for guardians.
-      // The sandbox provides the security boundary for bash commands, and
-      // host_bash is proxied to the connected desktop client where the user
-      // has physical access. Prompting is unnecessary friction in this context.
+      // Platform-hosted mode: auto-approve sandboxed bash for guardians.
+      // The sandbox provides the security boundary — prompting is unnecessary
+      // friction. host_bash is excluded because it runs unsandboxed on the
+      // user's machine and warrants explicit approval.
       // Deny rules are still respected (checked above). requireFreshApproval
-      // is preserved as a belt-and-suspenders guard even though it is not
-      // currently set on bash tools.
+      // is preserved as a belt-and-suspenders guard.
       if (
         result.decision === "prompt" &&
         context.isPlatformHosted &&
-        (name === "bash" || name === "host_bash") &&
+        name === "bash" &&
         context.trustClass === "guardian" &&
         !context.requireFreshApproval
       ) {

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -137,6 +137,27 @@ export class PermissionChecker {
         };
       }
 
+      // Platform-hosted mode: auto-approve bash and host_bash for guardians.
+      // The sandbox provides the security boundary for bash commands, and
+      // host_bash is proxied to the connected desktop client where the user
+      // has physical access. Prompting is unnecessary friction in this context.
+      // Deny rules are still respected (checked above). requireFreshApproval
+      // is preserved as a belt-and-suspenders guard even though it is not
+      // currently set on bash tools.
+      if (
+        result.decision === "prompt" &&
+        context.isPlatformHosted &&
+        (name === "bash" || name === "host_bash") &&
+        context.trustClass === "guardian" &&
+        !context.requireFreshApproval
+      ) {
+        log.info(
+          { toolName: name, riskLevel },
+          "Auto-approving bash tool for platform-hosted guardian session",
+        );
+        return { allowed: true, decision: "platform_auto_approve", riskLevel };
+      }
+
       if (result.decision === "prompt") {
         // Guardian-trust sessions (e.g. scheduled jobs, reminders) should be
         // able to use bundled tools without interactive approval. The guardian

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -181,6 +181,8 @@ export interface ToolContext {
   hostBashProxy?: import("../daemon/host-bash-proxy.js").HostBashProxy;
   /** Optional proxy for delegating host_file_read/write/edit execution to a connected client (managed/cloud-hosted mode). */
   hostFileProxy?: import("../daemon/host-file-proxy.js").HostFileProxy;
+  /** True when the assistant is running as a platform-managed remote instance. Used to auto-approve sandboxed bash tools. */
+  isPlatformHosted?: boolean;
   /** CES RPC client for credential execution operations. When present, the executor can bridge CES approval flows. */
   cesClient?: CesClient;
 }


### PR DESCRIPTION
## Summary
- When running in platform-hosted mode (`IS_PLATFORM=true`), auto-approve `bash` and `host_bash` tools for guardian actors without showing permission prompts
- The sandbox provides the security boundary for `bash` commands, and `host_bash` is proxied to the connected desktop client — prompting is unnecessary friction
- Deny trust rules, non-guardian actors, and `requireFreshApproval` are still respected

## PRs merged into feature branch
- #23586: Auto-approve bash and host_bash tools in platform-hosted mode

Part of plan: platform-bash-auto-approve.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23587" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
