### PR TITLE
fix: update tool-merge test for boundary preservation

### DIFF
--- a/assistant/src/__tests__/list-messages-tool-merge.test.ts
+++ b/assistant/src/__tests__/list-messages-tool-merge.test.ts
@@ -167,9 +167,11 @@ describe("handleListMessages tool_result merging", () => {
     expect(body.messages[2].content).toBe("how are you?");
   });
 
-  test("tool_result at start of array (no preceding assistant) is suppressed", async () => {
+  test("tool_result at start of array (no preceding assistant) is preserved", async () => {
     const conv = createConversation();
-    // Orphan tool_result with no preceding assistant (pagination boundary)
+    // Orphan tool_result with no preceding assistant (pagination boundary).
+    // The preceding assistant tool_use lives in the previous page — dropping
+    // the result would be unrecoverable, so it is kept as-is.
     await addMessage(
       conv.id,
       "user",
@@ -186,10 +188,11 @@ describe("handleListMessages tool_result merging", () => {
     const response = handleListMessages(createTestUrl(conv.id), null);
     const body = (await response.json()) as { messages: MessagePayload[] };
 
-    // Orphan tool_result user message should be suppressed
-    expect(body.messages).toHaveLength(1);
-    expect(body.messages[0].role).toBe("assistant");
-    expect(body.messages[0].content).toBe("response");
+    // Orphan tool_result is preserved (not suppressed) to avoid data loss
+    expect(body.messages).toHaveLength(2);
+    expect(body.messages[0].role).toBe("user");
+    expect(body.messages[1].role).toBe("assistant");
+    expect(body.messages[1].content).toBe("response");
   });
 
   test("multi-turn: each tool_result merges into correct assistant", async () => {


### PR DESCRIPTION
## Summary
- Updates `list-messages-tool-merge.test.ts` to match the behavior introduced in #23685 (preserve boundary tool results during paginated loads)
- The test previously expected orphan tool_result messages to be suppressed, but the implementation now preserves them to prevent data loss

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24025058883/job/70061642707
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23698" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
