### PR TITLE
feat(memory): add parseConversationDirName as inverse of getConversationDirName

### DIFF
--- a/assistant/src/__tests__/conversation-directories-parse.test.ts
+++ b/assistant/src/__tests__/conversation-directories-parse.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getConversationDirName,
+  parseConversationDirName,
+} from "../memory/conversation-directories.js";
+
+describe("parseConversationDirName", () => {
+  describe("round-trip with getConversationDirName", () => {
+    test("round-trips a UUID-shaped id", () => {
+      const id = "4ae7ea90-86e4-446a-8673-7bba94ecfea1";
+      const createdAtMs = Date.parse("2026-04-07T10:47:23.075Z");
+      const name = getConversationDirName(id, createdAtMs);
+      const parsed = parseConversationDirName(name);
+      expect(parsed).toEqual({ conversationId: id, createdAtMs });
+    });
+
+    test("round-trips an id with embedded hyphens", () => {
+      const id = "conv-with-hyphens-123";
+      const createdAtMs = Date.parse("2024-01-15T00:00:00.000Z");
+      const name = getConversationDirName(id, createdAtMs);
+      const parsed = parseConversationDirName(name);
+      expect(parsed).toEqual({ conversationId: id, createdAtMs });
+    });
+
+    test("round-trips an id with embedded underscores", () => {
+      const id = "foo_bar_baz";
+      const createdAtMs = Date.parse("2025-12-31T23:59:59.999Z");
+      const name = getConversationDirName(id, createdAtMs);
+      const parsed = parseConversationDirName(name);
+      expect(parsed).toEqual({ conversationId: id, createdAtMs });
+    });
+  });
+
+  describe("exact parsing against literal example", () => {
+    test("parses the canonical example from the spec", () => {
+      const name =
+        "2026-04-07T10-47-23.075Z_4ae7ea90-86e4-446a-8673-7bba94ecfea1";
+      const parsed = parseConversationDirName(name);
+      expect(parsed).not.toBeNull();
+      expect(parsed?.conversationId).toBe(
+        "4ae7ea90-86e4-446a-8673-7bba94ecfea1",
+      );
+      expect(parsed?.createdAtMs).toBe(Date.parse("2026-04-07T10:47:23.075Z"));
+    });
+  });
+
+  describe("returns null for malformed input", () => {
+    test("returns null for empty string", () => {
+      expect(parseConversationDirName("")).toBeNull();
+    });
+
+    test("returns null for missing underscore", () => {
+      expect(parseConversationDirName("2026-04-07T10-47-23.075Z")).toBeNull();
+    });
+
+    test("returns null for legacy format (id first, timestamp second)", () => {
+      expect(
+        parseConversationDirName(
+          "4ae7ea90-86e4-446a-8673-7bba94ecfea1_2026-04-07T10-47-23.075Z",
+        ),
+      ).toBeNull();
+    });
+
+    test("returns null for non-ISO prefix", () => {
+      expect(parseConversationDirName("hello_world")).toBeNull();
+    });
+
+    test("returns null for random garbage", () => {
+      expect(parseConversationDirName("drafts/foo")).toBeNull();
+    });
+  });
+
+  describe("ids containing underscores", () => {
+    test("captures everything after the timestamp as the conversationId", () => {
+      const name = "2026-04-07T10-47-23.075Z_my_test_id";
+      const parsed = parseConversationDirName(name);
+      expect(parsed).not.toBeNull();
+      expect(parsed?.conversationId).toBe("my_test_id");
+      expect(parsed?.createdAtMs).toBe(Date.parse("2026-04-07T10:47:23.075Z"));
+    });
+  });
+});

--- a/assistant/src/memory/conversation-directories.ts
+++ b/assistant/src/memory/conversation-directories.ts
@@ -27,6 +27,33 @@ export function getConversationDirName(
 }
 
 /**
+ * Parse a canonical conversation directory name (`<ISO-with-dashes>_<id>`)
+ * back into its components. Returns null for names that don't match the
+ * canonical format — callers should treat null as "skip this entry"
+ * rather than as an error.
+ *
+ * Inverse of {@link getConversationDirName}. Does NOT parse the legacy
+ * `<id>_<ISO-with-dashes>` format.
+ */
+export function parseConversationDirName(
+  name: string,
+): { conversationId: string; createdAtMs: number } | null {
+  // Canonical format: YYYY-MM-DDTHH-MM-SS.sssZ_<uuid>
+  // The timestamp portion has 4 hyphens (date + time-component separators)
+  // and ends in `Z`. Anchor the regex to enforce that.
+  const match = name.match(
+    /^(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2}\.\d{1,9}Z)_(.+)$/,
+  );
+  if (!match) return null;
+  const [, datePart, hh, mm, ssAndMs, conversationId] = match;
+  const iso = `${datePart}T${hh}:${mm}:${ssAndMs}`;
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) return null;
+  if (!conversationId) return null;
+  return { conversationId, createdAtMs: ms };
+}
+
+/**
  * Return the absolute path to a conversation's timestamp-first disk-view
  * directory.
  */


### PR DESCRIPTION
## Summary
- Add `parseConversationDirName` to `conversation-directories.ts` as the inverse of `getConversationDirName`
- Pure function with full unit test coverage including round-trip, malformed, and edge cases

Part of plan: ws-export-allowlist.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
