### PR TITLE
fix: wire deferral events, getToolByName, and all .run() call sites

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -951,6 +951,28 @@ export async function dispatchAgentEvent(
       case "usage":
         handleUsage(state, deps, event);
         break;
+      case "tool_deferred_to_background":
+        deps.onEvent({
+          type: "tool_deferred_to_background",
+          executionId: event.executionId,
+          toolName: event.toolName,
+          toolUseId: event.toolUseId,
+          elapsedMs: event.elapsedMs,
+          conversationId: deps.ctx.conversationId,
+        });
+        break;
+      case "background_tool_completed":
+        deps.onEvent({
+          type: "background_tool_completed",
+          executionId: event.executionId,
+          toolName: event.toolName,
+          toolUseId: event.toolUseId,
+          result: event.result,
+          isError: event.isError,
+          durationMs: event.durationMs,
+          conversationId: deps.ctx.conversationId,
+        });
+        break;
     }
   } catch (err) {
     log.error(

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1077,6 +1077,8 @@ export async function runAgentLoopImpl(
       abortController.signal,
       reqId,
       onCheckpoint,
+      ctx.conversationId,
+      scheduleCheckInCallback,
     );
 
     // ── Proactive mid-loop compaction ───────────────────────────────
@@ -1398,6 +1400,8 @@ export async function runAgentLoopImpl(
           abortController.signal,
           reqId,
           onCheckpoint,
+          ctx.conversationId,
+          scheduleCheckInCallback,
         );
 
         // If the rerun still yields at checkpoint, the turn is still
@@ -1517,6 +1521,8 @@ export async function runAgentLoopImpl(
               abortController.signal,
               reqId,
               onCheckpoint,
+              ctx.conversationId,
+              scheduleCheckInCallback,
             );
           } else {
             // User denied compression — emit a graceful assistant explanation
@@ -1633,6 +1639,8 @@ export async function runAgentLoopImpl(
             abortController.signal,
             reqId,
             onCheckpoint,
+            ctx.conversationId,
+            scheduleCheckInCallback,
           );
         }
         // action === "fail_gracefully" falls through to the final error below

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -58,6 +58,7 @@ import type { AuthContext } from "../runtime/auth/types.js";
 import * as approvalOverrides from "../runtime/conversation-approval-overrides.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { ToolExecutor } from "../tools/executor.js";
+import { getTool } from "../tools/registry.js";
 import { getLogger } from "../util/logger.js";
 import type { AssistantAttachmentDraft } from "./assistant-attachments.js";
 import { runAgentLoopImpl } from "./conversation-agent-loop.js";
@@ -430,6 +431,7 @@ export class Conversation {
       toolDefs.length > 0 ? toolExecutor : undefined,
       resolveTools,
       resolveSystemPromptCallback,
+      (name: string) => getTool(name),
     );
     this.contextWindowManager = new ContextWindowManager({
       provider,


### PR DESCRIPTION
## Summary
- Add dispatch cases for tool_deferred_to_background and background_tool_completed events so they reach WebSocket clients
- Wire getToolByName into AgentLoop constructor for deferralExempt support
- Pass conversationId and scheduleCheckInCallback to ALL agentLoop.run() calls (4 previously missing)

Part of plan: tool-deferral-background-execution.md (review fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23609" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
