### PR TITLE
refactor: extract supportsHostProxy helper for interface checks

### DIFF
--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -90,6 +90,11 @@ export function isInteractiveInterface(id: InterfaceId): boolean {
   return INTERACTIVE_INTERFACES.has(id);
 }
 
+/** Whether the interface supports host proxies (bash, file, computer-use). */
+export function supportsHostProxy(id: InterfaceId): boolean {
+  return id === "macos";
+}
+
 export interface TurnInterfaceContext {
   userMessageInterface: InterfaceId;
   assistantMessageInterface: InterfaceId;

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -15,7 +15,11 @@ import type {
   TurnChannelContext,
   TurnInterfaceContext,
 } from "../channels/types.js";
-import { parseChannelId, parseInterfaceId } from "../channels/types.js";
+import {
+  parseChannelId,
+  parseInterfaceId,
+  supportsHostProxy,
+} from "../channels/types.js";
 import { getConfig } from "../config/loader.js";
 import type { ContextWindowResult } from "../context/window-manager.js";
 import { listPendingRequestsByConversationScope } from "../memory/canonical-guardian-store.js";
@@ -302,7 +306,7 @@ export async function drainQueue(
     const interfaceCtx =
       queuedInterfaceCtx ?? conversation.getTurnInterfaceContext();
     const sourceInterface = interfaceCtx?.userMessageInterface;
-    if (sourceInterface === "macos") {
+    if (sourceInterface && supportsHostProxy(sourceInterface)) {
       conversation.restoreProxyAvailability();
       conversation.addPreactivatedSkillId("computer-use");
     }

--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -4,6 +4,7 @@ import {
   type InterfaceId,
   parseChannelId,
   parseInterfaceId,
+  supportsHostProxy,
 } from "../../channels/types.js";
 import { getConfig } from "../../config/loader.js";
 import {
@@ -301,7 +302,7 @@ export async function handleConversationCreate(
     // Only create the host bash proxy for desktop client interfaces that can
     // execute commands on the user's machine. Set before updateClient so
     // updateClient's call to hostBashProxy.updateSender targets the new proxy.
-    if (transportInterface === "macos") {
+    if (supportsHostProxy(transportInterface)) {
       const proxy = new HostBashProxy(sendEvent, (requestId) => {
         pendingInteractions.resolve(requestId);
       });

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -17,6 +17,7 @@ import {
   type InterfaceId,
   parseChannelId,
   parseInterfaceId,
+  supportsHostProxy,
 } from "../channels/types.js";
 import { getConfig } from "../config/loader.js";
 import { onContactChange } from "../contacts/contact-events.js";
@@ -1096,7 +1097,7 @@ export class DaemonServer {
     // Guard: don't replace an active proxy during concurrent turn races —
     // another request may have started processing between the isProcessing()
     // check above and the await on ensureActorScopedHistory().
-    if (resolvedInterface === "macos") {
+    if (supportsHostProxy(resolvedInterface)) {
       if (!conversation.isProcessing() || !conversation.hostBashProxy) {
         conversation.setHostBashProxy(
           new HostBashProxy(conversation.getCurrentSender(), (requestId) => {

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -17,6 +17,7 @@ import {
   isInteractiveInterface,
   parseChannelId,
   parseInterfaceId,
+  supportsHostProxy,
 } from "../../channels/types.js";
 import { isHttpAuthDisabled } from "../../config/env.js";
 import { getConfig } from "../../config/loader.js";
@@ -1117,7 +1118,7 @@ export async function handleSendMessage(
   // channels, headless) fall back to local execution.
   // Set the proxy BEFORE updateClient so updateClient's call to
   // hostBashProxy.updateSender targets the correct (new) proxy.
-  if (sourceInterface === "macos") {
+  if (supportsHostProxy(sourceInterface)) {
     // Reuse the existing proxy if the conversation is actively processing a
     // host bash request to avoid orphaning in-flight requests.
     if (!conversation.isProcessing() || !conversation.hostBashProxy) {
@@ -1154,7 +1155,7 @@ export async function handleSendMessage(
   // When proxies are preserved during an active turn (non-desktop request while
   // processing), skip updating proxy senders to avoid degrading them.
   const preservingProxies =
-    conversation.isProcessing() && sourceInterface !== "macos";
+    conversation.isProcessing() && !supportsHostProxy(sourceInterface);
   conversation.updateClient(onEvent, !isInteractive, {
     skipProxySenderUpdate: preservingProxies,
   });


### PR DESCRIPTION
## Summary
- Add `supportsHostProxy(id: InterfaceId): boolean` helper to `channels/types.ts` that centralizes the `=== "macos"` check used for host proxy setup
- Replace all 5 proxy-related `=== "macos"` / `!== "macos"` checks across `handlers/conversations.ts`, `server.ts`, `conversation-routes.ts`, and `conversation-process.ts` with calls to `supportsHostProxy()`
- If a new desktop interface is added in the future, only one function needs to change

## Original prompt
Extract a `supportsHostProxy` helper instead of having `=== "macos"` checks scattered across 4+ files for host proxy setup
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23786" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
