### PR TITLE
fix: replace contrast buttons with primary style

### DIFF
--- a/clients/ios/Views/InputBarView.swift
+++ b/clients/ios/Views/InputBarView.swift
@@ -187,7 +187,7 @@ struct InputBarView: View {
                 VButton(
                     label: "Stop generation",
                     iconOnly: VIcon.square.rawValue,
-                    style: .contrast,
+                    style: .primary,
                     action: onStop
                 )
             } else {

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -427,7 +427,7 @@ struct ComposerView: View {
                 VButton(
                     label: "Stop generation",
                     iconOnly: VIcon.square.rawValue,
-                    style: .contrast,
+                    style: .primary,
                     iconSize: composerActionButtonSize,
                     action: onStop
                 )
@@ -612,7 +612,7 @@ VStreamingWaveform(
                     VButton(
                         label: manager.state == .listening ? "Mute" : "Unmute",
                         iconOnly: manager.state == .listening ? VIcon.mic.rawValue : VIcon.micOff.rawValue,
-                        style: .contrast,
+                        style: .primary,
                         iconSize: composerActionButtonSize,
                         action: { manager.toggleListening() }
                     )

--- a/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
@@ -30,7 +30,6 @@ struct ButtonsGallerySection: View {
                                     (label: "Danger", tag: VButton.Style.danger),
                                     (label: "Danger Outline", tag: VButton.Style.dangerOutline),
                                     (label: "Ghost", tag: VButton.Style.ghost),
-                                    (label: "Contrast", tag: VButton.Style.contrast),
                                 ],
                                 selection: $selectedStyle
                             )
@@ -76,7 +75,7 @@ struct ButtonsGallerySection: View {
 
                 VCard {
                     HStack(spacing: VSpacing.xl) {
-                        ForEach([VButton.Style.primary, .outlined, .danger, .dangerOutline, .ghost, .contrast], id: \.self) { style in
+                        ForEach([VButton.Style.primary, .outlined, .danger, .dangerOutline, .ghost], id: \.self) { style in
                             VStack(spacing: VSpacing.md) {
                                 VButton(label: styleName(style), style: style) {}
                                 VButton(label: "Disabled", style: style, isDisabled: true) {}
@@ -154,10 +153,6 @@ struct ButtonsGallerySection: View {
                         VStack(alignment: .leading, spacing: VSpacing.md) {
                             Text("Danger").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                             VButton(label: "Delete", iconOnly: VIcon.trash.rawValue, style: .danger) {}
-                        }
-                        VStack(alignment: .leading, spacing: VSpacing.md) {
-                            Text("Contrast").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
-                            VButton(label: "Stop", iconOnly: VIcon.square.rawValue, style: .contrast) {}
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Replace all `.contrast` button usages with `.primary` in ComposerView (macOS) and InputBarView (iOS)
- Remove contrast from gallery demos
- Fixes white-on-white button visibility issue in chat composer

## Test plan
- [ ] Stop generation button in composer uses primary style
- [ ] Voice mode mute button uses primary style
- [ ] No white-on-white buttons visible in chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
