### PR TITLE
fix: scope streaming cache clear and filter emphasis runs

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -41,8 +41,13 @@ extension ChatBubble {
     func resolveSegments(for text: String, isStreaming: Bool) -> [MarkdownSegment] {
         // Check the synchronous cache first (fast path for all sizes)
         if let cached = Self.segmentCache.object(forKey: text as NSString) {
-            // Clear stale streaming data now that we have a stable cached result.
-            if !isStreaming { Self.lastStreamingSegments = nil }
+            // Clear stale streaming data only for the specific bubble that
+            // transitioned from streaming to finalized. Other non-streaming
+            // bubbles must not wipe the streaming cache or active streaming
+            // bubbles lose their dedup/throttle entry.
+            if !isStreaming, let last = Self.lastStreamingSegments, last.text == text {
+                Self.lastStreamingSegments = nil
+            }
             return cached.segments
         }
         // For large text with a cache miss, parse synchronously and cache.

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -512,7 +512,8 @@ struct MarkdownSegmentView: View, Equatable {
         for run in source.runs {
             let runContent = source[run.range]
             let utf16Length = String(runContent.characters).utf16.count
-            if let intent = runContent.inlinePresentationIntent {
+            if let intent = runContent.inlinePresentationIntent,
+               intent.contains(.emphasized) || intent.contains(.stronglyEmphasized) {
                 emphasisRuns.append(EmphasisRun(
                     utf16Offset: utf16Offset,
                     utf16Length: utf16Length,
@@ -533,7 +534,8 @@ struct MarkdownSegmentView: View, Equatable {
             mdConvertLog.warning("UTF-16 offset mismatch: computed \(utf16Offset) vs NSAttributedString length \(ns.length) — recomputing emphasis offsets")
             emphasisRuns.removeAll()
             for run in source.runs {
-                if let intent = source[run.range].inlinePresentationIntent {
+                if let intent = source[run.range].inlinePresentationIntent,
+                   intent.contains(.emphasized) || intent.contains(.stronglyEmphasized) {
                     let prefixStr = String(source.characters[source.startIndex..<run.range.lowerBound])
                     let nsOffset = (prefixStr as NSString).length
                     let runStr = String(source[run.range].characters)


### PR DESCRIPTION
Prevent cross-bubble cache invalidation and exclude non-emphasis runs from the unresolved check.\n\nAddresses feedback on #23668.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23714" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
