### PR TITLE
fix: suppress typing indicator when thinking indicator is visible

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
@@ -244,6 +244,7 @@ extension MessageListView {
             && (lastVisible?.isStreaming == true)
             && (lastVisible?.text.isEmpty ?? true)
             && !hasActiveToolCall
+            && !canInlineProcessing
 
         let result = MessageListDerivedState(
             messageIndexById: layout.messageIndexById,


### PR DESCRIPTION
## Summary
- When the inline thinking indicator ("Wrapping up •••") is visible on an assistant message, the standalone typing dots below were also showing simultaneously
- Root cause: `canInlineProcessing` and `isStreamingWithoutText` could both be true when `isThinking=true` and the last message is streaming with empty text
- Added `&& !canInlineProcessing` to the `isStreamingWithoutText` derived state condition to suppress the typing dots when the inline thinking bar is already showing

## Original prompt
Let's suppress the 3 dots typing indicator once the thinking indicator shows up