### PR TITLE
Teach JSONTreeView to parse JSONL content as a synthetic JSON array

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/JSONTreeView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/JSONTreeView.swift
@@ -4,7 +4,7 @@ import VellumAssistantShared
 // MARK: - JSON Node Model
 
 /// Recursive data model representing a parsed JSON value for tree rendering.
-private enum JSONNode: Identifiable {
+internal enum JSONNode: Identifiable {
     case object(id: String, entries: [(key: String, value: JSONNode)])
     case array(id: String, elements: [JSONNode])
     case string(id: String, value: String)
@@ -70,7 +70,7 @@ private enum JSONNode: Identifiable {
 // MARK: - Parse Result
 
 /// Result of parsing a JSON string: either a valid tree or an error message.
-private enum JSONParseResult {
+internal enum JSONParseResult {
     case success(JSONNode)
     case failure(String)
 }
@@ -78,7 +78,7 @@ private enum JSONParseResult {
 // MARK: - JSON Parsing
 
 /// Parses a JSON string into a recursive `JSONNode` tree.
-private func parseJSON(_ text: String) -> JSONParseResult {
+internal func parseJSON(_ text: String) -> JSONParseResult {
     do {
         let parsed = try JSONSerialization.jsonObject(
             with: Data(text.utf8),
@@ -88,6 +88,45 @@ private func parseJSON(_ text: String) -> JSONParseResult {
     } catch {
         return .failure(error.localizedDescription)
     }
+}
+
+/// Parses a JSONL (newline-delimited JSON) string by parsing each non-empty
+/// line as an independent JSON value. Returns a synthetic top-level array
+/// node containing one element per line. Lines that fail to parse are
+/// included as string nodes annotated with the parse error so the tree view
+/// shows them rather than dropping them silently.
+internal func parseJSONL(_ text: String) -> JSONParseResult {
+    // Split on \n. Trailing \r is stripped per-line so we tolerate CRLF
+    // files. Empty / whitespace-only lines are skipped — they're explicitly
+    // permitted by the de-facto JSONL spec and are common at end-of-file.
+    let rawLines = text.split(omittingEmptySubsequences: false, whereSeparator: { $0 == "\n" })
+    var elements: [JSONNode] = []
+    elements.reserveCapacity(rawLines.count)
+
+    for (index, rawLine) in rawLines.enumerated() {
+        var line = String(rawLine)
+        if line.hasSuffix("\r") { line.removeLast() }
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        if trimmed.isEmpty { continue }
+
+        let elementPath = "$[\(elements.count)]"
+        do {
+            let parsed = try JSONSerialization.jsonObject(
+                with: Data(line.utf8),
+                options: [.fragmentsAllowed]
+            )
+            elements.append(convert(parsed, path: elementPath))
+        } catch {
+            // Surface unparseable lines as string nodes so the tree view
+            // doesn't silently drop them. The label includes the original
+            // line number (1-indexed, matching most editors) and the parse
+            // error message for debuggability.
+            let label = "[line \(index + 1) parse error: \(error.localizedDescription)] \(line)"
+            elements.append(.string(id: elementPath, value: label))
+        }
+    }
+
+    return .success(.array(id: "$", elements: elements))
 }
 
 /// Escapes a JSON key for use in node ID paths, preventing ambiguity when keys
@@ -164,6 +203,11 @@ private func collectContainerPaths(_ node: JSONNode) -> Set<String> {
 /// `expandAllTrigger` or `collapseAllTrigger`.
 struct JSONTreeView: View {
     let content: String
+    /// When true, `content` is parsed as JSONL (one JSON value per non-empty
+    /// line) rather than as a single JSON document. Defaults to false to
+    /// preserve existing call-sites; set to true by `FileContentView` for
+    /// `.jsonl` / `.ndjson` files.
+    var isJSONL: Bool = false
     var expandAllTrigger: Int = 0
     var collapseAllTrigger: Int = 0
     @State private var root: JSONParseResult?
@@ -185,9 +229,16 @@ struct JSONTreeView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .task(id: content) {
-            let result = content.isEmpty
-                ? .success(.object(id: "$", entries: []))
-                : parseJSON(content)
+            let result: JSONParseResult
+            if content.isEmpty {
+                result = isJSONL
+                    ? .success(.array(id: "$", elements: []))
+                    : .success(.object(id: "$", entries: []))
+            } else if isJSONL {
+                result = parseJSONL(content)
+            } else {
+                result = parseJSON(content)
+            }
             root = result
             expandedPaths = []
             if case .success(let node) = result {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/JSONTreeView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/JSONTreeView.swift
@@ -96,10 +96,16 @@ internal func parseJSON(_ text: String) -> JSONParseResult {
 /// included as string nodes annotated with the parse error so the tree view
 /// shows them rather than dropping them silently.
 internal func parseJSONL(_ text: String) -> JSONParseResult {
-    // Split on \n. Trailing \r is stripped per-line so we tolerate CRLF
-    // files. Empty / whitespace-only lines are skipped — they're explicitly
+    // Normalize CRLF → LF before splitting. Swift's String treats "\r\n" as a
+    // single grapheme cluster (Character), so a per-Character split on "\n"
+    // would never match CRLF line endings. Replacing CRLF with LF up front
+    // ensures the split sees real newline boundaries on Windows-authored
+    // files. The per-line trailing "\r" strip below is kept as a safety net
+    // for legacy CR-only line endings.
+    let normalized = text.replacingOccurrences(of: "\r\n", with: "\n")
+    // Empty / whitespace-only lines are skipped — they're explicitly
     // permitted by the de-facto JSONL spec and are common at end-of-file.
-    let rawLines = text.split(omittingEmptySubsequences: false, whereSeparator: { $0 == "\n" })
+    let rawLines = normalized.split(omittingEmptySubsequences: false, whereSeparator: { $0 == "\n" })
     var elements: [JSONNode] = []
     elements.reserveCapacity(rawLines.count)
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/JSONTreeView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/JSONTreeView.swift
@@ -228,7 +228,7 @@ struct JSONTreeView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .task(id: content) {
+        .task(id: "jsonl=\(isJSONL)|\(content)") {
             let result: JSONParseResult
             if content.isEmpty {
                 result = isJSONL

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SharedFileViewerComponents.swift
@@ -23,12 +23,10 @@ func availableViewModes(for fileName: String, mimeType: String) -> [FileViewMode
         || mime == "application/x-ndjson"
         || mime == "application/x-jsonlines"
         || mime == "application/jsonlines" {
-        // Source is intentionally first until the follow-up PR wires the JSONL
-        // parser into FileContentView. Once the parser is wired, this returns
-        // [.tree, .source] so JSONL files default to the tree view (matching
-        // the JSON behavior above). Until then, defaulting to source avoids a
-        // broken tree-mode parse for jsonl files.
-        return [.source, .tree]
+        // Tree-first ordering matches the JSON branch above. JSONL files default
+        // to the tree view, which uses parseJSONL via FileContentView's isJSONL
+        // wiring (see the .tree case below).
+        return [.tree, .source]
     }
     if ext == "json" || mime.hasPrefix("application/json") {
         return [.tree, .source]
@@ -164,6 +162,7 @@ struct FileContentView: View {
                 case .tree:
                     JSONTreeView(
                         content: content,
+                        isJSONL: isJSONLContent(fileName: fileName, mimeType: mimeType),
                         expandAllTrigger: expandAllTrigger,
                         collapseAllTrigger: collapseAllTrigger
                     )

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -52,7 +52,7 @@ final class WorkspaceBrowserState {
             viewMode = .source
         } else if ext == "md" || ext == "markdown" {
             viewMode = .preview
-        } else if ext == "json" {
+        } else if ext == "json" || ext == "jsonl" || ext == "ndjson" {
             viewMode = .tree
         } else {
             viewMode = .source
@@ -70,8 +70,11 @@ final class WorkspaceBrowserState {
             let mime = detail?.mimeType.lowercased() ?? ""
             let isJSONL = isJSONLContent(fileName: detail?.name ?? targetPath, mimeType: mime)
             let isJSON = !isJSONL && (ext == "json" || mime.hasPrefix("application/json"))
+            // JSONL is intentionally NOT pretty-printed — each line is already a
+            // standalone JSON value, and reflowing the file would corrupt the
+            // format. We do still want JSONL files to default to the tree view.
             let content = isJSON ? Self.prettyPrintJSON(raw) : raw
-            if isJSON, !prefersSource, viewMode != .tree {
+            if (isJSON || isJSONL), !prefersSource, viewMode != .tree {
                 viewMode = .tree
             }
             editableContent = content

--- a/clients/macos/vellum-assistantTests/JSONLParserTests.swift
+++ b/clients/macos/vellum-assistantTests/JSONLParserTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import VellumAssistantLib
+
+final class JSONLParserTests: XCTestCase {
+
+    func testEmptyStringReturnsEmptyArray() {
+        let result = parseJSONL("")
+        guard case .success(let node) = result else { return XCTFail("Expected success") }
+        if case .array(_, let elements) = node {
+            XCTAssertEqual(elements.count, 0)
+        } else {
+            XCTFail("Expected array root")
+        }
+    }
+
+    func testSingleObjectLine() {
+        let result = parseJSONL(#"{"a":1}"#)
+        guard case .success(.array(_, let elements)) = result else {
+            return XCTFail("Expected array root")
+        }
+        XCTAssertEqual(elements.count, 1)
+        if case .object(_, let entries) = elements[0] {
+            XCTAssertEqual(entries.count, 1)
+            XCTAssertEqual(entries[0].key, "a")
+        } else {
+            XCTFail("Expected first element to be an object")
+        }
+    }
+
+    func testMultipleObjectLines() {
+        let input = "{\"a\":1}\n{\"b\":2}\n{\"c\":3}"
+        let result = parseJSONL(input)
+        guard case .success(.array(_, let elements)) = result else {
+            return XCTFail("Expected array root")
+        }
+        XCTAssertEqual(elements.count, 3)
+    }
+
+    func testTrailingNewlineIsIgnored() {
+        let input = "{\"a\":1}\n{\"b\":2}\n"
+        let result = parseJSONL(input)
+        guard case .success(.array(_, let elements)) = result else {
+            return XCTFail("Expected array root")
+        }
+        XCTAssertEqual(elements.count, 2, "Trailing newline should not produce an empty element")
+    }
+
+    func testBlankLineIsSkipped() {
+        let input = "{\"a\":1}\n\n{\"b\":2}"
+        let result = parseJSONL(input)
+        guard case .success(.array(_, let elements)) = result else {
+            return XCTFail("Expected array root")
+        }
+        XCTAssertEqual(elements.count, 2, "Blank lines should be skipped, not parsed")
+    }
+
+    func testCRLFLineEndingsAreHandled() {
+        let input = "{\"a\":1}\r\n{\"b\":2}\r\n"
+        let result = parseJSONL(input)
+        guard case .success(.array(_, let elements)) = result else {
+            return XCTFail("Expected array root")
+        }
+        XCTAssertEqual(elements.count, 2)
+    }
+
+    func testInvalidLineSurfacedAsStringNode() {
+        let input = "{\"a\":1}\nNOT_VALID_JSON\n{\"b\":2}"
+        let result = parseJSONL(input)
+        guard case .success(.array(_, let elements)) = result else {
+            return XCTFail("Expected array root")
+        }
+        XCTAssertEqual(elements.count, 3)
+        if case .string(_, let value) = elements[1] {
+            XCTAssertTrue(value.contains("parse error"))
+            XCTAssertTrue(value.contains("line 2"))
+            XCTAssertTrue(value.contains("NOT_VALID_JSON"))
+        } else {
+            XCTFail("Expected second element to be an error string node, got \(elements[1])")
+        }
+    }
+
+    func testMixedPrimitiveAndObjectLines() {
+        // JSONL technically permits any JSON value per line — strings,
+        // numbers, booleans, null. parseJSONL must accept fragments.
+        let input = "42\n\"hello\"\ntrue\nnull\n{\"k\":\"v\"}"
+        let result = parseJSONL(input)
+        guard case .success(.array(_, let elements)) = result else {
+            return XCTFail("Expected array root")
+        }
+        XCTAssertEqual(elements.count, 5)
+    }
+
+    func testElementPathsAreSequential() {
+        // Synthetic array element IDs must use sequential indices, not the
+        // raw line numbers — otherwise blank-line-skipping would produce
+        // non-contiguous IDs and confuse expandedPaths tracking.
+        let input = "{\"a\":1}\n\n{\"b\":2}\n\n{\"c\":3}"
+        let result = parseJSONL(input)
+        guard case .success(.array(_, let elements)) = result else {
+            return XCTFail("Expected array root")
+        }
+        XCTAssertEqual(elements.count, 3)
+        XCTAssertEqual(elements[0].id, "$[0]")
+        XCTAssertEqual(elements[1].id, "$[1]")
+        XCTAssertEqual(elements[2].id, "$[2]")
+    }
+}

--- a/clients/macos/vellum-assistantTests/SharedFileViewerComponentsTests.swift
+++ b/clients/macos/vellum-assistantTests/SharedFileViewerComponentsTests.swift
@@ -6,11 +6,11 @@ final class SharedFileViewerComponentsTests: XCTestCase {
     // MARK: availableViewModes
 
     func testJsonlReturnsTreeAndSource() {
-        XCTAssertEqual(availableViewModes(for: "messages.jsonl", mimeType: ""), [.source, .tree])
+        XCTAssertEqual(availableViewModes(for: "messages.jsonl", mimeType: ""), [.tree, .source])
     }
 
     func testNdjsonReturnsTreeAndSource() {
-        XCTAssertEqual(availableViewModes(for: "events.ndjson", mimeType: ""), [.source, .tree])
+        XCTAssertEqual(availableViewModes(for: "events.ndjson", mimeType: ""), [.tree, .source])
     }
 
     func testJsonStillReturnsTreeAndSource() {
@@ -22,21 +22,19 @@ final class SharedFileViewerComponentsTests: XCTestCase {
     }
 
     func testApplicationJsonlMimeReturnsTreeAndSource() {
-        XCTAssertEqual(availableViewModes(for: "weird.txt", mimeType: "application/jsonl"), [.source, .tree])
+        XCTAssertEqual(availableViewModes(for: "weird.txt", mimeType: "application/jsonl"), [.tree, .source])
     }
 
     func testApplicationXNdjsonMimeReturnsTreeAndSource() {
-        XCTAssertEqual(availableViewModes(for: "weird.txt", mimeType: "application/x-ndjson"), [.source, .tree])
+        XCTAssertEqual(availableViewModes(for: "weird.txt", mimeType: "application/x-ndjson"), [.tree, .source])
     }
 
-    func testSourceIsFirstUntilJsonlParserIsWired() {
+    func testTreeIsFirstSoSkillDetailDefaultsToTree() {
         // SkillDetailView uses `autoModes.first` to pick the default mode for
-        // newly opened files. JSONL files default to .source until the
-        // follow-up PR wires the JSONL parser into FileContentView, at which
-        // point the order will flip so JSONL files default to .tree.
+        // newly opened files. JSONL files must default to .tree (matching JSON
+        // behavior), now that FileContentView wires parseJSONL via isJSONL.
         let modes = availableViewModes(for: "messages.jsonl", mimeType: "")
-        XCTAssertEqual(modes.first, .source)
-        XCTAssertTrue(modes.contains(.tree), "Tree mode must still be reachable so users can toggle to it")
+        XCTAssertEqual(modes.first, .tree)
     }
 
     func testUnknownExtensionFallsBackToSourceOnly() {


### PR DESCRIPTION
## Summary
- New `parseJSONL` helper that builds a synthetic array node from newline-delimited JSON
- New `isJSONL: Bool = false` parameter on `JSONTreeView` (default preserves existing call-sites)
- Tolerates CRLF, blank lines, and trailing newlines
- Unparseable lines are surfaced as string nodes with line numbers + error messages
- New test file covering all the parser edge cases

Part of plan: macos-jsonl-viewer.md (PR 4 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23888" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
