### PR TITLE
feat(log-export): include allowlisted workspace data in /v1/export archive

### DIFF
--- a/assistant/src/__tests__/log-export-workspace.test.ts
+++ b/assistant/src/__tests__/log-export-workspace.test.ts
@@ -93,6 +93,35 @@ writeFileSync(
   JSON.stringify({ provider: "anthropic" }),
 );
 
+// Conversation directories — used for workspace allowlist tests
+const conversationsDir = join(testWorkspaceDir, "conversations");
+mkdirSync(conversationsDir, { recursive: true });
+
+function seedConversation(name: string, body: string) {
+  const dir = join(conversationsDir, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "meta.json"), "{}\n");
+  writeFileSync(join(dir, "messages.jsonl"), body);
+}
+
+seedConversation(
+  "2025-01-10T00-00-00.000Z_conv-jan10",
+  '{"role":"user","content":"jan 10"}\n',
+);
+seedConversation(
+  "2025-01-15T00-00-00.000Z_conv-jan15",
+  '{"role":"user","content":"jan 15"}\n',
+);
+seedConversation(
+  "2025-01-20T00-00-00.000Z_conv-jan20",
+  '{"role":"user","content":"jan 20"}\n',
+);
+seedConversation(
+  "2025-01-25T00-00-00.000Z_conv-jan25",
+  '{"role":"user","content":"jan 25"}\n',
+);
+seedConversation("malformed-name", '{"role":"user","content":"x"}\n');
+
 // Daemon log files — used for date filtering tests
 const logsDir = join(testWorkspaceDir, "data", "logs");
 mkdirSync(logsDir, { recursive: true });
@@ -236,6 +265,133 @@ describe("POST /v1/export — daemon log date filtering", () => {
       expect(logFiles).toContain("assistant-2025-01-20.log");
       expect(logFiles).toContain("assistant-2025-01-25.log");
       expect(logFiles).toContain("vellum.log");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("POST /v1/export — workspace allowlist", () => {
+  test("includes all valid conversation dirs by default", async () => {
+    const res = await callExport();
+    const dir = await extractArchive(res);
+    try {
+      const convs = readdirSync(join(dir, "workspace", "conversations"));
+      expect(convs).toContain("2025-01-10T00-00-00.000Z_conv-jan10");
+      expect(convs).toContain("2025-01-15T00-00-00.000Z_conv-jan15");
+      expect(convs).toContain("2025-01-20T00-00-00.000Z_conv-jan20");
+      expect(convs).toContain("2025-01-25T00-00-00.000Z_conv-jan25");
+      expect(convs).not.toContain("malformed-name");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("skips malformed conversation dir names", async () => {
+    const res = await callExport();
+    const dir = await extractArchive(res);
+    try {
+      const convs = readdirSync(join(dir, "workspace", "conversations"));
+      expect(convs).not.toContain("malformed-name");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("filters conversation dirs by startTime", async () => {
+    const startTime = Date.parse("2025-01-14T00:00:00Z");
+    const res = await callExport({ startTime });
+    const dir = await extractArchive(res);
+    try {
+      const convs = readdirSync(join(dir, "workspace", "conversations"));
+      expect(convs).not.toContain("2025-01-10T00-00-00.000Z_conv-jan10");
+      expect(convs).toContain("2025-01-15T00-00-00.000Z_conv-jan15");
+      expect(convs).toContain("2025-01-20T00-00-00.000Z_conv-jan20");
+      expect(convs).toContain("2025-01-25T00-00-00.000Z_conv-jan25");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("filters conversation dirs by endTime", async () => {
+    const endTime = Date.parse("2025-01-22T00:00:00Z");
+    const res = await callExport({ endTime });
+    const dir = await extractArchive(res);
+    try {
+      const convs = readdirSync(join(dir, "workspace", "conversations"));
+      expect(convs).toContain("2025-01-10T00-00-00.000Z_conv-jan10");
+      expect(convs).toContain("2025-01-15T00-00-00.000Z_conv-jan15");
+      expect(convs).toContain("2025-01-20T00-00-00.000Z_conv-jan20");
+      expect(convs).not.toContain("2025-01-25T00-00-00.000Z_conv-jan25");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("filters conversation dirs by both startTime and endTime", async () => {
+    const startTime = Date.parse("2025-01-14T00:00:00Z");
+    const endTime = Date.parse("2025-01-22T00:00:00Z");
+    const res = await callExport({ startTime, endTime });
+    const dir = await extractArchive(res);
+    try {
+      const convs = readdirSync(join(dir, "workspace", "conversations"));
+      expect(convs).not.toContain("2025-01-10T00-00-00.000Z_conv-jan10");
+      expect(convs).toContain("2025-01-15T00-00-00.000Z_conv-jan15");
+      expect(convs).toContain("2025-01-20T00-00-00.000Z_conv-jan20");
+      expect(convs).not.toContain("2025-01-25T00-00-00.000Z_conv-jan25");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("filters conversation dirs by conversationId", async () => {
+    const res = await callExport({ conversationId: "conv-jan15" });
+    const dir = await extractArchive(res);
+    try {
+      const convs = readdirSync(join(dir, "workspace", "conversations"));
+      expect(convs).toContain("2025-01-15T00-00-00.000Z_conv-jan15");
+      expect(convs).not.toContain("2025-01-10T00-00-00.000Z_conv-jan10");
+      expect(convs).not.toContain("2025-01-20T00-00-00.000Z_conv-jan20");
+      expect(convs).not.toContain("2025-01-25T00-00-00.000Z_conv-jan25");
+      expect(convs).not.toContain("malformed-name");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("conversationId + time filter intersect", async () => {
+    const res = await callExport({
+      conversationId: "conv-jan15",
+      startTime: Date.parse("2025-02-01T00:00:00Z"),
+    });
+    const dir = await extractArchive(res);
+    try {
+      const conversationsPath = join(dir, "workspace", "conversations");
+      let convs: string[] = [];
+      try {
+        convs = readdirSync(conversationsPath);
+      } catch {
+        // Directory does not exist — acceptable per the test contract.
+      }
+      expect(convs).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("conversation dir contents survive the round trip", async () => {
+    const res = await callExport();
+    const dir = await extractArchive(res);
+    try {
+      const messagesPath = join(
+        dir,
+        "workspace",
+        "conversations",
+        "2025-01-15T00-00-00.000Z_conv-jan15",
+        "messages.jsonl",
+      );
+      const content = readFileSync(messagesPath, "utf-8");
+      expect(content).toBe('{"role":"user","content":"jan 15"}\n');
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/assistant/src/__tests__/log-export-workspace.test.ts
+++ b/assistant/src/__tests__/log-export-workspace.test.ts
@@ -396,4 +396,38 @@ describe("POST /v1/export — workspace allowlist", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  test("treats empty-string conversationId as no filter", async () => {
+    const res = await callExport({ conversationId: "" });
+    const dir = await extractArchive(res);
+    try {
+      // With conversationId === "" (which the rest of handleExport treats as
+      // unfiltered), workspace conversations should also be unfiltered. All
+      // four canonical conversation dirs should be present.
+      const conversationsDir = join(dir, "workspace", "conversations");
+      const entries = readdirSync(conversationsDir);
+      expect(entries).toContain("2025-01-10T00-00-00.000Z_conv-jan10");
+      expect(entries).toContain("2025-01-15T00-00-00.000Z_conv-jan15");
+      expect(entries).toContain("2025-01-20T00-00-00.000Z_conv-jan20");
+      expect(entries).toContain("2025-01-25T00-00-00.000Z_conv-jan25");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("treats startTime=0 and endTime=0 as no filter", async () => {
+    const res = await callExport({ startTime: 0, endTime: 0 });
+    const dir = await extractArchive(res);
+    try {
+      const conversationsDir = join(dir, "workspace", "conversations");
+      const entries = readdirSync(conversationsDir);
+      // All four canonical conversation dirs should be present (no filtering).
+      expect(entries).toContain("2025-01-10T00-00-00.000Z_conv-jan10");
+      expect(entries).toContain("2025-01-15T00-00-00.000Z_conv-jan15");
+      expect(entries).toContain("2025-01-20T00-00-00.000Z_conv-jan20");
+      expect(entries).toContain("2025-01-25T00-00-00.000Z_conv-jan25");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -39,6 +39,7 @@ import { APP_VERSION, COMMIT_SHA } from "../../version.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 import { createTarGz } from "./archive-utils.js";
+import { collectWorkspaceData } from "./log-export/workspace-allowlist.js";
 
 const log = getLogger("log-export-routes");
 
@@ -241,6 +242,17 @@ async function handleExport(body: ExportRequestBody): Promise<Response> {
       }
     }
 
+    // --- Workspace allowlist ---
+    // Includes specific subpaths from <workspace>/ governed by the rules in
+    // ./log-export/AGENTS.md. Honors the same time + conversation filters as
+    // the rest of the export.
+    const workspaceResult = collectWorkspaceData({
+      staging,
+      conversationId,
+      startTime,
+      endTime,
+    });
+
     // --- Sanitized config snapshot ---
     const configSnapshot = readSanitizedConfig();
     if (configSnapshot) {
@@ -281,6 +293,8 @@ async function handleExport(body: ExportRequestBody): Promise<Response> {
         totalBytes,
         hasConfig: configSnapshot !== undefined,
         conversationId: conversationId ?? null,
+        workspaceEntries: workspaceResult.entries.length,
+        workspaceBytes: workspaceResult.totalBytes,
       },
       "Export collected, creating tar.gz archive",
     );

--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -248,9 +248,9 @@ async function handleExport(body: ExportRequestBody): Promise<Response> {
     // the rest of the export.
     const workspaceResult = collectWorkspaceData({
       staging,
-      conversationId,
-      startTime,
-      endTime,
+      conversationId: conversationId || undefined,
+      startTime: startTime || undefined,
+      endTime: endTime || undefined,
     });
 
     // --- Sanitized config snapshot ---


### PR DESCRIPTION
## Summary
- Wire `collectWorkspaceData` into `handleExport` so `POST /v1/export` includes `workspace/conversations/` entries that pass the time + conversationId filters
- Add 8 integration tests covering all filter combinations, malformed-name skip, and content round-trip

Part of plan: ws-export-allowlist.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23901" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
