### PR TITLE
fix: remove remember from researcher role allowlist

### DIFF
--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -100,12 +100,11 @@ export const SUBAGENT_ROLE_REGISTRY: Record<SubagentRole, SubagentRoleConfig> =
         "file_read",
         "file_list",
         "recall",
-        "remember",
         "notify_parent",
       ],
       skillIds: [],
       systemPromptPreamble:
-        "You are a research-focused subagent with read-only access. Search the web, read files, and recall and store memories. You cannot write files or run shell commands.",
+        "You are a research-focused subagent with read-only access. Search the web, read files, and recall memories. You cannot write files or run shell commands.",
     },
     coder: {
       allowedTools: [


### PR DESCRIPTION
Keep researcher role read-only by only allowing recall, not remember.\n\nAddresses feedback on #23521.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23691" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
