### PR TITLE
fix: remove unsupported discord channel from interface mapping

### DIFF
--- a/assistant/src/config/bundled-skills/schedule/SKILL.md
+++ b/assistant/src/config/bundled-skills/schedule/SKILL.md
@@ -117,7 +117,6 @@ Optionally pass `routing_hints` (a JSON object) to influence routing decisions (
      | `macos`, `ios` | `vellum` |
      | `telegram` | `telegram` |
      | `slack` | `slack` |
-     | `discord` | `discord` |
      | `cli` | _(omit — no routable channel)_ |
   3. If neither field is present or the interface is `cli`, omit `preferred_channels`.
 

--- a/skills/time-based-actions/SKILL.md
+++ b/skills/time-based-actions/SKILL.md
@@ -135,7 +135,6 @@ Use the following heuristics to pick `routing_intent`:
      | `macos`, `ios` | `vellum` |
      | `telegram` | `telegram` |
      | `slack` | `slack` |
-     | `discord` | `discord` |
      | `cli` | _(omit — no routable channel)_ |
   3. If neither field is present or the interface is `cli`, omit `preferred_channels`.
 


### PR DESCRIPTION
Remove discord from interface-to-channel mapping since it's not a valid deliverable channel.\n\nAddresses feedback on #23484.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
