### PR TITLE
fix: add fallback pagination trigger for non-pinned sections

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -346,6 +346,19 @@ extension MainWindowView {
             .padding(.leading, VSpacing.xs + SidebarLayoutMetrics.iconSlotSize + VSpacing.xs - VSpacing.sm)
             .padding(.bottom, VSpacing.xs)
         }
+
+        // Fallback pagination: the ungrouped section is always the last
+        // rendered section. When every section fits within its collapse
+        // limit (no "Show more" buttons visible) but the server has more
+        // conversations, auto-trigger loading so users can reach them.
+        if conversations.count <= 5,
+           conversationManager.hasMoreConversations {
+            Color.clear
+                .frame(height: 0)
+                .onAppear {
+                    conversationManager.loadAllRemainingConversations()
+                }
+        }
     }
 
     // MARK: - Pinned App Helpers


### PR DESCRIPTION
Address Codex feedback on PR #23683 — ensure pagination can still trigger when no section exceeds the collapse limit but server has more conversations.

The pinned-section-only sentinel guard prevented non-pinned sections from eagerly loading all conversations, but left a gap: when every section (including ungrouped) has <= 5 conversations and no pinned conversations exist, there is no pagination trigger at all.

Adds a fallback sentinel to the ungrouped section in `MainWindowView+Sidebar.swift`. Since ungrouped is always the last section rendered, it is the natural place for a catch-all pagination trigger. It fires only when `conversations.count <= 5` (no "Show more" button) and `hasMoreConversations` is true.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
