### PR TITLE
fix: daemon crash loop on corrupt DB and missing gateway import-preflight proxy

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -732,124 +732,128 @@ export async function runDaemon(): Promise<void> {
       log.warn({ err }, "Background Qdrant init failed"),
     );
 
-    registerWatcherProviders();
+    if (dbReady) {
+      registerWatcherProviders();
+    }
     registerMessagingProviders();
 
     // Register the broadcast function for the notification signal pipeline's
     // macOS adapter so it can deliver notification_intent messages to clients.
     registerBroadcastFn((msg) => server.broadcast(msg));
 
-    const scheduler = startScheduler(
-      async (conversationId, message, options) => {
-        await server.processMessage(
-          conversationId,
-          message,
-          undefined,
-          options?.trustClass
-            ? {
-                trustContext: {
-                  sourceChannel: "vellum",
-                  trustClass: options.trustClass,
-                },
-              }
-            : undefined,
-        );
-      },
-      async (schedule) => {
-        await emitNotificationSignal({
-          sourceEventName: "schedule.notify",
-          sourceChannel: "scheduler",
-          sourceContextId: schedule.id,
-          attentionHints: {
-            requiresAction: true,
-            urgency: "high",
-            isAsyncBackground: false,
-            visibleInSourceNow: false,
+    const scheduler = dbReady
+      ? startScheduler(
+          async (conversationId, message, options) => {
+            await server.processMessage(
+              conversationId,
+              message,
+              undefined,
+              options?.trustClass
+                ? {
+                    trustContext: {
+                      sourceChannel: "vellum",
+                      trustClass: options.trustClass,
+                    },
+                  }
+                : undefined,
+            );
           },
-          contextPayload: {
-            scheduleId: schedule.id,
-            label: schedule.label,
-            message: schedule.message,
+          async (schedule) => {
+            await emitNotificationSignal({
+              sourceEventName: "schedule.notify",
+              sourceChannel: "scheduler",
+              sourceContextId: schedule.id,
+              attentionHints: {
+                requiresAction: true,
+                urgency: "high",
+                isAsyncBackground: false,
+                visibleInSourceNow: false,
+              },
+              contextPayload: {
+                scheduleId: schedule.id,
+                label: schedule.label,
+                message: schedule.message,
+              },
+              routingIntent: schedule.routingIntent,
+              routingHints: schedule.routingHints,
+              conversationMetadata: {
+                groupId: "system:scheduled",
+                scheduleJobId: schedule.id,
+                source: "schedule",
+              },
+              dedupeKey: `schedule:notify:${schedule.id}:${Date.now()}`,
+              throwOnError: true,
+            });
           },
-          routingIntent: schedule.routingIntent,
-          routingHints: schedule.routingHints,
-          conversationMetadata: {
-            groupId: "system:scheduled",
-            scheduleJobId: schedule.id,
-            source: "schedule",
+          (schedule) => {
+            void emitNotificationSignal({
+              sourceEventName: "schedule.complete",
+              sourceChannel: "scheduler",
+              sourceContextId: schedule.id,
+              attentionHints: {
+                requiresAction: false,
+                urgency: "medium",
+                isAsyncBackground: true,
+                visibleInSourceNow: false,
+              },
+              contextPayload: {
+                scheduleId: schedule.id,
+                name: schedule.name,
+              },
+              conversationMetadata: {
+                groupId: "system:scheduled",
+                scheduleJobId: schedule.id,
+                source: "schedule",
+              },
+              dedupeKey: `schedule:complete:${schedule.id}:${Date.now()}`,
+            });
           },
-          dedupeKey: `schedule:notify:${schedule.id}:${Date.now()}`,
-          throwOnError: true,
-        });
-      },
-      (schedule) => {
-        void emitNotificationSignal({
-          sourceEventName: "schedule.complete",
-          sourceChannel: "scheduler",
-          sourceContextId: schedule.id,
-          attentionHints: {
-            requiresAction: false,
-            urgency: "medium",
-            isAsyncBackground: true,
-            visibleInSourceNow: false,
+          (notification) => {
+            void emitNotificationSignal({
+              sourceEventName: "watcher.notification",
+              sourceChannel: "watcher",
+              sourceContextId: `watcher-${Date.now()}`,
+              attentionHints: {
+                requiresAction: false,
+                urgency: "low",
+                isAsyncBackground: true,
+                visibleInSourceNow: false,
+              },
+              contextPayload: {
+                title: notification.title,
+                body: notification.body,
+              },
+              dedupeKey: `watcher:notification:${crypto.randomUUID()}`,
+            });
           },
-          contextPayload: {
-            scheduleId: schedule.id,
-            name: schedule.name,
+          (params) => {
+            void emitNotificationSignal({
+              sourceEventName: "watcher.escalation",
+              sourceChannel: "watcher",
+              sourceContextId: `watcher-escalation-${Date.now()}`,
+              attentionHints: {
+                requiresAction: true,
+                urgency: "high",
+                isAsyncBackground: false,
+                visibleInSourceNow: false,
+              },
+              contextPayload: {
+                title: params.title,
+                body: params.body,
+              },
+              dedupeKey: `watcher:escalation:${crypto.randomUUID()}`,
+            });
           },
-          conversationMetadata: {
-            groupId: "system:scheduled",
-            scheduleJobId: schedule.id,
-            source: "schedule",
+          (info) => {
+            server.broadcast({
+              type: "schedule_conversation_created",
+              conversationId: info.conversationId,
+              scheduleJobId: info.scheduleJobId,
+              title: info.title,
+            });
           },
-          dedupeKey: `schedule:complete:${schedule.id}:${Date.now()}`,
-        });
-      },
-      (notification) => {
-        void emitNotificationSignal({
-          sourceEventName: "watcher.notification",
-          sourceChannel: "watcher",
-          sourceContextId: `watcher-${Date.now()}`,
-          attentionHints: {
-            requiresAction: false,
-            urgency: "low",
-            isAsyncBackground: true,
-            visibleInSourceNow: false,
-          },
-          contextPayload: {
-            title: notification.title,
-            body: notification.body,
-          },
-          dedupeKey: `watcher:notification:${crypto.randomUUID()}`,
-        });
-      },
-      (params) => {
-        void emitNotificationSignal({
-          sourceEventName: "watcher.escalation",
-          sourceChannel: "watcher",
-          sourceContextId: `watcher-escalation-${Date.now()}`,
-          attentionHints: {
-            requiresAction: true,
-            urgency: "high",
-            isAsyncBackground: false,
-            visibleInSourceNow: false,
-          },
-          contextPayload: {
-            title: params.title,
-            body: params.body,
-          },
-          dedupeKey: `watcher:escalation:${crypto.randomUUID()}`,
-        });
-      },
-      (info) => {
-        server.broadcast({
-          type: "schedule_conversation_created",
-          conversationId: info.conversationId,
-          scheduleJobId: info.scheduleJobId,
-          title: info.title,
-        });
-      },
-    );
+        )
+      : null;
 
     // Start the runtime HTTP server. Required for iOS pairing (gateway proxies
     // to it) and optional REST API access. Defaults to port 7821.

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -23,7 +23,7 @@ export interface ShutdownDeps {
   filing: FilingService;
   hookManager: HookManager;
   runtimeHttp: RuntimeHttpServer | null;
-  scheduler: { stop(): void };
+  scheduler: { stop(): void } | null;
   getMemoryWorker: () => { stop(): void } | null;
   getQdrantManager: () => QdrantManager | null;
   mcpManager: McpServerManager | null;
@@ -110,7 +110,7 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
     if (deps.runtimeHttp) await deps.runtimeHttp.stop();
     await browserManager.closeAllPages();
     cleanupShellOutputTempFiles();
-    deps.scheduler.stop();
+    deps.scheduler?.stop();
     deps.getMemoryWorker()?.stop();
 
     if (deps.mcpManager) {

--- a/gateway/src/http/routes/migration-proxy.ts
+++ b/gateway/src/http/routes/migration-proxy.ts
@@ -90,6 +90,86 @@ export function createMigrationExportProxyHandler(config: GatewayConfig) {
   };
 }
 
+export function createMigrationImportPreflightProxyHandler(
+  config: GatewayConfig,
+) {
+  return async function handleMigrationImportPreflight(
+    req: Request,
+  ): Promise<Response> {
+    const start = performance.now();
+    const bodyBuffer = await req.arrayBuffer();
+
+    const upstream = `${config.assistantRuntimeBaseUrl}/v1/migrations/import-preflight`;
+
+    const reqHeaders = stripHopByHop(new Headers(req.headers));
+    reqHeaders.delete("host");
+    reqHeaders.delete("authorization");
+
+    reqHeaders.set("authorization", `Bearer ${mintServiceToken()}`);
+    reqHeaders.set("content-length", String(bodyBuffer.byteLength));
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort(
+        new DOMException(
+          "The operation was aborted due to timeout",
+          "TimeoutError",
+        ),
+      );
+    }, MIGRATION_TIMEOUT_MS);
+
+    let response: Response;
+    try {
+      response = await fetchImpl(upstream, {
+        method: "POST",
+        headers: reqHeaders,
+        body: bodyBuffer,
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+    } catch (err) {
+      clearTimeout(timeoutId);
+      const duration = Math.round(performance.now() - start);
+      if (err instanceof DOMException && err.name === "TimeoutError") {
+        log.error(
+          { duration },
+          "Migration import-preflight proxy upstream timed out",
+        );
+        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
+      }
+      log.error(
+        { err, duration },
+        "Migration import-preflight proxy upstream connection failed",
+      );
+      return Response.json({ error: "Bad Gateway" }, { status: 502 });
+    }
+
+    const resHeaders = stripHopByHop(new Headers(response.headers));
+    const duration = Math.round(performance.now() - start);
+
+    if (response.status >= 400) {
+      const body = await response.text();
+      log.warn(
+        { status: response.status, duration },
+        "Migration import-preflight proxy upstream error",
+      );
+      return new Response(body, {
+        status: response.status,
+        headers: resHeaders,
+      });
+    }
+
+    log.info(
+      { status: response.status, duration },
+      "Migration import-preflight proxy completed",
+    );
+    return new Response(response.body, {
+      status: response.status,
+      headers: resHeaders,
+    });
+  };
+}
+
 export function createMigrationImportProxyHandler(config: GatewayConfig) {
   return async function handleMigrationImport(req: Request): Promise<Response> {
     const start = performance.now();

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -63,6 +63,7 @@ import { createRuntimeHealthProxyHandler } from "./http/routes/runtime-health-pr
 import { createUpgradeBroadcastProxyHandler } from "./http/routes/upgrade-broadcast-proxy.js";
 import {
   createMigrationExportProxyHandler,
+  createMigrationImportPreflightProxyHandler,
   createMigrationImportProxyHandler,
 } from "./http/routes/migration-proxy.js";
 import { createMigrationRollbackProxyHandler } from "./http/routes/migration-rollback-proxy.js";
@@ -285,6 +286,8 @@ async function main() {
   const runtimeHealthProxy = createRuntimeHealthProxyHandler(config);
   const upgradeBroadcastProxy = createUpgradeBroadcastProxyHandler(config);
   const migrationExportProxy = createMigrationExportProxyHandler(config);
+  const migrationImportPreflightProxy =
+    createMigrationImportPreflightProxyHandler(config);
   const migrationImportProxy = createMigrationImportProxyHandler(config);
   const migrationRollbackProxy = createMigrationRollbackProxyHandler(config);
   const workspaceCommitProxy = createWorkspaceCommitProxyHandler(config);
@@ -794,6 +797,13 @@ async function main() {
       auth: "edge-scoped",
       scope: "settings.write",
       handler: (req) => migrationExportProxy(req),
+    },
+    {
+      path: "/v1/migrations/import-preflight",
+      method: "POST",
+      auth: "edge-scoped",
+      scope: "settings.write",
+      handler: (req) => migrationImportPreflightProxy(req),
     },
     {
       path: "/v1/migrations/import",

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -2950,6 +2950,31 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/v1/migrations/import-preflight": {
+        post: {
+          summary: "Dry-run import analysis",
+          description:
+            "Proxies a migration import-preflight request to the assistant daemon. Validates a .vbundle archive and returns a report of what would change on import without modifying data. Authenticated with an edge JWT. Timeout is 120 seconds to accommodate large backups.",
+          operationId: "migrationImportPreflight",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/octet-stream": {
+                schema: { type: "string", format: "binary" },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Preflight analysis completed" },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "502": { description: "Failed to reach assistant daemon" },
+            "504": { description: "Assistant daemon request timed out" },
+          },
+        },
+      },
       "/v1/migrations/import": {
         post: {
           summary: "Import workspace backup",


### PR DESCRIPTION
## Summary

When the assistant's SQLite database becomes corrupted, the daemon enters a crash loop — it attempts to start in "degraded mode" but an unguarded DB access crashes the process before the HTTP server can start. This makes backup restoration impossible: the user can't push a healthy database because the daemon is unreachable.

This PR fixes two issues:

- **Daemon survives corrupt DB**: `registerWatcherProviders()` and `startScheduler()` both call `getDb()` but were placed outside the `dbReady` guard in the startup sequence. When the DB is corrupt, these throw `SQLITE_CORRUPT` and crash the process. Moving them behind the guard lets the daemon continue in degraded mode with the HTTP server running, so `vellum restore` can replace the corrupt database.

- **Gateway routes import-preflight correctly**: The gateway had dedicated proxy routes for `/v1/migrations/export` and `/v1/migrations/import` with 120-second timeouts, but was missing one for `/v1/migrations/import-preflight`. Preflight requests fell through to the catch-all runtime proxy which has only a 30-second timeout — too short for validating large backup files.

## Test plan

- [ ] Verify daemon starts in degraded mode when DB file is corrupt (no crash loop)
- [ ] Verify `vellum restore --dry-run` works through the gateway (120s timeout)
- [ ] Verify normal startup path is unaffected when DB is healthy
- [ ] Type-check passes for both `assistant/` and `gateway/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23831" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
