### PR TITLE
fix: distinguish unknown subagent label from missing selector

### DIFF
--- a/assistant/src/tools/subagent/abort.ts
+++ b/assistant/src/tools/subagent/abort.ts
@@ -7,6 +7,12 @@ export async function executeSubagentAbort(
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const subagentId = resolveSubagentId(input, context);
+  if (!subagentId && input.label) {
+    return {
+      content: `No subagent found with label "${input.label as string}".`,
+      isError: true,
+    };
+  }
   if (!subagentId) {
     return {
       content: '"subagent_id" or "label" is required.',

--- a/assistant/src/tools/subagent/message.ts
+++ b/assistant/src/tools/subagent/message.ts
@@ -9,6 +9,12 @@ export async function executeSubagentMessage(
   const subagentId = resolveSubagentId(input, context);
   const content = input.content as string;
 
+  if (!subagentId && input.label) {
+    return {
+      content: `No subagent found with label "${input.label as string}".`,
+      isError: true,
+    };
+  }
   if (!subagentId || !content) {
     return {
       content: '"subagent_id" or "label", and "content" are required.',

--- a/assistant/src/tools/subagent/read.ts
+++ b/assistant/src/tools/subagent/read.ts
@@ -8,6 +8,12 @@ export async function executeSubagentRead(
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const subagentId = resolveSubagentId(input, context);
+  if (!subagentId && input.label) {
+    return {
+      content: `No subagent found with label "${input.label as string}".`,
+      isError: true,
+    };
+  }
   if (!subagentId) {
     return {
       content: '"subagent_id" or "label" is required.',


### PR DESCRIPTION
Return distinct error for unknown labels instead of undefined in abort, read, and message tool executors — matching the pattern already used in status.ts.

When a label is provided but doesn't resolve, tools now return `No subagent found with label "..."` instead of the misleading `"subagent_id" or "label" is required` error.

Addresses feedback on #23477.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23682" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
