### PR TITLE
fix(chat): isolate pulsing dot animation to prevent jump on parent re-eval (LUM-691)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -563,10 +563,7 @@ struct AssistantProgressView: View {
                     .foregroundStyle(VColor.systemNegativeStrong)
             }
         default:
-            Circle()
-                .fill(VColor.primaryBase)
-                .frame(width: 8, height: 8)
-                .modifier(AssistantProgressPulsingModifier())
+            PulsingDot(size: 8)
         }
     }
 
@@ -813,10 +810,7 @@ private struct StepDetailRow: View {
                             .foregroundStyle(VColor.contentTertiary)
                             .frame(width: 16)
                     } else {
-                        Circle()
-                            .fill(VColor.primaryBase)
-                            .frame(width: 6, height: 6)
-                            .modifier(AssistantProgressPulsingModifier())
+                        PulsingDot(size: 6)
                             .frame(width: 16)
                     }
 
@@ -1149,13 +1143,26 @@ private struct CompactPermissionChip: View {
     }
 }
 
-// MARK: - Pulsing Modifier
+// MARK: - Pulsing Dot
 
-private struct AssistantProgressPulsingModifier: ViewModifier {
+/// Isolated pulsing dot view with its own @State for the animation flag.
+///
+/// Extracting the animation into its own struct prevents the repeatForever
+/// animation from restarting ("jumping") when the parent AssistantProgressView
+/// body re-evaluates due to tool call updates. Each body re-eval in the parent
+/// would otherwise re-create the ViewModifier and reset its @State, causing
+/// the animated opacity to jump back to its start value mid-pulse.
+///
+/// - SeeAlso: LUM-691
+private struct PulsingDot: View {
+    var size: CGFloat = 8
+
     @State private var isPulsing = false
 
-    func body(content: Content) -> some View {
-        content
+    var body: some View {
+        Circle()
+            .fill(VColor.primaryBase)
+            .frame(width: size, height: size)
             .opacity(isPulsing ? 0.6 : 1.0)
             .animation(
                 Animation.easeInOut(duration: 1.8).repeatForever(autoreverses: true),


### PR DESCRIPTION
> Authored by Merlin (coding agent) on behalf of Ashlee Radka
> Ticket: LUM-691

## Summary

Fixes the pulsing dot on `ToolConfirmationBubble` (and tool step rows) jumping offscreen when the app window is small.

## Root Cause

`AssistantProgressPulsingModifier` was a `ViewModifier` with `@State var isPulsing`. ViewModifier state is owned by the parent view — so every time `AssistantProgressView.body` re-evaluated (which happens constantly during tool execution as tool names, progress, and timing update), the modifier was re-created and its `@State` reset to `false`. This restarted the `repeatForever` animation from the beginning, causing the dot to visually jump.

At narrow window widths, the dot sits at the edge of a tight layout, so the animation restart appears as the dot jumping offscreen.

This is a well-known SwiftUI pattern issue: `repeatForever` animations must be isolated in their own view struct with independent `@State`, so their body only re-evaluates when their own animation flag changes — not when any parent property changes.

## Fix

Replaced `AssistantProgressPulsingModifier` (a `ViewModifier`) with `PulsingDot` (a standalone `View` struct). The struct owns its `@State var isPulsing` independently from the parent. Two call sites updated:
- `statusIcon` (8pt dot in the progress card header)
- `StepDetailRow` (6pt dot for in-progress steps)

## Why This Is Safe

- Purely structural change — identical visual output and animation behavior
- No behavior change to tool confirmation, keyboard handling, or progress phase logic
- The `frame(width: 16)` wrapper in `StepDetailRow` is preserved outside `PulsingDot` so layout is unchanged
- Build verified clean

## What Was Considered and Rejected

- **Adding `.clipped()` to the parent container**: Would hide the symptom but not fix the root cause (animation restart). The dot would stop appearing to go offscreen but would still stutter.
- **Keeping `ViewModifier`, using `withAnimation` in `onAppear` instead of `.animation(value:)`**: Still re-creates the modifier on parent re-eval, so `@State` still resets.
- **`TimelineView`-based animation**: More complex, no advantage over isolated struct for a simple opacity pulse.

## Files Changed

- `clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
