### PR TITLE
fix: deduplicate PKB injection across conversation turns

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -102,6 +102,7 @@ import {
   applyRuntimeInjections,
   buildUnifiedTurnContextBlock,
   findLastInjectedNowContent,
+  findLastInjectedPkbContent,
   inboundActorContextFromTrust,
   inboundActorContextFromTrustContext,
   readNowScratchpad,
@@ -786,8 +787,13 @@ export async function runAgentLoopImpl(
     const nowScratchpad =
       currentNowContent !== lastInjectedNow ? currentNowContent : null;
 
-    // Read PKB always-loaded files (INDEX, essentials, threads, buffer)
+    // Only inject PKB if it changed since the last injection in the
+    // conversation.  Keeping the previous injection in place avoids mutating
+    // historical user messages and preserves the cached prefix.
     const currentPkbContent = readPkbContext();
+    const lastInjectedPkb = findLastInjectedPkbContent(ctx.messages);
+    const pkbContext =
+      currentPkbContent !== lastInjectedPkb ? currentPkbContent : null;
 
     // Shared injection options — reused whenever we need to re-inject after reduction.
     const injectionOpts = {
@@ -798,7 +804,7 @@ export async function runAgentLoopImpl(
       channelCapabilities: ctx.channelCapabilities ?? null,
       channelCommandContext: ctx.commandIntent ?? null,
       unifiedTurnContext: unifiedTurnContextStr,
-      pkbContext: currentPkbContent,
+      pkbContext,
       nowScratchpad,
       voiceCallControlPrompt: ctx.voiceCallControlPrompt ?? null,
       transportHints: ctx.transportHints ?? null,
@@ -924,7 +930,7 @@ export async function runAgentLoopImpl(
         // value from injectionOpts to avoid duplicate injection.
         runMessages = applyRuntimeInjections(ctx.messages, {
           ...injectionOpts,
-          pkbContext: currentPkbContent,
+          ...(step.compactionResult?.compacted && { pkbContext: currentPkbContent }),
           ...(step.compactionResult?.compacted && { nowScratchpad: currentNowContent }),
           workspaceTopLevelContext: shouldInjectWorkspace
             ? ctx.workspaceTopLevelContext

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1086,6 +1086,28 @@ export function findLastInjectedNowContent(messages: Message[]): string | null {
 }
 
 /**
+ * Extract the most recently injected PKB content from the message history.
+ * Returns null if no PKB injection is found.
+ */
+export function findLastInjectedPkbContent(
+  messages: Message[],
+): string | null {
+  const prefix = "<pkb>\n";
+  const suffix = "\n</pkb>";
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.role !== "user") continue;
+    for (const block of msg.content) {
+      if (block.type === "text" && block.text.startsWith(prefix)) {
+        const end = block.text.lastIndexOf(suffix);
+        if (end > prefix.length) return block.text.slice(prefix.length, end);
+      }
+    }
+  }
+  return null;
+}
+
+/**
  * Controls which runtime injections are applied.
  *
  * - `'full'` (default): all injections are applied.


### PR DESCRIPTION
## Summary
- Add `findLastInjectedPkbContent()` to extract the last injected PKB content from message history
- Deduplicate PKB injection using the same pattern as NOW.md: only inject when content has changed since the last injection
- After compaction, forcefully reinject (compaction strips `<pkb>` blocks)

## Original prompt
Deduplicate PKB injection so it only reinjects after compaction, matching the NOW.md dedup pattern.