### PR TITLE
feat: enable PKB filing by default

### DIFF
--- a/assistant/src/config/schemas/filing.ts
+++ b/assistant/src/config/schemas/filing.ts
@@ -6,7 +6,7 @@ export const FilingConfigSchema = z
   .object({
     enabled: z
       .boolean({ error: "filing.enabled must be a boolean" })
-      .default(false)
+      .default(true)
       .describe(
         "Whether periodic PKB filing is enabled — processes buffer.md into topic files and reviews knowledge base organization",
       ),


### PR DESCRIPTION
## Summary
- Change `filing.enabled` default from `false` to `true` so new workspaces start with PKB filing active
- Filing service processes `buffer.md` into topic files every 4 hours during active hours (8 AM–10 PM)

## Original prompt
Enable PKB filing by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)