### PR TITLE
fix: defer SwiftUI state mutations to prevent view-update cycles

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -160,7 +160,7 @@ struct AssistantProgressView: View {
 
     @Environment(\.suppressAutoScroll) private var suppressAutoScroll
     @State private var isExpanded: Bool
-    @State private var startDate: Date = Date()
+    @State private var startDate: Date
     @State private var processingStartDate: Date?
     @State private var isOverflowPopoverShown: Bool = false
     @State private var suppressNextExpand: Bool = false
@@ -211,6 +211,12 @@ struct AssistantProgressView: View {
         let isDenied = derived.hasDeniedToolCalls && derived.hasTools && !derived.allComplete
         let expandFlag = MacOSClientFeatureFlagManager.shared.isEnabled("expand-completed-steps")
         let shouldAutoExpand = (isComplete || isDenied) && expandFlag
+        let initialStartDate = derived.earliestStartedAt ?? Date()
+        let initialProcessingStartDate: Date? = if isProcessing && (derived.allComplete || !derived.hasTools) {
+            Date()
+        } else {
+            nil
+        }
         // Seed from user override if one exists, otherwise use auto-expand logic.
         if let key = toolCalls.first?.id,
            let override = cardExpansionOverrides.wrappedValue[key] {
@@ -218,6 +224,8 @@ struct AssistantProgressView: View {
         } else {
             _isExpanded = State(initialValue: shouldAutoExpand || derived.hasPendingConfirmation)
         }
+        _startDate = State(initialValue: initialStartDate)
+        _processingStartDate = State(initialValue: initialProcessingStartDate)
     }
 
     /// Stable key for this progress card in `cardExpansionOverrides`.
@@ -386,10 +394,12 @@ struct AssistantProgressView: View {
 
     private func handleToolCallsChange(_ newToolCalls: [ToolCallData]) {
         derived = DerivedProgressState.compute(toolCalls: newToolCalls, decidedConfirmations: decidedConfirmations)
+        syncStartDateFromDerivedIfNeeded()
     }
 
     private func handleConfirmationsChange(_ newConfirmations: [ToolConfirmationData]) {
         derived = DerivedProgressState.compute(toolCalls: toolCalls, decidedConfirmations: newConfirmations)
+        syncStartDateFromDerivedIfNeeded()
     }
 
     private func handlePhaseChange(_ newPhase: ProgressPhase) {
@@ -399,27 +409,29 @@ struct AssistantProgressView: View {
             reason: "phase_change:\(newPhase) group=\(derived.groupId) phase=\(newPhase) expand_flag=\(expandFlag) completed=\(derived.completedToolCount)/\(derived.totalToolCount) denied=\(derived.deniedCount) pending_confirm=\(derived.hasPendingConfirmation) rehydrate=\(onRehydrate != nil)",
             toolCallCount: derived.totalToolCount
         ))
-        if newPhase == .processing {
-            processingStartDate = Date()
-            startDate = Date()
-        }
         // Auto-expand when a step group completes, if the flag is enabled.
         // Skip if the user has explicitly set a preference for this card.
         let hasUserCardPreference = cardKey != nil && cardExpansionOverrides[cardKey!] != nil
-        if (newPhase == .complete || newPhase == .denied),
-           !isExpanded,
-           !hasUserCardPreference,
-           MacOSClientFeatureFlagManager.shared.isEnabled("expand-completed-steps")
-        {
-            ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
-                kind: .progressCardTransition,
-                reason: "auto_expand:completed_steps_flag group=\(derived.groupId) phase=\(newPhase) expand_flag=true completed=\(derived.completedToolCount)/\(derived.totalToolCount) pending_confirm=\(derived.hasPendingConfirmation) rehydrate=\(onRehydrate != nil)",
-                toolCallCount: derived.totalToolCount
-            ))
-            withAnimation(VAnimation.fast) {
-                isExpanded = true
+        let shouldAutoExpandOnPhaseChange = (newPhase == .complete || newPhase == .denied)
+            && !hasUserCardPreference
+            && MacOSClientFeatureFlagManager.shared.isEnabled("expand-completed-steps")
+        deferProgressStateMutation {
+            if newPhase == .processing, phase == .processing {
+                processingStartDate = Date()
+                if derived.earliestStartedAt == nil {
+                    startDate = Date()
+                }
             }
-            if let key = cardKey { cardExpansionOverrides[key] = true }
+            if shouldAutoExpandOnPhaseChange, !isExpanded {
+                ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
+                    kind: .progressCardTransition,
+                    reason: "auto_expand:completed_steps_flag group=\(derived.groupId) phase=\(newPhase) expand_flag=true completed=\(derived.completedToolCount)/\(derived.totalToolCount) pending_confirm=\(derived.hasPendingConfirmation) rehydrate=\(onRehydrate != nil)",
+                    toolCallCount: derived.totalToolCount
+                ))
+                withAnimation(VAnimation.fast) {
+                    isExpanded = true
+                }
+            }
         }
     }
 
@@ -436,7 +448,9 @@ struct AssistantProgressView: View {
     private func handlePendingConfirmationChange(_ pending: Bool) {
         // Pending confirmations always force-expand — user must be able to
         // see and interact with the approval UI.
-        if pending && !isExpanded {
+        guard pending else { return }
+        deferProgressStateMutation {
+            guard derived.hasPendingConfirmation, !isExpanded else { return }
             ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
                 kind: .progressCardTransition,
                 reason: "auto_expand:pending_confirmation",
@@ -445,58 +459,35 @@ struct AssistantProgressView: View {
             withAnimation(VAnimation.fast) {
                 isExpanded = true
             }
-            if let key = cardKey { cardExpansionOverrides[key] = true }
         }
     }
 
     private func handleOnAppear() {
         let wasExpandedOnEntry = isExpanded
-        if phase == .processing && processingStartDate == nil {
-            processingStartDate = Date()
-        }
-        // Seed startDate from persisted timestamps so the header timer
-        // shows correct elapsed time after history restore.
-        if let earliest = derived.earliestStartedAt {
-            startDate = earliest
-        }
-        // Auto-expand completed step groups when the flag is enabled.
-        // Skip if the user has explicitly set a preference for this card.
-        let hasUserCardPreference = cardKey != nil && cardExpansionOverrides[cardKey!] != nil
-        if !isExpanded,
-           !hasUserCardPreference,
-           (phase == .complete || phase == .denied),
-           MacOSClientFeatureFlagManager.shared.isEnabled("expand-completed-steps")
-        {
-            ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
-                kind: .progressCardTransition,
-                reason: "auto_expand:completed_steps_flag_on_appear group=\(derived.groupId) phase=\(phase) expand_flag=true completed=\(derived.completedToolCount)/\(derived.totalToolCount) pending_confirm=\(derived.hasPendingConfirmation) rehydrate=\(onRehydrate != nil)",
-                toolCallCount: derived.totalToolCount
-            ))
-            isExpanded = true
-            if let key = cardKey { cardExpansionOverrides[key] = true }
-            // Rehydration is handled by onChange(of: isExpanded) above.
-        }
-        // Auto-expand when a pending confirmation exists on appear —
-        // always force-expand so the user can interact with the approval UI.
-        if derived.hasPendingConfirmation && !isExpanded {
-            ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
-                kind: .progressCardTransition,
-                reason: "auto_expand:pending_confirmation_on_appear",
-                toolCallCount: derived.totalToolCount
-            ))
-            withAnimation(VAnimation.fast) {
-                isExpanded = true
-            }
-            if let key = cardKey { cardExpansionOverrides[key] = true }
-        }
+        let shouldAutoExpandPendingOnAppear = derived.hasPendingConfirmation && !isExpanded
+        let shouldRehydrateOnAppear = wasExpandedOnEntry && onRehydrate != nil && hasStrippedToolCalls
 
-        // Rehydrate stripped tool calls for cards that start expanded.
-        // When isExpanded is set to true in init(), onChange(of: isExpanded)
-        // never fires (no false→true transition), so we must check here.
-        // Gate on wasExpandedOnEntry so cards that just expanded above
-        // don't double-fire — onChange already handles their rehydration.
-        if wasExpandedOnEntry, onRehydrate != nil {
-            if hasStrippedToolCalls {
+        deferProgressStateMutation {
+            syncStartDateFromDerivedIfNeeded()
+            if phase == .processing && processingStartDate == nil {
+                processingStartDate = Date()
+                if derived.earliestStartedAt == nil {
+                    startDate = Date()
+                }
+            }
+
+            if shouldAutoExpandPendingOnAppear && derived.hasPendingConfirmation && !isExpanded {
+                ChatDiagnosticsStore.shared.record(ChatDiagnosticEvent(
+                    kind: .progressCardTransition,
+                    reason: "auto_expand:pending_confirmation_on_appear",
+                    toolCallCount: derived.totalToolCount
+                ))
+                withAnimation(VAnimation.fast) {
+                    isExpanded = true
+                }
+            }
+
+            if shouldRehydrateOnAppear {
                 onRehydrate?()
             }
         }
@@ -510,6 +501,19 @@ struct AssistantProgressView: View {
                 && tc.result == nil
                 && tc.inputRawDict == nil
                 && tc.cachedImages.isEmpty
+        }
+    }
+
+    private func deferProgressStateMutation(_ update: @escaping @MainActor () -> Void) {
+        Task { @MainActor in
+            update()
+        }
+    }
+
+    @MainActor
+    private func syncStartDateFromDerivedIfNeeded() {
+        if let earliest = derived.earliestStartedAt, startDate != earliest {
+            startDate = earliest
         }
     }
 
@@ -795,15 +799,13 @@ private struct StepDetailRow: View {
     var skillLabel: String?
     var onRehydrate: (() -> Void)?
     @State private var isHovered = false
-    /// Cached formatted input — computed once on first expand.
-    @State private var cachedInputFull: String?
     @Environment(\.displayScale) private var displayScale
     @Environment(\.suppressAutoScroll) private var suppressAutoScroll
 
     /// Lazily resolved full input text.
     private var resolvedInputFull: String {
-        if let cached = cachedInputFull { return cached }
         if !toolCall.inputFull.isEmpty { return toolCall.inputFull }
+        if let dict = toolCall.inputRawDict { return ToolCallData.formatAllToolInput(dict) }
         return ""
     }
 
@@ -924,31 +926,15 @@ private struct StepDetailRow: View {
             if isDetailExpanded {
                 stepDetailContent
                     .transition(.opacity)
-                    .onAppear {
-                        if cachedInputFull == nil {
-                            if !toolCall.inputFull.isEmpty {
-                                cachedInputFull = toolCall.inputFull
-                            } else if let dict = toolCall.inputRawDict {
-                                cachedInputFull = ToolCallData.formatAllToolInput(dict)
-                            }
-                        }
-                        // Trigger on-demand rehydration when expanding truncated content.
-                        onRehydrate?()
-                    }
             }
         }
         .animation(VAnimation.fast, value: isDetailExpanded)
         .onChange(of: isDetailExpanded) { _, newValue in
-            if newValue, cachedInputFull == nil {
-                if !toolCall.inputFull.isEmpty {
-                    cachedInputFull = toolCall.inputFull
-                } else if let dict = toolCall.inputRawDict {
-                    cachedInputFull = ToolCallData.formatAllToolInput(dict)
+            if newValue {
+                Task { @MainActor in
+                    onRehydrate?()
                 }
             }
-        }
-        .onChange(of: toolCall.inputFull) {
-            cachedInputFull = nil
         }
     }
 
@@ -1212,7 +1198,10 @@ private struct AssistantProgressPulsingModifier: ViewModifier {
                 Animation.easeInOut(duration: 1.8).repeatForever(autoreverses: true),
                 value: isPulsing
             )
-            .onAppear { isPulsing = true }
+            .task {
+                guard !isPulsing else { return }
+                isPulsing = true
+            }
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -90,8 +90,8 @@ struct ChatBubble: View, Equatable {
     @State private var mediaEmbedIntents: [MediaEmbedIntent] = []
     // Cached interleaved content state — updated via .onChange(of:) to avoid
     // recomputing O(n) grouping on every body evaluation.
-    // Eagerly initialized in init() to prevent first-frame flash where the
-    // wrong layout path renders before .onAppear fires.
+    // Eagerly initialized in init() so the first body evaluation uses the
+    // correct layout path instead of flashing through the fallback layout.
     @State var cachedHasInterleavedContent: Bool
     @State var cachedContentGroups: [ContentGroup]
     /// Set of stableIds for tool-call groups that have non-empty text after them.
@@ -370,7 +370,6 @@ struct ChatBubble: View, Equatable {
                 .compositingGroup()
                 .frame(maxWidth: .infinity, alignment: isUser ? .trailing : .leading)
         .contentShape(Rectangle())
-        .onAppear { recomputeInterleavedContentCache() }
         .onChange(of: message.contentOrder) { _, _ in recomputeInterleavedContentCache() }
         .onChange(of: message.textSegments) { _, _ in recomputeInterleavedContentCache() }
         .onHover { hovering in

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -100,15 +100,22 @@ extension ChatBubble {
 
     // MARK: - Cache Recomputation
 
-    /// Recomputes all cached interleaved content state. Called from `.onAppear`
-    /// and `.onChange(of: message.contentOrder)` / `.onChange(of: message.textSegments)`.
+    /// Recomputes all cached interleaved content state when message structure
+    /// changes, while avoiding no-op `@State` writes that would otherwise
+    /// re-render the bubble on every streaming token.
     func recomputeInterleavedContentCache() {
         let interleaved = Self.computeHasInterleavedContent(message.contentOrder)
-        cachedHasInterleavedContent = interleaved
 
         guard interleaved else {
-            cachedContentGroups = []
-            cachedToolGroupsWithTrailingText = []
+            if cachedHasInterleavedContent {
+                cachedHasInterleavedContent = false
+            }
+            if !cachedContentGroups.isEmpty {
+                cachedContentGroups = []
+            }
+            if !cachedToolGroupsWithTrailingText.isEmpty {
+                cachedToolGroupsWithTrailingText = []
+            }
             // Update static cache with non-interleaved result
             Self.storeInterleavedResult(
                 InterleavedCacheValue(hasInterleaved: false, groups: [], trailingTextIds: []),
@@ -121,7 +128,6 @@ extension ChatBubble {
             contentOrder: message.contentOrder,
             hasInterleavedContent: interleaved
         )
-        cachedContentGroups = groups
 
         // Pre-compute which tool-call groups have trailing text so that
         // `interleavedContent` can look up the set instead of scanning
@@ -138,7 +144,15 @@ extension ChatBubble {
                 trailingTextIds.insert(group.stableId)
             }
         }
-        cachedToolGroupsWithTrailingText = trailingTextIds
+        if !cachedHasInterleavedContent {
+            cachedHasInterleavedContent = true
+        }
+        if cachedContentGroups != groups {
+            cachedContentGroups = groups
+        }
+        if cachedToolGroupsWithTrailingText != trailingTextIds {
+            cachedToolGroupsWithTrailingText = trailingTextIds
+        }
 
         // Update static cache so the next init() for this message uses fresh values
         Self.storeInterleavedResult(

--- a/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
@@ -11,8 +11,14 @@ struct ThinkingBlockView: View {
     let content: String
     let isStreaming: Bool
 
-    @State private var isExpanded: Bool = false
+    @State private var isExpanded: Bool
     @State private var userHasToggled: Bool = false
+
+    init(content: String, isStreaming: Bool) {
+        self.content = content
+        self.isStreaming = isStreaming
+        _isExpanded = State(initialValue: isStreaming)
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -46,20 +52,17 @@ struct ThinkingBlockView: View {
                 #endif
             }
         }
-        .onAppear {
-            if isStreaming {
-                isExpanded = true
-            }
-        }
         .onChange(of: isStreaming) { _, newValue in
-            if newValue {
-                userHasToggled = false
-                withAnimation(VAnimation.fast) {
-                    isExpanded = true
-                }
-            } else if !userHasToggled {
-                withAnimation(VAnimation.fast) {
-                    isExpanded = false
+            Task { @MainActor in
+                if newValue {
+                    userHasToggled = false
+                    withAnimation(VAnimation.fast) {
+                        isExpanded = true
+                    }
+                } else if !userHasToggled {
+                    withAnimation(VAnimation.fast) {
+                        isExpanded = false
+                    }
                 }
             }
         }

--- a/clients/macos/vellum-assistantTests/AssistantProgressViewLoggingTests.swift
+++ b/clients/macos/vellum-assistantTests/AssistantProgressViewLoggingTests.swift
@@ -30,23 +30,16 @@ struct AssistantProgressViewLoggingTests {
         return tc
     }
 
-    /// Simulates the auto-expand diagnostic that `onAppear` would emit for a
-    /// completed step group when the `expand-completed-steps` flag is enabled.
-    ///
-    /// This mirrors the exact recording logic in AssistantProgressView.onAppear
-    /// so that test assertions stay tightly coupled to production behavior.
+    /// Simulates the auto-expand diagnostic that `onAppear` emits when a
+    /// pending confirmation forces the card open.
     @MainActor
-    private static func simulateOnAppearAutoExpand(
+    private static func simulateOnAppearPendingConfirmationAutoExpand(
         store: ChatDiagnosticsStore,
-        toolCalls: [ToolCallData],
-        hasPendingConfirmation: Bool = false,
-        hasRehydrate: Bool = false
+        toolCalls: [ToolCallData]
     ) {
-        let groupId = toolCalls.first?.id.uuidString ?? "no-tools"
-        let completedCount = toolCalls.filter(\.isComplete).count
         store.record(ChatDiagnosticEvent(
             kind: .progressCardTransition,
-            reason: "auto_expand:completed_steps_flag_on_appear group=\(groupId) phase=complete expand_flag=true completed=\(completedCount)/\(toolCalls.count) pending_confirm=\(hasPendingConfirmation) rehydrate=\(hasRehydrate)",
+            reason: "auto_expand:pending_confirmation_on_appear",
             toolCallCount: toolCalls.count
         ))
     }
@@ -54,52 +47,36 @@ struct AssistantProgressViewLoggingTests {
     // MARK: - Enriched Fields
 
     @Test @MainActor
-    func autoExpandOnAppearIncludesEnrichedFields() {
+    func pendingConfirmationOnAppearIncludesToolCallCount() {
         let store = ChatDiagnosticsStore()
         let toolCalls = [
             Self.completedToolCall(index: 1),
             Self.completedToolCall(index: 2, toolName: "run_command"),
         ]
 
-        Self.simulateOnAppearAutoExpand(store: store, toolCalls: toolCalls)
+        Self.simulateOnAppearPendingConfirmationAutoExpand(store: store, toolCalls: toolCalls)
 
         let events = store.events.filter { $0.kind == .progressCardTransition }
         #expect(events.count == 1)
 
         let reason = events[0].reason ?? ""
-
-        // Group ID matches the first tool call's UUID.
-        #expect(reason.contains("group=00000000-0000-0000-0000-000000000001"))
-        // Phase is complete.
-        #expect(reason.contains("phase=complete"))
-        // Feature flag state is included.
-        #expect(reason.contains("expand_flag=true"))
-        // Completed tool count ratio is present.
-        #expect(reason.contains("completed=2/2"))
-        // Pending confirmation state is included.
-        #expect(reason.contains("pending_confirm=false"))
-        // Rehydration availability is included.
-        #expect(reason.contains("rehydrate=false"))
+        #expect(reason == "auto_expand:pending_confirmation_on_appear")
         // toolCallCount is populated.
         #expect(events[0].toolCallCount == 2)
     }
 
     @Test @MainActor
-    func autoExpandOnAppearWithRehydrateAvailable() {
+    func pendingConfirmationOnAppearSupportsSingleToolGroup() {
         let store = ChatDiagnosticsStore()
         let toolCalls = [Self.completedToolCall(index: 5)]
 
-        Self.simulateOnAppearAutoExpand(
-            store: store,
-            toolCalls: toolCalls,
-            hasRehydrate: true
-        )
+        Self.simulateOnAppearPendingConfirmationAutoExpand(store: store, toolCalls: toolCalls)
 
         let events = store.events.filter { $0.kind == .progressCardTransition }
         #expect(events.count == 1)
         let reason = events[0].reason ?? ""
-        #expect(reason.contains("rehydrate=true"))
-        #expect(reason.contains("completed=1/1"))
+        #expect(reason == "auto_expand:pending_confirmation_on_appear")
+        #expect(events[0].toolCallCount == 1)
     }
 
     // MARK: - Once-Per-Appearance Guard
@@ -111,7 +88,7 @@ struct AssistantProgressViewLoggingTests {
     /// confirming that the dedup is at the SwiftUI lifecycle level, not
     /// inside the store.
     @Test @MainActor
-    func autoExpandDiagnosticEmittedOncePerAppearance() {
+    func pendingConfirmationDiagnosticEmittedOncePerAppearance() {
         let store = ChatDiagnosticsStore()
         let toolCalls = [
             Self.completedToolCall(index: 10),
@@ -120,11 +97,11 @@ struct AssistantProgressViewLoggingTests {
         ]
 
         // First appearance: one diagnostic emitted.
-        Self.simulateOnAppearAutoExpand(store: store, toolCalls: toolCalls)
+        Self.simulateOnAppearPendingConfirmationAutoExpand(store: store, toolCalls: toolCalls)
 
         let afterFirstAppear = store.events.filter {
             $0.kind == .progressCardTransition
-                && ($0.reason ?? "").contains("auto_expand:completed_steps_flag_on_appear")
+                && ($0.reason ?? "").contains("auto_expand:pending_confirmation_on_appear")
         }
         #expect(afterFirstAppear.count == 1,
                 "onAppear should emit exactly one auto-expand diagnostic")
@@ -136,7 +113,7 @@ struct AssistantProgressViewLoggingTests {
         // in the SwiftUI lifecycle (onAppear vs body).
         let afterRerender = store.events.filter {
             $0.kind == .progressCardTransition
-                && ($0.reason ?? "").contains("auto_expand:completed_steps_flag_on_appear")
+                && ($0.reason ?? "").contains("auto_expand:pending_confirmation_on_appear")
         }
         #expect(afterRerender.count == 1,
                 "A render pass without a new onAppear must not produce duplicate diagnostics")
@@ -146,18 +123,18 @@ struct AssistantProgressViewLoggingTests {
     /// each emit their own diagnostic — the once-per-appearance invariant
     /// allows one event per appearance, not one event total.
     @Test @MainActor
-    func distinctAppearancesEachEmitDiagnostic() {
+    func distinctAppearancesEachEmitPendingConfirmationDiagnostic() {
         let store = ChatDiagnosticsStore()
         let toolCalls = [Self.completedToolCall(index: 20)]
 
         // First appearance.
-        Self.simulateOnAppearAutoExpand(store: store, toolCalls: toolCalls)
+        Self.simulateOnAppearPendingConfirmationAutoExpand(store: store, toolCalls: toolCalls)
         // Second appearance (view was removed and re-added to the hierarchy).
-        Self.simulateOnAppearAutoExpand(store: store, toolCalls: toolCalls)
+        Self.simulateOnAppearPendingConfirmationAutoExpand(store: store, toolCalls: toolCalls)
 
         let events = store.events.filter {
             $0.kind == .progressCardTransition
-                && ($0.reason ?? "").contains("auto_expand:completed_steps_flag_on_appear")
+                && ($0.reason ?? "").contains("auto_expand:pending_confirmation_on_appear")
         }
         #expect(events.count == 2,
                 "Each distinct appearance should emit its own diagnostic")


### PR DESCRIPTION
## Summary
- Defer state mutations in `AssistantProgressView`, `ThinkingBlockView` that fire during SwiftUI view updates (onChange, onAppear) using `Task { @MainActor }` to break out of the render pass
- Initialize `startDate`, `processingStartDate`, and `isExpanded` in `init()` instead of mutating in `onAppear`, preventing first-frame flashes and undefined mutation-during-update behavior
- Guard `@State` writes in `ChatBubbleInterleavedContent.recomputeInterleavedContentCache()` to skip no-op assignments, reducing unnecessary re-renders during streaming
- Remove `cachedInputFull` caching layer in `StepDetailRow` — resolve input text on-demand from the source of truth instead
- Remove redundant `.onAppear` in `ChatBubble` (cache is already eagerly initialized in `init()`)
- Update tests to match simplified onAppear behavior (only pending-confirmation auto-expand remains)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23729" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
