### PR TITLE
fix: read file attachment names from source and include aborted subagents

### DIFF
--- a/assistant/src/export/transcript-formatter.ts
+++ b/assistant/src/export/transcript-formatter.ts
@@ -20,8 +20,7 @@ interface ContentBlock {
   content?: string;
   tool_use_id?: string;
   is_error?: boolean;
-  source?: { media_type?: string };
-  filename?: string;
+  source?: { media_type?: string; filename?: string };
 }
 
 function formatTimestamp(ms: number): string {
@@ -57,7 +56,7 @@ function extractAnalysisText(blocks: ContentBlock[]): string {
         parts.push("[Image attachment]");
         break;
       case "file":
-        parts.push(`[File: ${block.filename ?? "unknown"}]`);
+        parts.push(`[File: ${block.source?.filename ?? "unknown"}]`);
         break;
       case "thinking":
       case "redacted_thinking":
@@ -129,7 +128,7 @@ export function buildAnalysisTranscript(conversationId: string): string {
         if (parsed.success && parsed.data.subagentNotification) {
           const notif = parsed.data.subagentNotification;
           if (
-            (notif.status === "completed" || notif.status === "failed") &&
+            (notif.status === "completed" || notif.status === "failed" || notif.status === "aborted") &&
             notif.conversationId
           ) {
             const subMessages = getMessages(notif.conversationId);


### PR DESCRIPTION
Fix filename path and include aborted subagent runs in transcript.

Addresses feedback on #23547.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23702" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
