### PR TITLE
fix: disambiguate sync deleteKey overload in SettingsStore async contexts

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -740,7 +740,7 @@ public final class SettingsStore: ObservableObject {
             } else if let error = result.error {
                 apiKeySaveError = error
                 if !result.isTransient {
-                    APIKeyManager.deleteKey(for: "anthropic")
+                    let _: Void = APIKeyManager.deleteKey(for: "anthropic")
                     hasKey = false
                     maskedKey = ""
                 }
@@ -774,7 +774,7 @@ public final class SettingsStore: ObservableObject {
             } else if let error = result.error {
                 braveKeySaveError = error
                 if !result.isTransient {
-                    APIKeyManager.deleteKey(for: "brave")
+                    let _: Void = APIKeyManager.deleteKey(for: "brave")
                 }
             }
         }
@@ -803,7 +803,7 @@ public final class SettingsStore: ObservableObject {
             } else if let error = result.error {
                 perplexityKeySaveError = error
                 if !result.isTransient {
-                    APIKeyManager.deleteKey(for: "perplexity")
+                    let _: Void = APIKeyManager.deleteKey(for: "perplexity")
                 }
             }
         }
@@ -834,7 +834,7 @@ public final class SettingsStore: ObservableObject {
             } else if let error = result.error {
                 imageGenKeySaveError = error
                 if !result.isTransient {
-                    APIKeyManager.deleteKey(for: "gemini")
+                    let _: Void = APIKeyManager.deleteKey(for: "gemini")
                 }
             }
         }
@@ -896,7 +896,7 @@ public final class SettingsStore: ObservableObject {
                     apiKeySaveError = error
                 }
                 if !result.isTransient {
-                    APIKeyManager.deleteKey(for: provider)
+                    let _: Void = APIKeyManager.deleteKey(for: provider)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Fix Swift compilation errors in SettingsStore where `APIKeyManager.deleteKey(for:)` inside `Task {}` blocks resolved to the async overload (added in #23866) instead of the sync one
- Use `let _: Void =` type annotation to explicitly select the sync overload for local keychain rollback paths

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24080612704/job/70239950740