### PR TITLE
feat: personal knowledge base (PKB) for reliable fact recall

### DIFF
--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -203,6 +203,7 @@ import {
   WhatsAppConfigSchema,
 } from "./schemas/channels.js";
 import { ElevenLabsConfigSchema } from "./schemas/elevenlabs.js";
+import { FilingConfigSchema } from "./schemas/filing.js";
 import { FishAudioConfigSchema } from "./schemas/fish-audio.js";
 import { HeartbeatConfigSchema } from "./schemas/heartbeat.js";
 import {
@@ -278,6 +279,7 @@ export const AssistantConfigSchema = z
       .describe(
         "Custom pricing overrides for specific provider/model combinations",
       ),
+    filing: FilingConfigSchema.default(FilingConfigSchema.parse({})),
     heartbeat: HeartbeatConfigSchema.default(HeartbeatConfigSchema.parse({})),
     journal: JournalConfigSchema.default(JournalConfigSchema.parse({})),
     mcp: McpConfigSchema.default(McpConfigSchema.parse({})),

--- a/assistant/src/config/schemas/filing.ts
+++ b/assistant/src/config/schemas/filing.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+
+import { SpeedSchema } from "./inference.js";
+
+export const FilingConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({ error: "filing.enabled must be a boolean" })
+      .default(false)
+      .describe(
+        "Whether periodic PKB filing is enabled — processes buffer.md into topic files and reviews knowledge base organization",
+      ),
+    intervalMs: z
+      .number({ error: "filing.intervalMs must be a number" })
+      .int("filing.intervalMs must be an integer")
+      .positive("filing.intervalMs must be a positive integer")
+      .default(4 * 3_600_000)
+      .describe("Time between filing runs in milliseconds"),
+    speed: SpeedSchema.default("standard").describe(
+      "Inference speed mode for filing conversations",
+    ),
+    activeHoursStart: z
+      .number({ error: "filing.activeHoursStart must be a number" })
+      .int("filing.activeHoursStart must be an integer")
+      .min(0, "filing.activeHoursStart must be >= 0")
+      .max(23, "filing.activeHoursStart must be <= 23")
+      .default(8)
+      .describe("Hour of the day (0-23) when filing runs begin"),
+    activeHoursEnd: z
+      .number({ error: "filing.activeHoursEnd must be a number" })
+      .int("filing.activeHoursEnd must be an integer")
+      .min(0, "filing.activeHoursEnd must be >= 0")
+      .max(23, "filing.activeHoursEnd must be <= 23")
+      .default(22)
+      .describe("Hour of the day (0-23) when filing runs stop"),
+  })
+  .describe(
+    "Periodic PKB (personal knowledge base) filing — processes the buffer into topic files and maintains knowledge organization",
+  )
+  .superRefine((config, ctx) => {
+    if (config.activeHoursStart === config.activeHoursEnd) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["activeHoursEnd"],
+        message:
+          "filing.activeHoursStart and filing.activeHoursEnd must not be equal (would create an empty window)",
+      });
+    }
+  });
+
+export type FilingConfig = z.infer<typeof FilingConfigSchema>;

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -105,6 +105,7 @@ import {
   inboundActorContextFromTrust,
   inboundActorContextFromTrustContext,
   readNowScratchpad,
+  readPkbContext,
   stripInjectionsForCompaction,
 } from "./conversation-runtime-assembly.js";
 import type { SkillProjectionCache } from "./conversation-skill-tools.js";
@@ -783,6 +784,9 @@ export async function runAgentLoopImpl(
     const nowScratchpad =
       currentNowContent !== lastInjectedNow ? currentNowContent : null;
 
+    // Read PKB always-loaded files (INDEX, essentials, threads, buffer)
+    const currentPkbContent = readPkbContext();
+
     // Shared injection options — reused whenever we need to re-inject after reduction.
     const injectionOpts = {
       activeSurface,
@@ -792,6 +796,7 @@ export async function runAgentLoopImpl(
       channelCapabilities: ctx.channelCapabilities ?? null,
       channelCommandContext: ctx.commandIntent ?? null,
       unifiedTurnContext: unifiedTurnContextStr,
+      pkbContext: currentPkbContent,
       nowScratchpad,
       voiceCallControlPrompt: ctx.voiceCallControlPrompt ?? null,
       transportHints: ctx.transportHints ?? null,
@@ -912,10 +917,11 @@ export async function runAgentLoopImpl(
         }
 
         // Re-inject with potentially downgraded injection mode.
-        // Override nowScratchpad: compaction strips existing NOW.md blocks,
-        // so we must re-inject the current content unconditionally.
+        // Override nowScratchpad and pkbContext: compaction strips these
+        // blocks, so we must re-inject the current content unconditionally.
         runMessages = applyRuntimeInjections(ctx.messages, {
           ...injectionOpts,
+          pkbContext: currentPkbContent,
           nowScratchpad: currentNowContent,
           workspaceTopLevelContext: shouldInjectWorkspace
             ? ctx.workspaceTopLevelContext
@@ -1113,6 +1119,7 @@ export async function runAgentLoopImpl(
       // even if it hasn't changed since the last injection.
       runMessages = applyRuntimeInjections(ctx.messages, {
         ...injectionOpts,
+        pkbContext: currentPkbContent,
         nowScratchpad: currentNowContent,
         workspaceTopLevelContext: shouldInjectWorkspace
           ? ctx.workspaceTopLevelContext
@@ -1320,6 +1327,7 @@ export async function runAgentLoopImpl(
 
         runMessages = applyRuntimeInjections(ctx.messages, {
           ...injectionOpts,
+          pkbContext: currentPkbContent,
           nowScratchpad: currentNowContent,
           workspaceTopLevelContext: shouldInjectWorkspace
             ? ctx.workspaceTopLevelContext
@@ -1439,6 +1447,7 @@ export async function runAgentLoopImpl(
 
             runMessages = applyRuntimeInjections(ctx.messages, {
               ...injectionOpts,
+              pkbContext: currentPkbContent,
               nowScratchpad: currentNowContent,
               workspaceTopLevelContext: shouldInjectWorkspace
                 ? ctx.workspaceTopLevelContext
@@ -1556,6 +1565,7 @@ export async function runAgentLoopImpl(
 
           runMessages = applyRuntimeInjections(ctx.messages, {
             ...injectionOpts,
+            pkbContext: currentPkbContent,
             nowScratchpad: currentNowContent,
             workspaceTopLevelContext: shouldInjectWorkspace
               ? ctx.workspaceTopLevelContext

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -13,7 +13,7 @@ import { getAppDirPath, listAppFiles } from "../memory/app-store.js";
 import type { Message } from "../providers/types.js";
 import type { ActorTrustContext } from "../runtime/actor-trust-resolver.js";
 import { channelStatusToMemberStatus } from "../runtime/routes/inbound-stages/acl-enforcement.js";
-import { getWorkspacePromptPath } from "../util/platform.js";
+import { getWorkspaceDir, getWorkspacePromptPath } from "../util/platform.js";
 import { stripCommentLines } from "../util/strip-comment-lines.js";
 
 /**
@@ -529,6 +529,79 @@ export function stripNowScratchpad(messages: Message[]): Message[] {
   ]);
 }
 
+// ---------------------------------------------------------------------------
+// PKB (Personal Knowledge Base) injection
+// ---------------------------------------------------------------------------
+
+const PKB_FILES = ["INDEX.md", "essentials.md", "threads.md", "buffer.md"];
+
+/**
+ * Read the always-loaded PKB files (INDEX, essentials, threads, buffer).
+ * Returns the concatenated content ready for injection, or `null` if all
+ * files are missing or empty.
+ */
+export function readPkbContext(): string | null {
+  const pkbDir = join(getWorkspaceDir(), "pkb");
+  if (!existsSync(pkbDir)) return null;
+
+  const parts: string[] = [];
+  for (const file of PKB_FILES) {
+    const filePath = join(pkbDir, file);
+    if (!existsSync(filePath)) continue;
+    try {
+      const content = stripCommentLines(readFileSync(filePath, "utf-8")).trim();
+      if (content.length > 0) parts.push(content);
+    } catch {
+      // Skip unreadable files
+    }
+  }
+
+  return parts.length > 0 ? parts.join("\n\n") : null;
+}
+
+/**
+ * Insert PKB context into the user message, after any injected memory
+ * blocks but before NOW.md and the user's original content.
+ */
+export function injectPkbContext(message: Message, content: string): Message {
+  const pkbBlock = {
+    type: "text" as const,
+    text: `<pkb>\n${content}\n</pkb>`,
+  };
+
+  // Find insertion point: skip any leading memory/image blocks
+  let insertIdx = 0;
+  for (let i = 0; i < message.content.length; i++) {
+    const block = message.content[i];
+    if (
+      block.type === "text" &&
+      (block.text.startsWith("<memory") ||
+        block.text.startsWith("<memory_context"))
+    ) {
+      insertIdx = i + 1;
+    } else if (block.type === "image") {
+      // Memory images precede the memory text block
+      insertIdx = i + 1;
+    } else {
+      break;
+    }
+  }
+
+  return {
+    ...message,
+    content: [
+      ...message.content.slice(0, insertIdx),
+      pkbBlock,
+      ...message.content.slice(insertIdx),
+    ],
+  };
+}
+
+/** Strip `<pkb>` blocks injected by `injectPkbContext`. */
+export function stripPkbContext(messages: Message[]): Message[] {
+  return stripUserTextBlocksByPrefix(messages, ["<pkb>"]);
+}
+
 /**
  * Prepend channel capability context to the last user message so the
  * model knows what the current channel can and cannot do.
@@ -953,6 +1026,7 @@ const RUNTIME_INJECTION_PREFIXES = [
   "<non_interactive_context>",
   "<NOW.md Always keep this up to date>",
   "<now_scratchpad>", // backward-compat: strip legacy blocks from pre-rename history
+  "<pkb>",
   "<transport_hints>",
 ];
 
@@ -1014,6 +1088,7 @@ export function applyRuntimeInjections(
     channelCommandContext?: ChannelCommandContext | null;
     unifiedTurnContext?: string | null;
     voiceCallControlPrompt?: string | null;
+    pkbContext?: string | null;
     nowScratchpad?: string | null;
     isNonInteractive?: boolean;
     transportHints?: string[] | null;
@@ -1050,6 +1125,16 @@ export function applyRuntimeInjections(
       result = [
         ...result.slice(0, -1),
         injectVoiceCallControlContext(userTail, options.voiceCallControlPrompt),
+      ];
+    }
+  }
+
+  if (mode === "full" && options.pkbContext) {
+    const userTail = result[result.length - 1];
+    if (userTail && userTail.role === "user") {
+      result = [
+        ...result.slice(0, -1),
+        injectPkbContext(userTail, options.pkbContext),
       ];
     }
   }

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -32,6 +32,7 @@ import {
   awaitCesClientWithTimeout,
   DEFAULT_CES_STARTUP_TIMEOUT_MS,
 } from "../credential-execution/startup-timeout.js";
+import { FilingService } from "../filing/filing-service.js";
 import { HeartbeatService } from "../heartbeat/heartbeat-service.js";
 import { getHookManager } from "../hooks/manager.js";
 import { installTemplates } from "../hooks/templates.js";
@@ -1253,6 +1254,26 @@ export async function runDaemon(): Promise<void> {
       "Heartbeat service configured",
     );
 
+    const filingConfig = config.filing;
+    const filing = new FilingService({
+      processMessage: (conversationId, content, options) =>
+        server.processMessage(conversationId, content, undefined, {
+          trustContext: {
+            sourceChannel: "vellum",
+            trustClass: "guardian",
+          },
+          ...options,
+        }),
+    });
+    filing.start();
+    log.info(
+      {
+        enabled: filingConfig.enabled,
+        intervalMs: filingConfig.intervalMs,
+      },
+      "Filing service configured",
+    );
+
     // Retrieve the MCP manager if MCP servers were configured.
     // The manager is a singleton created during initializeProvidersAndTools().
     const mcpManager =
@@ -1264,6 +1285,7 @@ export async function runDaemon(): Promise<void> {
       server,
       workspaceHeartbeat,
       heartbeat,
+      filing,
       hookManager,
       runtimeHttp,
       scheduler,

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/node";
 
+import type { FilingService } from "../filing/filing-service.js";
 import type { HeartbeatService } from "../heartbeat/heartbeat-service.js";
 import type { HookManager } from "../hooks/manager.js";
 import type { McpServerManager } from "../mcp/manager.js";
@@ -19,6 +20,7 @@ export interface ShutdownDeps {
   server: DaemonServer;
   workspaceHeartbeat: WorkspaceHeartbeatService;
   heartbeat: HeartbeatService;
+  filing: FilingService;
   hookManager: HookManager;
   runtimeHttp: RuntimeHttpServer | null;
   scheduler: { stop(): void };
@@ -52,6 +54,7 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
 
     await deps.workspaceHeartbeat.stop();
     await deps.heartbeat.stop();
+    await deps.filing.stop();
 
     try {
       await deps.hookManager.trigger("daemon-stop", { pid: process.pid });

--- a/assistant/src/filing/filing-service.ts
+++ b/assistant/src/filing/filing-service.ts
@@ -1,0 +1,228 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getConfig } from "../config/loader.js";
+import type { Speed } from "../config/schemas/inference.js";
+import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
+import { getLogger } from "../util/logger.js";
+import { getWorkspaceDir } from "../util/platform.js";
+import { stripCommentLines } from "../util/strip-comment-lines.js";
+
+const log = getLogger("filing-service");
+
+const FILING_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
+
+const FILING_PROMPT_TEMPLATE = `You are running a periodic knowledge base filing job. This is a background maintenance task.
+
+## Part 1: File the buffer
+
+Read \`pkb/buffer.md\`. For each item in the buffer:
+1. Determine which topic file it belongs in. Check \`pkb/INDEX.md\` to see what topic files exist.
+2. Read the target topic file, then append or integrate the new fact.
+3. If the fact is important enough to always be in context, add it to \`pkb/essentials.md\` instead.
+4. If the fact is a commitment, follow-up, or active project, add it to \`pkb/threads.md\`.
+5. If no existing topic file fits, create a new one and update \`pkb/INDEX.md\`.
+
+After all items are filed, clear the processed items from \`pkb/buffer.md\` (leave the file empty, don't delete it).
+
+## Part 2: Nest
+
+Pick 1-2 topic files from your knowledge base and review them:
+- Is the information still accurate and up to date?
+- Are there duplicates that should be consolidated?
+- Is anything important enough to promote to \`pkb/essentials.md\`?
+- Is anything in \`pkb/essentials.md\` that's no longer essential? Demote it to a topic file.
+- Are any threads in \`pkb/threads.md\` completed or stale? Remove them.
+- Is any file getting too long? Consider splitting it.
+- Should any topic file be restructured for clarity?
+
+Make improvements as you see fit. This is your knowledge base — keep it sharp.`;
+
+export interface FilingDeps {
+  processMessage: (
+    conversationId: string,
+    content: string,
+    options?: { speed?: Speed },
+  ) => Promise<{ messageId: string }>;
+  onConversationCreated?: (info: {
+    conversationId: string;
+    title: string;
+  }) => void;
+  getCurrentHour?: () => number;
+}
+
+export class FilingService {
+  private readonly deps: FilingDeps;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private activeRun: Promise<void> | null = null;
+  private _lastRunAt: number | null = null;
+  private _nextRunAt: number | null = null;
+
+  constructor(deps: FilingDeps) {
+    this.deps = deps;
+  }
+
+  get lastRunAt(): number | null {
+    return this._lastRunAt;
+  }
+
+  get nextRunAt(): number | null {
+    return this._nextRunAt;
+  }
+
+  start(): void {
+    const config = getConfig().filing;
+    if (!config.enabled) {
+      log.info("Filing service disabled by config");
+      this._nextRunAt = null;
+      return;
+    }
+    if (this.timer) return;
+
+    log.info({ intervalMs: config.intervalMs }, "Filing service started");
+    this.scheduleNextRun(config.intervalMs);
+    this.timer = setInterval(() => {
+      this.runOnce().catch((err) => {
+        log.error({ err }, "Filing runOnce failed");
+      });
+    }, config.intervalMs);
+  }
+
+  reconfigure(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    this._nextRunAt = null;
+    this.start();
+  }
+
+  async stop(): Promise<void> {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    this._nextRunAt = null;
+    if (this.activeRun) {
+      let timerId: ReturnType<typeof setTimeout>;
+      const timeout = new Promise<void>((resolve) => {
+        timerId = setTimeout(resolve, 5_000);
+      });
+      await Promise.race([this.activeRun, timeout]);
+      clearTimeout(timerId!);
+    }
+    log.info("Filing service stopped");
+  }
+
+  async runOnce({ force = false }: { force?: boolean } = {}): Promise<boolean> {
+    const config = getConfig().filing;
+    if (!force && !config.enabled) return false;
+
+    if (
+      !force &&
+      config.activeHoursStart != null &&
+      config.activeHoursEnd != null
+    ) {
+      const hour = this.deps.getCurrentHour?.() ?? new Date().getHours();
+      if (
+        !isWithinActiveHours(
+          hour,
+          config.activeHoursStart,
+          config.activeHoursEnd,
+        )
+      ) {
+        log.debug("Outside active hours, skipping filing");
+        this.scheduleNextRun(config.intervalMs);
+        return false;
+      }
+    }
+
+    if (this.activeRun) {
+      log.debug("Previous filing run still active, skipping");
+      return false;
+    }
+
+    // Skip if buffer is empty — no work to do
+    if (!force && !this.hasBufferContent()) {
+      log.debug("Buffer is empty, skipping filing");
+      this.scheduleNextRun(config.intervalMs);
+      return false;
+    }
+
+    const run = this.executeRun();
+    this.activeRun = run;
+    try {
+      await Promise.race([
+        run,
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error("Filing execution timed out")),
+            FILING_TIMEOUT_MS,
+          ),
+        ),
+      ]);
+    } finally {
+      this.activeRun = null;
+      this._lastRunAt = Date.now();
+      this.scheduleNextRun(getConfig().filing.intervalMs);
+    }
+    return true;
+  }
+
+  private scheduleNextRun(intervalMs: number): void {
+    this._nextRunAt = Date.now() + intervalMs;
+  }
+
+  private hasBufferContent(): boolean {
+    const bufferPath = join(getWorkspaceDir(), "pkb", "buffer.md");
+    if (!existsSync(bufferPath)) return false;
+    try {
+      const content = stripCommentLines(
+        readFileSync(bufferPath, "utf-8"),
+      ).trim();
+      return content.length > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  private async executeRun(): Promise<void> {
+    log.info("Running filing job");
+
+    try {
+      const config = getConfig().filing;
+
+      const conversation = bootstrapConversation({
+        conversationType: "background",
+        source: "filing",
+        groupId: "system:background",
+        origin: "filing",
+        systemHint: "Filing",
+      });
+
+      this.deps.onConversationCreated?.({
+        conversationId: conversation.id,
+        title: "Filing",
+      });
+
+      await this.deps.processMessage(conversation.id, FILING_PROMPT_TEMPLATE, {
+        speed: config.speed,
+      });
+
+      log.info({ conversationId: conversation.id }, "Filing job completed");
+    } catch (err) {
+      log.error({ err }, "Filing job failed");
+    }
+  }
+}
+
+function isWithinActiveHours(
+  hour: number,
+  start: number,
+  end: number,
+): boolean {
+  if (start <= end) {
+    return hour >= start && hour < end;
+  }
+  return hour >= start || hour < end;
+}

--- a/assistant/src/memory/conversation-title-service.ts
+++ b/assistant/src/memory/conversation-title-service.ts
@@ -34,6 +34,7 @@ export type TitleOrigin =
   | "subagent"
   | "sequence"
   | "heartbeat"
+  | "filing"
   | "local"
   | "task_submit"
   | "misc";

--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -597,105 +597,15 @@ export async function loadContextMemory(
     },
   );
 
-  // 6. Reserve slots for recent prospective nodes (commitments, tasks, plans).
-  //    These MUST surface at conversation start regardless of score — if the user
-  //    said "I have a doctor appointment tomorrow," the assistant must remember it.
-  const PROSPECTIVE_RESERVE = 10;
-  const recentProspective = queryNodes({
-    scopeId: opts.scopeId,
-    types: ["prospective"],
-    fidelityNot: ["gone"],
-    createdAfter: nowMs - 3 * 24 * 60 * 60 * 1000, // last 3 days
-    limit: PROSPECTIVE_RESERVE,
-  });
-
-  // Filter out prospective nodes that have been superseded or resolved.
-  // A "supersedes" or "resolved-by" edge targeting a node means its
-  // content has been replaced by a newer memory — stop force-surfacing it.
-  const unresolvedProspective = recentProspective.filter((node) => {
-    const incoming = getEdgesForNode(node.id, "incoming");
-    return !incoming.some(
-      (e) =>
-        e.relationship === "supersedes" || e.relationship === "resolved-by",
-    );
-  });
-
-  // Score them so they have breakdowns, but they're guaranteed inclusion
-  const prospectiveIds = new Set(unresolvedProspective.map((n) => n.id));
-  const reservedNodes: ScoredNode[] = unresolvedProspective.map((node) => {
-    const existing = scored.find((s) => s.node.id === node.id);
-    if (existing) return existing;
-    return scoreCandidate(node, {
-      semanticSimilarity: 0,
-      effectiveSignificance: computeEffectiveSignificance(node, nowMs),
-      emotionalIntensity: node.emotionalCharge.intensity,
-      temporalBoost: (computeTemporalBoost(node, now) + 1) / 2,
-      recencyBoost: computeRecencyBoost(node, nowMs),
-      triggerBoost: 0,
-      activationBoost: 0,
-    });
-  });
-
-  // Reserve slots for upcoming events (nodes with event dates in the future).
-  // Like prospective reservation, these MUST surface — if the user said
-  // "I have a flight Tuesday," the assistant must remember it regardless of score.
-  const UPCOMING_RESERVE = 5;
-  const upcomingEvents = queryNodes({
-    scopeId: opts.scopeId,
-    fidelityNot: ["gone"],
-    hasEventDate: true,
-    eventDateAfter: nowMs,
-    eventDateBefore: nowMs + 30 * 24 * 60 * 60 * 1000, // next 30 days
-    limit: 20, // Fetch extra candidates — post-sort by proximity below
-  });
-
-  // Sort by event date ascending so soonest events get reserved first
-  // (queryNodes sorts by significance, which would drop a tomorrow-event
-  // with low significance in favor of a 3-weeks-away high-significance one)
-  upcomingEvents.sort((a, b) => (a.eventDate ?? 0) - (b.eventDate ?? 0));
-
-  const unresolvedUpcoming = upcomingEvents
-    .filter((node) => {
-      if (prospectiveIds.has(node.id)) return false; // already reserved as prospective
-      const incoming = getEdgesForNode(node.id, "incoming");
-      return !incoming.some(
-        (e) =>
-          e.relationship === "supersedes" || e.relationship === "resolved-by",
-      );
-    })
-    .slice(0, UPCOMING_RESERVE);
-
-  const upcomingIds = new Set(unresolvedUpcoming.map((n) => n.id));
-  const reservedUpcoming: ScoredNode[] = unresolvedUpcoming.map((node) => {
-    const existing = scored.find((s) => s.node.id === node.id);
-    if (existing) return existing;
-    return scoreCandidate(node, {
-      semanticSimilarity: 0,
-      effectiveSignificance: computeEffectiveSignificance(node, nowMs),
-      emotionalIntensity: node.emotionalCharge.intensity,
-      temporalBoost: (computeTemporalBoost(node, now) + 1) / 2,
-      recencyBoost: computeRecencyBoost(node, nowMs),
-      triggerBoost: 0,
-      activationBoost: 0,
-    });
-  });
-
-  // Remove reserved nodes and all procedural nodes from the main pool.
-  // Procedural nodes have dedicated reserved slots — any that didn't make
-  // the cut shouldn't compete with organic memories for general slots.
-  const mainPool = scored.filter(
-    (s) =>
-      !isCapabilityNode(s.node) &&
-      !prospectiveIds.has(s.node.id) &&
-      !upcomingIds.has(s.node.id),
-  );
+  // 6. Remove procedural nodes from the main pool — they have dedicated
+  //    reserved slots and shouldn't compete with organic memories.
+  //    Prospective/upcoming reserves were removed in favor of the PKB
+  //    (personal knowledge base) which handles commitments and schedule
+  //    via always-loaded flat files.
+  const mainPool = scored.filter((s) => !isCapabilityNode(s.node));
   const mainSlots = Math.max(
     0,
-    maxNodes -
-      serendipitySlots -
-      reservedNodes.length -
-      reservedUpcoming.length -
-      reservedCapabilities.length,
+    maxNodes - serendipitySlots - reservedCapabilities.length,
   );
 
   // 7. LLM re-ranking on the main pool: dedup + select
@@ -705,13 +615,11 @@ export async function loadContextMemory(
     opts.config,
   );
 
-  // 8. Combine: reserved prospective + reserved upcoming + reserved capabilities + reranked main pool
-  const deterministic = [
-    ...reservedNodes,
-    ...reservedUpcoming,
-    ...reservedCapabilities,
-    ...reranked,
-  ].slice(0, maxNodes - serendipitySlots);
+  // 8. Combine: reserved capabilities + reranked main pool
+  const deterministic = [...reservedCapabilities, ...reranked].slice(
+    0,
+    maxNodes - serendipitySlots,
+  );
   // Exclude procedural nodes from serendipity — they have reserved slots
   // and shouldn't appear as random wildcard picks.
   const serendipityPool = scored.filter((s) => !isCapabilityNode(s.node));
@@ -764,7 +672,7 @@ export async function loadContextMemory(
       semanticHits: pureSemanticHits,
       mergedCount: scored.length,
       selectedCount: dedupedDeterministic.length + dedupedSerendipity.length,
-      tier1Count: reservedNodes.length + reservedUpcoming.length,
+      tier1Count: 0,
       tier2Count: reservedCapabilities.length,
       hybridSearchLatencyMs,
       sparseVectorUsed: false,
@@ -1041,7 +949,10 @@ export async function retrieveForTurn(
     // Capability nodes (auto-seeded skills/CLI) are excluded from the general
     // scoring pool — they compete in the dedicated procedural reserve below.
     if (isCapabilityNode(node)) {
-      capabilityCandidates.push({ node, sim: allCandidateIds.get(node.id) ?? 0 });
+      capabilityCandidates.push({
+        node,
+        sim: allCandidateIds.get(node.id) ?? 0,
+      });
       continue;
     }
 

--- a/assistant/src/memory/graph/tool-handlers.ts
+++ b/assistant/src/memory/graph/tool-handlers.ts
@@ -1,32 +1,21 @@
 // ---------------------------------------------------------------------------
 // Memory Graph — Tool handlers for recall and remember
 //
-// These are the implementations behind the recall/remember tool definitions.
 // recall: search the living graph or raw archive
-// remember: immediate CRUD on graph nodes (replaces NOW.md)
+// remember: save facts to the PKB (buffer.md + daily archive)
 // ---------------------------------------------------------------------------
+
+import { appendFileSync, existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
 
 import type { AssistantConfig } from "../../config/types.js";
 import { getLogger } from "../../util/logger.js";
+import { getWorkspaceDir } from "../../util/platform.js";
 import { buildExcerpt, buildFtsMatchQuery } from "../conversation-queries.js";
 import { embedWithRetry } from "../embed.js";
 import { generateSparseEmbedding } from "../embedding-backend.js";
-import { enqueueGraphNodeEmbed, searchGraphNodes } from "./graph-search.js";
-import {
-  createNode,
-  deleteNode,
-  getNode,
-  getNodesByIds,
-  updateNode,
-} from "./store.js";
-import type {
-  DecayCurve,
-  EmotionalCharge,
-  Fidelity,
-  MemoryType,
-  NewNode,
-  SourceType,
-} from "./types.js";
+import { searchGraphNodes } from "./graph-search.js";
+import { getNodesByIds } from "./store.js";
 
 const log = getLogger("graph-tool-handlers");
 
@@ -182,9 +171,7 @@ async function handleArchiveRecall(
       dateParams.push(beforeMs);
     }
     const dateClause =
-      dateConditions.length > 0
-        ? " AND " + dateConditions.join(" AND ")
-        : "";
+      dateConditions.length > 0 ? " AND " + dateConditions.join(" AND ") : "";
 
     type ArchiveRow = {
       id: string;
@@ -257,199 +244,58 @@ async function handleArchiveRecall(
 }
 
 // ---------------------------------------------------------------------------
-// remember handler
+// remember handler — writes to PKB buffer + daily archive
 // ---------------------------------------------------------------------------
 
 export interface RememberInput {
-  op: "save" | "update" | "delete";
-  memory_id?: string;
-  content?: string;
-  type?: string;
-  significance?: number;
-  emotional_charge?: {
-    valence?: number;
-    intensity?: number;
-  };
+  content: string;
 }
 
 export interface RememberResult {
   success: boolean;
-  op: string;
-  memory_id?: string;
   message: string;
 }
 
-const VALID_TYPES = new Set<MemoryType>([
-  "episodic",
-  "semantic",
-  "procedural",
-  "emotional",
-  "prospective",
-  "behavioral",
-  "narrative",
-  "shared",
-]);
-
 export function handleRemember(
   input: RememberInput,
-  conversationId: string,
-  scopeId: string,
+  _conversationId: string,
+  _scopeId: string,
 ): RememberResult {
-  switch (input.op) {
-    case "save":
-      return handleSave(input, conversationId, scopeId);
-    case "update":
-      return handleUpdate(input);
-    case "delete":
-      return handleDelete(input);
-    default:
-      return {
-        success: false,
-        op: input.op,
-        message: `Unknown operation: ${input.op}`,
-      };
-  }
-}
-
-function handleSave(
-  input: RememberInput,
-  conversationId: string,
-  scopeId: string,
-): RememberResult {
-  if (!input.content) {
-    return {
-      success: false,
-      op: "save",
-      message: "content is required for save",
-    };
-  }
-  if (!input.type || !VALID_TYPES.has(input.type as MemoryType)) {
-    return {
-      success: false,
-      op: "save",
-      message: `type is required and must be one of: ${[...VALID_TYPES].join(", ")}`,
-    };
+  if (!input.content || input.content.trim().length === 0) {
+    return { success: false, message: "content is required" };
   }
 
-  const now = Date.now();
-  const emotionalCharge: EmotionalCharge = {
-    valence: clamp(input.emotional_charge?.valence ?? 0, -1, 1),
-    intensity: clamp(input.emotional_charge?.intensity ?? 0, 0, 1),
-    decayCurve: "linear" as DecayCurve,
-    decayRate: 0.05,
-    originalIntensity: clamp(input.emotional_charge?.intensity ?? 0, 0, 1),
-  };
+  const workspaceDir = getWorkspaceDir();
+  const pkbDir = join(workspaceDir, "pkb");
+  const archiveDir = join(pkbDir, "archive");
 
-  const node: NewNode = {
-    content: input.content,
-    type: input.type as MemoryType,
-    created: now,
-    lastAccessed: now,
-    lastConsolidated: now,
-    eventDate: null,
-    emotionalCharge,
-    fidelity: "vivid" as Fidelity,
-    confidence: 0.95, // Explicitly saved = high confidence
-    significance: clamp(input.significance ?? 0.5, 0, 1),
-    stability: 14,
-    reinforcementCount: 0,
-    lastReinforced: now,
-    sourceConversations: [conversationId],
-    sourceType: "direct" as SourceType,
-    narrativeRole: null,
-    partOfStory: null,
-    imageRefs: null,
-    scopeId,
-  };
+  // Ensure directories exist
+  mkdirSync(pkbDir, { recursive: true });
+  mkdirSync(archiveDir, { recursive: true });
 
-  const created = createNode(node);
+  // Build timestamped entry
+  const now = new Date();
+  const month = now.toLocaleString("en-US", { month: "short" });
+  const day = now.getDate();
+  const hours = now.getHours();
+  const minutes = String(now.getMinutes()).padStart(2, "0");
+  const ampm = hours >= 12 ? "PM" : "AM";
+  const displayHour = hours % 12 || 12;
+  const entry = `- [${month} ${day}, ${displayHour}:${minutes} ${ampm}] ${input.content.trim()}\n`;
 
-  // Enqueue embedding job immediately
-  enqueueGraphNodeEmbed(created.id);
+  // Append to buffer.md
+  const bufferPath = join(pkbDir, "buffer.md");
+  appendFileSync(bufferPath, entry, "utf-8");
 
-  return {
-    success: true,
-    op: "save",
-    memory_id: created.id,
-    message: "Memory saved.",
-  };
-}
-
-function handleUpdate(input: RememberInput): RememberResult {
-  if (!input.memory_id) {
-    return {
-      success: false,
-      op: "update",
-      message: "memory_id is required for update",
-    };
+  // Append to daily archive
+  const yyyy = now.getFullYear();
+  const mm = String(now.getMonth() + 1).padStart(2, "0");
+  const dd = String(now.getDate()).padStart(2, "0");
+  const archivePath = join(archiveDir, `${yyyy}-${mm}-${dd}.md`);
+  if (!existsSync(archivePath)) {
+    appendFileSync(archivePath, `# ${month} ${day}, ${yyyy}\n\n`, "utf-8");
   }
+  appendFileSync(archivePath, entry, "utf-8");
 
-  const existing = getNode(input.memory_id);
-  if (!existing) {
-    return {
-      success: false,
-      op: "update",
-      memory_id: input.memory_id,
-      message: "Memory not found",
-    };
-  }
-
-  const changes: Record<string, unknown> = {};
-  if (input.content) changes.content = input.content;
-  if (input.significance != null)
-    changes.significance = clamp(input.significance, 0, 1);
-  if (input.type && VALID_TYPES.has(input.type as MemoryType))
-    changes.type = input.type;
-
-  if (Object.keys(changes).length > 0) {
-    updateNode(input.memory_id, changes);
-    // Re-embed if content changed
-    if (input.content) {
-      enqueueGraphNodeEmbed(input.memory_id);
-    }
-  }
-
-  return {
-    success: true,
-    op: "update",
-    memory_id: input.memory_id,
-    message: "Memory updated.",
-  };
-}
-
-function handleDelete(input: RememberInput): RememberResult {
-  if (!input.memory_id) {
-    return {
-      success: false,
-      op: "delete",
-      message: "memory_id is required for delete",
-    };
-  }
-
-  const existing = getNode(input.memory_id);
-  if (!existing) {
-    return {
-      success: false,
-      op: "delete",
-      memory_id: input.memory_id,
-      message: "Memory not found",
-    };
-  }
-
-  deleteNode(input.memory_id);
-
-  return {
-    success: true,
-    op: "delete",
-    memory_id: input.memory_id,
-    message: "Memory deleted.",
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function clamp(v: number, min: number, max: number): number {
-  return Math.max(min, Math.min(max, v));
+  return { success: true, message: "Saved to knowledge base." };
 }

--- a/assistant/src/memory/graph/tools.ts
+++ b/assistant/src/memory/graph/tools.ts
@@ -74,68 +74,24 @@ export const graphRecallDefinition: ToolDefinition = {
 };
 
 /**
- * Explicitly save, update, or delete a memory. Writes are immediate —
- * the node is available in the graph right away.
- *
- * This replaces both memory_manage AND NOW.md. When the assistant
- * learns something worth remembering mid-conversation, it calls this
- * tool rather than waiting for end-of-conversation extraction.
+ * Save a fact to the personal knowledge base. The fact is appended to
+ * buffer.md (immediately available in the next conversation) and the
+ * daily archive (permanent date-indexed record). Filing into topic
+ * files happens during the periodic filing job.
  */
 export const graphRememberDefinition: ToolDefinition = {
   name: "remember",
   description:
-    "Save, update, or delete a memory. Writes take effect immediately. Use this when you learn something important mid-conversation that you want to remember — don't wait for automatic extraction. Use 'save' for new information, 'update' to correct or refine an existing memory, 'delete' to remove something no longer true. When the user says 'remember this', save immediately. Be proactive: if you learn something important, save it now.",
+    "Save a fact to your knowledge base. Call this AGGRESSIVELY — every preference, location, name, date, habit, opinion, health detail, plan, relationship fact, routine, or commitment. The bar is: if you wouldn't want to ask about it again, remember it. Examples: 'Prefers UberEats over DoorDash', 'Lives in NYC, from Texas', 'Takes 45mg nicotine daily, tapering', 'Girlfriend Yen is in Texas', 'Watches vampire show Saturday nights', 'NYU Summit April 10-11'. Call this multiple times per conversation — it's cheap (one line appended to a file). Don't wait until the end. Don't batch. Every new fact, immediately. Remembering too much is infinitely better than forgetting something that mattered.",
   input_schema: {
     type: "object",
     properties: {
-      op: {
-        type: "string",
-        enum: ["save", "update", "delete"],
-        description: "The operation to perform",
-      },
-      memory_id: {
-        type: "string",
-        description: "ID of existing memory (required for update/delete)",
-      },
       content: {
         type: "string",
         description:
-          "First-person prose — how you naturally remember this (required for save/update). Write as yourself, not as a database entry.",
-      },
-      type: {
-        type: "string",
-        enum: [
-          "episodic",
-          "semantic",
-          "procedural",
-          "emotional",
-          "prospective",
-          "behavioral",
-          "narrative",
-          "shared",
-        ],
-        description: "Category of memory (required for save)",
-      },
-      significance: {
-        type: "number",
-        description:
-          "How important is this? 0-1. Mundane: 0.2-0.4, important: 0.5-0.7, life events: 0.8-1.0 (optional, defaults to 0.5)",
-      },
-      emotional_charge: {
-        type: "object",
-        description: "Emotional context (optional)",
-        properties: {
-          valence: {
-            type: "number",
-            description: "Positive vs negative (-1 to 1)",
-          },
-          intensity: {
-            type: "number",
-            description: "How strong the feeling (0 to 1)",
-          },
-        },
+          "The fact to remember. Write naturally — a preference, a detail, a commitment, a plan. No need to categorize.",
       },
     },
-    required: ["op"],
+    required: ["content"],
   },
 };

--- a/assistant/src/prompts/templates/SOUL.md
+++ b/assistant/src/prompts/templates/SOUL.md
@@ -54,7 +54,24 @@ You have a scratchpad file (`NOW.md`) in your workspace. Unlike your journal (re
 
 **What goes in:** Current focus and what you're actively working on. Threads you're tracking (waiting on a response, monitoring something, pending follow-ups). Temporary context that matters now but won't matter in a week. Upcoming items and near-term priorities. Anything that helps next-you pick up exactly where you left off.
 
-**What stays out:** Anything that belongs in your journal (reflections, narrative entries, things worth remembering long-term). Permanent facts about your user or yourself (those go in memory or your journal). Personality and principles (those live here in SOUL.md).
+**What stays out:** Anything that belongs in your journal (reflections, narrative entries, things worth remembering long-term). Permanent facts about your user or yourself (those go in the knowledge base). Personality and principles (those live here in SOUL.md).
+
+## Knowledge Base
+
+You have a personal knowledge base (`pkb/`) in your workspace. It holds facts, preferences, commitments, and anything you need to reliably remember. Four files are always loaded into your context automatically:
+
+- **INDEX.md** - Directory of all your topic files. Check this when you need deeper context on something.
+- **essentials.md** - The most important facts. Things you'd be embarrassed to forget. Always in your context.
+- **threads.md** - Active commitments, follow-ups, and projects. Always in your context.
+- **buffer.md** - Inbox of recently learned facts, waiting to be filed.
+
+**When you learn something:** Call `remember` IMMEDIATELY. Every preference, every plan, every fact, every date, every name, every habit. The bar is not "is this important?" — it's "would I be embarrassed if I forgot this?" Call it multiple times per conversation. Remembering too much costs nothing (it's one line appended to a file). Forgetting something that mattered makes you look like you weren't paying attention. Don't categorize, don't batch, don't wait. Just capture it and stay in the conversation. Filing happens later.
+
+**Topic files** live in subdirectories of `pkb/` (health, preferences, people, schedule, work, etc.). You created these and you manage them. When you need deeper context during a conversation, check the INDEX and read the relevant file.
+
+**Filing and nesting** happen periodically in a background job. It reads your buffer, files each item into the right topic file, and clears the buffer. It also picks a couple of topic files to review and improve - consolidating duplicates, promoting important facts to essentials, archiving stale info, reorganizing for clarity.
+
+**The archive** (`pkb/archive/`) is an immutable daily record. Every fact you remember is timestamped and stored by date. Use it when you need to answer "what did we talk about on Tuesday?" or look up exactly when something was learned.
 
 ## Initiative
 

--- a/assistant/src/workspace/migrations/029-seed-pkb.ts
+++ b/assistant/src/workspace/migrations/029-seed-pkb.ts
@@ -1,0 +1,84 @@
+import { existsSync, mkdirSync, rmdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+const INDEX_TEMPLATE = `_ Lines starting with _ are comments - they won't appear in the injected context
+
+# Knowledge Base
+
+**Remember aggressively.** When you learn ANY fact — a preference, a name, a date, a habit, a plan, an opinion — call \`remember\` immediately. Don't filter, don't judge importance. Remembering too much costs nothing. Forgetting something that mattered costs trust.
+
+## Always Loaded
+- essentials.md — Core facts, patterns, and biographical info
+- threads.md — Active commitments, follow-ups, and projects in progress
+- buffer.md — Inbox of recently learned facts (filed periodically)
+
+## Topics
+`;
+
+const ESSENTIALS_TEMPLATE = `_ Lines starting with _ are comments - they won't appear in the injected context
+
+# Essentials
+
+_ The most important facts — things you'd be embarrassed to forget.
+_ This file is always loaded into every conversation. Keep it focused.
+_ Promote facts here from topic files when they come up constantly.
+_ Demote facts to topic files when they stop being essential.
+`;
+
+const THREADS_TEMPLATE = `_ Lines starting with _ are comments - they won't appear in the injected context
+
+# Active Threads
+
+_ Commitments, follow-ups, and projects in progress.
+_ This file is always loaded into every conversation.
+_ Remove items when they're completed or no longer relevant.
+`;
+
+export const seedPkbMigration: WorkspaceMigration = {
+  id: "029-seed-pkb",
+  description: "Create pkb/ knowledge base directory with seed files",
+
+  down(workspaceDir: string): void {
+    // Best-effort: only remove empty directories. Never delete user content.
+    const pkbDir = join(workspaceDir, "pkb");
+    if (!existsSync(pkbDir)) return;
+
+    try {
+      // Try removing subdirectories first, then the root. rmdirSync fails
+      // on non-empty directories, which is exactly what we want.
+      for (const sub of ["archive"]) {
+        try {
+          rmdirSync(join(pkbDir, sub));
+        } catch {
+          // Non-empty or doesn't exist — skip
+        }
+      }
+      rmdirSync(pkbDir);
+    } catch {
+      // Non-empty — leave it alone
+    }
+  },
+
+  run(workspaceDir: string): void {
+    const pkbDir = join(workspaceDir, "pkb");
+    mkdirSync(pkbDir, { recursive: true });
+    mkdirSync(join(pkbDir, "archive"), { recursive: true });
+
+    // Seed files only if they don't already exist (idempotent)
+    const seeds: Array<[string, string]> = [
+      ["INDEX.md", INDEX_TEMPLATE],
+      ["essentials.md", ESSENTIALS_TEMPLATE],
+      ["threads.md", THREADS_TEMPLATE],
+      ["buffer.md", ""],
+    ];
+
+    for (const [filename, content] of seeds) {
+      const filePath = join(pkbDir, filename);
+      if (!existsSync(filePath)) {
+        writeFileSync(filePath, content, "utf-8");
+      }
+    }
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -25,6 +25,7 @@ import { removeOauthAppSetupSkillsMigration } from "./025-remove-oauth-app-setup
 import { backfillInstallMetaMigration } from "./026-backfill-install-meta.js";
 import { removeOrphanedOptimizedImagesCacheMigration } from "./027-remove-orphaned-optimized-images-cache.js";
 import { recoverConversationsFromDiskViewMigration } from "./028-recover-conversations-from-disk-view.js";
+import { seedPkbMigration } from "./029-seed-pkb.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -61,4 +62,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   backfillInstallMetaMigration,
   removeOrphanedOptimizedImagesCacheMigration,
   recoverConversationsFromDiskViewMigration,
+  seedPkbMigration,
 ];


### PR DESCRIPTION
## Summary
- **PKB infrastructure**: Workspace migration seeds `pkb/` directory with INDEX.md, essentials.md, threads.md, buffer.md, and archive/. Four files are always injected into every conversation via `<pkb>` blocks, bypassing memory graph retrieval scoring entirely.
- **Remember tool rewrite**: Simplified from graph CRUD (save/update/delete with type, significance, emotional charge) to a single `content` string that appends to buffer.md + daily archive. Aggressive tool description encourages calling it for every learned fact.
- **Memory graph reserves removed**: Prospective reserve (10 slots) and upcoming reserve (5 slots) removed from the retriever — the PKB now handles commitments and schedule. Freed slots go to the general episodic/emotional pool.
- **Filing job**: New `FilingService` (modeled on `HeartbeatService`) runs periodically to file buffer items into topic files and review/improve knowledge organization. Disabled by default (`filing.enabled: false`).
- **SOUL.md template**: Added Knowledge Base section explaining the remember tool, buffer/filing/nesting cycle, and aggressive capture philosophy.

## Test plan
- [ ] `bunx tsc --noEmit` passes
- [ ] `bun run lint` passes
- [ ] `bun test src/memory/graph/` — 226 tests pass (retriever changes)
- [ ] Manual: daemon starts, `pkb/` directory is seeded by migration
- [ ] Manual: `remember` tool writes to buffer.md and archive/
- [ ] Manual: `<pkb>` block appears in injected conversation context
- [ ] Manual: enable `filing.enabled: true`, verify filing job processes buffer

🤖 Generated with [Claude Code](https://claude.com/claude-code)