### PR TITLE
Map .jsonl/.ndjson and JSONL MIME types to JSON syntax highlighting

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxHighlighting/SyntaxLanguage.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SyntaxHighlighting/SyntaxLanguage.swift
@@ -20,7 +20,7 @@ enum SyntaxLanguage: String, CaseIterable {
             return .javascript
         case "ts", "tsx", "mts", "cts":
             return .typescript
-        case "json":
+        case "json", "jsonl", "ndjson":
             return .json
         case "md", "markdown":
             return .markdown
@@ -30,7 +30,7 @@ enum SyntaxLanguage: String, CaseIterable {
 
         let mime = mimeType.lowercased()
         switch mime {
-        case "application/json":
+        case "application/json", "application/jsonl", "application/x-ndjson", "application/x-jsonlines", "application/jsonlines":
             return .json
         case "application/javascript", "text/javascript":
             return .javascript

--- a/clients/macos/vellum-assistantTests/SyntaxLanguageTests.swift
+++ b/clients/macos/vellum-assistantTests/SyntaxLanguageTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import VellumAssistantLib
+
+final class SyntaxLanguageTests: XCTestCase {
+    func testJsonExtensionMapsToJson() {
+        XCTAssertEqual(SyntaxLanguage.detect(fileName: "data.json", mimeType: ""), .json)
+    }
+
+    func testJsonlExtensionMapsToJson() {
+        XCTAssertEqual(SyntaxLanguage.detect(fileName: "messages.jsonl", mimeType: ""), .json)
+    }
+
+    func testNdjsonExtensionMapsToJson() {
+        XCTAssertEqual(SyntaxLanguage.detect(fileName: "events.ndjson", mimeType: ""), .json)
+    }
+
+    func testUppercaseJsonlExtensionMapsToJson() {
+        XCTAssertEqual(SyntaxLanguage.detect(fileName: "DATA.JSONL", mimeType: ""), .json)
+    }
+
+    func testApplicationJsonlMimeMapsToJson() {
+        XCTAssertEqual(SyntaxLanguage.detect(fileName: "anything.txt", mimeType: "application/jsonl"), .json)
+    }
+
+    func testApplicationXNdjsonMimeMapsToJson() {
+        XCTAssertEqual(SyntaxLanguage.detect(fileName: "anything.txt", mimeType: "application/x-ndjson"), .json)
+    }
+
+    func testApplicationXJsonlinesMimeMapsToJson() {
+        XCTAssertEqual(SyntaxLanguage.detect(fileName: "anything.txt", mimeType: "application/x-jsonlines"), .json)
+    }
+
+    func testUnknownExtensionMapsToPlain() {
+        XCTAssertEqual(SyntaxLanguage.detect(fileName: "data.unknown", mimeType: ""), .plain)
+    }
+
+    func testJavascriptStillMapsCorrectly() {
+        XCTAssertEqual(SyntaxLanguage.detect(fileName: "app.js", mimeType: ""), .javascript)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `jsonl`/`ndjson` extensions and JSONL MIME types as aliases for `.json` in `SyntaxLanguage.detect`
- Add new test file `SyntaxLanguageTests.swift` covering jsonl/ndjson detection plus regression tests for existing language mappings
- No new `SyntaxLanguage` enum case — reuses the existing JSON tokenizer

Part of plan: macos-jsonl-viewer.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23886" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
