### PR TITLE
fix: createGroup ceiling returns 4xx, reorder skips unknown groups

### DIFF
--- a/assistant/src/memory/group-crud.ts
+++ b/assistant/src/memory/group-crud.ts
@@ -177,17 +177,22 @@ export function reorderGroups(
   updates: Array<{ groupId: string; sortPosition: number }>,
 ): void {
   ensureGroupMigration();
-  for (const update of updates) {
-    if (update.sortPosition >= 999999) {
-      throw new Error(
-        `Custom group sort_position must be < 999999 (got ${update.sortPosition} for ${update.groupId})`,
-      );
-    }
-  }
   const now = Math.floor(Date.now() / 1000);
   rawExec("BEGIN");
   try {
     for (const update of updates) {
+      // Look up the group first — skip unknown/stale IDs gracefully
+      const group = rawGet<{ id: string }>(
+        "SELECT id FROM conversation_groups WHERE id = ?",
+        update.groupId,
+      );
+      if (!group) continue;
+
+      if (update.sortPosition >= 999999) {
+        throw new Error(
+          `Custom group sort_position must be < 999999 (got ${update.sortPosition} for ${update.groupId})`,
+        );
+      }
       rawRun(
         "UPDATE conversation_groups SET sort_position = ?, updated_at = ? WHERE id = ?",
         update.sortPosition,

--- a/assistant/src/runtime/routes/group-routes.ts
+++ b/assistant/src/runtime/routes/group-routes.ts
@@ -63,8 +63,22 @@ export function groupRouteDefinitions(): RouteDefinition[] {
         if (!body.name || typeof body.name !== "string") {
           return httpError("BAD_REQUEST", "Missing or invalid name", 400);
         }
-        const group = createGroup(body.name);
-        return Response.json(serializeGroup(group), { status: 201 });
+        try {
+          const group = createGroup(body.name);
+          return Response.json(serializeGroup(group), { status: 201 });
+        } catch (err) {
+          if (
+            err instanceof Error &&
+            err.message.includes("sort_position must be < 999999")
+          ) {
+            return httpError(
+              "BAD_REQUEST",
+              "Too many custom groups — sort_position ceiling reached",
+              400,
+            );
+          }
+          throw err;
+        }
       },
     },
     {


### PR DESCRIPTION
## Summary
- Handle sortPosition ceiling violation in createGroup gracefully (4xx instead of 500)
- Move reorder ceiling check after group existence check so stale IDs are still skipped

Addresses review feedback on #23775
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
