### PR TITLE
fix: count actual tool cache breakpoints instead of assuming tools = 1

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -861,12 +861,15 @@ export class AnthropicProvider implements Provider {
       // benefits more from caching.
       const hasTailBreakpoint =
         turnStartIdx >= 0 && turnStartIdx < sentMessages.length - 1;
+      const hasToolCacheBreakpoint =
+        params.tools?.some(
+          (t) => "cache_control" in t && t.cache_control != null,
+        ) ?? false;
       if (
         hasTailBreakpoint &&
         Array.isArray(params.system) &&
         params.system.length === 2 &&
-        params.tools &&
-        params.tools.length > 0
+        hasToolCacheBreakpoint
       ) {
         delete (params.system[0] as unknown as Record<string, unknown>).cache_control;
       }


### PR DESCRIPTION
Check for actual cache_control entries on tools rather than treating any non-empty tools as a breakpoint.\n\nAddresses feedback on #23506.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23693" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
