### PR TITLE
fix: persist surface completion state so forms collapse after history reconstruction

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -44,6 +44,7 @@ import {
   updateConversationTitle,
   updateMessageMetadata,
 } from "../memory/conversation-crud.js";
+import { markSurfaceCompleted } from "./conversation-surfaces.js";
 import { syncMessageToDisk } from "../memory/conversation-disk-view.js";
 import {
   isReplaceableTitle,
@@ -438,6 +439,7 @@ export async function runAgentLoopImpl(
           surfaceId,
           summary: "Dismissed",
         });
+        markSurfaceCompleted(ctx, surfaceId, "Dismissed");
         ctx.pendingSurfaceActions.delete(surfaceId);
       }
     }

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -27,10 +27,69 @@ import type {
 } from "./message-protocol.js";
 import { INTERACTIVE_SURFACE_TYPES } from "./message-protocol.js";
 import type { UserMessageAttachment } from "./message-types/shared.js";
+import {
+  getMessages,
+  updateMessageContent,
+} from "../memory/conversation-crud.js";
 
 const log = getLogger("conversation-surfaces");
 
 const MAX_UNDO_DEPTH = 10;
+
+/**
+ * Mark a `ui_surface` content block as completed in the database so that
+ * history reconstruction preserves the completion state.  Also updates
+ * in-memory messages when available.
+ */
+export function markSurfaceCompleted(
+  ctx: { conversationId: string; messages?: Array<{ content: unknown }> },
+  surfaceId: string,
+  summary: string,
+): void {
+  // Update in-memory messages when available so subsequent reads within
+  // this session see the change without waiting for DB.
+  if (ctx.messages) {
+    for (let i = ctx.messages.length - 1; i >= 0; i--) {
+      const msg = ctx.messages[i];
+      if (!Array.isArray(msg.content)) continue;
+      for (const block of msg.content) {
+        const b = block as Record<string, unknown>;
+        if (b.type === "ui_surface" && b.surfaceId === surfaceId) {
+          b.completed = true;
+          b.completionSummary = summary;
+          break;
+        }
+      }
+    }
+  }
+
+  // Persist to DB.
+  try {
+    const rows = getMessages(ctx.conversationId);
+    for (let r = rows.length - 1; r >= 0; r--) {
+      const parsed = JSON.parse(rows[r].content) as unknown[];
+      let found = false;
+      for (const pb of parsed) {
+        const rb = pb as Record<string, unknown>;
+        if (rb.type === "ui_surface" && rb.surfaceId === surfaceId) {
+          rb.completed = true;
+          rb.completionSummary = summary;
+          found = true;
+          break;
+        }
+      }
+      if (found) {
+        updateMessageContent(rows[r].id, JSON.stringify(parsed));
+        return;
+      }
+    }
+  } catch (err) {
+    log.warn(
+      { err, surfaceId },
+      "Failed to persist surface completion to DB",
+    );
+  }
+}
 const TASK_PROGRESS_TEMPLATE_FIELDS = ["title", "status", "steps"] as const;
 
 /**
@@ -857,6 +916,7 @@ export function handleSurfaceAction(
       summary,
       submittedData: mergedData,
     });
+    markSurfaceCompleted(ctx, surfaceId, summary);
   }
 
   // Extract file attachments from action data so they are sent as proper
@@ -1442,6 +1502,7 @@ export async function surfaceProxyResolver(
         summary,
         submittedData: lastAction.data,
       });
+      markSurfaceCompleted(ctx, surfaceId, summary);
     } else {
       ctx.sendToClient({
         type: "ui_surface_dismiss",

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -81,6 +81,8 @@ export interface HistorySurface {
   data: Record<string, unknown>;
   actions?: Array<{ id: string; label: string; style?: string }>;
   display?: string;
+  completed?: boolean;
+  completionSummary?: string;
 }
 
 export interface RenderedHistoryContent {
@@ -281,6 +283,11 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
           : {},
         actions: Array.isArray(block.actions) ? block.actions : undefined,
         display: typeof block.display === "string" ? block.display : undefined,
+        completed: block.completed === true ? true : undefined,
+        completionSummary:
+          typeof block.completionSummary === "string"
+            ? block.completionSummary
+            : undefined,
       };
       surfaces.push(surface);
       contentOrder.push(`surface:${surfaces.length - 1}`);

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -309,6 +309,10 @@ export interface HistoryResponseSurface {
     data?: Record<string, unknown>;
   }>;
   display?: string;
+  /** True when the surface was completed (e.g. form submitted, action taken). */
+  completed?: boolean;
+  /** Human-readable summary shown in the completion chip. */
+  completionSummary?: string;
 }
 
 export interface HistoryResponse {

--- a/clients/shared/Features/Chat/HistoryReconstructionService.swift
+++ b/clients/shared/Features/Chat/HistoryReconstructionService.swift
@@ -113,7 +113,10 @@ enum HistoryReconstructionService {
                             title: surface.title,
                             data: surface.data,
                             actions: surface.actions,
-                            surfaceRef: ref
+                            surfaceRef: ref,
+                            completionState: surf.completed == true
+                                ? SurfaceCompletionState(summary: surf.completionSummary ?? "Completed")
+                                : nil
                         )
                         inlineSurfaces.append(inlineSurface)
                     }

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -2070,14 +2070,20 @@ public struct HistoryResponseSurface: Codable, Sendable {
     public let data: [String: AnyCodable]
     public let actions: [HistoryResponseSurfaceAction]?
     public let display: String?
+    /// True when the surface was completed (e.g. form submitted).
+    public let completed: Bool?
+    /// Human-readable summary shown in the completion chip.
+    public let completionSummary: String?
 
-    public init(surfaceId: String, surfaceType: String, title: String? = nil, data: [String: AnyCodable], actions: [HistoryResponseSurfaceAction]? = nil, display: String? = nil) {
+    public init(surfaceId: String, surfaceType: String, title: String? = nil, data: [String: AnyCodable], actions: [HistoryResponseSurfaceAction]? = nil, display: String? = nil, completed: Bool? = nil, completionSummary: String? = nil) {
         self.surfaceId = surfaceId
         self.surfaceType = surfaceType
         self.title = title
         self.data = data
         self.actions = actions
         self.display = display
+        self.completed = completed
+        self.completionSummary = completionSummary
     }
 }
 


### PR DESCRIPTION
## Summary
- Added `markSurfaceCompleted()` helper that persists `completed: true` and `completionSummary` to the `ui_surface` content block in both in-memory messages and the database
- Called at all three `ui_surface_complete` emission points: form auto-complete, `ui_dismiss` with prior action, and stale surface auto-dismiss in the agent loop
- Added `completed`/`completionSummary` fields to `HistoryResponseSurface` (backend + Swift DTO) and read them during history reconstruction to set `completionState` on `InlineSurfaceData`

🤖 Generated with [Claude Code](https://claude.com/claude-code)