### PR TITLE
feat(oauth): enable managed mode for Linear OAuth

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.0.0
 info:
   title: Vellum Assistant API
-  version: 0.6.0
+  version: 0.6.1
   description: Auto-generated OpenAPI specification for the Vellum Assistant runtime HTTP server.
 servers:
   - url: http://127.0.0.1:7821

--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -56,6 +56,11 @@ export const OutlookOAuthServiceSchema = BaseServiceSchema.extend({
 });
 export type OutlookOAuthService = z.infer<typeof OutlookOAuthServiceSchema>;
 
+export const LinearOAuthServiceSchema = BaseServiceSchema.extend({
+  mode: ServiceModeSchema.default("your-own"),
+});
+export type LinearOAuthService = z.infer<typeof LinearOAuthServiceSchema>;
+
 export const ServicesSchema = z.object({
   inference: InferenceServiceSchema.default(InferenceServiceSchema.parse({})),
   "image-generation": ImageGenerationServiceSchema.default(
@@ -69,6 +74,9 @@ export const ServicesSchema = z.object({
   ),
   "outlook-oauth": OutlookOAuthServiceSchema.default(
     OutlookOAuthServiceSchema.parse({}),
+  ),
+  "linear-oauth": LinearOAuthServiceSchema.default(
+    LinearOAuthServiceSchema.parse({}),
   ),
 });
 export type Services = z.infer<typeof ServicesSchema>;

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -295,6 +295,7 @@ const PROVIDER_SEED_DATA: Record<
     },
     extraParams: { prompt: "consent" },
     loopbackPort: 17324,
+    managedServiceConfigKey: "linear-oauth",
     injectionTemplates: [
       {
         hostPattern: "api.linear.app",

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -375,6 +375,8 @@ struct HatchingStepView: View {
             configValues["services.image-generation.mode"] = "managed"
             configValues["services.web-search.mode"] = "managed"
             configValues["services.google-oauth.mode"] = "managed"
+            configValues["services.outlook-oauth.mode"] = "managed"
+            configValues["services.linear-oauth.mode"] = "managed"
         }
         return configValues
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2234,6 +2234,14 @@ public final class SettingsStore: ObservableObject {
             self.managedOAuthMode["google"] = mode
             setManagedOAuthMode(mode, providerKey: "google")
         }
+        if let outlookOAuth = services["outlook-oauth"] as? [String: Any],
+           let mode = outlookOAuth["mode"] as? String {
+            self.managedOAuthMode["outlook"] = mode
+        }
+        if let linearOAuth = services["linear-oauth"] as? [String: Any],
+           let mode = linearOAuth["mode"] as? String {
+            self.managedOAuthMode["linear"] = mode
+        }
     }
 
     @discardableResult


### PR DESCRIPTION
## Summary
Enable the Linear OAuth provider to use managed mode in the desktop assistant. Adds `LinearOAuthServiceSchema` to the services config and sets `managedServiceConfigKey` on the Linear seed provider entry, allowing users to switch between BYO and managed Linear OAuth via `assistant oauth mode linear --set managed`.

Also sets both Outlook and Linear OAuth to managed mode by default during onboarding when the user logs in, and updates the macOS GUI to read those service modes.

## PRs merged into feature branch
- #23858: feat(oauth): enable managed mode for Linear OAuth
- #23864: feat(onboarding): set Outlook and Linear OAuth to managed by default

Part of plan: linear-managed-oauth.md