### PR TITLE
chore: reframe billing UI copy from USD to Credits

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -34,7 +34,7 @@ struct DrawerMenuView: View {
             if let balance = effectiveBalance {
                 VMenuCustomRow {
                     HStack {
-                        Text("$\(balance) remaining")
+                        Text("\(balance) credits remaining")
                             .font(VFont.bodyMediumDefault)
                             .foregroundStyle(
                                 isZeroBalance ? VColor.systemNegativeStrong :
@@ -43,7 +43,7 @@ struct DrawerMenuView: View {
                             )
                         Spacer()
                         if isBillingVisible {
-                            Button("Add funds") { onOpenBilling() }
+                            Button("Add credits") { onOpenBilling() }
                                 .font(VFont.labelDefault)
                                 .foregroundStyle(VColor.primaryBase)
                                 .buttonStyle(.plain)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingReferralCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingReferralCard.swift
@@ -105,7 +105,7 @@ struct SettingsBillingReferralCard: View {
                 }
 
                 // Earning cap note
-                Text("Earn up to \(code.earning_cap_usd.replacingOccurrences(of: ".00", with: "")) referral credits")
+                Text("Earn up to \(code.earning_cap_usd) referral credits")
                     .font(VFont.bodySmallDefault)
                     .foregroundStyle(VColor.contentTertiary)
             }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingReferralCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingReferralCard.swift
@@ -98,14 +98,14 @@ struct SettingsBillingReferralCard: View {
                                 .font(VFont.bodySmallDefault)
                                 .foregroundStyle(VColor.contentSecondary)
                         }
-                        Text("$\(code.total_earned_usd)")
+                        Text("\(code.total_earned_usd) credits")
                             .font(VFont.bodyMediumDefault)
                             .foregroundStyle(VColor.contentEmphasized)
                     }
                 }
 
                 // Earning cap note
-                Text("Earn up to $\(code.earning_cap_usd) in referral credits")
+                Text("Earn up to \(code.earning_cap_usd.replacingOccurrences(of: ".00", with: "")) referral credits")
                     .font(VFont.bodySmallDefault)
                     .foregroundStyle(VColor.contentTertiary)
             }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -59,7 +59,7 @@ struct SettingsBillingTab: View {
     // MARK: - Balance Card
 
     private var balanceCard: some View {
-        SettingsCard(title: "Balance") {
+        SettingsCard(title: "Credit Balance") {
             if isLoading {
                 VStack(alignment: .leading, spacing: VSpacing.lg) {
                     // Effective balance skeleton
@@ -109,10 +109,10 @@ struct SettingsBillingTab: View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             // Effective balance — large display
             VStack(alignment: .leading, spacing: VSpacing.xs) {
-                Text("Effective Balance")
+                Text("Effective Credit Balance")
                     .font(VFont.bodySmallDefault)
                     .foregroundStyle(VColor.contentSecondary)
-                Text("$\(summary.effective_balance_usd)")
+                Text("\(summary.effective_balance_usd) credits")
                     .font(VFont.titleMedium)
                     .foregroundStyle(VColor.contentEmphasized)
             }
@@ -137,18 +137,18 @@ struct SettingsBillingTab: View {
 
             HStack(spacing: VSpacing.xl) {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text("Settled Balance")
+                    Text("Settled Credit Balance")
                         .font(VFont.bodySmallDefault)
                         .foregroundStyle(VColor.contentSecondary)
-                    Text("$\(summary.settled_balance_usd)")
+                    Text("\(summary.settled_balance_usd) credits")
                         .font(VFont.bodyMediumDefault)
                         .foregroundStyle(VColor.contentDefault)
                 }
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text(summary.is_degraded ? "Pending Charges (estimated)" : "Pending Charges")
+                    Text(summary.is_degraded ? "Pending Usage (estimated)" : "Pending Usage")
                         .font(VFont.bodySmallDefault)
                         .foregroundStyle(VColor.contentSecondary)
-                    Text("$\(summary.pending_compute_usd)")
+                    Text("\(summary.pending_compute_usd) credits")
                         .font(VFont.bodyMediumDefault)
                         .foregroundStyle(summary.is_degraded ? VColor.contentSecondary : VColor.contentDefault)
                 }
@@ -156,10 +156,10 @@ struct SettingsBillingTab: View {
         }
     }
 
-    // MARK: - Add Funds Skeleton
+    // MARK: - Add Credits Skeleton
 
     private var addFundsSkeleton: some View {
-        SettingsCard(title: "Add Funds") {
+        SettingsCard(title: "Add Credits") {
             VStack(alignment: .leading, spacing: VSpacing.md) {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     VSkeletonBone(width: 90, height: 12)
@@ -171,10 +171,10 @@ struct SettingsBillingTab: View {
         }
     }
 
-    // MARK: - Add Funds Card
+    // MARK: - Add Credits Card
 
     private var addFundsCard: some View {
-        SettingsCard(title: "Add Funds") {
+        SettingsCard(title: "Add Credits") {
             topUpContent
         }
     }
@@ -184,24 +184,27 @@ struct SettingsBillingTab: View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
             VStack(alignment: .leading, spacing: VSpacing.xs) {
                 VDropdown(
-                    "Amount (USD)",
+                    "Amount",
                     placeholder: "",
                     selection: Binding(
                         get: { effectiveAmount },
                         set: { selectedAmount = $0 }
                     ),
-                    options: topUpAmounts.map { (label: "$\($0)", value: $0) }
+                    options: topUpAmounts.map { amount in
+                        let credits = amount.replacingOccurrences(of: ".00", with: "")
+                        return (label: "\(credits) ($\(amount))", value: amount)
+                    }
                 )
                 .frame(maxWidth: 200)
                 if let summary {
-                    Text("$\(summary.maximum_balance_usd) max balance. Credits expire 12 months after purchase.")
+                    Text("\(summary.maximum_balance_usd.replacingOccurrences(of: ".00", with: "")) max credit balance. Credits expire 12 months after purchase.")
                         .font(VFont.bodySmallDefault)
                         .foregroundStyle(VColor.contentTertiary)
                 }
             }
 
             VButton(
-                label: isProcessingTopUp ? "Processing..." : "Add funds",
+                label: isProcessingTopUp ? "Processing..." : "Add credits",
                 style: .primary,
                 isDisabled: isProcessingTopUp
             ) {
@@ -284,7 +287,7 @@ struct SettingsBillingTab: View {
            let maxBalance = Double(summary.maximum_balance_usd),
            let currentBalance = Double(summary.effective_balance_usd),
            currentBalance + amount > maxBalance {
-            topUpError = "This top-up would exceed the maximum balance of $\(summary.maximum_balance_usd)."
+            topUpError = "This top-up would exceed the maximum credit balance of \(summary.maximum_balance_usd.replacingOccurrences(of: ".00", with: ""))."
             return
         }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -197,7 +197,7 @@ struct SettingsBillingTab: View {
                 )
                 .frame(maxWidth: 200)
                 if let summary {
-                    Text("\(summary.maximum_balance_usd.replacingOccurrences(of: ".00", with: "")) max credit balance. Credits expire 12 months after purchase.")
+                    Text("\(summary.maximum_balance_usd) max credit balance. Credits expire 12 months after purchase.")
                         .font(VFont.bodySmallDefault)
                         .foregroundStyle(VColor.contentTertiary)
                 }
@@ -287,7 +287,7 @@ struct SettingsBillingTab: View {
            let maxBalance = Double(summary.maximum_balance_usd),
            let currentBalance = Double(summary.effective_balance_usd),
            currentBalance + amount > maxBalance {
-            topUpError = "This top-up would exceed the maximum credit balance of \(summary.maximum_balance_usd.replacingOccurrences(of: ".00", with: ""))."
+            topUpError = "This top-up would exceed the maximum credit balance of \(summary.maximum_balance_usd)."
             return
         }
 


### PR DESCRIPTION
## Summary
- Reframe all billing UI copy from USD/dollar notation to "Credits" (1 Credit = 1 USD)
- Update balance labels (Effective Balance -> Effective Credit Balance, etc.), value formatting ($93.37 -> 93.37 credits), and action labels (Add Funds -> Add Credits)
- Update dropdown options from `$10.00` to `10 ($10.00)` format, and referral card earned values to credits

## Original prompt
Reframe macOS billing UI copy from USD/dollars to "Credits" across SettingsBillingTab, DrawerMenuView, and SettingsBillingReferralCard. Changes include: Balance -> Credit Balance, Effective/Settled Balance -> Effective/Settled Credit Balance, Pending Charges -> Pending Usage, Add Funds -> Add Credits, Amount (USD) -> Amount, dropdown options to `N ($N.00)` format, and all `$X.XX` values to `X.XX credits`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23625" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
