### PR TITLE
fix: clamp side panel width to prevent chat pane collapse

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -208,6 +208,36 @@ extension MainWindowView {
         )
     }
 
+    /// Clamped binding for the side panel (config/subagent panel) so persisted
+    /// or default widths can't crush the main chat pane below its minimum.
+    func clampedSidePanelWidth(windowSize: CGSize) -> Binding<Double> {
+        let settingsOpen: Bool = {
+            if case .panel(.settings) = windowState.selection { return true }
+            return false
+        }()
+        let sidebarWidth: CGFloat = settingsOpen ? 0 : (sidebarExpanded ? sidebarExpandedWidth : sidebarCollapsedWidth)
+        let hstackSpacing: CGFloat = 16
+        let outerPadding: CGFloat = 32
+        let windowWidth: Double = Double(windowSize.width) / zoomManager.zoomLevel
+        let availableWidth: Double = windowWidth - Double(sidebarWidth) - Double(hstackSpacing) - Double(outerPadding)
+
+        let preferredMinPanel: Double = 300
+        let preferredMinMain: Double = 300
+        let dividerBudget: Double = Double(VSpacing.xs) + 12
+        let maxPanel: Double = availableWidth - preferredMinMain - dividerBudget
+        let effectiveMinPanel: Double = min(preferredMinPanel, max(maxPanel, 100))
+
+        return Binding<Double>(
+            get: {
+                let raw = sidePanelWidth
+                return min(max(raw, effectiveMinPanel), max(maxPanel, effectiveMinPanel))
+            },
+            set: {
+                sidePanelWidth = min(max($0, effectiveMinPanel), max(maxPanel, effectiveMinPanel))
+            }
+        )
+    }
+
     func clampedChatDockWidth(windowSize: CGSize) -> Binding<Double> {
         let settingsOpen: Bool = {
             if case .panel(.settings) = windowState.selection { return true }
@@ -299,7 +329,7 @@ extension MainWindowView {
             } else if panelType == .documentEditor {
                 let config = windowState.layoutConfig
                 VSplitView(
-                    panelWidth: $sidePanelWidth,
+                    panelWidth: clampedSidePanelWidth(windowSize: windowSize),
                     showPanel: documentManager.hasActiveDocument,
                     main: { slotView(for: config.center.content) },
                     panel: {
@@ -349,7 +379,7 @@ extension MainWindowView {
         let showSubagentPanel = windowState.selectedSubagentId != nil && conversationManager.activeViewModel != nil
 
         VSplitView(
-            panelWidth: $sidePanelWidth,
+            panelWidth: clampedSidePanelWidth(windowSize: windowSize),
             showPanel: showConfigPanel || showSubagentPanel,
             mainBackground: VColor.surfaceOverlay,
             mainCornerRadius: 0,


### PR DESCRIPTION
Address Codex feedback on PR #23697 — clamp sidePanelWidth at runtime to ensure the chat pane maintains minimum width, covering both default and persisted values.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23726" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
