### PR TITLE
fix: move scroll derived-state cache off SwiftUI observation graph

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -247,15 +247,55 @@ final class MessageListScrollState {
 
     // MARK: - Layout Cache Fields
 
-    @ObservationIgnored var cachedLayoutKey: PrecomputedCacheKey?
-    @ObservationIgnored var cachedLayoutMetadata: CachedMessageLayoutMetadata?
-    @ObservationIgnored var messageListVersion: Int = 0
-    @ObservationIgnored var lastKnownRawMessageCount: Int = 0
-    @ObservationIgnored var lastKnownVisibleMessageCount: Int = 0
-    @ObservationIgnored var lastKnownLastMessageStreaming: Bool = false
-    @ObservationIgnored var lastKnownIncompleteToolCallCount: Int = 0
-    @ObservationIgnored var lastKnownVisibleIdFingerprint: Int = 0
-    @ObservationIgnored var cachedFirstVisibleMessageId: UUID?
+    /// Memoization state intentionally lives outside the observed object so
+    /// `MessageListView` can update caches during body evaluation without
+    /// tripping SwiftUI's "Modifying state during view update" runtime guard.
+    @ObservationIgnored let derivedStateCache = MessageListDerivedStateCache()
+
+    @ObservationIgnored var cachedLayoutKey: PrecomputedCacheKey? {
+        get { derivedStateCache.cachedLayoutKey }
+        set { derivedStateCache.cachedLayoutKey = newValue }
+    }
+
+    @ObservationIgnored var cachedLayoutMetadata: CachedMessageLayoutMetadata? {
+        get { derivedStateCache.cachedLayoutMetadata }
+        set { derivedStateCache.cachedLayoutMetadata = newValue }
+    }
+
+    @ObservationIgnored var messageListVersion: Int {
+        get { derivedStateCache.messageListVersion }
+        set { derivedStateCache.messageListVersion = newValue }
+    }
+
+    @ObservationIgnored var lastKnownRawMessageCount: Int {
+        get { derivedStateCache.lastKnownRawMessageCount }
+        set { derivedStateCache.lastKnownRawMessageCount = newValue }
+    }
+
+    @ObservationIgnored var lastKnownVisibleMessageCount: Int {
+        get { derivedStateCache.lastKnownVisibleMessageCount }
+        set { derivedStateCache.lastKnownVisibleMessageCount = newValue }
+    }
+
+    @ObservationIgnored var lastKnownLastMessageStreaming: Bool {
+        get { derivedStateCache.lastKnownLastMessageStreaming }
+        set { derivedStateCache.lastKnownLastMessageStreaming = newValue }
+    }
+
+    @ObservationIgnored var lastKnownIncompleteToolCallCount: Int {
+        get { derivedStateCache.lastKnownIncompleteToolCallCount }
+        set { derivedStateCache.lastKnownIncompleteToolCallCount = newValue }
+    }
+
+    @ObservationIgnored var lastKnownVisibleIdFingerprint: Int {
+        get { derivedStateCache.lastKnownVisibleIdFingerprint }
+        set { derivedStateCache.lastKnownVisibleIdFingerprint = newValue }
+    }
+
+    @ObservationIgnored var cachedFirstVisibleMessageId: UUID? {
+        get { derivedStateCache.cachedFirstVisibleMessageId }
+        set { derivedStateCache.cachedFirstVisibleMessageId = newValue }
+    }
 
     // MARK: - Scroll Action Closures
 
@@ -269,33 +309,34 @@ final class MessageListScrollState {
 
     // MARK: - Circuit Breaker
 
-    @ObservationIgnored private var bodyEvalTimestamps: [CFAbsoluteTime] = []
-    @ObservationIgnored private(set) var isThrottled = false
-    @ObservationIgnored var cachedDerivedStateBox: Any?
-    @ObservationIgnored private var throttleRecoveryTask: Task<Void, Never>?
+    @ObservationIgnored var isThrottled: Bool {
+        get { derivedStateCache.isThrottled }
+        set { derivedStateCache.isThrottled = newValue }
+    }
 
     /// Called once per MessageListView body evaluation. Trips the circuit
     /// breaker when >100 evaluations occur in 2 seconds, suppressing
     /// `scheduleUISync()` for 500ms to break the loop.
     func recordBodyEvaluation() {
+        let cache = derivedStateCache
         let now = CFAbsoluteTimeGetCurrent()
-        bodyEvalTimestamps.append(now)
+        cache.bodyEvalTimestamps.append(now)
         let cutoff = now - 2.0
-        if let firstValid = bodyEvalTimestamps.firstIndex(where: { $0 >= cutoff }) {
-            bodyEvalTimestamps.removeFirst(firstValid)
+        if let firstValid = cache.bodyEvalTimestamps.firstIndex(where: { $0 >= cutoff }) {
+            cache.bodyEvalTimestamps.removeFirst(firstValid)
         }
 
-        if bodyEvalTimestamps.count > 100 && !isThrottled {
-            isThrottled = true
+        if cache.bodyEvalTimestamps.count > 100 && !cache.isThrottled {
+            cache.isThrottled = true
             os_log(.fault, "Scroll re-evaluation loop detected: %d evals in 2s — throttling for 500ms",
-                   bodyEvalTimestamps.count)
-            throttleRecoveryTask?.cancel()
-            throttleRecoveryTask = Task { @MainActor [weak self] in
+                   cache.bodyEvalTimestamps.count)
+            cache.throttleRecoveryTask?.cancel()
+            cache.throttleRecoveryTask = Task { @MainActor [weak self] in
                 try? await Task.sleep(nanoseconds: 500_000_000)
                 guard let self, !Task.isCancelled else { return }
-                self.isThrottled = false
-                self.bodyEvalTimestamps.removeAll()
-                self.throttleRecoveryTask = nil
+                self.derivedStateCache.isThrottled = false
+                self.derivedStateCache.bodyEvalTimestamps.removeAll()
+                self.derivedStateCache.throttleRecoveryTask = nil
                 self.scheduleUISync()
             }
         }
@@ -308,7 +349,7 @@ final class MessageListScrollState {
     /// Debounces observed-property updates so rapid mode changes coalesce
     /// into at most one view re-evaluation per frame.
     func scheduleUISync() {
-        guard !isThrottled else { return }
+        guard !derivedStateCache.isThrottled else { return }
         uiSyncTask?.cancel()
         uiSyncTask = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: 16_000_000)
@@ -378,6 +419,8 @@ final class MessageListScrollState {
     /// Tracks overlapping stabilization windows. Stabilization only ends
     /// when all active windows have completed, so concurrent reasons
     /// (e.g. resize during pagination) don't prematurely restore the mode.
+    /// Re-entering the same reason refreshes that window instead of stacking
+    /// duplicate counts that would require extra `endStabilization()` calls.
     @ObservationIgnored private var activeStabilizationCount = 0
 
     // MARK: - Deep-Link Anchor Tracking
@@ -450,8 +493,14 @@ final class MessageListScrollState {
             previousMode = .followingBottom
         case .freeBrowsing:
             previousMode = .freeBrowsing
-        case .stabilizing(let prev, _):
+        case .stabilizing(let prev, let activeReason):
             previousMode = prev
+            if activeReason == reason {
+                if reason == .expansion {
+                    scheduleExpansionTimeout()
+                }
+                return
+            }
         case .pushToTop, .programmaticScroll:
             return
         }
@@ -460,12 +509,7 @@ final class MessageListScrollState {
         transition(to: .stabilizing(previousMode: previousMode, reason: reason))
 
         if reason == .expansion {
-            expansionTimeoutTask?.cancel()
-            expansionTimeoutTask = Task { @MainActor [weak self] in
-                try? await Task.sleep(nanoseconds: 200_000_000)
-                guard !Task.isCancelled, let self else { return }
-                self.endStabilization()
-            }
+            scheduleExpansionTimeout()
         }
     }
 
@@ -487,6 +531,15 @@ final class MessageListScrollState {
     private func cancelStabilizationTasks() {
         expansionTimeoutTask?.cancel()
         expansionTimeoutTask = nil
+    }
+
+    private func scheduleExpansionTimeout() {
+        expansionTimeoutTask?.cancel()
+        expansionTimeoutTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 200_000_000)
+            guard !Task.isCancelled, let self else { return }
+            self.endStabilization()
+        }
     }
 
     // MARK: - Scroll Execution
@@ -593,15 +646,7 @@ final class MessageListScrollState {
         if _isPaginationInFlight { _isPaginationInFlight = false }
         wasPaginationTriggerInRange = false
         lastPaginationCompletedAt = .distantPast
-        cachedLayoutKey = nil
-        cachedLayoutMetadata = nil
-        cachedDerivedStateBox = nil
-        messageListVersion = 0
-        lastKnownRawMessageCount = 0
-        lastKnownVisibleMessageCount = 0
-        lastKnownLastMessageStreaming = false
-        lastKnownIncompleteToolCallCount = 0
-        lastKnownVisibleIdFingerprint = 0
+        derivedStateCache.reset()
         currentConversationId = newConversationId
         mode = .initialLoad
         activeStabilizationCount = 0
@@ -609,10 +654,6 @@ final class MessageListScrollState {
         // False: scroll geometry hasn't updated for the new content yet.
         isAtBottom = false
         lastContentOffsetY = 0
-        throttleRecoveryTask?.cancel()
-        throttleRecoveryTask = nil
-        isThrottled = false
-        bodyEvalTimestamps.removeAll()
         scrollIndicatorRestoreTask?.cancel()
         if !_hideScrollIndicators { _hideScrollIndicators = true }
         syncUIImmediately()
@@ -640,16 +681,12 @@ final class MessageListScrollState {
         highlightDismissTask = nil
         scrollIndicatorRestoreTask?.cancel()
         scrollIndicatorRestoreTask = nil
-        throttleRecoveryTask?.cancel()
-        throttleRecoveryTask = nil
-        isThrottled = false
-        bodyEvalTimestamps.removeAll()
+        derivedStateCache.reset()
         if _hideScrollIndicators { _hideScrollIndicators = false }
         pendingPushToTopTarget = nil
         if _isPaginationInFlight { _isPaginationInFlight = false }
         mode = .initialLoad
         activeStabilizationCount = 0
-        cachedDerivedStateBox = nil
         lastPaginationCompletedAt = .distantPast
         syncUIImmediately()
     }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
@@ -93,3 +93,46 @@ struct MessageListDerivedState {
     let shouldShowThinkingIndicator: Bool
     let hasMessages: Bool
 }
+
+// MARK: - Derived-State Cache
+
+/// Non-observable cache used by `MessageListView` during body evaluation.
+///
+/// SwiftUI logs "Modifying state during view update" when a view mutates
+/// `@State` / `@Observable` storage while computing its body. The message-list
+/// pipeline needs memoization for performance, but those cache writes must not
+/// flow through SwiftUI-managed state. This helper keeps the cache off the
+/// observation graph while preserving the existing hot-path behavior.
+@MainActor
+final class MessageListDerivedStateCache {
+    var cachedLayoutKey: PrecomputedCacheKey?
+    var cachedLayoutMetadata: CachedMessageLayoutMetadata?
+    var messageListVersion = 0
+    var lastKnownRawMessageCount = 0
+    var lastKnownVisibleMessageCount = 0
+    var lastKnownLastMessageStreaming = false
+    var lastKnownIncompleteToolCallCount = 0
+    var lastKnownVisibleIdFingerprint = 0
+    var cachedFirstVisibleMessageId: UUID?
+    var bodyEvalTimestamps: [CFAbsoluteTime] = []
+    var isThrottled = false
+    var cachedDerivedState: MessageListDerivedState?
+    var throttleRecoveryTask: Task<Void, Never>?
+
+    func reset() {
+        cachedLayoutKey = nil
+        cachedLayoutMetadata = nil
+        messageListVersion = 0
+        lastKnownRawMessageCount = 0
+        lastKnownVisibleMessageCount = 0
+        lastKnownLastMessageStreaming = false
+        lastKnownIncompleteToolCallCount = 0
+        lastKnownVisibleIdFingerprint = 0
+        cachedFirstVisibleMessageId = nil
+        cachedDerivedState = nil
+        bodyEvalTimestamps.removeAll()
+        throttleRecoveryTask?.cancel()
+        throttleRecoveryTask = nil
+        isThrottled = false
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
@@ -31,6 +31,7 @@ extension MessageListView {
     /// transitions). All checks are O(1). `isSending` / `isThinking`
     /// transitions are handled via `PrecomputedCacheKey` fields directly.
     func refreshMessageListVersionIfNeeded(visibleMessages: [ChatMessage]) {
+        let cache = scrollState.derivedStateCache
         let currentRawCount = messages.count
         let currentVisibleCount = visibleMessages.count
         let currentLastStreaming = visibleMessages.last?.isStreaming ?? false
@@ -44,29 +45,29 @@ extension MessageListView {
 
         var changed = false
 
-        if currentRawCount != scrollState.lastKnownRawMessageCount {
-            scrollState.lastKnownRawMessageCount = currentRawCount
+        if currentRawCount != cache.lastKnownRawMessageCount {
+            cache.lastKnownRawMessageCount = currentRawCount
             changed = true
         }
-        if currentVisibleCount != scrollState.lastKnownVisibleMessageCount {
-            scrollState.lastKnownVisibleMessageCount = currentVisibleCount
+        if currentVisibleCount != cache.lastKnownVisibleMessageCount {
+            cache.lastKnownVisibleMessageCount = currentVisibleCount
             changed = true
         }
-        if currentLastStreaming != scrollState.lastKnownLastMessageStreaming {
-            scrollState.lastKnownLastMessageStreaming = currentLastStreaming
+        if currentLastStreaming != cache.lastKnownLastMessageStreaming {
+            cache.lastKnownLastMessageStreaming = currentLastStreaming
             changed = true
         }
-        if currentIncompleteToolCalls != scrollState.lastKnownIncompleteToolCallCount {
-            scrollState.lastKnownIncompleteToolCallCount = currentIncompleteToolCalls
+        if currentIncompleteToolCalls != cache.lastKnownIncompleteToolCallCount {
+            cache.lastKnownIncompleteToolCallCount = currentIncompleteToolCalls
             changed = true
         }
-        if currentIdFingerprint != scrollState.lastKnownVisibleIdFingerprint {
-            scrollState.lastKnownVisibleIdFingerprint = currentIdFingerprint
+        if currentIdFingerprint != cache.lastKnownVisibleIdFingerprint {
+            cache.lastKnownVisibleIdFingerprint = currentIdFingerprint
             changed = true
         }
 
         if changed {
-            scrollState.messageListVersion += 1
+            cache.messageListVersion += 1
         }
     }
 
@@ -92,16 +93,17 @@ extension MessageListView {
     /// Computes all derived values needed by the message list body.
     ///
     /// Structural metadata (IDs, timestamps, role-based indices, subagent
-    /// grouping) is memoized behind a lightweight O(1) cache key stored on
-    /// the `@ObservationIgnored` fields of `MessageListScrollState`. Content-derived state
-    /// (message data, confirmation placement, thinking indicators) is
+    /// grouping) is memoized behind a lightweight O(1) cache key stored in a
+    /// non-observable cache attached to `MessageListScrollState`.
+    /// Content-derived state (message data, confirmation placement, thinking indicators) is
     /// always computed fresh from the live `visibleMessages` array so
     /// SwiftUI's `.equatable()` diffing sees every mutation.
     var derivedState: MessageListDerivedState {
         os_signpost(.begin, log: stallLog, name: "DerivedState.resolve")
         scrollState.recordBodyEvaluation()
+        let cache = scrollState.derivedStateCache
 
-        if scrollState.isThrottled, let cached = scrollState.cachedDerivedStateBox as? MessageListDerivedState {
+        if cache.isThrottled, let cached = cache.cachedDerivedState {
             os_signpost(.end, log: stallLog, name: "DerivedState.resolve")
             return cached
         }
@@ -109,11 +111,11 @@ extension MessageListView {
         // Compute visible messages first so version tracking and layout
         // both operate on the same filtered set.
         let liveMessages = visibleMessages
-        scrollState.cachedFirstVisibleMessageId = liveMessages.first?.id
+        cache.cachedFirstVisibleMessageId = liveMessages.first?.id
         refreshMessageListVersionIfNeeded(visibleMessages: liveMessages)
 
         let key = PrecomputedCacheKey(
-            messageListVersion: scrollState.messageListVersion,
+            messageListVersion: cache.messageListVersion,
             isSending: isSending,
             isThinking: isThinking,
             isCompacting: isCompacting,
@@ -124,8 +126,8 @@ extension MessageListView {
 
         // --- Stage 1: Cached structural metadata ---
         let layout: CachedMessageLayoutMetadata
-        if key == scrollState.cachedLayoutKey,
-           let cached = scrollState.cachedLayoutMetadata,
+        if key == cache.cachedLayoutKey,
+           let cached = cache.cachedLayoutMetadata,
            cached.displayMessageIds.count == liveMessages.count {
             #if DEBUG
             var seen = Set<UUID>()
@@ -138,7 +140,7 @@ extension MessageListView {
             os_signpost(.event, log: stallLog, name: "DerivedState.layoutCacheHit")
             layout = cached
         } else {
-            os_signpost(.event, log: stallLog, name: "DerivedState.layoutCacheMiss", "version=%d", scrollState.messageListVersion)
+            os_signpost(.event, log: stallLog, name: "DerivedState.layoutCacheMiss", "version=%d", cache.messageListVersion)
 
             let displayMessageIds: [UUID] = {
                 var seen = Set<UUID>()
@@ -174,8 +176,8 @@ extension MessageListView {
                 orphanSubagents: orphanSubagents,
                 effectiveStatusText: effectiveStatusText
             )
-            scrollState.cachedLayoutKey = key
-            scrollState.cachedLayoutMetadata = layout
+            cache.cachedLayoutKey = key
+            cache.cachedLayoutMetadata = layout
         }
 
         // --- Stage 2: Live content-derived state (always fresh) ---
@@ -265,7 +267,7 @@ extension MessageListView {
             hasMessages: !liveMessages.isEmpty
         )
 
-        scrollState.cachedDerivedStateBox = result
+        cache.cachedDerivedState = result
         os_signpost(.end, log: stallLog, name: "DerivedState.resolve")
         return result
     }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -120,7 +120,7 @@ extension MessageListView {
         // (including cooldown) don't consume the one-shot rising edge.
         scrollState.wasPaginationTriggerInRange = isInRange
         scrollState.isPaginationInFlight = true
-        let anchorId = scrollState.cachedFirstVisibleMessageId
+        let anchorId = scrollState.derivedStateCache.cachedFirstVisibleMessageId
         let taskConversationId = scrollState.currentConversationId
         os_signpost(.event, log: PerfSignposts.log, name: "paginationSentinelFired")
         scrollState.paginationTask = Task { [scrollState] in

--- a/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
@@ -25,9 +25,14 @@ final class MessageListScrollStateTests: XCTestCase {
 
     // MARK: - Initial State
 
-    func testInitialStateIsFollowingBottom() {
-        XCTAssertTrue(state.isFollowingBottom)
+    func testInitialStateAllowsAutoScrollWithoutInteraction() {
+        XCTAssertFalse(state.isFollowingBottom)
         XCTAssertFalse(state.hasBeenInteracted)
+        XCTAssertTrue(state.mode.allowsAutoScroll)
+
+        let result = state.requestPinToBottom()
+        XCTAssertTrue(result, "initialLoad should still allow bottom pinning")
+        XCTAssertEqual(scrollToCalls.first?.id, "scroll-bottom-anchor" as AnyHashable)
     }
 
     func testInitialModeIsInitialLoad() {
@@ -306,12 +311,18 @@ final class MessageListScrollStateTests: XCTestCase {
 
         state.reset(for: newId)
 
-        XCTAssertTrue(state.isFollowingBottom, "Should restore following state")
+        if case .initialLoad = state.mode {
+            // correct
+        } else {
+            XCTFail("Reset should return to .initialLoad mode")
+        }
+        XCTAssertFalse(state.isFollowingBottom, "initialLoad is distinct from followingBottom")
+        XCTAssertTrue(state.mode.allowsAutoScroll, "Reset should restore auto-scroll eligibility")
         XCTAssertFalse(state.showScrollToLatest, "Should sync showScrollToLatest immediately on reset")
         XCTAssertFalse(state.isSuppressed, "Should clear stabilization")
         XCTAssertFalse(state.isPaginationInFlight, "Should clear pagination flag")
         XCTAssertFalse(state.wasPaginationTriggerInRange, "Should clear trigger range flag")
-        XCTAssertTrue(state.isAtBottom, "Should reset isAtBottom to true")
+        XCTAssertFalse(state.isAtBottom, "Should wait for fresh geometry before claiming bottom")
         XCTAssertFalse(state.hasBeenInteracted, "Should reset to initialLoad mode")
         XCTAssertEqual(state.currentConversationId, newId, "Should update conversation ID")
         XCTAssertNil(state.mode.pushToTopMessageId, "Should clear pushToTopMessageId")


### PR DESCRIPTION
## Summary
- Extract memoization/circuit-breaker fields from `MessageListScrollState` into a non-observable `MessageListDerivedStateCache` class so cache writes during `body` evaluation don't trigger SwiftUI's "Modifying state during view update" warning
- Fix stabilization re-entrancy: calling `beginStabilization` with an already-active reason now refreshes that window instead of stacking duplicate counts that require extra `endStabilization()` calls
- Update scroll state tests to reflect `initialLoad` vs `followingBottom` distinction