### PR TITLE
fix: guard applyTransportMetadata when conversation is busy

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -969,7 +969,13 @@ export class DaemonServer {
       }
       this.evictor.touch(conversationId);
     } else {
-      this.applyTransportMetadata(conversation, options);
+      // Only apply transport metadata when the conversation is idle.
+      // When processing, the hints are stored on the queued message and
+      // will be applied at dequeue time — applying them here would
+      // overwrite the in-flight conversation's transportHints.
+      if (!conversation.isProcessing()) {
+        this.applyTransportMetadata(conversation, options);
+      }
       this.evictor.touch(conversationId);
     }
     return conversation;


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for transport-hints-queue-hardening.md.

**Gap:** applyTransportMetadata still overwrites conversation hints on every getOrCreateConversation call
**What was expected:** Transport hints should only be applied when a message becomes active
**What was found:** The else branch for existing conversations calls applyTransportMetadata unconditionally, overwriting in-flight hints
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23844" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
