### PR TITLE
refactor: rewrite MessageListView body with ScrollViewReader for Claude-style scroll

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListHelperViews.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListHelperViews.swift
@@ -9,19 +9,15 @@ import VellumAssistantShared
 /// this view — not the parent `MessageListView.body` or `ForEach`.
 struct ScrollToLatestOverlayView: View {
     let scrollState: MessageListScrollState
+    /// Closure that scrolls to the bottom via the parent's `ScrollViewProxy`.
+    var onScrollToBottom: (() -> Void)?
 
     var body: some View {
         if scrollState.showScrollToLatest {
             Button(action: {
                 os_signpost(.event, log: PerfSignposts.log, name: "scrollToLatestPressed")
-                // Spring animation drives both the CTA exit transition
-                // and the scroll-to-bottom. syncUIImmediately() inside
-                // requestPinToBottom captures showScrollToLatest = false
-                // within this animation transaction, so the .move/.opacity
-                // transition runs in sync with the scroll.
-                _ = withAnimation(VAnimation.spring) {
-                    scrollState.requestPinToBottom(animated: true, userInitiated: true)
-                }
+                scrollState.handleScrollToLatestTapped()
+                onScrollToBottom?()
             }) {
                 HStack(spacing: VSpacing.xs) {
                     VIconView(.arrowDown, size: 10)

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -78,6 +78,12 @@ final class MessageListScrollState {
     /// Used as the primary scroll-to-bottom target.
     @ObservationIgnored var lastMessageId: (any Hashable)?
 
+    // MARK: - Confirmation Focus
+
+    /// Tracks the last confirmation request ID that was auto-focused,
+    /// so the same request isn't focused twice.
+    @ObservationIgnored var lastAutoFocusedRequestId: String?
+
     // MARK: - Pagination
 
     /// Tracks whether the pagination sentinel was previously inside the trigger band.
@@ -153,6 +159,14 @@ final class MessageListScrollState {
         return true
     }
 
+    /// Called when the user taps "Scroll to latest". Resets near-bottom
+    /// state and hides the CTA so the caller can perform the actual scroll.
+    func handleScrollToLatestTapped() {
+        isNearBottom = true
+        showScrollToLatest = false
+        scrollLog.debug("Scroll to latest tapped — resetting near-bottom state")
+    }
+
     /// Resets all state for a conversation switch.
     func reset(for conversationId: UUID) {
         currentConversationId = conversationId
@@ -168,6 +182,7 @@ final class MessageListScrollState {
         lastPaginationCompletedAt = .distantPast
         showScrollToLatest = false
         scrollIndicatorsHidden = false
+        lastAutoFocusedRequestId = nil
 
         scrollLog.debug("Reset for conversation: \(conversationId)")
     }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -94,9 +94,10 @@ struct MessageListView: View {
     @State var scrollState = MessageListScrollState()
     /// In-flight resize scroll stabilization task; cancelled on each new resize.
     @State var resizeScrollTask: Task<Void, Never>?
-    /// Native SwiftUI scroll position struct (macOS 15+). Replaces
-    /// `ScrollViewReader` + `proxy.scrollTo()` and distance-from-bottom math.
-    @State var scrollPosition = ScrollPosition()
+    /// Captured `ScrollViewProxy` from `ScrollViewReader`. Used by onChange
+    /// handlers and the "Scroll to latest" overlay to perform programmatic
+    /// scrolls via `proxy.scrollTo(_:anchor:)`.
+    @State var scrollProxy: ScrollViewProxy?
 
     // MARK: - Body
 
@@ -104,6 +105,7 @@ struct MessageListView: View {
         #if DEBUG
         let _ = os_signpost(.event, log: PerfSignposts.log, name: "MessageListView.body")
         #endif
+        ScrollViewReader { proxy in
             ScrollView {
                 scrollViewContent
             }
@@ -111,34 +113,6 @@ struct MessageListView: View {
             .scrollContentBackground(.hidden)
             .coordinateSpace(name: "chatScrollView")
             .scrollDisabled(messages.isEmpty && !isSending)
-            // Apply only to .initialOffset — where the scroll view starts
-            // when first displayed (including .id() recreation on switch).
-            // Deliberately NOT using the all-roles overload (.sizeChanges)
-            // because it fights user scroll-up during streaming: SwiftUI's
-            // definition of "at bottom" for anchor purposes can differ from
-            // our hysteresis-based isAtBottom, causing the viewport to snap
-            // back to bottom on every content-height change even after the
-            // user has entered freeBrowsing. Our explicit content-height
-            // auto-follow handles streaming growth with proper mode checks.
-            // https://developer.apple.com/documentation/swiftui/view/defaultscrollanchor(_:for:)
-            .defaultScrollAnchor(.bottom, for: .initialOffset)
-            .scrollPosition($scrollPosition)
-            .environment(\.suppressAutoScroll, { [self] in
-                scrollState.endStabilization()
-                if scrollState.isFollowingBottom {
-                    os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "on reason=expansionPinning")
-                    scrollState.requestPinToBottom()
-                } else {
-                    os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "on reason=offBottomExpansion")
-                    scrollState.beginStabilization(.expansion)
-                }
-            })
-            .onScrollPhaseChange { oldPhase, newPhase in
-                scrollState.scrollPhase = newPhase
-                if newPhase == .idle && oldPhase != .idle && scrollState.isAtBottom {
-                    scrollState.handleReachedBottom()
-                }
-            }
             .onScrollGeometryChange(for: ScrollGeometrySnapshot.self) { geometry in
                 ScrollGeometrySnapshot(
                     contentOffsetY: geometry.contentOffset.y,
@@ -147,15 +121,28 @@ struct MessageListView: View {
                     visibleRectHeight: geometry.visibleRect.height
                 )
             } action: { _, newState in
-                enqueueScrollGeometryUpdate(newState)
+                scrollState.contentOffsetY = newState.contentOffsetY
+                scrollState.contentHeight = newState.contentHeight
+                scrollState.viewportHeight = newState.visibleRectHeight
+                scrollState.updateNearBottom()
+                if scrollState.canAutoFollow() {
+                    proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                }
             }
             .scrollIndicators(scrollState.scrollIndicatorsHidden ? .hidden : .automatic)
             .overlay(alignment: .bottom) {
-                ScrollToLatestOverlayView(scrollState: scrollState)
+                ScrollToLatestOverlayView(scrollState: scrollState) {
+                    withAnimation(VAnimation.spring) {
+                        proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                    }
+                }
             }
-            .onAppear { handleAppear() }
+            .onAppear {
+                scrollProxy = proxy
+                handleAppear()
+            }
             .onDisappear {
-                scrollState.cancelAll()
+                scrollProxy = nil
                 resizeScrollTask?.cancel()
                 resizeScrollTask = nil
                 highlightedMessageId = nil
@@ -179,5 +166,6 @@ struct MessageListView: View {
                     scrollState.lastAutoFocusedRequestId = requestId
                 }
             }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Replace ScrollPosition-based scroll with ScrollViewReader + proxy
- Remove scrollPosition state, defaultScrollAnchor, scrollPosition binding
- Feed geometry into simplified scroll state for near-bottom detection and auto-follow
- Wire scroll-to-latest overlay to proxy-based bottom scroll
- Add `handleScrollToLatestTapped()` and `lastAutoFocusedRequestId` to simplified scroll state

Part of plan: claude-style-chat-scroll.md (PR 2 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23890" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
