### PR TITLE
fix: extract scroll geometry coalescing into shared dispatcher

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -406,8 +406,6 @@ final class MessageListScrollState {
     @ObservationIgnored var highlightDismissTask: Task<Void, Never>?
     @ObservationIgnored var scrollIndicatorRestoreTask: Task<Void, Never>?
     @ObservationIgnored var anchorTimeoutTask: Task<Void, Never>?
-    @ObservationIgnored var pendingScrollGeometrySnapshot: ScrollGeometrySnapshot?
-    @ObservationIgnored var scrollGeometryDispatchTask: Task<Void, Never>?
 
     /// The message ID awaiting a deferred scroll-to-top. Set when entering
     /// `pushToTop` mode and consumed by `TailSpacerView.onAppear` (fresh
@@ -647,9 +645,7 @@ final class MessageListScrollState {
         cancelStabilizationTasks()
         paginationTask?.cancel()
         paginationTask = nil
-        scrollGeometryDispatchTask?.cancel()
-        scrollGeometryDispatchTask = nil
-        pendingScrollGeometrySnapshot = nil
+        ScrollGeometryUpdateDispatcher.shared.cancel(for: self)
         if _isPaginationInFlight { _isPaginationInFlight = false }
         wasPaginationTriggerInRange = false
         lastPaginationCompletedAt = .distantPast
@@ -682,9 +678,7 @@ final class MessageListScrollState {
         scrollRestoreTask = nil
         paginationTask?.cancel()
         paginationTask = nil
-        scrollGeometryDispatchTask?.cancel()
-        scrollGeometryDispatchTask = nil
-        pendingScrollGeometrySnapshot = nil
+        ScrollGeometryUpdateDispatcher.shared.cancel(for: self)
         anchorTimeoutTask?.cancel()
         anchorTimeoutTask = nil
         highlightDismissTask?.cancel()

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
@@ -45,6 +45,56 @@ struct ScrollGeometrySnapshot: Equatable {
     let visibleRectHeight: CGFloat
 }
 
+// MARK: - Scroll Geometry Dispatcher
+
+/// Coalesces `onScrollGeometryChange` callbacks outside SwiftUI-managed state.
+///
+/// macOS 26 faults when an `OnScrollGeometryChange` action updates view state
+/// multiple times in the same frame. The message list still needs to process
+/// the latest geometry snapshot, but the queue bookkeeping itself must not
+/// live on `@State` / `@Observable` storage owned by the view.
+@MainActor
+final class ScrollGeometryUpdateDispatcher {
+    static let shared = ScrollGeometryUpdateDispatcher()
+
+    private var pendingSnapshots: [ObjectIdentifier: ScrollGeometrySnapshot] = [:]
+    private var tasks: [ObjectIdentifier: Task<Void, Never>] = [:]
+
+    func enqueue(
+        for owner: MessageListScrollState,
+        snapshot: ScrollGeometrySnapshot,
+        handler: @escaping @MainActor (ScrollGeometrySnapshot) -> Void
+    ) {
+        let key = ObjectIdentifier(owner)
+        pendingSnapshots[key] = snapshot
+        guard tasks[key] == nil else { return }
+
+        tasks[key] = Task { @MainActor [weak self, weak owner] in
+            guard let self else { return }
+            defer {
+                self.tasks[key] = nil
+                self.pendingSnapshots[key] = nil
+            }
+
+            while !Task.isCancelled {
+                await Task.yield()
+                guard owner != nil else { return }
+                guard let latest = self.pendingSnapshots[key] else { return }
+                self.pendingSnapshots[key] = nil
+                handler(latest)
+                guard self.pendingSnapshots[key] != nil else { return }
+            }
+        }
+    }
+
+    func cancel(for owner: MessageListScrollState) {
+        let key = ObjectIdentifier(owner)
+        tasks[key]?.cancel()
+        tasks[key] = nil
+        pendingSnapshots[key] = nil
+    }
+}
+
 // MARK: - Cached Message Layout Metadata
 
 /// Structural metadata cached behind a version-counter key on

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -14,16 +14,8 @@ extension MessageListView {
     /// the modifier in the same frame. We only store the latest geometry
     /// snapshot inside the callback, then process it after the callback unwinds.
     func enqueueScrollGeometryUpdate(_ newState: ScrollGeometrySnapshot) {
-        scrollState.pendingScrollGeometrySnapshot = newState
-        guard scrollState.scrollGeometryDispatchTask == nil else { return }
-        scrollState.scrollGeometryDispatchTask = Task { @MainActor [scrollState] in
-            defer { scrollState.scrollGeometryDispatchTask = nil }
-            while !Task.isCancelled {
-                await Task.yield()
-                guard let snapshot = scrollState.pendingScrollGeometrySnapshot else { break }
-                scrollState.pendingScrollGeometrySnapshot = nil
-                handleScrollGeometryUpdate(snapshot)
-            }
+        ScrollGeometryUpdateDispatcher.shared.enqueue(for: scrollState, snapshot: newState) { snapshot in
+            handleScrollGeometryUpdate(snapshot)
         }
     }
 


### PR DESCRIPTION
## Summary
- Introduces `ScrollGeometryUpdateDispatcher`, a `@MainActor` singleton that coalesces `onScrollGeometryChange` callbacks outside SwiftUI-managed state
- Removes `pendingScrollGeometrySnapshot` and `scrollGeometryDispatchTask` from `MessageListScrollState`, routing through the shared dispatcher instead
- Prevents re-entrant `OnScrollGeometryChange` modifier faults on macOS 26 by ensuring dispatch bookkeeping never triggers view updates in the same frame
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
