### PR TITLE
fix: disable 'Mark as unread' for scheduled conversations in sidebar view

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -56,6 +56,7 @@ struct SidebarConversationItem: View, Equatable {
     private var hasTrailingIcon: Bool { isHovered || isMenuOpen }
     private var canMarkUnread: Bool {
         !conversation.hasUnseenLatestAssistantMessage &&
+            !conversation.shouldSuppressUnreadIndicator &&
             conversation.conversationId != nil &&
             conversation.latestAssistantMessageAt != nil
     }


### PR DESCRIPTION
## Summary

- Add missing `shouldSuppressUnreadIndicator` check to `SidebarConversationItem.canMarkUnread`, aligning it with the store-level guard in `ConversationListStore.canMarkConversationUnread`
- Previously, the menu item appeared clickable for scheduled conversations but silently did nothing when clicked

## Original prompt
Fix mark-as-unread appearing enabled on scheduled conversations despite being blocked by store guard.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23859" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
