### PR TITLE
fix: preserve user-expanded thinking blocks when streaming ends

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
@@ -12,6 +12,7 @@ struct ThinkingBlockView: View {
     let isStreaming: Bool
 
     @State private var isExpanded: Bool = false
+    @State private var userHasToggled: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -45,6 +46,23 @@ struct ThinkingBlockView: View {
                 #endif
             }
         }
+        .onAppear {
+            if isStreaming {
+                isExpanded = true
+            }
+        }
+        .onChange(of: isStreaming) { _, newValue in
+            if newValue {
+                userHasToggled = false
+                withAnimation(VAnimation.fast) {
+                    isExpanded = true
+                }
+            } else if !userHasToggled {
+                withAnimation(VAnimation.fast) {
+                    isExpanded = false
+                }
+            }
+        }
         .background(VColor.surfaceOverlay)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
     }
@@ -53,6 +71,7 @@ struct ThinkingBlockView: View {
 
     private var headerRow: some View {
         Button(action: {
+            userHasToggled = true
             withAnimation(VAnimation.fast) {
                 isExpanded.toggle()
             }


### PR DESCRIPTION
Track manual user expansion and skip auto-collapse when user has toggled the block.\n\nAddresses feedback on #23416.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
