### PR TITLE
feat: inject interface ID and macOS host environment into transport hints

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -373,7 +373,28 @@ export class DaemonServer {
       { channelId: transport.channelId },
       "Transport metadata received",
     );
-    conversation.setTransportHints(transport.hints);
+
+    // Build enriched hints: interface ID first, then host environment (macOS
+    // only), then any client-provided hints.
+    const enrichedHints: string[] = [];
+
+    const interfaceLabel = parseInterfaceId(transport.interfaceId) ?? "vellum";
+    enrichedHints.push(`User is messaging from interface: ${interfaceLabel}`);
+
+    if (transport.interfaceId === "macos") {
+      if (transport.hostHomeDir) {
+        enrichedHints.push(`Host home directory: ${transport.hostHomeDir}`);
+      }
+      if (transport.hostUsername) {
+        enrichedHints.push(`Host username: ${transport.hostUsername}`);
+      }
+    }
+
+    if (transport.hints) {
+      enrichedHints.push(...transport.hints);
+    }
+
+    conversation.setTransportHints(enrichedHints);
   }
 
   constructor() {


### PR DESCRIPTION
## Summary
- Enrich transport hints with interface ID on every turn
- For macOS interface, also inject host home directory and username when available
- Preserves existing client-provided hints

Part of plan: host-env-transport-hints.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23777" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
