### PR TITLE
fix: wire cleanup to conversation abort and fix stale test

### DIFF
--- a/assistant/src/__tests__/agent-loop-deferral.test.ts
+++ b/assistant/src/__tests__/agent-loop-deferral.test.ts
@@ -536,9 +536,9 @@ describe("AgentLoop deferral", () => {
     }
   });
 
-  // ── Cleanup on conversation end ────────────────────────────────────
+  // ── Background executions survive across run() calls ────────────────
 
-  test("cleanup on conversation end", async () => {
+  test("background executions survive across run() calls", async () => {
     mockDeferralEnabled = true;
     mockThresholdSec = 60; // High threshold so no deferral happens
 
@@ -569,8 +569,10 @@ describe("AgentLoop deferral", () => {
       "conv-cleanup",
     );
 
-    // After loop exits, cleanup should have been called
-    expect(testBgManager.getActiveCount("conv-cleanup")).toBe(0);
+    // After loop exits, background executions should still be active —
+    // cleanup is the conversation lifecycle's responsibility (abort/dispose),
+    // not the agent loop's.
+    expect(testBgManager.getActiveCount("conv-cleanup")).toBe(1);
   });
 
   // ── Deferral-exempt tools skip threshold ───────────────────────────

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -15,6 +15,7 @@
  * - conversation-usage.ts        — recordUsage
  */
 
+import { backgroundToolManager } from "../agent/background-tool-manager.js";
 import type { ResolvedSystemPrompt } from "../agent/loop.js";
 import { AgentLoop } from "../agent/loop.js";
 import type {
@@ -579,6 +580,7 @@ export class Conversation {
       clearTimeout(handle);
     }
     this.checkInTimers.clear();
+    backgroundToolManager.cleanup(this.conversationId);
     abortConversation(this);
   }
 


### PR DESCRIPTION
## Summary
- Add backgroundToolManager.cleanup(conversationId) to Conversation.abort() to prevent memory leaks
- Update agent-loop-deferral test to verify background executions survive across run() calls

Part of plan: tool-deferral-background-execution.md (review fix round 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23610" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
