### PR TITLE
fix: track actual tail cache breakpoint placement

### DIFF
--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -828,6 +828,7 @@ export class AnthropicProvider implements Provider {
       // cheaply without conflicting with the 1h breakpoints above.
       // Skip thinking/redacted_thinking blocks — Anthropic doesn't allow
       // cache_control on those types.
+      let tailBreakpointApplied = false;
       if (turnStartIdx >= 0 && turnStartIdx < sentMessages.length - 1) {
         const lastMsg = sentMessages[sentMessages.length - 1];
         if (Array.isArray(lastMsg.content) && lastMsg.content.length > 0) {
@@ -848,6 +849,7 @@ export class AnthropicProvider implements Provider {
               type: "ephemeral",
               ttl: "5m",
             };
+            tailBreakpointApplied = true;
           }
         }
       }
@@ -859,8 +861,7 @@ export class AnthropicProvider implements Provider {
       // small (<1K tokens) so the re-read cost is negligible, while the
       // dynamic block (workspace context) rarely changes mid-session and
       // benefits more from caching.
-      const hasTailBreakpoint =
-        turnStartIdx >= 0 && turnStartIdx < sentMessages.length - 1;
+      const hasTailBreakpoint = tailBreakpointApplied;
       const hasToolCacheBreakpoint =
         params.tools?.some(
           (t) => "cache_control" in t && t.cache_control != null,


### PR DESCRIPTION
Address Codex+Devin feedback on PR #23678 — replace position-based hasTailBreakpoint heuristic with a flag set when a cache_control is actually applied, preventing unnecessary system breakpoint removal on thinking-heavy turns.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23720" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
