### PR TITLE
fix: restore bundled metadata in meta/bun.lock

### DIFF
--- a/meta/bun.lock
+++ b/meta/bun.lock
@@ -818,17 +818,17 @@
 
     "@prisma/instrumentation/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "import-in-the-middle": "^2.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA=="],
 
-    "@vellumai/assistant/@vellumai/ces-contracts": ["@vellumai/ces-contracts@file:../packages/ces-contracts", {}],
+    "@vellumai/assistant/@vellumai/ces-contracts": ["@vellumai/ces-contracts@file:../packages/ces-contracts", { "bundled": true }],
 
-    "@vellumai/assistant/@vellumai/credential-storage": ["@vellumai/credential-storage@file:../packages/credential-storage", {}],
+    "@vellumai/assistant/@vellumai/credential-storage": ["@vellumai/credential-storage@file:../packages/credential-storage", { "bundled": true }],
 
-    "@vellumai/assistant/@vellumai/egress-proxy": ["@vellumai/egress-proxy@file:../packages/egress-proxy", {}],
+    "@vellumai/assistant/@vellumai/egress-proxy": ["@vellumai/egress-proxy@file:../packages/egress-proxy", { "bundled": true }],
 
-    "@vellumai/credential-executor/@vellumai/ces-contracts": ["@vellumai/ces-contracts@file:../packages/ces-contracts", {}],
+    "@vellumai/credential-executor/@vellumai/ces-contracts": ["@vellumai/ces-contracts@file:../packages/ces-contracts", { "bundled": true }],
 
-    "@vellumai/credential-executor/@vellumai/credential-storage": ["@vellumai/credential-storage@file:../packages/credential-storage", {}],
+    "@vellumai/credential-executor/@vellumai/credential-storage": ["@vellumai/credential-storage@file:../packages/credential-storage", { "bundled": true }],
 
-    "@vellumai/credential-executor/@vellumai/egress-proxy": ["@vellumai/egress-proxy@file:../packages/egress-proxy", {}],
+    "@vellumai/credential-executor/@vellumai/egress-proxy": ["@vellumai/egress-proxy@file:../packages/egress-proxy", { "bundled": true }],
 
     "@vellumai/vellum-gateway/uuid": ["uuid@13.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="],
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-trivy-dep-vulns.md.

**Gap:** Bundled metadata stripped from meta/bun.lock
**What was expected:** The bundled: true metadata flags on workspace package references should be preserved
**What was found:** Running bun install stripped the bundled: true flags from 6 workspace package entries
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23660" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
