### PR TITLE
fix: extend old-format capability cleanup to cli:* nodes

### DIFF
--- a/assistant/src/memory/graph/capability-seed.ts
+++ b/assistant/src/memory/graph/capability-seed.ts
@@ -126,11 +126,11 @@ export function seedSkillGraphNodes(): void {
 
     pruneStaleCapabilities(SKILL_SOURCE_PREFIX, seenKeys);
 
-    // Clean up old-format nodes created by the legacy skill-memory.ts system.
-    // Those nodes have content like "skill:{id}\n..." instead of the current
-    // 'The "..." skill ...' format. Mark them as gone so they stop appearing
-    // as duplicates. Idempotent — once cleaned, subsequent runs find nothing.
-    cleanupOldFormatSkillNodes();
+    // Clean up old-format capability nodes (skill:* and cli:*) that use the
+    // legacy "{prefix}:{id}\n..." content format. Mark them as gone so they
+    // stop appearing as duplicates. Idempotent — once cleaned, subsequent
+    // runs find nothing.
+    cleanupOldFormatCapabilityNodes();
   } catch (err) {
     log.warn({ err }, "Failed to seed skill graph nodes");
   }
@@ -311,15 +311,18 @@ function deleteCapabilityNode(sourceKey: string): void {
 }
 
 /**
- * Find and soft-delete old-format skill memory nodes.
+ * Find and soft-delete old-format capability memory nodes (skill:* and cli:*).
  *
- * The legacy skill-memory.ts system stored content as "skill:{id}\n{statement}".
- * The current system uses "The "..." skill ..." prose format. This marks any
- * remaining old-format nodes as gone so they no longer surface in retrieval.
+ * The legacy system stored content as "skill:{id}\n{statement}" or
+ * "cli:{command}\n{statement}". The current system uses prose format.
+ * This marks any remaining old-format nodes as gone so they no longer
+ * surface in retrieval.
  */
-function cleanupOldFormatSkillNodes(): void {
+function cleanupOldFormatCapabilityNodes(): void {
   const db = getDb();
+  const now = Date.now();
 
+  // --- skill:* old-format nodes ---
   const oldFormatNodes = db
     .select()
     .from(memoryGraphNodes)
@@ -333,7 +336,6 @@ function cleanupOldFormatSkillNodes(): void {
     )
     .all();
 
-  const now = Date.now();
   for (const node of oldFormatNodes) {
     // Verify this is truly old-format: "skill:{id}\n..."
     if (!/^skill:\S+\n/.test(node.content)) continue;
@@ -343,6 +345,29 @@ function cleanupOldFormatSkillNodes(): void {
       .where(eq(memoryGraphNodes.id, node.id))
       .run();
     log.info({ nodeId: node.id }, "Cleaned up old-format skill memory node");
+  }
+
+  // --- cli:* old-format nodes ---
+  const oldCliNodes = db
+    .select()
+    .from(memoryGraphNodes)
+    .where(
+      and(
+        eq(memoryGraphNodes.type, "procedural"),
+        eq(memoryGraphNodes.scopeId, "default"),
+        sql`${memoryGraphNodes.fidelity} != 'gone'`,
+        sql`${memoryGraphNodes.content} LIKE 'cli:%'`,
+      ),
+    )
+    .all();
+
+  for (const node of oldCliNodes) {
+    if (!/^cli:\S+\n/.test(node.content)) continue;
+    db.update(memoryGraphNodes)
+      .set({ fidelity: "gone", lastAccessed: now })
+      .where(eq(memoryGraphNodes.id, node.id))
+      .run();
+    log.info({ nodeId: node.id }, "Cleaned up old-format CLI memory node");
   }
 }
 


### PR DESCRIPTION
## Summary
- Rename `cleanupOldFormatSkillNodes` to `cleanupOldFormatCapabilityNodes`
- Add cleanup pass for old-format `cli:*` nodes matching `^cli:\S+\n`
- Removes 20+ duplicate CLI capability nodes that were crowding the procedural reserve

Part of plan: fix-skill-retrieval.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23602" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
