### PR TITLE
feat: send `amount` instead of `amount_usd` in top-up checkout requests

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -296,7 +296,7 @@ struct SettingsBillingTab: View {
         defer { isProcessingTopUp = false }
 
         do {
-            let checkoutURL = try await BillingService.shared.createTopUpCheckout(amountUsd: amountStr)
+            let checkoutURL = try await BillingService.shared.createTopUpCheckout(amount: amountStr)
             NSWorkspace.shared.open(checkoutURL)
         } catch let PlatformAPIError.serverError(_, detail) {
             self.topUpError = Self.parseValidationError(detail) ?? "Failed to create checkout session. Please try again."

--- a/clients/shared/App/Auth/AuthModels.swift
+++ b/clients/shared/App/Auth/AuthModels.swift
@@ -319,7 +319,7 @@ public struct BillingSummaryResponse: Codable, Sendable {
 }
 
 public struct TopUpCheckoutRequest: Codable, Sendable {
-    public let amount_usd: String
+    public let amount: String
     public let return_path: String
 }
 

--- a/clients/shared/App/Auth/BillingService.swift
+++ b/clients/shared/App/Auth/BillingService.swift
@@ -214,7 +214,7 @@ public final class BillingService {
     }
 
     /// Create a top-up checkout session and return the Stripe checkout URL.
-    public func createTopUpCheckout(amountUsd: String) async throws -> URL {
+    public func createTopUpCheckout(amount: String) async throws -> URL {
         let urlString = "\(AuthService.shared.baseURL)/v1/organizations/billing/top-ups/checkout-session/"
         guard let url = URL(string: urlString) else {
             throw PlatformAPIError.invalidURL
@@ -236,7 +236,7 @@ public final class BillingService {
         }
         urlRequest.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
 
-        let requestBody = TopUpCheckoutRequest(amount_usd: amountUsd, return_path: "/billing/top-up/success")
+        let requestBody = TopUpCheckoutRequest(amount: amount, return_path: "/billing/top-up/success")
         let encoder = JSONEncoder()
         urlRequest.httpBody = try encoder.encode(requestBody)
 


### PR DESCRIPTION
## Summary
- Replace amount_usd with amount in TopUpCheckoutRequest struct
- Rename createTopUpCheckout(amountUsd:) to createTopUpCheckout(amount:) in BillingService
- Update caller in SettingsBillingTab

Part of plan: client-credits-api-keys.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
