### PR TITLE
fix: update mock Qdrant payloads to use graph_node target type

### DIFF
--- a/assistant/src/runtime/routes/memory-item-routes.test.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.test.ts
@@ -407,12 +407,12 @@ describe("Memory Item Routes", () => {
         {
           id: "pt-2",
           score: 0.95,
-          payload: { target_type: "item", target_id: "i2" },
+          payload: { target_type: "graph_node", target_id: "i2" },
         },
         {
           id: "pt-1",
           score: 0.7,
-          payload: { target_type: "item", target_id: "i1" },
+          payload: { target_type: "graph_node", target_id: "i1" },
         },
       ];
 
@@ -488,17 +488,17 @@ describe("Memory Item Routes", () => {
         {
           id: "pt-1",
           score: 0.9,
-          payload: { target_type: "item", target_id: "i1" },
+          payload: { target_type: "graph_node", target_id: "i1" },
         },
         {
           id: "pt-2",
           score: 0.8,
-          payload: { target_type: "item", target_id: "i2" },
+          payload: { target_type: "graph_node", target_id: "i2" },
         },
         {
           id: "pt-3",
           score: 0.7,
-          payload: { target_type: "item", target_id: "i3" },
+          payload: { target_type: "graph_node", target_id: "i3" },
         },
       ];
 


### PR DESCRIPTION
Fix stale target_type in test mocks.\n\nAddresses feedback on #23538.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
