### PR TITLE
fix: stale comment and explicit null groupId in batchSetDisplayOrders

### DIFF
--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -1549,11 +1549,13 @@ export function batchSetDisplayOrders(
       if (update.groupId !== undefined) {
         // New client: groupId is authoritative.
         // Derive is_pinned from groupId.
-        // Sanitize: if groupId references a deleted/unknown group, fall back
-        // to NULL to avoid FK violation that would roll back the entire batch.
+        // Sanitize: if groupId is null or references a deleted/unknown group,
+        // fall back to "system:all" to avoid FK violation that would roll back
+        // the entire batch.
         let safeGroupId = update.groupId;
-        if (
-          safeGroupId !== null &&
+        if (safeGroupId === null) {
+          safeGroupId = "system:all";
+        } else if (
           !rawGet<{ id: string }>(
             "SELECT id FROM conversation_groups WHERE id = ?",
             safeGroupId,


### PR DESCRIPTION
## Summary
- Update comment that still referenced NULL fallback to say system:all
- Intercept explicit null groupId from new clients to map to system:all

Addresses review feedback on #23780
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
