### PR TITLE
fix: defer SelectableTextView updates to avoid reentrancy

### DIFF
--- a/clients/shared/DesignSystem/Components/Display/SelectableTextView.swift
+++ b/clients/shared/DesignSystem/Components/Display/SelectableTextView.swift
@@ -9,7 +9,9 @@ private final class SelectableNSTextView: NSTextView {
     override func resignFirstResponder() -> Bool {
         let result = super.resignFirstResponder()
         if result {
-            setSelectedRange(NSRange(location: 0, length: 0))
+            DispatchQueue.main.async { [weak self] in
+                self?.setSelectedRange(NSRange(location: 0, length: 0))
+            }
         }
         return result
     }
@@ -155,7 +157,7 @@ public struct VSelectableTextView: NSViewRepresentable {
         let coordinator = context.coordinator
         guard coordinator.lastAttributedString != attributedString
             || coordinator.lastLineSpacing != lineSpacing else { return }
-        coordinator.applyAttributedString(attributedString, lineSpacing: lineSpacing, to: textView)
+        coordinator.scheduleAttributedStringApply(attributedString, lineSpacing: lineSpacing, to: textView)
     }
 
     /// When `useExternalSizing` is `true`, returns `nil` so SwiftUI uses
@@ -181,7 +183,7 @@ public struct VSelectableTextView: NSViewRepresentable {
 
     public static func dismantleNSView(_ textView: NSTextView, coordinator: Coordinator) {
         textView.textStorage?.setAttributedString(NSAttributedString())
-        coordinator.lastAttributedString = nil
+        coordinator.reset()
     }
 
     public func makeCoordinator() -> Coordinator { Coordinator() }
@@ -189,6 +191,43 @@ public struct VSelectableTextView: NSViewRepresentable {
     public final class Coordinator {
         var lastAttributedString: NSAttributedString?
         var lastLineSpacing: CGFloat = 0
+        private var pendingAttributedString: NSAttributedString?
+        private var pendingLineSpacing: CGFloat?
+        private weak var pendingTextView: NSTextView?
+        private var hasScheduledApply = false
+
+        func reset() {
+            lastAttributedString = nil
+            lastLineSpacing = 0
+            pendingAttributedString = nil
+            pendingLineSpacing = nil
+            pendingTextView = nil
+            hasScheduledApply = false
+        }
+
+        func scheduleAttributedStringApply(
+            _ attributedString: NSAttributedString,
+            lineSpacing: CGFloat,
+            to textView: NSTextView
+        ) {
+            pendingAttributedString = attributedString
+            pendingLineSpacing = lineSpacing
+            pendingTextView = textView
+            guard !hasScheduledApply else { return }
+            hasScheduledApply = true
+
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.hasScheduledApply = false
+                guard let textView = self.pendingTextView,
+                      let attributedString = self.pendingAttributedString,
+                      let lineSpacing = self.pendingLineSpacing else { return }
+                self.pendingTextView = nil
+                self.pendingAttributedString = nil
+                self.pendingLineSpacing = nil
+                self.applyAttributedString(attributedString, lineSpacing: lineSpacing, to: textView)
+            }
+        }
 
         func applyAttributedString(
             _ attributedString: NSAttributedString,


### PR DESCRIPTION
## Summary
- Coalesce `applyAttributedString` calls through a new `scheduleAttributedStringApply` method that defers to the next run loop, preventing reentrancy when SwiftUI rapidly invokes `updateNSView`
- Defer `setSelectedRange` on `resignFirstResponder` via `DispatchQueue.main.async` to avoid mutating text storage mid-layout
- Add `reset()` to the Coordinator to properly clean up pending state on dismantle