### PR TITLE
fix: gate fallback pagination on all sections (#23725)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -351,8 +351,15 @@ extension MainWindowView {
         // rendered section. When every section fits within its collapse
         // limit (no "Show more" buttons visible) but the server has more
         // conversations, auto-trigger loading so users can reach them.
+        // Gate on ALL sections — not just ungrouped — to avoid eager
+        // full-load in grouped-heavy workspaces.
         if conversations.count <= 5,
-           conversationManager.hasMoreConversations {
+           conversationManager.hasMoreConversations,
+           !conversationManager.groupedConversations.contains(where: { entry in
+               guard let group = entry.group else { return false }
+               let limit = group.id == ConversationGroup.pinned.id ? Int.max : 5
+               return entry.conversations.count > limit
+           }) {
             Color.clear
                 .frame(height: 0)
                 .onAppear {


### PR DESCRIPTION
Gate the fallback pagination trigger on all sidebar sections being within their collapse limits, not just the ungrouped section. This prevents eager full-load in grouped-heavy workspaces where ungrouped is empty but other groups have visible Show More triggers. Addresses feedback from Codex on #23725.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23734" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
