### PR TITLE
fix: skill_load reuses existing skill instead of failing

### DIFF
--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -392,6 +392,14 @@ export async function autoInstallFromCatalog(
     return false;
   }
 
+  // If the skill already exists on disk (stale index), re-index it instead
+  // of attempting a fresh install that would fail.
+  const skillDir = join(getWorkspaceSkillsDir(), skillId);
+  if (existsSync(join(skillDir, "SKILL.md"))) {
+    upsertSkillsIndex(skillId);
+    return true;
+  }
+
   // installSkillLocally handles dependency installation and SKILLS.md indexing.
   await installSkillLocally(skillId, entry, false);
 


### PR DESCRIPTION
## Summary
- When `skill_load` encounters a skill already installed on disk but missing from the SKILLS.md index, it now re-indexes the existing skill instead of failing with "Skill is already installed. Use --overwrite to replace it."
- This fixes a common scenario where the index becomes stale but the skill files are intact.

## Original prompt
skill_load should use the existing skill if one already exists with that name instead of failing
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
