### PR TITLE
Implement tool deferral threshold in agent loop with placeholder results

### DIFF
--- a/assistant/src/__tests__/agent-loop-deferral.test.ts
+++ b/assistant/src/__tests__/agent-loop-deferral.test.ts
@@ -1,0 +1,632 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { AgentEvent } from "../agent/loop.js";
+import { RiskLevel } from "../permissions/types.js";
+import type {
+  ContentBlock,
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+  ToolDefinition,
+} from "../providers/types.js";
+
+// ---------------------------------------------------------------------------
+// Module mocks — must precede imports of the module under test
+// ---------------------------------------------------------------------------
+
+// Feature flag: defaults to disabled
+let mockDeferralEnabled = false;
+mock.module("../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: (key: string) => {
+    if (key === "tool-deferral") return mockDeferralEnabled;
+    return true;
+  },
+}));
+
+// Config: provide toolDeferralThresholdSec (default 10s, overridable per test)
+let mockThresholdSec = 10;
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    timeouts: { toolDeferralThresholdSec: mockThresholdSec },
+  }),
+}));
+
+// Background tool manager: real implementation for integration tests
+// We import the real class and create a fresh instance per test
+import { BackgroundToolManager } from "../agent/background-tool-manager.js";
+
+let testBgManager: BackgroundToolManager;
+mock.module("../agent/background-tool-manager.js", () => ({
+  get backgroundToolManager() {
+    return testBgManager;
+  },
+  BackgroundToolManager,
+}));
+
+// Hooks — no-op
+mock.module("../hooks/manager.js", () => ({
+  getHookManager: () => ({
+    trigger: async () => ({ blocked: false }),
+  }),
+}));
+
+// Logger — no-op
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+// Token estimator — trivial
+mock.module("../context/token-estimator.js", () => ({
+  estimateToolsTokens: () => 0,
+}));
+
+// Tool result truncation — pass through
+mock.module("../context/tool-result-truncation.js", () => ({
+  truncateOversizedToolResults: (blocks: ContentBlock[]) => ({
+    blocks,
+    truncatedCount: 0,
+  }),
+}));
+
+// Sensitive output placeholders — pass through
+mock.module("../tools/sensitive-output-placeholders.js", () => ({
+  applyStreamingSubstitution: (text: string) => ({ emit: text, pending: "" }),
+  applySubstitutions: (text: string) => text,
+}));
+
+// Sentry — no-op
+mock.module("@sentry/node", () => ({
+  captureException: () => {},
+}));
+
+// Now import the module under test (after mocks are registered)
+const { AgentLoop } = await import("../agent/loop.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockProvider(responses: ProviderResponse[]): {
+  provider: Provider;
+  calls: {
+    messages: Message[];
+    tools?: ToolDefinition[];
+    systemPrompt?: string;
+  }[];
+} {
+  const calls: {
+    messages: Message[];
+    tools?: ToolDefinition[];
+    systemPrompt?: string;
+  }[] = [];
+  let callIndex = 0;
+
+  const provider: Provider = {
+    name: "mock",
+    async sendMessage(
+      messages: Message[],
+      tools?: ToolDefinition[],
+      systemPrompt?: string,
+      options?: SendMessageOptions,
+    ): Promise<ProviderResponse> {
+      calls.push({ messages: [...messages], tools, systemPrompt });
+      const response = responses[callIndex] ?? responses[responses.length - 1];
+      callIndex++;
+      if (options?.onEvent) {
+        for (const block of response.content) {
+          if (block.type === "text") {
+            options.onEvent({ type: "text_delta", text: block.text });
+          }
+        }
+      }
+      return response;
+    },
+  };
+
+  return { provider, calls };
+}
+
+function textResponse(text: string): ProviderResponse {
+  return {
+    content: [{ type: "text", text }],
+    model: "mock-model",
+    usage: { inputTokens: 10, outputTokens: 5 },
+    stopReason: "end_turn",
+  };
+}
+
+function toolUseResponse(
+  id: string,
+  name: string,
+  input: Record<string, unknown>,
+): ProviderResponse {
+  return {
+    content: [{ type: "tool_use", id, name, input }],
+    model: "mock-model",
+    usage: { inputTokens: 10, outputTokens: 5 },
+    stopReason: "tool_use",
+  };
+}
+
+const dummyTools: ToolDefinition[] = [
+  {
+    name: "slow_tool",
+    description: "A tool that takes a while",
+    input_schema: { type: "object", properties: {} },
+  },
+  {
+    name: "fast_tool",
+    description: "A fast tool",
+    input_schema: { type: "object", properties: {} },
+  },
+];
+
+const userMessage: Message = {
+  role: "user",
+  content: [{ type: "text", text: "Hello" }],
+};
+
+function collectEvents(events: AgentEvent[]): (event: AgentEvent) => void {
+  return (event) => events.push(event);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AgentLoop deferral", () => {
+  beforeEach(() => {
+    mockDeferralEnabled = false;
+    mockThresholdSec = 10;
+    testBgManager = new BackgroundToolManager();
+  });
+
+  // ── Feature flag disabled ────────────────────────────────────────────
+
+  test("feature flag disabled: all tools use blocking Promise.all (no deferral)", async () => {
+    mockDeferralEnabled = false;
+
+    const { provider } = createMockProvider([
+      toolUseResponse("t1", "slow_tool", {}),
+      textResponse("Done"),
+    ]);
+
+    let toolExecuted = false;
+    const toolExecutor = async () => {
+      // Simulate a tool that takes "long" — but since deferral is off, it blocks
+      await Bun.sleep(50);
+      toolExecuted = true;
+      return { content: "result", isError: false };
+    };
+
+    const loop = new AgentLoop(
+      provider,
+      "system",
+      { minTurnIntervalMs: 0 },
+      dummyTools,
+      toolExecutor,
+    );
+    const events: AgentEvent[] = [];
+    const history = await loop.run(
+      [userMessage],
+      collectEvents(events),
+      undefined,
+      undefined,
+      undefined,
+      "conv-1",
+    );
+
+    // Tool completed normally (blocking)
+    expect(toolExecuted).toBe(true);
+
+    // No deferral events
+    const deferralEvents = events.filter(
+      (e) => e.type === "tool_deferred_to_background",
+    );
+    expect(deferralEvents).toHaveLength(0);
+
+    // History ends with assistant text
+    expect(history[history.length - 1].role).toBe("assistant");
+    expect(history[history.length - 1].content).toEqual([
+      { type: "text", text: "Done" },
+    ]);
+  });
+
+  // ── Feature flag enabled, all tools complete before threshold ──────
+
+  test("feature flag enabled, all tools complete before threshold: normal flow", async () => {
+    mockDeferralEnabled = true;
+    // Set a very long threshold so tools always finish first
+    mockThresholdSec = 60;
+
+    const { provider } = createMockProvider([
+      toolUseResponse("t1", "fast_tool", {}),
+      textResponse("Done"),
+    ]);
+
+    const toolExecutor = async () => {
+      return { content: "fast result", isError: false };
+    };
+
+    const loop = new AgentLoop(
+      provider,
+      "system",
+      { minTurnIntervalMs: 0 },
+      dummyTools,
+      toolExecutor,
+    );
+    const events: AgentEvent[] = [];
+    const history = await loop.run(
+      [userMessage],
+      collectEvents(events),
+      undefined,
+      undefined,
+      undefined,
+      "conv-1",
+    );
+
+    // No deferral events
+    const deferralEvents = events.filter(
+      (e) => e.type === "tool_deferred_to_background",
+    );
+    expect(deferralEvents).toHaveLength(0);
+
+    // Normal tool_result event emitted
+    const toolResultEvents = events.filter((e) => e.type === "tool_result");
+    expect(toolResultEvents).toHaveLength(1);
+    const toolResultEvent = toolResultEvents[0] as Extract<
+      AgentEvent,
+      { type: "tool_result" }
+    >;
+    expect(toolResultEvent.content).toBe("fast result");
+
+    // History ends with assistant text
+    expect(history[history.length - 1].content).toEqual([
+      { type: "text", text: "Done" },
+    ]);
+  });
+
+  // ── Feature flag enabled, one tool exceeds threshold ──────────────
+
+  test("feature flag enabled, one tool exceeds threshold: placeholder result + system notice", async () => {
+    mockDeferralEnabled = true;
+    // Very short threshold so the slow tool definitely exceeds it
+    mockThresholdSec = 0.05; // 50ms
+
+    const { provider, calls } = createMockProvider([
+      toolUseResponse("t1", "slow_tool", {}),
+      textResponse("I see the tool is running in the background."),
+    ]);
+
+    const toolExecutor = async () => {
+      // This tool takes longer than the 50ms threshold
+      await Bun.sleep(200);
+      return { content: "slow result", isError: false };
+    };
+
+    const loop = new AgentLoop(
+      provider,
+      "system",
+      { minTurnIntervalMs: 0 },
+      dummyTools,
+      toolExecutor,
+    );
+    const events: AgentEvent[] = [];
+    await loop.run(
+      [userMessage],
+      collectEvents(events),
+      undefined,
+      undefined,
+      undefined,
+      "conv-1",
+    );
+
+    // Should have emitted a tool_deferred_to_background event
+    const deferralEvents = events.filter(
+      (e) => e.type === "tool_deferred_to_background",
+    );
+    expect(deferralEvents).toHaveLength(1);
+    const deferralEvent = deferralEvents[0] as Extract<
+      AgentEvent,
+      { type: "tool_deferred_to_background" }
+    >;
+    expect(deferralEvent.executionId).toBe("t1");
+    expect(deferralEvent.toolName).toBe("slow_tool");
+
+    // The provider should have been called twice: once for the tool_use, once after placeholder
+    expect(calls).toHaveLength(2);
+
+    // The second call's last user message should contain:
+    // 1. A tool_result placeholder for the slow tool
+    // 2. A system_notice text block
+    const secondCallMsgs = calls[1].messages;
+    const lastUserMsg = secondCallMsgs[secondCallMsgs.length - 1];
+    expect(lastUserMsg.role).toBe("user");
+
+    const toolResultBlock = lastUserMsg.content.find(
+      (b) => b.type === "tool_result",
+    );
+    expect(toolResultBlock).toBeDefined();
+    if (toolResultBlock && toolResultBlock.type === "tool_result") {
+      expect(toolResultBlock.content).toContain(
+        "still running in the background",
+      );
+      expect(toolResultBlock.content).toContain("execution_id: t1");
+    }
+
+    const systemNotice = lastUserMsg.content.find(
+      (b) => b.type === "text" && b.text.includes("deferral threshold"),
+    );
+    expect(systemNotice).toBeDefined();
+  });
+
+  // ── Mix of fast and slow tools ─────────────────────────────────────
+
+  test("feature flag enabled, mix of fast and slow tools: fast get real results, slow get placeholders", async () => {
+    mockDeferralEnabled = true;
+    mockThresholdSec = 0.1; // 100ms
+
+    // Provider returns two tool_use blocks in one response
+    const multiToolResponse: ProviderResponse = {
+      content: [
+        { type: "tool_use", id: "fast-1", name: "fast_tool", input: {} },
+        { type: "tool_use", id: "slow-1", name: "slow_tool", input: {} },
+      ],
+      model: "mock-model",
+      usage: { inputTokens: 10, outputTokens: 5 },
+      stopReason: "tool_use",
+    };
+
+    const { provider, calls } = createMockProvider([
+      multiToolResponse,
+      textResponse("Background tool noted."),
+    ]);
+
+    const toolExecutor = async (name: string) => {
+      if (name === "slow_tool") {
+        await Bun.sleep(300);
+        return { content: "slow result", isError: false };
+      }
+      // fast_tool completes instantly
+      return { content: "fast result", isError: false };
+    };
+
+    const loop = new AgentLoop(
+      provider,
+      "system",
+      { minTurnIntervalMs: 0 },
+      dummyTools,
+      toolExecutor,
+    );
+    const events: AgentEvent[] = [];
+    await loop.run(
+      [userMessage],
+      collectEvents(events),
+      undefined,
+      undefined,
+      undefined,
+      "conv-1",
+    );
+
+    // fast_tool should have a real tool_result event
+    const toolResultEvents = events.filter(
+      (e) => e.type === "tool_result",
+    ) as Extract<AgentEvent, { type: "tool_result" }>[];
+    const fastResult = toolResultEvents.find((e) => e.toolUseId === "fast-1");
+    expect(fastResult).toBeDefined();
+    expect(fastResult!.content).toBe("fast result");
+
+    // slow_tool should have a deferred event (no real tool_result)
+    const deferralEvents = events.filter(
+      (e) => e.type === "tool_deferred_to_background",
+    ) as Extract<AgentEvent, { type: "tool_deferred_to_background" }>[];
+    expect(deferralEvents).toHaveLength(1);
+    expect(deferralEvents[0].toolName).toBe("slow_tool");
+    expect(deferralEvents[0].executionId).toBe("slow-1");
+
+    // Check that the user message sent to provider has both results
+    const secondCallMsgs = calls[1].messages;
+    const lastUserMsg = secondCallMsgs[secondCallMsgs.length - 1];
+    const toolResults = lastUserMsg.content.filter(
+      (b) => b.type === "tool_result",
+    );
+    expect(toolResults).toHaveLength(2);
+
+    // First result (fast) should be real
+    const fastBlock = toolResults.find(
+      (b) => b.type === "tool_result" && b.tool_use_id === "fast-1",
+    );
+    expect(fastBlock).toBeDefined();
+    if (fastBlock && fastBlock.type === "tool_result") {
+      expect(fastBlock.content).toBe("fast result");
+    }
+
+    // Second result (slow) should be placeholder
+    const slowBlock = toolResults.find(
+      (b) => b.type === "tool_result" && b.tool_use_id === "slow-1",
+    );
+    expect(slowBlock).toBeDefined();
+    if (slowBlock && slowBlock.type === "tool_result") {
+      expect(slowBlock.content).toContain("still running in the background");
+    }
+  });
+
+  // ── Auto-injection of completed background results ─────────────────
+
+  test("auto-injection of completed background results on next loop iteration", async () => {
+    mockDeferralEnabled = true;
+    mockThresholdSec = 0.05; // 50ms
+
+    // Setup: Pre-populate the background manager with a "completed" execution
+    // that should be drained on the next iteration
+    let resolveSlowTool: (v: { content: string; isError: boolean }) => void;
+    const slowPromise = new Promise<{ content: string; isError: boolean }>(
+      (resolve) => {
+        resolveSlowTool = resolve;
+      },
+    );
+    testBgManager.register({
+      executionId: "bg-exec-1",
+      toolName: "slow_tool",
+      toolUseId: "bg-tu-1",
+      conversationId: "conv-inject",
+      startedAt: Date.now() - 5000,
+      promise: slowPromise,
+    });
+    // Resolve it so it's drained as "completed"
+    resolveSlowTool!({ content: "bg result done", isError: false });
+    // Give the promise .then handler time to fire
+    await Bun.sleep(10);
+
+    const { provider, calls } = createMockProvider([
+      textResponse("I see the background result."),
+    ]);
+
+    // No tool executor needed — this is a text-only turn, but background
+    // results should be injected before the provider call.
+    const loop = new AgentLoop(provider, "system", { minTurnIntervalMs: 0 });
+    const events: AgentEvent[] = [];
+    await loop.run(
+      [userMessage],
+      collectEvents(events),
+      undefined,
+      undefined,
+      undefined,
+      "conv-inject",
+    );
+
+    // Should have emitted a background_tool_completed event
+    const bgCompleted = events.filter(
+      (e) => e.type === "background_tool_completed",
+    ) as Extract<AgentEvent, { type: "background_tool_completed" }>[];
+    expect(bgCompleted).toHaveLength(1);
+    expect(bgCompleted[0].executionId).toBe("bg-exec-1");
+    expect(bgCompleted[0].result).toBe("bg result done");
+    expect(bgCompleted[0].isError).toBe(false);
+
+    // The injected content should appear in the user message sent to the provider
+    const firstCallMsgs = calls[0].messages;
+    const injectedUserMsg = firstCallMsgs[0]; // user message should have injected blocks
+    const bgBlock = injectedUserMsg.content.find(
+      (b) => b.type === "text" && b.text.includes("background_tool_result"),
+    );
+    expect(bgBlock).toBeDefined();
+    if (bgBlock && bgBlock.type === "text") {
+      expect(bgBlock.text).toContain("bg result done");
+      expect(bgBlock.text).toContain("bg-exec-1");
+    }
+  });
+
+  // ── Cleanup on conversation end ────────────────────────────────────
+
+  test("cleanup on conversation end", async () => {
+    mockDeferralEnabled = true;
+    mockThresholdSec = 60; // High threshold so no deferral happens
+
+    // Pre-register a background execution
+    const neverResolve = new Promise<{ content: string; isError: boolean }>(
+      () => {},
+    );
+    testBgManager.register({
+      executionId: "cleanup-exec",
+      toolName: "slow_tool",
+      toolUseId: "cleanup-tu",
+      conversationId: "conv-cleanup",
+      startedAt: Date.now(),
+      promise: neverResolve,
+    });
+
+    expect(testBgManager.getActiveCount("conv-cleanup")).toBe(1);
+
+    const { provider } = createMockProvider([textResponse("Done")]);
+    const loop = new AgentLoop(provider, "system", { minTurnIntervalMs: 0 });
+    const events: AgentEvent[] = [];
+    await loop.run(
+      [userMessage],
+      collectEvents(events),
+      undefined,
+      undefined,
+      undefined,
+      "conv-cleanup",
+    );
+
+    // After loop exits, cleanup should have been called
+    expect(testBgManager.getActiveCount("conv-cleanup")).toBe(0);
+  });
+
+  // ── Deferral-exempt tools skip threshold ───────────────────────────
+
+  test("all deferral-exempt tools skip threshold racing", async () => {
+    mockDeferralEnabled = true;
+    mockThresholdSec = 0.01; // 10ms — would normally trigger deferral
+
+    const { provider } = createMockProvider([
+      toolUseResponse("exempt-1", "exempt_tool", {}),
+      textResponse("Done"),
+    ]);
+
+    const toolExecutor = async () => {
+      // Takes longer than threshold, but tool is exempt
+      await Bun.sleep(50);
+      return { content: "exempt result", isError: false };
+    };
+
+    const exemptTools: ToolDefinition[] = [
+      {
+        name: "exempt_tool",
+        description: "An exempt tool",
+        input_schema: { type: "object", properties: {} },
+      },
+    ];
+
+    const getToolByName = (name: string) => {
+      if (name === "exempt_tool") {
+        return {
+          name: "exempt_tool",
+          description: "An exempt tool",
+          category: "test",
+          defaultRiskLevel: RiskLevel.Low,
+          deferralExempt: true,
+          getDefinition: () => exemptTools[0],
+          execute: async () => ({ content: "", isError: false }),
+        };
+      }
+      return undefined;
+    };
+
+    const loop = new AgentLoop(
+      provider,
+      "system",
+      { minTurnIntervalMs: 0 },
+      exemptTools,
+      toolExecutor,
+      undefined,
+      undefined,
+      getToolByName,
+    );
+    const events: AgentEvent[] = [];
+    await loop.run(
+      [userMessage],
+      collectEvents(events),
+      undefined,
+      undefined,
+      undefined,
+      "conv-exempt",
+    );
+
+    // Should NOT have deferred — exempt tools block regardless
+    const deferralEvents = events.filter(
+      (e) => e.type === "tool_deferred_to_background",
+    );
+    expect(deferralEvents).toHaveLength(0);
+
+    // Should have a real tool_result
+    const toolResultEvents = events.filter(
+      (e) => e.type === "tool_result",
+    ) as Extract<AgentEvent, { type: "tool_result" }>[];
+    expect(toolResultEvents).toHaveLength(1);
+    expect(toolResultEvents[0].content).toBe("exempt result");
+  });
+});

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -1,5 +1,8 @@
 import * as Sentry from "@sentry/node";
 
+import { backgroundToolManager } from "../agent/background-tool-manager.js";
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { getConfig } from "../config/loader.js";
 import { estimateToolsTokens } from "../context/token-estimator.js";
 import { truncateOversizedToolResults } from "../context/tool-result-truncation.js";
 import { getHookManager } from "../hooks/manager.js";
@@ -15,6 +18,7 @@ import {
   applyStreamingSubstitution,
   applySubstitutions,
 } from "../tools/sensitive-output-placeholders.js";
+import type { Tool, ToolExecutionResult } from "../tools/types.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("agent-loop");
@@ -83,6 +87,22 @@ export type AgentEvent =
       input: Record<string, unknown>;
     }
   | { type: "server_tool_complete"; toolUseId: string; isError: boolean }
+  | {
+      type: "tool_deferred_to_background";
+      executionId: string;
+      toolName: string;
+      toolUseId: string;
+      elapsedMs: number;
+    }
+  | {
+      type: "background_tool_completed";
+      executionId: string;
+      toolName: string;
+      toolUseId: string;
+      result: string;
+      isError: boolean;
+      durationMs: number;
+    }
   | { type: "error"; error: Error }
   | {
       type: "usage";
@@ -104,6 +124,17 @@ const DEFAULT_CONFIG: AgentLoopConfig = {
 };
 
 const MAX_CONSECUTIVE_ERROR_NUDGES = 3;
+
+/**
+ * Callback type for scheduling a background tool check-in.
+ * Implemented by the conversation layer (PR 6). The agent loop
+ * calls this when a tool result contains `scheduleCheckIn`.
+ */
+export type ScheduleCheckInCallback = (checkIn: {
+  delayMs: number;
+  executionId: string;
+  reason: string;
+}) => void;
 
 export interface ResolvedSystemPrompt {
   systemPrompt: string;
@@ -139,8 +170,15 @@ export class AgentLoop {
         contentBlocks?: ContentBlock[];
         sensitiveBindings?: SensitiveOutputBinding[];
         yieldToUser?: boolean;
+        scheduleCheckIn?: {
+          delayMs: number;
+          executionId: string;
+          reason: string;
+        };
       }>)
     | null;
+  /** Optional lookup for Tool objects — used to check deferralExempt. */
+  private getToolByName: ((name: string) => Tool | undefined) | null;
 
   constructor(
     provider: Provider,
@@ -165,9 +203,15 @@ export class AgentLoop {
       contentBlocks?: ContentBlock[];
       sensitiveBindings?: SensitiveOutputBinding[];
       yieldToUser?: boolean;
+      scheduleCheckIn?: {
+        delayMs: number;
+        executionId: string;
+        reason: string;
+      };
     }>,
     resolveTools?: (history: Message[]) => ToolDefinition[],
     resolveSystemPrompt?: (history: Message[]) => ResolvedSystemPrompt,
+    getToolByName?: (name: string) => Tool | undefined,
   ) {
     this.provider = provider;
     this.systemPrompt = systemPrompt;
@@ -176,6 +220,7 @@ export class AgentLoop {
     this.resolveTools = resolveTools ?? null;
     this.resolveSystemPrompt = resolveSystemPrompt ?? null;
     this.toolExecutor = toolExecutor ?? null;
+    this.getToolByName = getToolByName ?? null;
   }
 
   /**
@@ -198,6 +243,8 @@ export class AgentLoop {
     signal?: AbortSignal,
     requestId?: string,
     onCheckpoint?: (checkpoint: CheckpointInfo) => CheckpointDecision,
+    conversationId?: string,
+    scheduleCheckInCallback?: ScheduleCheckInCallback,
   ): Promise<Message[]> {
     const history = [...messages];
     let toolUseTurns = 0;
@@ -212,8 +259,52 @@ export class AgentLoop {
     const substitutionMap = new Map<string, string>();
     let streamingPending = "";
 
+    // Check the tool-deferral feature flag once per run.
+    const deferralEnabled = isAssistantFeatureFlagEnabled(
+      "tool-deferral",
+      getConfig(),
+    );
+
     while (true) {
       if (signal?.aborted) break;
+
+      // Auto-inject completed background results at the top of each
+      // iteration (before sending to the provider). Only when deferral
+      // is enabled and we have a conversationId.
+      if (deferralEnabled && conversationId) {
+        const completedBgExecs =
+          backgroundToolManager.drainCompleted(conversationId);
+        if (completedBgExecs.length > 0) {
+          const injectionBlocks: ContentBlock[] = [];
+          for (const exec of completedBgExecs) {
+            const resultContent = exec.result?.content ?? "No result available";
+            const isError = exec.result?.isError ?? false;
+            const durationMs = Date.now() - exec.startedAt;
+            injectionBlocks.push({
+              type: "text",
+              text: `<background_tool_result execution_id="${exec.executionId}" tool="${exec.toolName}" tool_use_id="${exec.toolUseId}" status="${isError ? "error" : "success"}" duration_ms="${durationMs}">\n${resultContent}\n</background_tool_result>`,
+            });
+            onEvent({
+              type: "background_tool_completed",
+              executionId: exec.executionId,
+              toolName: exec.toolName,
+              toolUseId: exec.toolUseId,
+              result: resultContent,
+              isError,
+              durationMs,
+            });
+          }
+
+          // Prepend to the last user message's content blocks if available,
+          // otherwise add a new user message
+          const lastMsg = history[history.length - 1];
+          if (lastMsg?.role === "user") {
+            lastMsg.content = [...injectionBlocks, ...lastMsg.content];
+          } else {
+            history.push({ role: "user", content: injectionBlocks });
+          }
+        }
+      }
 
       let toolUseBlocks: Extract<ContentBlock, { type: "tool_use" }>[] = [];
 
@@ -462,47 +553,229 @@ export class AgentLoop {
         // Execute all tools concurrently for reduced latency.
         // Race against the abort signal so cancellation isn't blocked by
         // stuck tools (e.g. a hung browser navigation).
-        const toolExecutionPromise = Promise.all(
-          toolUseBlocks.map(async (toolUse) => {
-            const result = await this.toolExecutor!(
-              toolUse.name,
-              toolUse.input,
-              (chunk) => {
-                onEvent({
-                  type: "tool_output_chunk",
-                  toolUseId: toolUse.id,
-                  chunk,
-                });
-              },
-              toolUse.id,
-            );
+        type ToolUseBlock = Extract<ContentBlock, { type: "tool_use" }>;
+        type ToolResultPair = {
+          toolUse: ToolUseBlock;
+          result: ToolExecutionResult;
+        };
 
-            return { toolUse, result };
-          }),
-        );
-
-        let toolResults: Awaited<typeof toolExecutionPromise>;
-        if (signal && !signal.aborted) {
-          let abortHandler!: () => void;
-          const abortPromise = new Promise<never>((_, reject) => {
-            abortHandler = () =>
-              reject(
-                new DOMException("The operation was aborted", "AbortError"),
-              );
-            signal.addEventListener("abort", abortHandler, { once: true });
+        // Determine if all tools in this batch are deferral-exempt.
+        // If so, skip the threshold race even when deferral is enabled.
+        const allDeferralExempt =
+          deferralEnabled &&
+          this.getToolByName != null &&
+          toolUseBlocks.every((toolUse) => {
+            const toolObj = this.getToolByName!(toolUse.name);
+            return toolObj?.deferralExempt === true;
           });
-          try {
-            toolResults = await Promise.race([
-              toolExecutionPromise,
-              abortPromise,
-            ]);
-          } finally {
+
+        // Should we apply deferral racing for this batch?
+        const applyDeferral =
+          deferralEnabled && conversationId != null && !allDeferralExempt;
+
+        // Track which individual promises have settled (used for deferral)
+        const settled = new Map<number, ToolResultPair>();
+        const toolExecutions = toolUseBlocks.map(async (toolUse, idx) => {
+          const result = await this.toolExecutor!(
+            toolUse.name,
+            toolUse.input,
+            (chunk) => {
+              onEvent({
+                type: "tool_output_chunk",
+                toolUseId: toolUse.id,
+                chunk,
+              });
+            },
+            toolUse.id,
+          );
+          settled.set(idx, { toolUse, result });
+          return { toolUse, result };
+        });
+        const toolExecutionPromise = Promise.all(toolExecutions);
+
+        let toolResults: ToolResultPair[];
+
+        if (applyDeferral) {
+          // Race the batch against the deferral threshold timer
+          const thresholdMs =
+            getConfig().timeouts.toolDeferralThresholdSec * 1000;
+          let thresholdHandle: ReturnType<typeof setTimeout>;
+          const thresholdTimer = new Promise<"threshold">((resolve) => {
+            thresholdHandle = setTimeout(
+              () => resolve("threshold"),
+              thresholdMs,
+            );
+          });
+
+          // Also race against abort if an abort signal is provided
+          let abortHandler: (() => void) | undefined;
+          const racers: Promise<
+            | { type: "all_complete"; results: ToolResultPair[] }
+            | { type: "threshold" }
+            | { type: "aborted" }
+          >[] = [
+            toolExecutionPromise.then((results) => ({
+              type: "all_complete" as const,
+              results,
+            })),
+            thresholdTimer.then(() => ({ type: "threshold" as const })),
+          ];
+          if (signal && !signal.aborted) {
+            const abortPromise = new Promise<{ type: "aborted" }>((resolve) => {
+              abortHandler = () => resolve({ type: "aborted" as const });
+              signal.addEventListener("abort", abortHandler, { once: true });
+            });
+            racers.push(abortPromise);
+          }
+
+          const raceResult = await Promise.race(racers);
+          clearTimeout(thresholdHandle!);
+          if (abortHandler && signal) {
             signal.removeEventListener("abort", abortHandler);
-            // Suppress unhandled rejection from abandoned tool executions
+          }
+
+          if (raceResult.type === "aborted") {
+            // Cancelled — suppress unhandled rejections and synthesize cancellation
             toolExecutionPromise.catch(() => {});
+            const cancelledBlocks: ContentBlock[] = toolUseBlocks.map(
+              (toolUse) => ({
+                type: "tool_result" as const,
+                tool_use_id: toolUse.id,
+                content: "Cancelled by user",
+                is_error: true,
+              }),
+            );
+            history.push({ role: "user", content: cancelledBlocks });
+            break;
+          }
+
+          if (raceResult.type === "all_complete") {
+            // All tools completed before threshold — proceed as normal
+            toolResults = raceResult.results;
+          } else {
+            // Threshold fired — partition into completed and still-running
+            const completedResults: ToolResultPair[] = [];
+            const resultBlocks: ContentBlock[] = [];
+
+            for (let idx = 0; idx < toolUseBlocks.length; idx++) {
+              const toolUse = toolUseBlocks[idx];
+              const completedPair = settled.get(idx);
+              if (completedPair) {
+                completedResults.push(completedPair);
+                // Build a real tool_result block
+                resultBlocks.push({
+                  type: "tool_result" as const,
+                  tool_use_id: toolUse.id,
+                  content: completedPair.result.content,
+                  is_error: completedPair.result.isError,
+                  ...(completedPair.result.contentBlocks
+                    ? { contentBlocks: completedPair.result.contentBlocks }
+                    : {}),
+                });
+                // Merge sensitive bindings from completed results
+                if (completedPair.result.sensitiveBindings) {
+                  for (const binding of completedPair.result
+                    .sensitiveBindings) {
+                    substitutionMap.set(binding.placeholder, binding.value);
+                  }
+                }
+                // Emit tool_result event for the completed tool
+                onEvent({
+                  type: "tool_result",
+                  toolUseId: toolUse.id,
+                  content: completedPair.result.content,
+                  isError: completedPair.result.isError,
+                  diff: completedPair.result.diff,
+                  status: completedPair.result.status,
+                  contentBlocks: completedPair.result.contentBlocks,
+                });
+              } else {
+                // Still running — register with background manager and build placeholder
+                backgroundToolManager.register({
+                  executionId: toolUse.id,
+                  toolName: toolUse.name,
+                  toolUseId: toolUse.id,
+                  conversationId: conversationId!,
+                  startedAt: Date.now() - thresholdMs,
+                  promise: toolExecutions[idx].then((pair) => pair.result),
+                });
+                resultBlocks.push({
+                  type: "tool_result" as const,
+                  tool_use_id: toolUse.id,
+                  content: `This tool is still running in the background (execution_id: ${toolUse.id}).\nElapsed: ${Math.round(thresholdMs / 1000)}s. Use background_tool_control to wait longer, check status, or cancel it.`,
+                  is_error: false,
+                });
+                onEvent({
+                  type: "tool_deferred_to_background",
+                  executionId: toolUse.id,
+                  toolName: toolUse.name,
+                  toolUseId: toolUse.id,
+                  elapsedMs: thresholdMs,
+                });
+              }
+            }
+
+            // Append system notice about deferred tools
+            resultBlocks.push({
+              type: "text",
+              text: `<system_notice>One or more tool executions exceeded the ${Math.round(thresholdMs / 1000)}s deferral threshold and are now running in the background. You have full agency — you can respond to the user, call other tools, or use background_tool_control to wait longer, check status, or cancel background executions. Each deferred tool's placeholder result above includes its execution_id.</system_notice>`,
+            });
+
+            // Suppress unhandled rejections from background promises
+            toolExecutionPromise.catch(() => {});
+
+            // Push combined result blocks and continue the agent loop
+            history.push({ role: "user", content: resultBlocks });
+            toolUseTurns++;
+
+            // Handle scheduleCheckIn from completed results
+            if (scheduleCheckInCallback) {
+              for (const { result } of completedResults) {
+                if (result.scheduleCheckIn) {
+                  scheduleCheckInCallback(result.scheduleCheckIn);
+                }
+              }
+            }
+
+            // Invoke checkpoint callback after tool results are in history
+            if (onCheckpoint) {
+              const decision = onCheckpoint({
+                turnIndex: toolUseTurns - 1,
+                toolCount: toolUseBlocks.length,
+                hasToolUse: true,
+                history,
+              });
+              if (decision === "yield") {
+                break;
+              }
+            }
+
+            continue;
           }
         } else {
-          toolResults = await toolExecutionPromise;
+          // Non-deferral path: original blocking Promise.all with abort racing
+          if (signal && !signal.aborted) {
+            let abortHandler!: () => void;
+            const abortPromise = new Promise<never>((_, reject) => {
+              abortHandler = () =>
+                reject(
+                  new DOMException("The operation was aborted", "AbortError"),
+                );
+              signal.addEventListener("abort", abortHandler, { once: true });
+            });
+            try {
+              toolResults = await Promise.race([
+                toolExecutionPromise,
+                abortPromise,
+              ]);
+            } finally {
+              signal.removeEventListener("abort", abortHandler);
+              // Suppress unhandled rejection from abandoned tool executions
+              toolExecutionPromise.catch(() => {});
+            }
+          } else {
+            toolResults = await toolExecutionPromise;
+          }
         }
 
         // Merge sensitive output bindings from tool results into the
@@ -578,6 +851,15 @@ export class AgentLoop {
 
         toolUseTurns++;
 
+        // Handle scheduleCheckIn from tool results
+        if (scheduleCheckInCallback) {
+          for (const { result } of toolResults) {
+            if (result.scheduleCheckIn) {
+              scheduleCheckInCallback(result.scheduleCheckIn);
+            }
+          }
+        }
+
         // When any tool returned an error, nudge the LLM to retry with
         // corrected parameters instead of ending its turn. Skip the nudge
         // after MAX_CONSECUTIVE_ERROR_NUDGES consecutive error turns
@@ -640,6 +922,11 @@ export class AgentLoop {
         onEvent({ type: "error", error: err });
         break;
       }
+    }
+
+    // Cleanup background tool state for this conversation on loop exit
+    if (deferralEnabled && conversationId) {
+      backgroundToolManager.cleanup(conversationId);
     }
 
     return history;

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -224,6 +224,16 @@ export interface ToolExecutionResult {
    * approval flow transparently.
    */
   cesApprovalRequired?: ApprovalRequired;
+  /**
+   * When present, requests the conversation layer to schedule a check-in
+   * after the specified delay. Used by background_tool_control to schedule
+   * periodic status checks on deferred tool executions.
+   */
+  scheduleCheckIn?: {
+    delayMs: number;
+    executionId: string;
+    reason: string;
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -282,6 +292,12 @@ export interface Tool {
   /** Declared execution target from the skill manifest. Used by resolveExecutionTarget
    * to accurately label lifecycle events for skill-provided tools. */
   executionTarget?: ExecutionTarget;
+  /**
+   * When true, this tool is exempt from the deferral threshold — it will
+   * always block until completion rather than being sent to the background.
+   * Used for tools that must return a real result (e.g. background_tool_control).
+   */
+  deferralExempt?: boolean;
   getDefinition(): ToolDefinition;
   execute(
     input: Record<string, unknown>,


### PR DESCRIPTION
## Summary
- Add deferral threshold racing to agent loop tool execution, gated behind `tool-deferral` feature flag
- When tools exceed the threshold, register them in BackgroundToolManager and return placeholder results
- Auto-inject completed background results at the top of each loop iteration
- Emit `tool_deferred_to_background` and `background_tool_completed` client events
- Add `scheduleCheckInCallback` parameter for PR 6 integration
- Add `deferralExempt` to Tool interface and `scheduleCheckIn` to ToolExecutionResult (PR 4 compatibility)

Part of plan: tool-deferral-background-execution.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
