### PR TITLE
feat: migrate ReferralCodeResponse to credits-neutral API keys

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingReferralCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingReferralCard.swift
@@ -98,14 +98,14 @@ struct SettingsBillingReferralCard: View {
                                 .font(VFont.bodySmallDefault)
                                 .foregroundStyle(VColor.contentSecondary)
                         }
-                        Text("\(code.total_earned_usd) credits")
+                        Text("\(code.total_earned) credits")
                             .font(VFont.bodyMediumDefault)
                             .foregroundStyle(VColor.contentEmphasized)
                     }
                 }
 
                 // Earning cap note
-                Text("Earn up to \(code.earning_cap_usd) referral credits")
+                Text("Earn up to \(code.earning_cap) referral credits")
                     .font(VFont.bodySmallDefault)
                     .foregroundStyle(VColor.contentTertiary)
             }

--- a/clients/shared/App/Auth/AuthModels.swift
+++ b/clients/shared/App/Auth/AuthModels.swift
@@ -330,6 +330,6 @@ public struct TopUpCheckoutResponse: Codable, Sendable {
 public struct ReferralCodeResponse: Codable, Sendable {
     public let referral_url: String
     public let referred_count: Int
-    public let total_earned_usd: String
-    public let earning_cap_usd: String
+    public let total_earned: String
+    public let earning_cap: String
 }


### PR DESCRIPTION
## Summary
- Replace total_earned_usd and earning_cap_usd with total_earned and earning_cap in ReferralCodeResponse
- Update SettingsBillingReferralCard to use new property names

Part of plan: client-credits-api-keys.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
