### PR TITLE
fix: set trust context before loading analysis conversation history

### DIFF
--- a/assistant/src/runtime/routes/conversation-analysis-routes.ts
+++ b/assistant/src/runtime/routes/conversation-analysis-routes.ts
@@ -130,6 +130,7 @@ If you identify insights worth remembering for future conversations, use your me
         const analysisConversation =
           await deps.sendMessageDeps.getOrCreateConversation(newConv.id);
         analysisConversation.setTrustContext(resolveLocalTrustContext("vellum"));
+        await analysisConversation.ensureActorScopedHistory();
 
         // j. Build onEvent using inline hub publisher
         const onEvent = (msg: ServerMessage) => {


### PR DESCRIPTION
Reorder trust context setup to occur before history load in conversation analysis route. After `setTrustContext`, call `ensureActorScopedHistory()` so the guardian-provenance seed message is correctly treated as trusted.

Addresses feedback on #23592.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
