### PR TITLE
fix: use non-optional Int binding for max balance formatting

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -198,7 +198,8 @@ struct SettingsBillingTab: View {
                 .frame(maxWidth: 200)
                 if let summary {
                     let maxFormatted: String = {
-                        if let value = Int(Double(summary.maximum_balance) ?? 0), value > 0 {
+                        let value = Int(Double(summary.maximum_balance) ?? 0)
+                        if value > 0 {
                             let formatter = NumberFormatter()
                             formatter.numberStyle = .decimal
                             return formatter.string(from: NSNumber(value: value)) ?? summary.maximum_balance
@@ -296,7 +297,8 @@ struct SettingsBillingTab: View {
            let currentBalance = Double(summary.effective_balance),
            currentBalance + amount > maxBalance {
             let maxFormatted: String = {
-                if let value = Int(maxBalance), value > 0 {
+                let value = Int(maxBalance)
+                if value > 0 {
                     let formatter = NumberFormatter()
                     formatter.numberStyle = .decimal
                     return formatter.string(from: NSNumber(value: value)) ?? summary.maximum_balance


### PR DESCRIPTION
## Summary
- Replace `if let value = Int(...)` with `let value = Int(...)` + `if value > 0` in two places where `Int.init(_: Double)` returns a non-optional, fixing a potential compile error flagged by Codex and Devin on #23635
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
