### PR TITLE
fix: scroll geometry dispatcher main-queue drain

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
@@ -58,7 +58,7 @@ final class ScrollGeometryUpdateDispatcher {
     static let shared = ScrollGeometryUpdateDispatcher()
 
     private var pendingSnapshots: [ObjectIdentifier: ScrollGeometrySnapshot] = [:]
-    private var tasks: [ObjectIdentifier: Task<Void, Never>] = [:]
+    private var scheduledKeys: Set<ObjectIdentifier> = []
 
     func enqueue(
         for owner: MessageListScrollState,
@@ -67,31 +67,53 @@ final class ScrollGeometryUpdateDispatcher {
     ) {
         let key = ObjectIdentifier(owner)
         pendingSnapshots[key] = snapshot
-        guard tasks[key] == nil else { return }
-
-        tasks[key] = Task { @MainActor [weak self, weak owner] in
-            guard let self else { return }
-            defer {
-                self.tasks[key] = nil
-                self.pendingSnapshots[key] = nil
-            }
-
-            while !Task.isCancelled {
-                await Task.yield()
-                guard owner != nil else { return }
-                guard let latest = self.pendingSnapshots[key] else { return }
-                self.pendingSnapshots[key] = nil
-                handler(latest)
-                guard self.pendingSnapshots[key] != nil else { return }
-            }
-        }
+        guard scheduledKeys.insert(key).inserted else { return }
+        scheduleDrain(for: key, owner: owner, handler: handler)
     }
 
     func cancel(for owner: MessageListScrollState) {
         let key = ObjectIdentifier(owner)
-        tasks[key]?.cancel()
-        tasks[key] = nil
+        scheduledKeys.remove(key)
         pendingSnapshots[key] = nil
+    }
+
+    private func scheduleDrain(
+        for key: ObjectIdentifier,
+        owner: MessageListScrollState,
+        handler: @escaping @MainActor (ScrollGeometrySnapshot) -> Void
+    ) {
+        DispatchQueue.main.async { [weak self, weak owner] in
+            Task { @MainActor [weak self, weak owner] in
+                guard let self else { return }
+                guard let owner else {
+                    self.pendingSnapshots[key] = nil
+                    self.scheduledKeys.remove(key)
+                    return
+                }
+                self.drainNext(for: key, owner: owner, handler: handler)
+            }
+        }
+    }
+
+    private func drainNext(
+        for key: ObjectIdentifier,
+        owner: MessageListScrollState,
+        handler: @escaping @MainActor (ScrollGeometrySnapshot) -> Void
+    ) {
+        guard let latest = pendingSnapshots[key] else {
+            scheduledKeys.remove(key)
+            return
+        }
+
+        pendingSnapshots[key] = nil
+        handler(latest)
+
+        guard pendingSnapshots[key] != nil else {
+            scheduledKeys.remove(key)
+            return
+        }
+
+        scheduleDrain(for: key, owner: owner, handler: handler)
     }
 }
 

--- a/clients/macos/vellum-assistantTests/MessageListScrollGeometryDispatcherTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollGeometryDispatcherTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class MessageListScrollGeometryDispatcherTests: XCTestCase {
+
+    func testEnqueueDefersDeliveryAndCoalescesToLatestSnapshot() async {
+        let dispatcher = ScrollGeometryUpdateDispatcher()
+        let owner = MessageListScrollState()
+        let delivered = expectation(description: "geometry delivered")
+
+        let first = ScrollGeometrySnapshot(
+            contentOffsetY: 1,
+            contentHeight: 100,
+            containerHeight: 80,
+            visibleRectHeight: 80
+        )
+        let second = ScrollGeometrySnapshot(
+            contentOffsetY: 2,
+            contentHeight: 120,
+            containerHeight: 80,
+            visibleRectHeight: 80
+        )
+
+        var received: [ScrollGeometrySnapshot] = []
+        let handler: @MainActor (ScrollGeometrySnapshot) -> Void = { snapshot in
+            received.append(snapshot)
+            delivered.fulfill()
+        }
+
+        dispatcher.enqueue(for: owner, snapshot: first, handler: handler)
+        dispatcher.enqueue(for: owner, snapshot: second, handler: handler)
+
+        XCTAssertTrue(received.isEmpty, "Geometry updates should not run inline inside the modifier callback")
+
+        await fulfillment(of: [delivered], timeout: 1.0)
+        XCTAssertEqual(received, [second])
+    }
+
+    func testEnqueueDuringHandlerSchedulesFollowUpOnLaterMainQueueTurn() async {
+        let dispatcher = ScrollGeometryUpdateDispatcher()
+        let owner = MessageListScrollState()
+        let markerReached = expectation(description: "marker reached")
+        let secondDelivery = expectation(description: "second delivery")
+
+        let first = ScrollGeometrySnapshot(
+            contentOffsetY: 10,
+            contentHeight: 200,
+            containerHeight: 100,
+            visibleRectHeight: 100
+        )
+        let second = ScrollGeometrySnapshot(
+            contentOffsetY: 20,
+            contentHeight: 220,
+            containerHeight: 100,
+            visibleRectHeight: 100
+        )
+
+        var trace: [String] = []
+        var handler: (@MainActor (ScrollGeometrySnapshot) -> Void)!
+        handler = { snapshot in
+            if snapshot == first {
+                trace.append("first-start")
+                dispatcher.enqueue(for: owner, snapshot: second, handler: handler)
+                DispatchQueue.main.async {
+                    trace.append("marker")
+                    markerReached.fulfill()
+                }
+                trace.append("first-end")
+            } else {
+                trace.append("second")
+                secondDelivery.fulfill()
+            }
+        }
+
+        dispatcher.enqueue(for: owner, snapshot: first, handler: handler)
+
+        await fulfillment(of: [markerReached, secondDelivery], timeout: 1.0)
+        XCTAssertEqual(trace, ["first-start", "first-end", "marker", "second"])
+    }
+}


### PR DESCRIPTION
## Summary
- Refactor `ScrollGeometryUpdateDispatcher` from a `Task` drain loop to `DispatchQueue.main.async` scheduling, ensuring each geometry drain runs on a distinct main queue turn and preventing re-entrant updates inside SwiftUI modifier callbacks
- Add `MessageListScrollGeometryDispatcherTests` covering coalescence and follow-up drain ordering
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23899" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
