### PR TITLE
fix(ios): move countLines out of macOS-only VCodeView in LazyVStackScrollFrameModifier

### DIFF
--- a/clients/shared/DesignSystem/Modifiers/LazyVStackScrollFrameModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/LazyVStackScrollFrameModifier.swift
@@ -17,9 +17,17 @@ extension View {
         maxHeight: CGFloat,
         lineThreshold: Int = 500
     ) -> some View {
-        let isLong = VCodeView.countLines(in: text) > lineThreshold
+        let isLong = countLines(in: text) > lineThreshold
         return self
             .frame(height: isLong ? maxHeight : nil)
             .frame(maxHeight: isLong ? nil : maxHeight)
     }
+}
+
+/// Counts newlines without allocating N substrings.
+/// Equivalent to `text.components(separatedBy: "\n").count` but O(1) memory.
+private func countLines(in text: String) -> Int {
+    var count = 1
+    for byte in text.utf8 where byte == 0x0A { count += 1 }
+    return count
 }


### PR DESCRIPTION
## Summary
- `LazyVStackScrollFrameModifier.swift` is cross-platform but referenced `VCodeView.countLines(in:)`, which only exists inside `#if os(macOS)`. iOS builds failed with 'Cannot find VCodeView in scope'.
- Follow-up to #23648 which fixed the same issue in `ToolCallChip` but missed this modifier.
- Inlined `countLines` as a file-private helper to keep it trivial and platform-agnostic.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23996210364
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
