### PR TITLE
fix: filter gone nodes from inspect --query results

### DIFF
--- a/assistant/src/memory/graph/inspect.ts
+++ b/assistant/src/memory/graph/inspect.ts
@@ -271,6 +271,7 @@ async function showQuery(query: string) {
     for (const r of results) {
       const node = nodeMap.get(r.nodeId);
       if (!node) continue;
+      if (node.fidelity === "gone") continue;
       const preview =
         node.content.length > 120
           ? node.content.slice(0, 120) + "…"


### PR DESCRIPTION
## Summary
- Add `node.fidelity === "gone"` check in `showQuery()` display loop
- Prevents stale gone nodes from appearing in `--query` results

Part of plan: fix-skill-retrieval.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23600" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
