### PR TITLE
Increase teleport import timeout from 2 to 5 minutes

### DIFF
--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -422,7 +422,7 @@ async function importViaHttp(
         "Content-Type": "application/octet-stream",
       },
       body: new Blob([bundleData]),
-      signal: AbortSignal.timeout(120_000),
+      signal: AbortSignal.timeout(300_000),
     });
 
     // Retry once with a fresh token on 401
@@ -446,13 +446,13 @@ async function importViaHttp(
             "Content-Type": "application/octet-stream",
           },
           body: new Blob([bundleData]),
-          signal: AbortSignal.timeout(120_000),
+          signal: AbortSignal.timeout(300_000),
         });
       }
     }
   } catch (err) {
     if (err instanceof Error && err.name === "TimeoutError") {
-      console.error("Error: Import request timed out after 2 minutes.");
+      console.error("Error: Import request timed out after 5 minutes.");
       process.exit(1);
     }
     const msg = err instanceof Error ? err.message : String(err);

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -706,7 +706,7 @@ async function importToAssistant(
         : await platformImportBundle(bundleData, token, entry.runtimeUrl);
     } catch (err) {
       if (err instanceof Error && err.name === "TimeoutError") {
-        console.error("Error: Import request timed out after 2 minutes.");
+        console.error("Error: Import request timed out after 5 minutes.");
         process.exit(1);
       }
       throw err;

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -421,7 +421,7 @@ export async function platformImportBundle(
       "Content-Type": "application/octet-stream",
     },
     body: new Blob([bundleData]),
-    signal: AbortSignal.timeout(120_000),
+    signal: AbortSignal.timeout(300_000),
   });
 
   const body = (await response.json().catch(() => ({}))) as Record<
@@ -529,7 +529,7 @@ export async function platformImportBundleFromGcs(
       method: "POST",
       headers: await authHeaders(token, platformUrl),
       body: JSON.stringify({ bundle_key: bundleKey }),
-      signal: AbortSignal.timeout(120_000),
+      signal: AbortSignal.timeout(300_000),
     },
   );
 


### PR DESCRIPTION
## Summary
- Increase the timeout for the data import step (post-hatch) in the teleport flow from 2 minutes to 5 minutes (120s → 300s)
- Applies to both inline import (`teleport.ts`) and platform import paths (`platform-client.ts`: direct and GCS)
- Updates the timeout error message to reflect the new 5-minute duration

## Original prompt
increase the timeout for the step of importing the data to the platform assistant post hatch to 5 minutes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
