### PR TITLE
fix(test): sync safe-env allowlist tests with production list

### DIFF
--- a/assistant/src/__tests__/terminal-tools.test.ts
+++ b/assistant/src/__tests__/terminal-tools.test.ts
@@ -67,7 +67,11 @@ mock.module("../tools/network/script-proxy/index.js", () => ({
 
 import type { SandboxConfig } from "../config/schema.js";
 import { parse } from "../tools/terminal/parser.js";
-import { buildSanitizedEnv } from "../tools/terminal/safe-env.js";
+import {
+  ALWAYS_INJECTED_ENV_VARS,
+  buildSanitizedEnv,
+  SAFE_ENV_VARS,
+} from "../tools/terminal/safe-env.js";
 import { wrapCommand } from "../tools/terminal/sandbox.js";
 import { ToolError } from "../util/errors.js";
 
@@ -451,29 +455,9 @@ describe("buildSanitizedEnv", () => {
   test("result is a plain object with no prototype-inherited secrets", () => {
     const env = buildSanitizedEnv();
     const keys = Object.keys(env);
-    const safeKeys = [
-      "PATH",
-      "HOME",
-      "TERM",
-      "LANG",
-      "EDITOR",
-      "SHELL",
-      "USER",
-      "TMPDIR",
-      "LC_ALL",
-      "LC_CTYPE",
-      "XDG_RUNTIME_DIR",
-      "DISPLAY",
-      "COLORTERM",
-      "TERM_PROGRAM",
-      "SSH_AUTH_SOCK",
-      "SSH_AGENT_PID",
-      "GPG_TTY",
-      "GNUPGHOME",
-      "VELLUM_DEV",
-      "INTERNAL_GATEWAY_BASE_URL",
-      "VELLUM_DATA_DIR",
-      "VELLUM_WORKSPACE_DIR",
+    const safeKeys: string[] = [
+      ...SAFE_ENV_VARS,
+      ...ALWAYS_INJECTED_ENV_VARS,
     ];
     for (const key of keys) {
       expect(safeKeys).toContain(key);

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -2072,7 +2072,8 @@ describe("ToolExecutor persistentDecisionsAllowed contract", () => {
 // ---------------------------------------------------------------------------
 
 // Import the real buildSanitizedEnv (not mocked) for baseline credential tests
-const { buildSanitizedEnv } = await import("../tools/terminal/safe-env.js");
+const { buildSanitizedEnv, SAFE_ENV_VARS, ALWAYS_INJECTED_ENV_VARS } =
+  await import("../tools/terminal/safe-env.js");
 
 describe("buildSanitizedEnv — baseline: credential exclusion", () => {
   // Credential-like env vars that must never appear in the sanitized env.
@@ -2130,33 +2131,10 @@ describe("buildSanitizedEnv — baseline: credential exclusion", () => {
   });
 
   test("sanitized env only contains keys from the allowlist", () => {
-    const SAFE_ENV_VARS = [
-      "PATH",
-      "HOME",
-      "TERM",
-      "LANG",
-      "EDITOR",
-      "SHELL",
-      "USER",
-      "TMPDIR",
-      "LC_ALL",
-      "LC_CTYPE",
-      "XDG_RUNTIME_DIR",
-      "DISPLAY",
-      "COLORTERM",
-      "TERM_PROGRAM",
-      "SSH_AUTH_SOCK",
-      "SSH_AGENT_PID",
-      "GPG_TTY",
-      "GNUPGHOME",
-      "INTERNAL_GATEWAY_BASE_URL",
-      "VELLUM_DATA_DIR",
-      "VELLUM_WORKSPACE_DIR",
-    ];
-
+    const allowed: string[] = [...SAFE_ENV_VARS, ...ALWAYS_INJECTED_ENV_VARS];
     const env = buildSanitizedEnv();
     for (const key of Object.keys(env)) {
-      expect(SAFE_ENV_VARS).toContain(key);
+      expect(allowed).toContain(key);
     }
   });
 });

--- a/assistant/src/tools/terminal/safe-env.ts
+++ b/assistant/src/tools/terminal/safe-env.ts
@@ -8,7 +8,7 @@
 import { getGatewayInternalBaseUrl } from "../../config/env.js";
 import { getDataDir, getWorkspaceDir } from "../../util/platform.js";
 
-const SAFE_ENV_VARS = [
+export const SAFE_ENV_VARS = [
   "PATH",
   "HOME",
   "TERM",
@@ -42,6 +42,16 @@ const SAFE_ENV_VARS = [
   "VELLUM_PROFILER_MAX_BYTES",
   "VELLUM_PROFILER_MAX_RUNS",
   "VELLUM_PROFILER_MIN_FREE_MB",
+] as const;
+
+/**
+ * Keys that buildSanitizedEnv always injects into the returned env,
+ * independent of what is present in process.env.
+ */
+export const ALWAYS_INJECTED_ENV_VARS = [
+  "INTERNAL_GATEWAY_BASE_URL",
+  "VELLUM_DATA_DIR",
+  "VELLUM_WORKSPACE_DIR",
 ] as const;
 
 export function buildSanitizedEnv(): Record<string, string> {


### PR DESCRIPTION
## Summary
- Test assertions in tool-executor.test.ts and terminal-tools.test.ts hardcoded their own SAFE_ENV_VARS lists that drifted from the real allowlist in \`safe-env.ts\`.
- In CI, env vars like \`VELLUM_PLATFORM_URL\` (and other newer entries) were set, so \`buildSanitizedEnv()\` forwarded them — but the tests' stale allowlists rejected them.
- Exported \`SAFE_ENV_VARS\` and a new \`ALWAYS_INJECTED_ENV_VARS\` from \`safe-env.ts\`, and consumed them directly in both tests. Prevents this drift from recurring.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/23996126983/job/69984402366
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
