### PR TITLE
fix: wrap memory-injected images in 3-block pattern for clear provenance

### DIFF
--- a/assistant/src/__tests__/strip-memory-injections.test.ts
+++ b/assistant/src/__tests__/strip-memory-injections.test.ts
@@ -30,6 +30,17 @@ const memoryTextBlock: ContentBlock = {
 
 const memoryImageMarker: ContentBlock = {
   type: "text",
+  text: "<memory_image __injected>\nA photo of a sunset",
+};
+
+const memoryImageClose: ContentBlock = {
+  type: "text",
+  text: "</memory_image>",
+};
+
+// Legacy 2-block format (persisted in older conversations)
+const legacyMemoryImageMarker: ContentBlock = {
+  type: "text",
   text: "<memory_image>A photo of a sunset</memory_image>",
 };
 
@@ -66,27 +77,37 @@ describe("stripExistingMemoryInjections", () => {
     expect(result[0].content).toEqual([textBlock("hello")]);
   });
 
-  test("strips memory_image marker + image pair", () => {
+  test("strips 3-block memory image (marker + image + close)", () => {
     const messages = [
-      userMsg(memoryTextBlock, memoryImageMarker, memoryImage, textBlock("hi")),
+      userMsg(memoryTextBlock, memoryImageMarker, memoryImage, memoryImageClose, textBlock("hi")),
     ];
     const result = stripExistingMemoryInjections(messages);
     expect(result[0].content).toEqual([textBlock("hi")]);
   });
 
-  test("strips multiple memory image pairs", () => {
+  test("strips multiple 3-block memory image groups", () => {
     const messages = [
       userMsg(
         memoryTextBlock,
         memoryImageMarker,
         memoryImage,
+        memoryImageClose,
         memoryImageMarker,
         memoryImage,
+        memoryImageClose,
         textBlock("hello"),
       ),
     ];
     const result = stripExistingMemoryInjections(messages);
     expect(result[0].content).toEqual([textBlock("hello")]);
+  });
+
+  test("strips legacy 2-block memory image (no closing tag)", () => {
+    const messages = [
+      userMsg(memoryTextBlock, legacyMemoryImageMarker, memoryImage, textBlock("hi")),
+    ];
+    const result = stripExistingMemoryInjections(messages);
+    expect(result[0].content).toEqual([textBlock("hi")]);
   });
 
   test("preserves user-attached image when it is the only content", () => {
@@ -104,12 +125,13 @@ describe("stripExistingMemoryInjections", () => {
     ]);
   });
 
-  test("preserves user image after stripping memory blocks", () => {
+  test("preserves user image after stripping 3-block memory blocks", () => {
     const messages = [
       userMsg(
         memoryTextBlock,
         memoryImageMarker,
         memoryImage,
+        memoryImageClose,
         imageBlock,
         textBlock("look at this"),
       ),

--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -528,9 +528,10 @@ export function stripExistingMemoryInjections(messages: Message[]): Message[] {
 
   // Walk from the front and skip all memory-injected blocks.
   // The injection prefix is always contiguous at the start of content.
-  // Memory-injected images are always preceded by a <memory_image> text
-  // marker (see injectMemoryBlock). Only strip image blocks that follow
-  // such a marker — user-attached images must be preserved.
+  // Memory-injected images use a 3-block pattern: opening <memory_image> text,
+  // image block, closing </memory_image> text (see injectMemoryBlock).
+  // Legacy 2-block pattern (no closing tag) is also handled for backward compat.
+  // Only strip image blocks that follow a marker — user-attached images must be preserved.
   let firstNonMemory = 0;
   let prevWasMemoryImageMarker = false;
   const content = last.content;
@@ -544,13 +545,19 @@ export function stripExistingMemoryInjections(messages: Message[]): Message[] {
       prevWasMemoryImageMarker = false;
     } else if (
       block.type === "text" &&
-      block.text.startsWith("<memory_image>")
+      block.text.startsWith("<memory_image")
     ) {
       firstNonMemory++;
       prevWasMemoryImageMarker = true;
     } else if (block.type === "image" && prevWasMemoryImageMarker) {
       firstNonMemory++;
       prevWasMemoryImageMarker = false;
+    } else if (
+      block.type === "text" &&
+      block.text === "</memory_image>"
+    ) {
+      // Closing tag from the 3-block pattern
+      firstNonMemory++;
     } else {
       break;
     }
@@ -606,7 +613,7 @@ function injectMemoryBlock(
   for (const [_nodeId, img] of images) {
     blocks.push({
       type: "text" as const,
-      text: `<memory_image>${img.description}</memory_image>`,
+      text: `<memory_image __injected>\n${img.description}`,
     });
     blocks.push({
       type: "image" as const,
@@ -616,6 +623,10 @@ function injectMemoryBlock(
         data: img.base64Data,
       },
     } as ImageContent);
+    blocks.push({
+      type: "text" as const,
+      text: `</memory_image>`,
+    });
   }
 
   blocks.push({


### PR DESCRIPTION
## Summary
- Changes memory image injection from a 2-block pattern (`<memory_image>desc</memory_image>` + image) to a 3-block pattern (`<memory_image __injected>\ndesc` + image + `</memory_image>`) so images are visually sandwiched inside the XML tags
- Adds `__injected` attribute to `<memory_image>` tag for consistency with other injected tags like `<memory __injected>`
- Updates stripping logic to handle both old 2-block and new 3-block formats for backward compatibility with persisted conversation history

## Original prompt
Velissa is getting confused by the automatic memory injections of images, thinking that I sent them to her. Can you look at the injection formatting and figure out why this might be happening?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
