### PR TITLE
feat: pass transport metadata through enqueueMessage and store on queued items

### DIFF
--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -41,6 +41,7 @@ import type {
   ServerMessage,
   UserMessageAttachment,
 } from "./message-protocol.js";
+import type { ConversationTransportMetadata } from "./message-types/conversations.js";
 
 const log = getLogger("conversation-messaging");
 
@@ -222,6 +223,7 @@ export function enqueueMessage(
   metadata?: Record<string, unknown>,
   options?: { isInteractive?: boolean },
   displayContent?: string,
+  transport?: ConversationTransportMetadata,
 ): { queued: boolean; requestId: string; rejected?: boolean } {
   if (!ctx.processing) {
     return { queued: false, requestId };
@@ -246,6 +248,7 @@ export function enqueueMessage(
     turnChannelContext,
     turnInterfaceContext,
     isInteractive: options?.isInteractive,
+    transport,
     displayContent,
     sentAt: Date.now(),
   });

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -114,6 +114,7 @@ import type {
   UsageStats,
   UserMessageAttachment,
 } from "./message-protocol.js";
+import type { ConversationTransportMetadata } from "./message-types/conversations.js";
 import type {
   AssistantActivityState,
   ConfirmationStateChanged,
@@ -609,6 +610,7 @@ export class Conversation {
     metadata?: Record<string, unknown>,
     options?: { isInteractive?: boolean },
     displayContent?: string,
+    transport?: ConversationTransportMetadata,
   ): { queued: boolean; requestId: string; rejected?: boolean } {
     return enqueueMessageImpl(
       this,
@@ -621,6 +623,7 @@ export class Conversation {
       metadata,
       options,
       displayContent,
+      transport,
     );
   }
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1339,6 +1339,8 @@ export async function handleSendMessage(
         ...(body.automated === true ? { automated: true } : {}),
       },
       { isInteractive },
+      undefined, // displayContent
+      transport,
     );
     if (enqueueResult.rejected) {
       return Response.json(


### PR DESCRIPTION
## Summary
- Add optional `transport` parameter to `enqueueMessage()` in conversation.ts, stored on the QueuedMessage
- Pass transport metadata from the HTTP message handler to `enqueueMessage()` when messages are queued due to busy conversation
- Preserves transport metadata on queued items for dequeue-time application in a follow-up PR

Part of plan: transport-hints-queue-hardening.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23839" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
