### PR TITLE
fix: remove reconciled message ID from pendingMessageIds

### DIFF
--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -689,6 +689,7 @@ final class ChatActionHandler {
                 }
             }
             if let reconciledId {
+                vm.pendingMessageIds.removeAll { $0 == reconciledId }
                 vm.activeRequestIdToMessageId[msg.requestId] = reconciledId
             }
         }


### PR DESCRIPTION
Clean up pendingMessageIds when recording reconciliation mapping in handleMessageDequeued. Without this, a reconciled send-failed message ID stays in the FIFO forever, causing the next MessageQueued event to pop the stale ID instead of the correct one.\n\nAddresses feedback on #23647.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23706" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
