### PR TITLE
fix: escape all PKB close-tag variants in sanitizer

### DIFF
--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -586,7 +586,7 @@ export function readPkbContext(): string | null {
  */
 export function injectPkbContext(message: Message, content: string): Message {
   // Escape closing tags that could break out of the XML wrapper
-  const escaped = content.replace(/<\/pkb>/gi, "&lt;/pkb&gt;");
+  const escaped = content.replace(/<\/pkb\s*>/gi, "&lt;/pkb&gt;");
   const pkbBlock = {
     type: "text" as const,
     text: `<pkb>\n${escaped}\n</pkb>`,


### PR DESCRIPTION
Address Codex feedback on PR #23684 — use regex to escape all </pkb\s*> close-tag variants including whitespace-padded forms to prevent prompt-structure injection.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23718" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
