### PR TITLE
fix: align fallback pagination check with actual rendering logic

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -357,8 +357,26 @@ extension MainWindowView {
            conversationManager.hasMoreConversations,
            !conversationManager.groupedConversations.contains(where: { entry in
                guard let group = entry.group else { return false }
-               let limit = group.id == ConversationGroup.pinned.id ? Int.max : 5
-               return entry.conversations.count > limit
+               // Skip custom groups when feature flag is off — rendering
+               // hides them and folds their conversations into ungrouped.
+               if !group.isSystemGroup && !assistantFeatureFlagStore.isEnabled("conversation-groups-ui") {
+                   return false
+               }
+               let isPinned = group.id == ConversationGroup.pinned.id
+               let isScheduled = group.id == ConversationGroup.scheduled.id
+               let isBackground = group.id == ConversationGroup.background.id
+               let maxCollapsed = isPinned ? Int.max : 5
+               if isScheduled || isBackground {
+                   // Subgroup count mode — "Show more" triggers on distinct
+                   // subgroup count, not total conversation count.
+                   let grouper: (ConversationModel) -> String? = isScheduled
+                       ? { $0.scheduleJobId }
+                       : { $0.source }
+                   var keys = Set<String>()
+                   for c in entry.conversations { keys.insert(grouper(c) ?? c.id.uuidString) }
+                   return keys.count > maxCollapsed
+               }
+               return entry.conversations.count > maxCollapsed
            }) {
             Color.clear
                 .frame(height: 0)


### PR DESCRIPTION
Address Codex + Devin feedback on #23734 — fix fallback pagination gating to account for subgroup count mode and feature-flag filtering of custom groups.

**Issue 1:** Scheduled/Background sections use subgroup count mode where `Show more` is determined by `subGroups.count > maxCollapsed`, not total conversation count. The check now counts distinct subgroup keys for these sections.

**Issue 2:** When `conversation-groups-ui` feature flag is off, custom groups are hidden and their conversations folded into ungrouped. The check now skips non-system groups when the flag is off, matching the rendering logic in `conversationGroupsList`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23739" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
