### PR TITLE
fix: skip capability pruning when catalog cache is cold

### DIFF
--- a/assistant/src/memory/graph/capability-seed.ts
+++ b/assistant/src/memory/graph/capability-seed.ts
@@ -115,16 +115,21 @@ export function seedSkillGraphNodes(): void {
     // Protect uninstalled catalog skills from pruning — they are seeded
     // asynchronously by seedUninstalledCatalogSkillMemories() and should
     // not be marked as "gone" just because they aren't locally installed.
-    // Only include catalog entries whose feature-flag is enabled, matching
-    // the filter in seedUninstalledCatalogSkillMemories().
+    // Skip pruning entirely when the catalog cache is cold (empty before
+    // the async fetch completes) to avoid incorrectly marking valid
+    // uninstalled catalog nodes as gone during cold start.
     const cachedCatalog = getCachedCatalogSync();
-    for (const entry of cachedCatalog) {
-      const flagKey = entry.metadata?.vellum?.["feature-flag"];
-      if (flagKey && !isAssistantFeatureFlagEnabled(flagKey, config)) continue;
-      seenKeys.add(`${SKILL_SOURCE_PREFIX}${entry.id}`);
+    if (cachedCatalog.length === 0) {
+      log.info("Skipping skill capability pruning — catalog cache is cold");
+    } else {
+      for (const entry of cachedCatalog) {
+        const flagKey = entry.metadata?.vellum?.["feature-flag"];
+        if (flagKey && !isAssistantFeatureFlagEnabled(flagKey, config))
+          continue;
+        seenKeys.add(`${SKILL_SOURCE_PREFIX}${entry.id}`);
+      }
+      pruneStaleCapabilities(SKILL_SOURCE_PREFIX, seenKeys);
     }
-
-    pruneStaleCapabilities(SKILL_SOURCE_PREFIX, seenKeys);
 
     // Clean up old-format capability nodes (skill:* and cli:*) that use the
     // legacy "{prefix}:{id}\n..." content format. Mark them as gone so they


### PR DESCRIPTION
Guard pruning in seedSkillGraphNodes() with a cache-populated check to avoid marking valid uninstalled catalog nodes as gone during cold start.\n\nAddresses feedback on #23325.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23673" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
