### PR TITLE
fix: prevent zombie instances on app restart

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -174,6 +174,12 @@ extension AppDelegate {
                 // a file that could bypass the guard on the next launch.
                 try? FileManager.default.removeItem(at: sentinelPath)
                 self?.isRestarting = false
+                // Reconnect SSE and health checks so the app doesn't stay
+                // in a disconnected state after a failed relaunch attempt.
+                // (Same pattern as performRetireAsync()'s cancel path.)
+                Task { @MainActor [weak self] in
+                    try? await self?.connectionManager.connect()
+                }
                 return
             }
             Task { @MainActor [weak self] in

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -144,7 +144,15 @@ extension AppDelegate {
     }
 
     @objc func performRestart() {
+        isRestarting = true
         let bundleURL = Bundle.main.bundleURL
+
+        // Disconnect SSE and health checks *before* the CLI kills the
+        // daemon/gateway.  Otherwise the health check detects the daemon
+        // dying, triggers autoWakeIfAssistantDied(), and wakes the daemon
+        // right back up — fighting with the shutdown.  (Same pattern as
+        // performRetireAsync().)
+        connectionManager.disconnect()
 
         // Write a timestamped sentinel so the new instance's single-instance
         // guard knows this is an intentional restart, not a duplicate launch.

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -173,6 +173,7 @@ extension AppDelegate {
                 // Clean up the sentinel so a failed restart doesn't leave
                 // a file that could bypass the guard on the next launch.
                 try? FileManager.default.removeItem(at: sentinelPath)
+                self?.isRestarting = false
                 return
             }
             Task { @MainActor [weak self] in

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -38,6 +38,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var lastRegisteredQuickInputHotkey: String?
     var globalHotkeyObserver: AnyCancellable?
     var escapeMonitor: Any?
+    var isRestarting = false
     var hasSetupHotKey = false
     var fnVGlobalMonitor: Any?
     var fnVLocalMonitor: Any?
@@ -745,6 +746,14 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     ///
     /// Reference: https://developer.apple.com/documentation/appkit/nsapplicationdelegate/applicationshouldterminate(_:)
     public func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        // During a restart, performRestart() already stopped the CLI and
+        // disconnected the connection manager.  Skip the async
+        // .terminateLater path whose MainActor.run dispatch is fragile
+        // during AppKit shutdown and can leave the process as a zombie.
+        if isRestarting {
+            return .terminateNow
+        }
+
         let cli = vellumCli
         Task.detached {
             await cli.stop()


### PR DESCRIPTION
## Summary
- Disconnect `connectionManager` before daemon stop in `performRestart()` to prevent `autoWakeIfAssistantDied()` from fighting the shutdown (same pattern as `performRetireAsync()`)
- Add `isRestarting` flag so `applicationShouldTerminate` returns `.terminateNow`, skipping the redundant second `cli.stop()` and fragile async `MainActor.run` dispatch that could leave the process as a zombie

## Test plan
- [ ] Click "Restart" from the menu bar and verify the old app instance terminates cleanly (no zombie process, no lingering menu bar icon)
- [ ] Verify the new app instance launches and connects successfully after restart
- [ ] Verify normal quit (Cmd+Q) still works correctly via the `.terminateLater` path

Fixes #23756.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23757" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
