### PR TITLE
M4: macOS — simplify sidebar rendering to remove ungrouped code path

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -7,7 +7,7 @@ import VellumAssistantShared
 /// Lightweight identifiable wrapper for ForEach over grouped conversations.
 private struct SidebarGroupEntry: Identifiable {
     let id: String
-    let group: ConversationGroup?
+    let group: ConversationGroup
     let conversations: [ConversationModel]
 }
 
@@ -238,8 +238,6 @@ extension MainWindowView {
         )
     }
 
-    // MARK: - Ungrouped Rows
-
     /// The main conversation groups list content, extracted from the ScrollView body
     /// to reduce type-checker pressure (avoids "ambiguous use of init" on ScrollView).
     @ViewBuilder
@@ -253,136 +251,28 @@ extension MainWindowView {
             let groupEntries: [SidebarGroupEntry] = {
                 let raw = conversationManager.groupedConversations
                 var entries: [SidebarGroupEntry] = []
-                var extraUngrouped: [ConversationModel] = []
+                // When custom groups are disabled, fold their conversations into system:all
+                var extraForAll: [ConversationModel] = []
                 for entry in raw {
-                    if let group = entry.group {
-                        // Hide custom groups when custom groups flag is off
-                        if !group.isSystemGroup && !customGroupsEnabled {
-                            extraUngrouped.append(contentsOf: entry.conversations)
-                        } else {
-                            entries.append(SidebarGroupEntry(id: group.id, group: group, conversations: entry.conversations))
-                        }
+                    guard let group = entry.group else { continue }
+                    if !group.isSystemGroup && !customGroupsEnabled {
+                        extraForAll.append(contentsOf: entry.conversations)
                     } else {
-                        extraUngrouped.append(contentsOf: entry.conversations)
+                        entries.append(SidebarGroupEntry(id: group.id, group: group, conversations: entry.conversations))
                     }
                 }
-                entries.append(SidebarGroupEntry(id: "ungrouped", group: nil, conversations: extraUngrouped))
+                // Merge extra conversations into the system:all entry
+                if !extraForAll.isEmpty,
+                   let allIndex = entries.firstIndex(where: { $0.group.id == ConversationGroup.all.id }) {
+                    let existing = entries[allIndex]
+                    entries[allIndex] = SidebarGroupEntry(id: existing.id, group: existing.group, conversations: existing.conversations + extraForAll)
+                }
                 return entries
             }()
             ForEach(groupEntries) { entry in
-                if let group = entry.group {
-                    makeSectionView(group: group, conversations: entry.conversations)
-                } else {
-                    ungroupedConversationRows(entry.conversations)
-                }
+                makeSectionView(group: entry.group, conversations: entry.conversations)
             }
 
-        }
-    }
-
-    /// Renders ungrouped conversations with drag-reorder support.
-    /// These appear without a collapsible header, matching the pre-groups layout.
-    @ViewBuilder
-    private func ungroupedConversationRows(_ conversations: [ConversationModel]) -> some View {
-        let displayed = sidebar.showAllInSection.contains("ungrouped")
-            ? conversations
-            : Array(conversations.prefix(5))
-
-        ForEach(displayed) { conversation in
-            makeSidebarRow(conversation: conversation)
-                .equatable()
-                .id(ConversationRowIdentity(conversationId: conversation.id, groupId: conversation.groupId))
-                .padding(.bottom, SidebarLayoutMetrics.listRowGap)
-                .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
-                    if sidebar.dropTargetConversationId == conversation.id {
-                        Rectangle()
-                            .fill(VColor.primaryBase)
-                            .frame(height: 2)
-                            .transition(.opacity)
-                    }
-                }
-                .dropDestination(for: String.self) { items, _ in
-                    guard let droppedId = items.first,
-                          let sourceUUID = UUID(uuidString: droppedId),
-                          sourceUUID != conversation.id else {
-                        sidebar.endConversationDrag()
-                        return false
-                    }
-                    let moved = conversationManager.moveConversation(sourceId: sourceUUID, targetId: conversation.id)
-                    sidebar.endConversationDrag()
-                    return moved
-                } isTargeted: { isTargeted in
-                    if isTargeted && conversation.id != sidebar.draggingConversationId {
-                        sidebar.dropTargetConversationId = conversation.id
-                        if let dragId = sidebar.draggingConversationId {
-                            // Use section-local index (ungrouped conversations only)
-                            let ungroupedConvs = conversationManager.groupedConversations
-                                .first { $0.group == nil }?.conversations ?? []
-                            let sIdx = ungroupedConvs.firstIndex(where: { $0.id == dragId }) ?? 0
-                            let tIdx = ungroupedConvs.firstIndex(where: { $0.id == conversation.id }) ?? 0
-                            sidebar.dropIndicatorAtBottom = sIdx < tIdx
-                        }
-                    } else if !isTargeted && sidebar.dropTargetConversationId == conversation.id {
-                        sidebar.dropTargetConversationId = nil
-                    }
-                }
-        }
-
-        if conversations.count > 5 {
-            HStack {
-                VButton(
-                    label: sidebar.showAllInSection.contains("ungrouped") ? "Show less" : "Show more",
-                    style: .ghost,
-                    size: .compact
-                ) {
-                    let wasCollapsed = !sidebar.showAllInSection.contains("ungrouped")
-                    withAnimation(VAnimation.fast) { sidebar.toggleShowAll("ungrouped") }
-                    if wasCollapsed {
-                        conversationManager.loadAllRemainingConversations()
-                    }
-                }
-                Spacer()
-            }
-            .padding(.leading, VSpacing.xs + SidebarLayoutMetrics.iconSlotSize + VSpacing.xs - VSpacing.sm)
-            .padding(.bottom, VSpacing.xs)
-        }
-
-        // Fallback pagination: the ungrouped section is always the last
-        // rendered section. When every section fits within its collapse
-        // limit (no "Show more" buttons visible) but the server has more
-        // conversations, auto-trigger loading so users can reach them.
-        // Gate on ALL sections — not just ungrouped — to avoid eager
-        // full-load in grouped-heavy workspaces.
-        if conversations.count <= 5,
-           conversationManager.hasMoreConversations,
-           !conversationManager.groupedConversations.contains(where: { entry in
-               guard let group = entry.group else { return false }
-               // Skip custom groups when feature flag is off — rendering
-               // hides them and folds their conversations into ungrouped.
-               if !group.isSystemGroup && !assistantFeatureFlagStore.isEnabled("conversation-groups-ui") {
-                   return false
-               }
-               let isPinned = group.id == ConversationGroup.pinned.id
-               let isScheduled = group.id == ConversationGroup.scheduled.id
-               let isBackground = group.id == ConversationGroup.background.id
-               let maxCollapsed = isPinned ? Int.max : 5
-               if isScheduled || isBackground {
-                   // Subgroup count mode — "Show more" triggers on distinct
-                   // subgroup count, not total conversation count.
-                   let grouper: (ConversationModel) -> String? = isScheduled
-                       ? { $0.scheduleJobId }
-                       : { $0.source }
-                   var keys = Set<String>()
-                   for c in entry.conversations { keys.insert(grouper(c) ?? c.id.uuidString) }
-                   return keys.count > maxCollapsed
-               }
-               return entry.conversations.count > maxCollapsed
-           }) {
-            Color.clear
-                .frame(height: 0)
-                .onAppear {
-                    conversationManager.loadAllRemainingConversations()
-                }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
@@ -18,23 +18,25 @@ struct ConversationSwitcherDrawer: View {
     /// Tracks which sub-groups (schedule/background) are expanded in the drawer.
     @State private var expandedSubGroups: Set<String> = []
 
-    /// Group entries filtered by flags: custom groups and Background merged into ungrouped when their flags are off.
-    private var drawerEntries: [(group: ConversationGroup?, conversations: [ConversationModel])] {
+    /// Group entries filtered by flags: custom groups merged into system:all when their flag is off.
+    private var drawerEntries: [(group: ConversationGroup, conversations: [ConversationModel])] {
         let raw = conversationManager.groupedConversations
-        var entries: [(ConversationGroup?, [ConversationModel])] = []
-        var extraUngrouped: [ConversationModel] = []
+        var entries: [(ConversationGroup, [ConversationModel])] = []
+        var extraForAll: [ConversationModel] = []
         for entry in raw {
-            if let group = entry.group {
-                if !group.isSystemGroup && !customGroupsEnabled {
-                    extraUngrouped.append(contentsOf: entry.conversations)
-                } else {
-                    entries.append(entry)
-                }
+            guard let group = entry.group else { continue }
+            if !group.isSystemGroup && !customGroupsEnabled {
+                extraForAll.append(contentsOf: entry.conversations)
             } else {
-                extraUngrouped.append(contentsOf: entry.conversations)
+                entries.append((group, entry.conversations))
             }
         }
-        entries.append((nil, extraUngrouped))
+        // Merge extra conversations into the system:all entry
+        if !extraForAll.isEmpty,
+           let allIndex = entries.firstIndex(where: { $0.group.id == ConversationGroup.all.id }) {
+            let existing = entries[allIndex]
+            entries[allIndex] = (existing.group, existing.conversations + extraForAll)
+        }
         return entries
     }
     /// Measured content height for size-to-fit behavior.
@@ -104,7 +106,7 @@ struct ConversationSwitcherDrawer: View {
                     let nonEmptyEntries = drawerEntries.filter { !$0.conversations.isEmpty }
                     ForEach(nonEmptyEntries.indices, id: \.self) { index in
                         let entry = nonEmptyEntries[index]
-                        let sectionId = entry.group?.id ?? "ungrouped"
+                        let sectionId = entry.group.id
                         let isExpanded = expandedSections.contains(sectionId)
 
                         if index > 0 {
@@ -113,7 +115,7 @@ struct ConversationSwitcherDrawer: View {
                         sectionContent(
                             sectionId: sectionId,
                             group: entry.group,
-                            title: entry.group?.name ?? "Conversations",
+                            title: entry.group.name,
                             conversations: entry.conversations,
                             isExpanded: isExpanded
                         )
@@ -155,7 +157,7 @@ struct ConversationSwitcherDrawer: View {
     @ViewBuilder
     private func sectionContent(
         sectionId: String,
-        group: ConversationGroup?,
+        group: ConversationGroup,
         title: String,
         conversations: [ConversationModel],
         isExpanded: Bool
@@ -173,8 +175,8 @@ struct ConversationSwitcherDrawer: View {
         .padding(.top, VSpacing.xs)
         .padding(.bottom, VSpacing.xs)
 
-        let isScheduled = group?.id == ConversationGroup.scheduled.id
-        let isBackground = group?.id == ConversationGroup.background.id
+        let isScheduled = group.id == ConversationGroup.scheduled.id
+        let isBackground = group.id == ConversationGroup.background.id
 
         if isScheduled || isBackground {
             let grouper: (ConversationModel) -> String? = isScheduled ? { $0.scheduleJobId } : { $0.source }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -14,7 +14,7 @@ struct ScheduleSubGroup: Identifiable {
 /// Handles expand/collapse, show-more/less truncation, auto-expand on unread,
 /// and optional schedule sub-grouping for the Scheduled system group.
 struct SidebarSectionView: View {
-    let group: ConversationGroup?
+    let group: ConversationGroup
     let conversations: [ConversationModel]
     let isExpanded: Bool
     let showAll: Bool
@@ -101,49 +101,44 @@ struct SidebarSectionView: View {
     }
 
     var body: some View {
-        if let group = group {
-            SidebarSectionHeader(
-                group: group,
-                conversationCount: displayCount,
-                isExpanded: isExpanded,
-                isDropTarget: isDropTarget,
-                isGroupReorderTarget: !group.isSystemGroup && sidebar?.dropTargetSectionId == group.id && sidebar?.draggingConversationId == nil,
-                groupDropIndicatorAtBottom: sidebar?.groupDropIndicatorAtBottom ?? false,
-                aggregateState: aggregateState,
-                isRenaming: isRenaming,
-                renamingName: $renamingName,
-                onToggleExpand: onToggleExpand,
-                onRename: onRename,
-                onCommitRename: onCommitRename,
-                onCancelRename: onCancelRename,
-                onDelete: onDelete,
-                sidebar: sidebar
+        SidebarSectionHeader(
+            group: group,
+            conversationCount: displayCount,
+            isExpanded: isExpanded,
+            isDropTarget: isDropTarget,
+            isGroupReorderTarget: !group.isSystemGroup && sidebar?.dropTargetSectionId == group.id && sidebar?.draggingConversationId == nil,
+            groupDropIndicatorAtBottom: sidebar?.groupDropIndicatorAtBottom ?? false,
+            aggregateState: aggregateState,
+            isRenaming: isRenaming,
+            renamingName: $renamingName,
+            onToggleExpand: onToggleExpand,
+            onRename: onRename,
+            onCommitRename: onCommitRename,
+            onCancelRename: onCancelRename,
+            onDelete: onDelete,
+            sidebar: sidebar
+        )
+        .modifier(SectionHeaderDropModifier(
+            group: group,
+            sidebar: sidebar,
+            conversationManager: conversationManager
+        ))
+
+        if isExpanded && !conversations.isEmpty {
+            VStack(spacing: 0) {
+                sectionContent
+            }
+            .padding(.bottom, VSpacing.xxs)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(isDropTarget ? VColor.systemPositiveWeak : .clear)
             )
-            .modifier(SectionHeaderDropModifier(
-                group: group,
+            .modifier(SectionBodyDropModifier(
+                groupId: group.id,
                 sidebar: sidebar,
                 conversationManager: conversationManager
             ))
-
-            if isExpanded && !conversations.isEmpty {
-                VStack(spacing: 0) {
-                    sectionContent
-                }
-                .padding(.bottom, VSpacing.xxs)
-                .background(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .fill(isDropTarget ? VColor.systemPositiveWeak : .clear)
-                )
-                .modifier(SectionBodyDropModifier(
-                    groupId: group.id,
-                    sidebar: sidebar,
-                    conversationManager: conversationManager
-                ))
-                .transition(.opacity)
-            }
-        } else {
-            // Ungrouped -- no header, render conversations directly
-            sectionContent
+            .transition(.opacity)
         }
     }
 
@@ -190,7 +185,7 @@ struct SidebarSectionView: View {
                             sidebar.dropTargetConversationId = conversation.id
                             if let dragId = sidebar.draggingConversationId {
                                 let groupConversations = conversationManager.groupedConversations
-                                    .first { $0.group?.id == group?.id }?.conversations ?? []
+                                    .first { $0.group?.id == group.id }?.conversations ?? []
                                 let sIdx = groupConversations.firstIndex(where: { $0.id == dragId }) ?? 0
                                 let tIdx = groupConversations.firstIndex(where: { $0.id == conversation.id }) ?? 0
                                 sidebar.dropIndicatorAtBottom = sIdx < tIdx
@@ -216,7 +211,7 @@ struct SidebarSectionView: View {
         // on the server beyond the initial page. Auto-trigger a full load so
         // those items become visible. Scoped to the pinned section only to
         // avoid eagerly loading all conversations for small non-pinned sections.
-        if group?.id == ConversationGroup.pinned.id,
+        if group.id == ConversationGroup.pinned.id,
            conversations.count <= maxCollapsed,
            let conversationManager,
            conversationManager.hasMoreConversations {


### PR DESCRIPTION
## Summary
- Remove `ungroupedConversationRows()` — all conversations now route through `makeSectionView()`
- Remove nil-group fallback in `SidebarSectionView` and `ConversationSwitcherDrawer`
- Make `SidebarSectionView.group` non-optional since every section has a group
- Remove `"ungrouped"` string literal section IDs
- When custom groups are disabled, fold conversations into `system:all` instead of a nil-group bucket

Part of #23769

## Test plan
- [ ] Verify sidebar renders all conversations through grouped code path
- [ ] Verify collapsed sidebar conversation switcher drawer still works
- [ ] Verify expand/collapse state works for all sections
- [ ] Verify drag-and-drop between sections still works
- [ ] Verify "Show more" / "Show less" buttons work in each section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23783" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
