### PR TITLE
fix: update stale stabilization count comment (#23716)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -419,8 +419,10 @@ final class MessageListScrollState {
     /// Tracks overlapping stabilization windows. Stabilization only ends
     /// when all active windows have completed, so concurrent reasons
     /// (e.g. resize during pagination) don't prematurely restore the mode.
-    /// Re-entering the same reason refreshes that window instead of stacking
-    /// duplicate counts that would require extra `endStabilization()` calls.
+    /// Re-entering the same reason increments the count like any other entry.
+    /// Callers are structured so that each `beginStabilization` has a matching
+    /// `endStabilization` (cancelled task cleanup for resize, preceding
+    /// `endStabilization` in `suppressAutoScroll` for expansion).
     @ObservationIgnored private var activeStabilizationCount = 0
 
     // MARK: - Deep-Link Anchor Tracking


### PR DESCRIPTION
Update the activeStabilizationCount comment in MessageListScrollState.swift to reflect the new same-reason stacking behavior introduced in #23716. The old comment incorrectly stated that same-reason re-entry doesn't stack counts. Addresses feedback from Devin on #23716.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23731" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
