### PR TITLE
test: verify transport hints lifecycle through message queue

### DIFF
--- a/assistant/src/__tests__/transport-hints-queue.test.ts
+++ b/assistant/src/__tests__/transport-hints-queue.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+  MacosTransportMetadata,
+  NonMacosTransportMetadata,
+} from "../daemon/message-types/conversations.js";
+import { buildTransportHints } from "../daemon/transport-hints.js";
+
+// ---------------------------------------------------------------------------
+// buildTransportHints
+// ---------------------------------------------------------------------------
+
+describe("buildTransportHints", () => {
+  test("produces correct hints for macOS transport", () => {
+    const transport: MacosTransportMetadata = {
+      channelId: "vellum",
+      interfaceId: "macos",
+      hostHomeDir: "/Users/alice",
+      hostUsername: "alice",
+    };
+
+    const hints = buildTransportHints(transport);
+
+    expect(hints).toContain("User is messaging from interface: macos");
+    expect(hints).toContain("Host home directory: /Users/alice");
+    expect(hints).toContain("Host username: alice");
+    expect(hints).toHaveLength(3);
+  });
+
+  test("produces correct hints for non-macOS transport", () => {
+    const transport: NonMacosTransportMetadata = {
+      channelId: "vellum",
+      interfaceId: "ios",
+    };
+
+    const hints = buildTransportHints(transport);
+
+    expect(hints).toContain("User is messaging from interface: ios");
+    expect(hints).toHaveLength(1);
+    // Should not include host environment hints
+    expect(hints.some((h) => h.includes("Host home directory"))).toBe(false);
+    expect(hints.some((h) => h.includes("Host username"))).toBe(false);
+  });
+
+  test("includes client-provided hints", () => {
+    const transport: MacosTransportMetadata = {
+      channelId: "vellum",
+      interfaceId: "macos",
+      hostHomeDir: "/Users/bob",
+      hostUsername: "bob",
+      hints: ["custom hint"],
+    };
+
+    const hints = buildTransportHints(transport);
+
+    expect(hints).toContain("User is messaging from interface: macos");
+    expect(hints).toContain("Host home directory: /Users/bob");
+    expect(hints).toContain("Host username: bob");
+    expect(hints).toContain("custom hint");
+    expect(hints).toHaveLength(4);
+  });
+
+  test("handles missing optional fields on macOS transport", () => {
+    const transport: MacosTransportMetadata = {
+      channelId: "vellum",
+      interfaceId: "macos",
+    };
+
+    const hints = buildTransportHints(transport);
+
+    expect(hints).toContain("User is messaging from interface: macos");
+    // Without hostHomeDir and hostUsername, only the interface hint is present
+    expect(hints).toHaveLength(1);
+    expect(hints.some((h) => h.includes("Host home directory"))).toBe(false);
+    expect(hints.some((h) => h.includes("Host username"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for `buildTransportHints()` covering macOS transport, non-macOS transport, client-provided hints, and missing optional fields
- Verifies the shared hint-building function produces correct enriched hints for all transport configurations

Part of plan: transport-hints-queue-hardening.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23842" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
