### PR TITLE
fix(ios): move countLines out of macOS-only VCodeView to unblock iOS build

### DIFF
--- a/clients/shared/Features/Chat/ToolCallChip.swift
+++ b/clients/shared/Features/Chat/ToolCallChip.swift
@@ -66,6 +66,14 @@ public struct ToolCallChip: View {
         toolCall.result != nil || !toolCall.cachedImages.isEmpty
     }
 
+    /// Counts newlines without allocating N substrings.
+    /// Equivalent to `text.components(separatedBy: "\n").count` but O(1) memory.
+    static func countLines(in text: String) -> Int {
+        var count = 1
+        for byte in text.utf8 where byte == 0x0A { count += 1 }
+        return count
+    }
+
     /// Lazily resolved full input text, using the cached value when available.
     private var resolvedInputFull: String {
         if let cached = cachedInputFull { return cached }
@@ -218,7 +226,7 @@ public struct ToolCallChip: View {
                                         .foregroundStyle(VColor.contentSecondary)
                                 }
                             } else {
-                                let lineCount = cachedResultLineCount ?? VCodeView.countLines(in: result)
+                                let lineCount = cachedResultLineCount ?? Self.countLines(in: result)
                                 if Self.isFileEditTool(toolCall.toolName) {
                                     VDiffView(result, maxHeight: lineCount > 500 ? 400 : nil)
                                 } else {
@@ -250,7 +258,7 @@ public struct ToolCallChip: View {
                     }
                     // Cache the result line count so subsequent renders are O(1).
                     if cachedResultLineCount == nil, let result = toolCall.result {
-                        cachedResultLineCount = VCodeView.countLines(in: result)
+                        cachedResultLineCount = Self.countLines(in: result)
                     }
                     // Trigger on-demand rehydration when expanding truncated content.
                     onRehydrate?()
@@ -283,7 +291,7 @@ public struct ToolCallChip: View {
                     }
                 }
                 if cachedResultLineCount == nil, let result = toolCall.result {
-                    cachedResultLineCount = VCodeView.countLines(in: result)
+                    cachedResultLineCount = Self.countLines(in: result)
                 }
             }
         }
@@ -294,7 +302,7 @@ public struct ToolCallChip: View {
         }
         .onChange(of: toolCall.result) {
             if isExpanded, let result = toolCall.result {
-                cachedResultLineCount = VCodeView.countLines(in: result)
+                cachedResultLineCount = Self.countLines(in: result)
             } else {
                 cachedResultLineCount = nil
             }


### PR DESCRIPTION
## Summary
- iOS CI was failing with `Cannot find 'VCodeView' in scope` because `ToolCallChip.swift` (cross-platform) called `VCodeView.countLines(in:)`, but `VCodeView` is wrapped in `#if os(macOS)`.
- Moved the trivial `countLines` helper onto `ToolCallChip` itself so it's available on both macOS and iOS.
- No behavior change — same algorithm, just relocated.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23996126997/job/69984402401
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
