### PR TITLE
fix: remove internal artifacts from LLM API requests

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -419,15 +419,20 @@ export class AgentLoop {
 
           if (!hasTextBlock && lastWasToolResult && !nudgedForEmptyResponse) {
             nudgedForEmptyResponse = true;
-            history.push({
-              role: "user",
-              content: [
-                {
-                  type: "text",
-                  text: "<system_notice>You executed tools but didn't tell the user what happened. Provide a brief, conversational summary of the results.</system_notice>",
-                },
-              ],
-            });
+            // Remove the empty assistant response we just pushed — it carries
+            // no content and would force the provider to inject a placeholder
+            // to maintain role alternation.
+            history.pop();
+            // Append the nudge to the existing tool_result user message
+            // (same pattern as the error nudge below) so neither a separate
+            // system_notice message nor a PLACEHOLDER appears in the API request.
+            const toolResultMsg = history[history.length - 1];
+            if (toolResultMsg?.role === "user") {
+              toolResultMsg.content.push({
+                type: "text",
+                text: "<system_notice>You executed tools but didn't tell the user what happened. Provide a brief, conversational summary of the results.</system_notice>",
+              });
+            }
             continue;
           }
 

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1081,6 +1081,7 @@ const RUNTIME_INJECTION_PREFIXES = [
   "<now_scratchpad>", // backward-compat: strip legacy blocks from pre-rename history
   "<pkb>",
   "<transport_hints>",
+  "<system_notice>",
 ];
 
 /**

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -722,9 +722,15 @@ function mergeToolResultsIntoAssistantMessages(
       }
     }
 
-    // No tool results → pass through unchanged.
+    // No tool results → pass through unless the message is purely system notices.
     if (toolResultBlocks.length === 0) {
-      result.push(msg);
+      const hasRealContent = blocks.some((block) => {
+        if (typeof block !== "object" || block === null) return true;
+        return !isSystemNoticeText(block as Record<string, unknown>);
+      });
+      if (hasRealContent) {
+        result.push(msg);
+      }
       continue;
     }
 


### PR DESCRIPTION
## Summary
- Pop the empty assistant response when nudging for empty text, and merge the nudge into the existing tool_result user message (same pattern as the error nudge). This eliminates both `__PLACEHOLDER__[empty assistant turn]` and the standalone `<system_notice>` from actual API requests.
- Add `<system_notice>` to `RUNTIME_INJECTION_PREFIXES` for backward-compat cleanup of existing conversations during compaction.
- Filter standalone system_notice user messages in `mergeToolResultsIntoAssistantMessages` for backward-compat in the conversation history API.

## Original prompt
Get rid of this system notice and the placeholder above it (from context inspector view showing PLACEHOLDER and system_notice in raw LLM request payloads)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23900" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
