### PR TITLE
Transport hints queue hardening

### DIFF
--- a/assistant/src/__tests__/transport-hints-queue.test.ts
+++ b/assistant/src/__tests__/transport-hints-queue.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+  MacosTransportMetadata,
+  NonMacosTransportMetadata,
+} from "../daemon/message-types/conversations.js";
+import { buildTransportHints } from "../daemon/transport-hints.js";
+
+// ---------------------------------------------------------------------------
+// buildTransportHints
+// ---------------------------------------------------------------------------
+
+describe("buildTransportHints", () => {
+  test("produces correct hints for macOS transport", () => {
+    const transport: MacosTransportMetadata = {
+      channelId: "vellum",
+      interfaceId: "macos",
+      hostHomeDir: "/Users/alice",
+      hostUsername: "alice",
+    };
+
+    const hints = buildTransportHints(transport);
+
+    expect(hints).toContain("User is messaging from interface: macos");
+    expect(hints).toContain("Host home directory: /Users/alice");
+    expect(hints).toContain("Host username: alice");
+    expect(hints).toHaveLength(3);
+  });
+
+  test("produces correct hints for non-macOS transport", () => {
+    const transport: NonMacosTransportMetadata = {
+      channelId: "vellum",
+      interfaceId: "ios",
+    };
+
+    const hints = buildTransportHints(transport);
+
+    expect(hints).toContain("User is messaging from interface: ios");
+    expect(hints).toHaveLength(1);
+    // Should not include host environment hints
+    expect(hints.some((h) => h.includes("Host home directory"))).toBe(false);
+    expect(hints.some((h) => h.includes("Host username"))).toBe(false);
+  });
+
+  test("includes client-provided hints", () => {
+    const transport: MacosTransportMetadata = {
+      channelId: "vellum",
+      interfaceId: "macos",
+      hostHomeDir: "/Users/bob",
+      hostUsername: "bob",
+      hints: ["custom hint"],
+    };
+
+    const hints = buildTransportHints(transport);
+
+    expect(hints).toContain("User is messaging from interface: macos");
+    expect(hints).toContain("Host home directory: /Users/bob");
+    expect(hints).toContain("Host username: bob");
+    expect(hints).toContain("custom hint");
+    expect(hints).toHaveLength(4);
+  });
+
+  test("handles missing optional fields on macOS transport", () => {
+    const transport: MacosTransportMetadata = {
+      channelId: "vellum",
+      interfaceId: "macos",
+    };
+
+    const hints = buildTransportHints(transport);
+
+    expect(hints).toContain("User is messaging from interface: macos");
+    // Without hostHomeDir and hostUsername, only the interface hint is present
+    expect(hints).toHaveLength(1);
+    expect(hints.some((h) => h.includes("Host home directory"))).toBe(false);
+    expect(hints.some((h) => h.includes("Host username"))).toBe(false);
+  });
+});

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -41,6 +41,7 @@ import type {
   ServerMessage,
   UserMessageAttachment,
 } from "./message-protocol.js";
+import type { ConversationTransportMetadata } from "./message-types/conversations.js";
 
 const log = getLogger("conversation-messaging");
 
@@ -222,6 +223,7 @@ export function enqueueMessage(
   metadata?: Record<string, unknown>,
   options?: { isInteractive?: boolean },
   displayContent?: string,
+  transport?: ConversationTransportMetadata,
 ): { queued: boolean; requestId: string; rejected?: boolean } {
   if (!ctx.processing) {
     return { queued: false, requestId };
@@ -246,6 +248,7 @@ export function enqueueMessage(
     turnChannelContext,
     turnInterfaceContext,
     isInteractive: options?.isInteractive,
+    transport,
     displayContent,
     sentAt: Date.now(),
   });

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -298,12 +298,12 @@ export async function drainQueue(
   }
 
   // Apply transport hints from the queued message so each turn uses the
-  // transport metadata that arrived with its message, not whatever the
-  // conversation happened to have from a previous turn.
+  // transport metadata that arrived with its message. Messages without
+  // transport (subagent notifications, surface actions, etc.) inherit the
+  // conversation's existing hints — clearing them would erase the user's
+  // environment context for internal turns.
   if (next.transport) {
     conversation.setTransportHints(buildTransportHints(next.transport));
-  } else {
-    conversation.setTransportHints(undefined);
   }
 
   // Non-interactive queued messages (channel requests) must not execute tools

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -302,6 +302,8 @@ export async function drainQueue(
   // conversation happened to have from a previous turn.
   if (next.transport) {
     conversation.setTransportHints(buildTransportHints(next.transport));
+  } else {
+    conversation.setTransportHints(undefined);
   }
 
   // Non-interactive queued messages (channel requests) must not execute tools

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -48,6 +48,7 @@ import type {
   UserMessageAttachment,
 } from "./message-protocol.js";
 import type { TraceEmitter } from "./trace-emitter.js";
+import { buildTransportHints } from "./transport-hints.js";
 import { resolveVerificationSessionIntent } from "./verification-session-intent.js";
 
 const log = getLogger("conversation-process");
@@ -161,6 +162,8 @@ export interface ProcessConversationContext {
   ): void;
   /** Force context compaction regardless of threshold/cooldown. */
   forceCompact(): Promise<ContextWindowResult>;
+  /** Set transport-derived hints for the conversation. */
+  setTransportHints(hints: string[] | undefined): void;
 }
 
 function resolveQueuedTurnContext(
@@ -292,6 +295,13 @@ export async function drainQueue(
   );
   if (queuedInterfaceCtx) {
     conversation.setTurnInterfaceContext(queuedInterfaceCtx);
+  }
+
+  // Apply transport hints from the queued message so each turn uses the
+  // transport metadata that arrived with its message, not whatever the
+  // conversation happened to have from a previous turn.
+  if (next.transport) {
+    conversation.setTransportHints(buildTransportHints(next.transport));
   }
 
   // Non-interactive queued messages (channel requests) must not execute tools

--- a/assistant/src/daemon/conversation-queue-manager.ts
+++ b/assistant/src/daemon/conversation-queue-manager.ts
@@ -14,6 +14,7 @@ import type {
   ServerMessage,
   UserMessageAttachment,
 } from "./message-protocol.js";
+import type { ConversationTransportMetadata } from "./message-types/conversations.js";
 
 const log = getLogger("conversation-queue");
 
@@ -29,6 +30,8 @@ export interface QueuedMessage {
   turnInterfaceContext?: TurnInterfaceContext;
   /** When false, the turn has no interactive user and should skip clarification prompts. */
   isInteractive?: boolean;
+  /** Transport metadata snapshot captured at enqueue time, applied when this message becomes active. */
+  transport?: ConversationTransportMetadata;
   /** Original user message text to persist to DB when recording intent stripping produced a different `content`. */
   displayContent?: string;
   /** Wall-clock time (ms since epoch) when the message was enqueued, used as the display timestamp. */

--- a/assistant/src/daemon/conversation-queue-manager.ts
+++ b/assistant/src/daemon/conversation-queue-manager.ts
@@ -158,6 +158,11 @@ function estimateItemBytes(item: QueuedMessage): number {
     bytes += a.data.length * 2;
     if (a.extractedText) bytes += a.extractedText.length * 2;
   }
+  // Include transport metadata in the estimate so large transport
+  // payloads (e.g. hostHomeDir, hostUsername) count against the budget.
+  if (item.transport) {
+    bytes += JSON.stringify(item.transport).length * 2;
+  }
   // Small fixed overhead for metadata, pointers, etc. (not worth
   // measuring precisely — the content/attachment data dominates).
   bytes += 512;

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -30,6 +30,7 @@ import type {
   UiSurfaceShow,
 } from "./message-protocol.js";
 import { INTERACTIVE_SURFACE_TYPES } from "./message-protocol.js";
+import type { ConversationTransportMetadata } from "./message-types/conversations.js";
 import type { UserMessageAttachment } from "./message-types/shared.js";
 
 const log = getLogger("conversation-surfaces");
@@ -84,10 +85,7 @@ export function markSurfaceCompleted(
       }
     }
   } catch (err) {
-    log.warn(
-      { err, surfaceId },
-      "Failed to persist surface completion to DB",
-    );
+    log.warn({ err, surfaceId }, "Failed to persist surface completion to DB");
   }
 }
 const TASK_PROGRESS_TEMPLATE_FIELDS = ["title", "status", "steps"] as const;
@@ -285,6 +283,7 @@ export interface SurfaceConversationContext {
     metadata?: Record<string, unknown>,
     options?: { isInteractive?: boolean },
     displayContent?: string,
+    transport?: ConversationTransportMetadata,
   ): { queued: boolean; requestId: string; rejected?: boolean };
   getQueueDepth(): number;
   processMessage(

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -114,6 +114,7 @@ import type {
   UsageStats,
   UserMessageAttachment,
 } from "./message-protocol.js";
+import type { ConversationTransportMetadata } from "./message-types/conversations.js";
 import type {
   AssistantActivityState,
   ConfirmationStateChanged,
@@ -609,6 +610,7 @@ export class Conversation {
     metadata?: Record<string, unknown>,
     options?: { isInteractive?: boolean },
     displayContent?: string,
+    transport?: ConversationTransportMetadata,
   ): { queued: boolean; requestId: string; rejected?: boolean } {
     return enqueueMessageImpl(
       this,
@@ -621,6 +623,7 @@ export class Conversation {
       metadata,
       options,
       displayContent,
+      transport,
     );
   }
 

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -969,7 +969,13 @@ export class DaemonServer {
       }
       this.evictor.touch(conversationId);
     } else {
-      this.applyTransportMetadata(conversation, options);
+      // Only apply transport metadata when the conversation is idle.
+      // When processing, the hints are stored on the queued message and
+      // will be applied at dequeue time — applying them here would
+      // overwrite the in-flight conversation's transportHints.
+      if (!conversation.isProcessing()) {
+        this.applyTransportMetadata(conversation, options);
+      }
       this.evictor.touch(conversationId);
     }
     return conversation;

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -92,6 +92,7 @@ import type {
   ServerMessage,
   UserMessageAttachment,
 } from "./message-protocol.js";
+import { buildTransportHints } from "./transport-hints.js";
 
 const log = getLogger("server");
 
@@ -374,28 +375,7 @@ export class DaemonServer {
       { channelId: transport.channelId },
       "Transport metadata received",
     );
-
-    // Build enriched hints: interface ID first, then host environment (macOS
-    // only), then any client-provided hints.
-    const enrichedHints: string[] = [];
-
-    const interfaceLabel = parseInterfaceId(transport.interfaceId) ?? "vellum";
-    enrichedHints.push(`User is messaging from interface: ${interfaceLabel}`);
-
-    if (transport.interfaceId === "macos") {
-      if (transport.hostHomeDir) {
-        enrichedHints.push(`Host home directory: ${transport.hostHomeDir}`);
-      }
-      if (transport.hostUsername) {
-        enrichedHints.push(`Host username: ${transport.hostUsername}`);
-      }
-    }
-
-    if (transport.hints) {
-      enrichedHints.push(...transport.hints);
-    }
-
-    conversation.setTransportHints(enrichedHints);
+    conversation.setTransportHints(buildTransportHints(transport));
   }
 
   constructor() {

--- a/assistant/src/daemon/transport-hints.ts
+++ b/assistant/src/daemon/transport-hints.ts
@@ -1,0 +1,33 @@
+import { parseInterfaceId } from "../channels/types.js";
+import type { ConversationTransportMetadata } from "./message-types/conversations.js";
+
+/**
+ * Build enriched transport hints from conversation transport metadata.
+ *
+ * Interface ID first, then host environment (macOS only), then any
+ * client-provided hints. Shared between the conversation creation path
+ * (server.ts) and the queue drain path (conversation-process.ts).
+ */
+export function buildTransportHints(
+  transport: ConversationTransportMetadata,
+): string[] {
+  const hints: string[] = [];
+
+  const interfaceLabel = parseInterfaceId(transport.interfaceId) ?? "vellum";
+  hints.push(`User is messaging from interface: ${interfaceLabel}`);
+
+  if (transport.interfaceId === "macos") {
+    if (transport.hostHomeDir) {
+      hints.push(`Host home directory: ${transport.hostHomeDir}`);
+    }
+    if (transport.hostUsername) {
+      hints.push(`Host username: ${transport.hostUsername}`);
+    }
+  }
+
+  if (transport.hints) {
+    hints.push(...transport.hints);
+  }
+
+  return hints;
+}

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1339,6 +1339,8 @@ export async function handleSendMessage(
         ...(body.automated === true ? { automated: true } : {}),
       },
       { isInteractive },
+      undefined, // displayContent
+      transport,
     );
     if (enqueueResult.rejected) {
       return Response.json(


### PR DESCRIPTION
## Summary
Hardens the transport hints lifecycle so transport metadata (hostHomeDir, hostUsername, interfaceId) travels with each queued message and is applied when the message becomes active, rather than being immediately overwritten on the conversation object when a message arrives while the conversation is busy.

## PRs merged into feature branch
- #23838: feat: add transport metadata field to QueuedMessage type
- #23839: feat: pass transport metadata through enqueueMessage and store on queued items
- #23841: fix: apply transport metadata at dequeue time, extract shared buildTransportHints
- #23842: test: verify transport hints lifecycle through message queue

Part of plan: transport-hints-queue-hardening.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23843" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
