### PR TITLE
revert: disable Teleport feature flag by default

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -279,7 +279,7 @@
       "key": "teleport",
       "label": "Teleport",
       "description": "Enable teleport UI in General settings for moving assistants between hosting environments",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "permission-controls-v2",


### PR DESCRIPTION
## Summary
- Reverts #23744 by setting `defaultEnabled: false` for the `teleport` feature flag
- The Teleport UI in General settings will no longer be on by default

## Original prompt
help revert this PR https://github.com/vellum-ai/vellum-assistant/pull/23744
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23815" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
