### PR TITLE
fix: prevent zombie instances on macOS app restart

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -144,7 +144,6 @@ extension AppDelegate {
     }
 
     @objc func performRestart() {
-        isRestarting = true
         let bundleURL = Bundle.main.bundleURL
 
         // Disconnect SSE and health checks *before* the CLI kills the
@@ -173,7 +172,6 @@ extension AppDelegate {
                 // Clean up the sentinel so a failed restart doesn't leave
                 // a file that could bypass the guard on the next launch.
                 try? FileManager.default.removeItem(at: sentinelPath)
-                self?.isRestarting = false
                 // Reconnect SSE and health checks so the app doesn't stay
                 // in a disconnected state after a failed relaunch attempt.
                 // (Same pattern as performRetireAsync()'s cancel path.)
@@ -184,6 +182,7 @@ extension AppDelegate {
             }
             Task { @MainActor [weak self] in
                 await self?.vellumCli.stop()
+                self?.isRestarting = true
                 NSApp.terminate(nil)
             }
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -144,7 +144,15 @@ extension AppDelegate {
     }
 
     @objc func performRestart() {
+        isRestarting = true
         let bundleURL = Bundle.main.bundleURL
+
+        // Disconnect SSE and health checks *before* the CLI kills the
+        // daemon/gateway.  Otherwise the health check detects the daemon
+        // dying, triggers autoWakeIfAssistantDied(), and wakes the daemon
+        // right back up — fighting with the shutdown.  (Same pattern as
+        // performRetireAsync().)
+        connectionManager.disconnect()
 
         // Write a timestamped sentinel so the new instance's single-instance
         // guard knows this is an intentional restart, not a duplicate launch.
@@ -165,6 +173,13 @@ extension AppDelegate {
                 // Clean up the sentinel so a failed restart doesn't leave
                 // a file that could bypass the guard on the next launch.
                 try? FileManager.default.removeItem(at: sentinelPath)
+                self?.isRestarting = false
+                // Reconnect SSE and health checks so the app doesn't stay
+                // in a disconnected state after a failed relaunch attempt.
+                // (Same pattern as performRetireAsync()'s cancel path.)
+                Task { @MainActor [weak self] in
+                    try? await self?.connectionManager.connect()
+                }
                 return
             }
             Task { @MainActor [weak self] in

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -38,6 +38,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var lastRegisteredQuickInputHotkey: String?
     var globalHotkeyObserver: AnyCancellable?
     var escapeMonitor: Any?
+    var isRestarting = false
     var hasSetupHotKey = false
     var fnVGlobalMonitor: Any?
     var fnVLocalMonitor: Any?
@@ -745,6 +746,14 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     ///
     /// Reference: https://developer.apple.com/documentation/appkit/nsapplicationdelegate/applicationshouldterminate(_:)
     public func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        // During a restart, performRestart() already stopped the CLI and
+        // disconnected the connection manager.  Skip the async
+        // .terminateLater path whose MainActor.run dispatch is fragile
+        // during AppKit shutdown and can leave the process as a zombie.
+        if isRestarting {
+            return .terminateNow
+        }
+
         let cli = vellumCli
         Task.detached {
             await cli.stop()


### PR DESCRIPTION
## Summary
Fixes a bug where clicking "Restart" from the menu bar leaves the old app instance alive as a zombie (with its menu bar icon still visible), compounding with each subsequent restart.

## Changes
- Disconnect `connectionManager` before `vellumCli.stop()` in `performRestart()` to prevent auto-wake from fighting with shutdown
- Add `isRestarting` flag so `applicationShouldTerminate` returns `.terminateNow` when restarting (skips redundant second `cli.stop()` and fragile async reply dispatch)
- Reset `isRestarting` and reconnect `connectionManager` on relaunch failure so the app doesn't stay in a disconnected state

## Milestone PRs (merged into feature branch)
- #23757: fix: prevent zombie instances on app restart

## Project issue
Closes #23755

## Test plan
- [ ] Click "Restart" from menu bar — verify only one app instance remains
- [ ] Click "Restart" multiple times — verify no compounding instances
- [ ] Simulate relaunch failure (e.g., corrupt bundle path) — verify app stays functional and connected
- [ ] Normal Cmd+Q quit — verify daemon is properly stopped (unaffected by changes)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
