### PR TITLE
Add referral invite URL and stats UI to macOS Billing tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingReferralCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingReferralCard.swift
@@ -1,0 +1,197 @@
+import AppKit
+import SwiftUI
+import VellumAssistantShared
+
+/// Referral panel — shows referral URL, copy button, stats, and earning cap.
+@MainActor
+struct SettingsBillingReferralCard: View {
+    @State private var referralCode: ReferralCodeResponse?
+    @State private var isLoading: Bool = true
+    @State private var isCreating: Bool = false
+    @State private var error: String?
+    @State private var hasNoCode: Bool = false
+    @State private var copied: Bool = false
+
+    var body: some View {
+        Group {
+            if isLoading {
+                loadingState
+            } else if let error {
+                errorState(error)
+            } else if hasNoCode {
+                noCodeState
+            } else if let referralCode {
+                hasCodeState(referralCode)
+            }
+        }
+        .task {
+            await loadReferralCode()
+        }
+    }
+
+    // MARK: - Loading State
+
+    private var loadingState: some View {
+        SettingsCard(title: "Referrals") {
+            VStack(alignment: .leading, spacing: VSpacing.lg) {
+                VSkeletonBone(height: 28)
+                HStack(spacing: VSpacing.xl) {
+                    VSkeletonBone(width: 80, height: 14)
+                    VSkeletonBone(width: 80, height: 14)
+                }
+            }
+            .accessibilityHidden(true)
+        }
+    }
+
+    // MARK: - No Code State
+
+    private var noCodeState: some View {
+        SettingsCard(title: "Referrals", subtitle: "Share your link and earn credits") {
+            VStack(alignment: .leading, spacing: VSpacing.lg) {
+                Text("Get your personal referral link to share with friends. You'll both earn credits when they sign up.")
+                    .font(VFont.bodyMediumLighter)
+                    .foregroundStyle(VColor.contentSecondary)
+
+                VButton(
+                    label: isCreating ? "Creating..." : "Get Referral Link",
+                    style: .primary,
+                    isDisabled: isCreating
+                ) {
+                    Task { await createCode() }
+                }
+            }
+        }
+    }
+
+    // MARK: - Has Code State
+
+    private func hasCodeState(_ code: ReferralCodeResponse) -> some View {
+        SettingsCard(title: "Referrals", subtitle: "Share your link and earn credits") {
+            VStack(alignment: .leading, spacing: VSpacing.lg) {
+                // Referral URL row
+                HStack(spacing: VSpacing.sm) {
+                    Text(code.referral_url)
+                        .font(.custom("DMMono-Regular", size: 13))
+                        .foregroundStyle(VColor.contentDefault)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(VSpacing.sm)
+                        .background(VColor.surfaceBase)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: VRadius.md)
+                                .stroke(VColor.borderBase, lineWidth: 1)
+                        )
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+
+                    VButton(
+                        label: "",
+                        iconOnly: copied ? VIcon.check.rawValue : VIcon.copy.rawValue,
+                        style: .ghost
+                    ) {
+                        copyToClipboard(code.referral_url)
+                    }
+                }
+
+                SettingsDivider()
+
+                // Stats row
+                HStack(spacing: VSpacing.xl) {
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        HStack(spacing: VSpacing.xs) {
+                            VIconView(.users, size: 14)
+                                .foregroundStyle(VColor.contentSecondary)
+                            Text("Friends Referred")
+                                .font(VFont.bodySmallDefault)
+                                .foregroundStyle(VColor.contentSecondary)
+                        }
+                        Text("\(code.referred_count)")
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentEmphasized)
+                    }
+
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        HStack(spacing: VSpacing.xs) {
+                            VIconView(.creditCard, size: 14)
+                                .foregroundStyle(VColor.contentSecondary)
+                            Text("Credits Earned")
+                                .font(VFont.bodySmallDefault)
+                                .foregroundStyle(VColor.contentSecondary)
+                        }
+                        Text("$\(code.total_earned_usd)")
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentEmphasized)
+                    }
+                }
+
+                // Earning cap note
+                Text("Earn up to $\(code.earning_cap_usd) in referral credits")
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+        }
+    }
+
+    // MARK: - Error State
+
+    private func errorState(_ message: String) -> some View {
+        SettingsCard(title: "Referrals") {
+            VStack(alignment: .leading, spacing: VSpacing.md) {
+                HStack(spacing: VSpacing.sm) {
+                    VIconView(.circleAlert, size: 14)
+                        .foregroundStyle(VColor.systemNegativeStrong)
+                    Text(message)
+                        .font(VFont.bodyMediumLighter)
+                        .foregroundStyle(VColor.systemNegativeStrong)
+                }
+                VButton(label: "Try Again", style: .outlined) {
+                    Task { await loadReferralCode() }
+                }
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    private func loadReferralCode() async {
+        if referralCode == nil {
+            isLoading = true
+        }
+        error = nil
+        do {
+            let result = try await BillingService.shared.getReferralCode()
+            referralCode = result
+            hasNoCode = false
+        } catch PlatformAPIError.notFound {
+            hasNoCode = true
+        } catch {
+            if referralCode == nil {
+                self.error = "Failed to load referral information."
+            }
+        }
+        isLoading = false
+    }
+
+    private func createCode() async {
+        isCreating = true
+        defer { isCreating = false }
+        do {
+            let result = try await BillingService.shared.createReferralCode()
+            referralCode = result
+            hasNoCode = false
+        } catch {
+            self.error = "Failed to create referral code. Please try again."
+        }
+    }
+
+    private func copyToClipboard(_ url: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(url, forType: .string)
+        copied = true
+        Task {
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            copied = false
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingReferralCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingReferralCard.swift
@@ -11,6 +11,7 @@ struct SettingsBillingReferralCard: View {
     @State private var isLoading: Bool = true
     @State private var error: String?
     @State private var copied: Bool = false
+    @State private var copyResetTask: Task<Void, Never>?
 
     var body: some View {
         Group {
@@ -64,7 +65,7 @@ struct SettingsBillingReferralCard: View {
                         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
 
                     VButton(
-                        label: "",
+                        label: copied ? "Copied" : "Copy referral link",
                         iconOnly: copied ? VIcon.check.rawValue : VIcon.copy.rawValue,
                         style: .ghost
                     ) {
@@ -151,8 +152,10 @@ struct SettingsBillingReferralCard: View {
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(url, forType: .string)
         copied = true
-        Task {
+        copyResetTask?.cancel()
+        copyResetTask = Task {
             try? await Task.sleep(nanoseconds: 2_000_000_000)
+            guard !Task.isCancelled else { return }
             copied = false
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingReferralCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingReferralCard.swift
@@ -3,13 +3,13 @@ import SwiftUI
 import VellumAssistantShared
 
 /// Referral panel — shows referral URL, copy button, stats, and earning cap.
+/// The backend lazily creates a referral code on first GET, so there is
+/// no explicit creation step needed on the client.
 @MainActor
 struct SettingsBillingReferralCard: View {
     @State private var referralCode: ReferralCodeResponse?
     @State private var isLoading: Bool = true
-    @State private var isCreating: Bool = false
     @State private var error: String?
-    @State private var hasNoCode: Bool = false
     @State private var copied: Bool = false
 
     var body: some View {
@@ -18,8 +18,6 @@ struct SettingsBillingReferralCard: View {
                 loadingState
             } else if let error {
                 errorState(error)
-            } else if hasNoCode {
-                noCodeState
             } else if let referralCode {
                 hasCodeState(referralCode)
             }
@@ -41,26 +39,6 @@ struct SettingsBillingReferralCard: View {
                 }
             }
             .accessibilityHidden(true)
-        }
-    }
-
-    // MARK: - No Code State
-
-    private var noCodeState: some View {
-        SettingsCard(title: "Referrals", subtitle: "Share your link and earn credits") {
-            VStack(alignment: .leading, spacing: VSpacing.lg) {
-                Text("Get your personal referral link to share with friends. You'll both earn credits when they sign up.")
-                    .font(VFont.bodyMediumLighter)
-                    .foregroundStyle(VColor.contentSecondary)
-
-                VButton(
-                    label: isCreating ? "Creating..." : "Get Referral Link",
-                    style: .primary,
-                    isDisabled: isCreating
-                ) {
-                    Task { await createCode() }
-                }
-            }
         }
     }
 
@@ -160,29 +138,13 @@ struct SettingsBillingReferralCard: View {
         }
         error = nil
         do {
-            let result = try await BillingService.shared.getReferralCode()
-            referralCode = result
-            hasNoCode = false
-        } catch PlatformAPIError.notFound {
-            hasNoCode = true
+            referralCode = try await BillingService.shared.getReferralCode()
         } catch {
             if referralCode == nil {
                 self.error = "Failed to load referral information."
             }
         }
         isLoading = false
-    }
-
-    private func createCode() async {
-        isCreating = true
-        defer { isCreating = false }
-        do {
-            let result = try await BillingService.shared.createReferralCode()
-            referralCode = result
-            hasNoCode = false
-        } catch {
-            self.error = "Failed to create referral code. Please try again."
-        }
     }
 
     private func copyToClipboard(_ url: String) {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -22,6 +22,7 @@ struct SettingsBillingTab: View {
     @State private var topUpError: String?
     @State private var hostWindow: NSWindow?
     @State private var inviteCode: String = ""
+    @State private var isReferralCodesEnabled: Bool = false
     private var devModeManager: DevModeManager { DevModeManager.shared }
 
     var body: some View {
@@ -35,8 +36,12 @@ struct SettingsBillingTab: View {
             if devModeManager.isDevMode {
                 inviteCodeCard
             }
+            if isReferralCodesEnabled {
+                SettingsBillingReferralCard()
+            }
         }
         .task {
+            isReferralCodesEnabled = MacOSClientFeatureFlagManager.shared.isEnabled("referral-codes")
             await loadSummary()
         }
         .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { notification in
@@ -47,6 +52,13 @@ struct SettingsBillingTab: View {
             }
         }
         .background(WindowReader(window: $hostWindow))
+        .onReceive(NotificationCenter.default.publisher(for: .assistantFeatureFlagDidChange)) { notification in
+            if let key = notification.userInfo?["key"] as? String,
+               key == "referral-codes",
+               let enabled = notification.userInfo?["enabled"] as? Bool {
+                isReferralCodesEnabled = enabled
+            }
+        }
     }
 
     // MARK: - Balance Card

--- a/clients/shared/App/Auth/AuthModels.swift
+++ b/clients/shared/App/Auth/AuthModels.swift
@@ -207,6 +207,7 @@ public enum PlatformAPIError: LocalizedError, Sendable {
     case serverError(statusCode: Int, detail: String?)
     case authenticationRequired
     case accessDenied(detail: String)
+    case notFound
 
     public var errorDescription: String? {
         switch self {
@@ -222,6 +223,8 @@ public enum PlatformAPIError: LocalizedError, Sendable {
             return "Authentication required"
         case .accessDenied(let detail):
             return detail
+        case .notFound:
+            return "Not found"
         }
     }
 }
@@ -322,4 +325,11 @@ public struct TopUpCheckoutRequest: Codable, Sendable {
 
 public struct TopUpCheckoutResponse: Codable, Sendable {
     public let checkout_url: String
+}
+
+public struct ReferralCodeResponse: Codable, Sendable {
+    public let referral_url: String
+    public let referred_count: Int
+    public let total_earned_usd: String
+    public let earning_cap_usd: String
 }

--- a/clients/shared/App/Auth/BillingService.swift
+++ b/clients/shared/App/Auth/BillingService.swift
@@ -161,6 +161,115 @@ public final class BillingService {
         }
     }
 
+    /// Fetch the current user's referral code.
+    /// Throws `PlatformAPIError.notFound` if the user has no referral code yet.
+    public func getReferralCode() async throws -> ReferralCodeResponse {
+        let urlString = "\(AuthService.shared.baseURL)/v1/referral-codes/me/"
+        guard let url = URL(string: urlString) else {
+            throw PlatformAPIError.invalidURL
+        }
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "GET"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        if let token = await SessionTokenManager.getTokenAsync() {
+            urlRequest.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        } else {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        guard let organizationId = UserDefaults.standard.string(forKey: "connectedOrganizationId") else {
+            throw PlatformAPIError.authenticationRequired
+        }
+        urlRequest.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: urlRequest)
+        } catch {
+            throw PlatformAPIError.networkError(error.localizedDescription)
+        }
+
+        let httpResponse = response as? HTTPURLResponse
+        let statusCode = httpResponse?.statusCode ?? 0
+
+        log.debug("Platform request GET referral-codes/me/ -> \(statusCode)")
+
+        if statusCode == 401 || statusCode == 403 {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        if statusCode == 404 {
+            throw PlatformAPIError.notFound
+        }
+
+        guard (200..<300).contains(statusCode) else {
+            let detail = String(data: data, encoding: .utf8)
+            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
+        }
+
+        do {
+            return try JSONDecoder().decode(ReferralCodeResponse.self, from: data)
+        } catch {
+            throw PlatformAPIError.decodingError(error.localizedDescription)
+        }
+    }
+
+    /// Create a referral code for the current user.
+    public func createReferralCode() async throws -> ReferralCodeResponse {
+        let urlString = "\(AuthService.shared.baseURL)/v1/referral-codes/me/"
+        guard let url = URL(string: urlString) else {
+            throw PlatformAPIError.invalidURL
+        }
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.httpBody = "{}".data(using: .utf8)
+
+        if let token = await SessionTokenManager.getTokenAsync() {
+            urlRequest.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        } else {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        guard let organizationId = UserDefaults.standard.string(forKey: "connectedOrganizationId") else {
+            throw PlatformAPIError.authenticationRequired
+        }
+        urlRequest.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: urlRequest)
+        } catch {
+            throw PlatformAPIError.networkError(error.localizedDescription)
+        }
+
+        let httpResponse = response as? HTTPURLResponse
+        let statusCode = httpResponse?.statusCode ?? 0
+
+        log.debug("Platform request POST referral-codes/me/ -> \(statusCode)")
+
+        if statusCode == 401 || statusCode == 403 {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        guard (200..<300).contains(statusCode) else {
+            let detail = String(data: data, encoding: .utf8)
+            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
+        }
+
+        do {
+            return try JSONDecoder().decode(ReferralCodeResponse.self, from: data)
+        } catch {
+            throw PlatformAPIError.decodingError(error.localizedDescription)
+        }
+    }
+
     /// Create a top-up checkout session and return the Stripe checkout URL.
     public func createTopUpCheckout(amountUsd: String) async throws -> URL {
         let urlString = "\(AuthService.shared.baseURL)/v1/organizations/billing/top-ups/checkout-session/"

--- a/clients/shared/App/Auth/BillingService.swift
+++ b/clients/shared/App/Auth/BillingService.swift
@@ -161,8 +161,8 @@ public final class BillingService {
         }
     }
 
-    /// Fetch the current user's referral code.
-    /// Throws `PlatformAPIError.notFound` if the user has no referral code yet.
+    /// Fetch the current user's referral code and stats.
+    /// The backend lazily creates a referral code if one doesn't exist yet.
     public func getReferralCode() async throws -> ReferralCodeResponse {
         let urlString = "\(AuthService.shared.baseURL)/v1/referral-codes/me/"
         guard let url = URL(string: urlString) else {
@@ -196,63 +196,6 @@ public final class BillingService {
         let statusCode = httpResponse?.statusCode ?? 0
 
         log.debug("Platform request GET referral-codes/me/ -> \(statusCode)")
-
-        if statusCode == 401 || statusCode == 403 {
-            throw PlatformAPIError.authenticationRequired
-        }
-
-        if statusCode == 404 {
-            throw PlatformAPIError.notFound
-        }
-
-        guard (200..<300).contains(statusCode) else {
-            let detail = String(data: data, encoding: .utf8)
-            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
-        }
-
-        do {
-            return try JSONDecoder().decode(ReferralCodeResponse.self, from: data)
-        } catch {
-            throw PlatformAPIError.decodingError(error.localizedDescription)
-        }
-    }
-
-    /// Create a referral code for the current user.
-    public func createReferralCode() async throws -> ReferralCodeResponse {
-        let urlString = "\(AuthService.shared.baseURL)/v1/referral-codes/me/"
-        guard let url = URL(string: urlString) else {
-            throw PlatformAPIError.invalidURL
-        }
-
-        var urlRequest = URLRequest(url: url)
-        urlRequest.httpMethod = "POST"
-        urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
-        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        urlRequest.httpBody = "{}".data(using: .utf8)
-
-        if let token = await SessionTokenManager.getTokenAsync() {
-            urlRequest.setValue(token, forHTTPHeaderField: "X-Session-Token")
-        } else {
-            throw PlatformAPIError.authenticationRequired
-        }
-
-        guard let organizationId = UserDefaults.standard.string(forKey: "connectedOrganizationId") else {
-            throw PlatformAPIError.authenticationRequired
-        }
-        urlRequest.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
-
-        let data: Data
-        let response: URLResponse
-        do {
-            (data, response) = try await URLSession.shared.data(for: urlRequest)
-        } catch {
-            throw PlatformAPIError.networkError(error.localizedDescription)
-        }
-
-        let httpResponse = response as? HTTPURLResponse
-        let statusCode = httpResponse?.statusCode ?? 0
-
-        log.debug("Platform request POST referral-codes/me/ -> \(statusCode)")
 
         if statusCode == 401 || statusCode == 403 {
             throw PlatformAPIError.authenticationRequired

--- a/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
@@ -209,6 +209,8 @@ public final class ManagedAssistantBootstrapService {
             return .serverError(statusCode: 0, detail: "Invalid URL configuration")
         case .decodingError(let message):
             return .unexpectedResponse(message)
+        case .notFound:
+            return .serverError(statusCode: 404, detail: "Not found")
         }
     }
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -122,6 +122,14 @@
       "defaultEnabled": true
     },
     {
+      "id": "referral-codes",
+      "scope": "macos",
+      "key": "referral-codes",
+      "label": "Referral Codes",
+      "description": "Show the referral invite link and stats panel on the Billing tab in Settings",
+      "defaultEnabled": false
+    },
+    {
       "id": "managed-sign-in",
       "scope": "macos",
       "key": "managed-sign-in",


### PR DESCRIPTION
## Summary
Add a referral panel to the macOS client's Billing settings tab, matching the web UI from PR #3744 (vellum-assistant-platform). Users can generate a personal referral link, copy it to clipboard, and see stats (friends referred, credits earned, earning cap). The feature is gated behind a `referral-codes` feature flag (default: off).

## PRs merged into feature branch
- #23580: Add referral-codes feature flag to the macOS flag registry
- #23581: Add referral code response model and BillingService API methods
- #23588: Add referral panel UI to the macOS Billing settings tab

Part of plan: referral-billing-ui.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23589" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
