### PR TITLE
fix: assert preserved tool_result payload in boundary test

### DIFF
--- a/assistant/src/__tests__/list-messages-tool-merge.test.ts
+++ b/assistant/src/__tests__/list-messages-tool-merge.test.ts
@@ -191,6 +191,11 @@ describe("handleListMessages tool_result merging", () => {
     // Orphan tool_result is preserved (not suppressed) to avoid data loss
     expect(body.messages).toHaveLength(2);
     expect(body.messages[0].role).toBe("user");
+    // The preserved message must retain the actual tool_result payload
+    const orphanToolCalls = body.messages[0].toolCalls;
+    expect(orphanToolCalls).toBeDefined();
+    expect(orphanToolCalls).toHaveLength(1);
+    expect(orphanToolCalls![0].result).toBe("stale result");
     expect(body.messages[1].role).toBe("assistant");
     expect(body.messages[1].content).toBe("response");
   });


### PR DESCRIPTION
Address Codex feedback on PR #23698 — add assertion that the boundary-preserved message contains the actual tool_result content, not just checking message count and roles.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
