### PR TITLE
fix(docker): move port mapping back to gateway container

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1006,6 +1006,7 @@ async function main() {
 
   const server = Bun.serve({
     port: config.port,
+    hostname: "0.0.0.0",
     idleTimeout: 0,
     // Match the daemon's 512 MB limit (assistant/src/runtime/http-server.ts)
     // so large .vbundle imports proxied through the gateway aren't rejected.


### PR DESCRIPTION
## Summary
- Reverts the shared network namespace topology from #22640
- Moves `-p 7830:7830` port mapping from the assistant container back to the gateway container
- Puts all three containers back on the bridge network (`--network=${res.network}`) instead of `--network=container:`
- Updates inter-container URLs from `localhost` to container names (required for bridge network DNS resolution)

## Context
#22640 moved all containers to a shared network namespace and put the port mapping on the assistant container. The gateway binds to `[::]` (IPv6) via Bun, but Docker's port forwarding sends traffic to IPv4 — so the gateway was unreachable.

## Test plan
- [ ] Hatch a Docker assistant and verify the gateway is reachable at `localhost:7830`
- [ ] Verify containers can communicate (assistant → gateway, gateway → assistant, both → CES)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23747" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
