### PR TITLE
Remove dead invite code UI from macOS Billing tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -21,9 +21,7 @@ struct SettingsBillingTab: View {
     @State private var isProcessingTopUp: Bool = false
     @State private var topUpError: String?
     @State private var hostWindow: NSWindow?
-    @State private var inviteCode: String = ""
     @State private var isReferralCodesEnabled: Bool = false
-    private var devModeManager: DevModeManager { DevModeManager.shared }
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
@@ -32,9 +30,6 @@ struct SettingsBillingTab: View {
                 addFundsSkeleton
             } else if !topUpAmounts.isEmpty {
                 addFundsCard
-            }
-            if devModeManager.isDevMode {
-                inviteCodeCard
             }
             if isReferralCodesEnabled {
                 SettingsBillingReferralCard()
@@ -220,33 +215,6 @@ struct SettingsBillingTab: View {
                     Text(topUpError)
                         .font(VFont.bodyMediumLighter)
                         .foregroundStyle(VColor.systemNegativeStrong)
-                }
-            }
-        }
-    }
-
-    // MARK: - Invite Code Card
-
-    private var inviteCodeCard: some View {
-        SettingsCard(title: "Invite Code") {
-            VStack(alignment: .leading, spacing: VSpacing.md) {
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text("Code")
-                        .font(VFont.bodySmallDefault)
-                        .foregroundStyle(VColor.contentSecondary)
-                    VTextField(
-                        placeholder: "Enter invite code",
-                        text: $inviteCode
-                    )
-                    .frame(maxWidth: 200)
-                }
-
-                VButton(
-                    label: "Submit",
-                    style: .primary,
-                    isDisabled: inviteCode.isEmpty
-                ) {
-                    // No backend connection yet
                 }
             }
         }


### PR DESCRIPTION
## Summary
Remove the unused "Invite Code" card from the macOS app's Billing settings tab. This card was dev-mode-only with no backend connection (the submit button was a no-op), and is superseded by the production "Referrals" section.

## PRs merged into feature branch
- #23621: Remove dead invite code UI from macOS Billing tab

Part of plan: rm-invite-code-ui.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23622" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
