### PR TITLE
fix: conversation-scope check and terminal status in background_tool_control

### DIFF
--- a/assistant/src/__tests__/background-tool-control.test.ts
+++ b/assistant/src/__tests__/background-tool-control.test.ts
@@ -253,6 +253,8 @@ describe("background_tool_control", () => {
 
   describe("unknown action", () => {
     test("returns error for invalid action", async () => {
+      registerFakeExecution("exec-x");
+
       const result = await backgroundToolControlTool.execute(
         { execution_id: "exec-x", action: "restart" },
         makeContext(),
@@ -260,6 +262,93 @@ describe("background_tool_control", () => {
 
       expect(result.isError).toBe(true);
       expect(result.content).toContain("Unknown action");
+    });
+  });
+
+  describe("conversation ownership", () => {
+    test("returns error when execution belongs to a different conversation", async () => {
+      // Register under a different conversation
+      backgroundToolManager.register({
+        executionId: "exec-other-conv",
+        toolName: "test_tool",
+        toolUseId: "tu-other",
+        conversationId: "conv-different",
+        startedAt: Date.now(),
+        promise: new Promise(() => {}),
+      });
+
+      const result = await backgroundToolControlTool.execute(
+        { execution_id: "exec-other-conv", action: "wait" },
+        makeContext(), // uses conversationId "conv-test-123"
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("does not belong to this conversation");
+
+      // Cleanup the other conversation's entry
+      backgroundToolManager.cleanup("conv-different");
+    });
+
+    test("cancel returns error when execution belongs to a different conversation", async () => {
+      backgroundToolManager.register({
+        executionId: "exec-other-cancel",
+        toolName: "test_tool",
+        toolUseId: "tu-other-cancel",
+        conversationId: "conv-different",
+        startedAt: Date.now(),
+        promise: new Promise(() => {}),
+      });
+
+      const result = await backgroundToolControlTool.execute(
+        { execution_id: "exec-other-cancel", action: "cancel" },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("does not belong to this conversation");
+
+      backgroundToolManager.cleanup("conv-different");
+    });
+  });
+
+  describe("terminal status before deferred check-in", () => {
+    test("long wait on completed execution returns result immediately without scheduleCheckIn", async () => {
+      const { resolve } = registerFakeExecution("exec-terminal-done");
+      resolve({ content: "Already finished", isError: false });
+      // Allow microtask to settle
+      await new Promise((r) => setTimeout(r, 10));
+
+      const result = await backgroundToolControlTool.execute(
+        {
+          execution_id: "exec-terminal-done",
+          action: "wait",
+          wait_seconds: 30,
+        },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("completed");
+      expect(result.content).toContain("Already finished");
+      expect(result.scheduleCheckIn).toBeUndefined();
+    });
+
+    test("long wait on cancelled execution returns immediately without scheduleCheckIn", async () => {
+      registerFakeExecution("exec-terminal-cancelled");
+      backgroundToolManager.cancel("exec-terminal-cancelled");
+
+      const result = await backgroundToolControlTool.execute(
+        {
+          execution_id: "exec-terminal-cancelled",
+          action: "wait",
+          wait_seconds: 30,
+        },
+        makeContext(),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("cancelled");
+      expect(result.scheduleCheckIn).toBeUndefined();
     });
   });
 });

--- a/assistant/src/agent/background-tool-manager.ts
+++ b/assistant/src/agent/background-tool-manager.ts
@@ -52,6 +52,7 @@ export class BackgroundToolManager {
     status: "running" | "completed" | "cancelled";
     elapsedMs: number;
     toolName: string;
+    conversationId: string;
     result?: ToolExecutionResult;
   } | null {
     const entry = this.executions.get(executionId);
@@ -60,6 +61,7 @@ export class BackgroundToolManager {
       status: entry.status,
       elapsedMs: Date.now() - entry.startedAt,
       toolName: entry.toolName,
+      conversationId: entry.conversationId,
       result: entry.result,
     };
   }

--- a/assistant/src/tools/background-tool-control.ts
+++ b/assistant/src/tools/background-tool-control.ts
@@ -61,6 +61,21 @@ class BackgroundToolControlTool implements Tool {
     const action = input.action as string;
     const waitSeconds = input.wait_seconds as number | undefined;
 
+    // Verify the execution exists and belongs to this conversation
+    const status = backgroundToolManager.getStatus(executionId);
+    if (!status) {
+      return {
+        content: `No execution found with ID ${executionId}`,
+        isError: true,
+      };
+    }
+    if (status.conversationId !== context.conversationId) {
+      return {
+        content: `Execution ${executionId} does not belong to this conversation`,
+        isError: true,
+      };
+    }
+
     if (action === "cancel") {
       const result = backgroundToolManager.cancel(executionId);
       return {
@@ -70,15 +85,6 @@ class BackgroundToolControlTool implements Tool {
     }
 
     if (action === "wait") {
-      // Unknown execution ID check
-      const status = backgroundToolManager.getStatus(executionId);
-      if (!status) {
-        return {
-          content: `No execution found with ID ${executionId}`,
-          isError: true,
-        };
-      }
-
       // Immediate status check (no wait_seconds or 0)
       if (waitSeconds === undefined || waitSeconds === 0) {
         if (status.status === "completed" && status.result) {
@@ -115,7 +121,21 @@ class BackgroundToolControlTool implements Tool {
         };
       }
 
-      // Long wait — return immediately with scheduleCheckIn
+      // Long wait — but if already terminal, return immediately
+      if (status.status === "completed" && status.result) {
+        return {
+          content: `Execution ${executionId} completed:\n${status.result.content}`,
+          isError: status.result.isError,
+        };
+      }
+      if (status.status === "cancelled") {
+        return {
+          content: `Execution ${executionId} was cancelled`,
+          isError: false,
+        };
+      }
+
+      // Still running — schedule deferred check-in
       return {
         content: `Deferred check-in scheduled for execution ${executionId} in ${waitSeconds}s`,
         isError: false,


### PR DESCRIPTION
## Summary
- Add conversation ownership check: background_tool_control now verifies the calling conversation owns the execution before allowing wait/cancel operations
- Return terminal results immediately for completed/cancelled executions instead of scheduling pointless deferred check-ins
- Extend BackgroundToolManager.getStatus() to include conversationId for ownership verification

## Test plan
- [x] Existing tests updated and passing (31 tests across 2 files)
- [x] New tests for conversation ownership enforcement (wait + cancel)
- [x] New tests for terminal status short-circuit on long waits (completed + cancelled)
- [x] Type-check passes

Part of plan: tool-deferral-background-execution.md (review fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23607" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
