### PR TITLE
feat(oauth): enable managed mode for Linear OAuth

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.0.0
 info:
   title: Vellum Assistant API
-  version: 0.6.0
+  version: 0.6.1
   description: Auto-generated OpenAPI specification for the Vellum Assistant runtime HTTP server.
 servers:
   - url: http://127.0.0.1:7821

--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -56,6 +56,11 @@ export const OutlookOAuthServiceSchema = BaseServiceSchema.extend({
 });
 export type OutlookOAuthService = z.infer<typeof OutlookOAuthServiceSchema>;
 
+export const LinearOAuthServiceSchema = BaseServiceSchema.extend({
+  mode: ServiceModeSchema.default("your-own"),
+});
+export type LinearOAuthService = z.infer<typeof LinearOAuthServiceSchema>;
+
 export const ServicesSchema = z.object({
   inference: InferenceServiceSchema.default(InferenceServiceSchema.parse({})),
   "image-generation": ImageGenerationServiceSchema.default(
@@ -69,6 +74,9 @@ export const ServicesSchema = z.object({
   ),
   "outlook-oauth": OutlookOAuthServiceSchema.default(
     OutlookOAuthServiceSchema.parse({}),
+  ),
+  "linear-oauth": LinearOAuthServiceSchema.default(
+    LinearOAuthServiceSchema.parse({}),
   ),
 });
 export type Services = z.infer<typeof ServicesSchema>;

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -295,6 +295,7 @@ const PROVIDER_SEED_DATA: Record<
     },
     extraParams: { prompt: "consent" },
     loopbackPort: 17324,
+    managedServiceConfigKey: "linear-oauth",
     injectionTemplates: [
       {
         hostPattern: "api.linear.app",


### PR DESCRIPTION
## Summary
- Add `LinearOAuthServiceSchema` to `services.ts` with mode defaulting to `your-own`
- Register `linear-oauth` key in `ServicesSchema`
- Set `managedServiceConfigKey: "linear-oauth"` on the Linear seed provider entry

Part of plan: linear-managed-oauth.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23858" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
