### PR TITLE
fix: use exact key matching in deleteCapabilityNode to prevent prefix collisions

### DIFF
--- a/assistant/src/memory/graph/capability-seed.ts
+++ b/assistant/src/memory/graph/capability-seed.ts
@@ -237,7 +237,7 @@ function upsertCapabilityNode(sourceKey: string, content: string): void {
     .where(
       and(
         eq(memoryGraphNodes.scopeId, "default"),
-        like(memoryGraphNodes.sourceConversations, `%${sourceKey}%`),
+        eq(memoryGraphNodes.sourceConversations, JSON.stringify([sourceKey])),
       ),
     )
     .get();
@@ -318,7 +318,7 @@ function deleteCapabilityNode(sourceKey: string): void {
     .where(
       and(
         eq(memoryGraphNodes.scopeId, "default"),
-        like(memoryGraphNodes.sourceConversations, `%${sourceKey}%`),
+        eq(memoryGraphNodes.sourceConversations, JSON.stringify([sourceKey])),
       ),
     )
     .get();


### PR DESCRIPTION
Address Codex feedback on #23721 — replace fuzzy LIKE pattern with exact matching in deleteCapabilityNode and upsertCapabilityNode to prevent prefix collisions between skill IDs (e.g. foo vs foo-bar).

`sourceConversations` stores a JSON-serialized single-element array (e.g. `["capability:skill:foo"]`). The old `LIKE '%key%'` substring match could match `foo-bar` when looking for `foo`. Switched to `eq()` with `JSON.stringify([sourceKey])` for exact matching.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
