### PR TITLE
fix: set lastMessageAt on forked conversations

### DIFF
--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -585,6 +585,16 @@ export function forkConversation(params: {
       });
     }
 
+    // Set lastMessageAt to the max createdAt of copied messages so the
+    // forked conversation sorts correctly by message recency.
+    const lastCopiedMessage = messagesToCopy.at(-1);
+    if (lastCopiedMessage) {
+      db.update(conversations)
+        .set({ lastMessageAt: lastCopiedMessage.createdAt })
+        .where(eq(conversations.id, fc.id))
+        .run();
+    }
+
     seedForkedConversationAttention({
       conversationId: fc.id,
       latestAssistantMessageId: latestForkedAssistant?.messageId ?? null,


### PR DESCRIPTION
Set lastMessageAt to the max createdAt of copied messages during fork to preserve message-based sort order.\n\nAddresses feedback on #23350.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23695" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
