### PR TITLE
fix: improve error message for manual-token oauth connect

### DIFF
--- a/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
@@ -689,8 +689,8 @@ describe("assistant oauth connect", () => {
     expect(exitCode).toBe(1);
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(false);
-    expect(parsed.error).toContain("does not use OAuth");
-    expect(parsed.error).toContain("credentials set");
+    expect(parsed.error).toContain("manual token configuration");
+    expect(parsed.error).toContain("credentials set --service");
   });
 
   // -------------------------------------------------------------------------

--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -341,8 +341,8 @@ Examples:
             // `assistant credentials` or chat setup instead.
             if (providerRow.authUrl === "urn:manual-token") {
               writeError(
-                `"${provider}" does not use OAuth. ` +
-                  `Configure it with 'assistant credentials set ${provider}'.`,
+                `"${provider}" uses manual token configuration, not an OAuth browser flow. ` +
+                  `Set credentials with 'assistant credentials set --service ${provider} --field <key> <value>'.`,
               );
               return;
             }


### PR DESCRIPTION
## Summary
- Changed error wording from "does not use OAuth" to "uses manual token configuration" — Slack does use OAuth, `slack_channel` just takes pre-generated tokens
- Fixed the suggested command to include the correct `--service` and `--field` flags