### PR TITLE
chore: polish billing credits copy across macOS app

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -34,7 +34,7 @@ struct DrawerMenuView: View {
             if let balance = effectiveBalance {
                 VMenuCustomRow {
                     HStack {
-                        Text("\(balance) credits remaining")
+                        Text("\(balance) credits")
                             .font(VFont.bodyMediumDefault)
                             .foregroundStyle(
                                 isZeroBalance ? VColor.systemNegativeStrong :

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingReferralCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingReferralCard.swift
@@ -98,14 +98,14 @@ struct SettingsBillingReferralCard: View {
                                 .font(VFont.bodySmallDefault)
                                 .foregroundStyle(VColor.contentSecondary)
                         }
-                        Text("\(code.total_earned) credits")
+                        Text("\(code.total_earned.replacingOccurrences(of: ".00", with: "")) credits")
                             .font(VFont.bodyMediumDefault)
                             .foregroundStyle(VColor.contentEmphasized)
                     }
                 }
 
                 // Earning cap note
-                Text("Earn up to \(code.earning_cap) referral credits")
+                Text("Earn up to \(code.earning_cap.replacingOccurrences(of: ".00", with: "")) referral credits")
                     .font(VFont.bodySmallDefault)
                     .foregroundStyle(VColor.contentTertiary)
             }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -109,10 +109,10 @@ struct SettingsBillingTab: View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             // Effective balance — large display
             VStack(alignment: .leading, spacing: VSpacing.xs) {
-                Text("Effective Credit Balance")
+                Text("Balance")
                     .font(VFont.bodySmallDefault)
                     .foregroundStyle(VColor.contentSecondary)
-                Text("\(summary.effective_balance) credits")
+                Text(summary.effective_balance)
                     .font(VFont.titleMedium)
                     .foregroundStyle(VColor.contentEmphasized)
             }
@@ -137,10 +137,10 @@ struct SettingsBillingTab: View {
 
             HStack(spacing: VSpacing.xl) {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text("Settled Credit Balance")
+                    Text("Settled Balance")
                         .font(VFont.bodySmallDefault)
                         .foregroundStyle(VColor.contentSecondary)
-                    Text("\(summary.settled_balance) credits")
+                    Text(summary.settled_balance)
                         .font(VFont.bodyMediumDefault)
                         .foregroundStyle(VColor.contentDefault)
                 }
@@ -148,7 +148,7 @@ struct SettingsBillingTab: View {
                     Text(summary.is_degraded ? "Pending Usage (estimated)" : "Pending Usage")
                         .font(VFont.bodySmallDefault)
                         .foregroundStyle(VColor.contentSecondary)
-                    Text("\(summary.pending_compute) credits")
+                    Text(summary.pending_compute)
                         .font(VFont.bodyMediumDefault)
                         .foregroundStyle(summary.is_degraded ? VColor.contentSecondary : VColor.contentDefault)
                 }
@@ -192,12 +192,20 @@ struct SettingsBillingTab: View {
                     ),
                     options: topUpAmounts.map { amount in
                         let credits = amount.replacingOccurrences(of: ".00", with: "")
-                        return (label: "\(credits) ($\(amount))", value: amount)
+                        return (label: "\(credits) credits", value: amount)
                     }
                 )
                 .frame(maxWidth: 200)
                 if let summary {
-                    Text("\(summary.maximum_balance) max credit balance. Credits expire 12 months after purchase.")
+                    let maxFormatted: String = {
+                        if let value = Int(Double(summary.maximum_balance) ?? 0), value > 0 {
+                            let formatter = NumberFormatter()
+                            formatter.numberStyle = .decimal
+                            return formatter.string(from: NSNumber(value: value)) ?? summary.maximum_balance
+                        }
+                        return summary.maximum_balance
+                    }()
+                    Text("1 credit = $1 USD. \(maxFormatted) max credit balance. Credits expire 12 months after purchase.")
                         .font(VFont.bodySmallDefault)
                         .foregroundStyle(VColor.contentTertiary)
                 }
@@ -287,7 +295,15 @@ struct SettingsBillingTab: View {
            let maxBalance = Double(summary.maximum_balance),
            let currentBalance = Double(summary.effective_balance),
            currentBalance + amount > maxBalance {
-            topUpError = "This top-up would exceed the maximum credit balance of \(summary.maximum_balance)."
+            let maxFormatted: String = {
+                if let value = Int(maxBalance), value > 0 {
+                    let formatter = NumberFormatter()
+                    formatter.numberStyle = .decimal
+                    return formatter.string(from: NSNumber(value: value)) ?? summary.maximum_balance
+                }
+                return summary.maximum_balance
+            }()
+            topUpError = "This top-up would exceed the maximum credit balance of \(maxFormatted)."
             return
         }
 


### PR DESCRIPTION
## Summary
- Shorten redundant labels: "Effective Credit Balance" → "Balance", "Settled Credit Balance" → "Settled Balance" (card title already establishes context)
- Remove " credits" suffix from balance values since the card title says "Credit Balance"
- Sidebar: "92.70 credits remaining" → "92.70 credits" (prevents two-line wrapping)
- Dropdown: "10 ($10.00)" → "10 credits" with "1 credit = $1 USD" note in help text
- Format max balance with commas: "1000.00" → "1,000"
- Strip ".00" from whole-number referral amounts: "0.00 credits" → "0 credits"

## Original prompt
Polish billing UI copy to reduce redundancy, improve readability, and clean up formatting across the macOS billing tab, sidebar, and referral card.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
