### PR TITLE
perf(chat): add MessageCellHeightCache to eliminate recursive sizeThatFits on completed cells (LUM-720)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -184,6 +184,18 @@ struct MessageListContentView: View, Equatable {
                 let cellActivePendingRequestId: String? =
                     (message.confirmation != nil || !message.toolCalls.isEmpty)
                     ? state.activePendingRequestId : nil
+                // A cell is height-cacheable when its rendered size is stable:
+                // not streaming, no pending confirmation, all tool calls done,
+                // not the latest assistant cell (may still grow), not highlighted.
+                // Exempt cells always re-measure; cached cells get a definite
+                // frame(height:) so LazyVStack.sizeThatFits returns immediately
+                // without recursing into the cell subtree.
+                let isCellHeightCacheable = !message.isStreaming
+                    && message.confirmation?.state != .pending
+                    && message.toolCalls.allSatisfy { $0.isComplete }
+                    && !isLatestAssistant
+                    && highlightedMessageId != message.id
+                let cachedHeight = isCellHeightCacheable ? scrollState.cellHeightCache[message.id] : nil
                 MessageCellView(
                     message: message,
                     showTimestamp: state.showTimestamp.contains(message.id),
@@ -226,6 +238,13 @@ struct MessageListContentView: View, Equatable {
                     providerCatalogHash: providerCatalogHash
                 )
                 .equatable()
+                .frame(height: cachedHeight)
+                .onGeometryChange(for: CGFloat.self) { proxy in
+                    proxy.size.height
+                } action: { height in
+                    guard isCellHeightCacheable, height > 0 else { return }
+                    scrollState.cellHeightCache[message.id] = height
+                }
             }
 
             ForEach(state.orphanSubagents) { subagent in

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -238,13 +238,20 @@ struct MessageListContentView: View, Equatable {
                     providerCatalogHash: providerCatalogHash
                 )
                 .equatable()
-                .frame(height: cachedHeight)
+                // Measure natural content height BEFORE applying the cached frame
+                // so the cache is always updated from unconstrained layout, not
+                // from the pinned frame. This makes the cache self-correcting:
+                // if anything changes cell height (window resize, showTimestamp
+                // toggle, dismissedDocumentSurfaceIds) the next layout pass
+                // writes the correct height and the pinned frame updates on the
+                // following render.
                 .onGeometryChange(for: CGFloat.self) { proxy in
                     proxy.size.height
                 } action: { height in
                     guard isCellHeightCacheable, height > 0 else { return }
                     scrollState.cellHeightCache[message.id] = height
                 }
+                .frame(height: cachedHeight)
             }
 
             ForEach(state.orphanSubagents) { subagent in

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -247,6 +247,13 @@ final class MessageListScrollState {
 
     // MARK: - Layout Cache Fields
 
+    /// Cached rendered heights for completed, non-streaming message cells.
+    /// Applied as `.frame(height:)` so `LazyVStack.sizeThatFits` returns
+    /// immediately without recursing into the cell subtree on every flush.
+    /// Keyed by message ID; invalidated on conversation switch and when a
+    /// message transitions back to active (streaming, pending confirmation).
+    @ObservationIgnored var cellHeightCache: [UUID: CGFloat] = [:]
+
     @ObservationIgnored var cachedLayoutKey: PrecomputedCacheKey?
     @ObservationIgnored var cachedLayoutMetadata: CachedMessageLayoutMetadata?
     @ObservationIgnored var messageListVersion: Int = 0
@@ -593,6 +600,7 @@ final class MessageListScrollState {
         if _isPaginationInFlight { _isPaginationInFlight = false }
         wasPaginationTriggerInRange = false
         lastPaginationCompletedAt = .distantPast
+        cellHeightCache.removeAll()
         cachedLayoutKey = nil
         cachedLayoutMetadata = nil
         cachedDerivedStateBox = nil

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -168,6 +168,9 @@ extension MessageListView {
     func handleContainerWidthChanged() {
         guard containerWidth > 0, abs(containerWidth - scrollState.lastHandledContainerWidth) > 2 else { return }
         scrollState.lastHandledContainerWidth = containerWidth
+        // Cell heights are width-dependent (text reflows). Invalidate so cells
+        // re-measure at their natural height on the next layout pass.
+        scrollState.cellHeightCache.removeAll()
         resizeScrollTask?.cancel()
         resizeScrollTask = Task { @MainActor [scrollState] in
             scrollState.beginStabilization(.resize)


### PR DESCRIPTION
> Authored by Merlin (coding agent) on behalf of Ashlee Radka
> Ticket: LUM-720

## Summary

Adds a cell height cache to `MessageListScrollState` that eliminates recursive `sizeThatFits` traversal for completed message cells during `LazyVStack` measurement — the root cause of multi-second hangs during streaming and tool execution.

## Root Cause

SwiftUI's `LazyVStack` calls `sizeThatFits` on every visible cell on every transaction flush, regardless of whether the cell's body was re-evaluated. With ~7+ layout nodes per cell, this costs O(visible\_cells × nesting\_depth) per flush. During streaming (every ~16ms), a conversation with 10 completed cells means 10 full subtree measurements per flush.

The `Equatable + .equatable()` chain we built prevents **body re-evaluation** — that work is correct. But layout measurement is a separate pass that `LazyVStack` always runs.

## Fix

Cache the rendered height of each completed cell in `MessageListScrollState.cellHeightCache`. Apply cached heights as `.frame(height:)` so `sizeThatFits` returns immediately without recursing into the cell subtree.

A cell is height-cacheable when its rendered size is stable:
- Not streaming
- No pending confirmation
- All tool calls complete
- Not the latest assistant cell (may still grow)
- Not highlighted

All other cells remain uncached and measure normally.

Heights are captured via `.onGeometryChange(for: CGFloat.self)` after first render, so cells always display correctly before being cached. Cache is cleared on conversation switch via `MessageListScrollState.reset()`.

## Before / After

| | Before (#23611) | After (this PR) |
|---|---|---|
| Spindump hang | ~24s | Expected ~0s for completed cells |
| Measurement cost | O(visible\_cells × depth) per flush | O(1) per flush for cached cells |

## Files Changed

- `MessageListScrollState.swift` — adds `cellHeightCache: [UUID: CGFloat]`, clears on reset
- `MessageListContentView.swift` — computes `isCellHeightCacheable`, applies `.frame(height: cachedHeight)`, captures via `.onGeometryChange`

## Why This Is Safe

- First render always measures normally — cache only applied on subsequent flushes
- Cacheable condition is conservative — any active state (streaming, tool running, pending confirmation, highlight) exempts the cell
- `@ObservationIgnored` field — no SwiftUI observable writes on cache update
- Conversation switch clears cache via existing `reset()` call
- No change to `MessageCellView`, `ChatBubble`, or any leaf views

## Testing

Build and send a message that triggers tool calls. After the tool completes and the assistant finishes responding, the conversation should remain fully responsive — no freeze when the next message is sent.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23612" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
