### PR TITLE
fix: normalize nil groupId in restorer, creation paths, and sidebar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationListStore.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationListStore.swift
@@ -129,7 +129,7 @@ final class ConversationListStore {
     private(set) var sortedGroups: [ConversationGroup] = []
 
     /// Conversations organized by group. Groups appear in sortPosition order;
-    /// ungrouped conversations (including orphans with unknown groupId) appear last.
+    /// ungrouped and orphaned conversations are folded into the system:all bucket.
     private(set) var groupedConversations: [(group: ConversationGroup?, conversations: [ConversationModel])] = []
 
     /// Non-archived, non-private conversations sorted for the sidebar.
@@ -188,9 +188,14 @@ final class ConversationListStore {
 
         var grouped: [(ConversationGroup?, [ConversationModel])] = []
         for group in currentSortedGroups {
-            grouped.append((group, buckets[group.id] ?? []))
+            if group.id == ConversationGroup.all.id {
+                // Fold nil-groupId and orphaned conversations into the system:all bucket
+                // so they are never silently dropped by sidebar rendering.
+                grouped.append((group, (buckets[group.id] ?? []) + ungrouped + orphaned))
+            } else {
+                grouped.append((group, buckets[group.id] ?? []))
+            }
         }
-        grouped.append((nil, ungrouped + orphaned))
         groupedConversations = grouped
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -486,7 +486,7 @@ final class ConversationManager: ConversationRestorerDelegate {
     private func promoteDraft(fromUserSend: Bool) {
         guard let viewModel = selectionStore.draftViewModel else { return }
 
-        let conversation = ConversationModel(title: "Untitled")
+        let conversation = ConversationModel(title: "Untitled", groupId: ConversationGroup.all.id)
         let localId = conversation.id
         listStore.conversations.insert(conversation, at: 0)
         selectionStore.chatViewModels[conversation.id] = viewModel
@@ -611,7 +611,8 @@ final class ConversationManager: ConversationRestorerDelegate {
             conversationId: conversationId,
             title: title,
             source: "notification",
-            markHistoryLoaded: false
+            markHistoryLoaded: false,
+            groupId: ConversationGroup.all.id
         ) else { return }
         log.info("Created notification conversation \(localId) for conversation \(conversationId) (source: \(sourceEventName))")
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -253,7 +253,7 @@ final class ConversationRestorer {
         for session in recentConversations {
             let isPinned = session.isPinned ?? false
             let groupId: String? = daemonSupportsGroups
-                ? (session.groupId ?? (isPinned ? ConversationGroup.pinned.id : nil))
+                ? (session.groupId ?? (isPinned ? ConversationGroup.pinned.id : ConversationGroup.all.id))
                 : ConversationModel.deriveGroupId(
                     serverGroupId: session.groupId,
                     isPinned: isPinned,

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -262,10 +262,14 @@ extension MainWindowView {
                     }
                 }
                 // Merge extra conversations into the system:all entry
-                if !extraForAll.isEmpty,
-                   let allIndex = entries.firstIndex(where: { $0.group.id == ConversationGroup.all.id }) {
-                    let existing = entries[allIndex]
-                    entries[allIndex] = SidebarGroupEntry(id: existing.id, group: existing.group, conversations: existing.conversations + extraForAll)
+                if !extraForAll.isEmpty {
+                    if let allIndex = entries.firstIndex(where: { $0.group.id == ConversationGroup.all.id }) {
+                        let existing = entries[allIndex]
+                        entries[allIndex] = SidebarGroupEntry(id: existing.id, group: existing.group, conversations: existing.conversations + extraForAll)
+                    } else {
+                        // system:all absent from entries — create one so conversations aren't dropped
+                        entries.append(SidebarGroupEntry(id: ConversationGroup.all.id, group: ConversationGroup.all, conversations: extraForAll))
+                    }
                 }
                 return entries
             }()

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ConversationSwitcherDrawer.swift
@@ -32,10 +32,14 @@ struct ConversationSwitcherDrawer: View {
             }
         }
         // Merge extra conversations into the system:all entry
-        if !extraForAll.isEmpty,
-           let allIndex = entries.firstIndex(where: { $0.group.id == ConversationGroup.all.id }) {
-            let existing = entries[allIndex]
-            entries[allIndex] = (existing.group, existing.conversations + extraForAll)
+        if !extraForAll.isEmpty {
+            if let allIndex = entries.firstIndex(where: { $0.group.id == ConversationGroup.all.id }) {
+                let existing = entries[allIndex]
+                entries[allIndex] = (existing.group, existing.conversations + extraForAll)
+            } else {
+                // system:all absent from entries — create one so conversations aren't dropped
+                entries.append((ConversationGroup.all, extraForAll))
+            }
         }
         return entries
     }


### PR DESCRIPTION
## Summary
- Normalize nil→system:all in ConversationRestorer when daemon returns null groupId
- Set groupId to system:all in promoteDraft and notification conversation creation
- Fold nil-group/orphaned conversations into system:all bucket in groupedConversations
- Add fallback when system:all entry is absent for extraForAll conversations in sidebar and drawer

Addresses review feedback on #23781 and #23783
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
