### PR TITLE
fix: render italic/bold markdown in chat messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -472,6 +472,33 @@ struct MarkdownSegmentView: View, Equatable {
         font: NSFont,
         textColor: NSColor
     ) -> NSAttributedString {
+        // Pre-collect emphasis info from the source AttributedString.
+        // Reading inlinePresentationIntent directly from AttributedString.runs
+        // avoids relying on NSAttributedString attribute bridging, which can
+        // silently drop InlinePresentationIntent (a Swift struct / OptionSet)
+        // when it doesn't bridge to NSNumber during the conversion.
+        struct EmphasisRun {
+            let utf16Offset: Int
+            let utf16Length: Int
+            let intent: InlinePresentationIntent
+            let hasExplicitFont: Bool
+        }
+        var emphasisRuns: [EmphasisRun] = []
+        var utf16Offset = 0
+        for run in source.runs {
+            let runContent = source[run.range]
+            let utf16Length = String(runContent.characters).utf16.count
+            if let intent = runContent.inlinePresentationIntent {
+                emphasisRuns.append(EmphasisRun(
+                    utf16Offset: utf16Offset,
+                    utf16Length: utf16Length,
+                    intent: intent,
+                    hasExplicitFont: runContent.font != nil
+                ))
+            }
+            utf16Offset += utf16Length
+        }
+
         let ns = NSMutableAttributedString(source)
         let fullRange = NSRange(location: 0, length: ns.length)
 
@@ -496,21 +523,19 @@ struct MarkdownSegmentView: View, Equatable {
             CTFontDescriptorCreateWithAttributes([kCTFontVariationAttribute: boldVars] as CFDictionary)
         ) as NSFont
 
-        ns.enumerateAttribute(.inlinePresentationIntent, in: fullRange, options: []) { value, range, _ in
-            guard let rawValue = (value as? NSNumber)?.uintValue else { return }
-            let intent = InlinePresentationIntent(rawValue: rawValue)
-            guard !intent.contains(.code) else { return }
+        for emphRun in emphasisRuns {
+            guard !emphRun.intent.contains(.code) else { continue }
             // Skip runs that already have an explicit font (e.g. headings)
-            if ns.attribute(.font, at: range.location, effectiveRange: nil) != nil { return }
-
-            let isEmph = intent.contains(.emphasized)
-            let isBold = intent.contains(.stronglyEmphasized)
+            guard !emphRun.hasExplicitFont else { continue }
+            let nsRange = NSRange(location: emphRun.utf16Offset, length: emphRun.utf16Length)
+            let isEmph = emphRun.intent.contains(.emphasized)
+            let isBold = emphRun.intent.contains(.stronglyEmphasized)
             if isEmph && isBold {
-                ns.addAttribute(.font, value: boldItalicNS, range: range)
+                ns.addAttribute(.font, value: boldItalicNS, range: nsRange)
             } else if isEmph {
-                ns.addAttribute(.font, value: italicNS, range: range)
+                ns.addAttribute(.font, value: italicNS, range: nsRange)
             } else if isBold {
-                ns.addAttribute(.font, value: boldNS, range: range)
+                ns.addAttribute(.font, value: boldNS, range: nsRange)
             }
         }
 


### PR DESCRIPTION
## Summary
- **Bug**: `*italicized*` text had its asterisks correctly stripped by the markdown parser but was not rendered with italic styling — appeared as plain text.
- **Root cause**: `convertToNSAttributedString` enumerated `.inlinePresentationIntent` on the `NSMutableAttributedString`, but `InlinePresentationIntent` (a Swift `OptionSet` struct) can silently fail to bridge to `NSNumber` during the `AttributedString` → `NSAttributedString` conversion, causing the `(value as? NSNumber)?.uintValue` guard to bail on every emphasized run.
- **Fix**: Pre-collect emphasis info directly from `AttributedString.runs` (where the attribute is always present as its native Swift type), then apply synthetic italic/bold fonts using the pre-collected UTF-16 ranges on the `NSMutableAttributedString`.

## Original prompt
Markdown isn't rendering properly for *italicized* text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23614" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
