### PR TITLE
feat: migrate macOS client to credits-neutral API keys

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -89,7 +89,7 @@ struct DrawerMenuView: View {
             if let bootstrapped = await BillingService.shared.bootstrapBillingSummaryIfNeeded(summary: summary) {
                 summary = bootstrapped
             }
-            let balanceString = summary.effective_balance_usd
+            let balanceString = summary.effective_balance
             effectiveBalance = balanceString
             if let value = Double(balanceString) {
                 isZeroBalance = value <= 0

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingReferralCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingReferralCard.swift
@@ -98,14 +98,14 @@ struct SettingsBillingReferralCard: View {
                                 .font(VFont.bodySmallDefault)
                                 .foregroundStyle(VColor.contentSecondary)
                         }
-                        Text("\(code.total_earned_usd) credits")
+                        Text("\(code.total_earned) credits")
                             .font(VFont.bodyMediumDefault)
                             .foregroundStyle(VColor.contentEmphasized)
                     }
                 }
 
                 // Earning cap note
-                Text("Earn up to \(code.earning_cap_usd) referral credits")
+                Text("Earn up to \(code.earning_cap) referral credits")
                     .font(VFont.bodySmallDefault)
                     .foregroundStyle(VColor.contentTertiary)
             }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -296,7 +296,7 @@ struct SettingsBillingTab: View {
         defer { isProcessingTopUp = false }
 
         do {
-            let checkoutURL = try await BillingService.shared.createTopUpCheckout(amountUsd: amountStr)
+            let checkoutURL = try await BillingService.shared.createTopUpCheckout(amount: amountStr)
             NSWorkspace.shared.open(checkoutURL)
         } catch let PlatformAPIError.serverError(_, detail) {
             self.topUpError = Self.parseValidationError(detail) ?? "Failed to create checkout session. Please try again."

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -112,7 +112,7 @@ struct SettingsBillingTab: View {
                 Text("Effective Credit Balance")
                     .font(VFont.bodySmallDefault)
                     .foregroundStyle(VColor.contentSecondary)
-                Text("\(summary.effective_balance_usd) credits")
+                Text("\(summary.effective_balance) credits")
                     .font(VFont.titleMedium)
                     .foregroundStyle(VColor.contentEmphasized)
             }
@@ -140,7 +140,7 @@ struct SettingsBillingTab: View {
                     Text("Settled Credit Balance")
                         .font(VFont.bodySmallDefault)
                         .foregroundStyle(VColor.contentSecondary)
-                    Text("\(summary.settled_balance_usd) credits")
+                    Text("\(summary.settled_balance) credits")
                         .font(VFont.bodyMediumDefault)
                         .foregroundStyle(VColor.contentDefault)
                 }
@@ -148,7 +148,7 @@ struct SettingsBillingTab: View {
                     Text(summary.is_degraded ? "Pending Usage (estimated)" : "Pending Usage")
                         .font(VFont.bodySmallDefault)
                         .foregroundStyle(VColor.contentSecondary)
-                    Text("\(summary.pending_compute_usd) credits")
+                    Text("\(summary.pending_compute) credits")
                         .font(VFont.bodyMediumDefault)
                         .foregroundStyle(summary.is_degraded ? VColor.contentSecondary : VColor.contentDefault)
                 }
@@ -197,7 +197,7 @@ struct SettingsBillingTab: View {
                 )
                 .frame(maxWidth: 200)
                 if let summary {
-                    Text("\(summary.maximum_balance_usd) max credit balance. Credits expire 12 months after purchase.")
+                    Text("\(summary.maximum_balance) max credit balance. Credits expire 12 months after purchase.")
                         .font(VFont.bodySmallDefault)
                         .foregroundStyle(VColor.contentTertiary)
                 }
@@ -284,10 +284,10 @@ struct SettingsBillingTab: View {
         let amount = Double(amountStr) ?? 0
 
         if let summary,
-           let maxBalance = Double(summary.maximum_balance_usd),
-           let currentBalance = Double(summary.effective_balance_usd),
+           let maxBalance = Double(summary.maximum_balance),
+           let currentBalance = Double(summary.effective_balance),
            currentBalance + amount > maxBalance {
-            topUpError = "This top-up would exceed the maximum credit balance of \(summary.maximum_balance_usd)."
+            topUpError = "This top-up would exceed the maximum credit balance of \(summary.maximum_balance)."
             return
         }
 

--- a/clients/shared/App/Auth/AuthModels.swift
+++ b/clients/shared/App/Auth/AuthModels.swift
@@ -319,7 +319,7 @@ public struct BillingSummaryResponse: Codable, Sendable {
 }
 
 public struct TopUpCheckoutRequest: Codable, Sendable {
-    public let amount_usd: String
+    public let amount: String
     public let return_path: String
 }
 

--- a/clients/shared/App/Auth/AuthModels.swift
+++ b/clients/shared/App/Auth/AuthModels.swift
@@ -308,12 +308,12 @@ public struct SelfHostedProvisioningInfo: Codable, Sendable {
 // MARK: - Billing Models
 
 public struct BillingSummaryResponse: Codable, Sendable {
-    public let settled_balance_usd: String
-    public let pending_compute_usd: String
-    public let effective_balance_usd: String
-    public let minimum_top_up_usd: String
-    public let maximum_top_up_usd: String
-    public let maximum_balance_usd: String
+    public let settled_balance: String
+    public let pending_compute: String
+    public let effective_balance: String
+    public let minimum_top_up: String
+    public let maximum_top_up: String
+    public let maximum_balance: String
     public let allowed_top_up_amounts: [String]?
     public let is_degraded: Bool
 }

--- a/clients/shared/App/Auth/AuthModels.swift
+++ b/clients/shared/App/Auth/AuthModels.swift
@@ -330,6 +330,6 @@ public struct TopUpCheckoutResponse: Codable, Sendable {
 public struct ReferralCodeResponse: Codable, Sendable {
     public let referral_url: String
     public let referred_count: Int
-    public let total_earned_usd: String
-    public let earning_cap_usd: String
+    public let total_earned: String
+    public let earning_cap: String
 }

--- a/clients/shared/App/Auth/BillingService.swift
+++ b/clients/shared/App/Auth/BillingService.swift
@@ -76,9 +76,9 @@ public final class BillingService {
         guard let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") else { return nil }
 
         // Only attempt bootstrap for all-zero balances
-        let isAllZero = summary.effective_balance_usd == "0.00"
-            && summary.settled_balance_usd == "0.00"
-            && summary.pending_compute_usd == "0.00"
+        let isAllZero = summary.effective_balance == "0.00"
+            && summary.settled_balance == "0.00"
+            && summary.pending_compute == "0.00"
         guard isAllZero else { return nil }
 
         // Skip if we've already attempted bootstrap for this org

--- a/clients/shared/App/Auth/BillingService.swift
+++ b/clients/shared/App/Auth/BillingService.swift
@@ -214,7 +214,7 @@ public final class BillingService {
     }
 
     /// Create a top-up checkout session and return the Stripe checkout URL.
-    public func createTopUpCheckout(amountUsd: String) async throws -> URL {
+    public func createTopUpCheckout(amount: String) async throws -> URL {
         let urlString = "\(AuthService.shared.baseURL)/v1/organizations/billing/top-ups/checkout-session/"
         guard let url = URL(string: urlString) else {
             throw PlatformAPIError.invalidURL
@@ -236,7 +236,7 @@ public final class BillingService {
         }
         urlRequest.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
 
-        let requestBody = TopUpCheckoutRequest(amount_usd: amountUsd, return_path: "/billing/top-up/success")
+        let requestBody = TopUpCheckoutRequest(amount: amount, return_path: "/billing/top-up/success")
         let encoder = JSONEncoder()
         urlRequest.httpBody = try encoder.encode(requestBody)
 


### PR DESCRIPTION
## Summary
Migrate all macOS client billing models and UI from deprecated `_usd` API keys to new credits-neutral keys (`settled_balance`, `effective_balance`, `amount`, etc.). After this change, there are zero references to `_usd` fields in the client codebase.

## PRs merged into feature branch
- #23632: feat: migrate BillingSummaryResponse to credits-neutral API keys
- #23633: feat: send `amount` instead of `amount_usd` in top-up checkout requests
- #23631: feat: migrate ReferralCodeResponse to credits-neutral API keys

Part of plan: client-credits-api-keys.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
