### PR TITLE
fix: enforce paired nullability for active hours bounds

### DIFF
--- a/assistant/src/config/schemas/heartbeat.ts
+++ b/assistant/src/config/schemas/heartbeat.ts
@@ -40,6 +40,17 @@ export const HeartbeatConfigSchema = z
   })
   .describe("Periodic heartbeat configuration for health monitoring")
   .superRefine((config, ctx) => {
+    const startNull = config.activeHoursStart == null;
+    const endNull = config.activeHoursEnd == null;
+    if (startNull !== endNull) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [startNull ? "activeHoursStart" : "activeHoursEnd"],
+        message:
+          "heartbeat.activeHoursStart and heartbeat.activeHoursEnd must both be set or both be null",
+      });
+      return;
+    }
     if (
       config.activeHoursStart != null &&
       config.activeHoursEnd != null &&


### PR DESCRIPTION
Reject mixed null/non-null active hours bounds in schema validation.

Addresses feedback on #23663.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23708" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
