### PR TITLE
M1: seed system:all group and backfill NULL conversations

### DIFF
--- a/assistant/src/memory/conversation-group-migration.ts
+++ b/assistant/src/memory/conversation-group-migration.ts
@@ -57,13 +57,15 @@ export function ensureGroupMigration(): void {
     }
   }
 
-  // 3. Seed system groups (three: pinned, scheduled, background)
+  // 3. Seed system groups (four: pinned, scheduled, background, all)
+  const now = Math.floor(Date.now() / 1000);
   rawExec(`
-    INSERT OR IGNORE INTO conversation_groups (id, name, sort_position, is_system_group)
+    INSERT OR IGNORE INTO conversation_groups (id, name, sort_position, is_system_group, created_at, updated_at)
     VALUES
-      ('system:pinned', 'Pinned', 0, TRUE),
-      ('system:scheduled', 'Scheduled', 1, TRUE),
-      ('system:background', 'Background', 2, TRUE)
+      ('system:pinned', 'Pinned', 0, TRUE, ${now}, ${now}),
+      ('system:scheduled', 'Scheduled', 1, TRUE, ${now}, ${now}),
+      ('system:background', 'Background', 2, TRUE, ${now}, ${now}),
+      ('system:all', 'Recents', 999999, TRUE, ${now}, ${now})
   `);
 
   // 4. One-time backfill (guard: persistent marker prevents re-running on restart)
@@ -149,6 +151,36 @@ export function ensureGroupMigration(): void {
     } catch (err) {
       rawExec("ROLLBACK");
       log.error({ err }, "Group backfill transaction failed, rolled back");
+      throw err;
+    }
+  }
+
+  // 5. One-time backfill: assign all ungrouped conversations to system:all
+  //
+  // Separate from the initial backfill above because system:all is added later.
+  // Uses its own sentinel so it runs exactly once, even on existing installations
+  // where the original backfill already completed.
+  const allBackfillDone = rawGet<{ id: string }>(
+    "SELECT id FROM conversation_groups WHERE id = '_backfill_all_complete'",
+  );
+
+  if (!allBackfillDone) {
+    try {
+      rawExec("BEGIN");
+
+      rawExec(`
+        UPDATE conversations SET group_id = 'system:all' WHERE group_id IS NULL
+      `);
+
+      rawExec(`
+        INSERT OR IGNORE INTO conversation_groups (id, name, sort_position, is_system_group)
+        VALUES ('_backfill_all_complete', '_backfill_all_complete', -1, TRUE)
+      `);
+
+      rawExec("COMMIT");
+    } catch (err) {
+      rawExec("ROLLBACK");
+      log.error({ err }, "system:all backfill transaction failed, rolled back");
       throw err;
     }
   }

--- a/assistant/src/memory/group-crud.ts
+++ b/assistant/src/memory/group-crud.ts
@@ -33,7 +33,7 @@ export function listGroups(): ConversationGroupRow[] {
     created_at: number;
     updated_at: number;
   }>(
-    "SELECT id, name, sort_position, is_system_group, created_at, updated_at FROM conversation_groups WHERE id != '_backfill_complete' ORDER BY sort_position ASC",
+    "SELECT id, name, sort_position, is_system_group, created_at, updated_at FROM conversation_groups WHERE id NOT IN ('_backfill_complete', '_backfill_all_complete') ORDER BY sort_position ASC",
   );
   return rows.map((r) => ({
     id: r.id,
@@ -90,6 +90,11 @@ export function createGroup(name: string): ConversationGroupRow {
       "SELECT MAX(sort_position) as max FROM conversation_groups WHERE is_system_group = 0",
     )?.max ?? 2;
   const sortPosition = maxPos + 1;
+  if (sortPosition >= 999999) {
+    throw new Error(
+      "Custom group sort_position must be < 999999 (reserved for system:all)",
+    );
+  }
   const id = uuid();
   const now = Math.floor(Date.now() / 1000);
   rawRun(
@@ -172,6 +177,13 @@ export function reorderGroups(
   updates: Array<{ groupId: string; sortPosition: number }>,
 ): void {
   ensureGroupMigration();
+  for (const update of updates) {
+    if (update.sortPosition >= 999999) {
+      throw new Error(
+        `Custom group sort_position must be < 999999 (got ${update.sortPosition} for ${update.groupId})`,
+      );
+    }
+  }
   const now = Math.floor(Date.now() / 1000);
   rawExec("BEGIN");
   try {

--- a/assistant/src/runtime/routes/group-routes.ts
+++ b/assistant/src/runtime/routes/group-routes.ts
@@ -105,16 +105,17 @@ export function groupRouteDefinitions(): RouteDefinition[] {
             403,
           );
         }
-        // Custom group sort_position must be >= 3
+        // Custom group sort_position must be >= 3 and < 999999
         if (
           body.sortPosition !== undefined &&
           (typeof body.sortPosition !== "number" ||
             !isFinite(body.sortPosition) ||
-            body.sortPosition < 3)
+            body.sortPosition < 3 ||
+            body.sortPosition >= 999999)
         ) {
           return httpError(
             "BAD_REQUEST",
-            "Custom group sort_position must be >= 3",
+            "Custom group sort_position must be >= 3 and < 999999",
             400,
           );
         }
@@ -190,11 +191,12 @@ export function groupRouteDefinitions(): RouteDefinition[] {
           if (
             typeof update.sortPosition !== "number" ||
             !isFinite(update.sortPosition) ||
-            update.sortPosition < 3
+            update.sortPosition < 3 ||
+            update.sortPosition >= 999999
           ) {
             return httpError(
               "BAD_REQUEST",
-              `Custom group sort_position must be >= 3 (got ${update.sortPosition} for ${update.groupId})`,
+              `Custom group sort_position must be >= 3 and < 999999 (got ${update.sortPosition} for ${update.groupId})`,
               400,
             );
           }


### PR DESCRIPTION
## Summary
- Seed new system:all system group named 'Recents' (sortPosition 999999) in conversation group migration
- Backfill all existing NULL group_id conversations to system:all
- Enforce sortPosition ceiling (< 999999) for custom groups in CRUD and routes

Part of #23769
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
