### PR TITLE
Update billing tab copy for referrals and credit info

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingReferralCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingReferralCard.swift
@@ -46,7 +46,7 @@ struct SettingsBillingReferralCard: View {
     // MARK: - Has Code State
 
     private func hasCodeState(_ code: ReferralCodeResponse) -> some View {
-        SettingsCard(title: "Referrals", subtitle: "Share your link and earn credits") {
+        SettingsCard(title: "Referrals", subtitle: "Share your referral link to earn up to 100 free credits") {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
                 // Referral URL row
                 HStack(spacing: VSpacing.sm) {
@@ -104,10 +104,6 @@ struct SettingsBillingReferralCard: View {
                     }
                 }
 
-                // Earning cap note
-                Text("Earn up to \(code.earning_cap.replacingOccurrences(of: ".00", with: "")) referral credits")
-                    .font(VFont.bodySmallDefault)
-                    .foregroundStyle(VColor.contentTertiary)
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -174,9 +174,23 @@ struct SettingsBillingTab: View {
     // MARK: - Add Credits Card
 
     private var addFundsCard: some View {
-        SettingsCard(title: "Add Credits") {
+        SettingsCard(title: "Add Credits", subtitle: addCreditsSubtitle) {
             topUpContent
         }
+    }
+
+    private var addCreditsSubtitle: String? {
+        guard let summary else { return nil }
+        let maxFormatted: String = {
+            let value = Int(Double(summary.maximum_balance) ?? 0)
+            if value > 0 {
+                let formatter = NumberFormatter()
+                formatter.numberStyle = .decimal
+                return formatter.string(from: NSNumber(value: value)) ?? summary.maximum_balance
+            }
+            return summary.maximum_balance
+        }()
+        return "Credits cost $1 each, with a maximum balance of \(maxFormatted). Unused credits expire 12 months after purchase."
     }
 
     @ViewBuilder
@@ -196,20 +210,6 @@ struct SettingsBillingTab: View {
                     }
                 )
                 .frame(maxWidth: 200)
-                if let summary {
-                    let maxFormatted: String = {
-                        let value = Int(Double(summary.maximum_balance) ?? 0)
-                        if value > 0 {
-                            let formatter = NumberFormatter()
-                            formatter.numberStyle = .decimal
-                            return formatter.string(from: NSNumber(value: value)) ?? summary.maximum_balance
-                        }
-                        return summary.maximum_balance
-                    }()
-                    Text("1 credit = $1 USD. \(maxFormatted) max credit balance. Credits expire 12 months after purchase.")
-                        .font(VFont.bodySmallDefault)
-                        .foregroundStyle(VColor.contentTertiary)
-                }
             }
 
             VButton(


### PR DESCRIPTION
## Summary
- Update referral card subtitle from "Share your link and earn credits" to "Share your referral link to earn up to 100 free credits"
- Remove the "Earn up to X referral credits" note from the bottom of the referral card
- Move credit pricing/limits info from below the amount dropdown to the "Add Credits" card subtitle with improved copy: "Credits cost $1 each, with a maximum balance of X. Unused credits expire 12 months after purchase."