### PR TITLE
Avoid progress header layout feedback loop

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -164,7 +164,6 @@ struct AssistantProgressView: View {
     @State private var processingStartDate: Date?
     @State private var isOverflowPopoverShown: Bool = false
     @State private var suppressNextExpand: Bool = false
-    @State private var hideInlineChips: Bool = false
     @State private var derived: DerivedProgressState
 
     // MARK: - Init
@@ -537,32 +536,12 @@ struct AssistantProgressView: View {
             }
             if let key = cardKey { cardExpansionOverrides[key] = isExpanded }
         }) {
-            HStack(spacing: VSpacing.sm) {
-                // Status icon
-                statusIcon
-
-                // Headline text with cross-fade
-                headlineLabel
-
-                // Inline permission chips (collapsed only, hidden at narrow widths)
-                if !isExpanded && !hideInlineChips {
-                    inlinePermissionChips
-                }
-
-                Spacer()
-
-                // Elapsed time: live counter when active, final duration when complete
-                if isActive {
-                    elapsedTimeLabel
-                } else if derived.hasTools {
-                    completedDurationLabel
-                }
-
-                // Chevron (only if tools exist)
-                if hasChevron {
-                    VIconView(isExpanded ? .chevronUp : .chevronDown, size: 9)
-                        .foregroundStyle(VColor.contentTertiary)
-                }
+            // Let SwiftUI choose the compact variant instead of toggling local
+            // state from a geometry callback, which can create layout feedback
+            // loops while the progress card is updating mid-send.
+            ViewThatFits(in: .horizontal) {
+                headerRowContent(showInlinePermissionChips: !isExpanded)
+                headerRowContent(showInlinePermissionChips: false)
             }
             .contentShape(Rectangle())
         }
@@ -571,10 +550,35 @@ struct AssistantProgressView: View {
         .padding(.horizontal, VSpacing.sm)
         .padding(.vertical, VSpacing.xs)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .onGeometryChange(for: Bool.self) { proxy in
-            proxy.size.width < 350
-        } action: { shouldHide in
-            hideInlineChips = shouldHide
+    }
+
+    @ViewBuilder
+    private func headerRowContent(showInlinePermissionChips: Bool) -> some View {
+        HStack(spacing: VSpacing.sm) {
+            // Status icon
+            statusIcon
+
+            // Headline text with cross-fade
+            headlineLabel
+
+            if showInlinePermissionChips {
+                inlinePermissionChips
+            }
+
+            Spacer()
+
+            // Elapsed time: live counter when active, final duration when complete
+            if isActive {
+                elapsedTimeLabel
+            } else if derived.hasTools {
+                completedDurationLabel
+            }
+
+            // Chevron (only if tools exist)
+            if hasChevron {
+                VIconView(isExpanded ? .chevronUp : .chevronDown, size: 9)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace the progress header's geometry-driven local state toggle with `ViewThatFits` so SwiftUI chooses the compact variant without mutating view state during layout.
- Keep the collapsed header behavior the same while avoiding layout feedback loops and `Modifying state during view update` warnings when chat progress updates mid-send.
- Cover the change with the focused `AssistantProgressViewLoggingTests` slice and the broader `MessageList` regression suite.

## Original prompt
ok [$mainline](/Users/sidd/vocify/claude-skills/skills/mainline/SKILL.md) this
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23670" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
