### PR TITLE
Remove workspace directory from log exports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,9 +169,9 @@ The assistant's container root (`/`) stores per-container ephemeral and persiste
 - **Credentials** are owned by the CES. In Docker mode, the assistant and gateway access credentials via the CES HTTP API (`CES_CREDENTIAL_URL`). Neither service has direct filesystem access to `keys.enc` or `store.key`.
 - The legacy shared data volume (`<name>-data`) is no longer created for new instances. Existing instances are migrated: gateway security files and CES security files are copied from the data volume to their respective security volumes on startup (see `migrateGatewaySecurityFiles()` and `migrateCesSecurityFiles()` in `cli/src/lib/docker.ts`).
 
-## Workspace Export & Secrets
+## Workspace & Secrets
 
-The entire ~/.vellum/workspace directory (minus embedding models, Qdrant vector indices, attachments, and conversation disk-view files) is included in diagnostic log exports when users choose "Send logs to Vellum". **Never store secrets, API keys, or sensitive credentials in the workspace directory.**
+**Never store secrets, API keys, or sensitive credentials in the workspace directory.**
 
 - **Local mode**: Use the credential store (`assistant credentials`) or the `~/.vellum/protected/` directory for sensitive data.
 - **Docker mode**: Sensitive files are isolated on dedicated security volumes that only the owning service can access. Trust rules (`trust.json`, `actor-token-signing-key`) live on the gateway security volume (`/gateway-security`). Credential keys (`keys.enc`, `store.key`) live on the CES security volume (`/ces-security`). The assistant and gateway access credentials via the CES HTTP API (`CES_CREDENTIAL_URL`), and the assistant accesses trust rules via the gateway's trust HTTP API. Neither the assistant nor the gateway has direct filesystem access to the other service's security volume.

--- a/assistant/docs/architecture/integrations.md
+++ b/assistant/docs/architecture/integrations.md
@@ -532,7 +532,7 @@ Each conversation is projected to a directory named `{isoDate}_{id}`:
 
 The disk view is updated at the daemon level, not automatically by the DB CRUD layer. Conversation creation, metadata updates, and deletion are synced from `conversation-crud.ts`, but message sync (`syncMessageToDisk`) is only called from daemon-level code paths (e.g. `conversation-messaging.ts`) — not from the CRUD `addMessage()` function. This means `messages.jsonl` reflects messages processed through the daemon's messaging pipeline, not every message write. All disk writes are best-effort; failures are logged but never thrown, so the disk view cannot break DB operations.
 
-> **Privacy note:** Conversation disk-view files live under `~/.vellum/workspace/conversations/` and are **excluded** from diagnostic log exports ("Send logs to Vellum") via the `WORKSPACE_SKIP_DIRS` filter in `log-export-routes.ts`. However, the SQLite database (`assistant.db`) is included in exports as a SQL dump, and it contains conversation messages and attachment data in its tables. The disk-view exclusion prevents the raw conversation files and decoded attachments from being exported, but conversation content stored in the database may still be present in the export.
+> **Privacy note:** Conversation disk-view files live under `~/.vellum/workspace/conversations/`. Workspace files are not included in diagnostic log exports ("Send logs to Vellum"). However, the SQLite database (`assistant.db`) is included in exports as a SQL dump, and it contains conversation messages and attachment data in its tables. Conversation content stored in the database may still be present in the export.
 
 ```mermaid
 sequenceDiagram

--- a/assistant/docs/architecture/integrations.md
+++ b/assistant/docs/architecture/integrations.md
@@ -532,7 +532,7 @@ Each conversation is projected to a directory named `{isoDate}_{id}`:
 
 The disk view is updated at the daemon level, not automatically by the DB CRUD layer. Conversation creation, metadata updates, and deletion are synced from `conversation-crud.ts`, but message sync (`syncMessageToDisk`) is only called from daemon-level code paths (e.g. `conversation-messaging.ts`) — not from the CRUD `addMessage()` function. This means `messages.jsonl` reflects messages processed through the daemon's messaging pipeline, not every message write. All disk writes are best-effort; failures are logged but never thrown, so the disk view cannot break DB operations.
 
-> **Privacy note:** Conversation disk-view files live under `~/.vellum/workspace/conversations/`. Workspace files are not included in diagnostic log exports ("Send logs to Vellum"). However, the SQLite database (`assistant.db`) is included in exports as a SQL dump, and it contains conversation messages and attachment data in its tables. Conversation content stored in the database may still be present in the export.
+> **Privacy note:** Conversation disk-view files live under `~/.vellum/workspace/conversations/`. Workspace files are not included in diagnostic log exports ("Send logs to Vellum"). For conversation-scoped exports, conversation data is included as structured JSON tables (e.g. `messages.json`, `llm-request-logs.json`), not as a raw database dump.
 
 ```mermaid
 sequenceDiagram

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -3119,7 +3119,7 @@ paths:
     post:
       operationId: export_post
       summary: Export logs and audit data
-      description: Export audit records, assistant logs, workspace contents, and config as a tar.gz archive.
+      description: Export audit records, assistant logs, and config as a tar.gz archive.
       tags:
         - export
       responses:
@@ -4277,7 +4277,7 @@ paths:
     post:
       operationId: logs_export_post
       summary: Export logs and audit data (alias)
-      description: Alias for /v1/export. Export audit records, assistant logs, workspace contents, and config as a tar.gz archive.
+      description: Alias for /v1/export. Export audit records, assistant logs, and config as a tar.gz archive.
       tags:
         - export
       responses:

--- a/assistant/src/__tests__/log-export-workspace.test.ts
+++ b/assistant/src/__tests__/log-export-workspace.test.ts
@@ -5,8 +5,6 @@
  * - audit-data.json with tool invocation records
  * - daemon-logs/ with log file contents
  * - config-snapshot.json with sanitized config
- * - workspace/ with text files, SQL dumps for .db files, and proper
- *   filtering (excluded directories, binary files, symlinks).
  */
 
 import { spawnSync } from "node:child_process";
@@ -16,7 +14,6 @@ import {
   readdirSync,
   readFileSync,
   rmSync,
-  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -24,8 +21,7 @@ import { join } from "node:path";
 import { describe, expect, mock, test } from "bun:test";
 
 // Set up temp directories before mocking
-const testDir = process.env.VELLUM_WORKSPACE_DIR!;
-const testWorkspaceDir = testDir;
+const testWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR!;
 mkdirSync(testWorkspaceDir, { recursive: true });
 
 mock.module("../util/logger.js", () => ({
@@ -87,83 +83,15 @@ async function extractArchive(res: Response): Promise<string> {
   return extractDir;
 }
 
-/** Recursively lists all files under a directory as relative paths. */
-function listFiles(dir: string, base = dir): string[] {
-  const result: string[] = [];
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const full = join(dir, entry.name);
-    if (entry.isDirectory()) {
-      result.push(...listFiles(full, base));
-    } else {
-      result.push(full.slice(base.length + 1));
-    }
-  }
-  return result;
-}
-
 // ---------------------------------------------------------------------------
-// Seed workspace files
+// Seed test data
 // ---------------------------------------------------------------------------
 
-// Text files — should be included
-writeFileSync(join(testWorkspaceDir, "IDENTITY.md"), "# My Identity\nHello");
-mkdirSync(join(testWorkspaceDir, "notes"), { recursive: true });
-writeFileSync(join(testWorkspaceDir, "notes", "daily.txt"), "Some daily notes");
-
-// SQLite DB file — should be dumped as .sql
-mkdirSync(join(testWorkspaceDir, "data", "db"), { recursive: true });
-// Create a real sqlite db with a table
-import { Database } from "bun:sqlite";
-const wsDbPath = join(testWorkspaceDir, "data", "db", "assistant.db");
-const wsDb = new Database(wsDbPath);
-wsDb.run("CREATE TABLE test_table (id INTEGER PRIMARY KEY, name TEXT)");
-wsDb.run("INSERT INTO test_table (name) VALUES ('hello')");
-wsDb.close();
-
-// Excluded directory: embedding-models/
-mkdirSync(join(testWorkspaceDir, "embedding-models"), { recursive: true });
-writeFileSync(
-  join(testWorkspaceDir, "embedding-models", "model.bin"),
-  "large binary model data",
-);
-
-// Excluded directory: data/qdrant/
-mkdirSync(join(testWorkspaceDir, "data", "qdrant"), { recursive: true });
-writeFileSync(
-  join(testWorkspaceDir, "data", "qdrant", "index.bin"),
-  "vector index data",
-);
-
-// Binary file — should be skipped
-writeFileSync(
-  join(testWorkspaceDir, "binary-file.dat"),
-  Buffer.from([0x48, 0x65, 0x6c, 0x00, 0x6f]), // contains null byte
-);
-
-// config.json at workspace root — should be skipped (already in configSnapshot)
+// config.json at workspace root — needed for config-snapshot test
 writeFileSync(
   join(testWorkspaceDir, "config.json"),
   JSON.stringify({ provider: "anthropic" }),
 );
-
-// Symlink pointing outside workspace — should be skipped
-const outsideFile = join(testDir, "outside-secret.txt");
-writeFileSync(outsideFile, "sensitive data outside workspace");
-try {
-  symlinkSync(outsideFile, join(testWorkspaceDir, "sneaky-link.txt"));
-} catch {
-  // Symlink creation may fail on some platforms; tests will still pass
-}
-
-// Symlinked skipped directory: bin/ → outside dir (should NOT get a manifest)
-const outsideBinDir = join(testDir, "outside-bin");
-mkdirSync(outsideBinDir, { recursive: true });
-writeFileSync(join(outsideBinDir, "bun"), "fake bun binary");
-try {
-  symlinkSync(outsideBinDir, join(testWorkspaceDir, "bin"));
-} catch {
-  // Symlink creation may fail on some platforms; tests will still pass
-}
 
 // Daemon log files — used for date filtering tests
 const logsDir = join(testWorkspaceDir, "data", "logs");
@@ -214,105 +142,6 @@ describe("POST /v1/export — tar.gz archive", () => {
       const content = readFileSync(auditPath, "utf-8");
       const parsed = JSON.parse(content);
       expect(Array.isArray(parsed)).toBe(true);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  test("archive contains workspace text files", async () => {
-    const res = await callExport();
-    const dir = await extractArchive(res);
-    try {
-      const identity = readFileSync(
-        join(dir, "workspace", "IDENTITY.md"),
-        "utf-8",
-      );
-      expect(identity).toBe("# My Identity\nHello");
-
-      const daily = readFileSync(
-        join(dir, "workspace", "notes", "daily.txt"),
-        "utf-8",
-      );
-      expect(daily).toBe("Some daily notes");
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  test("archive contains SQLite DB dumps as .sql files", async () => {
-    const res = await callExport();
-    const dir = await extractArchive(res);
-    try {
-      const sqlContent = readFileSync(
-        join(dir, "workspace", "data", "db", "assistant.db.sql"),
-        "utf-8",
-      );
-      expect(sqlContent).toContain("CREATE TABLE");
-      expect(sqlContent).toContain("test_table");
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  test("archive excludes embedding-models/ and data/qdrant/ data but includes redacted manifests", async () => {
-    const res = await callExport();
-    const dir = await extractArchive(res);
-    try {
-      const files = listFiles(join(dir, "workspace"));
-
-      // Original data files are excluded
-      expect(files).not.toContain("embedding-models/model.bin");
-      expect(files).not.toContain("data/qdrant/index.bin");
-
-      // Redacted manifests show entry counts and sizes, not filenames
-      const embeddingManifest = readFileSync(
-        join(dir, "workspace", "embedding-models", "_manifest.txt"),
-        "utf-8",
-      );
-      expect(embeddingManifest).toContain("1 file(s)");
-
-      const qdrantManifest = readFileSync(
-        join(dir, "workspace", "data", "qdrant", "_manifest.txt"),
-        "utf-8",
-      );
-      expect(qdrantManifest).toContain("1 file(s)");
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  test("archive skips manifest for symlinked skipped directories", async () => {
-    const res = await callExport();
-    const dir = await extractArchive(res);
-    try {
-      const files = listFiles(join(dir, "workspace"));
-
-      // bin/ is a symlink to an outside directory — no manifest should be emitted
-      const binFiles = files.filter((f) => f.startsWith("bin/"));
-      expect(binFiles).toHaveLength(0);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  test("archive excludes binary files and config.json at workspace root", async () => {
-    const res = await callExport();
-    const dir = await extractArchive(res);
-    try {
-      const files = listFiles(join(dir, "workspace"));
-      expect(files).not.toContain("binary-file.dat");
-      expect(files).not.toContain("config.json");
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  test("archive excludes symlinks", async () => {
-    const res = await callExport();
-    const dir = await extractArchive(res);
-    try {
-      const files = listFiles(join(dir, "workspace"));
-      expect(files).not.toContain("sneaky-link.txt");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/assistant/src/runtime/routes/archive-utils.ts
+++ b/assistant/src/runtime/routes/archive-utils.ts
@@ -1,13 +1,11 @@
 /**
- * Shared tar.gz archive creation and size-cap enforcement utilities used by
+ * Shared tar.gz archive creation utilities used by
  * log export and profiler export routes.
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
 
-/** Maximum compressed archive size before pruning workspace directories (50 MB). */
+/** Maximum compressed archive size (50 MB). */
 export const MAX_ARCHIVE_BYTES = 50 * 1024 * 1024;
 
 /**
@@ -28,61 +26,4 @@ export function createTarGz(
     ? proc.stdout
     : Buffer.from(proc.stdout);
   return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
-}
-
-/**
- * Returns the name and total byte size of the largest top-level subdirectory
- * inside `dir`, or `undefined` if `dir` has no subdirectories.
- */
-export function findLargestSubdirectory(
-  dir: string,
-): { name: string; bytes: number } | undefined {
-  if (!existsSync(dir)) return undefined;
-
-  let largest: { name: string; bytes: number } | undefined;
-
-  for (const entry of readdirSync(dir)) {
-    const fullPath = join(dir, entry);
-    try {
-      if (!statSync(fullPath).isDirectory()) continue;
-    } catch {
-      continue;
-    }
-    const bytes = directorySize(fullPath);
-    if (!largest || bytes > largest.bytes) {
-      largest = { name: entry, bytes };
-    }
-  }
-
-  return largest;
-}
-
-/** Recursively sums the byte size of all files in `dir`. */
-export function directorySize(dir: string): number {
-  let total = 0;
-  try {
-    for (const entry of readdirSync(dir)) {
-      const fullPath = join(dir, entry);
-      try {
-        const stat = statSync(fullPath);
-        if (stat.isDirectory()) {
-          total += directorySize(fullPath);
-        } else if (stat.isFile()) {
-          total += stat.size;
-        }
-      } catch {
-        // skip
-      }
-    }
-  } catch {
-    // skip
-  }
-  return total;
-}
-
-/** Formats a byte count as a human-readable string (e.g. "12.3 MB"). */
-export function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }

--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -2,14 +2,12 @@
  * HTTP route handler for exporting audit data and daemon log files.
  *
  * A single POST /v1/export endpoint allows clients (e.g. macOS Export Logs)
- * to retrieve audit database records, daemon log files, workspace contents,
- * and a sanitized config snapshot as a tar.gz archive.
+ * to retrieve audit database records, daemon log files, and a sanitized
+ * config snapshot as a tar.gz archive.
  */
 
-import { spawnSync } from "node:child_process";
 import {
   existsSync,
-  lstatSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
@@ -19,7 +17,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, relative } from "node:path";
+import { join } from "node:path";
 
 import { and, desc, eq, gte, lte } from "drizzle-orm";
 import { z } from "zod";
@@ -36,16 +34,11 @@ import {
   getDaemonStderrLogPath,
   getDataDir,
   getWorkspaceConfigPath,
-  getWorkspaceDir,
 } from "../../util/platform.js";
 import { APP_VERSION, COMMIT_SHA } from "../../version.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
-import {
-  createTarGz,
-  findLargestSubdirectory,
-  formatBytes,
-} from "./archive-utils.js";
+import { createTarGz } from "./archive-utils.js";
 
 const log = getLogger("log-export-routes");
 
@@ -60,14 +53,13 @@ interface ExportRequestBody {
 }
 
 /**
- * Collect audit data, daemon log files, workspace contents, and a sanitized
- * config snapshot, then package everything into a tar.gz archive.
+ * Collect audit data, daemon log files, and a sanitized config snapshot,
+ * then package everything into a tar.gz archive.
  *
  * Archive layout:
  *   audit-data.json          — tool invocation records
  *   config-snapshot.json     — sanitized workspace config
  *   daemon-logs/<name>       — daemon log files
- *   workspace/<relpath>      — workspace file tree
  */
 async function handleExport(body: ExportRequestBody): Promise<Response> {
   const staging = mkdtempSync(join(tmpdir(), "vellum-export-"));
@@ -259,20 +251,6 @@ async function handleExport(body: ExportRequestBody): Promise<Response> {
       );
     }
 
-    // --- Workspace files (skip for conversation-scoped exports) ---
-    let workspaceFileCount = 0;
-    if (!conversationId) {
-      const workspaceFiles = collectWorkspaceFiles();
-      const workspaceDir = join(staging, "workspace");
-      mkdirSync(workspaceDir, { recursive: true });
-      for (const [relPath, content] of Object.entries(workspaceFiles)) {
-        const dest = join(workspaceDir, relPath);
-        mkdirSync(join(dest, ".."), { recursive: true });
-        writeFileSync(dest, content, "utf-8");
-      }
-      workspaceFileCount = Object.keys(workspaceFiles).length;
-    }
-
     // --- Export manifest ---
     const manifest = conversationId
       ? {
@@ -302,64 +280,15 @@ async function handleExport(body: ExportRequestBody): Promise<Response> {
         logFileCount,
         totalBytes,
         hasConfig: configSnapshot !== undefined,
-        workspaceFileCount,
         conversationId: conversationId ?? null,
       },
       "Export collected, creating tar.gz archive",
     );
 
-    // --- Create tar.gz archive, pruning workspace dirs if too large ---
-    const excludedDirs: string[] = [];
-    let archiveBytes = createTarGz(staging);
-
-    while (!archiveBytes) {
-      // Conversation-scoped exports have no workspace directory to prune —
-      // if the archive still exceeds the size limit, report a clear error.
-      if (conversationId) {
-        log.error(
-          "Conversation-scoped export exceeds archive size limit with no workspace dirs to prune",
-        );
-        return httpError(
-          "INTERNAL_ERROR",
-          "Conversation export exceeds the maximum archive size",
-          500,
-        );
-      }
-
-      // Find the largest top-level directory under workspace/ and remove it
-      const wsDir = join(staging, "workspace");
-      const largest = findLargestSubdirectory(wsDir);
-      if (!largest) {
-        log.error("tar command failed and no workspace dirs to prune");
-        return httpError("INTERNAL_ERROR", "Failed to create archive", 500);
-      }
-
-      log.warn(
-        { dir: largest.name, bytes: largest.bytes },
-        "Archive exceeds size limit, removing largest workspace directory",
-      );
-      excludedDirs.push(
-        `workspace/${largest.name} (${formatBytes(largest.bytes)})`,
-      );
-      rmSync(join(wsDir, largest.name), { recursive: true, force: true });
-      archiveBytes = createTarGz(staging);
-    }
-
-    if (excludedDirs.length > 0) {
-      const errorLines = [
-        "The following workspace directories were excluded because the archive exceeded the size limit:",
-        "",
-        ...excludedDirs.map((d) => `  - ${d}`),
-        "",
-        "Use the streaming export endpoint for full workspace exports.",
-      ];
-      writeFileSync(join(staging, "error.log"), errorLines.join("\n"), "utf-8");
-
-      // Re-create the archive now that error.log is included
-      const withErrorLog = createTarGz(staging);
-      if (withErrorLog) {
-        archiveBytes = withErrorLog;
-      }
+    // --- Create tar.gz archive ---
+    const archiveBytes = createTarGz(staging);
+    if (!archiveBytes) {
+      return httpError("INTERNAL_ERROR", "Failed to create archive", 500);
     }
 
     return new Response(archiveBytes, {
@@ -381,184 +310,6 @@ async function handleExport(body: ExportRequestBody): Promise<Response> {
       // Best-effort cleanup
     }
   }
-}
-
-/** Directory prefixes to skip when collecting workspace files. */
-const WORKSPACE_SKIP_DIRS = new Set([
-  "bin",
-  "embedding-models",
-  "data/qdrant",
-  "data/attachments",
-  "data/sounds",
-  "data/profiler",
-  "conversations",
-  "signals",
-  "deprecated",
-]);
-
-/** Files at the workspace root to skip (already covered by sanitized fields). */
-const WORKSPACE_SKIP_ROOT_FILES = new Set(["config.json"]);
-
-/** Maximum cumulative size for workspace file contents (10 MB). */
-const MAX_WORKSPACE_PAYLOAD_BYTES = 10 * 1024 * 1024;
-
-/**
- * Recursively collects files from the workspace directory into a
- * `Record<string, string>` map of relative path to content.
- *
- * - Skips `config.json` at the workspace root (already exported as a
- *   sanitized `configSnapshot`; the raw file contains secrets).
- * - Skips symlinks to prevent reading files outside the workspace.
- * - Skips directories in `WORKSPACE_SKIP_DIRS`.
- * - For `.db` files, shells out to `sqlite3 <path> .dump` and stores the
- *   SQL text output with a `.sql` suffix appended to the key.
- * - Skips binary files (detected via null-byte heuristic).
- * - Stops collecting once `MAX_WORKSPACE_PAYLOAD_BYTES` is reached.
- */
-function collectWorkspaceFiles(): Record<string, string> {
-  const wsDir = getWorkspaceDir();
-  if (!existsSync(wsDir)) return {};
-
-  const result: Record<string, string> = {};
-  let totalBytes = 0;
-
-  function walk(dir: string): void {
-    let entries: string[];
-    try {
-      entries = readdirSync(dir);
-    } catch {
-      return;
-    }
-
-    for (const entry of entries) {
-      const fullPath = join(dir, entry);
-      const relPath = relative(wsDir, fullPath);
-
-      // Check if this path falls under a skipped directory prefix
-      if (
-        [...WORKSPACE_SKIP_DIRS].some(
-          (prefix) => relPath === prefix || relPath.startsWith(prefix + "/"),
-        )
-      ) {
-        continue;
-      }
-
-      // Skip root-level files that are already exported separately
-      if (dir === wsDir && WORKSPACE_SKIP_ROOT_FILES.has(entry)) {
-        continue;
-      }
-
-      try {
-        // Use lstatSync to avoid following symlinks
-        const stat = lstatSync(fullPath);
-
-        // Skip symlinks — they could point outside the workspace
-        if (stat.isSymbolicLink()) continue;
-
-        if (stat.isDirectory()) {
-          walk(fullPath);
-          continue;
-        }
-        if (!stat.isFile()) continue;
-
-        // SQLite DB handling: dump as SQL text, then enforce size cap
-        if (entry.endsWith(".db")) {
-          // Skip the dump entirely if the budget is already exhausted
-          if (totalBytes >= MAX_WORKSPACE_PAYLOAD_BYTES) continue;
-          try {
-            const proc = spawnSync("sqlite3", [fullPath, ".dump"], {
-              timeout: 10_000,
-            });
-            if (proc.status === 0 && proc.stdout) {
-              const output =
-                proc.stdout instanceof Buffer
-                  ? proc.stdout.toString("utf-8")
-                  : String(proc.stdout);
-              const outputBytes = Buffer.byteLength(output, "utf-8");
-              if (totalBytes + outputBytes > MAX_WORKSPACE_PAYLOAD_BYTES)
-                continue;
-              result[relPath + ".sql"] = output;
-              totalBytes += outputBytes;
-            }
-          } catch {
-            // Skip if dump fails
-          }
-          continue;
-        }
-
-        // Enforce cumulative size cap for non-DB files
-        if (totalBytes + stat.size > MAX_WORKSPACE_PAYLOAD_BYTES) continue;
-
-        // Read as UTF-8 and skip binary files (null-byte heuristic)
-        const content = readFileSync(fullPath, "utf-8");
-        if (content.includes("\0")) continue;
-        result[relPath] = content;
-        totalBytes += stat.size;
-      } catch {
-        // Skip unreadable files
-      }
-    }
-  }
-
-  walk(wsDir);
-
-  // For each skipped directory that exists, emit a lightweight manifest
-  // showing entry counts and sizes so diagnostics show what was excluded.
-  for (const prefix of WORKSPACE_SKIP_DIRS) {
-    const dirPath = join(wsDir, prefix);
-    if (!existsSync(dirPath)) continue;
-    try {
-      // Skip symlinks — they could point outside the workspace boundary
-      if (lstatSync(dirPath).isSymbolicLink()) continue;
-      const manifest = buildSkippedDirManifest(dirPath);
-      if (manifest) {
-        result[`${prefix}/_manifest.txt`] = manifest;
-      }
-    } catch {
-      // Best-effort — skip if unreadable
-    }
-  }
-
-  return result;
-}
-
-/**
- * Build a redacted summary manifest for a skipped workspace directory.
- * Reports entry counts and shallow size totals without disclosing
- * individual filenames (which may contain user-sensitive data).
- * Only uses stat.size on direct children — no recursive walks.
- */
-function buildSkippedDirManifest(dirPath: string): string | undefined {
-  const entries = readdirSync(dirPath);
-  if (entries.length === 0) return undefined;
-
-  let fileCount = 0;
-  let dirCount = 0;
-  let totalFileBytes = 0;
-
-  for (const entry of entries) {
-    try {
-      const stat = lstatSync(join(dirPath, entry));
-      if (stat.isDirectory()) {
-        dirCount++;
-      } else if (stat.isFile()) {
-        fileCount++;
-        totalFileBytes += stat.size;
-      }
-    } catch {
-      // Skip unreadable entries
-    }
-  }
-
-  const lines: string[] = [];
-  if (fileCount > 0) {
-    lines.push(`${fileCount} file(s), ${formatBytes(totalFileBytes)}`);
-  }
-  if (dirCount > 0) {
-    lines.push(`${dirCount} subdirectory(ies)`);
-  }
-
-  return lines.length > 0 ? lines.join("\n") + "\n" : undefined;
 }
 
 /**
@@ -686,7 +437,7 @@ export function logExportRouteDefinitions(): RouteDefinition[] {
       policyKey: "export",
       summary: "Export logs and audit data",
       description:
-        "Export audit records, assistant logs, workspace contents, and config as a tar.gz archive.",
+        "Export audit records, assistant logs, and config as a tar.gz archive.",
       tags: ["export"],
       requestBody: exportRequestBody,
       handler: async ({ req }) => {
@@ -700,7 +451,7 @@ export function logExportRouteDefinitions(): RouteDefinition[] {
       policyKey: "export",
       summary: "Export logs and audit data (alias)",
       description:
-        "Alias for /v1/export. Export audit records, assistant logs, workspace contents, and config as a tar.gz archive.",
+        "Alias for /v1/export. Export audit records, assistant logs, and config as a tar.gz archive.",
       tags: ["export"],
       requestBody: exportRequestBody,
       handler: async ({ req }) => {

--- a/assistant/src/runtime/routes/workspace-routes.ts
+++ b/assistant/src/runtime/routes/workspace-routes.ts
@@ -1,7 +1,6 @@
 /**
  * Route handlers for workspace file browsing and content serving.
  *
- * WARNING: Workspace contents are included in diagnostic log exports.
  * Do not store secrets here — use the credential store or protected/ directory.
  */
 import {

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -220,7 +220,7 @@ export function getHistoryPath(): string {
  * overrides, device approval lists — live here.
  *
  * This directory is:
- * - Outside the workspace (not included in diagnostic exports)
+ * - Outside the workspace
  * - Outside the sandbox write boundary (tools cannot modify it)
  * - Skipped in containerized mode (credentials via CES, trust via gateway)
  */

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -95,8 +95,7 @@ export function getInterfacesDir(): string {
 
 /**
  * Returns the sounds directory (~/.vellum/workspace/data/sounds).
- * Custom sound files and sound configuration live here. Sound files
- * can be large, so this directory is excluded from diagnostic exports.
+ * Custom sound files and sound configuration live here.
  */
 export function getSoundsDir(): string {
   return join(getWorkspaceDir(), "data", "sounds");

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -274,10 +274,6 @@ export function getEmbedWorkerPidPath(): string {
  * When the VELLUM_WORKSPACE_DIR env var is set, returns that value (used in
  * containerized deployments where the workspace is a separate volume).
  * Otherwise falls back to ~/.vellum/workspace.
- *
- * WARNING: The entire workspace directory is included in diagnostic log exports
- * ("Send logs to Vellum"). Do not store secrets, API keys, or sensitive
- * credentials here — use the credential store or ~/.vellum/protected/ instead.
  */
 export function getWorkspaceDir(): string {
   const override = getWorkspaceDirOverride();

--- a/assistant/src/workspace/migrations/023-move-config-files-to-workspace.ts
+++ b/assistant/src/workspace/migrations/023-move-config-files-to-workspace.ts
@@ -3,8 +3,8 @@
  *
  * Previously, dictation-profiles.json, email-guardrails.json, and
  * active-call-leases.json lived directly under getRootDir() (~/.vellum/).
- * This migration moves them into the workspace directory so they are
- * included in diagnostic exports and follow the workspace convention.
+ * This migration moves them into the workspace directory so they follow
+ * the workspace convention for organizational consistency.
  */
 
 import { existsSync, renameSync, unlinkSync } from "node:fs";

--- a/assistant/src/workspace/migrations/024-move-runtime-files-to-workspace.ts
+++ b/assistant/src/workspace/migrations/024-move-runtime-files-to-workspace.ts
@@ -40,8 +40,8 @@ function getRootDir(): string {
 const FILE_MOVES: Array<{ name: string; subdir?: string }> = [
   { name: "daemon-stderr.log", subdir: "logs" },
   { name: "daemon-startup.lock" },
-  // .env stays at root — it contains secrets (API keys) and the entire
-  // workspace directory is included in diagnostic log exports.
+  // .env stays at root — it contains secrets (API keys) and should not
+  // be in the sandbox working directory.
   { name: "embed-worker.pid" },
 ];
 

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -21,7 +21,6 @@ private let log = Logger(
 /// - Multi-service logs via `POST /v1/logs/export` gateway HTTP API — the gateway orchestrates
 ///   collection from all services (gateway, daemon, CES), returning a combined archive that
 ///   includes gateway logs, CES logs, daemon logs, audit data, and sanitized config
-/// - Workspace files via the gateway export — full workspace contents (config, skills, prompts, hooks, DB dump, logs)
 /// - `~/.config/vellum/logs/` — CLI XDG logs (hatch.log, retire.log, etc.)
 /// - `~/.vellum.lock.json` — sanitized lockfile with assistant entries and resource ports (credentials stripped)
 /// - `user-defaults.json` — snapshot of app-relevant UserDefaults keys
@@ -613,7 +612,7 @@ enum LogExporter {
 
     /// Calls POST /v1/logs/export on the gateway to download a tar.gz archive
     /// containing logs from all services (gateway, daemon, CES), along with
-    /// audit data, workspace files, and config snapshot.
+    /// audit data and config snapshot.
     /// Extracts the archive into `directory/service-exports/`.
     /// Returns `true` if the export succeeded, `false` if the assistant was unreachable.
     ///

--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -46,9 +46,9 @@ import os
     }
 
     /// Maximum Sentry attachment size (100 MB). The SDK default is 20 MB,
-    /// but workspace files included in log archives can exceed that. Sentry's
-    /// server-side limit is 200 MB uncompressed / 40 MB compressed, so 100 MB
-    /// provides sufficient headroom.
+    /// but large log archives can exceed that. Sentry's server-side limit is
+    /// 200 MB uncompressed / 40 MB compressed, so 100 MB provides sufficient
+    /// headroom.
     nonisolated static let sentryMaxAttachmentSize: UInt = 100 * 1024 * 1024
 
     /// DSN for the macOS app Sentry project. Read from SENTRY_DSN_MACOS env var;

--- a/clients/macos/vellum-assistantTests/SentryMaxAttachmentSizeTests.swift
+++ b/clients/macos/vellum-assistantTests/SentryMaxAttachmentSizeTests.swift
@@ -7,7 +7,7 @@ final class SentryMaxAttachmentSizeTests: XCTestCase {
         XCTAssertEqual(
             MetricKitManager.sentryMaxAttachmentSize,
             expectedSize,
-            "Sentry maxAttachmentSize should be 100 MB to accommodate workspace file exports"
+            "Sentry maxAttachmentSize should be 100 MB to accommodate large log archives"
         )
     }
 }


### PR DESCRIPTION
## Summary
Remove all workspace file collection from the daemon's log export endpoint (`POST /v1/export`). The workspace directory was previously bundled into diagnostic exports, leaking user content unnecessarily. After this change, exports contain only audit data, daemon logs, config snapshots, and conversation-scoped data.

## PRs merged into feature branch
- #23743: Remove workspace file collection from log export

Part of plan: remove-workspace-log-export.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23745" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
