### PR TITLE
feat(onboarding): set Outlook and Linear OAuth to managed by default

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -375,6 +375,8 @@ struct HatchingStepView: View {
             configValues["services.image-generation.mode"] = "managed"
             configValues["services.web-search.mode"] = "managed"
             configValues["services.google-oauth.mode"] = "managed"
+            configValues["services.outlook-oauth.mode"] = "managed"
+            configValues["services.linear-oauth.mode"] = "managed"
         }
         return configValues
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2234,6 +2234,14 @@ public final class SettingsStore: ObservableObject {
             self.managedOAuthMode["google"] = mode
             setManagedOAuthMode(mode, providerKey: "google")
         }
+        if let outlookOAuth = services["outlook-oauth"] as? [String: Any],
+           let mode = outlookOAuth["mode"] as? String {
+            self.managedOAuthMode["outlook"] = mode
+        }
+        if let linearOAuth = services["linear-oauth"] as? [String: Any],
+           let mode = linearOAuth["mode"] as? String {
+            self.managedOAuthMode["linear"] = mode
+        }
     }
 
     @discardableResult


### PR DESCRIPTION
## Summary
- Add `services.outlook-oauth.mode` and `services.linear-oauth.mode` to the onboarding config values set when the user logs in
- Update `loadServiceModes()` in `SettingsStore.swift` to read `outlook-oauth` and `linear-oauth` modes so the macOS GUI reflects the correct state

Part of plan: linear-managed-oauth.md (follow-up)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23864" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
