### PR TITLE
feat(log-export): collect workspace conversations dirs via allowlist

### DIFF
--- a/assistant/src/runtime/routes/log-export/AGENTS.md
+++ b/assistant/src/runtime/routes/log-export/AGENTS.md
@@ -81,4 +81,14 @@ most-relevant records first.
 
 ## Allowlisted entries
 
-- _(none yet — first entry will land in a follow-up PR)_
+- **`conversations/`**
+  - **Path**: `<workspace>/conversations/<ISO-with-dashes>_<conversationId>/`
+  - **Honors filters**: time (via the parsed timestamp prefix on each
+    directory name) and `conversationId` (exact match on the suffix — no
+    substring matching).
+  - **Cap**: shares the 10 MB workspace cap defined by
+    `MAX_WORKSPACE_PAYLOAD_BYTES` in `workspace-allowlist.ts`.
+  - **Notes**: Directory names that don't match the canonical
+    `<ISO-with-dashes>_<conversationId>` format are silently skipped
+    (Rule 3 — default deny). Legacy `<id>_<ISO>` directories are
+    intentionally excluded until they migrate to the canonical format.

--- a/assistant/src/runtime/routes/log-export/__tests__/workspace-allowlist.test.ts
+++ b/assistant/src/runtime/routes/log-export/__tests__/workspace-allowlist.test.ts
@@ -366,11 +366,11 @@ describe("collectWorkspaceData — conversations entry", () => {
     if (process.platform === "win32") return;
 
     // Seed a single canonical conversation directory and stick a
-    // symlink loop inside it (`loop -> .`). The recursive sizing walk
-    // used to follow symlinks via statSync, which would cause it to
-    // descend into the loop forever and hang the export. With lstat we
-    // expect the function to return promptly and still process the
-    // conversation directory.
+    // symlink loop inside it (`loop -> .`). `dirSizeWithinBudget` uses
+    // `lstatSync` so that symlinks are skipped rather than dereferenced;
+    // without this, following the symlink would recurse infinitely and
+    // hang the export. We expect the function to return promptly and
+    // still process the conversation directory.
     const conversationsDir = getConversationsDir();
     mkdirSync(conversationsDir, { recursive: true });
 
@@ -389,9 +389,10 @@ describe("collectWorkspaceData — conversations entry", () => {
     const result = collectWorkspaceData({ staging });
     const elapsedMs = Date.now() - startMs;
 
-    // Sanity check: the call must complete quickly. If lstat were ever
-    // reverted back to stat, this would hang and time out the bun test
-    // runner long before this assertion ever fired.
+    // Sanity check: the call must complete quickly. The `lstatSync`
+    // guard is what keeps this from hanging — if the recursive walker
+    // were to dereference the symlink, the bun test runner would time
+    // out long before this assertion ever fired.
     expect(elapsedMs).toBeLessThan(5000);
 
     expect(result.entries).toHaveLength(1);
@@ -405,5 +406,61 @@ describe("collectWorkspaceData — conversations entry", () => {
 
     const copied = readdirSync(join(staging, "workspace", "conversations"));
     expect(copied).toContain(CONV_DIRS.jan20);
+  });
+
+  test("rejects top-level symlinks pointing outside the conversations dir", () => {
+    // Symlink creation requires elevated permissions on Windows; skip
+    // there to avoid spurious failures in CI on Windows hosts.
+    if (process.platform === "win32") return;
+
+    // Create a directory OUTSIDE `conversations/` that masquerades as a
+    // valid conversation dir (with a `meta.json`). The allowlist guard
+    // must not allow a symlink with a canonical name to escape the
+    // `conversations/` boundary by dereferencing into this external
+    // target.
+    const externalTarget = mkdtempSync(
+      join(tmpdir(), "ws-allowlist-external-"),
+    );
+    try {
+      writeFileSync(
+        join(externalTarget, "meta.json"),
+        JSON.stringify({ name: "evil" }, null, 2),
+        "utf-8",
+      );
+      writeFileSync(
+        join(externalTarget, "secret.txt"),
+        "should never be copied",
+        "utf-8",
+      );
+
+      // Seed the conversations dir and add a symlink with a canonical
+      // name pointing at the external target.
+      const conversationsDir = getConversationsDir();
+      mkdirSync(conversationsDir, { recursive: true });
+
+      const evilName = "2025-01-30T00-00-00.000Z_evil-target";
+      symlinkSync(externalTarget, join(conversationsDir, evilName), "dir");
+
+      const result = collectWorkspaceData({ staging });
+
+      // The symlink must be skipped by the top-level `lstatSync` guard.
+      // Nothing from the external target should land in the staging
+      // directory and the entry summary should not count it.
+      expect(result.entries).toHaveLength(1);
+      const [entry] = result.entries;
+      expect(entry.entry).toBe("conversations");
+      expect(entry.itemCount).toBe(0);
+      expect(entry.skippedDueToCap).toBe(0);
+      expect(entry.bytes).toBe(0);
+      expect(result.totalBytes).toBe(0);
+
+      // No staging directory should have been created because nothing
+      // qualified for copying.
+      expect(existsSync(join(staging, "workspace", "conversations"))).toBe(
+        false,
+      );
+    } finally {
+      rmSync(externalTarget, { recursive: true, force: true });
+    }
   });
 });

--- a/assistant/src/runtime/routes/log-export/__tests__/workspace-allowlist.test.ts
+++ b/assistant/src/runtime/routes/log-export/__tests__/workspace-allowlist.test.ts
@@ -239,6 +239,86 @@ describe("collectWorkspaceData — conversations entry", () => {
     expect(existsSync(join(staging, "workspace", "conversations"))).toBe(false);
   });
 
+  test("byte cap keeps the newest conversations first", () => {
+    // Seed three dirs with distinct, non-trivial sizes and known
+    // timestamps. Use a padding file per dir so the per-dir byte total
+    // is predictable and large enough to push us past the cap after a
+    // couple entries have been copied.
+    const conversationsDir = getConversationsDir();
+    mkdirSync(conversationsDir, { recursive: true });
+
+    const PADDING_BYTES = 4000;
+    const padding = "a".repeat(PADDING_BYTES);
+    for (const name of [CONV_DIRS.jan10, CONV_DIRS.jan15, CONV_DIRS.jan20]) {
+      const dir = join(conversationsDir, name);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, "pad.txt"), padding, "utf-8");
+    }
+
+    // Each dir weighs ~PADDING_BYTES. A 10 KB cap fits exactly 2 dirs
+    // (but not the third).
+    const result = collectWorkspaceData({
+      staging,
+      maxBytes: PADDING_BYTES * 2 + 500,
+    });
+
+    expect(result.entries).toHaveLength(1);
+    const [entry] = result.entries;
+    expect(entry.itemCount).toBe(2);
+    expect(entry.skippedDueToCap).toBe(1);
+
+    // The two newest dirs (jan20 and jan15) should have been copied;
+    // jan10 (oldest) should be the one skipped due to the cap.
+    const copied = readdirSync(join(staging, "workspace", "conversations"));
+    expect(copied).toContain(CONV_DIRS.jan20);
+    expect(copied).toContain(CONV_DIRS.jan15);
+    expect(copied).not.toContain(CONV_DIRS.jan10);
+  });
+
+  test("non-directory entries with canonical-looking names are skipped", () => {
+    // Make sure the conversations dir exists and seed one valid dir so
+    // we can confirm the function still copies legit entries alongside
+    // the bogus regular file.
+    const conversationsDir = getConversationsDir();
+    mkdirSync(conversationsDir, { recursive: true });
+
+    // Seed a real canonical conversation dir so there's something to copy.
+    const validDir = join(conversationsDir, CONV_DIRS.jan20);
+    mkdirSync(validDir, { recursive: true });
+    writeFileSync(
+      join(validDir, "meta.json"),
+      JSON.stringify({ name: CONV_DIRS.jan20 }, null, 2),
+      "utf-8",
+    );
+
+    // Seed a REGULAR FILE whose name matches the canonical
+    // `<ISO>_<conversationId>` pattern. Fill it with data that is big
+    // enough to exceed the cap, to prove that the non-dir guard bails
+    // before `dirSizeWithinBudget`/`cpSync` could silently copy it.
+    const bogusName = "2025-01-15T00-00-00.000Z_conv-jan15-as-file";
+    const bogusPath = join(conversationsDir, bogusName);
+    writeFileSync(bogusPath, "x".repeat(1024 * 1024), "utf-8"); // 1 MB
+
+    // Use a tight cap (larger than the valid dir but smaller than the
+    // bogus file) to prove the bogus file is skipped before copying.
+    const result = collectWorkspaceData({
+      staging,
+      maxBytes: 100 * 1024, // 100 KB
+    });
+
+    expect(result.entries).toHaveLength(1);
+    const [entry] = result.entries;
+    // Only the real conversation dir should have been copied.
+    expect(entry.itemCount).toBe(1);
+    // skippedDueToCap should NOT include the bogus file — it's rejected
+    // by the non-dir guard, not by the cap.
+    expect(entry.skippedDueToCap).toBe(0);
+
+    const copied = readdirSync(join(staging, "workspace", "conversations"));
+    expect(copied).toEqual([CONV_DIRS.jan20]);
+    expect(copied).not.toContain(bogusName);
+  });
+
   test("missing conversations dir returns an empty entry summary", () => {
     // Do NOT seed — workspace has no conversations/ subdir.
     const conversationsDir = getConversationsDir();

--- a/assistant/src/runtime/routes/log-export/__tests__/workspace-allowlist.test.ts
+++ b/assistant/src/runtime/routes/log-export/__tests__/workspace-allowlist.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Tests for the workspace allowlist module used by `POST /v1/export`.
+ *
+ * Validates that `collectWorkspaceData` honors the time + conversationId
+ * filters, enforces the workspace cap, ignores malformed conversation
+ * directory names, and never throws.
+ *
+ * The shared `test-preload.ts` sets `VELLUM_WORKSPACE_DIR` to a per-file
+ * temp directory before any test code runs, so `getConversationsDir()`
+ * already resolves under our temp workspace. We just seed the
+ * `conversations/` subdirectory before each test and tear it down
+ * afterwards.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { getConversationsDir } from "../../../../util/platform.js";
+import { collectWorkspaceData } from "../workspace-allowlist.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CONV_DIRS = {
+  jan10: "2025-01-10T00-00-00.000Z_conv-jan10",
+  jan15: "2025-01-15T00-00-00.000Z_conv-jan15",
+  jan20: "2025-01-20T00-00-00.000Z_conv-jan20",
+  jan25: "2025-01-25T00-00-00.000Z_conv-jan25",
+  invalid: "not-a-valid-name",
+  jan15Attachments: "2025-01-15T00-00-00.000Z_conv-jan15-with-attachments",
+} as const;
+
+function seedConversations(): void {
+  const conversationsDir = getConversationsDir();
+  mkdirSync(conversationsDir, { recursive: true });
+
+  // Four canonical conversation dirs with a meta + messages file each.
+  for (const name of [
+    CONV_DIRS.jan10,
+    CONV_DIRS.jan15,
+    CONV_DIRS.jan20,
+    CONV_DIRS.jan25,
+  ]) {
+    const dir = join(conversationsDir, name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "meta.json"),
+      JSON.stringify({ name }, null, 2),
+      "utf-8",
+    );
+    writeFileSync(
+      join(dir, "messages.jsonl"),
+      `{"role":"user","content":"hi from ${name}"}\n`,
+      "utf-8",
+    );
+  }
+
+  // Malformed dir — should be skipped because parseConversationDirName
+  // returns null for it.
+  const invalidDir = join(conversationsDir, CONV_DIRS.invalid);
+  mkdirSync(invalidDir, { recursive: true });
+  writeFileSync(join(invalidDir, "junk.txt"), "should not be copied", "utf-8");
+
+  // A separate canonical conversation dir whose id is *not* an exact match
+  // for "conv-jan15" — used to verify that the conversationId filter does
+  // exact matching, not substring matching.
+  const attachmentsDir = join(conversationsDir, CONV_DIRS.jan15Attachments);
+  mkdirSync(join(attachmentsDir, "attachments"), { recursive: true });
+  writeFileSync(
+    join(attachmentsDir, "meta.json"),
+    JSON.stringify({ name: CONV_DIRS.jan15Attachments }, null, 2),
+    "utf-8",
+  );
+  writeFileSync(
+    join(attachmentsDir, "attachments", "photo.png"),
+    "PNGDATA",
+    "utf-8",
+  );
+}
+
+let staging: string;
+
+beforeEach(() => {
+  // Fresh staging directory for each test.
+  staging = mkdtempSync(join(tmpdir(), "ws-allowlist-staging-"));
+  // Reset the workspace's conversations dir between tests.
+  const conversationsDir = getConversationsDir();
+  rmSync(conversationsDir, { recursive: true, force: true });
+});
+
+afterEach(() => {
+  try {
+    rmSync(staging, { recursive: true, force: true });
+  } catch {
+    /* best-effort cleanup */
+  }
+  // Wipe the workspace's conversations dir so test files can't bleed into
+  // each other.
+  try {
+    rmSync(getConversationsDir(), { recursive: true, force: true });
+  } catch {
+    /* best-effort cleanup */
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("collectWorkspaceData — conversations entry", () => {
+  test("copies all valid conversation dirs when no filters are set", () => {
+    seedConversations();
+
+    const result = collectWorkspaceData({ staging });
+
+    expect(result.entries).toHaveLength(1);
+    const [entry] = result.entries;
+    expect(entry.entry).toBe("conversations");
+    // Four valid + one extra canonical (jan15-with-attachments) = 5
+    expect(entry.itemCount).toBe(5);
+    expect(entry.skippedDueToCap).toBe(0);
+    expect(entry.bytes).toBeGreaterThan(0);
+    expect(result.totalBytes).toBe(entry.bytes);
+
+    const copied = readdirSync(join(staging, "workspace", "conversations"));
+    expect(copied).toContain(CONV_DIRS.jan10);
+    expect(copied).toContain(CONV_DIRS.jan15);
+    expect(copied).toContain(CONV_DIRS.jan20);
+    expect(copied).toContain(CONV_DIRS.jan25);
+    expect(copied).toContain(CONV_DIRS.jan15Attachments);
+    // Malformed dir is skipped.
+    expect(copied).not.toContain(CONV_DIRS.invalid);
+  });
+
+  test("startTime filter excludes earlier conversations", () => {
+    seedConversations();
+    const startTime = Date.parse("2025-01-14T00:00:00Z");
+
+    const result = collectWorkspaceData({ staging, startTime });
+
+    const copied = readdirSync(join(staging, "workspace", "conversations"));
+    expect(copied).not.toContain(CONV_DIRS.jan10);
+    expect(copied).toContain(CONV_DIRS.jan15);
+    expect(copied).toContain(CONV_DIRS.jan20);
+    expect(copied).toContain(CONV_DIRS.jan25);
+    // jan15-with-attachments has the same timestamp as jan15 → still included.
+    expect(copied).toContain(CONV_DIRS.jan15Attachments);
+    expect(result.entries[0].itemCount).toBe(4);
+  });
+
+  test("endTime filter excludes later conversations", () => {
+    seedConversations();
+    const endTime = Date.parse("2025-01-22T00:00:00Z");
+
+    const result = collectWorkspaceData({ staging, endTime });
+
+    const copied = readdirSync(join(staging, "workspace", "conversations"));
+    expect(copied).toContain(CONV_DIRS.jan10);
+    expect(copied).toContain(CONV_DIRS.jan15);
+    expect(copied).toContain(CONV_DIRS.jan20);
+    expect(copied).not.toContain(CONV_DIRS.jan25);
+    expect(copied).toContain(CONV_DIRS.jan15Attachments);
+    expect(result.entries[0].itemCount).toBe(4);
+  });
+
+  test("startTime + endTime keeps only conversations inside the window", () => {
+    seedConversations();
+    const startTime = Date.parse("2025-01-14T00:00:00Z");
+    const endTime = Date.parse("2025-01-22T00:00:00Z");
+
+    const result = collectWorkspaceData({ staging, startTime, endTime });
+
+    const copied = readdirSync(join(staging, "workspace", "conversations"));
+    expect(copied).not.toContain(CONV_DIRS.jan10);
+    expect(copied).toContain(CONV_DIRS.jan15);
+    expect(copied).toContain(CONV_DIRS.jan20);
+    expect(copied).not.toContain(CONV_DIRS.jan25);
+    // jan15-with-attachments shares the Jan 15 timestamp → still included.
+    expect(copied).toContain(CONV_DIRS.jan15Attachments);
+    expect(result.entries[0].itemCount).toBe(3);
+  });
+
+  test("conversationId filter matches exactly (no substrings)", () => {
+    seedConversations();
+
+    const result = collectWorkspaceData({
+      staging,
+      conversationId: "conv-jan15",
+    });
+
+    const copied = readdirSync(join(staging, "workspace", "conversations"));
+    expect(copied).toEqual([CONV_DIRS.jan15]);
+    // Crucially, the substring-match attachments dir is NOT included.
+    expect(copied).not.toContain(CONV_DIRS.jan15Attachments);
+    expect(result.entries[0].itemCount).toBe(1);
+  });
+
+  test("conversationId + time filter intersection can be empty", () => {
+    seedConversations();
+
+    const result = collectWorkspaceData({
+      staging,
+      conversationId: "conv-jan15",
+      // Window that excludes Jan 15.
+      startTime: Date.parse("2025-01-16T00:00:00Z"),
+      endTime: Date.parse("2025-01-22T00:00:00Z"),
+    });
+
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].itemCount).toBe(0);
+    expect(result.entries[0].bytes).toBe(0);
+    expect(result.totalBytes).toBe(0);
+    // No directory should have been created because nothing was copied.
+    expect(existsSync(join(staging, "workspace", "conversations"))).toBe(false);
+  });
+
+  test("byte cap enforcement skips every conversation when too tight", () => {
+    seedConversations();
+
+    // 1 byte cap is impossible to fit any seeded dir into.
+    const result = collectWorkspaceData({ staging, maxBytes: 1 });
+
+    expect(result.entries).toHaveLength(1);
+    const [entry] = result.entries;
+    expect(entry.itemCount).toBe(0);
+    expect(entry.bytes).toBe(0);
+    expect(entry.skippedDueToCap).toBe(5);
+    expect(result.totalBytes).toBe(0);
+    expect(existsSync(join(staging, "workspace", "conversations"))).toBe(false);
+  });
+
+  test("missing conversations dir returns an empty entry summary", () => {
+    // Do NOT seed — workspace has no conversations/ subdir.
+    const conversationsDir = getConversationsDir();
+    rmSync(conversationsDir, { recursive: true, force: true });
+    expect(existsSync(conversationsDir)).toBe(false);
+
+    const result = collectWorkspaceData({ staging });
+
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0]).toEqual({
+      entry: "conversations",
+      itemCount: 0,
+      bytes: 0,
+      skippedDueToCap: 0,
+    });
+    expect(result.totalBytes).toBe(0);
+    expect(existsSync(join(staging, "workspace"))).toBe(false);
+  });
+
+  test("recursive copy preserves nested attachments", () => {
+    seedConversations();
+
+    collectWorkspaceData({
+      staging,
+      conversationId: "conv-jan15-with-attachments",
+    });
+
+    const copied = readdirSync(join(staging, "workspace", "conversations"));
+    expect(copied).toEqual([CONV_DIRS.jan15Attachments]);
+    const photoPath = join(
+      staging,
+      "workspace",
+      "conversations",
+      CONV_DIRS.jan15Attachments,
+      "attachments",
+      "photo.png",
+    );
+    expect(existsSync(photoPath)).toBe(true);
+  });
+});

--- a/assistant/src/runtime/routes/log-export/__tests__/workspace-allowlist.test.ts
+++ b/assistant/src/runtime/routes/log-export/__tests__/workspace-allowlist.test.ts
@@ -18,6 +18,7 @@ import {
   mkdtempSync,
   readdirSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -357,5 +358,52 @@ describe("collectWorkspaceData — conversations entry", () => {
       "photo.png",
     );
     expect(existsSync(photoPath)).toBe(true);
+  });
+
+  test("skips symlinked directories to avoid infinite loops", () => {
+    // Symlink creation requires elevated permissions on Windows; skip
+    // there to avoid spurious failures in CI on Windows hosts.
+    if (process.platform === "win32") return;
+
+    // Seed a single canonical conversation directory and stick a
+    // symlink loop inside it (`loop -> .`). The recursive sizing walk
+    // used to follow symlinks via statSync, which would cause it to
+    // descend into the loop forever and hang the export. With lstat we
+    // expect the function to return promptly and still process the
+    // conversation directory.
+    const conversationsDir = getConversationsDir();
+    mkdirSync(conversationsDir, { recursive: true });
+
+    const convDir = join(conversationsDir, CONV_DIRS.jan20);
+    mkdirSync(convDir, { recursive: true });
+    writeFileSync(
+      join(convDir, "meta.json"),
+      JSON.stringify({ name: CONV_DIRS.jan20 }, null, 2),
+      "utf-8",
+    );
+
+    // Create the loop: <conv-dir>/loop -> .
+    symlinkSync(".", join(convDir, "loop"), "dir");
+
+    const startMs = Date.now();
+    const result = collectWorkspaceData({ staging });
+    const elapsedMs = Date.now() - startMs;
+
+    // Sanity check: the call must complete quickly. If lstat were ever
+    // reverted back to stat, this would hang and time out the bun test
+    // runner long before this assertion ever fired.
+    expect(elapsedMs).toBeLessThan(5000);
+
+    expect(result.entries).toHaveLength(1);
+    const [entry] = result.entries;
+    expect(entry.entry).toBe("conversations");
+    // The conversation directory should still be processed and copied;
+    // we don't care whether the symlink itself was reproduced in the
+    // copy — the key invariant is that the function completed.
+    expect(entry.itemCount).toBe(1);
+    expect(entry.skippedDueToCap).toBe(0);
+
+    const copied = readdirSync(join(staging, "workspace", "conversations"));
+    expect(copied).toContain(CONV_DIRS.jan20);
   });
 });

--- a/assistant/src/runtime/routes/log-export/workspace-allowlist.ts
+++ b/assistant/src/runtime/routes/log-export/workspace-allowlist.ts
@@ -143,6 +143,15 @@ function collectConversations(
 
   const destBase = join(opts.staging, "workspace", "conversations");
 
+  // First pass: parse + filter all names and collect the surviving
+  // candidates so we can sort them deterministically before applying the
+  // byte cap. Without this, `readdirSync` order determines which
+  // conversations are dropped on truncation, which both makes capped
+  // exports nondeterministic and can drop the newest conversations.
+  const candidates: Array<{
+    name: string;
+    parsed: { conversationId: string; createdAtMs: number };
+  }> = [];
   for (const name of names) {
     let parsed: ReturnType<typeof parseConversationDirName>;
     try {
@@ -169,7 +178,32 @@ function collectConversations(
       continue;
     }
 
+    candidates.push({ name, parsed });
+  }
+
+  // Newest first so cap-truncation keeps the most recent conversations.
+  candidates.sort((a, b) => b.parsed.createdAtMs - a.parsed.createdAtMs);
+
+  for (const { name } of candidates) {
     const srcPath = join(sourceDir, name);
+
+    // Guard: a canonical-looking entry might actually be a regular file
+    // (not a directory). Without this check, `dirSizeWithinBudget` would
+    // log an ENOTDIR warning and return 0, causing `cpSync` to blindly
+    // copy the file and bypass the byte cap. Skip non-directories
+    // entirely — they don't match the conversation-directory contract.
+    let srcStat: ReturnType<typeof statSync>;
+    try {
+      srcStat = statSync(srcPath);
+    } catch (err) {
+      log.warn({ err, srcPath }, "Failed to stat conversation entry; skipping");
+      continue;
+    }
+    if (!srcStat.isDirectory()) {
+      log.warn({ srcPath }, "Conversation entry is not a directory; skipping");
+      continue;
+    }
+
     const remainingBudget = maxBytes - result.totalBytes;
     let dirBytes: number | null;
     try {

--- a/assistant/src/runtime/routes/log-export/workspace-allowlist.ts
+++ b/assistant/src/runtime/routes/log-export/workspace-allowlist.ts
@@ -14,14 +14,7 @@
  * `<ISO-with-dashes>_<conversationId>` format are silently skipped (Rule 3).
  */
 
-import {
-  cpSync,
-  existsSync,
-  lstatSync,
-  mkdirSync,
-  readdirSync,
-  statSync,
-} from "node:fs";
+import { cpSync, existsSync, lstatSync, mkdirSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { parseConversationDirName } from "../../../memory/conversation-directories.js";
@@ -200,16 +193,25 @@ function collectConversations(
   for (const { name } of candidates) {
     const srcPath = join(sourceDir, name);
 
-    // Guard: a canonical-looking entry might actually be a regular file
-    // (not a directory). Without this check, `dirSizeWithinBudget` would
-    // log an ENOTDIR warning and return 0, causing `cpSync` to blindly
-    // copy the file and bypass the byte cap. Skip non-directories
-    // entirely — they don't match the conversation-directory contract.
-    let srcStat: ReturnType<typeof statSync>;
+    // Guard: a canonical-looking entry must be a real directory under
+    // `conversations/`. Use `lstatSync` (not `statSync`) so symlinks are
+    // not dereferenced — a symlink with a canonical name pointing at an
+    // external directory must not be allowed to escape the allowlist
+    // boundary. Symlinks are rejected explicitly below; regular files
+    // (and anything else that isn't a directory) are also skipped so
+    // `dirSizeWithinBudget` and `cpSync` never see them.
+    let srcStat: ReturnType<typeof lstatSync>;
     try {
-      srcStat = statSync(srcPath);
+      srcStat = lstatSync(srcPath);
     } catch (err) {
       log.warn({ err, srcPath }, "Failed to stat conversation entry; skipping");
+      continue;
+    }
+    if (srcStat.isSymbolicLink()) {
+      log.warn(
+        { srcPath },
+        "Conversation entry is a symbolic link; skipping to preserve allowlist boundary",
+      );
       continue;
     }
     if (!srcStat.isDirectory()) {

--- a/assistant/src/runtime/routes/log-export/workspace-allowlist.ts
+++ b/assistant/src/runtime/routes/log-export/workspace-allowlist.ts
@@ -1,0 +1,248 @@
+/**
+ * Workspace allowlist module for the daemon log export endpoint.
+ *
+ * `POST /v1/export` collects audit DB rows, daemon logs, and a sanitized
+ * `config.json` snapshot. This module governs which subpaths of the user's
+ * workspace directory (`~/.vellum/workspace/`) are *opted in* to the export
+ * archive. The default is "nothing from the workspace ships" — every entry
+ * here must be justified against the rules in `./AGENTS.md`.
+ *
+ * The first allowlisted entry is `<workspace>/conversations/`, which honors
+ * both the time filter (via the parsed timestamp prefix on each conversation
+ * directory name) and the conversationId filter (via exact match on the id
+ * suffix). Directory names that don't match the canonical
+ * `<ISO-with-dashes>_<conversationId>` format are silently skipped (Rule 3).
+ */
+
+import { cpSync, existsSync, mkdirSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { parseConversationDirName } from "../../../memory/conversation-directories.js";
+import { getLogger } from "../../../util/logger.js";
+import { getConversationsDir } from "../../../util/platform.js";
+
+const log = getLogger("log-export-workspace");
+
+/**
+ * Maximum total bytes that the workspace allowlist may contribute to a
+ * single export archive. Mirrors `MAX_LOG_PAYLOAD_BYTES` in
+ * `log-export-routes.ts` so that the workspace section can never blow past
+ * the same 10 MB cap that already governs the daemon-logs section.
+ */
+export const MAX_WORKSPACE_PAYLOAD_BYTES = 10 * 1024 * 1024;
+
+export interface CollectWorkspaceDataOptions {
+  /** Absolute path of the export staging directory. */
+  staging: string;
+  /** When set, restrict allowlisted entries to this conversation. */
+  conversationId?: string;
+  /** Lower bound (epoch ms, inclusive). */
+  startTime?: number;
+  /** Upper bound (epoch ms, inclusive). */
+  endTime?: number;
+  /** Override the default 10 MB cap (used in tests). */
+  maxBytes?: number;
+}
+
+export interface CollectWorkspaceDataResult {
+  /** Allowlisted entries that were copied to staging/workspace/. */
+  entries: Array<{
+    /** Allowlist entry name (e.g. "conversations"). */
+    entry: string;
+    /** Number of items (files or subdirs) copied. */
+    itemCount: number;
+    /** Total bytes copied for this entry. */
+    bytes: number;
+    /** Items skipped because the cap would be exceeded. */
+    skippedDueToCap: number;
+  }>;
+  totalBytes: number;
+}
+
+/**
+ * Walk a directory recursively and sum the sizes of every regular file
+ * underneath it. Bails out early once the running total would push the
+ * workspace cap over `remainingBudget` bytes — that way we never burn
+ * cycles totalling a multi-gigabyte directory only to discard it.
+ *
+ * Returns `null` to signal "this directory is too big to fit in the
+ * remaining budget"; returns the exact byte total otherwise.
+ */
+function dirSizeWithinBudget(
+  rootDir: string,
+  remainingBudget: number,
+): number | null {
+  let total = 0;
+  const stack: string[] = [rootDir];
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    let entries: string[];
+    try {
+      entries = readdirSync(current);
+    } catch (err) {
+      log.warn(
+        { err, dir: current },
+        "Failed to read workspace directory while sizing; skipping",
+      );
+      continue;
+    }
+    for (const name of entries) {
+      const child = join(current, name);
+      let stat: ReturnType<typeof statSync>;
+      try {
+        stat = statSync(child);
+      } catch (err) {
+        log.warn(
+          { err, path: child },
+          "Failed to stat workspace path while sizing; skipping",
+        );
+        continue;
+      }
+      if (stat.isDirectory()) {
+        stack.push(child);
+      } else if (stat.isFile()) {
+        total += stat.size;
+        if (total > remainingBudget) {
+          return null;
+        }
+      }
+    }
+  }
+  return total;
+}
+
+function collectConversations(
+  opts: CollectWorkspaceDataOptions,
+  result: CollectWorkspaceDataResult,
+): void {
+  const maxBytes = opts.maxBytes ?? MAX_WORKSPACE_PAYLOAD_BYTES;
+  const entry = {
+    entry: "conversations",
+    itemCount: 0,
+    bytes: 0,
+    skippedDueToCap: 0,
+  };
+
+  const sourceDir = getConversationsDir();
+  if (!existsSync(sourceDir)) {
+    result.entries.push(entry);
+    return;
+  }
+
+  let names: string[];
+  try {
+    names = readdirSync(sourceDir);
+  } catch (err) {
+    log.warn(
+      { err, sourceDir },
+      "Failed to read conversations directory; skipping conversations entry",
+    );
+    result.entries.push(entry);
+    return;
+  }
+
+  const destBase = join(opts.staging, "workspace", "conversations");
+
+  for (const name of names) {
+    let parsed: ReturnType<typeof parseConversationDirName>;
+    try {
+      parsed = parseConversationDirName(name);
+    } catch (err) {
+      log.warn(
+        { err, name },
+        "Failed to parse conversation directory name; skipping",
+      );
+      continue;
+    }
+    if (!parsed) continue; // Rule 3 — default deny non-canonical names.
+
+    if (
+      opts.conversationId !== undefined &&
+      parsed.conversationId !== opts.conversationId
+    ) {
+      continue;
+    }
+    if (opts.startTime !== undefined && parsed.createdAtMs < opts.startTime) {
+      continue;
+    }
+    if (opts.endTime !== undefined && parsed.createdAtMs > opts.endTime) {
+      continue;
+    }
+
+    const srcPath = join(sourceDir, name);
+    const remainingBudget = maxBytes - result.totalBytes;
+    let dirBytes: number | null;
+    try {
+      dirBytes = dirSizeWithinBudget(srcPath, remainingBudget);
+    } catch (err) {
+      log.warn(
+        { err, srcPath },
+        "Failed to compute conversation directory size; skipping",
+      );
+      continue;
+    }
+
+    if (dirBytes === null) {
+      // Including this directory would exceed the workspace cap.
+      entry.skippedDueToCap += 1;
+      continue;
+    }
+
+    try {
+      mkdirSync(destBase, { recursive: true });
+      cpSync(srcPath, join(destBase, name), { recursive: true });
+    } catch (err) {
+      log.warn(
+        { err, srcPath },
+        "Failed to copy conversation directory; skipping",
+      );
+      continue;
+    }
+
+    entry.itemCount += 1;
+    entry.bytes += dirBytes;
+    result.totalBytes += dirBytes;
+  }
+
+  result.entries.push(entry);
+}
+
+/**
+ * Collect allowlisted workspace data into `<staging>/workspace/`.
+ *
+ * Currently the only allowlisted entry is `conversations/`. Future entries
+ * should follow the rules in `./AGENTS.md` (time filter, conversation
+ * filter, byte cap, registry update). The function never throws — all
+ * filesystem errors are logged at warn level so the rest of the export
+ * pipeline can continue regardless.
+ */
+export function collectWorkspaceData(
+  opts: CollectWorkspaceDataOptions,
+): CollectWorkspaceDataResult {
+  const result: CollectWorkspaceDataResult = {
+    entries: [],
+    totalBytes: 0,
+  };
+
+  try {
+    collectConversations(opts, result);
+  } catch (err) {
+    log.warn(
+      { err },
+      "Unexpected error while collecting workspace conversations entry",
+    );
+  }
+
+  log.info(
+    {
+      entries: result.entries,
+      totalBytes: result.totalBytes,
+      conversationId: opts.conversationId ?? null,
+      startTime: opts.startTime ?? null,
+      endTime: opts.endTime ?? null,
+    },
+    "Workspace allowlist collection complete",
+  );
+
+  return result;
+}

--- a/assistant/src/runtime/routes/log-export/workspace-allowlist.ts
+++ b/assistant/src/runtime/routes/log-export/workspace-allowlist.ts
@@ -14,7 +14,14 @@
  * `<ISO-with-dashes>_<conversationId>` format are silently skipped (Rule 3).
  */
 
-import { cpSync, existsSync, mkdirSync, readdirSync, statSync } from "node:fs";
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  statSync,
+} from "node:fs";
 import { join } from "node:path";
 
 import { parseConversationDirName } from "../../../memory/conversation-directories.js";
@@ -88,9 +95,15 @@ function dirSizeWithinBudget(
     }
     for (const name of entries) {
       const child = join(current, name);
-      let stat: ReturnType<typeof statSync>;
+      let stat: ReturnType<typeof lstatSync>;
       try {
-        stat = statSync(child);
+        // Use lstat (not stat) so symlinks are NOT dereferenced. Without
+        // this, a symlink cycle inside a conversation directory (e.g.
+        // `loop -> .`) would cause the walker to recurse forever and
+        // hang `collectWorkspaceData`. With lstat, symlinks show up as
+        // symlinks — neither `isDirectory()` nor `isFile()` is true on
+        // the lstat result, so they're naturally skipped below.
+        stat = lstatSync(child);
       } catch (err) {
         log.warn(
           { err, path: child },


### PR DESCRIPTION
## Summary
- Add `collectWorkspaceData` to a new `log-export/workspace-allowlist.ts` module
- First allowlist entry: `<workspace>/conversations/` with time + conversationId filtering via the parser from PR 2
- Update AGENTS.md to document the conversations entry; full unit test coverage including all filter combinations, cap enforcement, and malformed-name handling

Part of plan: ws-export-allowlist.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23883" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
