### PR TITLE
fix: align SurfaceConversationContext.enqueueMessage with Conversation implementation

### DIFF
--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -30,6 +30,7 @@ import type {
   UiSurfaceShow,
 } from "./message-protocol.js";
 import { INTERACTIVE_SURFACE_TYPES } from "./message-protocol.js";
+import type { ConversationTransportMetadata } from "./message-types/conversations.js";
 import type { UserMessageAttachment } from "./message-types/shared.js";
 
 const log = getLogger("conversation-surfaces");
@@ -84,10 +85,7 @@ export function markSurfaceCompleted(
       }
     }
   } catch (err) {
-    log.warn(
-      { err, surfaceId },
-      "Failed to persist surface completion to DB",
-    );
+    log.warn({ err, surfaceId }, "Failed to persist surface completion to DB");
   }
 }
 const TASK_PROGRESS_TEMPLATE_FIELDS = ["title", "status", "steps"] as const;
@@ -285,6 +283,7 @@ export interface SurfaceConversationContext {
     metadata?: Record<string, unknown>,
     options?: { isInteractive?: boolean },
     displayContent?: string,
+    transport?: ConversationTransportMetadata,
   ): { queued: boolean; requestId: string; rejected?: boolean };
   getQueueDepth(): number;
   processMessage(


### PR DESCRIPTION
## Summary
Adds missing `transport?` parameter to the `SurfaceConversationContext` interface's `enqueueMessage` method to match the actual `Conversation` class implementation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23845" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
