### PR TITLE
fix: restore skills key in list --json for backwards compat

### DIFF
--- a/assistant/src/cli/commands/skills.ts
+++ b/assistant/src/cli/commands/skills.ts
@@ -105,23 +105,26 @@ Examples:
           bundled.length + installed.length + availableCatalog.length;
 
         if (opts.json) {
+          const bundledJson = bundled.map((r) => ({
+            id: r.summary.id,
+            name: r.summary.displayName,
+            description: r.summary.description,
+            emoji: r.summary.emoji,
+            state: r.state,
+          }));
+          const installedJson = installed.map((r) => ({
+            id: r.summary.id,
+            name: r.summary.displayName,
+            description: r.summary.description,
+            emoji: r.summary.emoji,
+            state: r.state,
+          }));
           console.log(
             JSON.stringify({
               ok: true,
-              bundled: bundled.map((r) => ({
-                id: r.summary.id,
-                name: r.summary.displayName,
-                description: r.summary.description,
-                emoji: r.summary.emoji,
-                state: r.state,
-              })),
-              installed: installed.map((r) => ({
-                id: r.summary.id,
-                name: r.summary.displayName,
-                description: r.summary.description,
-                emoji: r.summary.emoji,
-                state: r.state,
-              })),
+              skills: [...bundledJson, ...installedJson, ...availableCatalog],
+              bundled: bundledJson,
+              installed: installedJson,
               catalog: availableCatalog,
             }),
           );


### PR DESCRIPTION
Keep the `skills` key as a union of bundled+installed+catalog arrays alongside the new category keys.\n\nAddresses feedback on #23537.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23675" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
