### PR TITLE
fix: compute query result count after filtering gone nodes

### DIFF
--- a/assistant/src/memory/graph/inspect.ts
+++ b/assistant/src/memory/graph/inspect.ts
@@ -267,11 +267,19 @@ async function showQuery(query: string) {
     const nodes = getNodesByIds(results.map((r) => r.nodeId));
     const nodeMap = new Map(nodes.map((n) => [n.id, n]));
 
-    console.log(`  Found ${results.length} results:\n`);
-    for (const r of results) {
+    const visible = results.filter((r) => {
       const node = nodeMap.get(r.nodeId);
-      if (!node) continue;
-      if (node.fidelity === "gone") continue;
+      return node && node.fidelity !== "gone";
+    });
+
+    if (visible.length === 0) {
+      console.log("  No results found.");
+      return;
+    }
+
+    console.log(`  Found ${visible.length} results:\n`);
+    for (const r of visible) {
+      const node = nodeMap.get(r.nodeId)!;
       const preview =
         node.content.length > 120
           ? node.content.slice(0, 120) + "…"


### PR DESCRIPTION
Print accurate result count after excluding gone capability nodes.\n\nAddresses feedback on #23600.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23705" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
