### PR TITLE
fix(macos): preserve avatar traits through rehatch/replay flows

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -551,10 +551,16 @@ extension AppDelegate {
         featureFlagStore.reloadFromDisk()
 
         // Reload avatar for the new assistant via the gateway.
-        AvatarAppearanceManager.shared.reloadAvatar()
-        // If we just hatched a new assistant, sync the onboarding avatar traits
-        // to the daemon so the randomly-generated character avatar is preserved.
-        syncOnboardingAvatarIfNeeded()
+        // Skip the reload when onboarding avatar traits are pending — the async
+        // fetchTraitsViaHTTP inside reloadAvatar would find no traits on the
+        // freshly-hatched assistant and clear the locally-saved character avatar.
+        // syncOnboardingAvatarIfNeeded saves locally first, then syncs to the
+        // assistant, which triggers its own reloadAvatar on success.
+        if onboardingState?.hatchAvatarBodyShape != nil {
+            syncOnboardingAvatarIfNeeded()
+        } else {
+            AvatarAppearanceManager.shared.reloadAvatar()
+        }
 
         showMainWindow()
     }

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -552,6 +552,9 @@ extension AppDelegate {
 
         // Reload avatar for the new assistant via the gateway.
         AvatarAppearanceManager.shared.reloadAvatar()
+        // If we just hatched a new assistant, sync the onboarding avatar traits
+        // to the daemon so the randomly-generated character avatar is preserved.
+        syncOnboardingAvatarIfNeeded()
 
         showMainWindow()
     }

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -313,7 +313,7 @@ extension AppDelegate {
             UserDefaults.standard.removeObject(forKey: "lastActivePanel")
 
             // Retain the onboarding state so avatar traits generated during
-            // hatching can be synced to the daemon.
+            // hatching can be synced to the assistant.
             self?.onboardingState = state
             self?.syncOnboardingAvatarIfNeeded()
 
@@ -363,7 +363,7 @@ extension AppDelegate {
             UserDefaults.standard.removeObject(forKey: "lastActivePanel")
 
             // Retain the onboarding state so avatar traits generated during
-            // hatching can be synced to the daemon after the assistant switch.
+            // hatching can be synced to the assistant after the switch.
             self?.onboardingState = state
 
             // Detect the newly hatched assistant by diffing lockfile against snapshot.

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -312,6 +312,11 @@ extension AppDelegate {
             // Clear any stale panel state so the user lands on chat, not settings
             UserDefaults.standard.removeObject(forKey: "lastActivePanel")
 
+            // Retain the onboarding state so avatar traits generated during
+            // hatching can be synced to the daemon.
+            self?.onboardingState = state
+            self?.syncOnboardingAvatarIfNeeded()
+
             self?.showMainWindow()
         }
         onboarding.onDismiss = { [weak self] in
@@ -356,6 +361,10 @@ extension AppDelegate {
             onboarding.close()
             self?.onboardingWindow = nil
             UserDefaults.standard.removeObject(forKey: "lastActivePanel")
+
+            // Retain the onboarding state so avatar traits generated during
+            // hatching can be synced to the daemon after the assistant switch.
+            self?.onboardingState = state
 
             // Detect the newly hatched assistant by diffing lockfile against snapshot.
             // loadAll() returns newest-first, so the first new ID is the most recently hatched.

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -814,9 +814,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         SoundManager.shared.play(.newConversation)
     }
 
-    /// If onboarding generated avatar traits, sync them to the daemon and clear the state.
+    /// If onboarding generated avatar traits, sync them to the assistant and clear the state.
     /// Called from both the first-launch and non-first-launch paths in `proceedToApp`
-    /// so that auth-gate onboarding flows also persist avatar traits on the daemon.
+    /// so that auth-gate onboarding flows also persist avatar traits on the assistant.
     func syncOnboardingAvatarIfNeeded() {
         guard let body = onboardingState?.hatchAvatarBodyShape,
               let eyes = onboardingState?.hatchAvatarEyeStyle,

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -666,8 +666,16 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                     // Gateway is healthy — reload the avatar now so it
                     // reflects the user's saved image instead of the
                     // bundled Vellum logo.
-                    AvatarAppearanceManager.shared.reloadAvatar()
-                    self.syncOnboardingAvatarIfNeeded()
+                    // Skip the reload when onboarding avatar traits are pending —
+                    // the async fetchTraitsViaHTTP inside reloadAvatar would find
+                    // no traits on the freshly-hatched assistant and clear the
+                    // locally-saved character avatar.
+                    if self.onboardingState?.hatchAvatarBodyShape != nil {
+                        log.info("[avatarSync] first-launch: skipping reloadAvatar, syncing onboarding traits instead")
+                        self.syncOnboardingAvatarIfNeeded()
+                    } else {
+                        AvatarAppearanceManager.shared.reloadAvatar()
+                    }
 
                     // Record lifecycle telemetry events (fire-and-forget).
                     Task { await self.telemetryClient.recordLifecycleEvent("hatch") }
@@ -709,8 +717,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 if ready {
                     // Gateway is healthy — reload the avatar so
                     // logout→re-login cycles repopulate the dock icon.
-                    AvatarAppearanceManager.shared.reloadAvatar()
-                    self.syncOnboardingAvatarIfNeeded()
+                    if self.onboardingState?.hatchAvatarBodyShape != nil {
+                        log.info("[avatarSync] non-first-launch: skipping reloadAvatar, syncing onboarding traits instead")
+                        self.syncOnboardingAvatarIfNeeded()
+                    } else {
+                        AvatarAppearanceManager.shared.reloadAvatar()
+                    }
                     await self.telemetryClient.recordLifecycleEvent("app_open")
                 } else {
                     // Can't sync traits (no daemon), but still clean up onboarding state.
@@ -821,17 +833,22 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         guard let body = onboardingState?.hatchAvatarBodyShape,
               let eyes = onboardingState?.hatchAvatarEyeStyle,
               let color = onboardingState?.hatchAvatarColor else {
+            log.info("[avatarSync] syncOnboardingAvatarIfNeeded: no onboarding traits, skipping")
             onboardingState = nil
             return
         }
+        log.info("[avatarSync] syncOnboardingAvatarIfNeeded: traits=\(body.rawValue)/\(eyes.rawValue)/\(color.rawValue)")
         // Eagerly apply onboarding avatar traits so the ComingAliveOverlay
         // (and any other UI) can render the character avatar immediately
         // instead of falling back to the bundled green V logo while the
-        // async daemon sync completes.
+        // async assistant sync completes.
         if AvatarAppearanceManager.shared.customAvatarImage == nil,
            AvatarAppearanceManager.shared.characterBodyShape == nil {
             let image = AvatarCompositor.render(bodyShape: body, eyeStyle: eyes, color: color)
             AvatarAppearanceManager.shared.saveAvatar(image, bodyShape: body, eyeStyle: eyes, color: color)
+            log.info("[avatarSync] saved avatar locally")
+        } else {
+            log.info("[avatarSync] skipping local save — customAvatarImage=\(AvatarAppearanceManager.shared.customAvatarImage != nil) characterBodyShape=\(AvatarAppearanceManager.shared.characterBodyShape?.rawValue ?? "nil")")
         }
         Task {
             await AvatarAppearanceManager.shared.syncTraitsToDaemon(

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -833,7 +833,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         guard let body = onboardingState?.hatchAvatarBodyShape,
               let eyes = onboardingState?.hatchAvatarEyeStyle,
               let color = onboardingState?.hatchAvatarColor else {
-            log.info("[avatarSync] syncOnboardingAvatarIfNeeded: no onboarding traits, skipping")
             onboardingState = nil
             return
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -817,7 +817,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     /// If onboarding generated avatar traits, sync them to the daemon and clear the state.
     /// Called from both the first-launch and non-first-launch paths in `proceedToApp`
     /// so that auth-gate onboarding flows also persist avatar traits on the daemon.
-    private func syncOnboardingAvatarIfNeeded() {
+    func syncOnboardingAvatarIfNeeded() {
         guard let body = onboardingState?.hatchAvatarBodyShape,
               let eyes = onboardingState?.hatchAvatarEyeStyle,
               let color = onboardingState?.hatchAvatarColor else {

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -184,6 +184,8 @@ final class AvatarAppearanceManager {
                 timeout: 10
             )
             guard response.isSuccess, !response.data.isEmpty else {
+                let prevBody = self.characterBodyShape?.rawValue ?? "nil"
+                log.info("[avatarSync] fetchTraitsViaHTTP: no traits on assistant (HTTP \(response.statusCode)), clearing local traits (was: \(prevBody))")
                 if characterBodyShape != nil { characterBodyShape = nil }
                 if characterEyeStyle != nil { characterEyeStyle = nil }
                 if characterColor != nil { characterColor = nil }
@@ -198,6 +200,7 @@ final class AvatarAppearanceManager {
             characterBodyShape = AvatarBodyShape(rawValue: components.bodyShape)
             characterEyeStyle = AvatarEyeStyle(rawValue: components.eyeStyle)
             characterColor = AvatarColor(rawValue: components.color)
+            log.info("[avatarSync] fetchTraitsViaHTTP: loaded traits \(components.bodyShape)/\(components.eyeStyle)/\(components.color)")
             // Character traits loaded — the PNG is just a daemon rendering
             // of the character, not a user upload. Clear it so the animated
             // path is used.
@@ -269,6 +272,10 @@ final class AvatarAppearanceManager {
     /// backward compatibility with the daemon's `avatar_updated` event
     /// payload but is not used — all data is fetched via the gateway.
     func reloadAvatar(avatarPath: String?) {
+        let currentBody = characterBodyShape?.rawValue ?? "nil"
+        let currentEyes = characterEyeStyle?.rawValue ?? "nil"
+        let currentColor = characterColor?.rawValue ?? "nil"
+        log.info("[avatarSync] reloadAvatar called (current traits: \(currentBody)/\(currentEyes)/\(currentColor))")
         identityLoadTask?.cancel()
         identityLoadTask = Task {
             let info = await IdentityInfo.loadAsync()
@@ -301,20 +308,34 @@ final class AvatarAppearanceManager {
             "eyeStyle": eyeStyle.rawValue,
             "color": color.rawValue,
         ]
-        do {
-            let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/avatar/render-from-traits",
-                json: json,
-                timeout: 15
-            )
-            if response.isSuccess {
-                log.info("Synced avatar traits to daemon: \(bodyShape.rawValue)/\(eyeStyle.rawValue)/\(color.rawValue)")
-                reloadAvatar()
-            } else {
-                log.warning("Failed to sync avatar traits to daemon: HTTP \(response.statusCode)")
+        log.info("[avatarSync] syncTraitsToDaemon: posting \(bodyShape.rawValue)/\(eyeStyle.rawValue)/\(color.rawValue)")
+        // Retry up to 3 times with a short delay for transient failures
+        // (e.g. 500 from a freshly-hatched assistant that isn't fully ready).
+        for attempt in 1...3 {
+            do {
+                let response = try await GatewayHTTPClient.post(
+                    path: "assistants/{assistantId}/avatar/render-from-traits",
+                    json: json,
+                    timeout: 15
+                )
+                if response.isSuccess {
+                    log.info("[avatarSync] syncTraitsToDaemon: success on attempt \(attempt)")
+                    reloadAvatar()
+                    return
+                } else if response.statusCode >= 500 && attempt < 3 {
+                    log.warning("[avatarSync] syncTraitsToDaemon: HTTP \(response.statusCode) on attempt \(attempt), retrying...")
+                    try await Task.sleep(nanoseconds: UInt64(attempt) * 1_000_000_000)
+                    continue
+                } else {
+                    log.warning("[avatarSync] syncTraitsToDaemon: HTTP \(response.statusCode) on attempt \(attempt), giving up")
+                    return
+                }
+            } catch {
+                log.warning("[avatarSync] syncTraitsToDaemon: error on attempt \(attempt): \(error.localizedDescription)")
+                if attempt < 3 {
+                    try? await Task.sleep(nanoseconds: UInt64(attempt) * 1_000_000_000)
+                }
             }
-        } catch {
-            log.warning("Failed to sync avatar traits to daemon: \(error.localizedDescription)")
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -184,8 +184,6 @@ final class AvatarAppearanceManager {
                 timeout: 10
             )
             guard response.isSuccess, !response.data.isEmpty else {
-                let prevBody = self.characterBodyShape?.rawValue ?? "nil"
-                log.info("[avatarSync] fetchTraitsViaHTTP: no traits on assistant (HTTP \(response.statusCode)), clearing local traits (was: \(prevBody))")
                 if characterBodyShape != nil { characterBodyShape = nil }
                 if characterEyeStyle != nil { characterEyeStyle = nil }
                 if characterColor != nil { characterColor = nil }
@@ -200,7 +198,6 @@ final class AvatarAppearanceManager {
             characterBodyShape = AvatarBodyShape(rawValue: components.bodyShape)
             characterEyeStyle = AvatarEyeStyle(rawValue: components.eyeStyle)
             characterColor = AvatarColor(rawValue: components.color)
-            log.info("[avatarSync] fetchTraitsViaHTTP: loaded traits \(components.bodyShape)/\(components.eyeStyle)/\(components.color)")
             // Character traits loaded — the PNG is just a daemon rendering
             // of the character, not a user upload. Clear it so the animated
             // path is used.
@@ -272,10 +269,6 @@ final class AvatarAppearanceManager {
     /// backward compatibility with the daemon's `avatar_updated` event
     /// payload but is not used — all data is fetched via the gateway.
     func reloadAvatar(avatarPath: String?) {
-        let currentBody = characterBodyShape?.rawValue ?? "nil"
-        let currentEyes = characterEyeStyle?.rawValue ?? "nil"
-        let currentColor = characterColor?.rawValue ?? "nil"
-        log.info("[avatarSync] reloadAvatar called (current traits: \(currentBody)/\(currentEyes)/\(currentColor))")
         identityLoadTask?.cancel()
         identityLoadTask = Task {
             let info = await IdentityInfo.loadAsync()


### PR DESCRIPTION
## Summary

https://www.loom.com/share/fb829ac6fb494ba79c5d16177e5c1120

- `hatchNewAssistant()` and `replayOnboarding()` did not set `onboardingState`, so `syncOnboardingAvatarIfNeeded()` had no avatar traits to sync to the daemon
- `performSwitchAssistant` clears avatar state via `resetForDisconnect()`, then `reloadAvatar()` loaded the default from the daemon instead of the hatching character avatar
- Adds `syncOnboardingAvatarIfNeeded()` to `finishSwitchAssistant` so traits are synced after the switch completes
- Changes `syncOnboardingAvatarIfNeeded` from `private` to `internal` since it's now called from multiple files

As a followup, we will need to add file watching support on the assistant side to let the client know to reload. Tackling that next

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23626" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
