### PR TITLE
fix: centralize markdown font resolution with per-variant validation

### DIFF
--- a/clients/macos/vellum-assistant/App/FontWarmupCoordinator.swift
+++ b/clients/macos/vellum-assistant/App/FontWarmupCoordinator.swift
@@ -46,6 +46,7 @@ final class FontWarmupCoordinator {
                 // NSFontManager.shared is an AppKit class that must not be
                 // accessed from a background thread.
                 VFont.prewarmNSFontManagerTokens()
+                self.refreshTypographyStateForReadyFonts()
                 self.markReady()
             }
         }
@@ -77,6 +78,14 @@ final class FontWarmupCoordinator {
     }
 
     // MARK: - Private
+
+    func refreshTypographyStateForReadyFonts() {
+        VFont.bumpTypographyGeneration()
+        MarkdownSegmentView.clearAttributedStringCache()
+        ChatBubble.segmentCache.removeAllObjects()
+        ChatBubble.lastStreamingSegments = nil
+        ChatBubble.lastStreamingParseTime = 0
+    }
 
     private func markReady() {
         isReady = true

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -298,6 +298,7 @@ struct MarkdownSegmentView: View, Equatable {
     @MainActor func resolveSelectableRunMeasurement(
         _ runSegments: [MarkdownSegment]
     ) -> (NSAttributedString, CGSize) {
+        let chatFonts = VFont.resolvedChatMarkdownFontSet()
         var hasher = Hasher()
         for segment in runSegments { hasher.combine(segment) }
         hasher.combine(textColor.description)
@@ -306,6 +307,7 @@ struct MarkdownSegmentView: View, Equatable {
         hasher.combine(codeBackgroundColor.description)
         let effectiveMaxWidth = maxContentWidth ?? VSpacing.chatBubbleMaxWidth
         hasher.combine(effectiveMaxWidth)
+        hasher.combine(VFont.typographyGeneration)
         let key = hasher.finalize()
 
         let keyNS = key as NSNumber
@@ -316,7 +318,9 @@ struct MarkdownSegmentView: View, Equatable {
         os_signpost(.begin, log: PerfSignposts.log, name: "selectableRunMeasure")
         let attributed = buildCombinedAttributedString(from: runSegments)
         let (nsAttributed, hasUnresolvedEmphasis) = Self.convertToNSAttributedString(
-            attributed, font: VFont.nsChat, textColor: NSColor(textColor)
+            attributed,
+            fontSet: chatFonts,
+            textColor: NSColor(textColor)
         )
         let size = VSelectableTextView.measureSize(
             attributedString: nsAttributed,
@@ -385,15 +389,8 @@ struct MarkdownSegmentView: View, Equatable {
                 case 2: 16
                 default: 14
                 }
-                let wght = 0x77676874 // 'wght' variation axis tag
                 let weightValue: Int = level == 1 ? 700 : 600
-                let baseCT = CTFontCreateWithName("DMSans-Regular" as CFString, headingSize, nil)
-                let vars: [CFNumber: CFNumber] = [wght as CFNumber: weightValue as CFNumber]
-                let headingCT = CTFontCreateCopyWithAttributes(
-                    baseCT, headingSize, nil,
-                    CTFontDescriptorCreateWithAttributes([kCTFontVariationAttribute: vars] as CFDictionary)
-                )
-                headingAttr.font = Font(headingCT as NSFont)
+                headingAttr.font = Font(VFont.resolvedDMSansFont(weight: weightValue, size: headingSize))
                 if index > 0 {
                     let paraStyle = NSMutableParagraphStyle()
                     paraStyle.paragraphSpacingBefore = level == 1 ? 8 : 4
@@ -429,7 +426,7 @@ struct MarkdownSegmentView: View, Equatable {
                     if let cached = prefixWidthCache[prefixText] {
                         prefixWidth = cached
                     } else {
-                        let font = NSFont(name: "DMSans-Regular", size: 16) ?? NSFont.systemFont(ofSize: 16)
+                        let font = VFont.resolvedChatMarkdownFontSet().regular
                         let prefixNS = NSString(string: prefixText)
                         prefixWidth = prefixNS.size(withAttributes: [.font: font]).width
                         if prefixWidthCache.count < 200 {
@@ -496,7 +493,7 @@ struct MarkdownSegmentView: View, Equatable {
     /// caching the result so the next render can retry.
     static func convertToNSAttributedString(
         _ source: AttributedString,
-        font: NSFont,
+        fontSet: VFont.ChatMarkdownFontSet,
         textColor: NSColor
     ) -> (NSAttributedString, Bool) {
         // Pre-collect emphasis info from the source AttributedString.
@@ -557,22 +554,22 @@ struct MarkdownSegmentView: View, Equatable {
         // (not the SwiftUI AttributedString) because SwiftUI Font attributes set via
         // Font(nsFont) don't reliably survive the AttributedString→NSAttributedString
         // conversion — the oblique transform is lost, leaving plain text.
-        let sz = font.pointSize
-        let wght = 0x77676874 // 'wght' variation axis tag
-        var oblique = CGAffineTransform(a: 1, b: 0, c: CGFloat(tan(12.0 * .pi / 180.0)), d: 1, tx: 0, ty: 0)
-        let italicNS = CTFontCreateWithName("DMSans-Regular" as CFString, sz, &oblique) as NSFont
-        let baseCT = CTFontCreateWithName("DMSans-Regular" as CFString, sz, nil)
-        let boldVars: [CFNumber: CFNumber] = [wght as CFNumber: 700 as CFNumber]
-        let boldNS = CTFontCreateCopyWithAttributes(
-            baseCT, sz, nil,
-            CTFontDescriptorCreateWithAttributes([kCTFontVariationAttribute: boldVars] as CFDictionary)
-        ) as NSFont
-        let boldItalicNS = CTFontCreateCopyWithAttributes(
-            baseCT, sz, &oblique,
-            CTFontDescriptorCreateWithAttributes([kCTFontVariationAttribute: boldVars] as CFDictionary)
-        ) as NSFont
+        var unresolvedEmphasisCount = 0
+        var loggedUnresolvedFonts = false
+        let font = fontSet.regular
 
-        var emphasisAppliedCount = 0
+        func logUnresolvedFontsIfNeeded() {
+            guard !loggedUnresolvedFonts else { return }
+            loggedUnresolvedFonts = true
+            let diagnostics = fontSet.diagnosticPostScriptNames
+                .sorted { $0.key < $1.key }
+                .map { "\($0.key)=\($0.value)" }
+                .joined(separator: ", ")
+            mdConvertLog.warning(
+                "Expected DM Sans emphasis fonts (family DM Sans), resolved: \(diagnostics, privacy: .public)"
+            )
+        }
+
         for emphRun in emphasisRuns {
             guard !emphRun.intent.contains(.code) else { continue }
             // Skip runs that already have an explicit font (e.g. headings)
@@ -580,25 +577,40 @@ struct MarkdownSegmentView: View, Equatable {
             let nsRange = NSRange(location: emphRun.utf16Offset, length: emphRun.utf16Length)
             guard nsRange.location + nsRange.length <= ns.length else {
                 mdConvertLog.warning("Emphasis range \(nsRange.location)+\(nsRange.length) exceeds NSAttributedString length \(ns.length) — skipping")
+                unresolvedEmphasisCount += 1
                 continue
             }
             let isEmph = emphRun.intent.contains(.emphasized)
             let isBold = emphRun.intent.contains(.stronglyEmphasized)
             if isEmph && isBold {
-                ns.addAttribute(.font, value: boldItalicNS, range: nsRange)
-                emphasisAppliedCount += 1
+                guard fontSet.boldItalicIsResolved else {
+                    unresolvedEmphasisCount += 1
+                    logUnresolvedFontsIfNeeded()
+                    continue
+                }
+                ns.addAttribute(.font, value: fontSet.boldItalic, range: nsRange)
             } else if isEmph {
-                ns.addAttribute(.font, value: italicNS, range: nsRange)
-                emphasisAppliedCount += 1
+                guard fontSet.italicIsResolved else {
+                    unresolvedEmphasisCount += 1
+                    logUnresolvedFontsIfNeeded()
+                    continue
+                }
+                ns.addAttribute(.font, value: fontSet.italic, range: nsRange)
             } else if isBold {
-                ns.addAttribute(.font, value: boldNS, range: nsRange)
-                emphasisAppliedCount += 1
+                guard fontSet.boldIsResolved else {
+                    unresolvedEmphasisCount += 1
+                    logUnresolvedFontsIfNeeded()
+                    continue
+                }
+                ns.addAttribute(.font, value: fontSet.bold, range: nsRange)
             }
         }
 
-        let hasUnresolvedEmphasis = !emphasisRuns.isEmpty && emphasisAppliedCount == 0
+        let hasUnresolvedEmphasis = unresolvedEmphasisCount > 0
         if hasUnresolvedEmphasis {
-            mdConvertLog.warning("Emphasis runs detected (\(emphasisRuns.count)) but none applied — italic/bold will be missing")
+            mdConvertLog.warning(
+                "Emphasis runs detected (\(emphasisRuns.count)) with \(unresolvedEmphasisCount) unresolved run(s) — skipping cache"
+            )
         }
 
         // Apply base font where no explicit font attribute exists
@@ -726,4 +738,3 @@ private extension View {
         }
     }
 }
-

--- a/clients/macos/vellum-assistantTests/MarkdownSegmentViewTests.swift
+++ b/clients/macos/vellum-assistantTests/MarkdownSegmentViewTests.swift
@@ -1,0 +1,198 @@
+import AppKit
+import CoreText
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+final class MarkdownSegmentViewTests: XCTestCase {
+    private static let markdownOptions = AttributedString.MarkdownParsingOptions(
+        interpretedSyntax: .inlineOnlyPreservingWhitespace
+    )
+
+    override class func setUp() {
+        super.setUp()
+        registerTestFonts()
+    }
+
+    override func setUp() {
+        super.setUp()
+        MarkdownSegmentView.clearAttributedStringCache()
+        ChatBubble.segmentCache.removeAllObjects()
+        ChatBubble.lastStreamingSegments = nil
+        ChatBubble.lastStreamingParseTime = 0
+        #if DEBUG
+        VFont._chatMarkdownFontSetOverride = nil
+        #endif
+    }
+
+    override func tearDown() {
+        #if DEBUG
+        VFont._chatMarkdownFontSetOverride = nil
+        #endif
+        MarkdownSegmentView.clearAttributedStringCache()
+        ChatBubble.segmentCache.removeAllObjects()
+        ChatBubble.lastStreamingSegments = nil
+        ChatBubble.lastStreamingParseTime = 0
+        super.tearDown()
+    }
+
+    func testItalicMarkdownUsesObliqueDMSansFont() throws {
+        let (rendered, hasUnresolvedEmphasis) = makeRenderedMarkdown("*settles in*")
+        let font = try renderedFont(from: rendered)
+
+        XCTAssertFalse(hasUnresolvedEmphasis)
+        XCTAssertEqual(familyName(for: font), "DM Sans")
+        XCTAssertGreaterThan(abs(CTFontGetMatrix(font as CTFont).c), 0.0001)
+    }
+
+    func testBoldMarkdownUsesWeightedDMSansFont() throws {
+        let (rendered, hasUnresolvedEmphasis) = makeRenderedMarkdown("**where I belong**")
+        let font = try renderedFont(from: rendered)
+        let weight = try XCTUnwrap(weightAxis(for: font))
+
+        XCTAssertFalse(hasUnresolvedEmphasis)
+        XCTAssertEqual(familyName(for: font), "DM Sans")
+        XCTAssertEqual(weight, 700, accuracy: 0.5)
+        XCTAssertEqual(CTFontGetMatrix(font as CTFont).c, 0, accuracy: 0.0001)
+    }
+
+    func testBoldItalicMarkdownUsesWeightedObliqueDMSansFont() throws {
+        let (rendered, hasUnresolvedEmphasis) = makeRenderedMarkdown("***ideas for something fun***")
+        let font = try renderedFont(from: rendered)
+        let weight = try XCTUnwrap(weightAxis(for: font))
+
+        XCTAssertFalse(hasUnresolvedEmphasis)
+        XCTAssertEqual(familyName(for: font), "DM Sans")
+        XCTAssertEqual(weight, 700, accuracy: 0.5)
+        XCTAssertGreaterThan(abs(CTFontGetMatrix(font as CTFont).c), 0.0001)
+    }
+
+    func testInvalidEmphasisFontsSkipMeasurementCaching() throws {
+        #if DEBUG
+        VFont._chatMarkdownFontSetOverride = { size in
+            let regular = NSFont.systemFont(ofSize: size)
+            let bold = NSFont.boldSystemFont(ofSize: size)
+            let italic = NSFontManager.shared.convert(regular, toHaveTrait: .italicFontMask)
+            let boldItalic = NSFontManager.shared.convert(bold, toHaveTrait: .italicFontMask)
+            return VFont.ChatMarkdownFontSet(
+                regular: regular,
+                bold: bold,
+                italic: italic,
+                boldItalic: boldItalic,
+                regularIsResolved: false,
+                boldIsResolved: false,
+                italicIsResolved: false,
+                boldItalicIsResolved: false,
+                isResolved: false,
+                diagnosticPostScriptNames: [
+                    "regular": regular.fontName,
+                    "bold": bold.fontName,
+                    "italic": italic.fontName,
+                    "boldItalic": boldItalic.fontName,
+                ]
+            )
+        }
+        #endif
+
+        let source = try makeAttributedString(from: "*italics disappear*")
+        let (_, hasUnresolvedEmphasis) = MarkdownSegmentView.convertToNSAttributedString(
+            source,
+            fontSet: VFont.resolvedChatMarkdownFontSet(),
+            textColor: .labelColor
+        )
+        XCTAssertTrue(hasUnresolvedEmphasis)
+
+        let segments = parseMarkdownSegments("*italics disappear*")
+        let view = MarkdownSegmentView(segments: segments)
+        _ = view.resolveSelectableRunMeasurement(segments)
+
+        XCTAssertEqual(
+            MarkdownSegmentView._measuredTextCacheInsertCount,
+            0,
+            "Unresolved emphasis must not be inserted into the measured text cache"
+        )
+    }
+
+    func testWarmupRefreshClearsRenderCachesAndForcesRebuild() {
+        let segments = parseMarkdownSegments("*warmup cache reset*")
+        let key = "*warmup cache reset*" as NSString
+        let view = MarkdownSegmentView(segments: segments)
+
+        ChatBubble.segmentCache.setObject(SegmentCacheEntry(segments), forKey: key)
+        ChatBubble.lastStreamingSegments = (text: key as String, value: segments)
+        ChatBubble.lastStreamingParseTime = 42
+
+        _ = view.resolveSelectableRunMeasurement(segments)
+        XCTAssertEqual(MarkdownSegmentView._measuredTextCacheInsertCount, 1)
+
+        let generationBefore = VFont.typographyGeneration
+        FontWarmupCoordinator.shared.refreshTypographyStateForReadyFonts()
+
+        XCTAssertEqual(VFont.typographyGeneration, generationBefore + 1)
+        XCTAssertNil(ChatBubble.segmentCache.object(forKey: key))
+        XCTAssertNil(ChatBubble.lastStreamingSegments)
+        XCTAssertEqual(ChatBubble.lastStreamingParseTime, 0)
+        XCTAssertEqual(MarkdownSegmentView._measuredTextCacheInsertCount, 0)
+
+        _ = view.resolveSelectableRunMeasurement(segments)
+        XCTAssertEqual(
+            MarkdownSegmentView._measuredTextCacheInsertCount,
+            1,
+            "A typography generation bump must force the next measurement to rebuild"
+        )
+    }
+
+    private func makeRenderedMarkdown(_ markdown: String) -> (NSAttributedString, Bool) {
+        let source = (try? makeAttributedString(from: markdown)) ?? AttributedString(markdown)
+        return MarkdownSegmentView.convertToNSAttributedString(
+            source,
+            fontSet: VFont.resolvedChatMarkdownFontSet(),
+            textColor: .labelColor
+        )
+    }
+
+    private func makeAttributedString(from markdown: String) throws -> AttributedString {
+        try AttributedString(markdown: markdown, options: Self.markdownOptions)
+    }
+
+    private func renderedFont(from rendered: NSAttributedString) throws -> NSFont {
+        let font = rendered.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
+        return try XCTUnwrap(font)
+    }
+
+    private func familyName(for font: NSFont) -> String {
+        CTFontCopyFamilyName(font as CTFont) as String
+    }
+
+    private func weightAxis(for font: NSFont) -> CGFloat? {
+        guard let variations = CTFontCopyVariation(font as CTFont) as? [NSNumber: NSNumber],
+              let value = variations[0x77676874 as NSNumber] else {
+            return nil
+        }
+        return CGFloat(truncating: value)
+    }
+
+    private static func registerTestFonts() {
+        let fontsDirectory = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("vellum-assistant/Resources/Fonts", isDirectory: true)
+
+        for name in [
+            "DMMono-Regular",
+            "DMMono-Medium",
+            "DMSans-Regular",
+            "DMSans-Medium",
+            "DMSans-SemiBold",
+            "InstrumentSerif-Regular",
+        ] {
+            var error: Unmanaged<CFError>?
+            _ = CTFontManagerRegisterFontsForURL(
+                fontsDirectory.appendingPathComponent("\(name).ttf") as CFURL,
+                .process,
+                &error
+            )
+        }
+    }
+}

--- a/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
@@ -135,21 +135,30 @@ public enum VFont {
     // MARK: - NSFont (AppKit — for NSTextView and TextKit 1)
 
     #if os(macOS)
+    package struct ChatMarkdownFontSet {
+        package let regular: NSFont
+        package let bold: NSFont
+        package let italic: NSFont
+        package let boldItalic: NSFont
+        package let regularIsResolved: Bool
+        package let boldIsResolved: Bool
+        package let italicIsResolved: Bool
+        package let boldItalicIsResolved: Bool
+        package let isResolved: Bool
+        package let diagnosticPostScriptNames: [String: String]
+    }
+
+    private static let dmSansFamilyName = "DM Sans"
+    @MainActor package static var typographyGeneration: Int = 0
+
+    #if DEBUG
+    package static var _chatMarkdownFontSetOverride: ((CGFloat) -> ChatMarkdownFontSet)?
+    #endif
+
     /// Creates a DM Sans `NSFont` at the given CSS weight and size.
     /// AppKit equivalent of the SwiftUI `dmSans(weight:size:)` helper.
     private static func nsDmSans(weight: Int, size: CGFloat) -> NSFont {
-        let baseName = "DMSans-Regular" as CFString
-        let baseFont = CTFontCreateWithName(baseName, size, nil)
-        let variations: [CFNumber: CFNumber] = [
-            wghtTag as CFNumber: weight as CFNumber,
-        ]
-        let variantFont = CTFontCreateCopyWithAttributes(
-            baseFont, size, nil,
-            CTFontDescriptorCreateWithAttributes([
-                kCTFontVariationAttribute: variations,
-            ] as CFDictionary)
-        )
-        return variantFont as NSFont
+        resolvedDMSansFont(weight: weight, size: size)
     }
 
     /// DM Sans 400 at 16pt — NSFont equivalent of `VFont.chat`.
@@ -177,6 +186,111 @@ public enum VFont {
     public static let nsMonoItalic: NSFont = {
         NSFontManager.shared.convert(nsMono, toHaveTrait: .italicFontMask)
     }()
+
+    @MainActor
+    package static func bumpTypographyGeneration() {
+        typographyGeneration &+= 1
+    }
+
+    package static func resolvedChatMarkdownFontSet(size: CGFloat = 16) -> ChatMarkdownFontSet {
+        #if DEBUG
+        if let override = _chatMarkdownFontSetOverride {
+            return override(size)
+        }
+        #endif
+
+        let regular = resolvedDMSansFont(weight: 400, size: size)
+        let bold = resolvedDMSansFont(weight: 700, size: size)
+        let italic = resolvedDMSansFont(weight: 400, size: size, obliqueDegrees: 12)
+        let boldItalic = resolvedDMSansFont(weight: 700, size: size, obliqueDegrees: 12)
+
+        let diagnosticPostScriptNames = [
+            "regular": postScriptName(for: regular),
+            "bold": postScriptName(for: bold),
+            "italic": postScriptName(for: italic),
+            "boldItalic": postScriptName(for: boldItalic),
+        ]
+
+        let regularIsResolved = isResolvedDMSans(regular)
+        let boldIsResolved = isResolvedDMSans(bold) && hasWeightAxis(bold, expected: 700)
+        let italicIsResolved = isResolvedDMSans(italic) && hasObliqueTransform(italic)
+        let boldItalicIsResolved =
+            isResolvedDMSans(boldItalic)
+            && hasWeightAxis(boldItalic, expected: 700)
+            && hasObliqueTransform(boldItalic)
+
+        return ChatMarkdownFontSet(
+            regular: regular,
+            bold: bold,
+            italic: italic,
+            boldItalic: boldItalic,
+            regularIsResolved: regularIsResolved,
+            boldIsResolved: boldIsResolved,
+            italicIsResolved: italicIsResolved,
+            boldItalicIsResolved: boldItalicIsResolved,
+            isResolved: regularIsResolved && boldIsResolved && italicIsResolved && boldItalicIsResolved,
+            diagnosticPostScriptNames: diagnosticPostScriptNames
+        )
+    }
+
+    package static func resolvedDMSansFont(
+        weight: Int,
+        size: CGFloat,
+        obliqueDegrees: CGFloat? = nil
+    ) -> NSFont {
+        let baseName = "DMSans-Regular" as CFString
+        let baseFont = CTFontCreateWithName(baseName, size, nil)
+        let variations: [CFNumber: CFNumber] = [
+            wghtTag as CFNumber: weight as CFNumber,
+        ]
+        let descriptor = CTFontDescriptorCreateWithAttributes([
+            kCTFontVariationAttribute: variations,
+        ] as CFDictionary)
+
+        if let obliqueDegrees {
+            var oblique = CGAffineTransform(
+                a: 1,
+                b: 0,
+                c: CGFloat(tan(obliqueDegrees * .pi / 180.0)),
+                d: 1,
+                tx: 0,
+                ty: 0
+            )
+            return CTFontCreateCopyWithAttributes(baseFont, size, &oblique, descriptor) as NSFont
+        }
+
+        return CTFontCreateCopyWithAttributes(baseFont, size, nil, descriptor) as NSFont
+    }
+
+    private static func isResolvedDMSans(_ font: NSFont) -> Bool {
+        familyName(for: font) == dmSansFamilyName
+    }
+
+    private static func familyName(for font: NSFont) -> String {
+        CTFontCopyFamilyName(font as CTFont) as String
+    }
+
+    private static func postScriptName(for font: NSFont) -> String {
+        CTFontCopyPostScriptName(font as CTFont) as String
+    }
+
+    private static func hasObliqueTransform(_ font: NSFont) -> Bool {
+        let matrix = CTFontGetMatrix(font as CTFont)
+        return abs(matrix.b) > 0.0001
+            || abs(matrix.c) > 0.0001
+            || abs(matrix.a - 1) > 0.0001
+            || abs(matrix.d - 1) > 0.0001
+            || abs(matrix.tx) > 0.0001
+            || abs(matrix.ty) > 0.0001
+    }
+
+    private static func hasWeightAxis(_ font: NSFont, expected: Int) -> Bool {
+        guard let variations = CTFontCopyVariation(font as CTFont) as? [NSNumber: NSNumber],
+              let value = variations[wghtTag as NSNumber] else {
+            return false
+        }
+        return abs(CGFloat(truncating: value) - CGFloat(expected)) < 0.5
+    }
     #endif
 
     // MARK: - Prewarm


### PR DESCRIPTION
## Summary
- Introduce `ChatMarkdownFontSet` in `TypographyTokens.swift` that centralizes DM Sans font construction with per-variant resolution flags, replacing inline CTFont creation scattered across `MarkdownSegmentView`
- Emphasis runs now check resolution state and skip unresolved variants (instead of applying wrong fallback fonts), with diagnostic logging when fonts aren't ready
- Font warmup coordinator bumps a `typographyGeneration` counter and clears all render caches, so cached attributed strings are rebuilt with correct fonts once DM Sans finishes loading
- Add `MarkdownSegmentViewTests` covering italic, bold, bold-italic rendering, unresolved emphasis skip behavior, and warmup cache invalidation