### PR TITLE
fix: heartbeat nextRunAt goes stale when runs are skipped

### DIFF
--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -244,6 +244,24 @@ describe("HeartbeatService", () => {
     expect(processMessageCalls).toHaveLength(0);
   });
 
+  test("active hours skip still advances nextRunAt", async () => {
+    mockConfig.heartbeat.activeHoursStart = 9;
+    mockConfig.heartbeat.activeHoursEnd = 17;
+
+    const service = createService({ getCurrentHour: () => 3 });
+    service.start();
+
+    const before = Date.now();
+    await service.runOnce();
+
+    expect(processMessageCalls).toHaveLength(0);
+    expect(service.nextRunAt).not.toBeNull();
+    expect(service.nextRunAt!).toBeGreaterThanOrEqual(
+      before + mockConfig.heartbeat.intervalMs,
+    );
+    service.stop();
+  });
+
   test("active hours guard allows within window", async () => {
     mockConfig.heartbeat.activeHoursStart = 9;
     mockConfig.heartbeat.activeHoursEnd = 17;
@@ -374,6 +392,22 @@ describe("HeartbeatService", () => {
     expect(alerterCalls[0].type).toBe("heartbeat_alert");
     expect(alerterCalls[0].title).toBe("Heartbeat Failed");
     expect(alerterCalls[0].body).toBe("LLM timeout");
+  });
+
+  test("successful run updates lastRunAt and nextRunAt", async () => {
+    const service = createService();
+    expect(service.lastRunAt).toBeNull();
+    expect(service.nextRunAt).toBeNull();
+
+    const before = Date.now();
+    await service.runOnce();
+
+    expect(service.lastRunAt).not.toBeNull();
+    expect(service.lastRunAt!).toBeGreaterThanOrEqual(before);
+    expect(service.nextRunAt).not.toBeNull();
+    expect(service.nextRunAt!).toBeGreaterThanOrEqual(
+      before + mockConfig.heartbeat.intervalMs,
+    );
   });
 
   test("alerts on conversation creation failure", async () => {

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -21,6 +21,7 @@ const DEFAULT_CHECKLIST = `- Check in with yourself. Read NOW.md. Is it still ac
 - If something has happened since your last journal entry, write one. Even a few sentences. The journal is how future-you stays connected.`;
 
 const REENGAGEMENT_COOLDOWN_MS = 18 * 60 * 60 * 1000; // 18 hours
+const HEARTBEAT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
 /** @internal Exported for testing. */
 export function isShallowProfile(): boolean {
@@ -191,6 +192,7 @@ export class HeartbeatService {
           },
           "Outside active hours, skipping",
         );
+        this.scheduleNextRun(config.intervalMs);
         return false;
       }
     }
@@ -204,7 +206,15 @@ export class HeartbeatService {
     const run = this.executeRun();
     this.activeRun = run;
     try {
-      await run;
+      await Promise.race([
+        run,
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error("Heartbeat execution timed out")),
+            HEARTBEAT_TIMEOUT_MS,
+          ),
+        ),
+      ]);
     } finally {
       this.activeRun = null;
       this._lastRunAt = Date.now();


### PR DESCRIPTION
## Summary
- Fix `_nextRunAt` not being updated when heartbeat ticks are skipped due to active hours, causing the UI to show stale "Next run Xm ago" timestamps
- Add 5-minute execution timeout via `Promise.race` so a hung LLM call can't permanently block all future heartbeats
- Add tests for `nextRunAt` advancement on active-hours skip and for `lastRunAt`/`nextRunAt` after successful runs

## Original prompt
Fix heartbeat nextRunAt staleness bug — update _nextRunAt when runs are skipped and add execution timeout
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
