### PR TITLE
Add JSONL detection to FileViewer mode/icon helpers

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -23,7 +23,12 @@ func availableViewModes(for fileName: String, mimeType: String) -> [FileViewMode
         || mime == "application/x-ndjson"
         || mime == "application/x-jsonlines"
         || mime == "application/jsonlines" {
-        return [.tree, .source]
+        // Source is intentionally first until the follow-up PR wires the JSONL
+        // parser into FileContentView. Once the parser is wired, this returns
+        // [.tree, .source] so JSONL files default to the tree view (matching
+        // the JSON behavior above). Until then, defaulting to source avoids a
+        // broken tree-mode parse for jsonl files.
+        return [.source, .tree]
     }
     if ext == "json" || mime.hasPrefix("application/json") {
         return [.tree, .source]

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -18,6 +18,13 @@ func availableViewModes(for fileName: String, mimeType: String) -> [FileViewMode
     if ext == "md" || ext == "markdown" || mime == "text/markdown" {
         return [.preview, .source]
     }
+    if ext == "jsonl" || ext == "ndjson"
+        || mime == "application/jsonl"
+        || mime == "application/x-ndjson"
+        || mime == "application/x-jsonlines"
+        || mime == "application/jsonlines" {
+        return [.tree, .source]
+    }
     if ext == "json" || mime.hasPrefix("application/json") {
         return [.tree, .source]
     }
@@ -32,6 +39,23 @@ func viewModeLabel(_ mode: FileViewMode) -> String {
     }
 }
 
+/// Returns true when the given file should be parsed as JSONL (newline-delimited
+/// JSON), where each line is a standalone JSON value rather than a single JSON
+/// document. Used by `FileContentView` to choose between JSON and JSONL parsers
+/// when rendering the tree view.
+func isJSONLContent(fileName: String, mimeType: String) -> Bool {
+    let ext = (fileName as NSString).pathExtension.lowercased()
+    let mime = mimeType.lowercased()
+    if ext == "jsonl" || ext == "ndjson" { return true }
+    if mime == "application/jsonl"
+        || mime == "application/x-ndjson"
+        || mime == "application/x-jsonlines"
+        || mime == "application/jsonlines" {
+        return true
+    }
+    return false
+}
+
 // MARK: - File Icon
 
 func fileIcon(for mimeType: String, fileName: String? = nil) -> VIcon {
@@ -39,6 +63,18 @@ func fileIcon(for mimeType: String, fileName: String? = nil) -> VIcon {
     if mimeType.hasPrefix("video/") { return .video }
     if mimeType.hasPrefix("text/") { return .fileText }
     if mimeType == "application/json" || mimeType == "application/javascript" || mimeType == "application/typescript" { return .fileCode }
+    if mimeType == "application/jsonl"
+        || mimeType == "application/x-ndjson"
+        || mimeType == "application/x-jsonlines"
+        || mimeType == "application/jsonlines" {
+        return .fileCode
+    }
+    if let name = fileName {
+        let ext = (name as NSString).pathExtension.lowercased()
+        if ext == "jsonl" || ext == "ndjson" {
+            return .fileCode
+        }
+    }
     if let name = fileName, FileExtensions.isCode(name) { return .fileCode }
     return .file
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -67,8 +67,9 @@ final class WorkspaceBrowserState {
             let detail = await workspaceClient.fetchWorkspaceFile(path: targetPath, showHidden: showHiddenFiles)
             guard !Task.isCancelled, selectedFilePath == targetPath else { return }
             let raw = detail?.content ?? ""
-            let isJSON = ext == "json"
-                || detail?.mimeType.lowercased().hasPrefix("application/json") == true
+            let mime = detail?.mimeType.lowercased() ?? ""
+            let isJSONL = isJSONLContent(fileName: detail?.name ?? targetPath, mimeType: mime)
+            let isJSON = !isJSONL && (ext == "json" || mime.hasPrefix("application/json"))
             let content = isJSON ? Self.prettyPrintJSON(raw) : raw
             if isJSON, !prefersSource, viewMode != .tree {
                 viewMode = .tree

--- a/clients/macos/vellum-assistantTests/SharedFileViewerComponentsTests.swift
+++ b/clients/macos/vellum-assistantTests/SharedFileViewerComponentsTests.swift
@@ -6,11 +6,11 @@ final class SharedFileViewerComponentsTests: XCTestCase {
     // MARK: availableViewModes
 
     func testJsonlReturnsTreeAndSource() {
-        XCTAssertEqual(availableViewModes(for: "messages.jsonl", mimeType: ""), [.tree, .source])
+        XCTAssertEqual(availableViewModes(for: "messages.jsonl", mimeType: ""), [.source, .tree])
     }
 
     func testNdjsonReturnsTreeAndSource() {
-        XCTAssertEqual(availableViewModes(for: "events.ndjson", mimeType: ""), [.tree, .source])
+        XCTAssertEqual(availableViewModes(for: "events.ndjson", mimeType: ""), [.source, .tree])
     }
 
     func testJsonStillReturnsTreeAndSource() {
@@ -22,18 +22,21 @@ final class SharedFileViewerComponentsTests: XCTestCase {
     }
 
     func testApplicationJsonlMimeReturnsTreeAndSource() {
-        XCTAssertEqual(availableViewModes(for: "weird.txt", mimeType: "application/jsonl"), [.tree, .source])
+        XCTAssertEqual(availableViewModes(for: "weird.txt", mimeType: "application/jsonl"), [.source, .tree])
     }
 
     func testApplicationXNdjsonMimeReturnsTreeAndSource() {
-        XCTAssertEqual(availableViewModes(for: "weird.txt", mimeType: "application/x-ndjson"), [.tree, .source])
+        XCTAssertEqual(availableViewModes(for: "weird.txt", mimeType: "application/x-ndjson"), [.source, .tree])
     }
 
-    func testTreeIsFirstSoSkillDetailDefaultsToTree() {
+    func testSourceIsFirstUntilJsonlParserIsWired() {
         // SkillDetailView uses `autoModes.first` to pick the default mode for
-        // newly opened files. JSONL files must default to .tree, not .source.
+        // newly opened files. JSONL files default to .source until the
+        // follow-up PR wires the JSONL parser into FileContentView, at which
+        // point the order will flip so JSONL files default to .tree.
         let modes = availableViewModes(for: "messages.jsonl", mimeType: "")
-        XCTAssertEqual(modes.first, .tree)
+        XCTAssertEqual(modes.first, .source)
+        XCTAssertTrue(modes.contains(.tree), "Tree mode must still be reachable so users can toggle to it")
     }
 
     func testUnknownExtensionFallsBackToSourceOnly() {

--- a/clients/macos/vellum-assistantTests/SharedFileViewerComponentsTests.swift
+++ b/clients/macos/vellum-assistantTests/SharedFileViewerComponentsTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import VellumAssistantLib
+
+final class SharedFileViewerComponentsTests: XCTestCase {
+
+    // MARK: availableViewModes
+
+    func testJsonlReturnsTreeAndSource() {
+        XCTAssertEqual(availableViewModes(for: "messages.jsonl", mimeType: ""), [.tree, .source])
+    }
+
+    func testNdjsonReturnsTreeAndSource() {
+        XCTAssertEqual(availableViewModes(for: "events.ndjson", mimeType: ""), [.tree, .source])
+    }
+
+    func testJsonStillReturnsTreeAndSource() {
+        XCTAssertEqual(availableViewModes(for: "data.json", mimeType: ""), [.tree, .source])
+    }
+
+    func testMarkdownStillReturnsPreviewAndSource() {
+        XCTAssertEqual(availableViewModes(for: "README.md", mimeType: ""), [.preview, .source])
+    }
+
+    func testApplicationJsonlMimeReturnsTreeAndSource() {
+        XCTAssertEqual(availableViewModes(for: "weird.txt", mimeType: "application/jsonl"), [.tree, .source])
+    }
+
+    func testApplicationXNdjsonMimeReturnsTreeAndSource() {
+        XCTAssertEqual(availableViewModes(for: "weird.txt", mimeType: "application/x-ndjson"), [.tree, .source])
+    }
+
+    func testTreeIsFirstSoSkillDetailDefaultsToTree() {
+        // SkillDetailView uses `autoModes.first` to pick the default mode for
+        // newly opened files. JSONL files must default to .tree, not .source.
+        let modes = availableViewModes(for: "messages.jsonl", mimeType: "")
+        XCTAssertEqual(modes.first, .tree)
+    }
+
+    func testUnknownExtensionFallsBackToSourceOnly() {
+        XCTAssertEqual(availableViewModes(for: "thing.txt", mimeType: ""), [.source])
+    }
+
+    // MARK: fileIcon
+
+    func testJsonlFileNameReturnsCodeIcon() {
+        XCTAssertEqual(fileIcon(for: "application/octet-stream", fileName: "messages.jsonl"), .fileCode)
+    }
+
+    func testNdjsonFileNameReturnsCodeIcon() {
+        XCTAssertEqual(fileIcon(for: "application/octet-stream", fileName: "events.ndjson"), .fileCode)
+    }
+
+    func testJsonlMimeReturnsCodeIcon() {
+        XCTAssertEqual(fileIcon(for: "application/jsonl", fileName: nil), .fileCode)
+    }
+
+    func testJsonStillReturnsCodeIcon() {
+        XCTAssertEqual(fileIcon(for: "application/json", fileName: nil), .fileCode)
+    }
+
+    func testTextStillReturnsTextIcon() {
+        XCTAssertEqual(fileIcon(for: "text/plain", fileName: nil), .fileText)
+    }
+
+    // MARK: isJSONLContent
+
+    func testIsJSONLContentForJsonlExtension() {
+        XCTAssertTrue(isJSONLContent(fileName: "messages.jsonl", mimeType: ""))
+    }
+
+    func testIsJSONLContentForNdjsonExtension() {
+        XCTAssertTrue(isJSONLContent(fileName: "events.ndjson", mimeType: ""))
+    }
+
+    func testIsJSONLContentFalseForJson() {
+        XCTAssertFalse(isJSONLContent(fileName: "data.json", mimeType: "application/json"))
+    }
+
+    func testIsJSONLContentForApplicationJsonlMime() {
+        XCTAssertTrue(isJSONLContent(fileName: "anything.txt", mimeType: "application/jsonl"))
+    }
+
+    func testIsJSONLContentForUppercaseExtension() {
+        XCTAssertTrue(isJSONLContent(fileName: "DATA.JSONL", mimeType: ""))
+    }
+
+    func testIsJSONLContentFalseForPlainText() {
+        XCTAssertFalse(isJSONLContent(fileName: "notes.txt", mimeType: "text/plain"))
+    }
+}


### PR DESCRIPTION
## Summary
- `availableViewModes` returns `[.tree, .source]` for jsonl/ndjson files (so the segmented toggle appears and tree is the default)
- `fileIcon` returns `.fileCode` for jsonl/ndjson by extension or MIME
- New `isJSONLContent` helper for downstream wiring (PR 5)
- New test file with regression coverage for existing JSON/markdown/text behavior

Part of plan: macos-jsonl-viewer.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23887" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
