### PR TITLE
fix: disable drag-to-reorder within Recents group

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -176,9 +176,11 @@ struct SidebarSectionView: View {
                             sidebar.endConversationDrag()
                             return false
                         }
-                        // Block within-section reorder for Recents — it uses recency sorting.
+                        // Block within-Recents reorder — Recents uses recency sorting.
+                        // Compare actual conversation groupIds (not section group.id) so
+                        // cross-group moves still work when custom groups are folded into Recents.
                         let sourceGroup = conversationManager.conversations.first(where: { $0.id == sourceUUID })?.groupId
-                        if sourceGroup == ConversationGroup.all.id && group.id == ConversationGroup.all.id {
+                        if sourceGroup == ConversationGroup.all.id && conversation.groupId == ConversationGroup.all.id {
                             sidebar.endConversationDrag()
                             return false
                         }
@@ -189,7 +191,7 @@ struct SidebarSectionView: View {
                     } isTargeted: { isTargeted in
                         if isTargeted && conversation.id != sidebar.draggingConversationId {
                             // Suppress drop indicator for within-Recents drags
-                            if group.id == ConversationGroup.all.id,
+                            if conversation.groupId == ConversationGroup.all.id,
                                let dragId = sidebar.draggingConversationId,
                                conversationManager.conversations.first(where: { $0.id == dragId })?.groupId == ConversationGroup.all.id {
                                 return

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -176,12 +176,24 @@ struct SidebarSectionView: View {
                             sidebar.endConversationDrag()
                             return false
                         }
+                        // Block within-section reorder for Recents — it uses recency sorting.
+                        let sourceGroup = conversationManager.conversations.first(where: { $0.id == sourceUUID })?.groupId
+                        if sourceGroup == ConversationGroup.all.id && group.id == ConversationGroup.all.id {
+                            sidebar.endConversationDrag()
+                            return false
+                        }
                         let insertAfter = sidebar.dropIndicatorAtBottom
                         let moved = conversationManager.moveConversation(sourceId: sourceUUID, targetId: conversation.id, insertAfterTarget: insertAfter)
                         sidebar.endConversationDrag()
                         return moved
                     } isTargeted: { isTargeted in
                         if isTargeted && conversation.id != sidebar.draggingConversationId {
+                            // Suppress drop indicator for within-Recents drags
+                            if group.id == ConversationGroup.all.id,
+                               let dragId = sidebar.draggingConversationId,
+                               conversationManager.conversations.first(where: { $0.id == dragId })?.groupId == ConversationGroup.all.id {
+                                return
+                            }
                             sidebar.dropTargetConversationId = conversation.id
                             if let dragId = sidebar.draggingConversationId {
                                 let groupConversations = conversationManager.groupedConversations


### PR DESCRIPTION
## Summary
- Block within-section reorder drops when both source and target are in system:all (Recents)
- Suppress the drop indicator visual for within-Recents drags
- Cross-group drags (into/out of Recents) still work normally

## Original prompt
Disable drag-to-reorder within the Recents (system:all) group in the sidebar, while still allowing dragging conversations out of Recents into other groups.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23826" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
