### PR TITLE
feat: enable spell checking in chat composer

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
@@ -110,6 +110,9 @@ struct ComposerTextEditor: NSViewRepresentable {
         textView.font = font
         textView.insertionPointColor = insertionPointColor
         textView.allowsUndo = true
+        textView.isContinuousSpellCheckingEnabled = true
+        textView.isAutomaticTextCompletionEnabled = false
+        textView.isAutomaticSpellingCorrectionEnabled = false
 
         let defaultColor = NSColor(VColor.contentDefault)
         let paragraphStyle = NSMutableParagraphStyle()


### PR DESCRIPTION
## Summary
- Enables continuous spell checking (red squiggles) in the chat composer's NSTextView
- Disables automatic text completion and auto-correct to avoid unwanted word replacements

## Test plan
- [ ] Type misspelled words in the composer — red squiggles should appear
- [ ] Verify no inline autocomplete suggestions appear
- [ ] Verify words are not auto-corrected while typing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23800" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
