### PR TITLE
fix: remove legacy `integration:` prefix shims and stale comments

### DIFF
--- a/assistant/src/messaging/provider.ts
+++ b/assistant/src/messaging/provider.ts
@@ -25,7 +25,7 @@ export interface MessagingProvider {
   id: string;
   /** Human-readable name (e.g. 'Slack', 'Gmail'). */
   displayName: string;
-  /** Credential service name for token-manager (e.g. 'integration:slack'). */
+  /** Credential service name for token-manager (e.g. 'slack'). */
   credentialService: string;
 
   // ── Universal operations (every platform must implement) ──────────

--- a/assistant/src/watcher/provider-types.ts
+++ b/assistant/src/watcher/provider-types.ts
@@ -28,7 +28,7 @@ export interface WatcherProvider {
   id: string;
   /** Human-readable name. */
   displayName: string;
-  /** Credential service required (e.g. 'integration:google'). */
+  /** Credential service required (e.g. 'google'). */
   requiredCredentialService: string;
 
   /**

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2225,14 +2225,6 @@ public final class SettingsStore: ObservableObject {
         if let googleOAuth = services["google-oauth"] as? [String: Any],
            let mode = googleOAuth["mode"] as? String {
             self.managedOAuthMode["google"] = mode
-        } else if let legacy = services["integration:google"] as? [String: Any],
-                  let mode = legacy["mode"] as? String {
-            // Migrate from the legacy key that was written due to a bug where
-            // setManagedOAuthMode fell back to the raw providerKey when metadata
-            // hadn't loaded yet. Read the value and re-save under the correct key
-            // so subsequent launches use the canonical path.
-            self.managedOAuthMode["google"] = mode
-            setManagedOAuthMode(mode, providerKey: "google")
         }
         if let outlookOAuth = services["outlook-oauth"] as? [String: Any],
            let mode = outlookOAuth["mode"] as? String {

--- a/packages/ces-contracts/src/handles.ts
+++ b/packages/ces-contracts/src/handles.ts
@@ -146,14 +146,12 @@ export function parseHandle(raw: string): ParseHandleResult {
     }
 
     case HandleType.LocalOAuth: {
-      // providerKey is typically a bare name (e.g. "google"), but legacy handles
-      // may contain a colon (e.g. "integration:google"), so we split on the
-      // *last* "/" to separate providerKey from connectionId.
-      const lastSlashIdx = rest.lastIndexOf("/");
+      // Split providerKey from connectionId.
+      const slashIdx = rest.indexOf("/");
       if (
-        lastSlashIdx === -1 ||
-        lastSlashIdx === 0 ||
-        lastSlashIdx === rest.length - 1
+        slashIdx === -1 ||
+        slashIdx === 0 ||
+        slashIdx === rest.length - 1
       ) {
         return {
           ok: false,
@@ -164,8 +162,8 @@ export function parseHandle(raw: string): ParseHandleResult {
         ok: true,
         handle: {
           type: HandleType.LocalOAuth,
-          providerKey: rest.slice(0, lastSlashIdx),
-          connectionId: rest.slice(lastSlashIdx + 1),
+          providerKey: rest.slice(0, slashIdx),
+          connectionId: rest.slice(slashIdx + 1),
           raw,
         },
       };


### PR DESCRIPTION
## Summary
Remove all legacy `integration:` prefix shims from the codebase. Migration 196 already stripped the prefix from DB provider keys — these are the leftover dead code, stale JSDoc examples, and a Swift fallback that are no longer needed.

## PRs merged into feature branch
- #23868: fix: remove legacy `integration:` prefix shims and stale comments

Part of plan: remove-integration-prefix-shims.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23869" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
