### PR TITLE
refactor: tighten drawer menu billing section

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -35,7 +35,9 @@ struct DrawerMenuView: View {
                 DrawerThemeToggle()
             }
 
-            VMenuDivider()
+            VMenuCustomRow {
+                tightDividerLine
+            }
 
             if let balance = effectiveBalance {
                 VMenuCustomRow {
@@ -55,29 +57,25 @@ struct DrawerMenuView: View {
                                 .buttonStyle(.plain)
                         }
                     }
+                    .frame(minHeight: VSize.rowMinHeight)
                 }
 
-                VMenuDivider()
+                VMenuCustomRow {
+                    tightDividerLine
+                }
 
                 if isReferralVisible {
                     VMenuItem(icon: VIcon.gift.rawValue, label: String(localized: "Earn credits")) {
                         onEarnCredits()
                     }
 
-                    VMenuDivider()
+                    VMenuCustomRow {
+                        tightDividerLine
+                    }
                 }
             }
 
             VMenuItem(icon: VIcon.settings.rawValue, label: String(localized: "Settings"), action: onSettings)
-
-            VMenuCustomRow {
-                Text("Ask the assistant in chat to help you with any settings you wish to alter.")
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(VColor.contentDisabled)
-                    .padding(.top, VSpacing.xs)
-            }
-
-            VMenuDivider()
 
             VMenuItem(icon: VIcon.barChart.rawValue, label: String(localized: "Usage"), action: onUsage)
             VMenuItem(icon: VIcon.scrollText.rawValue, label: String(localized: "Logs"), action: onDebug)
@@ -102,6 +100,14 @@ struct DrawerMenuView: View {
             isReferralCodesEnabled = MacOSClientFeatureFlagManager.shared.isEnabled("referral-codes")
             await loadBalance()
         }
+    }
+
+    /// 1pt divider line without VMenuDivider's 4pt vertical padding,
+    /// used for sections that should sit tight against neighboring rows.
+    private var tightDividerLine: some View {
+        Rectangle()
+            .fill(VColor.surfaceBase)
+            .frame(height: 1)
     }
 
     private func loadBalance() async {


### PR DESCRIPTION
## Summary
- Removed the "Ask the assistant in chat to help you with any settings you wish to alter" subtext from the drawer menu so Settings → Usage → Logs → Log Out flow as a uniform stack
- Made the "X credits / Add credits" row match the other menu items' height using `VSize.rowMinHeight`
- Replaced the three `VMenuDivider`s around the credits and Earn credits rows with a tighter custom 1pt line to remove the 4pt vertical chrome `VMenuDivider` adds — the dividers now sit close to each row's hover state instead of floating with extra padding around them

## Original prompt
Update this popper such that:
1. Remove the sub-text beneath "Settings" and move it into the section above "Usage" and remove the divider (and then later, remove the sub-text entirely)
2. Increase padding above and below the credits row so it matches the height of other popper options
3. Restore the divider between credits and Earn credits (which I had accidentally removed)
4. Reduce the vertical padding around the two credit-related sections so there's less space between the hover state and the divider
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23891" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
