### PR TITLE
fix: scan full emoji catalog before applying result limit

### DIFF
--- a/clients/shared/Features/Chat/EmojiCatalog.swift
+++ b/clients/shared/Features/Chat/EmojiCatalog.swift
@@ -1013,7 +1013,6 @@ public enum EmojiCatalog {
             } else if entry.shortcode.contains(lowered) {
                 substringMatches.append(entry)
             }
-            if prefixMatches.count + substringMatches.count >= limit { break }
         }
         return Array((prefixMatches + substringMatches).prefix(limit))
     }


### PR DESCRIPTION
Remove early break in emoji search to preserve prefix ranking. Collect all matches first, then sort and limit.

Addresses feedback on #23503.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23679" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
