### PR TITLE
fix: restore unsupersededItems in wipe response for CLI compat

### DIFF
--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -360,6 +360,7 @@ export function conversationManagementRouteDefinitions(
         );
         return Response.json({
           wiped: true,
+          unsupersededItems: 0,
           deletedSummaries: result.deletedSummaryIds.length,
           cancelledJobs: result.cancelledJobCount,
         });


### PR DESCRIPTION
Keep returning `unsupersededItems: 0` in wipe response to prevent CLI from logging "Restored undefined memory items".\n\nAddresses feedback on #23548.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23676" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
