### PR TITLE
fix: correct concat file paths in fish-audio skill

### DIFF
--- a/skills/fish-audio/SKILL.md
+++ b/skills/fish-audio/SKILL.md
@@ -75,11 +75,11 @@ ffmpeg -f lavfi -i anullsrc=r=44100:cl=mono -t 1.5 -q:a 9 -acodec libmp3lame scr
 
 ```bash
 cat > scratch/concat.txt << 'EOF'
-file 'scratch/clip1.mp3'
-file 'scratch/silence.mp3'
-file 'scratch/clip2.mp3'
-file 'scratch/silence.mp3'
-file 'scratch/clip3.mp3'
+file 'clip1.mp3'
+file 'silence.mp3'
+file 'clip2.mp3'
+file 'silence.mp3'
+file 'clip3.mp3'
 EOF
 ```
 


### PR DESCRIPTION
Update concat file entries to use correct paths after moving concat file to scratch/.

The ffmpeg concat demuxer resolves relative paths relative to the concat file's directory, not the working directory. Since the concat file lives at `scratch/concat.txt`, entries like `file 'scratch/clip1.mp3'` resolved to `scratch/scratch/clip1.mp3`. Fixed to use bare filenames.

Addresses feedback on #23490.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23689" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
