### PR TITLE
feat: make PKB autoinjection configurable via _autoinject.md

### DIFF
--- a/assistant/src/__tests__/pkb-autoinject.test.ts
+++ b/assistant/src/__tests__/pkb-autoinject.test.ts
@@ -1,0 +1,96 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { readAutoinjectList } from "../daemon/conversation-runtime-assembly.js";
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+let pkbDir: string;
+const dirs: string[] = [];
+
+beforeEach(() => {
+  pkbDir = join(
+    tmpdir(),
+    `vellum-pkb-autoinject-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(pkbDir, { recursive: true });
+  dirs.push(pkbDir);
+});
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("readAutoinjectList", () => {
+  test("returns null when _autoinject.md does not exist", () => {
+    expect(readAutoinjectList(pkbDir)).toBeNull();
+  });
+
+  test("returns null when _autoinject.md is empty", () => {
+    writeFileSync(join(pkbDir, "_autoinject.md"), "", "utf-8");
+    expect(readAutoinjectList(pkbDir)).toBeNull();
+  });
+
+  test("returns null when _autoinject.md contains only comments", () => {
+    writeFileSync(
+      join(pkbDir, "_autoinject.md"),
+      "_ This is a comment\n_ Another comment\n",
+      "utf-8",
+    );
+    expect(readAutoinjectList(pkbDir)).toBeNull();
+  });
+
+  test("parses standard default content", () => {
+    writeFileSync(
+      join(pkbDir, "_autoinject.md"),
+      "_ comment\n\nINDEX.md\nessentials.md\nthreads.md\nbuffer.md\n",
+      "utf-8",
+    );
+    expect(readAutoinjectList(pkbDir)).toEqual([
+      "INDEX.md",
+      "essentials.md",
+      "threads.md",
+      "buffer.md",
+    ]);
+  });
+
+  test("parses custom entries", () => {
+    writeFileSync(
+      join(pkbDir, "_autoinject.md"),
+      "INDEX.md\ncustom-topic.md\n",
+      "utf-8",
+    );
+    expect(readAutoinjectList(pkbDir)).toEqual([
+      "INDEX.md",
+      "custom-topic.md",
+    ]);
+  });
+
+  test("strips blank lines and whitespace", () => {
+    writeFileSync(
+      join(pkbDir, "_autoinject.md"),
+      "INDEX.md\n\n  essentials.md  \n\n",
+      "utf-8",
+    );
+    expect(readAutoinjectList(pkbDir)).toEqual(["INDEX.md", "essentials.md"]);
+  });
+
+  test("strips comment lines mixed with filenames", () => {
+    writeFileSync(
+      join(pkbDir, "_autoinject.md"),
+      "_ Always loaded files\nINDEX.md\n_ Core facts\nessentials.md\n",
+      "utf-8",
+    );
+    expect(readAutoinjectList(pkbDir)).toEqual(["INDEX.md", "essentials.md"]);
+  });
+});

--- a/assistant/src/__tests__/workspace-migration-030-seed-pkb-autoinject.test.ts
+++ b/assistant/src/__tests__/workspace-migration-030-seed-pkb-autoinject.test.ts
@@ -1,0 +1,168 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { seedPkbAutoinjectMigration } from "../workspace/migrations/030-seed-pkb-autoinject.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let workspaceDir: string;
+let pkbDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-030-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  pkbDir = join(workspaceDir, "pkb");
+  mkdirSync(pkbDir, { recursive: true });
+}
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+const dirs: string[] = [];
+
+beforeEach(() => {
+  freshWorkspace();
+  dirs.push(workspaceDir);
+});
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("030-seed-pkb-autoinject migration", () => {
+  test("has correct migration id", () => {
+    expect(seedPkbAutoinjectMigration.id).toBe("030-seed-pkb-autoinject");
+  });
+
+  // ─── run() ──────────────────────────────────────────────────────────────
+
+  test("creates _autoinject.md with default content", () => {
+    seedPkbAutoinjectMigration.run(workspaceDir);
+
+    const filePath = join(pkbDir, "_autoinject.md");
+    expect(existsSync(filePath)).toBe(true);
+
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain("INDEX.md");
+    expect(content).toContain("essentials.md");
+    expect(content).toContain("threads.md");
+    expect(content).toContain("buffer.md");
+  });
+
+  test("no-op when pkb/ does not exist", () => {
+    rmSync(pkbDir, { recursive: true, force: true });
+    seedPkbAutoinjectMigration.run(workspaceDir);
+    expect(existsSync(join(pkbDir, "_autoinject.md"))).toBe(false);
+  });
+
+  test("idempotent — does not overwrite existing _autoinject.md", () => {
+    const customContent = "INDEX.md\ncustom-topic.md\n";
+    writeFileSync(join(pkbDir, "_autoinject.md"), customContent, "utf-8");
+
+    seedPkbAutoinjectMigration.run(workspaceDir);
+
+    const content = readFileSync(join(pkbDir, "_autoinject.md"), "utf-8");
+    expect(content).toBe(customContent);
+  });
+
+  test("appends _autoinject.md entry to INDEX.md", () => {
+    const indexContent =
+      "# Knowledge Base\n\n## Always Loaded\n" +
+      "- essentials.md — Core facts\n" +
+      "- threads.md — Active threads\n" +
+      "- buffer.md — Inbox\n\n" +
+      "## Topics\n";
+    writeFileSync(join(pkbDir, "INDEX.md"), indexContent, "utf-8");
+
+    seedPkbAutoinjectMigration.run(workspaceDir);
+
+    const updated = readFileSync(join(pkbDir, "INDEX.md"), "utf-8");
+    expect(updated).toContain("_autoinject.md");
+    // Should appear after buffer.md
+    const bufferIdx = updated.indexOf("buffer.md");
+    const autoinjectIdx = updated.indexOf("_autoinject.md");
+    expect(autoinjectIdx).toBeGreaterThan(bufferIdx);
+  });
+
+  test("does not duplicate _autoinject.md entry in INDEX.md", () => {
+    const indexContent =
+      "# Knowledge Base\n\n## Always Loaded\n" +
+      "- buffer.md — Inbox\n" +
+      "- _autoinject.md — Controls autoinjection\n\n" +
+      "## Topics\n";
+    writeFileSync(join(pkbDir, "INDEX.md"), indexContent, "utf-8");
+
+    seedPkbAutoinjectMigration.run(workspaceDir);
+
+    const updated = readFileSync(join(pkbDir, "INDEX.md"), "utf-8");
+    const matches = updated.match(/_autoinject\.md/g);
+    expect(matches?.length).toBe(1);
+  });
+
+  test("handles missing INDEX.md gracefully", () => {
+    // No INDEX.md — should still create _autoinject.md without error
+    seedPkbAutoinjectMigration.run(workspaceDir);
+    expect(existsSync(join(pkbDir, "_autoinject.md"))).toBe(true);
+  });
+
+  // ─── down() ─────────────────────────────────────────────────────────────
+
+  describe("down()", () => {
+    test("removes _autoinject.md when content matches template", () => {
+      seedPkbAutoinjectMigration.run(workspaceDir);
+      expect(existsSync(join(pkbDir, "_autoinject.md"))).toBe(true);
+
+      seedPkbAutoinjectMigration.down(workspaceDir);
+      expect(existsSync(join(pkbDir, "_autoinject.md"))).toBe(false);
+    });
+
+    test("preserves _autoinject.md when user has customized it", () => {
+      const customContent = "INDEX.md\nmy-custom-file.md\n";
+      writeFileSync(join(pkbDir, "_autoinject.md"), customContent, "utf-8");
+
+      seedPkbAutoinjectMigration.down(workspaceDir);
+
+      expect(existsSync(join(pkbDir, "_autoinject.md"))).toBe(true);
+      expect(readFileSync(join(pkbDir, "_autoinject.md"), "utf-8")).toBe(
+        customContent,
+      );
+    });
+
+    test("no-op when _autoinject.md does not exist", () => {
+      seedPkbAutoinjectMigration.down(workspaceDir);
+      // Should not throw
+    });
+
+    test("no-op when pkb/ does not exist", () => {
+      rmSync(pkbDir, { recursive: true, force: true });
+      seedPkbAutoinjectMigration.down(workspaceDir);
+      // Should not throw
+    });
+
+    test("idempotent — calling down() twice is safe", () => {
+      seedPkbAutoinjectMigration.run(workspaceDir);
+      seedPkbAutoinjectMigration.down(workspaceDir);
+      seedPkbAutoinjectMigration.down(workspaceDir);
+      // Should not throw
+    });
+  });
+});

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -6,7 +6,7 @@
  */
 
 import { existsSync, readFileSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 import { type ChannelId, parseInterfaceId } from "../channels/types.js";
 import { getAppDirPath, listAppFiles } from "../memory/app-store.js";
@@ -533,7 +533,9 @@ export function stripNowScratchpad(messages: Message[]): Message[] {
 // PKB (Personal Knowledge Base) injection
 // ---------------------------------------------------------------------------
 
-const PKB_FILES = ["INDEX.md", "essentials.md", "threads.md", "buffer.md"];
+const PKB_DEFAULT_FILES = ["INDEX.md", "essentials.md", "threads.md", "buffer.md"];
+
+const AUTOINJECT_FILENAME = "_autoinject.md";
 
 /** Max buffer.md lines injected into prompts — keeps context bounded even when filing is off. */
 const MAX_BUFFER_LINES = 50;
@@ -547,9 +549,31 @@ const PKB_NUDGE =
   "Use `remember` for every new fact you learn, immediately, no batching.";
 
 /**
- * Read the always-loaded PKB files (INDEX, essentials, threads, buffer)
- * and append a nudge encouraging the assistant to proactively read topic
- * files and use `remember` aggressively.
+ * Read `_autoinject.md` from the PKB directory and return the list of
+ * filenames to inject. Returns `null` when the file is missing, empty,
+ * or unreadable — callers should fall back to the hardcoded defaults.
+ */
+export function readAutoinjectList(pkbDir: string): string[] | null {
+  const filePath = join(pkbDir, AUTOINJECT_FILENAME);
+  if (!existsSync(filePath)) return null;
+  try {
+    const raw = stripCommentLines(readFileSync(filePath, "utf-8"));
+    const files = raw
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0);
+    return files.length > 0 ? files : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the always-loaded PKB files and append a nudge encouraging the
+ * assistant to proactively read topic files and use `remember` aggressively.
+ *
+ * Which files are loaded is determined by `pkb/_autoinject.md` (one filename
+ * per line). Falls back to the built-in defaults when that file is absent.
  *
  * Returns the concatenated content ready for injection, or `null` if all
  * files are missing or empty.
@@ -558,9 +582,14 @@ export function readPkbContext(): string | null {
   const pkbDir = join(getWorkspaceDir(), "pkb");
   if (!existsSync(pkbDir)) return null;
 
+  const filesToInject = readAutoinjectList(pkbDir) ?? PKB_DEFAULT_FILES;
+
   const parts: string[] = [];
-  for (const file of PKB_FILES) {
-    const filePath = join(pkbDir, file);
+  for (const file of filesToInject) {
+    // Path traversal guard: reject entries that escape the pkb directory
+    const filePath = resolve(pkbDir, file);
+    if (!filePath.startsWith(pkbDir + "/")) continue;
+
     if (!existsSync(filePath)) continue;
     try {
       let content = stripCommentLines(readFileSync(filePath, "utf-8")).trim();

--- a/assistant/src/workspace/migrations/029-seed-pkb.ts
+++ b/assistant/src/workspace/migrations/029-seed-pkb.ts
@@ -13,6 +13,7 @@ const INDEX_TEMPLATE = `_ Lines starting with _ are comments - they won't appear
 - essentials.md — Core facts, patterns, and biographical info
 - threads.md — Active commitments, follow-ups, and projects in progress
 - buffer.md — Inbox of recently learned facts (filed periodically)
+- _autoinject.md — Controls which files are loaded into every conversation
 
 ## Topics
 `;

--- a/assistant/src/workspace/migrations/030-seed-pkb-autoinject.ts
+++ b/assistant/src/workspace/migrations/030-seed-pkb-autoinject.ts
@@ -1,0 +1,73 @@
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+const AUTOINJECT_TEMPLATE = `_ Lines starting with _ are comments - they won't appear in the injected context
+_ List one PKB filename per line. These files are loaded into every conversation.
+_ Remove a line to stop autoinjecting that file. Add new filenames to inject more.
+
+INDEX.md
+essentials.md
+threads.md
+buffer.md
+`;
+
+const INDEX_ENTRY = "- _autoinject.md — Controls which files are loaded into every conversation";
+
+export const seedPkbAutoinjectMigration: WorkspaceMigration = {
+  id: "030-seed-pkb-autoinject",
+  description: "Seed pkb/_autoinject.md for configurable PKB autoinjection",
+
+  run(workspaceDir: string): void {
+    const pkbDir = join(workspaceDir, "pkb");
+    if (!existsSync(pkbDir)) return;
+
+    // Seed _autoinject.md if it doesn't already exist
+    const autoinjectPath = join(pkbDir, "_autoinject.md");
+    if (!existsSync(autoinjectPath)) {
+      writeFileSync(autoinjectPath, AUTOINJECT_TEMPLATE, "utf-8");
+    }
+
+    // Append _autoinject.md entry to INDEX.md if not already present
+    const indexPath = join(pkbDir, "INDEX.md");
+    if (existsSync(indexPath)) {
+      try {
+        const indexContent = readFileSync(indexPath, "utf-8");
+        if (!indexContent.includes("_autoinject.md")) {
+          // Insert after the last "Always Loaded" entry (buffer.md line)
+          const bufferLine = "- buffer.md";
+          const bufferIdx = indexContent.indexOf(bufferLine);
+          if (bufferIdx !== -1) {
+            const endOfBufferLine = indexContent.indexOf("\n", bufferIdx);
+            const insertAt =
+              endOfBufferLine === -1 ? indexContent.length : endOfBufferLine;
+            const updated =
+              indexContent.slice(0, insertAt) +
+              "\n" +
+              INDEX_ENTRY +
+              indexContent.slice(insertAt);
+            writeFileSync(indexPath, updated, "utf-8");
+          }
+        }
+      } catch {
+        // INDEX.md unreadable — skip
+      }
+    }
+  },
+
+  down(workspaceDir: string): void {
+    const autoinjectPath = join(workspaceDir, "pkb", "_autoinject.md");
+    if (!existsSync(autoinjectPath)) return;
+
+    try {
+      const content = readFileSync(autoinjectPath, "utf-8");
+      // Only delete if content matches the template (preserve user edits)
+      if (content === AUTOINJECT_TEMPLATE) {
+        unlinkSync(autoinjectPath);
+      }
+    } catch {
+      // Unreadable — leave it alone
+    }
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -26,6 +26,7 @@ import { backfillInstallMetaMigration } from "./026-backfill-install-meta.js";
 import { removeOrphanedOptimizedImagesCacheMigration } from "./027-remove-orphaned-optimized-images-cache.js";
 import { recoverConversationsFromDiskViewMigration } from "./028-recover-conversations-from-disk-view.js";
 import { seedPkbMigration } from "./029-seed-pkb.js";
+import { seedPkbAutoinjectMigration } from "./030-seed-pkb-autoinject.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -63,4 +64,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   removeOrphanedOptimizedImagesCacheMigration,
   recoverConversationsFromDiskViewMigration,
   seedPkbMigration,
+  seedPkbAutoinjectMigration,
 ];


### PR DESCRIPTION
## Summary
- Add `pkb/_autoinject.md` that lists which PKB files are loaded into every conversation (one filename per line), replacing the hardcoded constant
- New workspace migration (030) seeds the file with the current defaults and updates INDEX.md
- `readPkbContext()` reads the autoinject list dynamically, with fallback to built-in defaults and a path traversal guard
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23894" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
