### PR TITLE
feat: add animated typing indicator to macOS chat

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -42,6 +42,7 @@ struct MessageListContentView: View, Equatable {
             && lhs.state.hasActiveToolCall == rhs.state.hasActiveToolCall
             && lhs.state.canInlineProcessing == rhs.state.canInlineProcessing
             && lhs.state.shouldShowThinkingIndicator == rhs.state.shouldShowThinkingIndicator
+            && lhs.state.isStreamingWithoutText == rhs.state.isStreamingWithoutText
             && lhs.state.hasMessages == rhs.state.hasMessages
             && lhs.providerCatalogHash == rhs.providerCatalogHash
             && lhs.isLoadingMoreMessages == rhs.isLoadingMoreMessages
@@ -108,12 +109,18 @@ struct MessageListContentView: View, Equatable {
 
     @ViewBuilder
     private func thinkingIndicatorRow(hasUserMessage: Bool) -> some View {
-        RunningIndicator(
-            label: !hasEverSentMessage && hasUserMessage
+        HStack(spacing: VSpacing.sm) {
+            TypingIndicatorView()
+            let label = !hasEverSentMessage && hasUserMessage
                 ? "Waking up..."
-                : assistantStatusText ?? "Thinking",
-            showIcon: false
-        )
+                : assistantStatusText
+            if let label, !label.isEmpty {
+                Text(label)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+            }
+            Spacer()
+        }
         .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
         .id("thinking-indicator")
         .transition(.opacity.combined(with: .move(edge: .bottom)))
@@ -247,6 +254,14 @@ struct MessageListContentView: View, Equatable {
                     thinkingIndicatorRow(hasUserMessage: state.hasUserMessage)
                 }
                 thinkingAvatarRow
+            } else if state.isStreamingWithoutText {
+                HStack {
+                    TypingIndicatorView()
+                    Spacer()
+                }
+                .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
+                .id("streaming-without-text-indicator")
+                .transition(.opacity.combined(with: .move(edge: .bottom)))
             } else if isCompacting && !state.shouldShowThinkingIndicator && !state.canInlineProcessing {
                 compactingIndicatorRow()
             }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
@@ -141,6 +141,7 @@ struct MessageListDerivedState {
     let hasActiveToolCall: Bool
     let canInlineProcessing: Bool
     let shouldShowThinkingIndicator: Bool
+    let isStreamingWithoutText: Bool
     let hasMessages: Bool
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
@@ -240,6 +240,10 @@ extension MessageListView {
         let lastVisibleIsAssistant = lastVisible?.role == .assistant
         let canInlineProcessing = wouldShowThinking && lastVisibleIsAssistant
         let shouldShowThinkingIndicator = wouldShowThinking && !canInlineProcessing
+        let isStreamingWithoutText = isSending
+            && (lastVisible?.isStreaming == true)
+            && (lastVisible?.text.isEmpty ?? true)
+            && !hasActiveToolCall
 
         let result = MessageListDerivedState(
             messageIndexById: layout.messageIndexById,
@@ -264,6 +268,7 @@ extension MessageListView {
             hasActiveToolCall: hasActiveToolCall,
             canInlineProcessing: canInlineProcessing,
             shouldShowThinkingIndicator: shouldShowThinkingIndicator,
+            isStreamingWithoutText: isStreamingWithoutText,
             hasMessages: !liveMessages.isEmpty
         )
 


### PR DESCRIPTION
## Summary
- Replace `RunningIndicator` with animated `TypingIndicatorView` in macOS thinking indicator row, matching iOS behavior
- Add `isStreamingWithoutText` derived state so typing dots show when streaming started but no text has arrived yet (e.g., between tool completion and first text chunk)
- Thread the new state through `MessageListDerivedState` and its `Equatable` conformance

## Original prompt
Add typing indicator to macOS chat (plan: prancy-finding-cosmos)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23877" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
