### PR TITLE
feat: allow disabling heartbeat active hours restriction

### DIFF
--- a/assistant/src/config/schemas/heartbeat.ts
+++ b/assistant/src/config/schemas/heartbeat.ts
@@ -22,19 +22,29 @@ export const HeartbeatConfigSchema = z
       .int("heartbeat.activeHoursStart must be an integer")
       .min(0, "heartbeat.activeHoursStart must be >= 0")
       .max(23, "heartbeat.activeHoursStart must be <= 23")
+      .nullable()
       .default(8)
-      .describe("Hour of the day (0-23) when heartbeat checks begin"),
+      .describe(
+        "Hour of the day (0-23) when heartbeat checks begin, or null to disable active hours restriction",
+      ),
     activeHoursEnd: z
       .number({ error: "heartbeat.activeHoursEnd must be a number" })
       .int("heartbeat.activeHoursEnd must be an integer")
       .min(0, "heartbeat.activeHoursEnd must be >= 0")
       .max(23, "heartbeat.activeHoursEnd must be <= 23")
+      .nullable()
       .default(22)
-      .describe("Hour of the day (0-23) when heartbeat checks stop"),
+      .describe(
+        "Hour of the day (0-23) when heartbeat checks stop, or null to disable active hours restriction",
+      ),
   })
   .describe("Periodic heartbeat configuration for health monitoring")
   .superRefine((config, ctx) => {
-    if (config.activeHoursStart === config.activeHoursEnd) {
+    if (
+      config.activeHoursStart != null &&
+      config.activeHoursEnd != null &&
+      config.activeHoursStart === config.activeHoursEnd
+    ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["activeHoursEnd"],


### PR DESCRIPTION
## Summary

- Make `activeHoursStart` and `activeHoursEnd` nullable in the heartbeat config schema
- Setting either to `null` disables the active hours restriction, allowing 24/7 heartbeat operation
- Backwards compatible — existing configs keep their 8/22 defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)