### PR TITLE
fix: only strip memory_image closing tag when in injection context

### DIFF
--- a/assistant/src/__tests__/strip-memory-injections.test.ts
+++ b/assistant/src/__tests__/strip-memory-injections.test.ts
@@ -156,4 +156,32 @@ describe("stripExistingMemoryInjections", () => {
     expect(result[0]).toBe(earlier);
     expect(result[2].content).toEqual([textBlock("second")]);
   });
+
+  test("does not strip user text that equals </memory_image>", () => {
+    const messages = [userMsg(textBlock("</memory_image>"))];
+    const result = stripExistingMemoryInjections(messages);
+    expect(result[0].content).toEqual([textBlock("</memory_image>")]);
+  });
+
+  test("does not strip </memory_image> after memory text block (no image context)", () => {
+    const messages = [
+      userMsg(memoryTextBlock, textBlock("</memory_image>"), textBlock("hello")),
+    ];
+    const result = stripExistingMemoryInjections(messages);
+    expect(result[0].content).toEqual([textBlock("</memory_image>"), textBlock("hello")]);
+  });
+
+  test("strips images-first then text (actual injectMemoryBlock order)", () => {
+    const messages = [
+      userMsg(
+        memoryImageMarker,
+        memoryImage,
+        memoryImageClose,
+        memoryTextBlock,
+        textBlock("hello"),
+      ),
+    ];
+    const result = stripExistingMemoryInjections(messages);
+    expect(result[0].content).toEqual([textBlock("hello")]);
+  });
 });

--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -515,8 +515,8 @@ export class ConversationGraphMemory {
  * Remove all memory-injected blocks from the last user message.
  *
  * `injectMemoryBlock` always prepends blocks in this order:
- *   1. `<memory __injected>…</memory>` text block
- *   2. For each image: `<memory_image>…</memory_image>` text + `image` block
+ *   1. For each image: `<memory_image __injected>…` text + `image` + `</memory_image>` text (3-block group)
+ *   2. `<memory __injected>…</memory>` text block
  *
  * We strip all leading blocks that match this pattern so that
  * `reinjectCachedMemory` is idempotent — no duplicate images after compaction.
@@ -534,6 +534,7 @@ export function stripExistingMemoryInjections(messages: Message[]): Message[] {
   // Only strip image blocks that follow a marker — user-attached images must be preserved.
   let firstNonMemory = 0;
   let prevWasMemoryImageMarker = false;
+  let prevWasInjectedImage = false;
   const content = last.content;
   while (firstNonMemory < content.length) {
     const block = content[firstNonMemory];
@@ -543,21 +544,26 @@ export function stripExistingMemoryInjections(messages: Message[]): Message[] {
     ) {
       firstNonMemory++;
       prevWasMemoryImageMarker = false;
+      prevWasInjectedImage = false;
     } else if (
       block.type === "text" &&
       block.text.startsWith("<memory_image")
     ) {
       firstNonMemory++;
       prevWasMemoryImageMarker = true;
+      prevWasInjectedImage = false;
     } else if (block.type === "image" && prevWasMemoryImageMarker) {
       firstNonMemory++;
       prevWasMemoryImageMarker = false;
+      prevWasInjectedImage = true;
     } else if (
       block.type === "text" &&
-      block.text === "</memory_image>"
+      block.text === "</memory_image>" &&
+      prevWasInjectedImage
     ) {
-      // Closing tag from the 3-block pattern
+      // Closing tag from the 3-block pattern — only strip after an injected image
       firstNonMemory++;
+      prevWasInjectedImage = false;
     } else {
       break;
     }


### PR DESCRIPTION
Guard closing-tag removal with injection state check so user messages starting with `</memory_image>` are not silently stripped. Fix outdated JSDoc to match actual injection order (images first, then memory text).

Addresses feedback on #23664.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
