### PR TITLE
Inject host environment via transport hints

### DIFF
--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -103,13 +103,10 @@ export function makeEventSender(params: {
             guardianPrincipalId: trustContext?.guardianPrincipalId ?? undefined,
             toolName: event.toolName,
             commandPreview:
-              redactSecrets(
-                summarizeToolInput(event.toolName, inputRecord),
-              ) || undefined,
+              redactSecrets(summarizeToolInput(event.toolName, inputRecord)) ||
+              undefined,
             riskLevel: event.riskLevel,
-            activityText: activityRaw
-              ? redactSecrets(activityRaw)
-              : undefined,
+            activityText: activityRaw ? redactSecrets(activityRaw) : undefined,
             executionTarget: event.executionTarget,
             status: "pending",
             requestCode: generateCanonicalRequestCode(),
@@ -304,7 +301,7 @@ export async function handleConversationCreate(
     // Only create the host bash proxy for desktop client interfaces that can
     // execute commands on the user's machine. Set before updateClient so
     // updateClient's call to hostBashProxy.updateSender targets the new proxy.
-    if (transportInterface === "macos" || transportInterface === "ios") {
+    if (transportInterface === "macos") {
       const proxy = new HostBashProxy(sendEvent, (requestId) => {
         pendingInteractions.resolve(requestId);
       });

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -14,12 +14,10 @@ export interface ConversationListRequest {
   limit?: number;
 }
 
-/** Lightweight conversation transport metadata for channel identity and natural-language guidance. */
-export interface ConversationTransportMetadata {
+/** Shared fields for all transport metadata variants. */
+interface BaseTransportMetadata {
   /** Logical channel identifier (e.g. "desktop", "telegram", "mobile"). */
   channelId: ChannelId;
-  /** Interface identifier for this transport (e.g. "macos", "ios", "cli"). */
-  interfaceId?: InterfaceId;
   /** Optional natural-language hints for channel-specific UX behavior. */
   hints?: string[];
   /** Optional concise UX brief for this channel. */
@@ -27,6 +25,27 @@ export interface ConversationTransportMetadata {
   /** Chat type from the gateway (e.g. "private", "group", "supergroup", "channel"). */
   chatType?: string;
 }
+
+/** Transport metadata for macOS desktop clients, including host environment fields. */
+export interface MacosTransportMetadata extends BaseTransportMetadata {
+  /** Interface identifier for macOS transport. */
+  interfaceId: "macos";
+  /** Home directory of the host macOS user. */
+  hostHomeDir?: string;
+  /** Username of the host macOS user. */
+  hostUsername?: string;
+}
+
+/** Transport metadata for non-macOS transports. */
+export interface NonMacosTransportMetadata extends BaseTransportMetadata {
+  /** Interface identifier for this transport (e.g. "ios", "cli"). */
+  interfaceId?: Exclude<InterfaceId, "macos">;
+}
+
+/** Lightweight conversation transport metadata for channel identity and natural-language guidance. */
+export type ConversationTransportMetadata =
+  | MacosTransportMetadata
+  | NonMacosTransportMetadata;
 
 export interface ConversationCreateRequest {
   type: "conversation_create";

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1075,7 +1075,7 @@ export class DaemonServer {
     // Guard: don't replace an active proxy during concurrent turn races —
     // another request may have started processing between the isProcessing()
     // check above and the await on ensureActorScopedHistory().
-    if (resolvedInterface === "macos" || resolvedInterface === "ios") {
+    if (resolvedInterface === "macos") {
       if (!conversation.isProcessing() || !conversation.hostBashProxy) {
         conversation.setHostBashProxy(
           new HostBashProxy(conversation.getCurrentSender(), (requestId) => {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -373,7 +373,28 @@ export class DaemonServer {
       { channelId: transport.channelId },
       "Transport metadata received",
     );
-    conversation.setTransportHints(transport.hints);
+
+    // Build enriched hints: interface ID first, then host environment (macOS
+    // only), then any client-provided hints.
+    const enrichedHints: string[] = [];
+
+    const interfaceLabel = parseInterfaceId(transport.interfaceId) ?? "vellum";
+    enrichedHints.push(`User is messaging from interface: ${interfaceLabel}`);
+
+    if (transport.interfaceId === "macos") {
+      if (transport.hostHomeDir) {
+        enrichedHints.push(`Host home directory: ${transport.hostHomeDir}`);
+      }
+      if (transport.hostUsername) {
+        enrichedHints.push(`Host username: ${transport.hostUsername}`);
+      }
+    }
+
+    if (transport.hints) {
+      enrichedHints.push(...transport.hints);
+    }
+
+    conversation.setTransportHints(enrichedHints);
   }
 
   constructor() {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -643,7 +643,9 @@ function isToolResultType(type: string): boolean {
 function isSystemNoticeText(block: Record<string, unknown>): boolean {
   if (block.type !== "text") return false;
   const text = typeof block.text === "string" ? block.text : "";
-  return text.startsWith("<system_notice>") && text.endsWith("</system_notice>");
+  return (
+    text.startsWith("<system_notice>") && text.endsWith("</system_notice>")
+  );
 }
 
 /**
@@ -1115,7 +1117,7 @@ export async function handleSendMessage(
   // channels, headless) fall back to local execution.
   // Set the proxy BEFORE updateClient so updateClient's call to
   // hostBashProxy.updateSender targets the correct (new) proxy.
-  if (sourceInterface === "macos" || sourceInterface === "ios") {
+  if (sourceInterface === "macos") {
     // Reuse the existing proxy if the conversation is actively processing a
     // host bash request to avoid orphaning in-flight requests.
     if (!conversation.isProcessing() || !conversation.hostBashProxy) {
@@ -1152,9 +1154,7 @@ export async function handleSendMessage(
   // When proxies are preserved during an active turn (non-desktop request while
   // processing), skip updating proxy senders to avoid degrading them.
   const preservingProxies =
-    conversation.isProcessing() &&
-    sourceInterface !== "macos" &&
-    sourceInterface !== "ios";
+    conversation.isProcessing() && sourceInterface !== "macos";
   conversation.updateClient(onEvent, !isInteractive, {
     skipProxySenderUpdate: preservingProxies,
   });

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -3588,12 +3588,18 @@ public struct ConversationTransportMetadata: Codable, Sendable {
     public let hints: [String]?
     /// Optional concise UX brief for this channel.
     public let uxBrief: String?
+    /// Home directory of the host macOS user. Only populated when interfaceId == "macos".
+    public let hostHomeDir: String?
+    /// Username of the host macOS user. Only populated when interfaceId == "macos".
+    public let hostUsername: String?
 
-    public init(channelId: String, interfaceId: String? = nil, hints: [String]? = nil, uxBrief: String? = nil) {
+    public init(channelId: String, interfaceId: String? = nil, hints: [String]? = nil, uxBrief: String? = nil, hostHomeDir: String? = nil, hostUsername: String? = nil) {
         self.channelId = channelId
         self.interfaceId = interfaceId
         self.hints = hints
         self.uxBrief = uxBrief
+        self.hostHomeDir = hostHomeDir
+        self.hostUsername = hostUsername
     }
 }
 

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -168,7 +168,9 @@ private func buildConversationTransportMetadata(
     channelId: String?,
     interfaceId: String?,
     hints: [String]?,
-    uxBrief: String?
+    uxBrief: String?,
+    hostHomeDir: String? = nil,
+    hostUsername: String? = nil
 ) -> ConversationTransportMetadata? {
     guard let channelId, !channelId.isEmpty else { return nil }
 
@@ -181,6 +183,12 @@ private func buildConversationTransportMetadata(
     }
     if let uxBrief {
         payload["uxBrief"] = uxBrief
+    }
+    if let hostHomeDir {
+        payload["hostHomeDir"] = hostHomeDir
+    }
+    if let hostUsername {
+        payload["hostUsername"] = hostUsername
     }
 
     guard JSONSerialization.isValidJSONObject(payload) else { return nil }
@@ -207,6 +215,24 @@ extension ConversationCreateRequest {
         self.init(type: "conversation_create", title: title, systemPromptOverride: systemPromptOverride, maxResponseTokens: maxResponseTokens, correlationId: correlationId, transport: transport, conversationType: conversationType, preactivatedSkillIds: preactivatedSkillIds, initialMessage: initialMessage)
     }
 
+    /// The host home directory, populated automatically on macOS.
+    private static var defaultHostHomeDir: String? {
+        #if os(macOS)
+        return NSHomeDirectory()
+        #else
+        return nil
+        #endif
+    }
+
+    /// The host username, populated automatically on macOS.
+    private static var defaultHostUsername: String? {
+        #if os(macOS)
+        return NSUserName()
+        #else
+        return nil
+        #endif
+    }
+
     public init(
         title: String?,
         systemPromptOverride: String? = nil,
@@ -215,8 +241,15 @@ extension ConversationCreateRequest {
         transportChannelId: String?,
         transportInterfaceId: String? = nil,
         transportHints: [String]? = nil,
-        transportUxBrief: String? = nil
+        transportUxBrief: String? = nil,
+        transportHostHomeDir: String? = nil,
+        transportHostUsername: String? = nil
     ) {
+        let effectiveInterface = transportInterfaceId ?? Self.defaultTransportInterface
+        // Auto-populate host environment on macOS when using the default transport interface.
+        let effectiveHostHomeDir = transportHostHomeDir ?? (effectiveInterface == "macos" ? Self.defaultHostHomeDir : nil)
+        let effectiveHostUsername = transportHostUsername ?? (effectiveInterface == "macos" ? Self.defaultHostUsername : nil)
+
         self.init(
             type: "conversation_create",
             title: title,
@@ -225,9 +258,11 @@ extension ConversationCreateRequest {
             correlationId: correlationId,
             transport: buildConversationTransportMetadata(
                 channelId: transportChannelId,
-                interfaceId: transportInterfaceId ?? Self.defaultTransportInterface,
+                interfaceId: effectiveInterface,
                 hints: transportHints,
-                uxBrief: transportUxBrief
+                uxBrief: transportUxBrief,
+                hostHomeDir: effectiveHostHomeDir,
+                hostUsername: effectiveHostUsername
             ),
             conversationType: nil,
             preactivatedSkillIds: nil,


### PR DESCRIPTION
## Summary
When the assistant runs on managed platform and uses `host_bash`, it guesses the user's home directory from their display name instead of knowing the actual macOS username. This adds `hostHomeDir` and `hostUsername` to transport metadata (macOS only, via discriminated union), removes iOS from host proxy setup, and injects the interface ID and macOS host environment into transport hints every turn.

## PRs merged into feature branch
- #23776: refactor: discriminated union for transport metadata, remove iOS proxy setup
- #23777: feat: inject interface ID and macOS host environment into transport hints
- #23778: feat: send hostHomeDir and hostUsername from macOS client

Part of plan: host-env-transport-hints.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23779" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
