### PR TITLE
Simplify referral UI for lazy-create backend

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingReferralCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingReferralCard.swift
@@ -3,13 +3,13 @@ import SwiftUI
 import VellumAssistantShared
 
 /// Referral panel — shows referral URL, copy button, stats, and earning cap.
+/// The backend lazily creates a referral code on first GET, so there is
+/// no explicit creation step needed on the client.
 @MainActor
 struct SettingsBillingReferralCard: View {
     @State private var referralCode: ReferralCodeResponse?
     @State private var isLoading: Bool = true
-    @State private var isCreating: Bool = false
     @State private var error: String?
-    @State private var hasNoCode: Bool = false
     @State private var copied: Bool = false
 
     var body: some View {
@@ -18,8 +18,6 @@ struct SettingsBillingReferralCard: View {
                 loadingState
             } else if let error {
                 errorState(error)
-            } else if hasNoCode {
-                noCodeState
             } else if let referralCode {
                 hasCodeState(referralCode)
             }
@@ -41,26 +39,6 @@ struct SettingsBillingReferralCard: View {
                 }
             }
             .accessibilityHidden(true)
-        }
-    }
-
-    // MARK: - No Code State
-
-    private var noCodeState: some View {
-        SettingsCard(title: "Referrals", subtitle: "Share your link and earn credits") {
-            VStack(alignment: .leading, spacing: VSpacing.lg) {
-                Text("Get your personal referral link to share with friends. You'll both earn credits when they sign up.")
-                    .font(VFont.bodyMediumLighter)
-                    .foregroundStyle(VColor.contentSecondary)
-
-                VButton(
-                    label: isCreating ? "Creating..." : "Get Referral Link",
-                    style: .primary,
-                    isDisabled: isCreating
-                ) {
-                    Task { await createCode() }
-                }
-            }
         }
     }
 
@@ -160,29 +138,13 @@ struct SettingsBillingReferralCard: View {
         }
         error = nil
         do {
-            let result = try await BillingService.shared.getReferralCode()
-            referralCode = result
-            hasNoCode = false
-        } catch PlatformAPIError.notFound {
-            hasNoCode = true
+            referralCode = try await BillingService.shared.getReferralCode()
         } catch {
             if referralCode == nil {
                 self.error = "Failed to load referral information."
             }
         }
         isLoading = false
-    }
-
-    private func createCode() async {
-        isCreating = true
-        defer { isCreating = false }
-        do {
-            let result = try await BillingService.shared.createReferralCode()
-            referralCode = result
-            hasNoCode = false
-        } catch {
-            self.error = "Failed to create referral code. Please try again."
-        }
     }
 
     private func copyToClipboard(_ url: String) {

--- a/clients/shared/App/Auth/BillingService.swift
+++ b/clients/shared/App/Auth/BillingService.swift
@@ -161,8 +161,8 @@ public final class BillingService {
         }
     }
 
-    /// Fetch the current user's referral code.
-    /// Throws `PlatformAPIError.notFound` if the user has no referral code yet.
+    /// Fetch the current user's referral code and stats.
+    /// The backend lazily creates a referral code if one doesn't exist yet.
     public func getReferralCode() async throws -> ReferralCodeResponse {
         let urlString = "\(AuthService.shared.baseURL)/v1/referral-codes/me/"
         guard let url = URL(string: urlString) else {
@@ -196,63 +196,6 @@ public final class BillingService {
         let statusCode = httpResponse?.statusCode ?? 0
 
         log.debug("Platform request GET referral-codes/me/ -> \(statusCode)")
-
-        if statusCode == 401 || statusCode == 403 {
-            throw PlatformAPIError.authenticationRequired
-        }
-
-        if statusCode == 404 {
-            throw PlatformAPIError.notFound
-        }
-
-        guard (200..<300).contains(statusCode) else {
-            let detail = String(data: data, encoding: .utf8)
-            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
-        }
-
-        do {
-            return try JSONDecoder().decode(ReferralCodeResponse.self, from: data)
-        } catch {
-            throw PlatformAPIError.decodingError(error.localizedDescription)
-        }
-    }
-
-    /// Create a referral code for the current user.
-    public func createReferralCode() async throws -> ReferralCodeResponse {
-        let urlString = "\(AuthService.shared.baseURL)/v1/referral-codes/me/"
-        guard let url = URL(string: urlString) else {
-            throw PlatformAPIError.invalidURL
-        }
-
-        var urlRequest = URLRequest(url: url)
-        urlRequest.httpMethod = "POST"
-        urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
-        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        urlRequest.httpBody = "{}".data(using: .utf8)
-
-        if let token = await SessionTokenManager.getTokenAsync() {
-            urlRequest.setValue(token, forHTTPHeaderField: "X-Session-Token")
-        } else {
-            throw PlatformAPIError.authenticationRequired
-        }
-
-        guard let organizationId = UserDefaults.standard.string(forKey: "connectedOrganizationId") else {
-            throw PlatformAPIError.authenticationRequired
-        }
-        urlRequest.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
-
-        let data: Data
-        let response: URLResponse
-        do {
-            (data, response) = try await URLSession.shared.data(for: urlRequest)
-        } catch {
-            throw PlatformAPIError.networkError(error.localizedDescription)
-        }
-
-        let httpResponse = response as? HTTPURLResponse
-        let statusCode = httpResponse?.statusCode ?? 0
-
-        log.debug("Platform request POST referral-codes/me/ -> \(statusCode)")
 
         if statusCode == 401 || statusCode == 403 {
             throw PlatformAPIError.authenticationRequired


### PR DESCRIPTION
## Summary
The backend now lazily creates referral codes on GET (vellum-assistant-platform#3807), removing the need for a separate POST endpoint. This simplifies the macOS client:

- Remove `createReferralCode()` POST method from BillingService
- Remove 404 special-case handling from `getReferralCode()` (GET always returns data now)
- Remove no-code CTA state, create button, and related state properties from SettingsBillingReferralCard
- The view now has three states: loading → has code → error (matching the simplified web UI)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
