### PR TITLE
fix: make query_context migration idempotent

### DIFF
--- a/assistant/src/memory/migrations/211-memory-recall-logs-query-context.ts
+++ b/assistant/src/memory/migrations/211-memory-recall-logs-query-context.ts
@@ -1,5 +1,6 @@
 import type { DrizzleDb } from "../db-connection.js";
 import { getSqliteFrom } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
 import { withCrashRecovery } from "./validate-migration-state.js";
 
 const CHECKPOINT_KEY = "migration_memory_recall_logs_query_context_v1";
@@ -10,9 +11,11 @@ const CHECKPOINT_KEY = "migration_memory_recall_logs_query_context_v1";
  */
 export function migrateMemoryRecallLogsQueryContext(database: DrizzleDb): void {
   withCrashRecovery(database, CHECKPOINT_KEY, () => {
-    const raw = getSqliteFrom(database);
-    raw.exec(
-      `ALTER TABLE memory_recall_logs ADD COLUMN query_context TEXT`,
-    );
+    if (!tableHasColumn(database, "memory_recall_logs", "query_context")) {
+      const raw = getSqliteFrom(database);
+      raw.exec(
+        `ALTER TABLE memory_recall_logs ADD COLUMN query_context TEXT`,
+      );
+    }
   });
 }


### PR DESCRIPTION
Guard ALTER TABLE ADD COLUMN with `tableHasColumn()` existence check to prevent duplicate-column error on crash recovery re-run.

Addresses feedback on #23518.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23677" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
