### PR TITLE
fix: coalesce scroll geometry updates to prevent re-entrant modifier faults

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -406,6 +406,8 @@ final class MessageListScrollState {
     @ObservationIgnored var highlightDismissTask: Task<Void, Never>?
     @ObservationIgnored var scrollIndicatorRestoreTask: Task<Void, Never>?
     @ObservationIgnored var anchorTimeoutTask: Task<Void, Never>?
+    @ObservationIgnored var pendingScrollGeometrySnapshot: ScrollGeometrySnapshot?
+    @ObservationIgnored var scrollGeometryDispatchTask: Task<Void, Never>?
 
     /// The message ID awaiting a deferred scroll-to-top. Set when entering
     /// `pushToTop` mode and consumed by `TailSpacerView.onAppear` (fresh
@@ -498,7 +500,6 @@ final class MessageListScrollState {
         case .stabilizing(let prev, let activeReason):
             previousMode = prev
             if activeReason == reason {
-                activeStabilizationCount += 1
                 if reason == .expansion {
                     scheduleExpansionTimeout()
                 }
@@ -646,6 +647,9 @@ final class MessageListScrollState {
         cancelStabilizationTasks()
         paginationTask?.cancel()
         paginationTask = nil
+        scrollGeometryDispatchTask?.cancel()
+        scrollGeometryDispatchTask = nil
+        pendingScrollGeometrySnapshot = nil
         if _isPaginationInFlight { _isPaginationInFlight = false }
         wasPaginationTriggerInRange = false
         lastPaginationCompletedAt = .distantPast
@@ -678,6 +682,9 @@ final class MessageListScrollState {
         scrollRestoreTask = nil
         paginationTask?.cancel()
         paginationTask = nil
+        scrollGeometryDispatchTask?.cancel()
+        scrollGeometryDispatchTask = nil
+        pendingScrollGeometrySnapshot = nil
         anchorTimeoutTask?.cancel()
         anchorTimeoutTask = nil
         highlightDismissTask?.cancel()

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -7,6 +7,26 @@ extension MessageListView {
 
     // MARK: - Scroll geometry handler
 
+    /// Coalesces `onScrollGeometryChange` updates onto the next main-actor turn.
+    ///
+    /// macOS 26's `OnScrollGeometryChange` modifier faults when its action
+    /// causes enough synchronous view-affecting state mutations to re-enter
+    /// the modifier in the same frame. We only store the latest geometry
+    /// snapshot inside the callback, then process it after the callback unwinds.
+    func enqueueScrollGeometryUpdate(_ newState: ScrollGeometrySnapshot) {
+        scrollState.pendingScrollGeometrySnapshot = newState
+        guard scrollState.scrollGeometryDispatchTask == nil else { return }
+        scrollState.scrollGeometryDispatchTask = Task { @MainActor [scrollState] in
+            defer { scrollState.scrollGeometryDispatchTask = nil }
+            while !Task.isCancelled {
+                await Task.yield()
+                guard let snapshot = scrollState.pendingScrollGeometrySnapshot else { break }
+                scrollState.pendingScrollGeometrySnapshot = nil
+                handleScrollGeometryUpdate(snapshot)
+            }
+        }
+    }
+
     func handleScrollGeometryUpdate(_ newState: ScrollGeometrySnapshot) {
         // --- Scroll direction detection ---
         let effectiveContentHeight = newState.contentHeight - scrollState.tailSpacerHeight

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -141,7 +141,7 @@ struct MessageListView: View {
                     visibleRectHeight: geometry.visibleRect.height
                 )
             } action: { _, newState in
-                handleScrollGeometryUpdate(newState)
+                enqueueScrollGeometryUpdate(newState)
             }
             .scrollIndicators(scrollState.scrollIndicatorsHidden ? .hidden : .automatic)
             .overlay(alignment: .bottom) {


### PR DESCRIPTION
## Summary
- Introduce `enqueueScrollGeometryUpdate` that coalesces `onScrollGeometryChange` callbacks onto the next main-actor turn, preventing re-entrant modifier faults on macOS 26
- Add `pendingScrollGeometrySnapshot` and `scrollGeometryDispatchTask` to `MessageListScrollState` with proper cleanup in reset/cancel paths
- Remove redundant `activeStabilizationCount` increment in stabilization re-entry