### PR TITLE
fix: use lstatSync to avoid broken symlink failures in listDirSafe

### DIFF
--- a/assistant/src/tools/shared/filesystem/file-ops-service.ts
+++ b/assistant/src/tools/shared/filesystem/file-ops-service.ts
@@ -1,4 +1,10 @@
-import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import {
+  lstatSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname, join } from "node:path";
 
 import { minimatch } from "minimatch";
@@ -290,7 +296,10 @@ export class FileSystemOps {
         if (entry.isDirectory()) {
           return `${entry.name}/`;
         }
-        const fileStat = statSync(join(resolved, entry.name));
+        if (entry.isSymbolicLink()) {
+          return `${entry.name}@`;
+        }
+        const fileStat = lstatSync(join(resolved, entry.name));
         return `${entry.name}  ${formatSize(fileStat.size)}`;
       });
 


### PR DESCRIPTION
Switch from `statSync` to `lstatSync` and handle symlinks via `entry.isSymbolicLink()` to prevent broken symlinks from failing directory listings with IO_ERROR. Symlinks are now displayed with `@` suffix (like `ls -F`) instead of trying to follow them.

Addresses feedback on #23562.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
