### PR TITLE
fix(macos): add pre-flight check for unsealed contents in .app bundle

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -1151,6 +1151,28 @@ if [ -f "$MACOS_DIR/vellum-daemon" ]; then
     echo "Daemon binary signed with entitlements"
 fi
 
+# Pre-flight: detect stray files in the .app bundle root that would cause
+# codesign to fail with the cryptic "unsealed contents present in the bundle
+# root" error. Only Contents/ belongs at the top level of a macOS .app bundle.
+STRAY_ITEMS=()
+for item in "$APP_DIR"/*; do
+    [ -e "$item" ] || continue
+    if [ "$(basename "$item")" != "Contents" ]; then
+        STRAY_ITEMS+=("$(basename "$item")")
+    fi
+done
+if [ ${#STRAY_ITEMS[@]} -gt 0 ]; then
+    echo ""
+    echo "ERROR: The .app bundle contains unexpected items in its root directory:"
+    printf '  - %s\n' "${STRAY_ITEMS[@]}"
+    echo ""
+    echo "macOS codesign rejects bundles with files outside Contents/."
+    echo "This is usually caused by stale artifacts from a previous build."
+    echo "Fix: run './build.sh clean' and rebuild, or delete the items above from:"
+    echo "  $APP_DIR/"
+    exit 1
+fi
+
 # Sign the outer app bundle with audio-input entitlement (without --deep to preserve nested signatures)
 APP_SIGN_FLAGS=(--force --sign "$SIGN_IDENTITY" --entitlements "$SCRIPT_DIR/app-entitlements.plist")
 if [ "$CONFIG" = "release" ] && [ "$SIGN_IDENTITY" != "-" ]; then


### PR DESCRIPTION
## Summary
- Adds a pre-flight check before the final `codesign` step in `build.sh` that detects stray files/directories in the `.app` bundle root (outside `Contents/`)
- Fails early with a clear error message listing the offending items and suggesting `./build.sh clean` as a fix
- Prevents the cryptic `unsealed contents present in the bundle root` codesign error from silently killing `build.sh run` before the watch loop starts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23758" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
