### PR TITLE
feat: migrate BillingSummaryResponse to credits-neutral API keys

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -89,7 +89,7 @@ struct DrawerMenuView: View {
             if let bootstrapped = await BillingService.shared.bootstrapBillingSummaryIfNeeded(summary: summary) {
                 summary = bootstrapped
             }
-            let balanceString = summary.effective_balance_usd
+            let balanceString = summary.effective_balance
             effectiveBalance = balanceString
             if let value = Double(balanceString) {
                 isZeroBalance = value <= 0

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -112,7 +112,7 @@ struct SettingsBillingTab: View {
                 Text("Effective Credit Balance")
                     .font(VFont.bodySmallDefault)
                     .foregroundStyle(VColor.contentSecondary)
-                Text("\(summary.effective_balance_usd) credits")
+                Text("\(summary.effective_balance) credits")
                     .font(VFont.titleMedium)
                     .foregroundStyle(VColor.contentEmphasized)
             }
@@ -140,7 +140,7 @@ struct SettingsBillingTab: View {
                     Text("Settled Credit Balance")
                         .font(VFont.bodySmallDefault)
                         .foregroundStyle(VColor.contentSecondary)
-                    Text("\(summary.settled_balance_usd) credits")
+                    Text("\(summary.settled_balance) credits")
                         .font(VFont.bodyMediumDefault)
                         .foregroundStyle(VColor.contentDefault)
                 }
@@ -148,7 +148,7 @@ struct SettingsBillingTab: View {
                     Text(summary.is_degraded ? "Pending Usage (estimated)" : "Pending Usage")
                         .font(VFont.bodySmallDefault)
                         .foregroundStyle(VColor.contentSecondary)
-                    Text("\(summary.pending_compute_usd) credits")
+                    Text("\(summary.pending_compute) credits")
                         .font(VFont.bodyMediumDefault)
                         .foregroundStyle(summary.is_degraded ? VColor.contentSecondary : VColor.contentDefault)
                 }
@@ -197,7 +197,7 @@ struct SettingsBillingTab: View {
                 )
                 .frame(maxWidth: 200)
                 if let summary {
-                    Text("\(summary.maximum_balance_usd) max credit balance. Credits expire 12 months after purchase.")
+                    Text("\(summary.maximum_balance) max credit balance. Credits expire 12 months after purchase.")
                         .font(VFont.bodySmallDefault)
                         .foregroundStyle(VColor.contentTertiary)
                 }
@@ -284,10 +284,10 @@ struct SettingsBillingTab: View {
         let amount = Double(amountStr) ?? 0
 
         if let summary,
-           let maxBalance = Double(summary.maximum_balance_usd),
-           let currentBalance = Double(summary.effective_balance_usd),
+           let maxBalance = Double(summary.maximum_balance),
+           let currentBalance = Double(summary.effective_balance),
            currentBalance + amount > maxBalance {
-            topUpError = "This top-up would exceed the maximum credit balance of \(summary.maximum_balance_usd)."
+            topUpError = "This top-up would exceed the maximum credit balance of \(summary.maximum_balance)."
             return
         }
 

--- a/clients/shared/App/Auth/AuthModels.swift
+++ b/clients/shared/App/Auth/AuthModels.swift
@@ -308,12 +308,12 @@ public struct SelfHostedProvisioningInfo: Codable, Sendable {
 // MARK: - Billing Models
 
 public struct BillingSummaryResponse: Codable, Sendable {
-    public let settled_balance_usd: String
-    public let pending_compute_usd: String
-    public let effective_balance_usd: String
-    public let minimum_top_up_usd: String
-    public let maximum_top_up_usd: String
-    public let maximum_balance_usd: String
+    public let settled_balance: String
+    public let pending_compute: String
+    public let effective_balance: String
+    public let minimum_top_up: String
+    public let maximum_top_up: String
+    public let maximum_balance: String
     public let allowed_top_up_amounts: [String]?
     public let is_degraded: Bool
 }

--- a/clients/shared/App/Auth/BillingService.swift
+++ b/clients/shared/App/Auth/BillingService.swift
@@ -76,9 +76,9 @@ public final class BillingService {
         guard let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") else { return nil }
 
         // Only attempt bootstrap for all-zero balances
-        let isAllZero = summary.effective_balance_usd == "0.00"
-            && summary.settled_balance_usd == "0.00"
-            && summary.pending_compute_usd == "0.00"
+        let isAllZero = summary.effective_balance == "0.00"
+            && summary.settled_balance == "0.00"
+            && summary.pending_compute == "0.00"
         guard isAllZero else { return nil }
 
         // Skip if we've already attempted bootstrap for this org


### PR DESCRIPTION
## Summary
- Replace all _usd field references in BillingSummaryResponse with credits-neutral keys (settled_balance, pending_compute, effective_balance, etc.)
- Update BillingService, SettingsBillingTab, and DrawerMenuView to use new property names

Part of plan: client-credits-api-keys.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23632" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
