### PR TITLE
fix: add period to referral card subtitle

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingReferralCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingReferralCard.swift
@@ -46,7 +46,7 @@ struct SettingsBillingReferralCard: View {
     // MARK: - Has Code State
 
     private func hasCodeState(_ code: ReferralCodeResponse) -> some View {
-        SettingsCard(title: "Referrals", subtitle: "Share your referral link to earn up to 100 free credits") {
+        SettingsCard(title: "Referrals", subtitle: "Share your referral link to earn up to 100 free credits.") {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
                 // Referral URL row
                 HStack(spacing: VSpacing.sm) {


### PR DESCRIPTION
## Summary
- Add trailing period to the referral card subtitle for consistent punctuation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23813" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
