### PR TITLE
fix: pass transport hints through HTTP message endpoint for managed-mode conversations

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -875,8 +875,8 @@ export async function runDaemon(): Promise<void> {
       guardianFollowUpConversationGenerator:
         createGuardianFollowUpConversationGenerator(),
       sendMessageDeps: {
-        getOrCreateConversation: (conversationId) =>
-          server.getConversationForMessages(conversationId),
+        getOrCreateConversation: (conversationId, options) =>
+          server.getConversationForMessages(conversationId, options),
         assistantEventHub,
         resolveAttachments: (attachmentIds) => {
           const resolved = attachmentsStore.getAttachmentsByIds(attachmentIds, {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1459,8 +1459,9 @@ export class DaemonServer {
    */
   async getConversationForMessages(
     conversationId: string,
+    options?: ConversationCreateOptions,
   ): Promise<Conversation> {
-    return this.getOrCreateConversation(conversationId);
+    return this.getOrCreateConversation(conversationId, options);
   }
 
   /**

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -150,7 +150,10 @@ export type MessageProcessor = (
  * Hub publishing wires outbound events to the SSE stream.
  */
 export interface SendMessageDeps {
-  getOrCreateConversation: (conversationId: string) => Promise<Conversation>;
+  getOrCreateConversation: (
+    conversationId: string,
+    options?: import("../daemon/handlers/shared.js").ConversationCreateOptions,
+  ) => Promise<Conversation>;
   assistantEventHub: AssistantEventHub;
   resolveAttachments: (attachmentIds: string[]) => Array<{
     id: string;

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -5,6 +5,7 @@ import type { ChannelId, InterfaceId } from "../channels/types.js";
 import type { CesClient } from "../credential-execution/client.js";
 import type { Conversation } from "../daemon/conversation.js";
 import type { TrustContext } from "../daemon/conversation-runtime-assembly.js";
+import type { ConversationCreateOptions } from "../daemon/handlers/shared.js";
 import type { SkillOperationContext } from "../daemon/handlers/skills.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import type {
@@ -152,7 +153,7 @@ export type MessageProcessor = (
 export interface SendMessageDeps {
   getOrCreateConversation: (
     conversationId: string,
-    options?: import("../daemon/handlers/shared.js").ConversationCreateOptions,
+    options?: ConversationCreateOptions,
   ) => Promise<Conversation>;
   assistantEventHub: AssistantEventHub;
   resolveAttachments: (attachmentIds: string[]) => Array<{

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -943,6 +943,8 @@ export async function handleSendMessage(
     conversationType?: string;
     automated?: boolean;
     bypassSecretCheck?: boolean;
+    hostHomeDir?: string;
+    hostUsername?: string;
   };
 
   const { conversationKey, content, attachmentIds } = body;
@@ -1046,8 +1048,25 @@ export async function handleSendMessage(
     conversationType,
   });
   const smDeps = deps.sendMessageDeps;
+
+  // Build transport metadata from the request so the daemon can inject
+  // host environment hints (home directory, username) into the LLM context.
+  const transport =
+    sourceInterface === "macos"
+      ? ({
+          channelId: sourceChannel,
+          interfaceId: "macos" as const,
+          hostHomeDir: body.hostHomeDir,
+          hostUsername: body.hostUsername,
+        } satisfies import("../../daemon/message-types/conversations.js").MacosTransportMetadata)
+      : ({
+          channelId: sourceChannel,
+          interfaceId: sourceInterface,
+        } satisfies import("../../daemon/message-types/conversations.js").NonMacosTransportMetadata);
+
   const conversation = await smDeps.getOrCreateConversation(
     mapping.conversationId,
+    { transport },
   );
 
   // Resolve guardian context from the AuthContext's actorPrincipalId.

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -39,6 +39,10 @@ import { HostBashProxy } from "../../daemon/host-bash-proxy.js";
 import { HostCuProxy } from "../../daemon/host-cu-proxy.js";
 import { HostFileProxy } from "../../daemon/host-file-proxy.js";
 import type { ServerMessage } from "../../daemon/message-protocol.js";
+import type {
+  MacosTransportMetadata,
+  NonMacosTransportMetadata,
+} from "../../daemon/message-types/conversations.js";
 import type { HeartbeatService } from "../../heartbeat/heartbeat-service.js";
 import * as attachmentsStore from "../../memory/attachments-store.js";
 import {
@@ -1058,11 +1062,11 @@ export async function handleSendMessage(
           interfaceId: "macos" as const,
           hostHomeDir: body.hostHomeDir,
           hostUsername: body.hostUsername,
-        } satisfies import("../../daemon/message-types/conversations.js").MacosTransportMetadata)
+        } satisfies MacosTransportMetadata)
       : ({
           channelId: sourceChannel,
           interfaceId: sourceInterface,
-        } satisfies import("../../daemon/message-types/conversations.js").NonMacosTransportMetadata);
+        } satisfies NonMacosTransportMetadata);
 
   const conversation = await smDeps.getOrCreateConversation(
     mapping.conversationId,

--- a/clients/shared/Network/MessageClient.swift
+++ b/clients/shared/Network/MessageClient.swift
@@ -44,6 +44,24 @@ public struct MessageClient: MessageClientProtocol {
         #endif
     }
 
+    /// The host home directory, populated automatically on macOS.
+    private static var hostHomeDir: String? {
+        #if os(macOS)
+        return NSHomeDirectory()
+        #else
+        return nil
+        #endif
+    }
+
+    /// The host username, populated automatically on macOS.
+    private static var hostUsername: String? {
+        #if os(macOS)
+        return NSUserName()
+        #else
+        return nil
+        #endif
+    }
+
     public func uploadAttachment(filename: String, mimeType: String, data: String, filePath: String? = nil) async -> AttachmentUploadResult {
         log.info("[send-pipeline] attachment upload start — filename=\(filename, privacy: .public), mimeType=\(mimeType, privacy: .public)")
 
@@ -105,6 +123,12 @@ public struct MessageClient: MessageClientProtocol {
         }
         if bypassSecretCheck == true {
             body["bypassSecretCheck"] = true
+        }
+        if let hostHomeDir = Self.hostHomeDir {
+            body["hostHomeDir"] = hostHomeDir
+        }
+        if let hostUsername = Self.hostUsername {
+            body["hostUsername"] = hostUsername
         }
 
         do {


### PR DESCRIPTION
## Summary
- The `POST /v1/messages` handler auto-creates conversations without passing transport metadata, so `applyTransportMetadata()` returns early and host environment hints (`hostHomeDir`, `hostUsername`) are never injected into the LLM context. This causes the assistant to hallucinate the user's home directory path from their display name (e.g. `/Users/Marina/`) instead of using the actual macOS username (`/Users/vellumaihq/`).
- Thread transport metadata from the HTTP message request body through `SendMessageDeps.getOrCreateConversation()` → `getConversationForMessages()` → `getOrCreateConversation()` → `applyTransportMetadata()`, and include `hostHomeDir`/`hostUsername` from the macOS client in every message request.
- This closes the gap where transport hints worked for daemon-to-daemon conversations (WebSocket `ConversationCreateRequest`) but not for HTTP-mode conversations used by managed-mode macOS clients.

## Original prompt
Fix the transport hints not being injected for managed-mode conversations created via POST /v1/messages.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23824" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
