### PR TITLE
fix: filter system notices from boundary-preserved messages

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -740,7 +740,22 @@ function mergeToolResultsIntoAssistantMessages(
       // original message as-is to avoid permanent data loss. The preceding
       // assistant tool_use lives in the previous page; dropping the result
       // here would be unrecoverable.
-      result.push(msg);
+      // Still strip system notices so internal prompt text isn't exposed.
+      const filteredBlocks = blocks.filter(
+        (b) =>
+          !(
+            typeof b === "object" &&
+            b !== null &&
+            isSystemNoticeText(b as Record<string, unknown>)
+          ),
+      );
+      result.push({
+        ...msg,
+        content:
+          filteredBlocks.length === blocks.length
+            ? msg.content
+            : JSON.stringify(filteredBlocks),
+      });
       continue;
     }
 


### PR DESCRIPTION
Address Codex feedback on PR #23685 — apply system notice filtering before the early return in the pagination boundary path to prevent leaking internal prompt text to clients.

When `lastAssistantIdx < 0` (pagination boundary), the `continue` at line 744 returned the original user message before the `realUserContent` filtering ran, exposing `<system_notice>` blocks in `/v1/messages` responses. Now system notices are stripped from the message content before the early return.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23722" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
