### PR TITLE
fix: remove .drawingGroup() from pinned apps to fix rendering issue

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -345,7 +345,6 @@ extension MainWindowView {
                         sidebarPinnedAppRow(app)
                     }
                 }
-                .drawingGroup() // Isolate into Metal layer to prevent re-renders from sibling hover
 
                 sidebarSectionDivider()
             }
@@ -477,7 +476,6 @@ extension MainWindowView {
                         sidebarPinnedAppRow(app, isExpanded: false)
                     }
                 }
-                .drawingGroup() // Isolate into Metal layer to prevent re-renders from sibling hover
 
                 sidebarSectionDivider()
             }


### PR DESCRIPTION
## Summary
- Removes `.drawingGroup()` from the pinned apps VStack in both expanded and collapsed sidebar modes
- This modifier was rendering pinned app rows into a Metal-backed offscreen CALayer, which could fail and show a yellow prohibition (🚫) banner instead of the actual app row
- The modifier was a performance optimization ("prevent re-renders from sibling hover") that isn't needed — pinned app rows are lightweight VNavItems

## Original prompt
it