### PR TITLE
fix: guard memory_items table drop with emptiness check

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -12,6 +12,7 @@ import { dirname, join } from "node:path";
 import { getLogger } from "../util/logger.js";
 import { ensureDataDir, getDbPath } from "../util/platform.js";
 import { getDb, getSqlite } from "./db-connection.js";
+import { migrateToolCreatedItems } from "./graph/bootstrap.js";
 import {
   addCoreColumns,
   createActorRefreshTokenRecordsTable,
@@ -163,8 +164,8 @@ function getTemplateDbPath(): string {
       hash.update(readFileSync(join(migrationsDir, name), "utf-8"));
     }
   }
-  // Include bootstrap.ts which contains cleanup migrations (cleanupStaleItemVectors)
-  // that run during initializeDb but live outside the migrations/ directory.
+  // Include the bootstrap migration (migrateToolCreatedItems) which also runs
+  // during initializeDb but lives outside the migrations/ directory.
   const bootstrapFile = join(dirname(thisFile), "graph", "bootstrap.ts");
   if (existsSync(bootstrapFile)) {
     hash.update(readFileSync(bootstrapFile, "utf-8"));
@@ -333,7 +334,14 @@ export function initializeDb(): void {
     migrateOAuthProvidersFeatureFlag,
     migrateDropCallbackTransportColumn,
     migrateCreateMemoryGraphTables,
+    // 101a. Add nullable image_refs column — must run before migrateToolCreatedItems
+    // which inserts rows into memory_graph_nodes including the image_refs column.
     migrateMemoryGraphImageRefs,
+    // 101b. Migrate tool-created items from legacy memory_items → graph nodes.
+    // Must run before migrateDropMemoryItemsTables so data is preserved.
+    function migrateToolCreatedItemsStep() {
+      migrateToolCreatedItems();
+    },
     migrateDropMemoryItemsTables,
     migrateRenameMemoryGraphTypeValues,
     migrateCreateMemoryGraphNodeEdits,

--- a/assistant/src/memory/graph/bootstrap.ts
+++ b/assistant/src/memory/graph/bootstrap.ts
@@ -13,12 +13,13 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { and, asc, ne, sql } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
 
 import { getConfig } from "../../config/loader.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
 import { getMemoryCheckpoint, setMemoryCheckpoint } from "../checkpoints.js";
-import { getDb } from "../db.js";
+import { getDb, rawAll, rawGet, rawRun } from "../db.js";
 import { enqueueMemoryJob, hasActiveJobOfType } from "../jobs-store.js";
 import { initQdrantClient } from "../qdrant-client.js";
 import { conversations, memoryGraphNodes, memorySegments } from "../schema.js";
@@ -345,6 +346,142 @@ export function maybeEnqueueGraphBootstrap(): void {
     "Graph empty with historical data — enqueueing bootstrap",
   );
   enqueueMemoryJob("graph_bootstrap", {});
+}
+
+// ---------------------------------------------------------------------------
+// One-time migration: port tool-created memoryItems to graph nodes
+// ---------------------------------------------------------------------------
+
+const MIGRATE_ITEMS_CHECKPOINT = "graph_bootstrap:migrated_tool_items";
+
+interface LegacyItem {
+  id: string;
+  kind: string;
+  subject: string;
+  statement: string;
+  confidence: number;
+  importance: number;
+  scope_id: string;
+  first_seen_at: number;
+}
+
+/** Source prefix mapping from old kind to new sourceConversations key. */
+const KIND_TO_PREFIX: Record<string, string> = {
+  playbook: "playbook:",
+  style: "style:",
+  relationship: "relationship:",
+};
+
+/**
+ * Migrate tool-created memoryItems (playbooks, style patterns, relationship
+ * dynamics) into graph nodes. These were created directly by tool handlers
+ * and won't be picked up by the conversation-based graph bootstrap.
+ *
+ * Idempotent: uses a checkpoint to run only once. Skips items whose
+ * sourceKey already exists in the graph.
+ *
+ * Uses raw SQL for the INSERT to avoid coupling to the evolving Drizzle
+ * schema. ORM-based inserts include every column in the schema definition,
+ * so adding a column in a later migration would cause this migration to
+ * fail with "table has no column named …" on upgrade paths.
+ */
+export function migrateToolCreatedItems(): void {
+  if (getMemoryCheckpoint(MIGRATE_ITEMS_CHECKPOINT)) return;
+
+  const kinds = Object.keys(KIND_TO_PREFIX);
+  const placeholders = kinds.map(() => "?").join(", ");
+
+  let rows: LegacyItem[];
+  try {
+    rows = rawAll<LegacyItem>(
+      `SELECT id, kind, subject, statement, confidence, importance, scope_id, first_seen_at
+       FROM memory_items
+       WHERE kind IN (${placeholders}) AND status = 'active'`,
+      ...kinds,
+    );
+  } catch {
+    // Table may not exist (fresh install) — nothing to migrate
+    setMemoryCheckpoint(MIGRATE_ITEMS_CHECKPOINT, "done");
+    return;
+  }
+
+  if (rows.length === 0) {
+    setMemoryCheckpoint(MIGRATE_ITEMS_CHECKPOINT, "done");
+    return;
+  }
+
+  let migrated = 0;
+
+  for (const row of rows) {
+    const prefix = KIND_TO_PREFIX[row.kind];
+    if (!prefix) continue;
+
+    // Build content in the format the new tools expect
+    const content =
+      row.kind === "playbook"
+        ? `${row.subject}\n${row.statement}`
+        : `${row.subject}: ${row.statement}`;
+
+    // Check if already migrated (sourceKey exists in graph)
+    const sourceKey = `${prefix}${row.id}`;
+    const existing = rawGet<{ id: string }>(
+      `SELECT id FROM memory_graph_nodes WHERE source_conversations LIKE ?`,
+      `%${sourceKey}%`,
+    );
+    if (existing) continue;
+
+    const now = Date.now();
+    const id = uuid();
+    const emotionalCharge = JSON.stringify({
+      valence: 0,
+      intensity: 0.1,
+      decayCurve: "linear",
+      decayRate: 0.05,
+      originalIntensity: 0.1,
+    });
+
+    rawRun(
+      `INSERT INTO memory_graph_nodes (
+        id, content, type, created, last_accessed, last_consolidated,
+        event_date, emotional_charge, fidelity, confidence, significance,
+        stability, reinforcement_count, last_reinforced,
+        source_conversations, source_type, narrative_role, part_of_story,
+        image_refs, scope_id
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      id,
+      content,
+      "semantic",
+      row.first_seen_at || now,
+      now,
+      now,
+      null,
+      emotionalCharge,
+      "vivid",
+      row.confidence,
+      row.importance,
+      14,
+      0,
+      now,
+      JSON.stringify([sourceKey]),
+      "direct",
+      null,
+      null,
+      null,
+      row.scope_id || "default",
+    );
+
+    enqueueMemoryJob("embed_graph_node", { nodeId: id });
+    migrated++;
+  }
+
+  setMemoryCheckpoint(MIGRATE_ITEMS_CHECKPOINT, "done");
+
+  if (migrated > 0) {
+    log.info(
+      { migrated, total: rows.length },
+      "Migrated tool-created items to graph nodes",
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/memory/migrations/203-drop-memory-items-tables.ts
+++ b/assistant/src/memory/migrations/203-drop-memory-items-tables.ts
@@ -6,13 +6,45 @@ import { getSqliteFrom } from "../db-connection.js";
  *
  * All consumers have been migrated to memory_graph_nodes (#22698).
  * These tables are now dead weight.
+ *
+ * Safety: only drops tables when they are empty or the tool-created-items
+ * migration has already copied relevant rows into memory_graph_nodes.
+ * Workspaces that haven't run migrateToolCreatedItems() yet keep the tables
+ * so data isn't silently lost.
  */
 export function migrateDropMemoryItemsTables(database: DrizzleDb): void {
   const raw = getSqliteFrom(database);
 
+  // Guard: verify tables are safe to drop (empty or already migrated).
+  try {
+    const row = raw
+      .prepare(
+        /*sql*/ `SELECT COUNT(*) as cnt FROM memory_items WHERE status = 'active'`,
+      )
+      .get() as { cnt: number } | undefined;
+
+    if (row && row.cnt > 0) {
+      // Tables have active rows — only drop if the migration checkpoint exists.
+      const checkpoint = raw
+        .prepare(
+          /*sql*/ `SELECT value FROM memory_checkpoints WHERE key = ?`,
+        )
+        .get("graph_bootstrap:migrated_tool_items") as
+        | { value: string }
+        | undefined;
+
+      if (!checkpoint?.value) {
+        // Data exists but hasn't been migrated — skip the drop to prevent data loss.
+        return;
+      }
+    }
+  } catch {
+    // Table doesn't exist (fresh install) — proceed with drop (IF EXISTS is a no-op).
+  }
+
   // Drop indexes first (idempotent — IF EXISTS).
   raw.exec(
-    /*sql*/ `DROP INDEX IF EXISTS idx_memory_item_sources_memory_item_id`
+    /*sql*/ `DROP INDEX IF EXISTS idx_memory_item_sources_memory_item_id`,
   );
   raw.exec(/*sql*/ `DROP INDEX IF EXISTS idx_memory_items_scope_id`);
   raw.exec(/*sql*/ `DROP INDEX IF EXISTS idx_memory_items_fingerprint`);


### PR DESCRIPTION
Addresses feedback on #23534:

1. **Restore `migrateToolCreatedItems`** in bootstrap.ts — this was the only migration path that copied tool-created playbook/style/relationship rows from legacy `memory_items` into `memory_graph_nodes`. Removing it before the table drop caused data loss for workspaces that hadn't yet run the migration.

2. **Guard the drop migration** (`migrateDropMemoryItemsTables`) with an emptiness check: tables are only dropped when empty or after the migration checkpoint confirms data has been copied. Workspaces with unmigrated data keep their tables until the migration runs.

3. **Re-add the migration call** in `db-init.ts` between `migrateMemoryGraphImageRefs` and the drop, restoring the original execution order.

4. **Fix incorrect comments**: the bootstrap.ts hash comment now correctly references `migrateToolCreatedItems` instead of falsely claiming `cleanupStaleItemVectors` runs during `initializeDb` (it runs during daemon lifecycle).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23688" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
