### PR TITLE
refactor: remove dead scroll types and unused code

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -94,6 +94,23 @@ final class MessageListScrollState {
     /// cooldown between successive pagination fires.
     @ObservationIgnored var lastPaginationCompletedAt: Date = .distantPast
 
+    // MARK: - Bottom Anchor Tracking
+
+    /// Whether the bottom anchor element has appeared in the LazyVStack.
+    /// Set by `MessageListContentView`'s `onAppear` on the bottom spacer.
+    @ObservationIgnored var bottomAnchorAppeared: Bool = false
+
+    /// Whether the user has interacted with the scroll view (scrolled away
+    /// from initial position). Used to gate initial auto-scroll behavior.
+    @ObservationIgnored var hasBeenInteracted: Bool = false
+
+    // MARK: - Derived State Cache
+
+    /// Non-observable cache for memoizing derived state computations.
+    /// Kept off the observation graph to avoid "modifying state during view
+    /// update" warnings while still enabling memoization hot paths.
+    @ObservationIgnored lazy var derivedStateCache = MessageListDerivedStateCache()
+
     // MARK: - Computed Properties
 
     /// Distance from the bottom of the scrollable content.
@@ -159,6 +176,41 @@ final class MessageListScrollState {
         return true
     }
 
+    /// Called when the viewport reaches the bottom of the content.
+    /// Marks the scroll state as interacted and near-bottom.
+    func handleReachedBottom() {
+        hasBeenInteracted = true
+        isNearBottom = true
+        showScrollToLatest = false
+    }
+
+    /// Records a body evaluation timestamp for circuit-breaker throttling.
+    /// If more than 60 evaluations occur within 500ms, activates throttle
+    /// mode to prevent runaway layout loops. Auto-recovers after 500ms.
+    func recordBodyEvaluation() {
+        let now = CFAbsoluteTimeGetCurrent()
+        let cache = derivedStateCache
+        cache.bodyEvalTimestamps.append(now)
+
+        // Prune timestamps older than 500ms
+        let cutoff = now - 0.5
+        cache.bodyEvalTimestamps.removeAll { $0 < cutoff }
+
+        if cache.bodyEvalTimestamps.count > 60 && !cache.isThrottled {
+            cache.isThrottled = true
+            scrollLog.warning("Circuit breaker tripped: \(cache.bodyEvalTimestamps.count) body evals in 500ms")
+
+            cache.throttleRecoveryTask?.cancel()
+            cache.throttleRecoveryTask = Task { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: 500_000_000)
+                guard !Task.isCancelled else { return }
+                self?.derivedStateCache.isThrottled = false
+                self?.derivedStateCache.bodyEvalTimestamps.removeAll()
+                scrollLog.debug("Circuit breaker recovered")
+            }
+        }
+    }
+
     /// Called when the user taps "Scroll to latest". Resets near-bottom
     /// state and hides the CTA so the caller can perform the actual scroll.
     func handleScrollToLatestTapped() {
@@ -183,6 +235,9 @@ final class MessageListScrollState {
         showScrollToLatest = false
         scrollIndicatorsHidden = false
         lastAutoFocusedRequestId = nil
+        bottomAnchorAppeared = false
+        hasBeenInteracted = false
+        derivedStateCache.reset()
 
         scrollLog.debug("Reset for conversation: \(conversationId)")
     }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
@@ -45,56 +45,6 @@ struct ScrollGeometrySnapshot: Equatable {
     let visibleRectHeight: CGFloat
 }
 
-// MARK: - Scroll Geometry Dispatcher
-
-/// Coalesces `onScrollGeometryChange` callbacks outside SwiftUI-managed state.
-///
-/// macOS 26 faults when an `OnScrollGeometryChange` action updates view state
-/// multiple times in the same frame. The message list still needs to process
-/// the latest geometry snapshot, but the queue bookkeeping itself must not
-/// live on `@State` / `@Observable` storage owned by the view.
-@MainActor
-final class ScrollGeometryUpdateDispatcher {
-    static let shared = ScrollGeometryUpdateDispatcher()
-
-    private var pendingSnapshots: [ObjectIdentifier: ScrollGeometrySnapshot] = [:]
-    private var tasks: [ObjectIdentifier: Task<Void, Never>] = [:]
-
-    func enqueue(
-        for owner: MessageListScrollState,
-        snapshot: ScrollGeometrySnapshot,
-        handler: @escaping @MainActor (ScrollGeometrySnapshot) -> Void
-    ) {
-        let key = ObjectIdentifier(owner)
-        pendingSnapshots[key] = snapshot
-        guard tasks[key] == nil else { return }
-
-        tasks[key] = Task { @MainActor [weak self, weak owner] in
-            guard let self else { return }
-            defer {
-                self.tasks[key] = nil
-                self.pendingSnapshots[key] = nil
-            }
-
-            while !Task.isCancelled {
-                await Task.yield()
-                guard owner != nil else { return }
-                guard let latest = self.pendingSnapshots[key] else { return }
-                self.pendingSnapshots[key] = nil
-                handler(latest)
-                guard self.pendingSnapshots[key] != nil else { return }
-            }
-        }
-    }
-
-    func cancel(for owner: MessageListScrollState) {
-        let key = ObjectIdentifier(owner)
-        tasks[key]?.cancel()
-        tasks[key] = nil
-        pendingSnapshots[key] = nil
-    }
-}
-
 // MARK: - Cached Message Layout Metadata
 
 /// Structural metadata cached behind a version-counter key on

--- a/clients/macos/vellum-assistantTests/MessageListAnchorPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListAnchorPerformanceTests.swift
@@ -80,19 +80,20 @@ final class MessageListAnchorPerformanceTests: XCTestCase {
 
     // MARK: - 1. Scroll State Bottom-Detection Rapid-Update Stress Test
 
-    /// Benchmarks setting `isAtBottom` 10,000 times in a tight loop. While
-    /// individually trivial (O(1)), this mirrors the per-scroll-frame hot path.
-    /// This test detects if any future refactoring adds overhead.
+    /// Benchmarks calling `updateNearBottom()` 10,000 times in a tight loop.
+    /// While individually trivial (O(1)), this mirrors the per-scroll-frame
+    /// hot path. This test detects if any future refactoring adds overhead.
     func testBottomDetectionRapidUpdateStress() {
         let scrollState = MessageListScrollState()
+        scrollState.contentHeight = 5000
+        scrollState.viewportHeight = 800
 
         measure(metrics: [XCTClockMetric(), XCTCPUMetric()]) {
             for i in 0..<10_000 {
-                // Simulate scroll position changes: alternate between bottom
-                // anchor and other views to stress isAtBottom updates.
-                // Simulate scroll geometry bottom detection: every 10th
-                // iteration is "at bottom", the rest are not.
-                scrollState.isAtBottom = (i % 10 == 0)
+                // Simulate scroll position changes: alternate between near-
+                // bottom and far-from-bottom positions.
+                scrollState.contentOffsetY = (i % 10 == 0) ? 4195 : 3000
+                scrollState.updateNearBottom()
             }
         }
     }

--- a/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
@@ -135,31 +135,27 @@ final class MessageListScrollPerformanceTests: XCTestCase {
         }
     }
 
-    // MARK: - Test 3: requestPinToBottom Hot Path
+    // MARK: - Test 3: Near-Bottom Update Hot Path
 
-    /// Measures the synchronous hot path of requestPinToBottom on the scroll
-    /// state: request a pin, transition back to followingBottom — repeated 100 times.
+    /// Measures the synchronous hot path of updateNearBottom on the scroll
+    /// state — repeated 100 times. This mirrors the per-scroll-frame hot path
+    /// for hysteresis-based near-bottom detection.
     @MainActor
-    func testPinToBottomPerformance() {
+    func testNearBottomUpdatePerformance() {
         measure(metrics: [XCTClockMetric()]) {
             let scrollState = MessageListScrollState()
-            var scrollCallCount = 0
+            scrollState.contentHeight = 5000
+            scrollState.viewportHeight = 800
 
-            scrollState.scrollTo = { _, _ in
-                scrollCallCount += 1
+            // Run 100 update cycles alternating between near and far positions.
+            for i in 0..<100 {
+                // Alternate between near-bottom and far-from-bottom.
+                scrollState.contentOffsetY = (i % 2 == 0) ? 4190 : 3000
+                scrollState.updateNearBottom()
             }
 
-            // Ensure we start in followingBottom mode.
-            scrollState.transition(to: .followingBottom)
-
-            // Run 100 pin request cycles to get a stable measurement.
-            for _ in 0..<100 {
-                scrollState.requestPinToBottom()
-                scrollState.transition(to: .followingBottom)
-            }
-
-            XCTAssertGreaterThan(scrollCallCount, 0)
-            scrollState.cancelAll()
+            // Verify final state is deterministic.
+            XCTAssertFalse(scrollState.isNearBottom)
         }
     }
 
@@ -203,8 +199,8 @@ final class MessageListScrollPerformanceTests: XCTestCase {
             orphanSubagents: [],
             effectiveStatusText: nil
         )
-        tracking.cachedLayoutKey = key
-        tracking.cachedLayoutMetadata = layout
+        tracking.derivedStateCache.cachedLayoutKey = key
+        tracking.derivedStateCache.cachedLayoutMetadata = layout
 
         // Simulate streaming: append text to the last message (same count,
         // same isStreaming flag — the version counter does NOT bump).
@@ -223,8 +219,8 @@ final class MessageListScrollPerformanceTests: XCTestCase {
         )
 
         // The cache key hasn't changed — layout cache should still hit.
-        XCTAssertEqual(key, tracking.cachedLayoutKey)
-        XCTAssertNotNil(tracking.cachedLayoutMetadata)
+        XCTAssertEqual(key, tracking.derivedStateCache.cachedLayoutKey)
+        XCTAssertNotNil(tracking.derivedStateCache.cachedLayoutMetadata)
 
         // But the live message must reflect the updated text.
         let lastId = messages.last!.id

--- a/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
@@ -5,427 +5,226 @@ import XCTest
 @MainActor
 final class MessageListScrollStateTests: XCTestCase {
     private var state: MessageListScrollState!
-    private var scrollToCalls: [(id: AnyHashable, anchor: UnitPoint?)] = []
-    private var scrollToEdgeCalls: [Edge] = []
 
     override func setUp() {
         super.setUp()
         state = MessageListScrollState()
-        scrollToCalls = []
-        scrollToEdgeCalls = []
-
-        state.scrollTo = { [weak self] id, anchor in
-            self?.scrollToCalls.append((id: id as! AnyHashable, anchor: anchor))
-        }
-        state.scrollToEdge = { [weak self] edge in
-            self?.scrollToEdgeCalls.append(edge)
-        }
     }
 
     override func tearDown() {
-        state.cancelAll()
         state = nil
         super.tearDown()
     }
 
     // MARK: - Initial State
 
-    func testInitialStateAllowsAutoScrollWithoutInteraction() {
-        XCTAssertFalse(state.isFollowingBottom)
-        XCTAssertFalse(state.hasBeenInteracted)
-        XCTAssertTrue(state.mode.allowsAutoScroll)
-
-        let result = state.requestPinToBottom()
-        XCTAssertTrue(result, "initialLoad should still allow bottom pinning")
-        // When lastMessageId is nil (fresh state), executeScrollToBottom
-        // falls through to scrollToEdge(.bottom) — not scrollTo(id:).
-        XCTAssertFalse(scrollToEdgeCalls.isEmpty,
-                       "Should fall back to edge-based scroll when lastMessageId is nil")
-        XCTAssertEqual(scrollToEdgeCalls.first, .bottom)
-    }
-
-    func testInitialModeIsInitialLoad() {
-        if case .initialLoad = state.mode {
-            // correct
-        } else {
-            XCTFail("Initial mode should be .initialLoad")
-        }
-    }
-
-    // MARK: - Mode Transitions
-
-    func testTransitionToFreeBrowsingSetsFollowingFalse() {
-        state.transition(to: .freeBrowsing)
-        XCTAssertFalse(state.isFollowingBottom)
-        XCTAssertTrue(state.hasBeenInteracted)
-    }
-
-    func testTransitionToFollowingBottomSetsFollowingTrue() {
-        state.transition(to: .freeBrowsing)
-        XCTAssertFalse(state.isFollowingBottom)
-
-        state.transition(to: .followingBottom)
-        XCTAssertTrue(state.isFollowingBottom)
-    }
-
-    func testTransitionToSameModeIsNoop() {
-        state.transition(to: .followingBottom)
-        state.transition(to: .followingBottom)
-        XCTAssertTrue(state.isFollowingBottom)
-    }
-
-    func testHandleUserScrollUpTransitionsToFreeBrowsing() {
-        state.transition(to: .followingBottom)
-        state.handleUserScrollUp()
-        XCTAssertFalse(state.isFollowingBottom)
-        if case .freeBrowsing = state.mode {
-            // correct
-        } else {
-            XCTFail("Expected .freeBrowsing after handleUserScrollUp")
-        }
-    }
-
-    func testHandleReachedBottomTransitionsToFollowingBottom() {
-        state.transition(to: .freeBrowsing)
-        XCTAssertFalse(state.isFollowingBottom)
-
-        state.handleReachedBottom()
-        XCTAssertTrue(state.isFollowingBottom)
-    }
-
-    /// Verifies that rapid transitions coalesce into a single UI sync.
-    func testRapidTransitionsDoNotAccumulate() async throws {
-        // GIVEN 100 rapid transitions to freeBrowsing
-        for _ in 0..<100 {
-            state.transition(to: .freeBrowsing)
-        }
-
-        // WHEN the debounced sync fires
-        XCTAssertFalse(state.isFollowingBottom)
+    func testInitialState() {
+        XCTAssertTrue(state.isNearBottom)
         XCTAssertFalse(state.showScrollToLatest)
-        try await Task.sleep(nanoseconds: 50_000_000)
-
-        // THEN only one property update occurs
-        XCTAssertTrue(state.showScrollToLatest,
-                      "showScrollToLatest should be true after debounced sync")
-        XCTAssertEqual(state.uiVersion, 1,
-                       "Only one internal uiVersion bump despite 100 transition calls")
+        XCTAssertFalse(state.scrollIndicatorsHidden)
+        XCTAssertFalse(state.hasBeenInteracted)
+        XCTAssertFalse(state.bottomAnchorAppeared)
+        XCTAssertFalse(state.didAnchorCurrentSendCycle)
+        XCTAssertEqual(state.viewportHeight, 0)
+        XCTAssertEqual(state.contentHeight, 0)
+        XCTAssertEqual(state.contentOffsetY, 0)
+        XCTAssertNil(state.currentConversationId)
+        XCTAssertNil(state.pendingAnchorMessageId)
+        XCTAssertNil(state.lastMessageId)
+        XCTAssertNil(state.lastAutoFocusedRequestId)
+        XCTAssertFalse(state.wasPaginationTriggerInRange)
     }
 
-    // MARK: - Pin Gating
+    // MARK: - Near-Bottom Hysteresis
 
-    func testPinSuppressedInFreeBrowsing() {
-        state.transition(to: .freeBrowsing)
-        let result = state.requestPinToBottom()
+    func testNearBottomHysteresisLeavesAt50pt() {
+        // Start near bottom
+        XCTAssertTrue(state.isNearBottom)
 
-        XCTAssertFalse(result, "requestPinToBottom should return false in freeBrowsing mode")
-        XCTAssertTrue(scrollToCalls.isEmpty,
-                      "Pin requests should be suppressed in freeBrowsing mode")
+        // Set geometry so distance > 50pt
+        state.contentHeight = 1000
+        state.viewportHeight = 400
+        state.contentOffsetY = 500 // distance = 1000 - 500 - 400 = 100pt
+        state.updateNearBottom()
+
+        XCTAssertFalse(state.isNearBottom)
+        XCTAssertTrue(state.showScrollToLatest)
     }
 
-    func testPinSuppressedWhileStabilizing() {
-        state.transition(to: .followingBottom)
-        state.beginStabilization(.expansion)
-        let result = state.requestPinToBottom()
+    func testNearBottomHysteresisEntersAt10pt() {
+        // Leave near-bottom first
+        state.contentHeight = 1000
+        state.viewportHeight = 400
+        state.contentOffsetY = 500
+        state.updateNearBottom()
+        XCTAssertFalse(state.isNearBottom)
 
-        XCTAssertFalse(result, "requestPinToBottom should return false when stabilizing")
-        XCTAssertTrue(scrollToCalls.isEmpty,
-                      "Pin requests should be suppressed when stabilizing")
+        // Move close to bottom (distance <= 10pt)
+        state.contentOffsetY = 595 // distance = 1000 - 595 - 400 = 5pt
+        state.updateNearBottom()
+
+        XCTAssertTrue(state.isNearBottom)
+        XCTAssertFalse(state.showScrollToLatest)
     }
 
-    func testPinAllowedWhenFollowingBottom() {
-        state.transition(to: .followingBottom)
-        // Seed lastMessageId so the ID-based path fires (not edge fallback).
-        state.lastMessageId = UUID()
-        let result = state.requestPinToBottom()
+    func testNearBottomDoesNotReenterBetween10And50() {
+        // Leave near-bottom
+        state.contentHeight = 1000
+        state.viewportHeight = 400
+        state.contentOffsetY = 500 // distance = 100pt
+        state.updateNearBottom()
+        XCTAssertFalse(state.isNearBottom)
 
-        XCTAssertTrue(result, "requestPinToBottom should return true when following bottom")
-        // ID-based scroll fires synchronously (targets real ForEach content).
-        // Edge-based is only used as fallback when lastMessageId is nil.
-        XCTAssertFalse(scrollToCalls.isEmpty,
-                       "scrollTo should have been called synchronously")
+        // Move to 30pt from bottom (in hysteresis band)
+        state.contentOffsetY = 570 // distance = 1000 - 570 - 400 = 30pt
+        state.updateNearBottom()
+        XCTAssertFalse(state.isNearBottom, "Should not re-enter near-bottom in hysteresis band")
     }
 
-    func testPinAllowedAfterTransitionToFollowingBottom() {
-        state.transition(to: .freeBrowsing)
-        let suppressed = state.requestPinToBottom()
-        XCTAssertFalse(suppressed)
-        XCTAssertTrue(scrollToCalls.isEmpty)
+    // MARK: - Send Cycle Anchoring
 
-        state.transition(to: .followingBottom)
-        // Seed lastMessageId so the ID-based path fires (not edge fallback).
-        state.lastMessageId = UUID()
-        let allowed = state.requestPinToBottom()
-        XCTAssertTrue(allowed)
-        XCTAssertFalse(scrollToCalls.isEmpty,
-                       "ID-based scroll should proceed after transitioning to followingBottom")
+    func testBeginSendCycleResetsAnchorFlag() {
+        state.markSendAnchored()
+        XCTAssertTrue(state.didAnchorCurrentSendCycle)
+
+        state.beginSendCycle()
+        XCTAssertFalse(state.didAnchorCurrentSendCycle)
     }
 
-    func testUserInitiatedBypassesGuards() {
-        state.transition(to: .freeBrowsing)
-        state.beginStabilization(.expansion)
+    func testShouldAutoFollow() {
+        XCTAssertTrue(state.shouldAutoFollow, "Near bottom + not anchored = should follow")
 
-        let result = state.requestPinToBottom(userInitiated: true)
+        state.markSendAnchored()
+        XCTAssertFalse(state.shouldAutoFollow, "Already anchored = should not follow")
 
-        XCTAssertTrue(result,
-                      "User-initiated requests should always return true")
-        // User-initiated uses ID-based scroll as primary (targets real
-        // ForEach content, never overshoots) with edge-based correction
-        // in a Task.
-        XCTAssertFalse(scrollToCalls.isEmpty,
-                       "User-initiated requests should bypass mode checks and scroll to ID")
+        state.beginSendCycle()
+        XCTAssertTrue(state.shouldAutoFollow, "Reset anchor = should follow again")
     }
 
-    // MARK: - Stabilization
+    // MARK: - Auto-Follow Throttle
 
-    func testStabilizationPreservesFollowingBottom() {
-        state.transition(to: .followingBottom)
-        state.beginStabilization(.resize)
-        XCTAssertTrue(state.isSuppressed)
-        XCTAssertTrue(state.isFollowingBottom,
-                      "isFollowingBottom should reflect the pre-stabilization mode")
-
-        state.endStabilization()
-        XCTAssertFalse(state.isSuppressed)
-        XCTAssertTrue(state.isFollowingBottom)
+    func testCanAutoFollowThrottles() {
+        XCTAssertTrue(state.canAutoFollow())
+        XCTAssertFalse(state.canAutoFollow(), "Should throttle within 80ms")
     }
 
-    func testStabilizationPreservesFreeBrowsing() {
-        state.transition(to: .freeBrowsing)
-        state.beginStabilization(.resize)
-        XCTAssertTrue(state.isSuppressed)
-        XCTAssertFalse(state.isFollowingBottom)
-
-        state.endStabilization()
-        XCTAssertFalse(state.isSuppressed)
-        XCTAssertFalse(state.isFollowingBottom)
+    func testCanAutoFollowReturnsFalseWhenNotNearBottom() {
+        state.isNearBottom = false
+        XCTAssertFalse(state.canAutoFollow())
     }
 
-    func testOverlappingStabilizationWaitsForAllWindows() {
-        state.transition(to: .followingBottom)
+    // MARK: - handleReachedBottom
 
-        // Window 1: resize
-        state.beginStabilization(.resize)
-        XCTAssertTrue(state.isSuppressed)
-
-        // Window 2: expansion (overlapping)
-        state.beginStabilization(.expansion)
-        XCTAssertTrue(state.isSuppressed)
-
-        // Window 1 completes — should still be stabilizing
-        state.endStabilization()
-        XCTAssertTrue(state.isSuppressed,
-                      "Should remain stabilizing while overlapping windows are active")
-
-        // Window 2 completes — now should exit
-        state.endStabilization()
-        XCTAssertFalse(state.isSuppressed,
-                       "Should exit stabilization after all windows complete")
-        XCTAssertTrue(state.isFollowingBottom,
-                      "Should restore followingBottom after overlapping stabilization")
+    func testHandleReachedBottomSetsInteracted() {
+        XCTAssertFalse(state.hasBeenInteracted)
+        state.handleReachedBottom()
+        XCTAssertTrue(state.hasBeenInteracted)
+        XCTAssertTrue(state.isNearBottom)
+        XCTAssertFalse(state.showScrollToLatest)
     }
 
-    func testOverlappingStabilizationPreservesOriginalMode() {
-        state.transition(to: .freeBrowsing)
+    // MARK: - handleScrollToLatestTapped
 
-        state.beginStabilization(.resize)
-        state.beginStabilization(.pagination)
-        state.endStabilization()
-        XCTAssertTrue(state.isSuppressed)
+    func testHandleScrollToLatestTapped() {
+        // First leave near-bottom so showScrollToLatest becomes true
+        state.contentHeight = 1000
+        state.viewportHeight = 400
+        state.contentOffsetY = 500
+        state.updateNearBottom()
+        XCTAssertTrue(state.showScrollToLatest)
 
-        state.endStabilization()
-        XCTAssertFalse(state.isSuppressed)
-        XCTAssertFalse(state.isFollowingBottom,
-                       "Should restore freeBrowsing (original mode before any stabilization)")
-    }
-
-    // MARK: - Stabilization: Expansion 200ms Auto-Clear
-
-    func testExpansionAutoClears() async throws {
-        state.transition(to: .followingBottom)
-        state.beginStabilization(.expansion)
-        XCTAssertTrue(state.isSuppressed)
-
-        try await Task.sleep(nanoseconds: 250_000_000)
-
-        XCTAssertFalse(state.isSuppressed,
-                       "Expansion stabilization should auto-clear after 200ms")
-    }
-
-    func testExpansionTimerReset() async throws {
-        state.transition(to: .followingBottom)
-        state.beginStabilization(.expansion)
-        XCTAssertTrue(state.isSuppressed)
-
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        state.beginStabilization(.expansion)
-        XCTAssertTrue(state.isSuppressed)
-
-        try await Task.sleep(nanoseconds: 150_000_000)
-
-        XCTAssertTrue(state.isSuppressed,
-                      "Timer was reset -- should still be stabilizing")
-
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        XCTAssertFalse(state.isSuppressed,
-                       "Expansion stabilization should auto-clear after the reset timeout")
+        state.handleScrollToLatestTapped()
+        XCTAssertTrue(state.isNearBottom)
+        XCTAssertFalse(state.showScrollToLatest)
     }
 
     // MARK: - Reset
 
     func testResetRestoresDefaults() {
-        let oldId = UUID()
         let newId = UUID()
 
-        state.transition(to: .freeBrowsing)
-        state.beginStabilization(.resize)
-        state.isPaginationInFlight = true
+        state.isNearBottom = false
+        state.viewportHeight = 500
+        state.contentHeight = 1000
+        state.contentOffsetY = 200
+        state.didAnchorCurrentSendCycle = true
+        state.pendingAnchorMessageId = UUID()
+        state.lastMessageId = UUID()
         state.wasPaginationTriggerInRange = true
-        state.isAtBottom = false
-        state.currentConversationId = oldId
+        state.bottomAnchorAppeared = true
+        state.hasBeenInteracted = true
+        state.lastAutoFocusedRequestId = "req-1"
 
         state.reset(for: newId)
 
-        if case .initialLoad = state.mode {
-            // correct
-        } else {
-            XCTFail("Reset should return to .initialLoad mode")
-        }
-        XCTAssertFalse(state.isFollowingBottom, "initialLoad is distinct from followingBottom")
-        XCTAssertTrue(state.mode.allowsAutoScroll, "Reset should restore auto-scroll eligibility")
-        XCTAssertFalse(state.showScrollToLatest, "Should sync showScrollToLatest immediately on reset")
-        XCTAssertFalse(state.isSuppressed, "Should clear stabilization")
-        XCTAssertFalse(state.isPaginationInFlight, "Should clear pagination flag")
-        XCTAssertFalse(state.wasPaginationTriggerInRange, "Should clear trigger range flag")
-        XCTAssertFalse(state.isAtBottom, "Should wait for fresh geometry before claiming bottom")
-        XCTAssertFalse(state.hasBeenInteracted, "Should reset to initialLoad mode")
-        XCTAssertEqual(state.currentConversationId, newId, "Should update conversation ID")
-        XCTAssertTrue(state.hideScrollIndicators,
-                      "Should hide scroll indicators during conversation switch")
-        XCTAssertTrue(state.scrollIndicatorsHidden)
+        XCTAssertEqual(state.currentConversationId, newId)
+        XCTAssertTrue(state.isNearBottom)
+        XCTAssertEqual(state.viewportHeight, 0)
+        XCTAssertEqual(state.contentHeight, 0)
+        XCTAssertEqual(state.contentOffsetY, 0)
+        XCTAssertFalse(state.didAnchorCurrentSendCycle)
+        XCTAssertNil(state.pendingAnchorMessageId)
+        XCTAssertNil(state.lastMessageId)
+        XCTAssertFalse(state.wasPaginationTriggerInRange)
+        XCTAssertEqual(state.lastPaginationCompletedAt, .distantPast)
         XCTAssertFalse(state.showScrollToLatest)
+        XCTAssertFalse(state.scrollIndicatorsHidden)
+        XCTAssertNil(state.lastAutoFocusedRequestId)
+        XCTAssertFalse(state.bottomAnchorAppeared)
+        XCTAssertFalse(state.hasBeenInteracted)
     }
 
-    func testResetClearsBottomAnchorAppeared() {
-        state.bottomAnchorAppeared = true
-        state.reset(for: UUID())
-        XCTAssertFalse(state.bottomAnchorAppeared,
-                       "Should reset bottomAnchorAppeared so recovery fires for new conversation")
-    }
-
-    func testResetClearsLastMessageId() {
-        state.lastMessageId = UUID()
-        state.reset(for: UUID())
-        XCTAssertNil(state.lastMessageId,
-                     "Should clear lastMessageId so it gets re-seeded for the new conversation")
-    }
-
-    func testResetClearsLayoutCache() {
-        state.messageListVersion = 5
-        state.lastKnownRawMessageCount = 10
-        state.lastKnownVisibleMessageCount = 8
-        state.lastKnownLastMessageStreaming = true
-        state.lastKnownIncompleteToolCallCount = 3
-        state.lastKnownVisibleIdFingerprint = 42
+    func testResetClearsDerivedStateCache() {
+        let cache = state.derivedStateCache
+        cache.messageListVersion = 5
+        cache.lastKnownRawMessageCount = 10
+        cache.lastKnownVisibleMessageCount = 8
+        cache.lastKnownLastMessageStreaming = true
+        cache.lastKnownIncompleteToolCallCount = 3
+        cache.lastKnownVisibleIdFingerprint = 42
 
         state.reset(for: UUID())
 
-        XCTAssertEqual(state.messageListVersion, 0)
-        XCTAssertEqual(state.lastKnownRawMessageCount, 0)
-        XCTAssertEqual(state.lastKnownVisibleMessageCount, 0)
-        XCTAssertFalse(state.lastKnownLastMessageStreaming)
-        XCTAssertEqual(state.lastKnownIncompleteToolCallCount, 0)
-        XCTAssertEqual(state.lastKnownVisibleIdFingerprint, 0)
-        XCTAssertNil(state.cachedLayoutKey)
-        XCTAssertNil(state.cachedLayoutMetadata)
+        XCTAssertEqual(cache.messageListVersion, 0)
+        XCTAssertEqual(cache.lastKnownRawMessageCount, 0)
+        XCTAssertEqual(cache.lastKnownVisibleMessageCount, 0)
+        XCTAssertFalse(cache.lastKnownLastMessageStreaming)
+        XCTAssertEqual(cache.lastKnownIncompleteToolCallCount, 0)
+        XCTAssertEqual(cache.lastKnownVisibleIdFingerprint, 0)
+        XCTAssertNil(cache.cachedLayoutKey)
+        XCTAssertNil(cache.cachedLayoutMetadata)
+        XCTAssertNil(cache.cachedDerivedState)
     }
 
-    // MARK: - cancelAll
+    // MARK: - Pagination Sentinel
 
-    func testCancelAllResetsMode() {
-        state.transition(to: .freeBrowsing)
-        state.beginStabilization(.resize)
-        XCTAssertTrue(state.isSuppressed)
+    func testPaginationSentinelRisingEdge() {
+        // Out of range initially
+        XCTAssertFalse(state.handlePaginationSentinel(sentinelMinY: -200))
 
-        state.cancelAll()
+        // Enter range — should fire
+        XCTAssertTrue(state.handlePaginationSentinel(sentinelMinY: 100))
 
-        XCTAssertFalse(state.isSuppressed, "cancelAll should clear stabilization")
-        XCTAssertFalse(state.hideScrollIndicators,
-                       "cancelAll should restore scroll indicators")
-        XCTAssertFalse(state.isPaginationInFlight,
-                       "cancelAll should clear pagination flag")
+        // Already in range — should not fire again
+        XCTAssertFalse(state.handlePaginationSentinel(sentinelMinY: 50))
     }
 
-    // MARK: - Computed Properties
+    func testPaginationCooldown() {
+        // First trigger
+        XCTAssertTrue(state.handlePaginationSentinel(sentinelMinY: 100))
 
-    /// Verifies that showScrollToLatest tracks mode transitions independently.
-    func testShowScrollToLatest() async throws {
-        // GIVEN initial state
-        XCTAssertFalse(state.showScrollToLatest,
-                       "Should be false when following bottom")
+        // Leave range
+        XCTAssertFalse(state.handlePaginationSentinel(sentinelMinY: -200))
 
-        // WHEN transitioning to freeBrowsing
-        state.transition(to: .freeBrowsing)
-        try await Task.sleep(nanoseconds: 50_000_000)
-
-        // THEN showScrollToLatest becomes true
-        XCTAssertTrue(state.showScrollToLatest,
-                      "Should be true when in freeBrowsing mode")
-
-        // WHEN transitioning back to followingBottom
-        state.transition(to: .followingBottom)
-        try await Task.sleep(nanoseconds: 50_000_000)
-
-        // THEN showScrollToLatest becomes false again
-        XCTAssertFalse(state.showScrollToLatest,
-                       "Should be false again after transitioning to followingBottom")
+        // Re-enter within cooldown — should not fire
+        // (lastPaginationCompletedAt was just set)
+        XCTAssertFalse(state.handlePaginationSentinel(sentinelMinY: 100))
     }
 
-    // MARK: - Property-Level Tracking
-
-    /// Verifies that each UI property reflects the final mode state after
-    /// multiple transitions and a debounced sync.
-    func testUIPropertiesReflectFinalState() async throws {
-        // GIVEN multiple mode transitions ending in freeBrowsing
-        state.transition(to: .followingBottom)
-        state.transition(to: .freeBrowsing)
-
-        // AND a scroll indicator change that requires a debounced sync
-        state.hideScrollIndicators = true
-
-        // WHEN the debounced sync fires
-        try await Task.sleep(nanoseconds: 50_000_000)
-
-        // THEN each property reflects the final mode (.freeBrowsing)
-        XCTAssertTrue(state.showScrollToLatest,
-                      "freeBrowsing mode shows scroll-to-latest")
-        XCTAssertTrue(state.scrollIndicatorsHidden,
-                      "scroll indicators should be hidden")
-    }
-
-    /// Verifies that syncUIImmediately bypasses debounce and updates all
-    /// properties immediately.
-    func testSyncUIImmediately() {
-        // GIVEN freeBrowsing mode
-        state.transition(to: .freeBrowsing)
-        state.syncUIImmediately()
-
-        // THEN properties reflect the current mode (.freeBrowsing)
-        XCTAssertTrue(state.showScrollToLatest,
-                      "freeBrowsing mode shows scroll-to-latest")
-    }
-
-    /// Verifies that syncUIImmediately reflects followingBottom correctly.
-    func testSyncUIImmediatelyFollowingBottom() {
-        // GIVEN followingBottom mode
-        state.transition(to: .followingBottom)
-        state.syncUIImmediately()
-
-        // THEN properties reflect the current mode (.followingBottom)
-        XCTAssertFalse(state.showScrollToLatest,
-                       "followingBottom mode does not show scroll-to-latest")
+    func testPaginationCooldownResetOnConversationSwitch() {
+        state.lastPaginationCompletedAt = Date()
+        state.reset(for: UUID())
+        XCTAssertEqual(state.lastPaginationCompletedAt, .distantPast)
     }
 
     // MARK: - Circuit Breaker
@@ -434,57 +233,24 @@ final class MessageListScrollStateTests: XCTestCase {
         for _ in 0...100 {
             state.recordBodyEvaluation()
         }
-        XCTAssertTrue(state.isThrottled, "Circuit breaker should be active")
+        XCTAssertTrue(state.derivedStateCache.isThrottled, "Circuit breaker should be active")
     }
 
     func testCircuitBreakerRecovery() async throws {
         for _ in 0...100 {
             state.recordBodyEvaluation()
         }
-        XCTAssertTrue(state.isThrottled)
+        XCTAssertTrue(state.derivedStateCache.isThrottled)
         try await Task.sleep(nanoseconds: 600_000_000)
-        XCTAssertFalse(state.isThrottled, "Circuit breaker should auto-recover")
+        XCTAssertFalse(state.derivedStateCache.isThrottled, "Circuit breaker should auto-recover")
     }
 
-    // MARK: - Pagination Cooldown
+    // MARK: - Distance From Bottom
 
-    func testPaginationCooldownResetOnConversationSwitch() {
-        state.lastPaginationCompletedAt = Date()
-        state.reset(for: UUID())
-        XCTAssertEqual(state.lastPaginationCompletedAt, .distantPast)
-    }
-
-    func testScheduleUISyncSuppressedWhenThrottled() async throws {
-        for _ in 0...100 {
-            state.recordBodyEvaluation()
-        }
-        XCTAssertTrue(state.isThrottled)
-        state.transition(to: .freeBrowsing)
-        XCTAssertFalse(state.isFollowingBottom)
-        try await Task.sleep(nanoseconds: 50_000_000)
-        XCTAssertFalse(state.showScrollToLatest,
-                       "showScrollToLatest should NOT update while throttled")
-    }
-
-    // MARK: - Programmatic Scroll Mode
-
-    func testProgrammaticScrollMode() {
-        state.transition(to: .programmaticScroll(reason: .deepLinkAnchor(id: UUID())))
-        XCTAssertFalse(state.isFollowingBottom)
-        XCTAssertFalse(state.mode.allowsAutoScroll)
-    }
-
-    func testProgrammaticScrollToFollowingBottomViaReachedBottom() {
-        state.transition(to: .programmaticScroll(reason: .deepLinkAnchor(id: UUID())))
-        state.handleReachedBottom()
-        XCTAssertTrue(state.isFollowingBottom)
-    }
-
-    // MARK: - scrollPhase Reset
-
-    func testResetClearsScrollPhase() {
-        state.scrollPhase = .interacting
-        state.reset(for: UUID())
-        XCTAssertEqual(state.scrollPhase, .idle)
+    func testDistanceFromBottom() {
+        state.contentHeight = 1000
+        state.viewportHeight = 400
+        state.contentOffsetY = 500
+        XCTAssertEqual(state.distanceFromBottom, 100)
     }
 }


### PR DESCRIPTION
## Summary
- Fix all compilation errors from scroll system rewrite (PRs 1-5)
- Remove dead ScrollGeometryUpdateDispatcher class (no longer referenced)
- Add missing properties to MessageListScrollState: derivedStateCache, recordBodyEvaluation(), bottomAnchorAppeared, hasBeenInteracted, handleReachedBottom()
- Rewrite scroll state tests to match simplified coordinator API
- Fix performance tests to use new API (derivedStateCache access, updateNearBottom)

Part of plan: claude-style-chat-scroll.md (PR 7 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23902" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
