### PR TITLE
fix: prevent PKB from being interleaved inside memory_image blocks

### DIFF
--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -599,6 +599,7 @@ export function injectPkbContext(message: Message, content: string): Message {
     if (
       block.type === "text" &&
       (block.text.startsWith("<memory") ||
+        block.text.startsWith("</memory") ||
         block.text.startsWith("<memory_context"))
     ) {
       insertIdx = i + 1;


### PR DESCRIPTION
## Summary
- Fix `injectPkbContext` insertion logic to also skip `</memory_image>` closing tags
- Without this fix, the PKB block gets nested inside the `<memory_image>` wrapper because the closing tag `</memory_image>` doesn't match `startsWith("<memory")`

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23875" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
