### PR TITLE
fix: scope auto-load trigger to pinned section only

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -211,11 +211,13 @@ struct SidebarSectionView: View {
 
         showMoreLessButton
 
-        // When all loaded conversations fit within maxCollapsed (e.g. pinned
-        // sections use .max) the show-more button never appears, yet more
-        // conversations may exist on the server beyond the initial page.
-        // Auto-trigger a full load so those items become visible.
-        if conversations.count <= maxCollapsed,
+        // When all loaded pinned conversations fit within maxCollapsed (.max)
+        // the show-more button never appears, yet more conversations may exist
+        // on the server beyond the initial page. Auto-trigger a full load so
+        // those items become visible. Scoped to the pinned section only to
+        // avoid eagerly loading all conversations for small non-pinned sections.
+        if group?.id == ConversationGroup.pinned.id,
+           conversations.count <= maxCollapsed,
            let conversationManager,
            conversationManager.hasMoreConversations {
             Color.clear


### PR DESCRIPTION
Add section type guard (`group?.id == ConversationGroup.pinned.id`) to prevent non-pinned sections from triggering `loadAllRemainingConversations()`. The previous condition fired for any expanded section where `conversations.count <= maxCollapsed`, which could eagerly load the full conversation history when any small non-pinned group appeared.

Addresses feedback on #23487.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23683" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
