### PR TITLE
fix: polish earn credits modal and drawer styling

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -656,6 +656,7 @@ struct MainWindowView: View {
             .overlay(alignment: .bottomLeading) { preferencesDrawerLayer }
             .sheet(isPresented: $showEarnCreditsModal) {
                 EarnCreditsModal()
+                    .preferredColorScheme(themePreference == "light" ? .light : themePreference == "dark" ? .dark : systemIsDark ? .dark : .light)
             }
             .overlay { conversationSwitcherDismissLayer }
             .overlay(alignment: .topLeading) { conversationSwitcherDrawerLayer }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -57,13 +57,15 @@ struct DrawerMenuView: View {
                     }
                 }
 
+                VMenuDivider()
+
                 if isReferralVisible {
                     VMenuItem(icon: VIcon.gift.rawValue, label: String(localized: "Earn credits")) {
                         onEarnCredits()
                     }
-                }
 
-                VMenuDivider()
+                    VMenuDivider()
+                }
             }
 
             VMenuItem(icon: VIcon.settings.rawValue, label: String(localized: "Settings"), action: onSettings)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/EarnCreditsModal.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/EarnCreditsModal.swift
@@ -81,9 +81,11 @@ struct EarnCreditsModal: View {
 
     private func howItWorksStep(icon: VIcon, title: String, subtitle: String) -> some View {
         HStack(alignment: .top, spacing: VSpacing.md) {
-            VIconView(icon, size: 16)
+            VIconView(icon, size: 14)
                 .foregroundStyle(VColor.primaryBase)
-                .frame(width: 24, height: 24)
+                .frame(width: 28, height: 28)
+                .background(VColor.primaryBase.opacity(0.1))
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
@@ -107,7 +109,7 @@ struct EarnCreditsModal: View {
                     .font(.custom("DMMono-Regular", size: 13))
                     .foregroundStyle(VColor.contentDefault)
                     .lineLimit(1)
-                    .truncationMode(.tail)
+                    .truncationMode(.middle)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(VSpacing.sm)
                     .background(VColor.surfaceBase)
@@ -118,8 +120,8 @@ struct EarnCreditsModal: View {
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
 
                 VButton(
-                    label: copied ? "Copied!" : "Copy link",
-                    leftIcon: copied ? VIcon.check.rawValue : VIcon.copy.rawValue,
+                    label: copied ? "Copied" : "Copy referral link",
+                    iconOnly: copied ? VIcon.check.rawValue : VIcon.copy.rawValue,
                     style: .primary
                 ) {
                     copyToClipboard(code.referral_url)


### PR DESCRIPTION
## Summary
- Fix modal appearing with light background in dark mode by passing `preferredColorScheme` into the sheet presentation context
- Make the copy button icon-only (was full "Copy link" button) so the referral URL has more display room; switch to middle truncation
- Add tinted background squares behind how-it-works step icons for better visual contrast and hierarchy
- Move "Earn credits" item into its own divider-separated section in the drawer for clearer visual grouping

## Original prompt
fixes to all of the issues you noted
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23871" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
