### PR TITLE
fix: agent-loop-deferral test mock setup

### DIFF
--- a/assistant/src/__tests__/agent-loop-deferral.test.ts
+++ b/assistant/src/__tests__/agent-loop-deferral.test.ts
@@ -32,15 +32,32 @@ mock.module("../config/loader.js", () => ({
   }),
 }));
 
-// Background tool manager: real implementation for integration tests
-// We import the real class and create a fresh instance per test
+// Background tool manager: real implementation for integration tests.
+// Bun's mock.module() snapshots exports at registration time, so a getter
+// won't re-evaluate dynamically. We create a stable instance up-front and
+// return it directly. In beforeEach we swap the delegate to a fresh instance
+// via our thin proxy wrapper, giving each test a clean slate.
 import { BackgroundToolManager } from "../agent/background-tool-manager.js";
 
-let testBgManager: BackgroundToolManager;
-mock.module("../agent/background-tool-manager.js", () => ({
-  get backgroundToolManager() {
-    return testBgManager;
+let testBgManager = new BackgroundToolManager();
+
+// Proxy that delegates all property access to whichever BackgroundToolManager
+// instance `testBgManager` currently points to. This lets mock.module()
+// capture one stable reference while beforeEach can swap the underlying
+// manager freely.
+const bgManagerProxy = new Proxy({} as BackgroundToolManager, {
+  get(_target, prop, _receiver) {
+    const value = Reflect.get(testBgManager, prop, testBgManager);
+    // Bind methods so `this` inside the real manager is correct
+    if (typeof value === "function") {
+      return value.bind(testBgManager);
+    }
+    return value;
   },
+});
+
+mock.module("../agent/background-tool-manager.js", () => ({
+  backgroundToolManager: bgManagerProxy,
   BackgroundToolManager,
 }));
 


### PR DESCRIPTION
## Summary
Fix BackgroundToolManager mock in agent-loop-deferral tests — use stable Proxy wrapper instead of getter pattern that doesn't work with Bun ESM module mocks.

The getter on the mock object (`get backgroundToolManager() { return testBgManager; }`) was evaluated once at mock registration time when `testBgManager` was undefined, causing all 6 of 7 tests that access the manager to fail. The fix uses a Proxy that delegates to the current `testBgManager` instance, which beforeEach can swap to a fresh manager each run.

Part of plan: tool-deferral-background-execution.md (review fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23608" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
