### PR TITLE
fix: wire nextOffset through conversation list networking layer

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -429,7 +429,7 @@ final class ConversationRestorer {
                     // Set serverOffset from foreground count BEFORE merging.
                     // loadMoreConversations pages the foreground endpoint only,
                     // so the offset must not include merged background rows.
-                    self.delegate?.serverOffset = foreground.conversations.count
+                    self.delegate?.serverOffset = foreground.nextOffset ?? foreground.conversations.count
                     let merged = ConversationListResponse(
                         type: foreground.type,
                         conversations: foreground.conversations + uniqueBackground,

--- a/clients/shared/Network/ConversationListClient.swift
+++ b/clients/shared/Network/ConversationListClient.swift
@@ -59,6 +59,7 @@ public struct ConversationListClient: ConversationListClientProtocol {
                 type: "conversation_list_response",
                 conversations: items,
                 hasMore: decoded.hasMore,
+                nextOffset: decoded.nextOffset,
                 groups: decoded.groups
             )
         } catch {
@@ -385,6 +386,7 @@ private struct HTTPConversationsListResponse: Decodable {
     }
     let conversations: [Conversation]
     let hasMore: Bool?
+    let nextOffset: Int?
     let groups: [ConversationGroupResponse]?
 }
 


### PR DESCRIPTION
Parse and propagate nextOffset from HTTP response through ConversationListClient and ConversationRestorer.

Addresses feedback on #23491.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23680" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
