### PR TITLE
feat: enable Teleport feature flag by default

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -279,7 +279,7 @@
       "key": "teleport",
       "label": "Teleport",
       "description": "Enable teleport UI in General settings for moving assistants between hosting environments",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "permission-controls-v2",


### PR DESCRIPTION
## Summary
- Set `defaultEnabled: true` for the `teleport` feature flag in the feature flag registry
- The Teleport UI in General settings for moving assistants between hosting environments will now be on by default for all macOS users

## Original prompt
Make the Teleport feature flag default on. The change is already made in meta/feature-flags/feature-flag-registry.json - just need to commit and PR it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
