### PR TITLE
chore: increase heartbeat execution timeout to 30 minutes

### DIFF
--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -21,7 +21,7 @@ const DEFAULT_CHECKLIST = `- Check in with yourself. Read NOW.md. Is it still ac
 - If something has happened since your last journal entry, write one. Even a few sentences. The journal is how future-you stays connected.`;
 
 const REENGAGEMENT_COOLDOWN_MS = 18 * 60 * 60 * 1000; // 18 hours
-const HEARTBEAT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+const HEARTBEAT_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 
 /** @internal Exported for testing. */
 export function isShallowProfile(): boolean {


### PR DESCRIPTION
## Summary
- Increase `HEARTBEAT_TIMEOUT_MS` from 5 minutes to 30 minutes to accommodate longer heartbeat runs that involve extended LLM interactions

## Original prompt
increase the execution timeout to 30 minutes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23616" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
