### PR TITLE
fix: handle graph_bootstrap job type in worker dispatch

### DIFF
--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -2,6 +2,7 @@ import { getConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/types.js";
 import { getLogger } from "../util/logger.js";
 import { getMemoryCheckpoint, setMemoryCheckpoint } from "./checkpoints.js";
+import { bootstrapFromHistory } from "./graph/bootstrap.js";
 import { runConsolidation } from "./graph/consolidation.js";
 import { runDecayTick } from "./graph/decay.js";
 import { graphExtractJob } from "./graph/extraction-job.js";
@@ -430,6 +431,9 @@ async function processJob(
       return;
     case "generate_conversation_starters":
       await generateConversationStartersJob(job);
+      return;
+    case "graph_bootstrap":
+      await bootstrapFromHistory();
       return;
 
     default: {


### PR DESCRIPTION
Address Devin feedback on PR #23699 — ensure graph_bootstrap jobs are handled correctly in the processJob switch to prevent silent permanent failure.

graph_bootstrap is actively enqueued via enqueueMemoryJob in maybeEnqueueGraphBootstrap() during daemon startup (lifecycle.ts:710), but had no corresponding case in the processJob switch. When the worker claimed the job, it fell through to the default case and threw 'Unknown memory job type: graph_bootstrap', permanently failing the job.

Added a case that calls bootstrapFromHistory() from graph/bootstrap.ts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
