### PR TITLE
fix: Remove stale workspace export references and dead code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,9 +169,9 @@ The assistant's container root (`/`) stores per-container ephemeral and persiste
 - **Credentials** are owned by the CES. In Docker mode, the assistant and gateway access credentials via the CES HTTP API (`CES_CREDENTIAL_URL`). Neither service has direct filesystem access to `keys.enc` or `store.key`.
 - The legacy shared data volume (`<name>-data`) is no longer created for new instances. Existing instances are migrated: gateway security files and CES security files are copied from the data volume to their respective security volumes on startup (see `migrateGatewaySecurityFiles()` and `migrateCesSecurityFiles()` in `cli/src/lib/docker.ts`).
 
-## Workspace Export & Secrets
+## Workspace & Secrets
 
-The entire ~/.vellum/workspace directory (minus embedding models, Qdrant vector indices, attachments, and conversation disk-view files) is included in diagnostic log exports when users choose "Send logs to Vellum". **Never store secrets, API keys, or sensitive credentials in the workspace directory.**
+**Never store secrets, API keys, or sensitive credentials in the workspace directory.**
 
 - **Local mode**: Use the credential store (`assistant credentials`) or the `~/.vellum/protected/` directory for sensitive data.
 - **Docker mode**: Sensitive files are isolated on dedicated security volumes that only the owning service can access. Trust rules (`trust.json`, `actor-token-signing-key`) live on the gateway security volume (`/gateway-security`). Credential keys (`keys.enc`, `store.key`) live on the CES security volume (`/ces-security`). The assistant and gateway access credentials via the CES HTTP API (`CES_CREDENTIAL_URL`), and the assistant accesses trust rules via the gateway's trust HTTP API. Neither the assistant nor the gateway has direct filesystem access to the other service's security volume.

--- a/assistant/docs/architecture/integrations.md
+++ b/assistant/docs/architecture/integrations.md
@@ -532,7 +532,7 @@ Each conversation is projected to a directory named `{isoDate}_{id}`:
 
 The disk view is updated at the daemon level, not automatically by the DB CRUD layer. Conversation creation, metadata updates, and deletion are synced from `conversation-crud.ts`, but message sync (`syncMessageToDisk`) is only called from daemon-level code paths (e.g. `conversation-messaging.ts`) — not from the CRUD `addMessage()` function. This means `messages.jsonl` reflects messages processed through the daemon's messaging pipeline, not every message write. All disk writes are best-effort; failures are logged but never thrown, so the disk view cannot break DB operations.
 
-> **Privacy note:** Conversation disk-view files live under `~/.vellum/workspace/conversations/` and are **excluded** from diagnostic log exports ("Send logs to Vellum") via the `WORKSPACE_SKIP_DIRS` filter in `log-export-routes.ts`. However, the SQLite database (`assistant.db`) is included in exports as a SQL dump, and it contains conversation messages and attachment data in its tables. The disk-view exclusion prevents the raw conversation files and decoded attachments from being exported, but conversation content stored in the database may still be present in the export.
+> **Privacy note:** Conversation disk-view files live under `~/.vellum/workspace/conversations/`. Workspace files are not included in diagnostic log exports ("Send logs to Vellum"). However, the SQLite database (`assistant.db`) is included in exports as a SQL dump, and it contains conversation messages and attachment data in its tables. Conversation content stored in the database may still be present in the export.
 
 ```mermaid
 sequenceDiagram

--- a/assistant/src/runtime/routes/archive-utils.ts
+++ b/assistant/src/runtime/routes/archive-utils.ts
@@ -1,13 +1,11 @@
 /**
- * Shared tar.gz archive creation and size-cap enforcement utilities used by
+ * Shared tar.gz archive creation utilities used by
  * log export and profiler export routes.
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
 
-/** Maximum compressed archive size before pruning workspace directories (50 MB). */
+/** Maximum compressed archive size (50 MB). */
 export const MAX_ARCHIVE_BYTES = 50 * 1024 * 1024;
 
 /**
@@ -28,61 +26,4 @@ export function createTarGz(
     ? proc.stdout
     : Buffer.from(proc.stdout);
   return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
-}
-
-/**
- * Returns the name and total byte size of the largest top-level subdirectory
- * inside `dir`, or `undefined` if `dir` has no subdirectories.
- */
-export function findLargestSubdirectory(
-  dir: string,
-): { name: string; bytes: number } | undefined {
-  if (!existsSync(dir)) return undefined;
-
-  let largest: { name: string; bytes: number } | undefined;
-
-  for (const entry of readdirSync(dir)) {
-    const fullPath = join(dir, entry);
-    try {
-      if (!statSync(fullPath).isDirectory()) continue;
-    } catch {
-      continue;
-    }
-    const bytes = directorySize(fullPath);
-    if (!largest || bytes > largest.bytes) {
-      largest = { name: entry, bytes };
-    }
-  }
-
-  return largest;
-}
-
-/** Recursively sums the byte size of all files in `dir`. */
-export function directorySize(dir: string): number {
-  let total = 0;
-  try {
-    for (const entry of readdirSync(dir)) {
-      const fullPath = join(dir, entry);
-      try {
-        const stat = statSync(fullPath);
-        if (stat.isDirectory()) {
-          total += directorySize(fullPath);
-        } else if (stat.isFile()) {
-          total += stat.size;
-        }
-      } catch {
-        // skip
-      }
-    }
-  } catch {
-    // skip
-  }
-  return total;
-}
-
-/** Formats a byte count as a human-readable string (e.g. "12.3 MB"). */
-export function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -95,8 +95,7 @@ export function getInterfacesDir(): string {
 
 /**
  * Returns the sounds directory (~/.vellum/workspace/data/sounds).
- * Custom sound files and sound configuration live here. Sound files
- * can be large, so this directory is excluded from diagnostic exports.
+ * Custom sound files and sound configuration live here.
  */
 export function getSoundsDir(): string {
   return join(getWorkspaceDir(), "data", "sounds");

--- a/assistant/src/workspace/migrations/023-move-config-files-to-workspace.ts
+++ b/assistant/src/workspace/migrations/023-move-config-files-to-workspace.ts
@@ -3,8 +3,8 @@
  *
  * Previously, dictation-profiles.json, email-guardrails.json, and
  * active-call-leases.json lived directly under getRootDir() (~/.vellum/).
- * This migration moves them into the workspace directory so they are
- * included in diagnostic exports and follow the workspace convention.
+ * This migration moves them into the workspace directory so they follow
+ * the workspace convention for organizational consistency.
  */
 
 import { existsSync, renameSync, unlinkSync } from "node:fs";

--- a/assistant/src/workspace/migrations/024-move-runtime-files-to-workspace.ts
+++ b/assistant/src/workspace/migrations/024-move-runtime-files-to-workspace.ts
@@ -40,8 +40,8 @@ function getRootDir(): string {
 const FILE_MOVES: Array<{ name: string; subdir?: string }> = [
   { name: "daemon-stderr.log", subdir: "logs" },
   { name: "daemon-startup.lock" },
-  // .env stays at root — it contains secrets (API keys) and the entire
-  // workspace directory is included in diagnostic log exports.
+  // .env stays at root — it contains secrets (API keys) and should not
+  // be in the sandbox working directory.
   { name: "embed-worker.pid" },
 ];
 

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -21,7 +21,6 @@ private let log = Logger(
 /// - Multi-service logs via `POST /v1/logs/export` gateway HTTP API — the gateway orchestrates
 ///   collection from all services (gateway, daemon, CES), returning a combined archive that
 ///   includes gateway logs, CES logs, daemon logs, audit data, and sanitized config
-/// - Workspace files via the gateway export — full workspace contents (config, skills, prompts, hooks, DB dump, logs)
 /// - `~/.config/vellum/logs/` — CLI XDG logs (hatch.log, retire.log, etc.)
 /// - `~/.vellum.lock.json` — sanitized lockfile with assistant entries and resource ports (credentials stripped)
 /// - `user-defaults.json` — snapshot of app-relevant UserDefaults keys
@@ -613,7 +612,7 @@ enum LogExporter {
 
     /// Calls POST /v1/logs/export on the gateway to download a tar.gz archive
     /// containing logs from all services (gateway, daemon, CES), along with
-    /// audit data, workspace files, and config snapshot.
+    /// audit data and config snapshot.
     /// Extracts the archive into `directory/service-exports/`.
     /// Returns `true` if the export succeeded, `false` if the assistant was unreachable.
     ///


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for remove-workspace-log-export.md.

- Remove dead exports from archive-utils.ts (findLargestSubdirectory, directorySize, formatBytes)
- Update stale comments/docs in AGENTS.md, integrations.md, LogExporter.swift, platform.ts, and workspace migration files
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
