### PR TITLE
fix(macos): include dotfiles in codesign pre-flight check

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -1155,11 +1155,12 @@ fi
 # codesign to fail with the cryptic "unsealed contents present in the bundle
 # root" error. Only Contents/ belongs at the top level of a macOS .app bundle.
 STRAY_ITEMS=()
-for item in "$APP_DIR"/*; do
+for item in "$APP_DIR"/* "$APP_DIR"/.*; do
     [ -e "$item" ] || continue
-    if [ "$(basename "$item")" != "Contents" ]; then
-        STRAY_ITEMS+=("$(basename "$item")")
-    fi
+    case "$(basename "$item")" in
+        .|..|Contents) continue ;;
+    esac
+    STRAY_ITEMS+=("$(basename "$item")")
 done
 if [ ${#STRAY_ITEMS[@]} -gt 0 ]; then
     echo ""


### PR DESCRIPTION
## Summary
- Extends the bundle-root pre-flight check from #23758 to also scan hidden files (dotfiles like `.DS_Store`) which are equally rejected by codesign
- Adds `"$APP_DIR"/.*` glob and skips `.` and `..` entries
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
