### PR TITLE
fix: preserve stabilization count on same-reason begin

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -496,6 +496,7 @@ final class MessageListScrollState {
         case .stabilizing(let prev, let activeReason):
             previousMode = prev
             if activeReason == reason {
+                activeStabilizationCount += 1
                 if reason == .expansion {
                     scheduleExpansionTimeout()
                 }


### PR DESCRIPTION
Address Codex feedback on PR #23669 — maintain activeStabilizationCount increment even on same-reason early return to preserve begin/end pairing for concurrent resize windows.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
