### PR TITLE
fix: gate Analyze action on conversation persistence (#23553)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationHeaderPresentation.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationHeaderPresentation.swift
@@ -12,6 +12,7 @@ struct ConversationHeaderPresentation {
     let isChannelConversation: Bool
     let canCopy: Bool
     let isPinned: Bool
+    let isPersisted: Bool
     let showsForkConversationAction: Bool
     let forkParentTitle: String?
     let forkParentConversationId: String?
@@ -30,6 +31,7 @@ struct ConversationHeaderPresentation {
             self.isChannelConversation = false
             self.canCopy = false
             self.isPinned = false
+            self.isPersisted = false
             self.showsForkConversationAction = false
             self.forkParentTitle = nil
             self.forkParentConversationId = nil
@@ -47,6 +49,7 @@ struct ConversationHeaderPresentation {
         // pipelines, avoiding O(n) work during view body evaluation.
         let hasNonEmptyMessage = activeViewModel?.hasNonEmptyMessage ?? false
         self.isStarted = conversation.conversationId != nil || hasNonEmptyMessage
+        self.isPersisted = conversation.conversationId != nil
 
         // Private conversations don't show the full actions menu
         self.showsActionsMenu = isStarted && !isPrivateConversation

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationTitleActionsControl.swift
@@ -72,7 +72,7 @@ struct ConversationActionsDrawer: View {
                 VMenuItem(icon: VIcon.gitBranch.rawValue, label: "Fork conversation", action: onForkConversation)
             }
 
-            if !presentation.isChannelConversation && !presentation.isPrivateConversation {
+            if presentation.isPersisted && !presentation.isChannelConversation && !presentation.isPrivateConversation {
                 VMenuItem(
                     icon: VIcon.sparkles.rawValue,
                     label: "Analyze conversation",


### PR DESCRIPTION
Gate the Analyze conversation menu item on conversationId != nil to prevent showing an action that fails for unpersisted conversations. Addresses feedback from Codex on #23553.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
