### PR TITLE
refactor: Claude-style chat scroll (full rewrite)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -19,6 +19,15 @@ extension EnvironmentValues {
     }
 }
 
+// MARK: - User Message Height Preference
+
+private struct IntrinsicHeightKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
 // MARK: - Chat Bubble
 
 struct ChatBubble: View, Equatable {
@@ -79,6 +88,13 @@ struct ChatBubble: View, Equatable {
     /// When true, suppress the inline avatar on this bubble because
     /// `thinkingAvatarRow` is rendering one below the thinking indicator.
     var hideInlineAvatar: Bool = false
+    /// Whether the user message is expanded beyond its collapsed height.
+    @State private var isUserMessageExpanded: Bool = false
+    /// The intrinsic (unconstrained) height of user message content, used to
+    /// determine whether the "Show more" button should appear.
+    @State private var userMessageIntrinsicHeight: CGFloat = 0
+    /// Max collapsed height for user message bubbles before "Show more" appears.
+    private let userMessageMaxCollapsedHeight: CGFloat = 150
     /// Owned but never read in this body — only ChatBubbleOverflowMenu reads it,
     /// so hover changes invalidate only the overflow menu, not this view.
     @State private var hoverState = ChatBubbleHoverState()
@@ -458,71 +474,73 @@ struct ChatBubble: View, Equatable {
     private var bubbleContent: some View {
         let partitioned = partitionedAttachments
         return bubbleChrome {
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
-                if hasText {
-                    let segments = resolveSegments(for: message.text, isStreaming: message.isStreaming)
-                    // Always render through MarkdownSegmentView to keep view
-                    // identity stable across async segment parsing transitions.
-                    // When a large message first renders, resolveSegments returns
-                    // [.text(text)] (plain placeholder) before async parsing
-                    // completes with rich segments (tables, headings, etc.).
-                    // Branching on hasRichContent used to switch between Text and
-                    // MarkdownSegmentView — different view types that caused
-                    // LazyVStack to use stale height measurements, resulting in
-                    // content truncation and footer overlap.
-                    MarkdownSegmentView(
-                        segments: segments,
-                        isStreaming: message.isStreaming,
-                        maxContentWidth: isUser ? max(bubbleMaxWidth - 2 * VSpacing.lg, 0) : bubbleMaxWidth,
-                        textColor: isUser ? VColor.contentDefault : VColor.contentDefault,
-                        secondaryTextColor: isUser ? VColor.contentSecondary : VColor.contentSecondary,
-                        mutedTextColor: isUser ? VColor.contentSecondary : VColor.contentTertiary,
-                        tintColor: isUser ? VColor.contentDefault : VColor.primaryBase,
-                        codeTextColor: isUser ? VColor.contentDefault : VColor.systemNegativeStrong,
-                        codeBackgroundColor: isUser ? VColor.contentDefault.opacity(0.1) : VColor.surfaceActive,
-                        hrColor: isUser ? VColor.contentDefault.opacity(0.3) : VColor.borderBase
-                    )
-                    .equatable()
-                } else if !message.attachments.isEmpty {
-                    Text(attachmentSummary)
-                        .font(VFont.labelDefault)
-                        .foregroundStyle(isUser ? VColor.contentSecondary : VColor.contentSecondary)
-                }
+            userMessageHeightWrapper {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    if hasText {
+                        let segments = resolveSegments(for: message.text, isStreaming: message.isStreaming)
+                        // Always render through MarkdownSegmentView to keep view
+                        // identity stable across async segment parsing transitions.
+                        // When a large message first renders, resolveSegments returns
+                        // [.text(text)] (plain placeholder) before async parsing
+                        // completes with rich segments (tables, headings, etc.).
+                        // Branching on hasRichContent used to switch between Text and
+                        // MarkdownSegmentView — different view types that caused
+                        // LazyVStack to use stale height measurements, resulting in
+                        // content truncation and footer overlap.
+                        MarkdownSegmentView(
+                            segments: segments,
+                            isStreaming: message.isStreaming,
+                            maxContentWidth: isUser ? max(bubbleMaxWidth - 2 * VSpacing.lg, 0) : bubbleMaxWidth,
+                            textColor: isUser ? VColor.contentDefault : VColor.contentDefault,
+                            secondaryTextColor: isUser ? VColor.contentSecondary : VColor.contentSecondary,
+                            mutedTextColor: isUser ? VColor.contentSecondary : VColor.contentTertiary,
+                            tintColor: isUser ? VColor.contentDefault : VColor.primaryBase,
+                            codeTextColor: isUser ? VColor.contentDefault : VColor.systemNegativeStrong,
+                            codeBackgroundColor: isUser ? VColor.contentDefault.opacity(0.1) : VColor.surfaceActive,
+                            hrColor: isUser ? VColor.contentDefault.opacity(0.3) : VColor.borderBase
+                        )
+                        .equatable()
+                    } else if !message.attachments.isEmpty {
+                        Text(attachmentSummary)
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(isUser ? VColor.contentSecondary : VColor.contentSecondary)
+                    }
 
-                let visibleImages = visibleAttachmentImages(partitioned.images)
-                if !visibleImages.isEmpty {
-                    attachmentImageGrid(visibleImages)
-                }
+                    let visibleImages = visibleAttachmentImages(partitioned.images)
+                    if !visibleImages.isEmpty {
+                        attachmentImageGrid(visibleImages)
+                    }
 
-                if !partitioned.videos.isEmpty {
-                    VStack(alignment: .leading, spacing: VSpacing.sm) {
-                        ForEach(partitioned.videos) { attachment in
-                            InlineVideoAttachmentView(attachment: attachment)
+                    if !partitioned.videos.isEmpty {
+                        VStack(alignment: .leading, spacing: VSpacing.sm) {
+                            ForEach(partitioned.videos) { attachment in
+                                InlineVideoAttachmentView(attachment: attachment)
+                            }
                         }
                     }
-                }
 
-                if !partitioned.audios.isEmpty {
-                    VStack(alignment: .leading, spacing: VSpacing.sm) {
-                        ForEach(partitioned.audios) { attachment in
-                            InlineAudioAttachmentView(attachment: attachment)
+                    if !partitioned.audios.isEmpty {
+                        VStack(alignment: .leading, spacing: VSpacing.sm) {
+                            ForEach(partitioned.audios) { attachment in
+                                InlineAudioAttachmentView(attachment: attachment)
+                            }
                         }
                     }
-                }
 
-                if !partitioned.files.isEmpty {
-                    VStack(alignment: .leading, spacing: VSpacing.xs) {
-                        ForEach(partitioned.files) { attachment in
-                            fileAttachmentChip(attachment)
+                    if !partitioned.files.isEmpty {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            ForEach(partitioned.files) { attachment in
+                                fileAttachmentChip(attachment)
+                            }
                         }
                     }
-                }
 
-                // User messages keep tool calls inside the bubble
-                if isUser && !message.toolCalls.isEmpty {
-                    VStack(alignment: .leading, spacing: VSpacing.xs) {
-                        ForEach(message.toolCalls) { toolCall in
-                            ToolCallChip(toolCall: toolCall)
+                    // User messages keep tool calls inside the bubble
+                    if isUser && !message.toolCalls.isEmpty {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            ForEach(message.toolCalls) { toolCall in
+                                ToolCallChip(toolCall: toolCall)
+                            }
                         }
                     }
                 }
@@ -535,6 +553,39 @@ struct ChatBubble: View, Equatable {
         // result was cached under a key never queried, producing only a wasted
         // @State update and re-render per message. Removed to eliminate the
         // redundant re-render cycle.
+    }
+
+    // MARK: - User Message Height Wrapper
+
+    /// Wraps user message content with a max collapsed height and "Show more" toggle.
+    /// For non-user messages, passes content through unchanged.
+    @ViewBuilder
+    private func userMessageHeightWrapper<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        if isUser {
+            VStack(alignment: .trailing, spacing: 0) {
+                content()
+                    .background(GeometryReader { geo in
+                        Color.clear.preference(key: IntrinsicHeightKey.self, value: geo.size.height)
+                    })
+                    .frame(maxHeight: isUserMessageExpanded ? nil : userMessageMaxCollapsedHeight, alignment: .top)
+                    .clipped()
+
+                if userMessageIntrinsicHeight > userMessageMaxCollapsedHeight {
+                    Button(action: {
+                        withAnimation(VAnimation.fast) { isUserMessageExpanded.toggle() }
+                    }) {
+                        Text(isUserMessageExpanded ? "Show less" : "Show more")
+                            .font(VFont.bodySmallDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.top, VSpacing.xs)
+                }
+            }
+            .onPreferenceChange(IntrinsicHeightKey.self) { userMessageIntrinsicHeight = $0 }
+        } else {
+            content()
+        }
     }
 
     // MARK: - Document Widget

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -165,6 +165,7 @@ struct MessageListContentView: View, Equatable {
     // MARK: - Body
 
     var body: some View {
+        let turnMinHeight: CGFloat = max(0, viewportHeight - 150)
         LazyVStack(alignment: .leading, spacing: VSpacing.md) {
             if isLoadingMoreMessages {
                 HStack {
@@ -235,6 +236,7 @@ struct MessageListContentView: View, Equatable {
                     providerCatalogHash: providerCatalogHash
                 )
                 .equatable()
+                .frame(minHeight: isLatestAssistant ? turnMinHeight : nil, alignment: .top)
             }
 
             ForEach(state.orphanSubagents) { subagent in
@@ -250,28 +252,28 @@ struct MessageListContentView: View, Equatable {
             }
 
             if state.shouldShowThinkingIndicator && state.anchoredThinkingIndex == nil {
-                if isCompacting {
-                    compactingIndicatorRow()
-                } else {
-                    thinkingIndicatorRow(hasUserMessage: state.hasUserMessage)
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    if isCompacting {
+                        compactingIndicatorRow()
+                    } else {
+                        thinkingIndicatorRow(hasUserMessage: state.hasUserMessage)
+                    }
+                    thinkingAvatarRow
                 }
-                thinkingAvatarRow
+                .frame(minHeight: turnMinHeight, alignment: .top)
             } else if state.isStreamingWithoutText {
                 HStack {
                     TypingIndicatorView()
                     Spacer()
                 }
                 .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
+                .frame(minHeight: turnMinHeight, alignment: .top)
                 .id("streaming-without-text-indicator")
                 .transition(.opacity.combined(with: .move(edge: .bottom)))
             } else if isCompacting && !state.shouldShowThinkingIndicator && !state.canInlineProcessing {
                 compactingIndicatorRow()
+                    .frame(minHeight: turnMinHeight, alignment: .top)
             }
-
-            // Smart spacer: animates open on send, shrinks as assistant content grows
-            Color.clear
-                .frame(height: scrollState.spacerHeight)
-                .id("scroll-bottom-spacer")
 
             // Bottom anchor for explicit jumps
             Color.clear

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -49,6 +49,7 @@ struct MessageListContentView: View, Equatable {
             && lhs.isCompacting == rhs.isCompacting
             && lhs.isInteractionEnabled == rhs.isInteractionEnabled
             && lhs.containerWidth == rhs.containerWidth
+            && round(lhs.viewportHeight / 10) == round(rhs.viewportHeight / 10)
             && lhs.dismissedDocumentSurfaceIds == rhs.dismissedDocumentSurfaceIds
             && lhs.activeSurfaceId == rhs.activeSurfaceId
             && lhs.highlightedMessageId == rhs.highlightedMessageId
@@ -80,6 +81,7 @@ struct MessageListContentView: View, Equatable {
     let isTTSEnabled: Bool
     let selectedModel: String
     let configuredProviders: Set<String>
+    let viewportHeight: CGFloat
     let subagentDetailStore: SubagentDetailStore
     let assistantStatusText: String?
 
@@ -266,13 +268,21 @@ struct MessageListContentView: View, Equatable {
                 compactingIndicatorRow()
             }
 
-            Color.clear.frame(height: 1)
+            // Dynamic spacer: ensures user message can reach top even with short assistant output
+            Color.clear
+                .frame(height: max(0, viewportHeight - 100))
+                .id("scroll-bottom-spacer")
+
+            // Bottom anchor for explicit jumps
+            Color.clear
+                .frame(height: 1)
                 .id("scroll-bottom-anchor")
                 .onAppear {
                     // Signal that the bottom anchor has materialized —
                     // isAtBottom is now reliable (based on actual content
                     // height, not LazyVStack estimates).
                     scrollState.bottomAnchorAppeared = true
+                    scrollState.isNearBottom = true
                     if !scrollState.hasBeenInteracted {
                         scrollState.handleReachedBottom()
                     }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -268,9 +268,9 @@ struct MessageListContentView: View, Equatable {
                 compactingIndicatorRow()
             }
 
-            // Dynamic spacer: ensures user message can reach top even with short assistant output
+            // Smart spacer: animates open on send, shrinks as assistant content grows
             Color.clear
-                .frame(height: max(0, viewportHeight - 100))
+                .frame(height: scrollState.spacerHeight)
                 .id("scroll-bottom-spacer")
 
             // Bottom anchor for explicit jumps

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListHelperViews.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListHelperViews.swift
@@ -9,19 +9,15 @@ import VellumAssistantShared
 /// this view — not the parent `MessageListView.body` or `ForEach`.
 struct ScrollToLatestOverlayView: View {
     let scrollState: MessageListScrollState
+    /// Closure that scrolls to the bottom via the parent's `ScrollViewProxy`.
+    var onScrollToBottom: (() -> Void)?
 
     var body: some View {
         if scrollState.showScrollToLatest {
             Button(action: {
                 os_signpost(.event, log: PerfSignposts.log, name: "scrollToLatestPressed")
-                // Spring animation drives both the CTA exit transition
-                // and the scroll-to-bottom. syncUIImmediately() inside
-                // requestPinToBottom captures showScrollToLatest = false
-                // within this animation transaction, so the .move/.opacity
-                // transition runs in sync with the scroll.
-                _ = withAnimation(VAnimation.spring) {
-                    scrollState.requestPinToBottom(animated: true, userInitiated: true)
-                }
+                scrollState.handleScrollToLatestTapped()
+                onScrollToBottom?()
             }) {
                 HStack(spacing: VSpacing.xs) {
                     VIconView(.arrowDown, size: 10)

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -104,6 +104,20 @@ final class MessageListScrollState {
     /// from initial position). Used to gate initial auto-scroll behavior.
     @ObservationIgnored var hasBeenInteracted: Bool = false
 
+    // MARK: - Smart Spacer
+
+    /// The spacer height that the view reads. Observable so the view updates.
+    private(set) var spacerHeight: CGFloat = 0
+
+    /// Whether a send cycle is actively streaming.
+    @ObservationIgnored var isInSendCycle: Bool = false
+
+    /// Target spacer height (viewportHeight - estimated user msg height).
+    @ObservationIgnored var targetSpacerHeight: CGFloat = 0
+
+    /// Content height when send started, for computing growth delta.
+    @ObservationIgnored var contentHeightAtSendStart: CGFloat = 0
+
     // MARK: - Derived State Cache
 
     /// Non-observable cache for memoizing derived state computations.
@@ -219,6 +233,38 @@ final class MessageListScrollState {
         scrollLog.debug("Scroll to latest tapped — resetting near-bottom state")
     }
 
+    // MARK: - Smart Spacer Methods
+
+    /// Begins the spacer animation when a send cycle starts.
+    /// Animates the spacer from 0 to `viewportHeight - 150` (estimated user message height).
+    func startSpacerAnimation() {
+        isInSendCycle = true
+        contentHeightAtSendStart = contentHeight
+        targetSpacerHeight = max(0, viewportHeight - 150)
+        withAnimation(VAnimation.standard) {
+            spacerHeight = targetSpacerHeight
+        }
+    }
+
+    /// Shrinks the spacer proportionally as assistant content grows during streaming.
+    /// Throttled to 10pt changes to avoid excessive re-renders.
+    func updateSpacerForContentGrowth(newContentHeight: CGFloat) {
+        guard isInSendCycle else { return }
+        let growth = max(0, newContentHeight - contentHeightAtSendStart)
+        let newHeight = max(100, targetSpacerHeight - growth)
+        if abs(newHeight - spacerHeight) >= 10 {
+            spacerHeight = newHeight
+        }
+    }
+
+    /// Ends the send cycle and settles the spacer at the 100pt floor.
+    func endSendCycle() {
+        isInSendCycle = false
+        withAnimation(VAnimation.standard) {
+            spacerHeight = 100
+        }
+    }
+
     /// Resets all state for a conversation switch.
     func reset(for conversationId: UUID) {
         currentConversationId = conversationId
@@ -237,6 +283,10 @@ final class MessageListScrollState {
         lastAutoFocusedRequestId = nil
         bottomAnchorAppeared = false
         hasBeenInteracted = false
+        spacerHeight = 0
+        targetSpacerHeight = 0
+        isInSendCycle = false
+        contentHeightAtSendStart = 0
         derivedStateCache.reset()
 
         scrollLog.debug("Reset for conversation: \(conversationId)")

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -3,842 +3,200 @@ import os
 import SwiftUI
 import VellumAssistantShared
 
-// MARK: - ScrollMode
-
-/// Explicit scroll behavior mode. Every scroll decision flows through the
-/// current mode, eliminating implicit priority races between scattered
-/// handlers. Inspired by ChatViewportKit's `ViewportMode` pattern.
-///
-/// References:
-/// - ChatViewportKit: https://github.com/danielraffel/ChatViewportKit
-/// - ScrollPosition: https://developer.apple.com/documentation/swiftui/scrollposition
-/// - ScrollAnchorRole: https://developer.apple.com/documentation/swiftui/scrollanchorrole
-enum ScrollMode: Equatable, CustomStringConvertible {
-    /// Initial render — content starts at bottom, no user interaction yet.
-    case initialLoad
-
-    /// User is at the bottom. Auto-scroll on new content, streaming, etc.
-    case followingBottom
-
-    /// User scrolled away from bottom. No auto-scroll.
-    /// "Scroll to latest" CTA is visible.
-    case freeBrowsing
-
-    /// A programmatic scroll is in flight (deep-link anchor, etc.).
-    /// Prevents other scroll operations from interfering until complete.
-    case programmaticScroll(reason: ProgrammaticScrollReason)
-
-    /// Temporarily stabilizing after a layout change.
-    /// Auto-scroll is paused until the stabilization window completes.
-    case stabilizing(previousMode: StabilizedMode, reason: StabilizationReason)
-
-    var description: String {
-        switch self {
-        case .initialLoad: "initialLoad"
-        case .followingBottom: "followingBottom"
-        case .freeBrowsing: "freeBrowsing"
-        case .programmaticScroll(let reason): "programmaticScroll(\(reason))"
-        case .stabilizing(let prev, let reason): "stabilizing(\(prev), \(reason))"
-        }
-    }
-
-    /// Whether the mode allows automatic bottom-pinning on new content.
-    /// Both `initialLoad` and `followingBottom` allow auto-scroll —
-    /// the only difference is `initialLoad` marks that no user interaction
-    /// has occurred yet (used by `hasBeenInteracted`).
-    /// Note: `stabilizing` returns `false` even when the previous mode was
-    /// `followingBottom` — stabilization explicitly suppresses auto-scroll
-    /// until the layout mutation completes.
-    var allowsAutoScroll: Bool {
-        switch self {
-        case .initialLoad, .followingBottom: true
-        default: false
-        }
-    }
-
-    /// Whether the "Scroll to latest" CTA should be visible.
-    /// Preserved during `.stabilizing` when the user was already scrolled
-    /// up — prevents the CTA from flashing off during expansion/resize
-    /// stabilization windows.
-    var showsScrollToLatest: Bool {
-        switch self {
-        case .freeBrowsing: true
-        case .stabilizing(let prev, _) where prev == .freeBrowsing: true
-        default: false
-        }
-    }
-
-}
-
-enum ProgrammaticScrollReason: Equatable, CustomStringConvertible {
-    case deepLinkAnchor(id: UUID)
-
-    var description: String {
-        switch self {
-        case .deepLinkAnchor(let id): "deepLinkAnchor(\(id))"
-        }
-    }
-}
-
-enum StabilizationReason: Equatable, CustomStringConvertible {
-    case resize
-    case expansion
-    case pagination
-
-    var description: String {
-        switch self {
-        case .resize: "resize"
-        case .expansion: "expansion"
-        case .pagination: "pagination"
-        }
-    }
-}
-
-/// The mode the scroll was in before entering `stabilizing`.
-/// Only tracks modes that can transition into stabilizing.
-enum StabilizedMode: Equatable, CustomStringConvertible {
-    case followingBottom
-    case freeBrowsing
-
-    var description: String {
-        switch self {
-        case .followingBottom: "followingBottom"
-        case .freeBrowsing: "freeBrowsing"
-        }
-    }
-}
-
 private let scrollLog = Logger(subsystem: Bundle.appBundleIdentifier, category: "ScrollState")
 
 // MARK: - MessageListScrollState
 
-/// Centralized scroll state machine with `@Observable` fine-grained tracking.
-/// Each UI-facing property (`showScrollToLatest`, `scrollIndicatorsHidden`)
-/// is individually tracked by the Observation framework, so SwiftUI only
-/// re-evaluates views that read the specific property that changed. The
-/// `mode` enum drives all scroll behavior decisions through explicit
-/// transitions rather than scattered handler logic.
+/// Simplified scroll coordinator with `@Observable` fine-grained tracking.
+///
+/// Replaces the previous mode-based state machine (ScrollMode enum,
+/// stabilization windows, recovery deadlines, circuit breaker) with a
+/// flat set of properties and hysteresis-based near-bottom detection.
+///
+/// UI-facing properties (`showScrollToLatest`, `scrollIndicatorsHidden`)
+/// are individually tracked by the Observation framework, so SwiftUI only
+/// re-evaluates views that read the specific property that changed. Other
+/// properties are queried imperatively by scroll handlers.
 ///
 /// References:
-/// - [WWDC23 — Discover Observation in SwiftUI](https://developer.apple.com/videos/play/wwdc2023/10149/)
+/// - [WWDC23 -- Discover Observation in SwiftUI](https://developer.apple.com/videos/play/wwdc2023/10149/)
 /// - [Observation framework](https://developer.apple.com/documentation/observation)
 @Observable @MainActor
 final class MessageListScrollState {
 
-    // MARK: - Mode (single source of truth for scroll behavior)
-
-    /// The current scroll behavior mode. All scroll decisions check this
-    /// before executing. Transitions are logged for debugging.
-    @ObservationIgnored private(set) var mode: ScrollMode = .initialLoad
-
-    // MARK: - UI State (fine-grained per-property observation)
-
-    /// Internal counter for debounce tracking and diagnostics.
-    /// Not observed by any view — individual properties below are tracked
-    /// independently by the Observation framework.
-    @ObservationIgnored private(set) var uiVersion: UInt64 = 0
+    // MARK: - Observed UI State
 
     /// Whether the "Scroll to latest" CTA should be visible.
-    /// Tracked independently — only views reading this property re-evaluate.
-    private(set) var showScrollToLatest = false
+    /// Tracked independently -- only views reading this property re-evaluate.
+    private(set) var showScrollToLatest: Bool = false
 
     /// Whether scroll indicators should be hidden.
-    /// Tracked independently — only the scroll indicator modifier re-evaluates.
-    private(set) var scrollIndicatorsHidden = false
+    /// Tracked independently -- only the scroll indicator modifier re-evaluates.
+    private(set) var scrollIndicatorsHidden: Bool = false
 
-    // MARK: - Scroll Indicator Visibility
+    // MARK: - Near-Bottom Detection (hysteresis)
 
-    /// Whether scroll indicators should be temporarily hidden during a
-    /// conversation switch. LazyVStack content size estimation causes the
-    /// scrollbar to visibly resize as views materialize with varying heights;
-    /// hiding the indicators during the initial layout window masks this.
-    @ObservationIgnored private var _hideScrollIndicators = false
+    /// Whether the viewport is considered "near bottom".
+    /// Uses hysteresis: enters at <= 10pt from bottom, leaves at > 50pt.
+    @ObservationIgnored var isNearBottom: Bool = true
 
-    var hideScrollIndicators: Bool {
-        get { _hideScrollIndicators }
-        set { _hideScrollIndicators = newValue; scheduleUISync() }
-    }
+    // MARK: - Geometry State
+
+    /// Current viewport height for dynamic spacer calculations.
+    @ObservationIgnored var viewportHeight: CGFloat = 0
+
+    /// Total content height from scroll geometry.
+    @ObservationIgnored var contentHeight: CGFloat = 0
+
+    /// Current content offset Y from scroll geometry.
+    @ObservationIgnored var contentOffsetY: CGFloat = 0
+
+    // MARK: - Send Cycle Anchoring
+
+    /// Prevents re-anchoring during the same send cycle.
+    /// Reset to `false` at the start of each send, set to `true` once anchored.
+    @ObservationIgnored var didAnchorCurrentSendCycle: Bool = false
+
+    // MARK: - Auto-Follow Throttle
+
+    /// Timestamp of the last successful auto-follow, used for 80ms throttle.
+    @ObservationIgnored var lastAutoFollowAt: Date = .distantPast
+
+    // MARK: - Conversation Tracking
+
+    /// The conversation ID currently being displayed.
+    @ObservationIgnored var currentConversationId: UUID?
+
+    // MARK: - Deep-Link / Search Anchor
+
+    /// Message ID for a pending deep-link or search anchor scroll.
+    @ObservationIgnored var pendingAnchorMessageId: UUID?
+
+    // MARK: - Scroll Target
+
+    /// The ID of the last message in the current conversation's ForEach.
+    /// Used as the primary scroll-to-bottom target.
+    @ObservationIgnored var lastMessageId: (any Hashable)?
 
     // MARK: - Pagination
 
-    /// Guards the pagination sentinel against re-entry during the brief window
-    /// between Task launch and the first `await`.
-    @ObservationIgnored private var _isPaginationInFlight = false
-
-    var isPaginationInFlight: Bool {
-        get { _isPaginationInFlight }
-        set { _isPaginationInFlight = newValue }
-    }
-
-    // MARK: - Geometry State (never trigger re-evaluation)
-
-    /// Current scroll phase from `onScrollPhaseChange`.
-    /// Reset to `.idle` in `reset()` to prevent stale phases from a
-    /// previous conversation (e.g. `.interacting`, `.decelerating`)
-    /// blocking `phaseAllowsAutoFollow` during the new conversation's
-    /// critical materialization window.
-    @ObservationIgnored var scrollPhase: ScrollPhase = .idle
-
-    /// Last content offset Y observed by onScrollGeometryChange.
-    @ObservationIgnored var lastContentOffsetY: CGFloat = 0
-
-    /// Whether the user is within the bottom dead-zone of the conversation.
-    @ObservationIgnored var isAtBottom: Bool = true
-
-    /// The most recent scroll viewport height.
-    @ObservationIgnored var viewportHeight: CGFloat = .infinity
-
     /// Tracks whether the pagination sentinel was previously inside the trigger band.
+    /// Used as a rising-edge detector to fire pagination only on entry.
     @ObservationIgnored var wasPaginationTriggerInRange: Bool = false
 
     /// Timestamp of the last pagination completion, used to enforce a 500ms
     /// cooldown between successive pagination fires.
     @ObservationIgnored var lastPaginationCompletedAt: Date = .distantPast
 
-    /// The conversation ID currently being displayed.
-    @ObservationIgnored var currentConversationId: UUID?
+    // MARK: - Computed Properties
 
-    /// Captures the `assistantActivityPhase` at the moment `isSending` goes false.
-    @ObservationIgnored var lastActivityPhaseWhenIdle: String = ""
-
-    /// Last container width that triggered a resize scroll handler.
-    @ObservationIgnored var lastHandledContainerWidth: CGFloat = 0
-
-    /// Tracks the last pending confirmation request ID that triggered an
-    /// auto-focus handoff.
-    @ObservationIgnored var lastAutoFocusedRequestId: String?
-
-    /// The ID of the last message in the current conversation's ForEach.
-    /// Used as the primary scroll-to-bottom target because ForEach items
-    /// are always indexable by `ScrollPosition.scrollTo(id:)` even when
-    /// not materialized — SwiftUI can locate them in the data source and
-    /// compute their position. The standalone `"scroll-bottom-anchor"`
-    /// view (outside ForEach) is only locatable when materialized.
-    @ObservationIgnored var lastMessageId: UUID?
-
-    /// Content height from scroll geometry.
-    @ObservationIgnored var scrollContentHeight: CGFloat = 0
-
-    /// Container (viewport) height from scroll geometry.
-    @ObservationIgnored var scrollContainerHeight: CGFloat = 0
-
-    /// Marker that a recovery window is active. When non-nil AND
-    /// `bottomAnchorAppeared` is false, persistent bottom-recovery fires
-    /// unconditionally (ignoring `isAtBottom`) until the bottom anchor
-    /// materializes OR the deadline expires (whichever comes first).
-    /// Set by `reset()`, `handleAppear`,
-    /// `requestPinToBottom(userInitiated:)`, and resize/send handlers.
-    /// The 2-second hard cutoff prevents infinite recovery when
-    /// `bottomAnchorAppeared` is reset to false while the anchor is
-    /// already visible in the hierarchy (since `onAppear` won't re-fire).
-    @ObservationIgnored var recoveryDeadline: Date?
-
-    /// Whether the "scroll-bottom-anchor" view has appeared in the view
-    /// hierarchy since the last `reset()`. Until this is true, `isAtBottom`
-    /// is unreliable because it's based on LazyVStack's estimated content
-    /// height — the viewport may be at the *estimated* bottom (blank space)
-    /// where `distanceFromBottom ≈ 0`. The persistent recovery fires
-    /// unconditionally until this flag is set by the anchor's `onAppear`.
-    @ObservationIgnored var bottomAnchorAppeared: Bool = false
-
-    /// Timestamp of the last recovery `requestPinToBottom()` call.
-    /// Throttles recovery to at most once per 100ms — without this,
-    /// geometry updates at ~60fps fire `scrollTo(id:)` every ~16ms,
-    /// never giving LazyVStack time to materialize views between
-    /// attempts. For very long conversations, this prevents the
-    /// viewport from overshooting into unmaterialized estimated space.
-    @ObservationIgnored var lastRecoveryAttempt: Date = .distantPast
-
-    /// Timestamp of the last user-initiated CTA tap. Used to suppress
-    /// `.decelerating` scroll-up detection for 500ms after the tap.
-    /// Without this cooldown, residual upward momentum from the user's
-    /// pre-CTA scroll fires `handleUserScrollUp()` on the very next
-    /// geometry update, undoing the CTA's mode transition to
-    /// `.followingBottom` and creating a "scroll lock" effect.
-    @ObservationIgnored var lastUserInitiatedPinTime: Date?
-
-    // MARK: - Layout Cache Fields
-
-    /// Memoization state intentionally lives outside the observed object so
-    /// `MessageListView` can update caches during body evaluation without
-    /// tripping SwiftUI's "Modifying state during view update" runtime guard.
-    @ObservationIgnored let derivedStateCache = MessageListDerivedStateCache()
-
-    @ObservationIgnored var cachedLayoutKey: PrecomputedCacheKey? {
-        get { derivedStateCache.cachedLayoutKey }
-        set { derivedStateCache.cachedLayoutKey = newValue }
+    /// Distance from the bottom of the scrollable content.
+    var distanceFromBottom: CGFloat {
+        contentHeight - contentOffsetY - viewportHeight
     }
 
-    @ObservationIgnored var cachedLayoutMetadata: CachedMessageLayoutMetadata? {
-        get { derivedStateCache.cachedLayoutMetadata }
-        set { derivedStateCache.cachedLayoutMetadata = newValue }
+    /// Whether auto-follow should engage: near bottom and not yet anchored
+    /// in the current send cycle.
+    var shouldAutoFollow: Bool {
+        isNearBottom && !didAnchorCurrentSendCycle
     }
 
-    @ObservationIgnored var messageListVersion: Int {
-        get { derivedStateCache.messageListVersion }
-        set { derivedStateCache.messageListVersion = newValue }
-    }
+    // MARK: - Methods
 
-    @ObservationIgnored var lastKnownRawMessageCount: Int {
-        get { derivedStateCache.lastKnownRawMessageCount }
-        set { derivedStateCache.lastKnownRawMessageCount = newValue }
-    }
-
-    @ObservationIgnored var lastKnownVisibleMessageCount: Int {
-        get { derivedStateCache.lastKnownVisibleMessageCount }
-        set { derivedStateCache.lastKnownVisibleMessageCount = newValue }
-    }
-
-    @ObservationIgnored var lastKnownLastMessageStreaming: Bool {
-        get { derivedStateCache.lastKnownLastMessageStreaming }
-        set { derivedStateCache.lastKnownLastMessageStreaming = newValue }
-    }
-
-    @ObservationIgnored var lastKnownIncompleteToolCallCount: Int {
-        get { derivedStateCache.lastKnownIncompleteToolCallCount }
-        set { derivedStateCache.lastKnownIncompleteToolCallCount = newValue }
-    }
-
-    @ObservationIgnored var lastKnownVisibleIdFingerprint: Int {
-        get { derivedStateCache.lastKnownVisibleIdFingerprint }
-        set { derivedStateCache.lastKnownVisibleIdFingerprint = newValue }
-    }
-
-    @ObservationIgnored var cachedFirstVisibleMessageId: UUID? {
-        get { derivedStateCache.cachedFirstVisibleMessageId }
-        set { derivedStateCache.cachedFirstVisibleMessageId = newValue }
-    }
-
-    // MARK: - Scroll Action Closures
-
-    /// Closure that performs a programmatic scroll to the given item ID and
-    /// anchor point. Set once during view configuration and captures the
-    /// view-owned `ScrollPosition` binding.
-    @ObservationIgnored var scrollTo: ((_ id: any Hashable, _ anchor: UnitPoint?) -> Void)?
-
-    /// Closure that scrolls to a given edge (e.g. `.bottom`).
-    @ObservationIgnored var scrollToEdge: ((_ edge: Edge) -> Void)?
-
-    /// Closure that cancels any in-flight programmatic scroll animation.
+    /// Updates `isNearBottom` using hysteresis thresholds.
     ///
-    /// SwiftUI's `withAnimation { scrollPosition = ... }` creates a SwiftUI-
-    /// managed animation that does NOT automatically cancel when the user
-    /// starts a new scroll gesture — unlike UIKit's
-    /// `UIScrollView.setContentOffset(animated:)` which cancels on touch.
-    /// This closure writes an empty `ScrollPosition()` (no target) to the
-    /// binding with `Transaction(disablesAnimations: true)`, which:
-    ///   1. Overwrites the in-flight spring animation (new value written)
-    ///   2. Doesn't move the viewport (empty position = no target)
-    ///   3. During `.interacting` phase, the user's gesture has priority
-    ///      over any programmatic position changes anyway
+    /// - If currently near bottom, leave at > 50pt from bottom.
+    /// - If not near bottom, enter at <= 10pt from bottom.
     ///
-    /// Called from `handleUserScrollUp()` when transitioning away from a
-    /// following state to prevent the CTA spring animation from fighting
-    /// the user's new scroll gesture.
-    @ObservationIgnored var cancelScrollAnimation: (() -> Void)?
+    /// Also updates `showScrollToLatest` based on the new value.
+    func updateNearBottom() {
+        let distance = distanceFromBottom
 
-    // MARK: - Circuit Breaker
-
-    @ObservationIgnored var isThrottled: Bool {
-        get { derivedStateCache.isThrottled }
-        set { derivedStateCache.isThrottled = newValue }
-    }
-
-    /// Called once per MessageListView body evaluation. Trips the circuit
-    /// breaker when >100 evaluations occur in 2 seconds, suppressing
-    /// `scheduleUISync()` for 500ms to break the loop.
-    func recordBodyEvaluation() {
-        let cache = derivedStateCache
-        let now = CFAbsoluteTimeGetCurrent()
-        cache.bodyEvalTimestamps.append(now)
-        let cutoff = now - 2.0
-        if let firstValid = cache.bodyEvalTimestamps.firstIndex(where: { $0 >= cutoff }) {
-            cache.bodyEvalTimestamps.removeFirst(firstValid)
-        }
-
-        if cache.bodyEvalTimestamps.count > 100 && !cache.isThrottled {
-            cache.isThrottled = true
-            os_log(.fault, "Scroll re-evaluation loop detected: %d evals in 2s — throttling for 500ms",
-                   cache.bodyEvalTimestamps.count)
-            cache.throttleRecoveryTask?.cancel()
-            cache.throttleRecoveryTask = Task { @MainActor [weak self] in
-                try? await Task.sleep(nanoseconds: 500_000_000)
-                guard let self, !Task.isCancelled else { return }
-                self.derivedStateCache.isThrottled = false
-                self.derivedStateCache.bodyEvalTimestamps.removeAll()
-                self.derivedStateCache.throttleRecoveryTask = nil
-                self.scheduleUISync()
-            }
-        }
-    }
-
-    // MARK: - Debounced UI Sync
-
-    @ObservationIgnored private var uiSyncTask: Task<Void, Never>?
-
-    /// Debounces observed-property updates so rapid mode changes coalesce
-    /// into at most one view re-evaluation per frame.
-    func scheduleUISync() {
-        guard !derivedStateCache.isThrottled else { return }
-        uiSyncTask?.cancel()
-        uiSyncTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(nanoseconds: 16_000_000)
-            guard let self, !Task.isCancelled else { return }
-            self.syncUISnapshots()
-            self.uiSyncTask = nil
-        }
-    }
-
-    /// Syncs snapshot properties from the current mode. Each property is
-    /// individually tracked by `@Observable`, so SwiftUI only re-evaluates
-    /// views that read the specific property that changed.
-    private func syncUISnapshots() {
-        let newShowScrollToLatest = mode.showsScrollToLatest
-        let newScrollIndicatorsHidden = _hideScrollIndicators
-
-        var changed = false
-
-        if showScrollToLatest != newShowScrollToLatest {
-            showScrollToLatest = newShowScrollToLatest
-            changed = true
-        }
-        if scrollIndicatorsHidden != newScrollIndicatorsHidden {
-            scrollIndicatorsHidden = newScrollIndicatorsHidden
-            changed = true
-        }
-
-        if changed { uiVersion &+= 1 }
-    }
-
-    /// Synchronous UI sync — bypasses debounce for instant state transitions.
-    func syncUIImmediately() {
-        uiSyncTask?.cancel()
-        uiSyncTask = nil
-        syncUISnapshots()
-    }
-
-    // MARK: - Task References
-
-    @ObservationIgnored var paginationTask: Task<Void, Never>?
-    @ObservationIgnored var scrollRestoreTask: Task<Void, Never>?
-    @ObservationIgnored var highlightDismissTask: Task<Void, Never>?
-    @ObservationIgnored var scrollIndicatorRestoreTask: Task<Void, Never>?
-    @ObservationIgnored var anchorTimeoutTask: Task<Void, Never>?
-
-    /// Timeout task for expansion stabilization — auto-ends after 200ms.
-    @ObservationIgnored private var expansionTimeoutTask: Task<Void, Never>?
-
-    /// Tracks overlapping stabilization windows. Stabilization only ends
-    /// when all active windows have completed, so concurrent reasons
-    /// (e.g. resize during pagination) don't prematurely restore the mode.
-    /// Re-entering the same reason increments the count like any other entry.
-    /// Callers are structured so that each `beginStabilization` has a matching
-    /// `endStabilization` (cancelled task cleanup for resize, preceding
-    /// `endStabilization` in `suppressAutoScroll` for expansion).
-    @ObservationIgnored private var activeStabilizationCount = 0
-
-    // MARK: - Deep-Link Anchor Tracking
-
-    @ObservationIgnored var anchorSetTime: Date?
-
-    // MARK: - Mode Transitions
-
-    /// Transitions to a new scroll mode. Performs exit actions for the
-    /// old mode and entry actions for the new mode.
-    func transition(to newMode: ScrollMode) {
-        let oldMode = mode
-        guard oldMode != newMode else { return }
-
-        scrollLog.debug("Scroll mode: \(oldMode.description) → \(newMode.description)")
-
-        // Exit actions
-        switch oldMode {
-        case .stabilizing:
-            cancelStabilizationTasks()
-            // Only reset the overlapping-window counter when leaving
-            // stabilizing entirely (e.g. user scroll-up → .freeBrowsing,
-            // CTA tap → .followingBottom). Without this, the count stays
-            // elevated: the deferred endStabilization() from the interrupted
-            // window early-returns (mode is no longer .stabilizing), and
-            // future beginStabilization calls keep incrementing from the
-            // stale base — eventually endStabilization can never reach 0,
-            // permanently locking mode in .stabilizing.
-            //
-            // Do NOT reset when transitioning between stabilizing variants
-            // (e.g. .stabilizing(.resize) → .stabilizing(.expansion)):
-            // beginStabilization increments the count before calling
-            // transition(), so resetting here would clobber the new count,
-            // causing the first endStabilization to prematurely exit.
-            if case .stabilizing = newMode {
-                // Staying in stabilizing: preserve the window count.
-            } else {
-                activeStabilizationCount = 0
-            }
-        default:
-            break
-        }
-
-        mode = newMode
-        scheduleUISync()
-    }
-
-    /// Enters stabilizing mode, remembering the previous mode to restore
-    /// after all stabilization windows have ended.
-    func beginStabilization(_ reason: StabilizationReason) {
-        let previousMode: StabilizedMode
-        switch mode {
-        case .followingBottom, .initialLoad:
-            previousMode = .followingBottom
-        case .freeBrowsing:
-            previousMode = .freeBrowsing
-        case .stabilizing(let prev, let activeReason):
-            previousMode = prev
-            if activeReason == reason {
-                if reason == .expansion {
-                    scheduleExpansionTimeout()
-                }
-                return
-            }
-        case .programmaticScroll:
-            return
-        }
-
-        activeStabilizationCount += 1
-        transition(to: .stabilizing(previousMode: previousMode, reason: reason))
-
-        if reason == .expansion {
-            scheduleExpansionTimeout()
-        }
-    }
-
-    /// Ends one stabilization window. Only restores the previous mode
-    /// when all overlapping windows have completed.
-    func endStabilization() {
-        guard case .stabilizing(let previousMode, _) = mode else { return }
-        activeStabilizationCount = max(0, activeStabilizationCount - 1)
-        guard activeStabilizationCount == 0 else { return }
-        cancelStabilizationTasks()
-        switch previousMode {
-        case .followingBottom:
-            transition(to: .followingBottom)
-        case .freeBrowsing:
-            transition(to: .freeBrowsing)
-        }
-    }
-
-    private func cancelStabilizationTasks() {
-        expansionTimeoutTask?.cancel()
-        expansionTimeoutTask = nil
-    }
-
-    private func scheduleExpansionTimeout() {
-        expansionTimeoutTask?.cancel()
-        expansionTimeoutTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(nanoseconds: 200_000_000)
-            guard !Task.isCancelled, let self else { return }
-            self.endStabilization()
-        }
-    }
-
-    // MARK: - Scroll Execution
-
-    /// Executes a bottom-pin scroll if the current mode allows it.
-    /// Returns `true` if the scroll was performed.
-    ///
-    /// `userInitiated: true` bypasses mode checks — user intent always wins.
-    @discardableResult
-    func requestPinToBottom(animated: Bool = false, userInitiated: Bool = false) -> Bool {
-        if userInitiated {
-            transition(to: .followingBottom)
-            // Sync UI immediately so showScrollToLatest is updated within
-            // the caller's withAnimation block — this animates the CTA's
-            // exit transition (.move + .opacity) in sync with the scroll.
-            syncUIImmediately()
-            // Start a fresh recovery window — the scroll-to-bottom might
-            // miss on first attempt (e.g. lastMessageId stale, anchor not
-            // materialized). Without this, no recovery fires because
-            // bottomAnchorAppeared is already true (from initial load)
-            // and the recovery deadline has passed.
-            bottomAnchorAppeared = false
-            recoveryDeadline = Date().addingTimeInterval(2.0)
-            // Record the CTA tap time so scroll-up detection ignores
-            // residual momentum for 500ms (see handleScrollGeometryUpdate).
-            lastUserInitiatedPinTime = Date()
-            executeScrollToBottom(animated: animated, userInitiated: true)
-            return true
-        }
-
-        guard mode.allowsAutoScroll else { return false }
-        executeScrollToBottom(animated: animated)
-        return true
-    }
-
-    /// Low-level scroll-to-bottom execution. Does not check mode.
-    ///
-    /// Two strategies depending on context:
-    ///
-    /// **User-initiated (CTA tap):** ID-based scroll only.
-    /// `scrollTo(id: lastMessageId, .bottom)` fires synchronously —
-    /// targets a real ForEach item that SwiftUI can always locate (even
-    /// when not materialized), so it never overshoots into blank
-    /// LazyVStack estimated space. No deferred edge-based correction:
-    /// a Task calling `scrollToEdge(.bottom)` on the next run loop would
-    /// fire during the in-flight spring animation (~16ms later),
-    /// interrupting it with a non-animated jump to the estimated bottom
-    /// (possibly blank space). Instead, the recovery window (set in
-    /// `requestPinToBottom`) handles the small gap between the last
-    /// message and the absolute content bottom (padding/anchor below).
-    /// Recovery is phase-gated (`.idle` only), so it waits until the
-    /// spring completes. Animation is provided by the caller's
-    /// `withAnimation` wrapper (spring for smooth CTA scroll).
-    ///
-    /// **Auto-follow / recovery:** ID-based scroll only (synchronous).
-    /// `scrollTo(id: lastMessageId, .bottom)` targets real ForEach content.
-    /// Falls back to `scrollToEdge(.bottom)` only when `lastMessageId` is
-    /// nil (empty conversations). The previous dual-scroll strategy (edge
-    /// synchronous + ID Task) caused blank screens on initial load and
-    /// conversation switch: during the recovery window, geometry updates
-    /// fire at ~60fps, each cancelling the previous ID Task before it
-    /// executes — only edge scrolls (estimated bottom = blank space)
-    /// actually landed.
-    ///
-    /// - SeeAlso: https://stackoverflow.com/q/79884780 (ScrollPosition unreliable with variable heights)
-    /// - SeeAlso: https://developer.apple.com/documentation/swiftui/scrollposition/scrollto(edge:)
-    private func executeScrollToBottom(animated: Bool, userInitiated: Bool = false) {
-        if userInitiated {
-            // ID-based only: targets a real ForEach item that SwiftUI
-            // can always locate — never overshoots into blank LazyVStack
-            // estimated space. If the user scrolls up immediately after
-            // tapping, they start from real content (not blank space).
-            // Animated with spring from the caller's withAnimation wrapper.
-            //
-            // No edge-based correction Task here. A deferred non-animated
-            // scrollToEdge(.bottom) would fire on the next run loop (~16ms)
-            // during the in-flight spring animation, interrupting it with
-            // a jarring jump to the estimated bottom (possibly blank space).
-            // Instead, the recovery window (set in requestPinToBottom)
-            // handles the small gap between lastMessageId and the absolute
-            // content bottom (padding/anchor below). Recovery is gated by
-            // phaseAllowsAutoFollow (.idle only), so it waits until the
-            // spring completes, then fires one clean correction.
-            let target: any Hashable = lastMessageId ?? ("scroll-bottom-anchor" as any Hashable)
-            scrollTo?(target, .bottom)
-            return
-        }
-
-        // Auto-follow / recovery: ID-based primary (synchronous).
-        if let target = lastMessageId {
-            // ID-based: targets a real ForEach item that SwiftUI can
-            // always locate (even when not materialized). Synchronous —
-            // no deferred Task that could be cancelled by the next
-            // recovery call before it executes. During the recovery
-            // window, geometry updates fire at ~60fps; a Task-based
-            // scroll would be cancelled by the next recovery call
-            // within ~16ms, leaving only edge scrolls (estimated
-            // bottom = blank space) actually landing.
-            if animated {
-                withAnimation(VAnimation.fast) {
-                    scrollTo?(target, .bottom)
-                }
-            } else {
-                scrollTo?(target, .bottom)
+        if isNearBottom {
+            // Leave near-bottom when distance exceeds 50pt
+            if distance > 50 {
+                isNearBottom = false
+                scrollLog.debug("Near-bottom: left (distance: \(distance, format: .fixed(precision: 1))pt)")
             }
         } else {
-            // No ForEach items to target (empty conversation).
-            // Fall back to edge-based scroll.
-            if animated {
-                withAnimation(VAnimation.fast) {
-                    scrollToEdge?(.bottom)
-                }
-            } else {
-                scrollToEdge?(.bottom)
+            // Enter near-bottom when distance is 10pt or less
+            if distance <= 10 {
+                isNearBottom = true
+                scrollLog.debug("Near-bottom: entered (distance: \(distance, format: .fixed(precision: 1))pt)")
             }
         }
+
+        showScrollToLatest = !isNearBottom
     }
 
-    /// Performs a programmatic scroll to the given item ID and anchor point.
-    func performScrollTo(_ id: any Hashable, anchor: UnitPoint? = nil) {
-        scrollTo?(id, anchor)
+    /// Marks the beginning of a new send cycle.
+    /// Resets the anchoring flag so the system can anchor once for this cycle.
+    func beginSendCycle() {
+        didAnchorCurrentSendCycle = false
     }
 
-    // MARK: - Scroll Event Handling
-
-    /// Handles user scrolling up — transitions to freeBrowsing if appropriate.
-    func handleUserScrollUp() {
-        // Capture whether we're leaving a state that could have an
-        // in-flight programmatic scroll (CTA spring animation, auto-
-        // follow, recovery). Used below to cancel the animation.
-        let wasFollowingOrInitial = mode.allowsAutoScroll
-        switch mode {
-        case .initialLoad, .followingBottom:
-            transition(to: .freeBrowsing)
-        case .stabilizing:
-            transition(to: .freeBrowsing)
-        case .freeBrowsing, .programmaticScroll:
-            break
-        }
-        // Cancel the active recovery window. Without this, recovery
-        // fires `scrollToEdge(.bottom)` in the brief `.idle` gap between
-        // user scroll gestures (trackpad lift → re-touch), yanking the
-        // viewport back to bottom and creating a "scroll lock" effect.
-        // User intent to scroll away always takes priority over recovery.
-        // The mode transition to .freeBrowsing blocks the `mode.allows-
-        // AutoScroll` check, but a recovery call from the PREVIOUS
-        // geometry update (before this handler ran) may already be
-        // in the pipeline. Clearing recoveryDeadline ensures the
-        // `isInRecoveryWindow` condition is false for ALL subsequent
-        // geometry updates, eliminating any race window.
-        recoveryDeadline = nil
-        // Cancel any in-flight CTA spring animation. SwiftUI's
-        // `withAnimation { scrollPosition = ... }` creates an animation
-        // that does NOT cancel when the user starts a new scroll gesture
-        // (unlike UIKit's UIScrollView.setContentOffset(animated:) which
-        // cancels on touch). Without this, the spring animation continues
-        // to drive the scroll position toward bottom while the user's
-        // gesture drives it upward — creating visible jitter/lock that
-        // persists until the spring settles (~300-500ms).
-        //
-        // Guard conditions:
-        //   1. wasFollowingOrInitial — only cancel when leaving a following
-        //      state (if already .freeBrowsing, there's no animation).
-        //   2. scrollPhase == .interacting — only cancel when the user has
-        //      active touch. During .interacting the user's gesture has
-        //      priority over programmatic position writes, so the empty
-        //      ScrollPosition() is safe (viewport doesn't jump).
-        //      During .decelerating (passive momentum), writing an empty
-        //      ScrollPosition() could interrupt the momentum or cause a
-        //      viewport jump since there's no active gesture to override it.
-        //      The .decelerating case is handled separately: the 500ms
-        //      cooldown suppresses stale pre-CTA momentum, and by the time
-        //      the cooldown expires the spring animation has already
-        //      completed (~300ms), so there's nothing to cancel.
-        if wasFollowingOrInitial, scrollPhase == .interacting {
-            cancelScrollAnimation?()
-        }
+    /// Marks that the current send cycle has been anchored.
+    /// Prevents additional anchoring until the next `beginSendCycle()`.
+    func markSendAnchored() {
+        didAnchorCurrentSendCycle = true
     }
 
-    /// Handles the user arriving at the bottom of the scroll view.
-    func handleReachedBottom() {
-        switch mode {
-        case .freeBrowsing, .initialLoad, .programmaticScroll:
-            transition(to: .followingBottom)
-        case .stabilizing:
-            break
-        case .followingBottom:
-            break
-        }
-        scrollRestoreTask?.cancel()
-        scrollRestoreTask = nil
-    }
+    /// Returns `true` if auto-follow is allowed (near bottom and at least
+    /// 80ms since the last auto-follow). Updates `lastAutoFollowAt` on success.
+    func canAutoFollow() -> Bool {
+        guard isNearBottom else { return false }
 
-    // MARK: - Convenience Queries
+        let now = Date()
+        guard now.timeIntervalSince(lastAutoFollowAt) >= 0.08 else { return false }
 
-    /// Whether the mode allows automatic bottom-pinning.
-    var isFollowingBottom: Bool {
-        switch mode {
-        case .followingBottom: true
-        case .stabilizing(let prev, _): prev == .followingBottom
-        default: false
-        }
-    }
-
-    /// Whether the scroll system has received initial interaction.
-    var hasBeenInteracted: Bool {
-        if case .initialLoad = mode { return false }
+        lastAutoFollowAt = now
         return true
     }
 
-    /// Whether auto-scroll is currently suppressed (stabilizing mode).
-    var isSuppressed: Bool {
-        if case .stabilizing = mode { return true }
-        return false
-    }
-
-    // MARK: - Lifecycle Methods
-
-    /// Resets state for a conversation switch.
-    func reset(for newConversationId: UUID?) {
-        cancelStabilizationTasks()
-        paginationTask?.cancel()
-        paginationTask = nil
-        ScrollGeometryUpdateDispatcher.shared.cancel(for: self)
-        if _isPaginationInFlight { _isPaginationInFlight = false }
+    /// Resets all state for a conversation switch.
+    func reset(for conversationId: UUID) {
+        currentConversationId = conversationId
+        isNearBottom = true
+        viewportHeight = 0
+        contentHeight = 0
+        contentOffsetY = 0
+        didAnchorCurrentSendCycle = false
+        lastAutoFollowAt = .distantPast
+        pendingAnchorMessageId = nil
+        lastMessageId = nil
         wasPaginationTriggerInRange = false
         lastPaginationCompletedAt = .distantPast
-        derivedStateCache.reset()
-        currentConversationId = newConversationId
-        lastMessageId = nil
-        mode = .initialLoad
-        activeStabilizationCount = 0
-        // False: scroll geometry hasn't updated for the new content yet.
-        isAtBottom = false
-        lastContentOffsetY = 0
-        scrollContentHeight = 0
-        scrollContainerHeight = 0
-        // Reset scroll phase — a stale .interacting/.decelerating from
-        // the previous conversation would block phaseAllowsAutoFollow,
-        // preventing all recovery and auto-follow during the new
-        // conversation's critical materialization window.
-        // onScrollPhaseChange may not fire for the new ScrollView's
-        // initial .idle state (only fires on *changes*).
-        scrollPhase = .idle
-        // Reset anchor-appeared flag — the new conversation's bottom anchor
-        // hasn't materialized yet. Until it does, isAtBottom is unreliable.
-        bottomAnchorAppeared = false
-        lastRecoveryAttempt = .distantPast
-        lastUserInitiatedPinTime = nil
-        // Mark that a recovery window is active. Recovery fires
-        // unconditionally until bottomAnchorAppeared becomes true.
-        recoveryDeadline = Date().addingTimeInterval(2.0)
-        scrollIndicatorRestoreTask?.cancel()
-        if !_hideScrollIndicators { _hideScrollIndicators = true }
-        syncUIImmediately()
-        scrollIndicatorRestoreTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(nanoseconds: 300_000_000)
-            guard !Task.isCancelled, let self else { return }
-            if self._hideScrollIndicators { self._hideScrollIndicators = false }
-            self.syncUIImmediately()
-            self.scrollIndicatorRestoreTask = nil
-        }
+        showScrollToLatest = false
+        scrollIndicatorsHidden = false
+
+        scrollLog.debug("Reset for conversation: \(conversationId)")
     }
 
-    /// Cancel all tasks and reset mode. Called from `onDisappear`.
-    func cancelAll() {
-        cancelStabilizationTasks()
-        uiSyncTask?.cancel()
-        uiSyncTask = nil
-        scrollRestoreTask?.cancel()
-        scrollRestoreTask = nil
-        paginationTask?.cancel()
-        paginationTask = nil
-        ScrollGeometryUpdateDispatcher.shared.cancel(for: self)
-        anchorTimeoutTask?.cancel()
-        anchorTimeoutTask = nil
-        highlightDismissTask?.cancel()
-        highlightDismissTask = nil
-        scrollIndicatorRestoreTask?.cancel()
-        scrollIndicatorRestoreTask = nil
-        derivedStateCache.reset()
-        if _hideScrollIndicators { _hideScrollIndicators = false }
-        if _isPaginationInFlight { _isPaginationInFlight = false }
-        mode = .initialLoad
-        activeStabilizationCount = 0
-        lastPaginationCompletedAt = .distantPast
-        // Reset recovery/scroll fields to match reset(). Without this,
-        // if the same @State-owned scrollState is reused after onDisappear
-        // (e.g. parent conditional toggle for the same conversation),
-        // stale values could block phaseAllowsAutoFollow or cause
-        // infinite recovery.
-        scrollPhase = .idle
-        recoveryDeadline = nil
-        bottomAnchorAppeared = false
-        lastRecoveryAttempt = .distantPast
-        lastUserInitiatedPinTime = nil
-        lastMessageId = nil
-        isAtBottom = false
-        lastContentOffsetY = 0
-        scrollContentHeight = 0
-        scrollContainerHeight = 0
-        syncUIImmediately()
+    /// Handles the pagination sentinel's geometry to trigger pagination
+    /// on a rising edge (sentinel enters the trigger band) with a 500ms cooldown.
+    ///
+    /// - Parameter sentinelMinY: The minY of the pagination sentinel in the
+    ///   scroll view's coordinate space.
+    func handlePaginationSentinel(sentinelMinY: CGFloat) {
+        // Trigger band: sentinel minY between -120pt (above viewport top)
+        // and +200pt (below viewport top).
+        let isInRange = sentinelMinY >= -120 && sentinelMinY <= 200
+
+        // Rising-edge detector: only fire when transitioning from out-of-range
+        // to in-range.
+        let shouldFire = isInRange && !wasPaginationTriggerInRange
+        wasPaginationTriggerInRange = isInRange
+
+        guard shouldFire else { return }
+
+        // 500ms cooldown between successive pagination fires.
+        let now = Date()
+        guard now.timeIntervalSince(lastPaginationCompletedAt) >= 0.5 else {
+            scrollLog.debug("Pagination sentinel: in range but cooldown active")
+            return
+        }
+
+        scrollLog.debug("Pagination sentinel: triggered (sentinelMinY: \(sentinelMinY, format: .fixed(precision: 1))pt)")
+        lastPaginationCompletedAt = now
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -192,7 +192,8 @@ final class MessageListScrollState {
     ///
     /// - Parameter sentinelMinY: The minY of the pagination sentinel in the
     ///   scroll view's coordinate space.
-    func handlePaginationSentinel(sentinelMinY: CGFloat) {
+    @discardableResult
+    func handlePaginationSentinel(sentinelMinY: CGFloat) -> Bool {
         // Trigger band: sentinel minY between -120pt (above viewport top)
         // and +200pt (below viewport top).
         let isInRange = sentinelMinY >= -120 && sentinelMinY <= 200
@@ -202,16 +203,17 @@ final class MessageListScrollState {
         let shouldFire = isInRange && !wasPaginationTriggerInRange
         wasPaginationTriggerInRange = isInRange
 
-        guard shouldFire else { return }
+        guard shouldFire else { return false }
 
         // 500ms cooldown between successive pagination fires.
         let now = Date()
         guard now.timeIntervalSince(lastPaginationCompletedAt) >= 0.5 else {
             scrollLog.debug("Pagination sentinel: in range but cooldown active")
-            return
+            return false
         }
 
         scrollLog.debug("Pagination sentinel: triggered (sentinelMinY: \(sentinelMinY, format: .fixed(precision: 1))pt)")
         lastPaginationCompletedAt = now
+        return true
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -78,6 +78,12 @@ final class MessageListScrollState {
     /// Used as the primary scroll-to-bottom target.
     @ObservationIgnored var lastMessageId: (any Hashable)?
 
+    // MARK: - Confirmation Focus
+
+    /// Tracks the last confirmation request ID that was auto-focused,
+    /// so the same request isn't focused twice.
+    @ObservationIgnored var lastAutoFocusedRequestId: String?
+
     // MARK: - Pagination
 
     /// Tracks whether the pagination sentinel was previously inside the trigger band.
@@ -153,6 +159,14 @@ final class MessageListScrollState {
         return true
     }
 
+    /// Called when the user taps "Scroll to latest". Resets near-bottom
+    /// state and hides the CTA so the caller can perform the actual scroll.
+    func handleScrollToLatestTapped() {
+        isNearBottom = true
+        showScrollToLatest = false
+        scrollLog.debug("Scroll to latest tapped — resetting near-bottom state")
+    }
+
     /// Resets all state for a conversation switch.
     func reset(for conversationId: UUID) {
         currentConversationId = conversationId
@@ -168,6 +182,7 @@ final class MessageListScrollState {
         lastPaginationCompletedAt = .distantPast
         showScrollToLatest = false
         scrollIndicatorsHidden = false
+        lastAutoFocusedRequestId = nil
 
         scrollLog.debug("Reset for conversation: \(conversationId)")
     }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -94,6 +94,23 @@ final class MessageListScrollState {
     /// cooldown between successive pagination fires.
     @ObservationIgnored var lastPaginationCompletedAt: Date = .distantPast
 
+    // MARK: - Bottom Anchor Tracking
+
+    /// Whether the bottom anchor element has appeared in the LazyVStack.
+    /// Set by `MessageListContentView`'s `onAppear` on the bottom spacer.
+    @ObservationIgnored var bottomAnchorAppeared: Bool = false
+
+    /// Whether the user has interacted with the scroll view (scrolled away
+    /// from initial position). Used to gate initial auto-scroll behavior.
+    @ObservationIgnored var hasBeenInteracted: Bool = false
+
+    // MARK: - Derived State Cache
+
+    /// Non-observable cache for memoizing derived state computations.
+    /// Kept off the observation graph to avoid "modifying state during view
+    /// update" warnings while still enabling memoization hot paths.
+    @ObservationIgnored lazy var derivedStateCache = MessageListDerivedStateCache()
+
     // MARK: - Computed Properties
 
     /// Distance from the bottom of the scrollable content.
@@ -159,6 +176,41 @@ final class MessageListScrollState {
         return true
     }
 
+    /// Called when the viewport reaches the bottom of the content.
+    /// Marks the scroll state as interacted and near-bottom.
+    func handleReachedBottom() {
+        hasBeenInteracted = true
+        isNearBottom = true
+        showScrollToLatest = false
+    }
+
+    /// Records a body evaluation timestamp for circuit-breaker throttling.
+    /// If more than 60 evaluations occur within 500ms, activates throttle
+    /// mode to prevent runaway layout loops. Auto-recovers after 500ms.
+    func recordBodyEvaluation() {
+        let now = CFAbsoluteTimeGetCurrent()
+        let cache = derivedStateCache
+        cache.bodyEvalTimestamps.append(now)
+
+        // Prune timestamps older than 500ms
+        let cutoff = now - 0.5
+        cache.bodyEvalTimestamps.removeAll { $0 < cutoff }
+
+        if cache.bodyEvalTimestamps.count > 60 && !cache.isThrottled {
+            cache.isThrottled = true
+            scrollLog.warning("Circuit breaker tripped: \(cache.bodyEvalTimestamps.count) body evals in 500ms")
+
+            cache.throttleRecoveryTask?.cancel()
+            cache.throttleRecoveryTask = Task { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: 500_000_000)
+                guard !Task.isCancelled else { return }
+                self?.derivedStateCache.isThrottled = false
+                self?.derivedStateCache.bodyEvalTimestamps.removeAll()
+                scrollLog.debug("Circuit breaker recovered")
+            }
+        }
+    }
+
     /// Called when the user taps "Scroll to latest". Resets near-bottom
     /// state and hides the CTA so the caller can perform the actual scroll.
     func handleScrollToLatestTapped() {
@@ -183,6 +235,9 @@ final class MessageListScrollState {
         showScrollToLatest = false
         scrollIndicatorsHidden = false
         lastAutoFocusedRequestId = nil
+        bottomAnchorAppeared = false
+        hasBeenInteracted = false
+        derivedStateCache.reset()
 
         scrollLog.debug("Reset for conversation: \(conversationId)")
     }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -104,20 +104,6 @@ final class MessageListScrollState {
     /// from initial position). Used to gate initial auto-scroll behavior.
     @ObservationIgnored var hasBeenInteracted: Bool = false
 
-    // MARK: - Smart Spacer
-
-    /// The spacer height that the view reads. Observable so the view updates.
-    private(set) var spacerHeight: CGFloat = 0
-
-    /// Whether a send cycle is actively streaming.
-    @ObservationIgnored var isInSendCycle: Bool = false
-
-    /// Target spacer height (viewportHeight - estimated user msg height).
-    @ObservationIgnored var targetSpacerHeight: CGFloat = 0
-
-    /// Content height when send started, for computing growth delta.
-    @ObservationIgnored var contentHeightAtSendStart: CGFloat = 0
-
     // MARK: - Derived State Cache
 
     /// Non-observable cache for memoizing derived state computations.
@@ -233,38 +219,6 @@ final class MessageListScrollState {
         scrollLog.debug("Scroll to latest tapped — resetting near-bottom state")
     }
 
-    // MARK: - Smart Spacer Methods
-
-    /// Begins the spacer animation when a send cycle starts.
-    /// Animates the spacer from 0 to `viewportHeight - 150` (estimated user message height).
-    func startSpacerAnimation() {
-        isInSendCycle = true
-        contentHeightAtSendStart = contentHeight
-        targetSpacerHeight = max(0, viewportHeight - 150)
-        withAnimation(VAnimation.standard) {
-            spacerHeight = targetSpacerHeight
-        }
-    }
-
-    /// Shrinks the spacer proportionally as assistant content grows during streaming.
-    /// Throttled to 10pt changes to avoid excessive re-renders.
-    func updateSpacerForContentGrowth(newContentHeight: CGFloat) {
-        guard isInSendCycle else { return }
-        let growth = max(0, newContentHeight - contentHeightAtSendStart)
-        let newHeight = max(100, targetSpacerHeight - growth)
-        if abs(newHeight - spacerHeight) >= 10 {
-            spacerHeight = newHeight
-        }
-    }
-
-    /// Ends the send cycle and settles the spacer at the 100pt floor.
-    func endSendCycle() {
-        isInSendCycle = false
-        withAnimation(VAnimation.standard) {
-            spacerHeight = 100
-        }
-    }
-
     /// Resets all state for a conversation switch.
     func reset(for conversationId: UUID) {
         currentConversationId = conversationId
@@ -283,10 +237,6 @@ final class MessageListScrollState {
         lastAutoFocusedRequestId = nil
         bottomAnchorAppeared = false
         hasBeenInteracted = false
-        spacerHeight = 0
-        targetSpacerHeight = 0
-        isInSendCycle = false
-        contentHeightAtSendStart = 0
         derivedStateCache.reset()
 
         scrollLog.debug("Reset for conversation: \(conversationId)")

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
@@ -45,56 +45,6 @@ struct ScrollGeometrySnapshot: Equatable {
     let visibleRectHeight: CGFloat
 }
 
-// MARK: - Scroll Geometry Dispatcher
-
-/// Coalesces `onScrollGeometryChange` callbacks outside SwiftUI-managed state.
-///
-/// macOS 26 faults when an `OnScrollGeometryChange` action updates view state
-/// multiple times in the same frame. The message list still needs to process
-/// the latest geometry snapshot, but the queue bookkeeping itself must not
-/// live on `@State` / `@Observable` storage owned by the view.
-@MainActor
-final class ScrollGeometryUpdateDispatcher {
-    static let shared = ScrollGeometryUpdateDispatcher()
-
-    private var pendingSnapshots: [ObjectIdentifier: ScrollGeometrySnapshot] = [:]
-    private var tasks: [ObjectIdentifier: Task<Void, Never>] = [:]
-
-    func enqueue(
-        for owner: MessageListScrollState,
-        snapshot: ScrollGeometrySnapshot,
-        handler: @escaping @MainActor (ScrollGeometrySnapshot) -> Void
-    ) {
-        let key = ObjectIdentifier(owner)
-        pendingSnapshots[key] = snapshot
-        guard tasks[key] == nil else { return }
-
-        tasks[key] = Task { @MainActor [weak self, weak owner] in
-            guard let self else { return }
-            defer {
-                self.tasks[key] = nil
-                self.pendingSnapshots[key] = nil
-            }
-
-            while !Task.isCancelled {
-                await Task.yield()
-                guard owner != nil else { return }
-                guard let latest = self.pendingSnapshots[key] else { return }
-                self.pendingSnapshots[key] = nil
-                handler(latest)
-                guard self.pendingSnapshots[key] != nil else { return }
-            }
-        }
-    }
-
-    func cancel(for owner: MessageListScrollState) {
-        let key = ObjectIdentifier(owner)
-        tasks[key]?.cancel()
-        tasks[key] = nil
-        pendingSnapshots[key] = nil
-    }
-}
-
 // MARK: - Cached Message Layout Metadata
 
 /// Structural metadata cached behind a version-counter key on

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
@@ -378,6 +378,7 @@ extension MessageListView {
             isTTSEnabled: isTTSEnabled,
             selectedModel: selectedModel,
             configuredProviders: configuredProviders,
+            viewportHeight: scrollState.viewportHeight,
             subagentDetailStore: subagentDetailStore,
             assistantStatusText: assistantStatusText,
             scrollState: scrollState,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -58,8 +58,11 @@ extension MessageListView {
                 }
                 scrollState.markSendAnchored()
             }
+            scrollState.startSpacerAnimation()
         } else {
-            // true → false transition: track first-message detection.
+            // true → false transition: end spacer send cycle.
+            scrollState.endSendCycle()
+            // Track first-message detection.
             if !hasEverSentMessage && messages.contains(where: { $0.role == .user }) {
                 hasEverSentMessage = true
                 UserDefaults.standard.set(true, forKey: "hasEverSentMessage")

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -58,10 +58,8 @@ extension MessageListView {
                 }
                 scrollState.markSendAnchored()
             }
-            scrollState.startSpacerAnimation()
         } else {
-            // true → false transition: end spacer send cycle.
-            scrollState.endSendCycle()
+            // true → false transition.
             // Track first-message detection.
             if !hasEverSentMessage && messages.contains(where: { $0.role == .user }) {
                 hasEverSentMessage = true

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -14,83 +14,26 @@ extension MessageListView {
         // .id(conversationId) on the ScrollView destroys and recreates it on
         // conversation switch, firing onAppear for the new view. Detect the
         // switch by comparing against the last-known conversation ID.
-        // Must check BEFORE configureScrollCallbacks() which updates
-        // currentConversationId.
-        //
-        // Skip when currentConversationId is nil (true first mount) — reset()
-        // on freshly-initialized state is redundant and its 300ms scroll-
-        // indicator-hide task would cause a visual flicker on app launch.
         let previousConversationId = scrollState.currentConversationId
         let isConversationSwitch = previousConversationId != nil
             && previousConversationId != conversationId
-        configureScrollCallbacks()
+        scrollState.currentConversationId = conversationId
         if isConversationSwitch {
             handleConversationSwitched()
         } else {
-            // Start the recovery window for the initial load — LazyVStack
-            // height estimates are unreliable until views materialize.
-            // (For conversation switches, reset() inside handleConversationSwitched
-            // already sets recoveryDeadline.)
-            scrollState.recoveryDeadline = Date().addingTimeInterval(2.0)
-            // Seed lastMessageId so the CTA and executeScrollToBottom always
-            // have a valid ForEach target. Without this, the initial load
-            // leaves lastMessageId nil — a CTA tap would fall back to the
-            // standalone "scroll-bottom-anchor" which may not be materialized.
+            // Seed lastMessageId so the scroll-to-bottom overlay always
+            // has a valid target.
             if let lastId = paginatedVisibleMessages.last?.id {
                 scrollState.lastMessageId = lastId
             }
-        }
-        // Seed the confirmation marker so a conversation already paused in
-        // awaiting_confirmation at launch or reconnect is correctly tracked.
-        if !isSending {
-            scrollState.lastActivityPhaseWhenIdle = assistantActivityPhase
-        }
-        if let id = anchorMessageId, messages.contains(where: { $0.id == id }) {
-            // Anchor is already set and the target message is loaded —
-            // scroll to it immediately instead of falling through to bottom.
-            os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=anchorMessage reason=onAppear")
-            os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundOnAppear")
-            $scrollPosition.wrappedValue.scrollTo(id: id, anchor: .center)
-            flashHighlight(messageId: id)
-            anchorMessageId = nil
-            scrollState.anchorSetTime = nil
-        } else if anchorMessageId != nil {
-            // Anchor is set but the target message isn't loaded yet.
-            os_signpost(.event, log: PerfSignposts.log, name: "anchorSet", "reason=onAppearPending")
-            if scrollState.anchorSetTime == nil { scrollState.anchorSetTime = Date() }
-            // Start the independent timeout if not already running.
-            if scrollState.anchorTimeoutTask == nil {
-                    scrollState.anchorTimeoutTask = Task { @MainActor [scrollState] in
-                        do {
-                            try await Task.sleep(nanoseconds: 10_000_000_000)
-                        } catch { return }
-                        guard !Task.isCancelled, anchorMessageId != nil else { return }
-                        os_signpost(.event, log: PerfSignposts.log, name: "anchorTimedOut")
-                        log.debug("Anchor message not found (timed out) — clearing stale anchor")
-                        anchorMessageId = nil
-                        scrollState.anchorSetTime = nil
-                        scrollState.anchorTimeoutTask = nil
-                        scrollState.transition(to: .followingBottom)
-                        _ = withAnimation(VAnimation.fast) {
-                            scrollState.requestPinToBottom(animated: true, userInitiated: true)
-                        }
-                    }
+            // Initial load — scroll to bottom via proxy.
+            if let id = anchorMessageId, messages.contains(where: { $0.id == id }) {
+                scrollProxy?.scrollTo(id, anchor: .center)
+                flashHighlight(messageId: id)
+                anchorMessageId = nil
+            } else if anchorMessageId == nil {
+                scrollProxy?.scrollTo("scroll-bottom-anchor", anchor: .bottom)
             }
-        } else {
-            // Initial load (first mount). Let `.defaultScrollAnchor(.bottom,
-            // for: .initialOffset)` handle positioning declaratively —
-            // it places the viewport at the bottom in the same layout pass
-            // as content rendering. An imperative `scrollToEdge(.bottom)`
-            // here would compete with the declarative anchor, causing visible
-            // flicker: the viewport jumps down (declarative), then gets
-            // yanked again by the imperative call, potentially overshooting
-            // into blank LazyVStack estimated space.
-            //
-            // The delayed `restoreScrollToBottom()` (100ms) acts as a safety
-            // net: if `.defaultScrollAnchor` didn't fully resolve (e.g. very
-            // long conversation with unreliable height estimates), the
-            // recovery window + restore fallback will catch it.
-            restoreScrollToBottom()
         }
     }
 
@@ -98,48 +41,25 @@ extension MessageListView {
 
     func handleSendingChanged() {
         // Guard against stale fires during a conversation switch.
-        // onChange handlers fire in declaration order; isSending fires
-        // before conversationId, so during a switch this handler sees
-        // the NEW isSending value but the OLD scroll state (reset()
-        // hasn't run yet). Animated pins targeting stale content
-        // accumulate and corrupt SwiftUI's scroll position.
         guard conversationId == scrollState.currentConversationId else { return }
         if isSending {
-            // Clear stale confirmation marker: if the phase left "awaiting_confirmation"
-            // while not sending, the marker is stale.
-            let effectivePhase: String
-            if scrollState.lastActivityPhaseWhenIdle == "awaiting_confirmation"
-                && assistantActivityPhase != "awaiting_confirmation"
-            {
-                effectivePhase = assistantActivityPhase
-            } else {
-                effectivePhase = scrollState.lastActivityPhaseWhenIdle
-            }
-            // Reattach and pin to bottom for user-initiated actions (send,
-            // regenerate, retry). Skip reattach only when the daemon resumes
-            // from a tool confirmation (not a user action during confirmation).
-            let isDaemonConfirmationResume =
-                effectivePhase == "awaiting_confirmation"
-                && assistantActivityPhase != "awaiting_confirmation"
-            if isDaemonConfirmationResume && !scrollState.isFollowingBottom {
-                // Daemon resumed from confirmation while user was scrolled up.
-            } else {
-                scrollState.transition(to: .followingBottom)
-                // Start a fresh recovery window: the animated scroll can
-                // overshoot into blank LazyVStack estimated space. Without
-                // this, isAtBottom is falsely true at the estimated bottom
-                // and persistent recovery doesn't fire — the viewport
-                // stays blank until the user scrolls manually.
-                scrollState.bottomAnchorAppeared = false
-                scrollState.recoveryDeadline = Date().addingTimeInterval(2.0)
-                scrollState.requestPinToBottom(animated: true)
-                os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested",
-                            "target=bottom reason=sendFollowingBottom")
+            // false → true transition: begin a new send cycle.
+            scrollState.beginSendCycle()
+
+            // Find the last user message to anchor to viewport top.
+            if let userMessage = messages.last(where: { $0.role == .user }),
+               scrollState.pendingAnchorMessageId == nil {
+                scrollProxy?.scrollTo(userMessage.id, anchor: .top)
+                // Schedule a 50ms delayed retry for layout timing —
+                // LazyVStack may not have materialized the target yet.
+                Task { @MainActor in
+                    try? await Task.sleep(nanoseconds: 50_000_000)
+                    scrollProxy?.scrollTo(userMessage.id, anchor: .top)
+                }
+                scrollState.markSendAnchored()
             }
         } else {
-            // Capture the activity phase at the moment sending stops.
-            scrollState.lastActivityPhaseWhenIdle = assistantActivityPhase
-            // First-message detection.
+            // true → false transition: track first-message detection.
             if !hasEverSentMessage && messages.contains(where: { $0.role == .user }) {
                 hasEverSentMessage = true
                 UserDefaults.standard.set(true, forKey: "hasEverSentMessage")
@@ -149,52 +69,35 @@ extension MessageListView {
 
     func handleMessagesCountChanged() {
         // Guard against stale fires during a conversation switch.
-        // onChange(of: messages.count) fires before onChange(of: conversationId),
-        // so during a switch this handler sees the NEW message count but
-        // the OLD scroll state (reset() hasn't run yet). An animated
-        // requestPinToBottom targeting stale content interferes with the
-        // subsequent conversation switch flow.
         guard conversationId == scrollState.currentConversationId else { return }
-        // --- Anchor message resolution ---
-        if let id = anchorMessageId, messages.contains(where: { $0.id == id }) {
-            os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=anchorMessage reason=messagesChanged")
-            os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundInMessages")
-            scrollState.transition(to: .programmaticScroll(reason: .deepLinkAnchor(id: id)))
-            withAnimation {
-                scrollState.scrollTo?(id, .center)
-            }
-            flashHighlight(messageId: id)
-            anchorMessageId = nil
-            scrollState.anchorSetTime = nil
-            scrollState.anchorTimeoutTask?.cancel()
-            scrollState.anchorTimeoutTask = nil
-            return
-        }
-        // If anchor is set but the target message still hasn't appeared,
-        // check pagination exhaustion with a minimum elapsed time guard.
-        if anchorMessageId != nil {
-            let paginationExhausted = !hasMoreMessages
-            let minWaitElapsed = scrollState.anchorSetTime.map { Date().timeIntervalSince($0) > 2 } ?? false
-            if paginationExhausted && minWaitElapsed {
-                os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=paginationExhausted")
-                log.debug("Anchor message not found (pagination exhausted) — clearing stale anchor")
-                anchorMessageId = nil
-                scrollState.anchorSetTime = nil
-                scrollState.anchorTimeoutTask?.cancel()
-                scrollState.anchorTimeoutTask = nil
-                scrollState.transition(to: .followingBottom)
-                scrollState.requestPinToBottom(animated: true)
-                return
-            }
-        }
-        // --- Bottom-pin on new messages ---
-        // Keep lastMessageId current so executeScrollToBottom targets ForEach items.
+
+        // Keep lastMessageId current.
         if let lastId = paginatedVisibleMessages.last?.id {
             scrollState.lastMessageId = lastId
         }
-        if anchorMessageId == nil {
-            scrollState.requestPinToBottom(animated: true)
+
+        // --- Deep-link anchor resolution ---
+        if let id = scrollState.pendingAnchorMessageId,
+           messages.contains(where: { $0.id == id }) {
+            scrollProxy?.scrollTo(id, anchor: .center)
+            flashHighlight(messageId: id)
+            scrollState.pendingAnchorMessageId = nil
+            return
         }
+
+        // --- Anchor message from binding ---
+        if let id = anchorMessageId, messages.contains(where: { $0.id == id }) {
+            scrollProxy?.scrollTo(id, anchor: .center)
+            flashHighlight(messageId: id)
+            anchorMessageId = nil
+            return
+        }
+
+        // --- Auto-follow on new messages ---
+        if scrollState.shouldAutoFollow, scrollProxy != nil {
+            scrollProxy?.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+        }
+
         // --- Confirmation focus handoff ---
         #if os(macOS)
         handleConfirmationFocusIfNeeded()
@@ -202,130 +105,37 @@ extension MessageListView {
     }
 
     func handleContainerWidthChanged() {
-        guard containerWidth > 0, abs(containerWidth - scrollState.lastHandledContainerWidth) > 2 else { return }
-        scrollState.lastHandledContainerWidth = containerWidth
-        resizeScrollTask?.cancel()
-        resizeScrollTask = Task { @MainActor [scrollState] in
-            scrollState.beginStabilization(.resize)
-            defer {
-                if !Task.isCancelled { resizeScrollTask = nil }
+        if scrollState.isNearBottom {
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 100_000_000)
+                scrollProxy?.scrollTo("scroll-bottom-anchor", anchor: .bottom)
             }
-            try? await Task.sleep(nanoseconds: 100_000_000)
-            guard !Task.isCancelled else {
-                scrollState.endStabilization()
-                return
-            }
-                scrollState.endStabilization()
-                if scrollState.mode.allowsAutoScroll && anchorMessageId == nil {
-                    // Use mode.allowsAutoScroll (covers both .initialLoad and
-                    // .followingBottom) instead of isFollowingBottom (which
-                    // returns false for .initialLoad). A resize during initial
-                    // load — e.g. app opens with side panel — must still re-pin.
-                    // Always re-pin after resize — don't check isAtBottom.
-                    // After a width change, LazyVStack re-estimates content heights.
-                    // The viewport can be at the *estimated* bottom (blank space)
-                    // where distanceFromBottom ≈ 0 → isAtBottom = true, even though
-                    // actual content is above. Start a fresh recovery window so
-                    // persistent recovery fires unconditionally for 2 seconds.
-                    scrollState.bottomAnchorAppeared = false
-                    scrollState.recoveryDeadline = Date().addingTimeInterval(2.0)
-                    scrollState.requestPinToBottom()
-                } else if case .freeBrowsing = scrollState.mode,
-                          anchorMessageId == nil,
-                          let visibleId = scrollState.cachedFirstVisibleMessageId {
-                    // User was scrolled up when resize happened. LazyVStack
-                    // re-estimates heights for the new container width, which
-                    // can shift content — the viewport may now show blank
-                    // estimated space instead of the message the user was
-                    // reading. Re-anchor at the first visible message to
-                    // maintain the user's reading position.
-                    scrollState.performScrollTo(visibleId, anchor: .top)
-                }
         }
     }
 
     func handleConversationSwitched() {
-        // Reset view-local state.
-        resizeScrollTask?.cancel()
-        resizeScrollTask = nil
-        highlightedMessageId = nil
-        scrollState.highlightDismissTask?.cancel()
-        scrollState.highlightDismissTask = nil
-        // Reset scroll state for the new conversation.
+        guard let conversationId else { return }
         scrollState.reset(for: conversationId)
-        // Capture the new conversation's activity phase so a conversation
-        // already paused in awaiting_confirmation is correctly tracked.
-        scrollState.lastActivityPhaseWhenIdle = isSending ? "" : assistantActivityPhase
-        scrollState.lastHandledContainerWidth = containerWidth
-        scrollState.anchorTimeoutTask?.cancel()
-        scrollState.anchorTimeoutTask = nil
-        scrollState.lastAutoFocusedRequestId = nil
-        // reset() already set mode to .initialLoad, which allows auto-scroll.
-        // Don't override with .programmaticScroll — that would block
-        // handleMessagesCountChanged and content-growth auto-follow during
-        // the critical window while LazyVStack materializes new content.
-        //
-        // Seed lastMessageId so executeScrollToBottom can target it.
+        anchorMessageId = nil
+        highlightedMessageId = nil
+        // Seed lastMessageId for the new conversation.
         scrollState.lastMessageId = paginatedVisibleMessages.last?.id
-        // Declarative position reset — processed in the same layout pass as new content.
-        // Prefer the last ForEach message ID over the standalone anchor because
-        // ForEach items are always indexable by ScrollPosition even when not
-        // materialized — SwiftUI locates them in the data source. The standalone
-        // "scroll-bottom-anchor" (outside ForEach) is only locatable when materialized.
-        // https://developer.apple.com/documentation/swiftui/scrollposition
-        scrollState.scrollRestoreTask?.cancel()
-        if anchorMessageId == nil {
-            if let lastId = paginatedVisibleMessages.last?.id {
-                scrollPosition = ScrollPosition(id: lastId, anchor: .bottom)
-            } else {
-                // Empty conversation — no ForEach items to target.
-                // Use edge-based position; the standalone "scroll-bottom-anchor"
-                // is outside ForEach and only locatable when materialized.
-                scrollPosition = ScrollPosition(edge: .bottom)
-            }
-        }
-        restoreScrollToBottom()
+        scrollProxy?.scrollTo("scroll-bottom-anchor", anchor: .bottom)
     }
 
     func handleAnchorMessageTask() async {
         // task(id:) fires on initial value and on changes. Only process
-        // non-nil anchor assignments; nil transitions are cleanup handled
-        // by messagesChanged and conversationSwitched.
+        // non-nil anchor assignments.
         guard let id = anchorMessageId else { return }
-        // Cancel scroll restore when a new anchor is set.
-        scrollState.scrollRestoreTask?.cancel()
-        scrollState.scrollRestoreTask = nil
-        scrollState.transition(to: .programmaticScroll(reason: .deepLinkAnchor(id: id)))
-        scrollState.anchorSetTime = Date()
-        scrollState.anchorTimeoutTask?.cancel()
-        scrollState.anchorTimeoutTask = nil
-        os_signpost(.event, log: PerfSignposts.log, name: "anchorSet", "reason=anchorMessageIdChanged")
+
+        // Deep-link anchor takes precedence — store for resolution.
+        scrollState.pendingAnchorMessageId = id
+
         if messages.contains(where: { $0.id == id }) {
-            os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=anchorMessage reason=anchorChanged")
-            os_signpost(.event, log: PerfSignposts.log, name: "anchorCleared", "reason=foundOnAnchorChange")
-            withAnimation {
-                scrollState.scrollTo?(id, .center)
-            }
+            scrollProxy?.scrollTo(id, anchor: .center)
             flashHighlight(messageId: id)
             anchorMessageId = nil
-            scrollState.anchorSetTime = nil
-        } else {
-            // Start an independent 10-second timeout that clears the
-            // anchor even if messages.count never changes.
-            scrollState.anchorTimeoutTask = Task { @MainActor [scrollState] in
-                do {
-                    try await Task.sleep(nanoseconds: 10_000_000_000)
-                } catch { return }
-                guard !Task.isCancelled, anchorMessageId != nil else { return }
-                os_signpost(.event, log: PerfSignposts.log, name: "anchorTimedOut")
-                log.debug("Anchor message not found (timed out) — clearing stale anchor")
-                anchorMessageId = nil
-                scrollState.anchorSetTime = nil
-                scrollState.anchorTimeoutTask = nil
-                _ = withAnimation(VAnimation.fast) {
-                    scrollState.requestPinToBottom(animated: true, userInitiated: true)
-                }
-            }
+            scrollState.pendingAnchorMessageId = nil
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -16,6 +16,10 @@ extension MessageListView {
         scrollState.viewportHeight = newState.visibleRectHeight
         scrollState.updateNearBottom()
 
+        if scrollState.isInSendCycle {
+            scrollState.updateSpacerForContentGrowth(newContentHeight: newState.contentHeight)
+        }
+
         // Derive sentinel position from content offset (inverted sign to
         // match the old coordinate-space convention where minY is negative
         // when scrolled past the viewport top).

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -7,395 +7,54 @@ extension MessageListView {
 
     // MARK: - Scroll geometry handler
 
-    /// Coalesces `onScrollGeometryChange` updates onto the next main-actor turn.
-    ///
-    /// macOS 26's `OnScrollGeometryChange` modifier faults when its action
-    /// causes enough synchronous view-affecting state mutations to re-enter
-    /// the modifier in the same frame. We only store the latest geometry
-    /// snapshot inside the callback, then process it after the callback unwinds.
-    func enqueueScrollGeometryUpdate(_ newState: ScrollGeometrySnapshot) {
-        ScrollGeometryUpdateDispatcher.shared.enqueue(for: scrollState, snapshot: newState) { snapshot in
-            handleScrollGeometryUpdate(snapshot)
-        }
-    }
-
+    /// Called from `.onScrollGeometryChange` in the message list body.
+    /// Feeds geometry into the simplified scroll coordinator and evaluates
+    /// the pagination sentinel.
     func handleScrollGeometryUpdate(_ newState: ScrollGeometrySnapshot) {
-        // --- Scroll direction detection ---
-        let effectiveContentHeight = newState.contentHeight
-        let isScrollable = effectiveContentHeight > newState.containerHeight
-        let isScrollingUp = newState.contentOffsetY < scrollState.lastContentOffsetY
-        let previousContentHeight = scrollState.scrollContentHeight
-        scrollState.scrollContentHeight = newState.contentHeight
-        scrollState.scrollContainerHeight = newState.containerHeight
-        scrollState.lastContentOffsetY = newState.contentOffsetY
+        scrollState.contentOffsetY = newState.contentOffsetY
+        scrollState.contentHeight = newState.contentHeight
+        scrollState.viewportHeight = newState.visibleRectHeight
+        scrollState.updateNearBottom()
 
-        // Detach on user gesture (interacting) AND user-initiated momentum
-        // (decelerating). A fast trackpad flick has a very brief .interacting
-        // phase — sometimes only 1-2 geometry updates fire before the phase
-        // transitions to .decelerating. If the first update hasn't registered
-        // a position change yet, handleUserScrollUp() never fires and the CTA
-        // never appears. .decelerating is exclusively user-initiated momentum
-        // (programmatic scrolls use .animating), so it's safe to detect here.
-        // Only detach when content is scrollable (prevents false detaches
-        // on short conversations).
-        let isUserScrollPhase = scrollState.scrollPhase == .interacting
-            || scrollState.scrollPhase == .decelerating
-        if isUserScrollPhase && isScrollingUp && isScrollable {
-            // During .decelerating, check if the momentum is stale (pre-CTA).
-            // When the user scrolls up and taps "Scroll to latest" while
-            // momentum is active, the CTA fires requestPinToBottom and sets
-            // mode to .followingBottom. But the residual upward momentum
-            // generates geometry updates with isScrollingUp=true in
-            // .decelerating phase — the very next update would fire
-            // handleUserScrollUp(), undoing the CTA's mode transition and
-            // creating a "scroll lock" effect.
-            //
-            // Only suppress during .decelerating (residual momentum from
-            // before the CTA tap). .interacting (new deliberate trackpad
-            // touch) is always respected — the user is explicitly starting
-            // a new scroll gesture, overriding the CTA.
-            if scrollState.scrollPhase == .decelerating,
-               let pinTime = scrollState.lastUserInitiatedPinTime,
-               Date().timeIntervalSince(pinTime) < 0.5 {
-                // Stale momentum from before CTA tap — ignore.
-            } else {
-                scrollState.scrollRestoreTask?.cancel()
-                scrollState.scrollRestoreTask = nil
-                scrollState.handleUserScrollUp()
-            }
-        }
+        // Derive sentinel position from content offset (inverted sign to
+        // match the old coordinate-space convention where minY is negative
+        // when scrolled past the viewport top).
+        let sentinelMinY = -newState.contentOffsetY
+        let shouldPaginate = scrollState.handlePaginationSentinel(sentinelMinY: sentinelMinY)
 
-        // --- Phase guard (shared by bottom detection, auto-follow, recovery) ---
-        // Only allow automatic scroll actions when scroll is fully at rest
-        // (.idle). Block during ALL non-idle phases including .animating.
-        //
-        // Why no .animating exception: recovery calls non-animated
-        // scrollToEdge(.bottom) which interrupts any in-flight spring
-        // animation (e.g. the CTA's smooth scroll). The user sees the
-        // spring start, then a jarring jump to bottom. By restricting
-        // to .idle only, recovery waits until the animation completes,
-        // then fires cleanly.
-        //
-        // This is safe for streaming auto-follow because the auto-follow
-        // path uses non-animated scrollToEdge(.bottom) which doesn't
-        // trigger .animating — the scroll position changes instantly and
-        // scrollPhase stays .idle.
-        //
-        // Animated pins (handleSendingChanged, handleMessagesCountChanged)
-        // briefly trigger .animating (~150ms with VAnimation.fast), during
-        // which auto-follow is paused. After the animation completes and
-        // phase returns to .idle, auto-follow resumes immediately.
-        let phaseAllowsAutoFollow = !scrollState.scrollPhase.isScrolling
-
-        // --- Viewport height update ---
-        // Filter non-finite viewport heights and sub-pixel jitter.
-        // A 0.5pt dead-zone prevents floating-point rounding differences
-        // from triggering continuous updates that feed back into layout.
-        let decision = PreferenceGeometryFilter.evaluate(
-            newValue: newState.visibleRectHeight,
-            previous: scrollState.viewportHeight,
-            deadZone: 0.5
-        )
-        if case .accept(let accepted) = decision {
-            os_signpost(.begin, log: PerfSignposts.log, name: "viewportHeightChanged")
-            scrollState.viewportHeight = accepted
-            os_signpost(.end, log: PerfSignposts.log, name: "viewportHeightChanged")
+        if shouldPaginate, hasMoreMessages, !isLoadingMoreMessages {
+            triggerPagination()
         }
-
-        // --- Bottom detection (with hysteresis) ---
-        // Asymmetric thresholds prevent oscillation during streaming:
-        // content-height growth can briefly push distanceFromBottom past
-        // the "at bottom" threshold before the scroll position catches
-        // up, causing rapid true→false→true flips. A wider leave
-        // threshold absorbs those transient spikes without overly
-        // widening the idle-reattach zone (onScrollPhaseChange reattaches
-        // when isAtBottom is true on idle).
-        let distanceFromBottom = effectiveContentHeight - newState.contentOffsetY - newState.visibleRectHeight
-        let nowAtBottom: Bool
-        if scrollState.isAtBottom {
-            // Stay "at bottom" until clearly scrolled away.
-            nowAtBottom = distanceFromBottom.isFinite && distanceFromBottom <= 30
-        } else {
-            // Only re-enter "at bottom" when truly close.
-            nowAtBottom = distanceFromBottom.isFinite && distanceFromBottom <= 10
-        }
-        if scrollState.isAtBottom != nowAtBottom {
-            scrollState.isAtBottom = nowAtBottom
-            // Only reattach during non-user-initiated phases. During
-            // .interacting the user is actively scrolling — reattaching
-            // would cause mode to oscillate between freeBrowsing and
-            // followingBottom within the 16ms UI-sync debounce window,
-            // preventing the CTA from ever appearing. The idle handler
-            // in onScrollPhaseChange provides deferred reattach when
-            // the scroll settles.
-            if nowAtBottom, phaseAllowsAutoFollow {
-                scrollState.handleReachedBottom()
-            }
-        }
-
-        // --- Content-height-change auto-follow ---
-        // Pin to bottom when content height changes in either direction:
-        //   Growth  → streaming, new messages
-        //   Shrinkage → LazyVStack height-estimate convergence after a
-        //               conversation switch (estimated height overshoots,
-        //               then shrinks as views materialize with actual heights)
-        // The 0.5pt threshold filters sub-pixel layout noise. Safe from
-        // feedback loops because pinning changes contentOffsetY, not
-        // contentHeight.
-        if abs(effectiveContentHeight - previousContentHeight) > 0.5,
-           scrollState.mode.allowsAutoScroll,
-           phaseAllowsAutoFollow {
-            scrollState.requestPinToBottom()
-        }
-        // --- Persistent bottom-recovery ---
-        // Independent of the content-height auto-follow. Catches cases
-        // the height-change check misses:
-        //   • LazyVStack estimate converging in <0.5pt increments
-        //   • ID-based scroll landing short due to height estimation
-        //     errors (long conversations with variable content like images)
-        //   • Race conditions during rapid conversation switching
-        //   • "False at-bottom" — viewport at the estimated bottom but
-        //     actual content is above (LazyVStack blank space)
-        //
-        // Uses edge-based scroll instead of ID-based (requestPinToBottom).
-        // ID-based ScrollPosition(id: lastMessageId, .bottom) depends on
-        // accurate height estimates for all preceding views — in long
-        // conversations with images, estimates are unreliable and the
-        // scroll lands short. Edge-based scrollToEdge(.bottom) targets
-        // the absolute content bottom, converging as LazyVStack
-        // materializes more views with each attempt.
-        //
-        // Recovery fires unconditionally until the bottom anchor view
-        // has appeared (meaning LazyVStack materialized to the actual
-        // bottom and isAtBottom is reliable) OR the 2-second deadline
-        // expires (whichever comes first). The deadline is critical
-        // because multiple paths reset bottomAnchorAppeared = false
-        // while the anchor may already be visible in the hierarchy
-        // (CTA taps, sends, resizes) — since onAppear only fires on
-        // hierarchy transitions, the flag won't be re-set and recovery
-        // would fire indefinitely without the time cutoff.
-        // Only fires in initialLoad/followingBottom.
-        let isInRecoveryWindow: Bool
-        if scrollState.bottomAnchorAppeared {
-            // Anchor materialized — isAtBottom is reliable now.
-            isInRecoveryWindow = false
-        } else if let deadline = scrollState.recoveryDeadline,
-                  Date() < deadline {
-            // Bottom anchor hasn't materialized yet and we're within
-            // the 2-second hard time limit. Each recovery attempt
-            // scrolls closer to the actual bottom, materializing more
-            // views. Eventually the bottom anchor materializes and
-            // recovery ends. The 100ms throttle limits this to at most
-            // 10 attempts/second. Recovery naturally stops via:
-            //   • bottomAnchorAppeared (anchor materializes)
-            //   • User scroll-up (mode → freeBrowsing)
-            //   • Conversation switch (reset())
-            //   • 2-second deadline expiry (hard limit)
-            // The deadline is critical because multiple paths reset
-            // bottomAnchorAppeared = false while the anchor may already
-            // be visible (CTA taps, sends, resizes). Since onAppear
-            // only fires on hierarchy transitions, the anchor won't
-            // re-fire if already materialized — without the deadline,
-            // recovery would fire at 10Hz indefinitely.
-            isInRecoveryWindow = true
-        } else {
-            isInRecoveryWindow = false
-        }
-        if scrollState.mode.allowsAutoScroll,
-           phaseAllowsAutoFollow,
-           effectiveContentHeight > newState.visibleRectHeight,
-           (!nowAtBottom || isInRecoveryWindow) {
-            // Throttle recovery to at most once per 100ms. Without this,
-            // geometry updates at ~60fps fire scrollToEdge every ~16ms.
-            // LazyVStack needs time between scroll attempts to materialize
-            // views at the new position — rapid-fire scrolls keep yanking
-            // the viewport before materialization completes, causing the
-            // chat to appear blank (especially in long conversations).
-            // 100ms ≈ 6 frames at 60fps — enough for LazyVStack to
-            // materialize a batch of views while still feeling responsive.
-            let now = Date()
-            if now.timeIntervalSince(scrollState.lastRecoveryAttempt) >= 0.1 {
-                scrollState.lastRecoveryAttempt = now
-                scrollState.scrollToEdge?(.bottom)
-            }
-        }
-
-        // --- Pagination trigger ---
-        // Derive pagination from scroll offset instead of a
-        // GeometryReader+PreferenceKey sentinel inside the
-        // LazyVStack. The old sentinel reported minY in the
-        // ScrollView coordinate space (0 at viewport top,
-        // negative when scrolled past). contentOffsetY has
-        // inverted sign (0 at top, positive when scrolled
-        // down), so we negate to preserve the same semantics.
-        handlePaginationSentinel(
-            sentinelMinY: -newState.contentOffsetY
-        )
     }
 
-    // MARK: - Pagination sentinel
+    // MARK: - Pagination
 
-    /// Evaluates a pagination sentinel preference change and triggers pagination
-    /// if the sentinel entered the trigger band.
-    func handlePaginationSentinel(sentinelMinY: CGFloat) {
-        guard PreferenceGeometryFilter.evaluate(
-            newValue: sentinelMinY,
-            previous: .infinity,
-            deadZone: 0
-        ) != .rejectNonFinite else { return }
-
-        let isInRange = MessageListPaginationTriggerPolicy.isInTriggerBand(
-            sentinelMinY: sentinelMinY,
-            viewportHeight: scrollState.viewportHeight
-        )
-        let shouldFire = MessageListPaginationTriggerPolicy.shouldTrigger(
-            sentinelMinY: sentinelMinY,
-            viewportHeight: scrollState.viewportHeight,
-            wasInRange: scrollState.wasPaginationTriggerInRange
-        )
-        guard shouldFire,
-              hasMoreMessages,
-              !isLoadingMoreMessages,
-              !scrollState.isPaginationInFlight
-        else { return }
-
-        guard Date().timeIntervalSince(scrollState.lastPaginationCompletedAt) > 0.5 else { return }
-
-        // Fire pagination — update edge state only now so guard rejections
-        // (including cooldown) don't consume the one-shot rising edge.
-        scrollState.wasPaginationTriggerInRange = isInRange
-        scrollState.isPaginationInFlight = true
-        let anchorId = scrollState.derivedStateCache.cachedFirstVisibleMessageId
-        let taskConversationId = scrollState.currentConversationId
+    /// Loads the previous page of messages and scrolls to maintain the
+    /// user's reading position after new content is prepended.
+    private func triggerPagination() {
         os_signpost(.event, log: PerfSignposts.log, name: "paginationSentinelFired")
-        scrollState.paginationTask = Task { [scrollState] in
-            defer {
-                if !Task.isCancelled {
-                    scrollState.lastPaginationCompletedAt = Date()
-                    scrollState.isPaginationInFlight = false
-                    scrollState.paginationTask = nil
-                } else if scrollState.paginationTask == nil,
-                          scrollState.currentConversationId == taskConversationId {
-                    scrollState.lastPaginationCompletedAt = Date()
-                    scrollState.isPaginationInFlight = false
-                }
-            }
+        Task { @MainActor in
+            let anchorId = paginatedVisibleMessages.first?.id
             let hadMore = await loadPreviousMessagePage?() ?? false
+            scrollState.lastPaginationCompletedAt = Date()
             if hadMore, let id = anchorId {
-                    scrollState.beginStabilization(.pagination)
-                    try? await Task.sleep(nanoseconds: 100_000_000)
-                    guard !Task.isCancelled else {
-                        scrollState.endStabilization()
-                        return
-                    }
-                    os_signpost(.event, log: PerfSignposts.log, name: "scrollToRequested", "target=paginationAnchor")
-                    scrollState.performScrollTo(id, anchor: .top)
-                    scrollState.endStabilization()
+                // Brief yield to let SwiftUI process the new content.
+                try? await Task.sleep(nanoseconds: 50_000_000)
+                scrollProxy?.scrollTo(id, anchor: .top)
             }
         }
     }
 
     // MARK: - Scroll helpers
 
-    /// Restores scroll-to-bottom after a conversation load or app restart.
-    /// Issues a delayed fallback pin that catches cases where the declarative
-    /// `ScrollPosition(edge: .bottom)` hasn't fully resolved for the new content.
-    /// The `isAtBottom` guard is intentionally omitted: during a conversation
-    /// switch, `isAtBottom` is unreliable because scroll geometry hasn't updated
-    /// yet for the new content. An extra pin when already at bottom is a no-op.
-    func restoreScrollToBottom() {
-        scrollState.scrollRestoreTask?.cancel()
-        scrollState.scrollRestoreTask = Task { @MainActor [scrollState] in
-            try? await Task.sleep(nanoseconds: 100_000_000)
-            guard !Task.isCancelled else { return }
-            if anchorMessageId == nil,
-               case .freeBrowsing = scrollState.mode {
-                // User scrolled away during the restore window — respect that.
-            } else if anchorMessageId == nil,
-                      case .programmaticScroll = scrollState.mode {
-                // A deep-link anchor scroll resolved and cleared anchorMessageId
-                // before this task fired. Don't yank the viewport back to bottom.
-            } else if anchorMessageId == nil,
-                      case .stabilizing = scrollState.mode {
-                // A resize or expansion stabilization started during the
-                // restore window. Overriding with .followingBottom would
-                // leak activeStabilizationCount — endStabilization() checks
-                // `guard case .stabilizing = mode` and bails if mode changed.
-            } else if anchorMessageId == nil {
-                os_signpost(.event, log: PerfSignposts.log, name: "scrollRestoreStage", "stage=fallback")
-                scrollState.transition(to: .followingBottom)
-                scrollState.requestPinToBottom()
-            }
-            scrollState.scrollRestoreTask = nil
-        }
-    }
-
     /// Flash-highlights a message and schedules auto-dismiss after 1.5 seconds.
     func flashHighlight(messageId: UUID) {
-        scrollState.highlightDismissTask?.cancel()
         highlightedMessageId = messageId
-        scrollState.highlightDismissTask = Task { @MainActor [scrollState] in
-            do {
-                try await Task.sleep(nanoseconds: 1_500_000_000)
-            } catch { return }
-            guard !Task.isCancelled else { return }
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
             withAnimation(VAnimation.slow) {
                 highlightedMessageId = nil
             }
-            scrollState.highlightDismissTask = nil
         }
-    }
-
-    /// Configures scroll action closures on the scroll state so it can
-    /// perform programmatic scrolls via the view-owned ScrollPosition.
-    func configureScrollCallbacks() {
-        let binding = $scrollPosition
-        // Replace the entire ScrollPosition value instead of calling the
-        // mutating `.scrollTo(id:anchor:)` method. Value replacement
-        // forces SwiftUI to process a fresh scroll command every time.
-        // The `.scrollTo()` method can be silently deduped when the
-        // position was previously set to the same ID (e.g. from a
-        // conversation switch `ScrollPosition(id: lastId, .bottom)`) —
-        // even after the user has scrolled away, the internal state may
-        // still consider itself "at" that ID.
-        scrollState.scrollTo = { id, anchor in
-            if let uuidId = id as? UUID {
-                binding.wrappedValue = ScrollPosition(id: uuidId, anchor: anchor)
-            } else if let stringId = id as? String {
-                binding.wrappedValue = ScrollPosition(id: stringId, anchor: anchor)
-            }
-        }
-        // Replace the entire ScrollPosition value (same as the ID-based
-        // closure above) instead of calling the mutating `.scrollTo(edge:)`
-        // method. Value replacement forces SwiftUI to process a fresh
-        // scroll command every time. The mutating method can be silently
-        // deduped when SwiftUI considers the position "already at that
-        // edge" — the same class of bug that affected `.scrollTo(id:)`.
-        // After SwiftUI processes the edge scroll, it updates the binding
-        // to the actual content offset, so the next value replacement
-        // with ScrollPosition(edge:) is always a new value.
-        scrollState.scrollToEdge = { edge in
-            binding.wrappedValue = ScrollPosition(edge: edge)
-        }
-        // Cancel in-flight spring animations on the scroll position.
-        //
-        // SwiftUI's `withAnimation { scrollPosition = ScrollPosition(...) }`
-        // creates a SwiftUI-managed spring animation that does NOT cancel
-        // when the user starts a new scroll gesture — unlike UIKit's
-        // `UIScrollView.setContentOffset(animated:)` which cancels on touch.
-        //
-        // Writing an empty `ScrollPosition()` (no target) with animations
-        // disabled overwrites the animated value, cancelling the spring.
-        // During `.interacting` phase the user's gesture has priority, so
-        // the empty position doesn't move the viewport — it just stops the
-        // animation from fighting the user's drag.
-        scrollState.cancelScrollAnimation = {
-            var transaction = Transaction()
-            transaction.disablesAnimations = true
-            withTransaction(transaction) {
-                binding.wrappedValue = ScrollPosition()
-            }
-        }
-        scrollState.currentConversationId = conversationId
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -16,10 +16,6 @@ extension MessageListView {
         scrollState.viewportHeight = newState.visibleRectHeight
         scrollState.updateNearBottom()
 
-        if scrollState.isInSendCycle {
-            scrollState.updateSpacerForContentGrowth(newContentHeight: newState.contentHeight)
-        }
-
         // Derive sentinel position from content offset (inverted sign to
         // match the old coordinate-space convention where minY is negative
         // when scrolled past the viewport top).

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -94,9 +94,10 @@ struct MessageListView: View {
     @State var scrollState = MessageListScrollState()
     /// In-flight resize scroll stabilization task; cancelled on each new resize.
     @State var resizeScrollTask: Task<Void, Never>?
-    /// Native SwiftUI scroll position struct (macOS 15+). Replaces
-    /// `ScrollViewReader` + `proxy.scrollTo()` and distance-from-bottom math.
-    @State var scrollPosition = ScrollPosition()
+    /// Captured `ScrollViewProxy` from `ScrollViewReader`. Used by onChange
+    /// handlers and the "Scroll to latest" overlay to perform programmatic
+    /// scrolls via `proxy.scrollTo(_:anchor:)`.
+    @State var scrollProxy: ScrollViewProxy?
 
     // MARK: - Body
 
@@ -104,6 +105,7 @@ struct MessageListView: View {
         #if DEBUG
         let _ = os_signpost(.event, log: PerfSignposts.log, name: "MessageListView.body")
         #endif
+        ScrollViewReader { proxy in
             ScrollView {
                 scrollViewContent
             }
@@ -111,34 +113,6 @@ struct MessageListView: View {
             .scrollContentBackground(.hidden)
             .coordinateSpace(name: "chatScrollView")
             .scrollDisabled(messages.isEmpty && !isSending)
-            // Apply only to .initialOffset — where the scroll view starts
-            // when first displayed (including .id() recreation on switch).
-            // Deliberately NOT using the all-roles overload (.sizeChanges)
-            // because it fights user scroll-up during streaming: SwiftUI's
-            // definition of "at bottom" for anchor purposes can differ from
-            // our hysteresis-based isAtBottom, causing the viewport to snap
-            // back to bottom on every content-height change even after the
-            // user has entered freeBrowsing. Our explicit content-height
-            // auto-follow handles streaming growth with proper mode checks.
-            // https://developer.apple.com/documentation/swiftui/view/defaultscrollanchor(_:for:)
-            .defaultScrollAnchor(.bottom, for: .initialOffset)
-            .scrollPosition($scrollPosition)
-            .environment(\.suppressAutoScroll, { [self] in
-                scrollState.endStabilization()
-                if scrollState.isFollowingBottom {
-                    os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "on reason=expansionPinning")
-                    scrollState.requestPinToBottom()
-                } else {
-                    os_signpost(.event, log: PerfSignposts.log, name: "scrollSuppressionChanged", "on reason=offBottomExpansion")
-                    scrollState.beginStabilization(.expansion)
-                }
-            })
-            .onScrollPhaseChange { oldPhase, newPhase in
-                scrollState.scrollPhase = newPhase
-                if newPhase == .idle && oldPhase != .idle && scrollState.isAtBottom {
-                    scrollState.handleReachedBottom()
-                }
-            }
             .onScrollGeometryChange(for: ScrollGeometrySnapshot.self) { geometry in
                 ScrollGeometrySnapshot(
                     contentOffsetY: geometry.contentOffset.y,
@@ -147,15 +121,28 @@ struct MessageListView: View {
                     visibleRectHeight: geometry.visibleRect.height
                 )
             } action: { _, newState in
-                enqueueScrollGeometryUpdate(newState)
+                scrollState.contentOffsetY = newState.contentOffsetY
+                scrollState.contentHeight = newState.contentHeight
+                scrollState.viewportHeight = newState.visibleRectHeight
+                scrollState.updateNearBottom()
+                if scrollState.canAutoFollow() {
+                    proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                }
             }
             .scrollIndicators(scrollState.scrollIndicatorsHidden ? .hidden : .automatic)
             .overlay(alignment: .bottom) {
-                ScrollToLatestOverlayView(scrollState: scrollState)
+                ScrollToLatestOverlayView(scrollState: scrollState) {
+                    withAnimation(VAnimation.spring) {
+                        proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                    }
+                }
             }
-            .onAppear { handleAppear() }
+            .onAppear {
+                scrollProxy = proxy
+                handleAppear()
+            }
             .onDisappear {
-                scrollState.cancelAll()
+                scrollProxy = nil
                 resizeScrollTask?.cancel()
                 resizeScrollTask = nil
                 highlightedMessageId = nil
@@ -179,5 +166,6 @@ struct MessageListView: View {
                     scrollState.lastAutoFocusedRequestId = requestId
                 }
             }
+        }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -121,10 +121,7 @@ struct MessageListView: View {
                     visibleRectHeight: geometry.visibleRect.height
                 )
             } action: { _, newState in
-                scrollState.contentOffsetY = newState.contentOffsetY
-                scrollState.contentHeight = newState.contentHeight
-                scrollState.viewportHeight = newState.visibleRectHeight
-                scrollState.updateNearBottom()
+                handleScrollGeometryUpdate(newState)
                 if scrollState.canAutoFollow() {
                     proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
                 }

--- a/clients/macos/vellum-assistantTests/MessageListAnchorPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListAnchorPerformanceTests.swift
@@ -80,19 +80,20 @@ final class MessageListAnchorPerformanceTests: XCTestCase {
 
     // MARK: - 1. Scroll State Bottom-Detection Rapid-Update Stress Test
 
-    /// Benchmarks setting `isAtBottom` 10,000 times in a tight loop. While
-    /// individually trivial (O(1)), this mirrors the per-scroll-frame hot path.
-    /// This test detects if any future refactoring adds overhead.
+    /// Benchmarks calling `updateNearBottom()` 10,000 times in a tight loop.
+    /// While individually trivial (O(1)), this mirrors the per-scroll-frame
+    /// hot path. This test detects if any future refactoring adds overhead.
     func testBottomDetectionRapidUpdateStress() {
         let scrollState = MessageListScrollState()
+        scrollState.contentHeight = 5000
+        scrollState.viewportHeight = 800
 
         measure(metrics: [XCTClockMetric(), XCTCPUMetric()]) {
             for i in 0..<10_000 {
-                // Simulate scroll position changes: alternate between bottom
-                // anchor and other views to stress isAtBottom updates.
-                // Simulate scroll geometry bottom detection: every 10th
-                // iteration is "at bottom", the rest are not.
-                scrollState.isAtBottom = (i % 10 == 0)
+                // Simulate scroll position changes: alternate between near-
+                // bottom and far-from-bottom positions.
+                scrollState.contentOffsetY = (i % 10 == 0) ? 4195 : 3000
+                scrollState.updateNearBottom()
             }
         }
     }

--- a/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
@@ -135,31 +135,27 @@ final class MessageListScrollPerformanceTests: XCTestCase {
         }
     }
 
-    // MARK: - Test 3: requestPinToBottom Hot Path
+    // MARK: - Test 3: Near-Bottom Update Hot Path
 
-    /// Measures the synchronous hot path of requestPinToBottom on the scroll
-    /// state: request a pin, transition back to followingBottom — repeated 100 times.
+    /// Measures the synchronous hot path of updateNearBottom on the scroll
+    /// state — repeated 100 times. This mirrors the per-scroll-frame hot path
+    /// for hysteresis-based near-bottom detection.
     @MainActor
-    func testPinToBottomPerformance() {
+    func testNearBottomUpdatePerformance() {
         measure(metrics: [XCTClockMetric()]) {
             let scrollState = MessageListScrollState()
-            var scrollCallCount = 0
+            scrollState.contentHeight = 5000
+            scrollState.viewportHeight = 800
 
-            scrollState.scrollTo = { _, _ in
-                scrollCallCount += 1
+            // Run 100 update cycles alternating between near and far positions.
+            for i in 0..<100 {
+                // Alternate between near-bottom and far-from-bottom.
+                scrollState.contentOffsetY = (i % 2 == 0) ? 4190 : 3000
+                scrollState.updateNearBottom()
             }
 
-            // Ensure we start in followingBottom mode.
-            scrollState.transition(to: .followingBottom)
-
-            // Run 100 pin request cycles to get a stable measurement.
-            for _ in 0..<100 {
-                scrollState.requestPinToBottom()
-                scrollState.transition(to: .followingBottom)
-            }
-
-            XCTAssertGreaterThan(scrollCallCount, 0)
-            scrollState.cancelAll()
+            // Verify final state is deterministic.
+            XCTAssertFalse(scrollState.isNearBottom)
         }
     }
 
@@ -203,8 +199,8 @@ final class MessageListScrollPerformanceTests: XCTestCase {
             orphanSubagents: [],
             effectiveStatusText: nil
         )
-        tracking.cachedLayoutKey = key
-        tracking.cachedLayoutMetadata = layout
+        tracking.derivedStateCache.cachedLayoutKey = key
+        tracking.derivedStateCache.cachedLayoutMetadata = layout
 
         // Simulate streaming: append text to the last message (same count,
         // same isStreaming flag — the version counter does NOT bump).
@@ -223,8 +219,8 @@ final class MessageListScrollPerformanceTests: XCTestCase {
         )
 
         // The cache key hasn't changed — layout cache should still hit.
-        XCTAssertEqual(key, tracking.cachedLayoutKey)
-        XCTAssertNotNil(tracking.cachedLayoutMetadata)
+        XCTAssertEqual(key, tracking.derivedStateCache.cachedLayoutKey)
+        XCTAssertNotNil(tracking.derivedStateCache.cachedLayoutMetadata)
 
         // But the live message must reflect the updated text.
         let lastId = messages.last!.id

--- a/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollStateTests.swift
@@ -5,427 +5,226 @@ import XCTest
 @MainActor
 final class MessageListScrollStateTests: XCTestCase {
     private var state: MessageListScrollState!
-    private var scrollToCalls: [(id: AnyHashable, anchor: UnitPoint?)] = []
-    private var scrollToEdgeCalls: [Edge] = []
 
     override func setUp() {
         super.setUp()
         state = MessageListScrollState()
-        scrollToCalls = []
-        scrollToEdgeCalls = []
-
-        state.scrollTo = { [weak self] id, anchor in
-            self?.scrollToCalls.append((id: id as! AnyHashable, anchor: anchor))
-        }
-        state.scrollToEdge = { [weak self] edge in
-            self?.scrollToEdgeCalls.append(edge)
-        }
     }
 
     override func tearDown() {
-        state.cancelAll()
         state = nil
         super.tearDown()
     }
 
     // MARK: - Initial State
 
-    func testInitialStateAllowsAutoScrollWithoutInteraction() {
-        XCTAssertFalse(state.isFollowingBottom)
-        XCTAssertFalse(state.hasBeenInteracted)
-        XCTAssertTrue(state.mode.allowsAutoScroll)
-
-        let result = state.requestPinToBottom()
-        XCTAssertTrue(result, "initialLoad should still allow bottom pinning")
-        // When lastMessageId is nil (fresh state), executeScrollToBottom
-        // falls through to scrollToEdge(.bottom) — not scrollTo(id:).
-        XCTAssertFalse(scrollToEdgeCalls.isEmpty,
-                       "Should fall back to edge-based scroll when lastMessageId is nil")
-        XCTAssertEqual(scrollToEdgeCalls.first, .bottom)
-    }
-
-    func testInitialModeIsInitialLoad() {
-        if case .initialLoad = state.mode {
-            // correct
-        } else {
-            XCTFail("Initial mode should be .initialLoad")
-        }
-    }
-
-    // MARK: - Mode Transitions
-
-    func testTransitionToFreeBrowsingSetsFollowingFalse() {
-        state.transition(to: .freeBrowsing)
-        XCTAssertFalse(state.isFollowingBottom)
-        XCTAssertTrue(state.hasBeenInteracted)
-    }
-
-    func testTransitionToFollowingBottomSetsFollowingTrue() {
-        state.transition(to: .freeBrowsing)
-        XCTAssertFalse(state.isFollowingBottom)
-
-        state.transition(to: .followingBottom)
-        XCTAssertTrue(state.isFollowingBottom)
-    }
-
-    func testTransitionToSameModeIsNoop() {
-        state.transition(to: .followingBottom)
-        state.transition(to: .followingBottom)
-        XCTAssertTrue(state.isFollowingBottom)
-    }
-
-    func testHandleUserScrollUpTransitionsToFreeBrowsing() {
-        state.transition(to: .followingBottom)
-        state.handleUserScrollUp()
-        XCTAssertFalse(state.isFollowingBottom)
-        if case .freeBrowsing = state.mode {
-            // correct
-        } else {
-            XCTFail("Expected .freeBrowsing after handleUserScrollUp")
-        }
-    }
-
-    func testHandleReachedBottomTransitionsToFollowingBottom() {
-        state.transition(to: .freeBrowsing)
-        XCTAssertFalse(state.isFollowingBottom)
-
-        state.handleReachedBottom()
-        XCTAssertTrue(state.isFollowingBottom)
-    }
-
-    /// Verifies that rapid transitions coalesce into a single UI sync.
-    func testRapidTransitionsDoNotAccumulate() async throws {
-        // GIVEN 100 rapid transitions to freeBrowsing
-        for _ in 0..<100 {
-            state.transition(to: .freeBrowsing)
-        }
-
-        // WHEN the debounced sync fires
-        XCTAssertFalse(state.isFollowingBottom)
+    func testInitialState() {
+        XCTAssertTrue(state.isNearBottom)
         XCTAssertFalse(state.showScrollToLatest)
-        try await Task.sleep(nanoseconds: 50_000_000)
-
-        // THEN only one property update occurs
-        XCTAssertTrue(state.showScrollToLatest,
-                      "showScrollToLatest should be true after debounced sync")
-        XCTAssertEqual(state.uiVersion, 1,
-                       "Only one internal uiVersion bump despite 100 transition calls")
+        XCTAssertFalse(state.scrollIndicatorsHidden)
+        XCTAssertFalse(state.hasBeenInteracted)
+        XCTAssertFalse(state.bottomAnchorAppeared)
+        XCTAssertFalse(state.didAnchorCurrentSendCycle)
+        XCTAssertEqual(state.viewportHeight, 0)
+        XCTAssertEqual(state.contentHeight, 0)
+        XCTAssertEqual(state.contentOffsetY, 0)
+        XCTAssertNil(state.currentConversationId)
+        XCTAssertNil(state.pendingAnchorMessageId)
+        XCTAssertNil(state.lastMessageId)
+        XCTAssertNil(state.lastAutoFocusedRequestId)
+        XCTAssertFalse(state.wasPaginationTriggerInRange)
     }
 
-    // MARK: - Pin Gating
+    // MARK: - Near-Bottom Hysteresis
 
-    func testPinSuppressedInFreeBrowsing() {
-        state.transition(to: .freeBrowsing)
-        let result = state.requestPinToBottom()
+    func testNearBottomHysteresisLeavesAt50pt() {
+        // Start near bottom
+        XCTAssertTrue(state.isNearBottom)
 
-        XCTAssertFalse(result, "requestPinToBottom should return false in freeBrowsing mode")
-        XCTAssertTrue(scrollToCalls.isEmpty,
-                      "Pin requests should be suppressed in freeBrowsing mode")
+        // Set geometry so distance > 50pt
+        state.contentHeight = 1000
+        state.viewportHeight = 400
+        state.contentOffsetY = 500 // distance = 1000 - 500 - 400 = 100pt
+        state.updateNearBottom()
+
+        XCTAssertFalse(state.isNearBottom)
+        XCTAssertTrue(state.showScrollToLatest)
     }
 
-    func testPinSuppressedWhileStabilizing() {
-        state.transition(to: .followingBottom)
-        state.beginStabilization(.expansion)
-        let result = state.requestPinToBottom()
+    func testNearBottomHysteresisEntersAt10pt() {
+        // Leave near-bottom first
+        state.contentHeight = 1000
+        state.viewportHeight = 400
+        state.contentOffsetY = 500
+        state.updateNearBottom()
+        XCTAssertFalse(state.isNearBottom)
 
-        XCTAssertFalse(result, "requestPinToBottom should return false when stabilizing")
-        XCTAssertTrue(scrollToCalls.isEmpty,
-                      "Pin requests should be suppressed when stabilizing")
+        // Move close to bottom (distance <= 10pt)
+        state.contentOffsetY = 595 // distance = 1000 - 595 - 400 = 5pt
+        state.updateNearBottom()
+
+        XCTAssertTrue(state.isNearBottom)
+        XCTAssertFalse(state.showScrollToLatest)
     }
 
-    func testPinAllowedWhenFollowingBottom() {
-        state.transition(to: .followingBottom)
-        // Seed lastMessageId so the ID-based path fires (not edge fallback).
-        state.lastMessageId = UUID()
-        let result = state.requestPinToBottom()
+    func testNearBottomDoesNotReenterBetween10And50() {
+        // Leave near-bottom
+        state.contentHeight = 1000
+        state.viewportHeight = 400
+        state.contentOffsetY = 500 // distance = 100pt
+        state.updateNearBottom()
+        XCTAssertFalse(state.isNearBottom)
 
-        XCTAssertTrue(result, "requestPinToBottom should return true when following bottom")
-        // ID-based scroll fires synchronously (targets real ForEach content).
-        // Edge-based is only used as fallback when lastMessageId is nil.
-        XCTAssertFalse(scrollToCalls.isEmpty,
-                       "scrollTo should have been called synchronously")
+        // Move to 30pt from bottom (in hysteresis band)
+        state.contentOffsetY = 570 // distance = 1000 - 570 - 400 = 30pt
+        state.updateNearBottom()
+        XCTAssertFalse(state.isNearBottom, "Should not re-enter near-bottom in hysteresis band")
     }
 
-    func testPinAllowedAfterTransitionToFollowingBottom() {
-        state.transition(to: .freeBrowsing)
-        let suppressed = state.requestPinToBottom()
-        XCTAssertFalse(suppressed)
-        XCTAssertTrue(scrollToCalls.isEmpty)
+    // MARK: - Send Cycle Anchoring
 
-        state.transition(to: .followingBottom)
-        // Seed lastMessageId so the ID-based path fires (not edge fallback).
-        state.lastMessageId = UUID()
-        let allowed = state.requestPinToBottom()
-        XCTAssertTrue(allowed)
-        XCTAssertFalse(scrollToCalls.isEmpty,
-                       "ID-based scroll should proceed after transitioning to followingBottom")
+    func testBeginSendCycleResetsAnchorFlag() {
+        state.markSendAnchored()
+        XCTAssertTrue(state.didAnchorCurrentSendCycle)
+
+        state.beginSendCycle()
+        XCTAssertFalse(state.didAnchorCurrentSendCycle)
     }
 
-    func testUserInitiatedBypassesGuards() {
-        state.transition(to: .freeBrowsing)
-        state.beginStabilization(.expansion)
+    func testShouldAutoFollow() {
+        XCTAssertTrue(state.shouldAutoFollow, "Near bottom + not anchored = should follow")
 
-        let result = state.requestPinToBottom(userInitiated: true)
+        state.markSendAnchored()
+        XCTAssertFalse(state.shouldAutoFollow, "Already anchored = should not follow")
 
-        XCTAssertTrue(result,
-                      "User-initiated requests should always return true")
-        // User-initiated uses ID-based scroll as primary (targets real
-        // ForEach content, never overshoots) with edge-based correction
-        // in a Task.
-        XCTAssertFalse(scrollToCalls.isEmpty,
-                       "User-initiated requests should bypass mode checks and scroll to ID")
+        state.beginSendCycle()
+        XCTAssertTrue(state.shouldAutoFollow, "Reset anchor = should follow again")
     }
 
-    // MARK: - Stabilization
+    // MARK: - Auto-Follow Throttle
 
-    func testStabilizationPreservesFollowingBottom() {
-        state.transition(to: .followingBottom)
-        state.beginStabilization(.resize)
-        XCTAssertTrue(state.isSuppressed)
-        XCTAssertTrue(state.isFollowingBottom,
-                      "isFollowingBottom should reflect the pre-stabilization mode")
-
-        state.endStabilization()
-        XCTAssertFalse(state.isSuppressed)
-        XCTAssertTrue(state.isFollowingBottom)
+    func testCanAutoFollowThrottles() {
+        XCTAssertTrue(state.canAutoFollow())
+        XCTAssertFalse(state.canAutoFollow(), "Should throttle within 80ms")
     }
 
-    func testStabilizationPreservesFreeBrowsing() {
-        state.transition(to: .freeBrowsing)
-        state.beginStabilization(.resize)
-        XCTAssertTrue(state.isSuppressed)
-        XCTAssertFalse(state.isFollowingBottom)
-
-        state.endStabilization()
-        XCTAssertFalse(state.isSuppressed)
-        XCTAssertFalse(state.isFollowingBottom)
+    func testCanAutoFollowReturnsFalseWhenNotNearBottom() {
+        state.isNearBottom = false
+        XCTAssertFalse(state.canAutoFollow())
     }
 
-    func testOverlappingStabilizationWaitsForAllWindows() {
-        state.transition(to: .followingBottom)
+    // MARK: - handleReachedBottom
 
-        // Window 1: resize
-        state.beginStabilization(.resize)
-        XCTAssertTrue(state.isSuppressed)
-
-        // Window 2: expansion (overlapping)
-        state.beginStabilization(.expansion)
-        XCTAssertTrue(state.isSuppressed)
-
-        // Window 1 completes — should still be stabilizing
-        state.endStabilization()
-        XCTAssertTrue(state.isSuppressed,
-                      "Should remain stabilizing while overlapping windows are active")
-
-        // Window 2 completes — now should exit
-        state.endStabilization()
-        XCTAssertFalse(state.isSuppressed,
-                       "Should exit stabilization after all windows complete")
-        XCTAssertTrue(state.isFollowingBottom,
-                      "Should restore followingBottom after overlapping stabilization")
+    func testHandleReachedBottomSetsInteracted() {
+        XCTAssertFalse(state.hasBeenInteracted)
+        state.handleReachedBottom()
+        XCTAssertTrue(state.hasBeenInteracted)
+        XCTAssertTrue(state.isNearBottom)
+        XCTAssertFalse(state.showScrollToLatest)
     }
 
-    func testOverlappingStabilizationPreservesOriginalMode() {
-        state.transition(to: .freeBrowsing)
+    // MARK: - handleScrollToLatestTapped
 
-        state.beginStabilization(.resize)
-        state.beginStabilization(.pagination)
-        state.endStabilization()
-        XCTAssertTrue(state.isSuppressed)
+    func testHandleScrollToLatestTapped() {
+        // First leave near-bottom so showScrollToLatest becomes true
+        state.contentHeight = 1000
+        state.viewportHeight = 400
+        state.contentOffsetY = 500
+        state.updateNearBottom()
+        XCTAssertTrue(state.showScrollToLatest)
 
-        state.endStabilization()
-        XCTAssertFalse(state.isSuppressed)
-        XCTAssertFalse(state.isFollowingBottom,
-                       "Should restore freeBrowsing (original mode before any stabilization)")
-    }
-
-    // MARK: - Stabilization: Expansion 200ms Auto-Clear
-
-    func testExpansionAutoClears() async throws {
-        state.transition(to: .followingBottom)
-        state.beginStabilization(.expansion)
-        XCTAssertTrue(state.isSuppressed)
-
-        try await Task.sleep(nanoseconds: 250_000_000)
-
-        XCTAssertFalse(state.isSuppressed,
-                       "Expansion stabilization should auto-clear after 200ms")
-    }
-
-    func testExpansionTimerReset() async throws {
-        state.transition(to: .followingBottom)
-        state.beginStabilization(.expansion)
-        XCTAssertTrue(state.isSuppressed)
-
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        state.beginStabilization(.expansion)
-        XCTAssertTrue(state.isSuppressed)
-
-        try await Task.sleep(nanoseconds: 150_000_000)
-
-        XCTAssertTrue(state.isSuppressed,
-                      "Timer was reset -- should still be stabilizing")
-
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        XCTAssertFalse(state.isSuppressed,
-                       "Expansion stabilization should auto-clear after the reset timeout")
+        state.handleScrollToLatestTapped()
+        XCTAssertTrue(state.isNearBottom)
+        XCTAssertFalse(state.showScrollToLatest)
     }
 
     // MARK: - Reset
 
     func testResetRestoresDefaults() {
-        let oldId = UUID()
         let newId = UUID()
 
-        state.transition(to: .freeBrowsing)
-        state.beginStabilization(.resize)
-        state.isPaginationInFlight = true
+        state.isNearBottom = false
+        state.viewportHeight = 500
+        state.contentHeight = 1000
+        state.contentOffsetY = 200
+        state.didAnchorCurrentSendCycle = true
+        state.pendingAnchorMessageId = UUID()
+        state.lastMessageId = UUID()
         state.wasPaginationTriggerInRange = true
-        state.isAtBottom = false
-        state.currentConversationId = oldId
+        state.bottomAnchorAppeared = true
+        state.hasBeenInteracted = true
+        state.lastAutoFocusedRequestId = "req-1"
 
         state.reset(for: newId)
 
-        if case .initialLoad = state.mode {
-            // correct
-        } else {
-            XCTFail("Reset should return to .initialLoad mode")
-        }
-        XCTAssertFalse(state.isFollowingBottom, "initialLoad is distinct from followingBottom")
-        XCTAssertTrue(state.mode.allowsAutoScroll, "Reset should restore auto-scroll eligibility")
-        XCTAssertFalse(state.showScrollToLatest, "Should sync showScrollToLatest immediately on reset")
-        XCTAssertFalse(state.isSuppressed, "Should clear stabilization")
-        XCTAssertFalse(state.isPaginationInFlight, "Should clear pagination flag")
-        XCTAssertFalse(state.wasPaginationTriggerInRange, "Should clear trigger range flag")
-        XCTAssertFalse(state.isAtBottom, "Should wait for fresh geometry before claiming bottom")
-        XCTAssertFalse(state.hasBeenInteracted, "Should reset to initialLoad mode")
-        XCTAssertEqual(state.currentConversationId, newId, "Should update conversation ID")
-        XCTAssertTrue(state.hideScrollIndicators,
-                      "Should hide scroll indicators during conversation switch")
-        XCTAssertTrue(state.scrollIndicatorsHidden)
+        XCTAssertEqual(state.currentConversationId, newId)
+        XCTAssertTrue(state.isNearBottom)
+        XCTAssertEqual(state.viewportHeight, 0)
+        XCTAssertEqual(state.contentHeight, 0)
+        XCTAssertEqual(state.contentOffsetY, 0)
+        XCTAssertFalse(state.didAnchorCurrentSendCycle)
+        XCTAssertNil(state.pendingAnchorMessageId)
+        XCTAssertNil(state.lastMessageId)
+        XCTAssertFalse(state.wasPaginationTriggerInRange)
+        XCTAssertEqual(state.lastPaginationCompletedAt, .distantPast)
         XCTAssertFalse(state.showScrollToLatest)
+        XCTAssertFalse(state.scrollIndicatorsHidden)
+        XCTAssertNil(state.lastAutoFocusedRequestId)
+        XCTAssertFalse(state.bottomAnchorAppeared)
+        XCTAssertFalse(state.hasBeenInteracted)
     }
 
-    func testResetClearsBottomAnchorAppeared() {
-        state.bottomAnchorAppeared = true
-        state.reset(for: UUID())
-        XCTAssertFalse(state.bottomAnchorAppeared,
-                       "Should reset bottomAnchorAppeared so recovery fires for new conversation")
-    }
-
-    func testResetClearsLastMessageId() {
-        state.lastMessageId = UUID()
-        state.reset(for: UUID())
-        XCTAssertNil(state.lastMessageId,
-                     "Should clear lastMessageId so it gets re-seeded for the new conversation")
-    }
-
-    func testResetClearsLayoutCache() {
-        state.messageListVersion = 5
-        state.lastKnownRawMessageCount = 10
-        state.lastKnownVisibleMessageCount = 8
-        state.lastKnownLastMessageStreaming = true
-        state.lastKnownIncompleteToolCallCount = 3
-        state.lastKnownVisibleIdFingerprint = 42
+    func testResetClearsDerivedStateCache() {
+        let cache = state.derivedStateCache
+        cache.messageListVersion = 5
+        cache.lastKnownRawMessageCount = 10
+        cache.lastKnownVisibleMessageCount = 8
+        cache.lastKnownLastMessageStreaming = true
+        cache.lastKnownIncompleteToolCallCount = 3
+        cache.lastKnownVisibleIdFingerprint = 42
 
         state.reset(for: UUID())
 
-        XCTAssertEqual(state.messageListVersion, 0)
-        XCTAssertEqual(state.lastKnownRawMessageCount, 0)
-        XCTAssertEqual(state.lastKnownVisibleMessageCount, 0)
-        XCTAssertFalse(state.lastKnownLastMessageStreaming)
-        XCTAssertEqual(state.lastKnownIncompleteToolCallCount, 0)
-        XCTAssertEqual(state.lastKnownVisibleIdFingerprint, 0)
-        XCTAssertNil(state.cachedLayoutKey)
-        XCTAssertNil(state.cachedLayoutMetadata)
+        XCTAssertEqual(cache.messageListVersion, 0)
+        XCTAssertEqual(cache.lastKnownRawMessageCount, 0)
+        XCTAssertEqual(cache.lastKnownVisibleMessageCount, 0)
+        XCTAssertFalse(cache.lastKnownLastMessageStreaming)
+        XCTAssertEqual(cache.lastKnownIncompleteToolCallCount, 0)
+        XCTAssertEqual(cache.lastKnownVisibleIdFingerprint, 0)
+        XCTAssertNil(cache.cachedLayoutKey)
+        XCTAssertNil(cache.cachedLayoutMetadata)
+        XCTAssertNil(cache.cachedDerivedState)
     }
 
-    // MARK: - cancelAll
+    // MARK: - Pagination Sentinel
 
-    func testCancelAllResetsMode() {
-        state.transition(to: .freeBrowsing)
-        state.beginStabilization(.resize)
-        XCTAssertTrue(state.isSuppressed)
+    func testPaginationSentinelRisingEdge() {
+        // Out of range initially
+        XCTAssertFalse(state.handlePaginationSentinel(sentinelMinY: -200))
 
-        state.cancelAll()
+        // Enter range — should fire
+        XCTAssertTrue(state.handlePaginationSentinel(sentinelMinY: 100))
 
-        XCTAssertFalse(state.isSuppressed, "cancelAll should clear stabilization")
-        XCTAssertFalse(state.hideScrollIndicators,
-                       "cancelAll should restore scroll indicators")
-        XCTAssertFalse(state.isPaginationInFlight,
-                       "cancelAll should clear pagination flag")
+        // Already in range — should not fire again
+        XCTAssertFalse(state.handlePaginationSentinel(sentinelMinY: 50))
     }
 
-    // MARK: - Computed Properties
+    func testPaginationCooldown() {
+        // First trigger
+        XCTAssertTrue(state.handlePaginationSentinel(sentinelMinY: 100))
 
-    /// Verifies that showScrollToLatest tracks mode transitions independently.
-    func testShowScrollToLatest() async throws {
-        // GIVEN initial state
-        XCTAssertFalse(state.showScrollToLatest,
-                       "Should be false when following bottom")
+        // Leave range
+        XCTAssertFalse(state.handlePaginationSentinel(sentinelMinY: -200))
 
-        // WHEN transitioning to freeBrowsing
-        state.transition(to: .freeBrowsing)
-        try await Task.sleep(nanoseconds: 50_000_000)
-
-        // THEN showScrollToLatest becomes true
-        XCTAssertTrue(state.showScrollToLatest,
-                      "Should be true when in freeBrowsing mode")
-
-        // WHEN transitioning back to followingBottom
-        state.transition(to: .followingBottom)
-        try await Task.sleep(nanoseconds: 50_000_000)
-
-        // THEN showScrollToLatest becomes false again
-        XCTAssertFalse(state.showScrollToLatest,
-                       "Should be false again after transitioning to followingBottom")
+        // Re-enter within cooldown — should not fire
+        // (lastPaginationCompletedAt was just set)
+        XCTAssertFalse(state.handlePaginationSentinel(sentinelMinY: 100))
     }
 
-    // MARK: - Property-Level Tracking
-
-    /// Verifies that each UI property reflects the final mode state after
-    /// multiple transitions and a debounced sync.
-    func testUIPropertiesReflectFinalState() async throws {
-        // GIVEN multiple mode transitions ending in freeBrowsing
-        state.transition(to: .followingBottom)
-        state.transition(to: .freeBrowsing)
-
-        // AND a scroll indicator change that requires a debounced sync
-        state.hideScrollIndicators = true
-
-        // WHEN the debounced sync fires
-        try await Task.sleep(nanoseconds: 50_000_000)
-
-        // THEN each property reflects the final mode (.freeBrowsing)
-        XCTAssertTrue(state.showScrollToLatest,
-                      "freeBrowsing mode shows scroll-to-latest")
-        XCTAssertTrue(state.scrollIndicatorsHidden,
-                      "scroll indicators should be hidden")
-    }
-
-    /// Verifies that syncUIImmediately bypasses debounce and updates all
-    /// properties immediately.
-    func testSyncUIImmediately() {
-        // GIVEN freeBrowsing mode
-        state.transition(to: .freeBrowsing)
-        state.syncUIImmediately()
-
-        // THEN properties reflect the current mode (.freeBrowsing)
-        XCTAssertTrue(state.showScrollToLatest,
-                      "freeBrowsing mode shows scroll-to-latest")
-    }
-
-    /// Verifies that syncUIImmediately reflects followingBottom correctly.
-    func testSyncUIImmediatelyFollowingBottom() {
-        // GIVEN followingBottom mode
-        state.transition(to: .followingBottom)
-        state.syncUIImmediately()
-
-        // THEN properties reflect the current mode (.followingBottom)
-        XCTAssertFalse(state.showScrollToLatest,
-                       "followingBottom mode does not show scroll-to-latest")
+    func testPaginationCooldownResetOnConversationSwitch() {
+        state.lastPaginationCompletedAt = Date()
+        state.reset(for: UUID())
+        XCTAssertEqual(state.lastPaginationCompletedAt, .distantPast)
     }
 
     // MARK: - Circuit Breaker
@@ -434,57 +233,24 @@ final class MessageListScrollStateTests: XCTestCase {
         for _ in 0...100 {
             state.recordBodyEvaluation()
         }
-        XCTAssertTrue(state.isThrottled, "Circuit breaker should be active")
+        XCTAssertTrue(state.derivedStateCache.isThrottled, "Circuit breaker should be active")
     }
 
     func testCircuitBreakerRecovery() async throws {
         for _ in 0...100 {
             state.recordBodyEvaluation()
         }
-        XCTAssertTrue(state.isThrottled)
+        XCTAssertTrue(state.derivedStateCache.isThrottled)
         try await Task.sleep(nanoseconds: 600_000_000)
-        XCTAssertFalse(state.isThrottled, "Circuit breaker should auto-recover")
+        XCTAssertFalse(state.derivedStateCache.isThrottled, "Circuit breaker should auto-recover")
     }
 
-    // MARK: - Pagination Cooldown
+    // MARK: - Distance From Bottom
 
-    func testPaginationCooldownResetOnConversationSwitch() {
-        state.lastPaginationCompletedAt = Date()
-        state.reset(for: UUID())
-        XCTAssertEqual(state.lastPaginationCompletedAt, .distantPast)
-    }
-
-    func testScheduleUISyncSuppressedWhenThrottled() async throws {
-        for _ in 0...100 {
-            state.recordBodyEvaluation()
-        }
-        XCTAssertTrue(state.isThrottled)
-        state.transition(to: .freeBrowsing)
-        XCTAssertFalse(state.isFollowingBottom)
-        try await Task.sleep(nanoseconds: 50_000_000)
-        XCTAssertFalse(state.showScrollToLatest,
-                       "showScrollToLatest should NOT update while throttled")
-    }
-
-    // MARK: - Programmatic Scroll Mode
-
-    func testProgrammaticScrollMode() {
-        state.transition(to: .programmaticScroll(reason: .deepLinkAnchor(id: UUID())))
-        XCTAssertFalse(state.isFollowingBottom)
-        XCTAssertFalse(state.mode.allowsAutoScroll)
-    }
-
-    func testProgrammaticScrollToFollowingBottomViaReachedBottom() {
-        state.transition(to: .programmaticScroll(reason: .deepLinkAnchor(id: UUID())))
-        state.handleReachedBottom()
-        XCTAssertTrue(state.isFollowingBottom)
-    }
-
-    // MARK: - scrollPhase Reset
-
-    func testResetClearsScrollPhase() {
-        state.scrollPhase = .interacting
-        state.reset(for: UUID())
-        XCTAssertEqual(state.scrollPhase, .idle)
+    func testDistanceFromBottom() {
+        state.contentHeight = 1000
+        state.viewportHeight = 400
+        state.contentOffsetY = 500
+        XCTAssertEqual(state.distanceFromBottom, 100)
     }
 }


### PR DESCRIPTION
## Summary
Full rewrite of the macOS chat scroll system to behave like Claude:
1. On every send action, scroll the initiating user message to the top of the viewport
2. Stream assistant output downward without forcing bottom-follow
3. Auto-follow only when user is near bottom (hysteresis-based)
4. Show "Scroll to latest" when user scrolls away

## PRs merged into feature branch
- #23884: refactor: replace scroll state machine with simplified scroll coordinator
- #23885: feat: add dynamic bottom spacer for top-anchor guarantee
- #23890: refactor: rewrite MessageListView body with ScrollViewReader
- #23892: feat: scroll user message to top on all send actions
- #23893: refactor: simplify scroll geometry handling and pagination
- #23902: refactor: remove dead scroll types and fix compilation
- #23911: fix: only show dynamic bottom spacer during active streaming
- #23912: fix: scroll-to-latest and auto-follow target last message, not empty anchor
- #23914: fix: adjust near-bottom detection to account for conditional spacer

Part of plan: claude-style-chat-scroll.md + scroll-to-latest-fix.md