### PR TITLE
fix(macos): auto-clean stray items from .app bundle root instead of erroring

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -1574,14 +1574,11 @@ for item in "$APP_DIR"/* "$APP_DIR"/.*; do
 done
 if [ ${#STRAY_ITEMS[@]} -gt 0 ]; then
     echo ""
-    echo "ERROR: The .app bundle contains unexpected items in its root directory:"
+    echo "warning: Removing unexpected items from .app bundle root (stale build artifacts):"
     printf '  - %s\n' "${STRAY_ITEMS[@]}"
-    echo ""
-    echo "macOS codesign rejects bundles with files outside Contents/."
-    echo "This is usually caused by stale artifacts from a previous build."
-    echo "Fix: run './build.sh clean' and rebuild, or delete the items above from:"
-    echo "  $APP_DIR/"
-    exit 1
+    for item in "${STRAY_ITEMS[@]}"; do
+        rm -rf "$APP_DIR/$item"
+    done
 fi
 
 # Sign the outer app bundle with entitlements (without --deep to preserve nested signatures)


### PR DESCRIPTION
## Summary
- Changes the codesign pre-flight check from a hard error + exit to an automatic cleanup with a warning
- Stray items in the `.app` bundle root are safely removed since only `Contents/` should ever be there
- Prevents `build.sh run` from dying before the watch loop due to leftover artifacts from previous builds

## Original prompt
a fix for this
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
