### PR TITLE
fix: reject `oauth connect` for manual-token providers

### DIFF
--- a/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
@@ -669,6 +669,31 @@ describe("assistant oauth connect", () => {
   });
 
   // -------------------------------------------------------------------------
+  // Manual-token providers (slack_channel, telegram)
+  // -------------------------------------------------------------------------
+
+  test("manual-token provider returns error directing to credentials command", async () => {
+    mockGetProvider = () => ({
+      providerKey: "slack_channel",
+      authUrl: "urn:manual-token",
+      tokenUrl: "urn:manual-token",
+      managedServiceConfigKey: null,
+    });
+    mockIsManagedMode = () => false;
+
+    const { exitCode, stdout } = await runCommand([
+      "connect",
+      "slack_channel",
+      "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("does not use OAuth");
+    expect(parsed.error).toContain("credentials set");
+  });
+
+  // -------------------------------------------------------------------------
   // Orchestrator error propagation
   // -------------------------------------------------------------------------
 

--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -336,6 +336,17 @@ Examples:
             // BYO PATH
             // =============================================================
 
+            // Manual-token providers (slack_channel, telegram) don't use
+            // OAuth2 browser flows — credentials are configured via
+            // `assistant credentials` or chat setup instead.
+            if (providerRow.authUrl === "urn:manual-token") {
+              writeError(
+                `"${provider}" does not use OAuth. ` +
+                  `Configure it with 'assistant credentials set ${provider}'.`,
+              );
+              return;
+            }
+
             // a. Resolve client credentials from the DB
             const dbApp = opts.clientId
               ? getAppByProviderAndClientId(provider, opts.clientId)


### PR DESCRIPTION
## Summary
- `assistant oauth connect slack_channel` was constructing a `urn:manual-token?...` authorization URL and opening it in the browser, which macOS routed to Microsoft Edge (registered as the `urn:` scheme handler)
- Added an early check in the BYO path that detects `urn:manual-token` providers and returns a clear error directing users to `assistant credentials set <provider>` instead
- Added test coverage for the new guard