### PR TITLE
Fix copy button accessibility label and task lifecycle

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingReferralCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingReferralCard.swift
@@ -11,6 +11,7 @@ struct SettingsBillingReferralCard: View {
     @State private var isLoading: Bool = true
     @State private var error: String?
     @State private var copied: Bool = false
+    @State private var copyResetTask: Task<Void, Never>?
 
     var body: some View {
         Group {
@@ -64,7 +65,7 @@ struct SettingsBillingReferralCard: View {
                         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
 
                     VButton(
-                        label: "",
+                        label: copied ? "Copied" : "Copy referral link",
                         iconOnly: copied ? VIcon.check.rawValue : VIcon.copy.rawValue,
                         style: .ghost
                     ) {
@@ -151,8 +152,10 @@ struct SettingsBillingReferralCard: View {
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(url, forType: .string)
         copied = true
-        Task {
+        copyResetTask?.cancel()
+        copyResetTask = Task {
             try? await Task.sleep(nanoseconds: 2_000_000_000)
+            guard !Task.isCancelled else { return }
             copied = false
         }
     }


### PR DESCRIPTION
## Summary
Addresses review feedback from Codex and Devin:

- **Accessibility**: Set `label` to `"Copy referral link"` / `"Copied"` on the icon-only copy button so VoiceOver exposes a meaningful label
- **Task lifecycle**: Store the copy-reset Task in `@State`, cancel the previous one before starting a new one, and guard `!Task.isCancelled` after sleep — prevents premature reset on rapid clicks
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23599" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
