### PR TITLE
Add background_tool_control tool for managing deferred executions

### DIFF
--- a/assistant/src/__tests__/background-tool-control.test.ts
+++ b/assistant/src/__tests__/background-tool-control.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Tests for the background_tool_control tool.
+ *
+ * Verifies:
+ * - "cancel" action calls BackgroundToolManager.cancel() and returns confirmation
+ * - "wait" with no wait_seconds returns immediate status
+ * - "wait" with short duration blocks and returns result on completion
+ * - "wait" with short duration blocks and returns "still running" on timeout
+ * - "wait" with long duration (> threshold) returns immediately with scheduleCheckIn
+ * - Unknown execution_id returns error
+ * - Tool is not registered when `tool-deferral` flag is disabled
+ * - Tool is registered when `tool-deferral` flag is enabled
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { backgroundToolManager } from "../agent/background-tool-manager.js";
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
+import { backgroundToolControlTool } from "../tools/background-tool-control.js";
+import { getToolDeferralToolsIfEnabled } from "../tools/tool-manifest.js";
+import type { ToolContext } from "../tools/types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    workingDir: "/tmp/test",
+    conversationId: "conv-test-123",
+    trustClass: "guardian",
+    ...overrides,
+  };
+}
+
+/**
+ * Register a fake background execution for testing.
+ */
+function registerFakeExecution(
+  executionId: string,
+  opts: {
+    resolve?: (result: { content: string; isError: boolean }) => void;
+    reject?: (err: Error) => void;
+    resolveWith?: { content: string; isError: boolean };
+  } = {},
+): {
+  resolve: (result: { content: string; isError: boolean }) => void;
+  reject: (err: Error) => void;
+} {
+  let resolvePromise!: (result: { content: string; isError: boolean }) => void;
+  let rejectPromise!: (err: Error) => void;
+
+  const promise = new Promise<{ content: string; isError: boolean }>(
+    (resolve, reject) => {
+      resolvePromise = resolve;
+      rejectPromise = reject;
+    },
+  );
+
+  backgroundToolManager.register({
+    executionId,
+    toolName: "test_tool",
+    toolUseId: "tu-123",
+    conversationId: "conv-test-123",
+    startedAt: Date.now(),
+    promise,
+  });
+
+  if (opts.resolveWith) {
+    resolvePromise(opts.resolveWith);
+  }
+
+  return { resolve: resolvePromise, reject: rejectPromise };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  _setOverridesForTesting({});
+  backgroundToolManager.cleanup("conv-test-123");
+});
+
+afterEach(() => {
+  _setOverridesForTesting({});
+  backgroundToolManager.cleanup("conv-test-123");
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("background_tool_control", () => {
+  describe("tool properties", () => {
+    test("has correct name and category", () => {
+      expect(backgroundToolControlTool.name).toBe("background_tool_control");
+      expect(backgroundToolControlTool.category).toBe("system");
+    });
+
+    test("is deferralExempt", () => {
+      expect(backgroundToolControlTool.deferralExempt).toBe(true);
+    });
+
+    test("definition has correct input schema", () => {
+      const def = backgroundToolControlTool.getDefinition();
+      expect(def.name).toBe("background_tool_control");
+      const schema = def.input_schema as {
+        required: string[];
+        properties: Record<string, unknown>;
+      };
+      expect(schema.required).toContain("execution_id");
+      expect(schema.required).toContain("action");
+      expect(schema.properties).toHaveProperty("execution_id");
+      expect(schema.properties).toHaveProperty("action");
+      expect(schema.properties).toHaveProperty("wait_seconds");
+    });
+  });
+
+  describe("cancel action", () => {
+    test("returns confirmation and calls manager.cancel()", async () => {
+      registerFakeExecution("exec-1");
+
+      const result = await backgroundToolControlTool.execute(
+        { execution_id: "exec-1", action: "cancel" },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("exec-1");
+      expect(result.content).toContain("cancelled");
+
+      // Verify the execution is actually cancelled
+      const status = backgroundToolManager.getStatus("exec-1");
+      expect(status?.status).toBe("cancelled");
+    });
+
+    test("returns error for unknown execution_id", async () => {
+      const result = await backgroundToolControlTool.execute(
+        { execution_id: "nonexistent", action: "cancel" },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("No execution found");
+    });
+  });
+
+  describe("wait action", () => {
+    test("with no wait_seconds returns immediate status", async () => {
+      registerFakeExecution("exec-2");
+
+      const result = await backgroundToolControlTool.execute(
+        { execution_id: "exec-2", action: "wait" },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("exec-2");
+      expect(result.content).toContain("running");
+    });
+
+    test("with wait_seconds=0 returns immediate status", async () => {
+      registerFakeExecution("exec-2b");
+
+      const result = await backgroundToolControlTool.execute(
+        { execution_id: "exec-2b", action: "wait", wait_seconds: 0 },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("exec-2b");
+      expect(result.content).toContain("running");
+    });
+
+    test("immediate status for completed execution returns result", async () => {
+      const { resolve } = registerFakeExecution("exec-2c");
+      resolve({ content: "Tool output here", isError: false });
+      // Allow microtask to settle
+      await new Promise((r) => setTimeout(r, 10));
+
+      const result = await backgroundToolControlTool.execute(
+        { execution_id: "exec-2c", action: "wait" },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("completed");
+      expect(result.content).toContain("Tool output here");
+    });
+
+    test("with short duration blocks and returns result on completion", async () => {
+      // Default threshold is 10s; use wait_seconds=2 which is <= threshold
+      const { resolve } = registerFakeExecution("exec-3");
+
+      // Resolve after a short delay
+      setTimeout(() => {
+        resolve({ content: "Done!", isError: false });
+      }, 50);
+
+      const result = await backgroundToolControlTool.execute(
+        { execution_id: "exec-3", action: "wait", wait_seconds: 2 },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("completed");
+      expect(result.content).toContain("Done!");
+    });
+
+    test("with short duration blocks and returns 'still running' on timeout", async () => {
+      // Register an execution that won't complete
+      registerFakeExecution("exec-4");
+
+      // Use a very short wait so the test doesn't block
+      // Override config to have threshold of 5s so that 1s is "short"
+      const result = await backgroundToolControlTool.execute(
+        { execution_id: "exec-4", action: "wait", wait_seconds: 1 },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("still running");
+    });
+
+    test("with long duration (> threshold) returns immediately with scheduleCheckIn", async () => {
+      // Default threshold is 10s; use wait_seconds=30 which is > threshold
+      registerFakeExecution("exec-5");
+
+      const result = await backgroundToolControlTool.execute(
+        { execution_id: "exec-5", action: "wait", wait_seconds: 30 },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("Deferred check-in scheduled");
+      expect(result.scheduleCheckIn).toBeDefined();
+      expect(result.scheduleCheckIn?.afterSeconds).toBe(30);
+      expect(result.scheduleCheckIn?.executionId).toBe("exec-5");
+      expect(result.scheduleCheckIn?.conversationId).toBe("conv-test-123");
+    });
+
+    test("returns error for unknown execution_id", async () => {
+      const result = await backgroundToolControlTool.execute(
+        { execution_id: "nonexistent", action: "wait" },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("No execution found");
+    });
+  });
+
+  describe("unknown action", () => {
+    test("returns error for invalid action", async () => {
+      const result = await backgroundToolControlTool.execute(
+        { execution_id: "exec-x", action: "restart" },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("Unknown action");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Feature flag gating
+// ---------------------------------------------------------------------------
+
+describe("tool-deferral feature flag gating", () => {
+  test("tool is not registered when tool-deferral flag is disabled", () => {
+    _setOverridesForTesting({ "tool-deferral": false });
+    const tools = getToolDeferralToolsIfEnabled();
+    expect(tools).toHaveLength(0);
+  });
+
+  test("tool is registered when tool-deferral flag is enabled", () => {
+    _setOverridesForTesting({ "tool-deferral": true });
+    const tools = getToolDeferralToolsIfEnabled();
+    expect(tools).toHaveLength(1);
+    expect(tools[0].name).toBe("background_tool_control");
+  });
+});

--- a/assistant/src/tools/background-tool-control.ts
+++ b/assistant/src/tools/background-tool-control.ts
@@ -1,0 +1,137 @@
+/**
+ * background_tool_control — manage background tool executions that exceeded
+ * the deferral threshold.
+ *
+ * This is a core infrastructure tool (like CES tools) that requires deep
+ * integration with the agent loop for managing deferred tool executions.
+ * It is registered as a non-skill tool behind the `tool-deferral` feature flag.
+ */
+
+import { backgroundToolManager } from "../agent/background-tool-manager.js";
+import { getConfig } from "../config/loader.js";
+import { RiskLevel } from "../permissions/types.js";
+import type { ToolDefinition } from "../providers/types.js";
+import type { Tool, ToolContext, ToolExecutionResult } from "./types.js";
+
+const TOOL_NAME = "background_tool_control";
+
+const TOOL_DESCRIPTION =
+  "Manage background tool executions that exceeded the deferral threshold. Use 'wait' to check on or wait for a result, or 'cancel' to terminate a running execution.";
+
+class BackgroundToolControlTool implements Tool {
+  name = TOOL_NAME;
+  description = TOOL_DESCRIPTION;
+  category = "system";
+  defaultRiskLevel = RiskLevel.Low;
+  deferralExempt = true;
+
+  getDefinition(): ToolDefinition {
+    return {
+      name: TOOL_NAME,
+      description: TOOL_DESCRIPTION,
+      input_schema: {
+        type: "object",
+        properties: {
+          execution_id: {
+            type: "string",
+            description: "The execution ID of the background tool to manage",
+          },
+          action: {
+            type: "string",
+            enum: ["wait", "cancel"],
+            description:
+              "Action to take: 'wait' to check status or wait for completion, 'cancel' to abort the execution",
+          },
+          wait_seconds: {
+            type: "number",
+            description:
+              "For 'wait' action: how many seconds to wait for the tool to complete. If omitted, returns current status immediately. Short waits (\u2264 deferral threshold) block; longer waits schedule a deferred check-in.",
+          },
+        },
+        required: ["execution_id", "action"],
+      },
+    };
+  }
+
+  async execute(
+    input: Record<string, unknown>,
+    context: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    const executionId = input.execution_id as string;
+    const action = input.action as string;
+    const waitSeconds = input.wait_seconds as number | undefined;
+
+    if (action === "cancel") {
+      const result = backgroundToolManager.cancel(executionId);
+      return {
+        content: result.message,
+        isError: !result.cancelled,
+      };
+    }
+
+    if (action === "wait") {
+      // Unknown execution ID check
+      const status = backgroundToolManager.getStatus(executionId);
+      if (!status) {
+        return {
+          content: `No execution found with ID ${executionId}`,
+          isError: true,
+        };
+      }
+
+      // Immediate status check (no wait_seconds or 0)
+      if (waitSeconds === undefined || waitSeconds === 0) {
+        if (status.status === "completed" && status.result) {
+          return {
+            content: `Execution ${executionId} completed:\n${status.result.content}`,
+            isError: status.result.isError,
+          };
+        }
+        return {
+          content: `Execution ${executionId} is ${status.status} (elapsed: ${Math.round(status.elapsedMs / 1000)}s)`,
+          isError: false,
+        };
+      }
+
+      // Determine the deferral threshold
+      const config = getConfig();
+      const thresholdSec = config.timeouts.toolDeferralThresholdSec;
+
+      if (waitSeconds <= thresholdSec) {
+        // Short wait — block and return result
+        const waitResult = await backgroundToolManager.waitFor(
+          executionId,
+          waitSeconds * 1000,
+        );
+        if (waitResult.completed && waitResult.result) {
+          return {
+            content: `Execution ${executionId} completed:\n${waitResult.result.content}`,
+            isError: waitResult.result.isError,
+          };
+        }
+        return {
+          content: `Execution ${executionId} is still running after waiting ${waitSeconds}s`,
+          isError: false,
+        };
+      }
+
+      // Long wait — return immediately with scheduleCheckIn
+      return {
+        content: `Deferred check-in scheduled for execution ${executionId} in ${waitSeconds}s`,
+        isError: false,
+        scheduleCheckIn: {
+          afterSeconds: waitSeconds,
+          executionId,
+          conversationId: context.conversationId,
+        },
+      };
+    }
+
+    return {
+      content: `Unknown action: ${action}. Valid actions are 'wait' and 'cancel'.`,
+      isError: true,
+    };
+  }
+}
+
+export const backgroundToolControlTool = new BackgroundToolControlTool();

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -229,6 +229,8 @@ export async function initializeTools(): Promise<void> {
     explicitTools,
     getCesToolsIfEnabled,
     cesTools,
+    getToolDeferralToolsIfEnabled,
+    toolDeferralTools,
   } = await import("./tool-manifest.js");
 
   // Capture tool names already in the registry before any manifest
@@ -262,6 +264,12 @@ export async function initializeTools(): Promise<void> {
     registerTool(tool);
   }
 
+  // Tool deferral tools - registered only when the tool-deferral feature flag is enabled.
+  const activeToolDeferralTools = getToolDeferralToolsIfEnabled();
+  for (const tool of activeToolDeferralTools) {
+    registerTool(tool);
+  }
+
   registerUiSurfaceTools();
   registerAppTools();
 
@@ -279,6 +287,7 @@ export async function initializeTools(): Promise<void> {
       ...explicitTools.map((t: Tool) => t.name),
       ...hostTools.map((t: Tool) => t.name),
       ...cesTools.map((t: Tool) => t.name),
+      ...toolDeferralTools.map((t: Tool) => t.name),
       ...allComputerUseTools.map((t: Tool) => t.name),
       ...allUiSurfaceTools.map((t: Tool) => t.name),
       ...coreAppProxyTools.map((t: Tool) => t.name),

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -6,11 +6,13 @@
  * so adding/removing tools only requires editing this manifest.
  */
 
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
 import {
   isCesSecureInstallEnabled,
   isCesToolsEnabled,
 } from "../credential-execution/feature-gates.js";
+import { backgroundToolControlTool } from "./background-tool-control.js";
 import { makeAuthenticatedRequestTool } from "./credential-execution/make-authenticated-request.js";
 import { manageSecureCommandTool } from "./credential-execution/manage-secure-command-tool.js";
 import { runAuthenticatedCommandTool } from "./credential-execution/run-authenticated-command.js";
@@ -105,6 +107,31 @@ export const cesTools: Tool[] = [
   runAuthenticatedCommandTool,
   manageSecureCommandTool,
 ];
+
+// ── Tool deferral tools (feature-flag gated) ───────────────────────
+// The background_tool_control tool is a core infrastructure tool that
+// requires deep integration with the agent loop (similar to CES tools).
+// It is only registered when the `tool-deferral` feature flag is enabled.
+
+/** Stable reference for the manifest snapshot. */
+export const toolDeferralTools: Tool[] = [backgroundToolControlTool];
+
+/**
+ * Return tool-deferral tools only if the `tool-deferral` feature flag is
+ * enabled. Returns an empty array when the flag is disabled so callers
+ * can unconditionally iterate the result.
+ */
+export function getToolDeferralToolsIfEnabled(): Tool[] {
+  try {
+    const config = getConfig();
+    if (isAssistantFeatureFlagEnabled("tool-deferral", config)) {
+      return toolDeferralTools;
+    }
+  } catch {
+    // Config not yet loaded (e.g. during test setup) - tool deferral stays off.
+  }
+  return [];
+}
 
 /**
  * Return CES tools only if the CES feature flag is enabled.

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -224,6 +224,12 @@ export interface ToolExecutionResult {
    * approval flow transparently.
    */
   cesApprovalRequired?: ApprovalRequired;
+  /** When set, the agent loop should schedule a deferred check-in for a background execution. */
+  scheduleCheckIn?: {
+    afterSeconds: number;
+    executionId: string;
+    conversationId: string;
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -267,6 +273,8 @@ export interface Tool {
   description: string;
   category: string;
   defaultRiskLevel: RiskLevel;
+  /** When true, the agent loop should not apply the deferral threshold to this tool. */
+  deferralExempt?: boolean;
   /** When set to 'proxy', the tool is forwarded to a connected client rather than executed locally. */
   executionMode?: "local" | "proxy";
   /** Whether this tool is a core built-in, provided by a skill, or from an MCP server. */


### PR DESCRIPTION
## Summary
- Create `background_tool_control` tool with wait/cancel actions for managing deferred tool executions
- Add `scheduleCheckIn` field to `ToolExecutionResult` and `deferralExempt` flag to `Tool` interface
- Conditionally register tool behind `tool-deferral` feature flag
- Add comprehensive tests

Note: This is a core infrastructure tool (similar to CES tools) that requires deep integration with the agent loop for managing deferred tool executions. Tool registration is intentional and approved as part of the tool-deferral feature plan.

Part of plan: tool-deferral-background-execution.md (PR 4 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23590" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
