### PR TITLE
Recognize .jsonl/.ndjson files as text in workspace + skill file APIs

### DIFF
--- a/assistant/src/runtime/routes/workspace-routes.test.ts
+++ b/assistant/src/runtime/routes/workspace-routes.test.ts
@@ -190,6 +190,28 @@ describe("isTextMimeType", () => {
     // A binary plist has a specific MIME type — extension should not override it
     expect(isTextMimeType("application/x-plist", "Info.plist")).toBe(false);
   });
+
+  test("application/octet-stream with .jsonl filename is text", () => {
+    expect(isTextMimeType("application/octet-stream", "messages.jsonl")).toBe(
+      true,
+    );
+  });
+
+  test("application/octet-stream with .ndjson filename is text", () => {
+    expect(isTextMimeType("application/octet-stream", "events.ndjson")).toBe(
+      true,
+    );
+  });
+
+  test("application/octet-stream with .JSONL uppercase is text", () => {
+    expect(isTextMimeType("application/octet-stream", "DATA.JSONL")).toBe(true);
+  });
+
+  test("application/octet-stream with .NDJSON uppercase is text", () => {
+    expect(isTextMimeType("application/octet-stream", "DATA.NDJSON")).toBe(
+      true,
+    );
+  });
 });
 
 // ===========================================================================

--- a/assistant/src/runtime/routes/workspace-utils.ts
+++ b/assistant/src/runtime/routes/workspace-utils.ts
@@ -159,6 +159,8 @@ const TEXT_FILE_EXTENSIONS = new Set([
   "patch",
   "log",
   "lock",
+  "jsonl",
+  "ndjson",
 ]);
 
 export function isTextMimeType(mimeType: string, fileName?: string): boolean {


### PR DESCRIPTION
## Summary
- Add `jsonl` and `ndjson` to `TEXT_FILE_EXTENSIONS` in `workspace-utils.ts`
- Add four regression tests in `workspace-routes.test.ts` covering both extensions and uppercase variants
- Single change fixes both the workspace and skill file viewers since both use `isTextMimeType`

Part of plan: macos-jsonl-viewer.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23881" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
