### PR TITLE
fix: backfill existing capability node significance to 0.6

### DIFF
--- a/assistant/src/memory/graph/capability-seed.ts
+++ b/assistant/src/memory/graph/capability-seed.ts
@@ -29,6 +29,9 @@ import { createNode } from "./store.js";
 
 const log = getLogger("graph-capability-seed");
 
+/** Default significance for capability nodes. */
+const CAPABILITY_SIGNIFICANCE = 0.6;
+
 /** Stable prefix for capability node source tracking. */
 const SKILL_SOURCE_PREFIX = "capability:skill:";
 const CLI_SOURCE_PREFIX = "capability:cli:";
@@ -234,9 +237,12 @@ function upsertCapabilityNode(sourceKey: string, content: string): void {
   if (existing) {
     if (existing.content === content && existing.fidelity !== "gone") {
       // Same content — just touch lastAccessed (and backfill lastConsolidated
-      // for nodes created before the fix so they don't decay immediately)
+      // for nodes created before the fix so they don't decay immediately,
+      // and backfill significance for nodes created before the raise to 0.6)
       const updates: Record<string, number> = { lastAccessed: now };
       if (existing.lastConsolidated === 0) updates.lastConsolidated = now;
+      if (existing.significance < CAPABILITY_SIGNIFICANCE)
+        updates.significance = CAPABILITY_SIGNIFICANCE;
       db.update(memoryGraphNodes)
         .set(updates)
         .where(eq(memoryGraphNodes.id, existing.id))
@@ -275,7 +281,7 @@ function upsertCapabilityNode(sourceKey: string, content: string): void {
     },
     fidelity: "vivid" as const,
     confidence: 1.0,
-    significance: 0.6,
+    significance: CAPABILITY_SIGNIFICANCE,
     stability: 1000, // Effectively permanent — never decays
     reinforcementCount: 0,
     lastReinforced: now,


### PR DESCRIPTION
Update existing capability nodes to the new default significance value during reseeding. Nodes created before #23566 kept the old 0.3 significance indefinitely because the upsert path only touched `lastAccessed` when content was unchanged. Now backfills significance to 0.6 on the same code path.

Addresses feedback on #23566.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
