### PR TITLE
M5: macOS — disable rename for system groups in sidebar context menu

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -149,7 +149,7 @@ extension MainWindowView {
                 get: { sidebar.renamingGroupName },
                 set: { sidebar.renamingGroupName = $0 }
             ),
-            onRename: { name in
+            onRename: group.isSystemGroup ? nil : { name in
                 sidebar.renamingGroupId = group.id
                 sidebar.renamingGroupName = name
             },


### PR DESCRIPTION
## Summary
- Guard onRename with group.isSystemGroup check, matching existing onDelete pattern
- System groups (Pinned, Scheduled, Background, Recents) no longer show rename in context menu

Part of #23769
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
