### PR TITLE
fix: include NULL source conversations in sidebar listing

### DIFF
--- a/assistant/src/memory/conversation-queries.ts
+++ b/assistant/src/memory/conversation-queries.ts
@@ -50,7 +50,7 @@ export function listConversations(
   ensureGroupMigration();
   const db = getDb();
   const where = backgroundOnly
-    ? sql`${conversations.conversationType} IN ('background', 'scheduled') AND ${conversations.source} != 'subagent'`
+    ? sql`${conversations.conversationType} IN ('background', 'scheduled') AND (${conversations.source} IS NULL OR ${conversations.source} != 'subagent')`
     : sql`${conversations.conversationType} NOT IN ('background', 'private', 'scheduled')`;
   const query = db
     .select()
@@ -91,7 +91,7 @@ export function listPinnedConversations(): ConversationRow[] {
 export function countConversations(backgroundOnly = false): number {
   const db = getDb();
   const where = backgroundOnly
-    ? sql`${conversations.conversationType} IN ('background', 'scheduled') AND ${conversations.source} != 'subagent'`
+    ? sql`${conversations.conversationType} IN ('background', 'scheduled') AND (${conversations.source} IS NULL OR ${conversations.source} != 'subagent')`
     : sql`${conversations.conversationType} NOT IN ('background', 'private', 'scheduled')`;
   const [{ total }] = db
     .select({ total: count() })


### PR DESCRIPTION
Change `source != 'subagent'` filter to `(source IS NULL OR source != 'subagent')` to include legacy conversations with NULL source values. SQL three-value logic causes `!= 'subagent'` to exclude NULL rows.

Addresses feedback on #23565.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23674" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
