### PR TITLE
fix: update stale heartbeat overlap guard comment (#23719)

### DIFF
--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -205,8 +205,11 @@ export class HeartbeatService {
 
     const run = this.executeRun();
     this.activeRun = run;
-    // Clear activeRun only once executeRun actually finishes, so the overlap
-    // guard keeps blocking even after a timeout.
+    // Clear activeRun once executeRun finishes. On timeout, runOnce releases
+    // activeRun separately (see catch block below) so future runs aren't
+    // permanently blocked. The .finally() handler still serves as the
+    // normal-completion cleanup path and uses an identity guard to avoid
+    // clearing a different run's activeRun.
     run.finally(() => {
       if (this.activeRun === run) {
         this.activeRun = null;


### PR DESCRIPTION
Update the activeRun comment in heartbeat-service.ts to reflect the new timeout-release behavior introduced in #23719. The old comment incorrectly stated that the overlap guard keeps blocking after timeout. Addresses feedback from Devin on #23719.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23732" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
