### PR TITLE
fix: waitFor() race with cancellation and cleanup() abort

### DIFF
--- a/assistant/src/agent/background-tool-manager.ts
+++ b/assistant/src/agent/background-tool-manager.ts
@@ -89,17 +89,27 @@ export class BackgroundToolManager {
         entry.promise
           .then((result) => {
             clearTimeout(timer);
-            resolve({ completed: true, result });
+            // Re-check the entry — it may have been cancelled while we waited
+            const current = this.executions.get(executionId);
+            if (current && current.status === "cancelled") {
+              resolve({ completed: false });
+            } else {
+              resolve({ completed: true, result });
+            }
           })
           .catch(() => {
             clearTimeout(timer);
             // Re-read the entry — the .then handler in register() may have
-            // already populated the error result.
+            // already populated the error result, or it may have been cancelled.
             const current = this.executions.get(executionId);
-            resolve({
-              completed: true,
-              result: current?.result,
-            });
+            if (current && current.status === "cancelled") {
+              resolve({ completed: false });
+            } else {
+              resolve({
+                completed: true,
+                result: current?.result,
+              });
+            }
           });
       },
     );
@@ -160,6 +170,9 @@ export class BackgroundToolManager {
   cleanup(conversationId: string): void {
     for (const [id, entry] of this.executions) {
       if (entry.conversationId === conversationId) {
+        if (entry.status === "running" && entry.abortController) {
+          entry.abortController.abort();
+        }
         this.executions.delete(id);
       }
     }


### PR DESCRIPTION
## Summary
Fixes two gaps in BackgroundToolManager:
- waitFor() now re-checks entry status after promise settles (cancelled entries return completed:false)
- cleanup() aborts running executions before removing them

Part of plan: tool-deferral-background-execution.md (review fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
