### PR TITLE
fix: replace stale Inter font reference with DM Sans

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/DictationOverlayWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/DictationOverlayWindow.swift
@@ -261,7 +261,7 @@ final class DictationOverlayWindow {
 
     private func makeTranscriptionLabel() -> NSTextField {
         let field = NSTextField(labelWithString: "")
-        field.font = NSFont(name: "Inter", size: 10) ?? NSFont.systemFont(ofSize: 10)
+        field.font = NSFont(name: "DMSans-Regular", size: 10) ?? NSFont.systemFont(ofSize: 10)
         field.textColor = NSColor(VColor.contentTertiary)
         field.lineBreakMode = .byWordWrapping
         field.maximumNumberOfLines = 2


### PR DESCRIPTION
Remove leftover Inter-Regular reference from typography revert.

Addresses feedback on #23567.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23703" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
