### PR TITLE
fix: apply last_n to assistant messages instead of text blocks

### DIFF
--- a/assistant/src/tools/subagent/read.ts
+++ b/assistant/src/tools/subagent/read.ts
@@ -55,27 +55,32 @@ export async function executeSubagentRead(
   }
 
   // Extract assistant messages only - that's the subagent's output.
-  const output: string[] = [];
+  // Group text blocks by message so last_n slices messages, not blocks.
+  const messageTexts: string[] = [];
   for (const msg of dbMessages) {
     if (msg.role !== "assistant") continue;
+    const blocks: string[] = [];
     try {
       const content = JSON.parse(msg.content);
       if (Array.isArray(content)) {
         for (const block of content) {
           if (block.type === "text" && typeof block.text === "string") {
-            output.push(block.text);
+            blocks.push(block.text);
           }
         }
       } else if (typeof content === "string") {
-        output.push(content);
+        blocks.push(content);
       }
     } catch {
       // Content might be plain text.
-      output.push(msg.content);
+      blocks.push(msg.content);
+    }
+    if (blocks.length > 0) {
+      messageTexts.push(blocks.join("\n\n"));
     }
   }
 
-  if (output.length === 0) {
+  if (messageTexts.length === 0) {
     return { content: "Subagent produced no text output.", isError: false };
   }
 
@@ -83,7 +88,7 @@ export async function executeSubagentRead(
     typeof input.last_n === "number" && input.last_n > 0
       ? input.last_n
       : undefined;
-  const sliced = lastN ? output.slice(-lastN) : output;
+  const sliced = lastN ? messageTexts.slice(-lastN) : messageTexts;
 
   return {
     content: sliced.join("\n\n"),


### PR DESCRIPTION
Group subagent output by assistant message before slicing with last_n parameter. Previously, last_n sliced the flattened text blocks array, which could truncate multi-block assistant messages. Now each assistant message's text blocks are joined first, and last_n correctly returns the last N complete messages.\n\nAddresses feedback on #23479.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
