### PR TITLE
feat: add PKB nudge for aggressive topic file reading

### DIFF
--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -535,8 +535,19 @@ export function stripNowScratchpad(messages: Message[]): Message[] {
 
 const PKB_FILES = ["INDEX.md", "essentials.md", "threads.md", "buffer.md"];
 
+const PKB_NUDGE =
+  "\n\n---\n" +
+  "Your knowledge base has topic files beyond what's loaded here — " +
+  "INDEX.md is your table of contents. At the start of each conversation, " +
+  "read any topic files that might be relevant. " +
+  "Don't wait to be asked — look things up proactively. " +
+  "Use `remember` for every new fact you learn, immediately, no batching.";
+
 /**
- * Read the always-loaded PKB files (INDEX, essentials, threads, buffer).
+ * Read the always-loaded PKB files (INDEX, essentials, threads, buffer)
+ * and append a nudge encouraging the assistant to proactively read topic
+ * files and use `remember` aggressively.
+ *
  * Returns the concatenated content ready for injection, or `null` if all
  * files are missing or empty.
  */
@@ -556,7 +567,7 @@ export function readPkbContext(): string | null {
     }
   }
 
-  return parts.length > 0 ? parts.join("\n\n") : null;
+  return parts.length > 0 ? parts.join("\n\n") + PKB_NUDGE : null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds a small instruction to the `<pkb>` block on every turn, nudging the assistant to proactively read topic files listed in INDEX.md and use `remember` for every new fact
- Scales naturally: INDEX.md stays small as a TOC, assistant reads only relevant topic files via `read_file` (0-3 calls per conversation), avoids injecting all topic file content on every turn

## Original prompt

I want Velissa to read entries from her PKB more aggressively