### PR TITLE
fix: apply transport metadata at dequeue time, not on getOrCreateConversation

### DIFF
--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -48,6 +48,7 @@ import type {
   UserMessageAttachment,
 } from "./message-protocol.js";
 import type { TraceEmitter } from "./trace-emitter.js";
+import { buildTransportHints } from "./transport-hints.js";
 import { resolveVerificationSessionIntent } from "./verification-session-intent.js";
 
 const log = getLogger("conversation-process");
@@ -161,6 +162,8 @@ export interface ProcessConversationContext {
   ): void;
   /** Force context compaction regardless of threshold/cooldown. */
   forceCompact(): Promise<ContextWindowResult>;
+  /** Set transport-derived hints for the conversation. */
+  setTransportHints(hints: string[] | undefined): void;
 }
 
 function resolveQueuedTurnContext(
@@ -292,6 +295,13 @@ export async function drainQueue(
   );
   if (queuedInterfaceCtx) {
     conversation.setTurnInterfaceContext(queuedInterfaceCtx);
+  }
+
+  // Apply transport hints from the queued message so each turn uses the
+  // transport metadata that arrived with its message, not whatever the
+  // conversation happened to have from a previous turn.
+  if (next.transport) {
+    conversation.setTransportHints(buildTransportHints(next.transport));
   }
 
   // Non-interactive queued messages (channel requests) must not execute tools

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -92,6 +92,7 @@ import type {
   ServerMessage,
   UserMessageAttachment,
 } from "./message-protocol.js";
+import { buildTransportHints } from "./transport-hints.js";
 
 const log = getLogger("server");
 
@@ -374,28 +375,7 @@ export class DaemonServer {
       { channelId: transport.channelId },
       "Transport metadata received",
     );
-
-    // Build enriched hints: interface ID first, then host environment (macOS
-    // only), then any client-provided hints.
-    const enrichedHints: string[] = [];
-
-    const interfaceLabel = parseInterfaceId(transport.interfaceId) ?? "vellum";
-    enrichedHints.push(`User is messaging from interface: ${interfaceLabel}`);
-
-    if (transport.interfaceId === "macos") {
-      if (transport.hostHomeDir) {
-        enrichedHints.push(`Host home directory: ${transport.hostHomeDir}`);
-      }
-      if (transport.hostUsername) {
-        enrichedHints.push(`Host username: ${transport.hostUsername}`);
-      }
-    }
-
-    if (transport.hints) {
-      enrichedHints.push(...transport.hints);
-    }
-
-    conversation.setTransportHints(enrichedHints);
+    conversation.setTransportHints(buildTransportHints(transport));
   }
 
   constructor() {

--- a/assistant/src/daemon/transport-hints.ts
+++ b/assistant/src/daemon/transport-hints.ts
@@ -1,0 +1,33 @@
+import { parseInterfaceId } from "../channels/types.js";
+import type { ConversationTransportMetadata } from "./message-types/conversations.js";
+
+/**
+ * Build enriched transport hints from conversation transport metadata.
+ *
+ * Interface ID first, then host environment (macOS only), then any
+ * client-provided hints. Shared between the conversation creation path
+ * (server.ts) and the queue drain path (conversation-process.ts).
+ */
+export function buildTransportHints(
+  transport: ConversationTransportMetadata,
+): string[] {
+  const hints: string[] = [];
+
+  const interfaceLabel = parseInterfaceId(transport.interfaceId) ?? "vellum";
+  hints.push(`User is messaging from interface: ${interfaceLabel}`);
+
+  if (transport.interfaceId === "macos") {
+    if (transport.hostHomeDir) {
+      hints.push(`Host home directory: ${transport.hostHomeDir}`);
+    }
+    if (transport.hostUsername) {
+      hints.push(`Host username: ${transport.hostUsername}`);
+    }
+  }
+
+  if (transport.hints) {
+    hints.push(...transport.hints);
+  }
+
+  return hints;
+}


### PR DESCRIPTION
## Summary
- Extract hint-building logic from `server.ts:applyTransportMetadata` into shared `buildTransportHints()` function in new `transport-hints.ts`
- Apply transport hints from queued messages at dequeue time in `drainQueue`, ensuring each turn uses the transport metadata that arrived with its message
- Conversation creation path unchanged — first message still applies hints immediately

Part of plan: transport-hints-queue-hardening.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23841" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
