### PR TITLE
fix: resolve `isConnected` scope error in InferenceServiceCard

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -128,7 +128,7 @@ struct InferenceServiceCard: View {
                             providerHasKey = false
                             apiKeyText = ""
                         },
-                        showReset: isConnected
+                        showReset: providerHasKey
                     )
                 }
             }


### PR DESCRIPTION
## Summary
- Replace undefined `isConnected` with `providerHasKey` on the `showReset` parameter of `ServiceCardActions` in `InferenceServiceCard.swift`
- This was a leftover from the per-component key fetch migration (#23854) — all other service cards already use their `*HasKey` state for this parameter

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24059359863/job/70172264948
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23860" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
