### PR TITLE
fix(macos): autolink bare URLs in chat messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AttributedStringAutolinker.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AttributedStringAutolinker.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Attaches `.link` attributes to bare URLs in AttributedStrings produced by
+/// Foundation's markdown parser. The parser (with `.inlineOnlyPreservingWhitespace`)
+/// only recognizes explicit `[text](url)` syntax; this fills the autolink gap
+/// so that URLs like "amazon.com/dp/B07978VPPH" become clickable in chat.
+///
+/// `NSDataDetector` handles schemeless URLs by synthesizing an `http://`
+/// scheme; the browser then upgrades to HTTPS as needed.
+enum AttributedStringAutolinker {
+    /// Shared detector — `NSDataDetector` is expensive to construct.
+    private static let urlDetector: NSDataDetector? = {
+        try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+    }()
+
+    /// Adds `.link` attributes to bare URLs, preserving existing links and
+    /// skipping code spans. No-op when no bare URLs are present.
+    static func autolinkBareURLs(in attributed: inout AttributedString) {
+        guard let detector = urlDetector else { return }
+
+        let plainText = String(attributed.characters)
+        let nsRange = NSRange(plainText.startIndex..., in: plainText)
+        let matches = detector.matches(in: plainText, options: [], range: nsRange)
+        guard !matches.isEmpty else { return }
+
+        for match in matches {
+            guard let url = match.url,
+                  let swiftRange = Range(match.range, in: plainText),
+                  let lo = AttributedString.Index(swiftRange.lowerBound, within: attributed),
+                  let hi = AttributedString.Index(swiftRange.upperBound, within: attributed),
+                  lo < hi else { continue }
+
+            let attrRange = lo..<hi
+
+            // Skip ranges already linked or inside inline code spans.
+            var skip = false
+            for run in attributed[attrRange].runs {
+                if run.link != nil { skip = true; break }
+                if let intent = run.inlinePresentationIntent, intent.contains(.code) {
+                    skip = true; break
+                }
+            }
+            if skip { continue }
+
+            attributed[attrRange].link = url
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
@@ -334,8 +334,9 @@ struct MarkdownTableView: View {
         let options = AttributedString.MarkdownParsingOptions(
             interpretedSyntax: .inlineOnlyPreservingWhitespace
         )
-        let attributed = (try? AttributedString(markdown: text, options: options))
+        var attributed = (try? AttributedString(markdown: text, options: options))
             ?? AttributedString(text)
+        AttributedStringAutolinker.autolinkBareURLs(in: &attributed)
 
         // Evict least-recently-used entry if over limit
         if cellCache.count >= cellCacheLimit {

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -359,13 +359,15 @@ struct MarkdownSegmentView: View, Equatable {
 
             switch segment {
             case .text(let text):
-                let attributed = (try? AttributedString(markdown: text, options: mdOptions))
+                var attributed = (try? AttributedString(markdown: text, options: mdOptions))
                     ?? AttributedString(text)
+                AttributedStringAutolinker.autolinkBareURLs(in: &attributed)
                 result += attributed
 
             case .heading(let level, let text):
                 var headingAttr = (try? AttributedString(markdown: text, options: mdOptions))
                     ?? AttributedString(text)
+                AttributedStringAutolinker.autolinkBareURLs(in: &headingAttr)
                 let headingSize: CGFloat = switch level {
                 case 1: 20
                 case 2: 16
@@ -399,8 +401,9 @@ struct MarkdownSegmentView: View, Equatable {
                     var prefixAttr = AttributedString(indentString + prefix)
                     prefixAttr.foregroundColor = secondaryTextColor
 
-                    let itemAttr = (try? AttributedString(markdown: item.text, options: mdOptions))
+                    var itemAttr = (try? AttributedString(markdown: item.text, options: mdOptions))
                         ?? AttributedString(item.text)
+                    AttributedStringAutolinker.autolinkBareURLs(in: &itemAttr)
 
                     // Apply hanging indent so wrapped lines align with item text
                     let prefixText = indentString + prefix

--- a/clients/macos/vellum-assistantTests/AttributedStringAutolinkerTests.swift
+++ b/clients/macos/vellum-assistantTests/AttributedStringAutolinkerTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+@testable import VellumAssistantLib
+
+/// Verifies that `AttributedStringAutolinker` attaches `.link` attributes to
+/// bare URLs after markdown parsing, while leaving existing links and inline
+/// code spans untouched.
+final class AttributedStringAutolinkerTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Builds an `AttributedString` the same way the chat renderers do —
+    /// with `.inlineOnlyPreservingWhitespace`, which does NOT autolink
+    /// bare URLs.
+    private func makeAttributed(_ source: String) -> AttributedString {
+        let options = AttributedString.MarkdownParsingOptions(
+            interpretedSyntax: .inlineOnlyPreservingWhitespace
+        )
+        return (try? AttributedString(markdown: source, options: options))
+            ?? AttributedString(source)
+    }
+
+    /// Collects all distinct `.link` URLs and the substring they cover.
+    private func extractLinks(from attributed: AttributedString) -> [(url: URL, text: String)] {
+        var results: [(url: URL, text: String)] = []
+        for run in attributed.runs {
+            guard let link = run.link else { continue }
+            let text = String(attributed[run.range].characters)
+            results.append((url: link, text: text))
+        }
+        return results
+    }
+
+    // MARK: - Tests
+
+    func testBareURLWithSchemeGetsLinked() {
+        var attributed = makeAttributed("Visit https://example.com now")
+        AttributedStringAutolinker.autolinkBareURLs(in: &attributed)
+
+        let links = extractLinks(from: attributed)
+        XCTAssertEqual(links.count, 1)
+        XCTAssertEqual(links.first?.url.absoluteString, "https://example.com")
+        XCTAssertEqual(links.first?.text, "https://example.com")
+    }
+
+    func testSchemelessURLGetsHTTPScheme() {
+        var attributed = makeAttributed("See amazon.com/dp/B07978VPPH")
+        AttributedStringAutolinker.autolinkBareURLs(in: &attributed)
+
+        let links = extractLinks(from: attributed)
+        XCTAssertEqual(links.count, 1)
+        // NSDataDetector synthesizes http:// for schemeless URLs.
+        XCTAssertEqual(links.first?.url.scheme, "http")
+        XCTAssertEqual(links.first?.url.absoluteString, "http://amazon.com/dp/B07978VPPH")
+    }
+
+    func testExplicitMarkdownLinkIsPreserved() {
+        // Markdown parser already sets .link on the bracketed text.
+        var attributed = makeAttributed("[GitHub](https://github.com)")
+        let before = extractLinks(from: attributed)
+        XCTAssertEqual(before.count, 1)
+        XCTAssertEqual(before.first?.url.absoluteString, "https://github.com")
+        XCTAssertEqual(before.first?.text, "GitHub")
+
+        AttributedStringAutolinker.autolinkBareURLs(in: &attributed)
+
+        let after = extractLinks(from: attributed)
+        XCTAssertEqual(after.count, 1, "autolinker must not touch existing links")
+        XCTAssertEqual(after.first?.url.absoluteString, "https://github.com")
+        XCTAssertEqual(after.first?.text, "GitHub")
+    }
+
+    func testURLInsideCodeSpanIsNotLinked() {
+        var attributed = makeAttributed("Run `curl https://secret.com` in your shell")
+        AttributedStringAutolinker.autolinkBareURLs(in: &attributed)
+
+        let links = extractLinks(from: attributed)
+        XCTAssertTrue(links.isEmpty, "code-span URLs must not be autolinked")
+    }
+
+    func testPlainTextWithoutURLsIsUnchanged() {
+        var attributed = makeAttributed("Just some text with no links at all.")
+        AttributedStringAutolinker.autolinkBareURLs(in: &attributed)
+
+        let links = extractLinks(from: attributed)
+        XCTAssertTrue(links.isEmpty)
+    }
+
+    func testMultipleURLsAreAllLinked() {
+        var attributed = makeAttributed(
+            "First https://a.example, then amazon.com/dp/X, and https://b.example/path"
+        )
+        AttributedStringAutolinker.autolinkBareURLs(in: &attributed)
+
+        let links = extractLinks(from: attributed)
+        XCTAssertEqual(links.count, 3)
+        XCTAssertEqual(links[0].url.absoluteString, "https://a.example")
+        XCTAssertEqual(links[1].url.absoluteString, "http://amazon.com/dp/X")
+        XCTAssertEqual(links[2].url.absoluteString, "https://b.example/path")
+    }
+
+    func testEmptyAttributedStringIsNoOp() {
+        var attributed = AttributedString("")
+        AttributedStringAutolinker.autolinkBareURLs(in: &attributed)
+
+        XCTAssertTrue(extractLinks(from: attributed).isEmpty)
+    }
+
+    func testBareURLInTableCellContext() {
+        // Simulates a table cell: cell text is just the bare URL.
+        var attributed = makeAttributed("amazon.com/dp/B07978VPPH")
+        AttributedStringAutolinker.autolinkBareURLs(in: &attributed)
+
+        let links = extractLinks(from: attributed)
+        XCTAssertEqual(links.count, 1)
+        XCTAssertEqual(links.first?.url.absoluteString, "http://amazon.com/dp/B07978VPPH")
+        XCTAssertEqual(links.first?.text, "amazon.com/dp/B07978VPPH")
+    }
+}


### PR DESCRIPTION
## Summary
- Foundation's markdown parser with `.inlineOnlyPreservingWhitespace` only recognizes explicit `[text](url)` syntax and does not autolink bare URLs — so URLs like `amazon.com/dp/B07978VPPH` in assistant-generated tables rendered as plain, non-clickable text.
- Added `AttributedStringAutolinker` that uses `NSDataDetector` to attach `.link` attributes to bare URLs in AttributedStrings after markdown parsing, preserving existing links and skipping inline code spans.
- Applied in `MarkdownTableView` (table cells via SwiftUI `Text`) and `MarkdownSegmentView` (regular text, headings, list items via NSTextView), covering both render paths.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
