### PR TITLE
fix: restore pagination fallback for thin conversation spread

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -273,6 +273,22 @@ extension MainWindowView {
                 makeSectionView(group: entry.group, conversations: entry.conversations)
             }
 
+            // Pagination fallback sentinel: when every non-pinned section fits
+            // within its collapse limit (maxCollapsed = 5), no "Show more" button
+            // appears, yet the server may have additional conversations beyond the
+            // initial page. Render an invisible trigger to load them automatically.
+            let maxCollapsed = 5
+            let allSectionsFit = groupEntries.allSatisfy { entry in
+                entry.group.id == ConversationGroup.pinned.id || entry.conversations.count <= maxCollapsed
+            }
+            if conversationManager.hasMoreConversations && allSectionsFit {
+                Color.clear
+                    .frame(height: 0)
+                    .onAppear {
+                        conversationManager.loadAllRemainingConversations()
+                    }
+            }
+
         }
     }
 


### PR DESCRIPTION
## Summary
- Re-add auto-pagination sentinel that was removed with the ungrouped section
- Triggers loadAllRemainingConversations when all sections fit within collapse limit but server has more

Addresses review feedback on #23783

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
