### PR TITLE
fix: restrict migration checkpoint to no-such-table error and use canonical format

### DIFF
--- a/assistant/src/memory/graph/bootstrap.ts
+++ b/assistant/src/memory/graph/bootstrap.ts
@@ -399,10 +399,13 @@ export function migrateToolCreatedItems(): void {
        WHERE kind IN (${placeholders}) AND status = 'active'`,
       ...kinds,
     );
-  } catch {
+  } catch (err) {
     // Table may not exist (fresh install) — nothing to migrate
-    setMemoryCheckpoint(MIGRATE_ITEMS_CHECKPOINT, "done");
-    return;
+    if (err instanceof Error && err.message.includes("no such table")) {
+      setMemoryCheckpoint(MIGRATE_ITEMS_CHECKPOINT, "done");
+      return;
+    }
+    throw err;
   }
 
   if (rows.length === 0) {
@@ -417,10 +420,7 @@ export function migrateToolCreatedItems(): void {
     if (!prefix) continue;
 
     // Build content in the format the new tools expect
-    const content =
-      row.kind === "playbook"
-        ? `${row.subject}\n${row.statement}`
-        : `${row.subject}: ${row.statement}`;
+    const content = `${row.subject}\n${row.statement}`;
 
     // Check if already migrated (sourceKey exists in graph)
     const sourceKey = `${prefix}${row.id}`;


### PR DESCRIPTION
Address Codex feedback on PR #23688 — only mark migration complete on 'no such table' error (not arbitrary failures), and use newline format for migrated style/relationship rows to match the canonical upsert path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23723" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
