### PR TITLE
fix: delete Qdrant embeddings when capability nodes are marked gone

### DIFF
--- a/assistant/src/memory/graph/capability-seed.ts
+++ b/assistant/src/memory/graph/capability-seed.ts
@@ -307,6 +307,10 @@ function deleteCapabilityNode(sourceKey: string): void {
       .set({ fidelity: "gone", lastAccessed: Date.now() })
       .where(eq(memoryGraphNodes.id, existing.id))
       .run();
+    enqueueMemoryJob("delete_qdrant_vectors", {
+      targetType: "graph_node",
+      targetId: existing.id,
+    });
   }
 }
 
@@ -344,6 +348,10 @@ function cleanupOldFormatCapabilityNodes(): void {
       .set({ fidelity: "gone", lastAccessed: now })
       .where(eq(memoryGraphNodes.id, node.id))
       .run();
+    enqueueMemoryJob("delete_qdrant_vectors", {
+      targetType: "graph_node",
+      targetId: node.id,
+    });
     log.info({ nodeId: node.id }, "Cleaned up old-format skill memory node");
   }
 
@@ -367,6 +375,10 @@ function cleanupOldFormatCapabilityNodes(): void {
       .set({ fidelity: "gone", lastAccessed: now })
       .where(eq(memoryGraphNodes.id, node.id))
       .run();
+    enqueueMemoryJob("delete_qdrant_vectors", {
+      targetType: "graph_node",
+      targetId: node.id,
+    });
     log.info({ nodeId: node.id }, "Cleaned up old-format CLI memory node");
   }
 }
@@ -404,6 +416,10 @@ function pruneStaleCapabilities(prefix: string, activeKeys: Set<string>): void {
           .set({ fidelity: "gone", lastAccessed: now })
           .where(eq(memoryGraphNodes.id, row.id))
           .run();
+        enqueueMemoryJob("delete_qdrant_vectors", {
+          targetType: "graph_node",
+          targetId: row.id,
+        });
       }
     } catch {
       // Skip malformed JSON


### PR DESCRIPTION
## Summary
- Enqueue `delete_qdrant_vectors` job whenever a capability node is marked as gone
- Covers all three paths: `deleteCapabilityNode`, `cleanupOldFormatCapabilityNodes`, `pruneStaleCapabilities`
- Prevents stale gone nodes from appearing in Qdrant vector search results

Part of plan: fix-skill-retrieval.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
