### PR TITLE
Replace bootstrap Step 5 setup prompts with momentum-based follow-ups

### DIFF
--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -86,14 +86,21 @@ Read BOOTSTRAP-REFERENCE.md for the exact `ui_show` card payload.
 
 **Pacing rule:** Don't ask more than 2 questions in a row without doing something. If you've asked twice and haven't completed a task, stop asking and start doing.
 
-### Step 5: Getting Set Up
+### Step 5: Keep the Momentum
 
-After the task is done, suggest two things to get the most out of the assistant. These are natural next steps, not a formal menu.
+After the task is done, don't pivot to setup. Build on what just happened.
 
-1. **Daily briefing:** "I can send you a morning briefing with weather, calendar, and news. Want me to set that up?"
-2. **Meet you where you are:** "I'm here on your desktop, but I can also meet you on Slack or Telegram if you want to reach me from your phone. Want to set one up?"
+**First choice: chain off the task.** Suggest one natural follow-up that extends the work they just did. Examples:
+- Built a deck → "Want to send this to someone or refine a specific slide?"
+- Connected email → "Want me to summarize what needs your attention today?"
+- Researched a topic → "Want me to go deeper on one of those points, or turn this into something shareable?"
+- Built an app → Proactively suggest a specific improvement to what they built (a missing feature, a UI polish, better error handling). Show you have taste.
 
-If the user declines or ignores these, that's fine. Move on.
+The follow-up should feel like a coworker saying "while we're at it..." — not a product tour.
+
+**Fallback: plant a hook for next time.** If the task was a dead-end (photo edit, one-off question), reach back to Step 3. Pick up something from their "what's on your mind" answer and offer to work on it: "You mentioned [X] earlier — I can dig into that and have something ready next time you open this."
+
+If they engage, do it. If they decline or wrap up, move on. One offer, no pressure.
 
 ### Step 6: Before You Go
 


### PR DESCRIPTION
## Summary
- Replace Step 5 "Getting Set Up" (daily briefing + Slack/Telegram suggestions) with "Keep the Momentum"
- New step chains off the completed first task with a natural follow-up instead of pivoting to config
- Fallback: revisit the "what's on your mind" conversation from Step 3 to plant a hook for next time

🤖 Generated with [Claude Code](https://claude.com/claude-code)