### PR TITLE
fix: Remove remaining stale workspace export references

### DIFF
--- a/assistant/docs/architecture/integrations.md
+++ b/assistant/docs/architecture/integrations.md
@@ -532,7 +532,7 @@ Each conversation is projected to a directory named `{isoDate}_{id}`:
 
 The disk view is updated at the daemon level, not automatically by the DB CRUD layer. Conversation creation, metadata updates, and deletion are synced from `conversation-crud.ts`, but message sync (`syncMessageToDisk`) is only called from daemon-level code paths (e.g. `conversation-messaging.ts`) — not from the CRUD `addMessage()` function. This means `messages.jsonl` reflects messages processed through the daemon's messaging pipeline, not every message write. All disk writes are best-effort; failures are logged but never thrown, so the disk view cannot break DB operations.
 
-> **Privacy note:** Conversation disk-view files live under `~/.vellum/workspace/conversations/`. Workspace files are not included in diagnostic log exports ("Send logs to Vellum"). However, the SQLite database (`assistant.db`) is included in exports as a SQL dump, and it contains conversation messages and attachment data in its tables. Conversation content stored in the database may still be present in the export.
+> **Privacy note:** Conversation disk-view files live under `~/.vellum/workspace/conversations/`. Workspace files are not included in diagnostic log exports ("Send logs to Vellum"). For conversation-scoped exports, conversation data is included as structured JSON tables (e.g. `messages.json`, `llm-request-logs.json`), not as a raw database dump.
 
 ```mermaid
 sequenceDiagram

--- a/assistant/src/runtime/routes/workspace-routes.ts
+++ b/assistant/src/runtime/routes/workspace-routes.ts
@@ -1,7 +1,6 @@
 /**
  * Route handlers for workspace file browsing and content serving.
  *
- * WARNING: Workspace contents are included in diagnostic log exports.
  * Do not store secrets here — use the credential store or protected/ directory.
  */
 import {

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -220,7 +220,7 @@ export function getHistoryPath(): string {
  * overrides, device approval lists — live here.
  *
  * This directory is:
- * - Outside the workspace (not included in diagnostic exports)
+ * - Outside the workspace
  * - Outside the sandbox write boundary (tools cannot modify it)
  * - Skipped in containerized mode (credentials via CES, trust via gateway)
  */

--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -46,9 +46,9 @@ import os
     }
 
     /// Maximum Sentry attachment size (100 MB). The SDK default is 20 MB,
-    /// but workspace files included in log archives can exceed that. Sentry's
-    /// server-side limit is 200 MB uncompressed / 40 MB compressed, so 100 MB
-    /// provides sufficient headroom.
+    /// but large log archives can exceed that. Sentry's server-side limit is
+    /// 200 MB uncompressed / 40 MB compressed, so 100 MB provides sufficient
+    /// headroom.
     nonisolated static let sentryMaxAttachmentSize: UInt = 100 * 1024 * 1024
 
     /// DSN for the macOS app Sentry project. Read from SENTRY_DSN_MACOS env var;

--- a/clients/macos/vellum-assistantTests/SentryMaxAttachmentSizeTests.swift
+++ b/clients/macos/vellum-assistantTests/SentryMaxAttachmentSizeTests.swift
@@ -7,7 +7,7 @@ final class SentryMaxAttachmentSizeTests: XCTestCase {
         XCTAssertEqual(
             MetricKitManager.sentryMaxAttachmentSize,
             expectedSize,
-            "Sentry maxAttachmentSize should be 100 MB to accommodate workspace file exports"
+            "Sentry maxAttachmentSize should be 100 MB to accommodate large log archives"
         )
     }
 }


### PR DESCRIPTION
## Summary
Fixes remaining stale references to workspace files being included in diagnostic exports.

- Remove stale WARNING in workspace-routes.ts
- Remove stale parenthetical in platform.ts getProtectedDir()
- Fix incorrect SQL dump claim in integrations.md
- Update stale Sentry size justifications in MetricKitManager.swift and test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23748" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
