### PR TITLE
fix: prevent false "Failed to send" on successfully queued messages

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1306,36 +1306,47 @@ export async function handleSendMessage(
     // Auto-deny pending confirmations only after enqueue succeeds, so we
     // don't cancel approval-gated workflows when the replacement message
     // is itself rejected by the queue budget.
-    if (conversation.hasAnyPendingConfirmation()) {
-      // Emit authoritative denial state for each pending request.
-      // sendToClient (wired to the SSE hub) delivers these to the client.
-      for (const interaction of pendingInteractions.getByConversation(
-        mapping.conversationId,
-      )) {
-        if (
-          interaction.conversation === conversation &&
-          interaction.kind === "confirmation"
-        ) {
-          conversation.emitConfirmationStateChanged({
-            conversationId: mapping.conversationId,
-            requestId: interaction.requestId,
-            state: "denied" as const,
-            source: "auto_deny" as const,
-          });
-          // Sync canonical guardian request status so stale "pending" DB
-          // records don't get matched by later guardian reply routing.
-          resolveCanonicalGuardianRequest(interaction.requestId, "pending", {
-            status: "denied",
-          });
+    // Wrapped in try-catch: the message is already enqueued, so a failure
+    // here must not turn the 202 response into a 500 — that would leave
+    // the client showing "Failed to send" for a message the daemon will
+    // process from the queue.
+    try {
+      if (conversation.hasAnyPendingConfirmation()) {
+        // Emit authoritative denial state for each pending request.
+        // sendToClient (wired to the SSE hub) delivers these to the client.
+        for (const interaction of pendingInteractions.getByConversation(
+          mapping.conversationId,
+        )) {
+          if (
+            interaction.conversation === conversation &&
+            interaction.kind === "confirmation"
+          ) {
+            conversation.emitConfirmationStateChanged({
+              conversationId: mapping.conversationId,
+              requestId: interaction.requestId,
+              state: "denied" as const,
+              source: "auto_deny" as const,
+            });
+            // Sync canonical guardian request status so stale "pending" DB
+            // records don't get matched by later guardian reply routing.
+            resolveCanonicalGuardianRequest(interaction.requestId, "pending", {
+              status: "denied",
+            });
+          }
         }
+        conversation.denyAllPendingConfirmations();
+        pendingInteractions.removeByConversation(conversation);
       }
-      conversation.denyAllPendingConfirmations();
-      pendingInteractions.removeByConversation(conversation);
-    }
 
-    // Expire any orphaned canonical requests that survived without a
-    // matching in-memory pending interaction (e.g. prompter timeouts).
-    expireOrphanedCanonicalRequests(mapping.conversationId);
+      // Expire any orphaned canonical requests that survived without a
+      // matching in-memory pending interaction (e.g. prompter timeouts).
+      expireOrphanedCanonicalRequests(mapping.conversationId);
+    } catch (err) {
+      log.warn(
+        { err, conversationId: mapping.conversationId },
+        "Post-enqueue auto-deny failed — queued message unaffected",
+      );
+    }
 
     return Response.json(
       { accepted: true, queued: true, conversationId: mapping.conversationId },

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -671,13 +671,25 @@ final class ChatActionHandler {
                 vm.currentTurnUserText = text
             }
         } else {
-            // No matching messageId — still recompute queued positions
+            // No matching messageId — still recompute queued positions and
+            // reconcile any false "Failed to send" state: the daemon is
+            // processing a queued message, so if a user message is marked as
+            // sendFailed, the send actually succeeded (transient HTTP error
+            // between enqueue and 202 response).
+            var reconciledId: UUID?
             vm.messageManager.batchUpdateMessages { msgs in
+                if let idx = msgs.lastIndex(where: { $0.role == .user && $0.status == .sendFailed }) {
+                    msgs[idx].status = .processing
+                    reconciledId = msgs[idx].id
+                }
                 for i in msgs.indices {
                     if case .queued(let position) = msgs[i].status, position > 0 {
                         msgs[i].status = .queued(position: position - 1)
                     }
                 }
+            }
+            if let reconciledId {
+                vm.activeRequestIdToMessageId[msg.requestId] = reconciledId
             }
         }
         // The dequeued message is now being processed


### PR DESCRIPTION
## Summary
- **Server-side**: Wrap post-enqueue auto-deny logic in try-catch in `conversation-routes.ts` so a failure can't turn a successful enqueue into a 500 error response
- **Client-side**: In `ChatActionHandler.handleMessageDequeued`, reconcile `.sendFailed` user messages when the daemon dequeues them — the dequeue event proves the message was delivered despite a transient HTTP error
- Fixes a race condition where `/compact` (or any message) sent while the assistant is busy shows "Failed to send" but actually succeeds