### PR TITLE
fix: release activeRun after timeout and suppress unhandled rejection

### DIFF
--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -211,7 +211,7 @@ export class HeartbeatService {
       if (this.activeRun === run) {
         this.activeRun = null;
       }
-    });
+    }).catch(() => {}); // Suppress unhandled rejection if executeRun rejects
 
     let timerId: ReturnType<typeof setTimeout> | undefined;
     try {
@@ -225,6 +225,9 @@ export class HeartbeatService {
       await Promise.race([run, timeout]);
     } catch (err) {
       log.warn({ err }, "Heartbeat run timed out");
+      // Release activeRun so the overlap guard doesn't permanently block
+      // future heartbeat runs when executeRun hangs past the timeout.
+      this.activeRun = null;
     } finally {
       clearTimeout(timerId);
       this._lastRunAt = Date.now();


### PR DESCRIPTION
Address Codex+Devin feedback on PR #23681 — clear activeRun in the timeout branch to prevent permanent scheduler stall, and add .catch(() => {}) to run.finally() to suppress unhandled rejection crash.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
