### PR TITLE
M3: macOS — add system group constant and update all nil groupId setters

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationGroup.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationGroup.swift
@@ -17,6 +17,9 @@ struct ConversationGroup: Identifiable, Hashable, Codable, Sendable {
     static let background = ConversationGroup(
         id: "system:background", name: "Background", sortPosition: 2, isSystemGroup: true
     )
+    static let all = ConversationGroup(
+        id: "system:all", name: "Recents", sortPosition: 999999, isSystemGroup: true
+    )
 
     init(id: String, name: String, sortPosition: Double, isSystemGroup: Bool) {
         self.id = id

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationListStore.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationListStore.swift
@@ -232,11 +232,11 @@ final class ConversationListStore {
     ) -> ConversationModel {
         let effectiveCreatedAtMillis = item.createdAt ?? item.updatedAt
         let isPinned = item.isPinned ?? false
-        // When the daemon supports groups, groupId: null means "explicitly ungrouped" —
-        // use the server value as-is. Only fall back to source-based heuristics for
-        // old daemons that don't return groupId at all.
+        // When the daemon supports groups, groupId: null means "Recents" (system:all).
+        // Only fall back to source-based heuristics for old daemons that don't return
+        // groupId at all.
         let groupId: String? = daemonSupportsGroups
-            ? (item.groupId ?? (isPinned ? ConversationGroup.pinned.id : nil))
+            ? (item.groupId ?? (isPinned ? ConversationGroup.pinned.id : ConversationGroup.all.id))
             : ConversationModel.deriveGroupId(
                 serverGroupId: item.groupId,
                 isPinned: isPinned,
@@ -295,8 +295,8 @@ final class ConversationListStore {
         guard let index = conversations.firstIndex(where: { $0.id == conversationId }) else { return }
         var conversation = conversations[index]
         conversation.lastInteractedAt = Date()
-        if conversation.groupId == nil {
-            // Clear explicit displayOrder so ungrouped conversations revert to recency-based sorting.
+        if conversation.groupId == ConversationGroup.all.id {
+            // Clear explicit displayOrder so Recents conversations revert to recency-based sorting.
             // Grouped conversations keep their manual ordering.
             let hadOrder = conversation.displayOrder != nil
             if hadOrder { conversation.displayOrder = nil }
@@ -333,13 +333,13 @@ final class ConversationListStore {
            stored == nil || groups.contains(where: { $0.id == stored }) {
             // Restore the saved group only if it still exists (or was nil/ungrouped).
             // If the group was deleted while pinned, fall through to heuristics.
-            conversation.groupId = stored
+            conversation.groupId = stored ?? ConversationGroup.all.id
         } else if conversation.isScheduleConversation {
             conversation.groupId = ConversationGroup.scheduled.id
         } else if conversation.shouldReturnToBackgroundOnUnpin {
             conversation.groupId = ConversationGroup.background.id
         } else {
-            conversation.groupId = nil
+            conversation.groupId = ConversationGroup.all.id
         }
         conversation.displayOrder = nil
         conversations[index] = conversation
@@ -356,18 +356,19 @@ final class ConversationListStore {
             prePinGroupIds[conversationId] = conversations[index].groupId
         }
         var conversation = conversations[index]
-        conversation.groupId = groupId
-        if let groupId {
-            // Place at the end of the target group by assigning max + 1.
-            let maxOrder = conversations
-                .filter { $0.groupId == groupId && $0.id != conversationId }
-                .compactMap(\.displayOrder).max() ?? -1
-            conversation.displayOrder = maxOrder + 1
-        } else {
-            // When ungrouping, clear displayOrder and bump lastInteractedAt so
-            // the conversation appears at the top of the ungrouped list.
+        let effectiveGroupId = groupId ?? ConversationGroup.all.id
+        conversation.groupId = effectiveGroupId
+        if effectiveGroupId == ConversationGroup.all.id {
+            // When moving to Recents (system:all), clear displayOrder and bump
+            // lastInteractedAt so the conversation sorts by recency.
             conversation.displayOrder = nil
             conversation.lastInteractedAt = Date()
+        } else {
+            // Place at the end of the target group by assigning max + 1.
+            let maxOrder = conversations
+                .filter { $0.groupId == effectiveGroupId && $0.id != conversationId }
+                .compactMap(\.displayOrder).max() ?? -1
+            conversation.displayOrder = maxOrder + 1
         }
         conversations[index] = conversation
         sendReorderConversations()
@@ -513,7 +514,7 @@ final class ConversationListStore {
         // Batch-mutate a copy to avoid per-element SwiftUI re-renders
         var updated = conversations
         for i in updated.indices where updated[i].groupId == groupId {
-            updated[i].groupId = nil
+            updated[i].groupId = ConversationGroup.all.id
             updated[i].displayOrder = nil
         }
         conversations = updated

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -190,7 +190,7 @@ final class ConversationManager: ConversationRestorerDelegate {
         conversationRestorer.delegate = self
         conversationRestorer.startObserving(skipInitialFetch: isFirstLaunch)
         if listStore.groups.isEmpty {
-            listStore.groups = [.pinned, .scheduled, .background]
+            listStore.groups = [.pinned, .scheduled, .background, .all]
         }
         Task { @MainActor [weak self] in
             guard let self else { return }
@@ -939,7 +939,7 @@ final class ConversationManager: ConversationRestorerDelegate {
         for i in updated.indices where updated[i].groupId == groupId {
             updated[i].isArchived = true
             updated[i].displayOrder = nil
-            updated[i].groupId = nil
+            updated[i].groupId = ConversationGroup.all.id
             if let cid = updated[i].conversationId {
                 newlyArchivedServerIds.insert(cid)
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationModel.swift
@@ -31,7 +31,7 @@ struct ConversationModel: Identifiable, Hashable {
         get { groupId == ConversationGroup.pinned.id }
         set {
             if newValue { groupId = ConversationGroup.pinned.id }
-            else if groupId == ConversationGroup.pinned.id { groupId = nil }
+            else if groupId == ConversationGroup.pinned.id { groupId = ConversationGroup.all.id }
         }
     }
     /// Explicit display order set by the user via drag-and-drop reordering.
@@ -109,7 +109,7 @@ struct ConversationModel: Identifiable, Hashable {
         if title.hasPrefix("Schedule: ") || title.hasPrefix("Schedule (manual): ") || title.hasPrefix("Reminder: ") {
             return ConversationGroup.scheduled.id
         }
-        return nil
+        return "system:all"
     }
 
     static func == (lhs: ConversationModel, rhs: ConversationModel) -> Bool {

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -223,7 +223,7 @@ final class ConversationRestorer {
         } else {
             if delegate.groups.isEmpty {
                 withTransaction(groupTransaction) {
-                    delegate.groups = [ConversationGroup.pinned, ConversationGroup.scheduled, ConversationGroup.background]
+                    delegate.groups = [ConversationGroup.pinned, ConversationGroup.scheduled, ConversationGroup.background, ConversationGroup.all]
                 }
             }
             delegate.daemonSupportsGroups = false

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -43,6 +43,7 @@ struct SidebarConversationItem: View, Equatable {
         if gid == ConversationGroup.pinned.id { return ConversationGroup.pinned }
         if gid == ConversationGroup.scheduled.id { return ConversationGroup.scheduled }
         if gid == ConversationGroup.background.id { return ConversationGroup.background }
+        if gid == ConversationGroup.all.id { return ConversationGroup.all }
         // Custom group — not in moveToGroups (it's filtered out), but we know it's non-system
         return ConversationGroup(id: gid, name: "", sortPosition: 0, isSystemGroup: false)
     }
@@ -92,10 +93,10 @@ struct SidebarConversationItem: View, Equatable {
                         onMoveToGroup(group.id)
                     }
                 }
-                if conversation.groupId != nil {
+                if let gid = conversation.groupId, !gid.hasPrefix("system:") {
                     VMenuDivider()
                     VMenuItem(label: "Remove from group") {
-                        onMoveToGroup(nil)
+                        onMoveToGroup(ConversationGroup.all.id)
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Add ConversationGroup.all static constant (system:all, 'Recents', sortPosition 999999)
- Update every place that sets groupId=nil to use ConversationGroup.all.id
- Update updateLastInteracted to check for system:all instead of nil
- Update deriveGroupId heuristic to return system:all as fallback
- Update 'Remove from group' to move to system:all instead of nil
- Update conversationModel(from:) to map daemon null groupId to system:all

Part of #23769
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23781" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
