### PR TITLE
feat(log-export): include allowlisted workspace data in /v1/export archive

### DIFF
--- a/assistant/src/__tests__/conversation-directories-parse.test.ts
+++ b/assistant/src/__tests__/conversation-directories-parse.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getConversationDirName,
+  parseConversationDirName,
+} from "../memory/conversation-directories.js";
+
+describe("parseConversationDirName", () => {
+  describe("round-trip with getConversationDirName", () => {
+    test("round-trips a UUID-shaped id", () => {
+      const id = "4ae7ea90-86e4-446a-8673-7bba94ecfea1";
+      const createdAtMs = Date.parse("2026-04-07T10:47:23.075Z");
+      const name = getConversationDirName(id, createdAtMs);
+      const parsed = parseConversationDirName(name);
+      expect(parsed).toEqual({ conversationId: id, createdAtMs });
+    });
+
+    test("round-trips an id with embedded hyphens", () => {
+      const id = "conv-with-hyphens-123";
+      const createdAtMs = Date.parse("2024-01-15T00:00:00.000Z");
+      const name = getConversationDirName(id, createdAtMs);
+      const parsed = parseConversationDirName(name);
+      expect(parsed).toEqual({ conversationId: id, createdAtMs });
+    });
+
+    test("round-trips an id with embedded underscores", () => {
+      const id = "foo_bar_baz";
+      const createdAtMs = Date.parse("2025-12-31T23:59:59.999Z");
+      const name = getConversationDirName(id, createdAtMs);
+      const parsed = parseConversationDirName(name);
+      expect(parsed).toEqual({ conversationId: id, createdAtMs });
+    });
+  });
+
+  describe("exact parsing against literal example", () => {
+    test("parses the canonical example from the spec", () => {
+      const name =
+        "2026-04-07T10-47-23.075Z_4ae7ea90-86e4-446a-8673-7bba94ecfea1";
+      const parsed = parseConversationDirName(name);
+      expect(parsed).not.toBeNull();
+      expect(parsed?.conversationId).toBe(
+        "4ae7ea90-86e4-446a-8673-7bba94ecfea1",
+      );
+      expect(parsed?.createdAtMs).toBe(Date.parse("2026-04-07T10:47:23.075Z"));
+    });
+  });
+
+  describe("returns null for malformed input", () => {
+    test("returns null for empty string", () => {
+      expect(parseConversationDirName("")).toBeNull();
+    });
+
+    test("returns null for missing underscore", () => {
+      expect(parseConversationDirName("2026-04-07T10-47-23.075Z")).toBeNull();
+    });
+
+    test("returns null for legacy format (id first, timestamp second)", () => {
+      expect(
+        parseConversationDirName(
+          "4ae7ea90-86e4-446a-8673-7bba94ecfea1_2026-04-07T10-47-23.075Z",
+        ),
+      ).toBeNull();
+    });
+
+    test("returns null for non-ISO prefix", () => {
+      expect(parseConversationDirName("hello_world")).toBeNull();
+    });
+
+    test("returns null for random garbage", () => {
+      expect(parseConversationDirName("drafts/foo")).toBeNull();
+    });
+  });
+
+  describe("ids containing underscores", () => {
+    test("captures everything after the timestamp as the conversationId", () => {
+      const name = "2026-04-07T10-47-23.075Z_my_test_id";
+      const parsed = parseConversationDirName(name);
+      expect(parsed).not.toBeNull();
+      expect(parsed?.conversationId).toBe("my_test_id");
+      expect(parsed?.createdAtMs).toBe(Date.parse("2026-04-07T10:47:23.075Z"));
+    });
+  });
+});

--- a/assistant/src/__tests__/conversation-directories-parse.test.ts
+++ b/assistant/src/__tests__/conversation-directories-parse.test.ts
@@ -69,6 +69,28 @@ describe("parseConversationDirName", () => {
     test("returns null for random garbage", () => {
       expect(parseConversationDirName("drafts/foo")).toBeNull();
     });
+
+    test("returns null when the conversation id is '.'", () => {
+      expect(parseConversationDirName("2025-01-15T00-00-00.000Z_.")).toBeNull();
+    });
+
+    test("returns null when the conversation id is '..'", () => {
+      expect(
+        parseConversationDirName("2025-01-15T00-00-00.000Z_.."),
+      ).toBeNull();
+    });
+
+    test("returns null when the conversation id contains a forward slash", () => {
+      expect(
+        parseConversationDirName("2025-01-15T00-00-00.000Z_foo/bar"),
+      ).toBeNull();
+    });
+
+    test("returns null when the conversation id contains a backslash", () => {
+      expect(
+        parseConversationDirName("2025-01-15T00-00-00.000Z_foo\\bar"),
+      ).toBeNull();
+    });
   });
 
   describe("ids containing underscores", () => {

--- a/assistant/src/__tests__/log-export-workspace.test.ts
+++ b/assistant/src/__tests__/log-export-workspace.test.ts
@@ -93,6 +93,35 @@ writeFileSync(
   JSON.stringify({ provider: "anthropic" }),
 );
 
+// Conversation directories — used for workspace allowlist tests
+const conversationsDir = join(testWorkspaceDir, "conversations");
+mkdirSync(conversationsDir, { recursive: true });
+
+function seedConversation(name: string, body: string) {
+  const dir = join(conversationsDir, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "meta.json"), "{}\n");
+  writeFileSync(join(dir, "messages.jsonl"), body);
+}
+
+seedConversation(
+  "2025-01-10T00-00-00.000Z_conv-jan10",
+  '{"role":"user","content":"jan 10"}\n',
+);
+seedConversation(
+  "2025-01-15T00-00-00.000Z_conv-jan15",
+  '{"role":"user","content":"jan 15"}\n',
+);
+seedConversation(
+  "2025-01-20T00-00-00.000Z_conv-jan20",
+  '{"role":"user","content":"jan 20"}\n',
+);
+seedConversation(
+  "2025-01-25T00-00-00.000Z_conv-jan25",
+  '{"role":"user","content":"jan 25"}\n',
+);
+seedConversation("malformed-name", '{"role":"user","content":"x"}\n');
+
 // Daemon log files — used for date filtering tests
 const logsDir = join(testWorkspaceDir, "data", "logs");
 mkdirSync(logsDir, { recursive: true });
@@ -236,6 +265,167 @@ describe("POST /v1/export — daemon log date filtering", () => {
       expect(logFiles).toContain("assistant-2025-01-20.log");
       expect(logFiles).toContain("assistant-2025-01-25.log");
       expect(logFiles).toContain("vellum.log");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("POST /v1/export — workspace allowlist", () => {
+  test("includes all valid conversation dirs by default", async () => {
+    const res = await callExport();
+    const dir = await extractArchive(res);
+    try {
+      const convs = readdirSync(join(dir, "workspace", "conversations"));
+      expect(convs).toContain("2025-01-10T00-00-00.000Z_conv-jan10");
+      expect(convs).toContain("2025-01-15T00-00-00.000Z_conv-jan15");
+      expect(convs).toContain("2025-01-20T00-00-00.000Z_conv-jan20");
+      expect(convs).toContain("2025-01-25T00-00-00.000Z_conv-jan25");
+      expect(convs).not.toContain("malformed-name");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("skips malformed conversation dir names", async () => {
+    const res = await callExport();
+    const dir = await extractArchive(res);
+    try {
+      const convs = readdirSync(join(dir, "workspace", "conversations"));
+      expect(convs).not.toContain("malformed-name");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("filters conversation dirs by startTime", async () => {
+    const startTime = Date.parse("2025-01-14T00:00:00Z");
+    const res = await callExport({ startTime });
+    const dir = await extractArchive(res);
+    try {
+      const convs = readdirSync(join(dir, "workspace", "conversations"));
+      expect(convs).not.toContain("2025-01-10T00-00-00.000Z_conv-jan10");
+      expect(convs).toContain("2025-01-15T00-00-00.000Z_conv-jan15");
+      expect(convs).toContain("2025-01-20T00-00-00.000Z_conv-jan20");
+      expect(convs).toContain("2025-01-25T00-00-00.000Z_conv-jan25");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("filters conversation dirs by endTime", async () => {
+    const endTime = Date.parse("2025-01-22T00:00:00Z");
+    const res = await callExport({ endTime });
+    const dir = await extractArchive(res);
+    try {
+      const convs = readdirSync(join(dir, "workspace", "conversations"));
+      expect(convs).toContain("2025-01-10T00-00-00.000Z_conv-jan10");
+      expect(convs).toContain("2025-01-15T00-00-00.000Z_conv-jan15");
+      expect(convs).toContain("2025-01-20T00-00-00.000Z_conv-jan20");
+      expect(convs).not.toContain("2025-01-25T00-00-00.000Z_conv-jan25");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("filters conversation dirs by both startTime and endTime", async () => {
+    const startTime = Date.parse("2025-01-14T00:00:00Z");
+    const endTime = Date.parse("2025-01-22T00:00:00Z");
+    const res = await callExport({ startTime, endTime });
+    const dir = await extractArchive(res);
+    try {
+      const convs = readdirSync(join(dir, "workspace", "conversations"));
+      expect(convs).not.toContain("2025-01-10T00-00-00.000Z_conv-jan10");
+      expect(convs).toContain("2025-01-15T00-00-00.000Z_conv-jan15");
+      expect(convs).toContain("2025-01-20T00-00-00.000Z_conv-jan20");
+      expect(convs).not.toContain("2025-01-25T00-00-00.000Z_conv-jan25");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("filters conversation dirs by conversationId", async () => {
+    const res = await callExport({ conversationId: "conv-jan15" });
+    const dir = await extractArchive(res);
+    try {
+      const convs = readdirSync(join(dir, "workspace", "conversations"));
+      expect(convs).toContain("2025-01-15T00-00-00.000Z_conv-jan15");
+      expect(convs).not.toContain("2025-01-10T00-00-00.000Z_conv-jan10");
+      expect(convs).not.toContain("2025-01-20T00-00-00.000Z_conv-jan20");
+      expect(convs).not.toContain("2025-01-25T00-00-00.000Z_conv-jan25");
+      expect(convs).not.toContain("malformed-name");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("conversationId + time filter intersect", async () => {
+    const res = await callExport({
+      conversationId: "conv-jan15",
+      startTime: Date.parse("2025-02-01T00:00:00Z"),
+    });
+    const dir = await extractArchive(res);
+    try {
+      const conversationsPath = join(dir, "workspace", "conversations");
+      let convs: string[] = [];
+      try {
+        convs = readdirSync(conversationsPath);
+      } catch {
+        // Directory does not exist — acceptable per the test contract.
+      }
+      expect(convs).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("conversation dir contents survive the round trip", async () => {
+    const res = await callExport();
+    const dir = await extractArchive(res);
+    try {
+      const messagesPath = join(
+        dir,
+        "workspace",
+        "conversations",
+        "2025-01-15T00-00-00.000Z_conv-jan15",
+        "messages.jsonl",
+      );
+      const content = readFileSync(messagesPath, "utf-8");
+      expect(content).toBe('{"role":"user","content":"jan 15"}\n');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("treats empty-string conversationId as no filter", async () => {
+    const res = await callExport({ conversationId: "" });
+    const dir = await extractArchive(res);
+    try {
+      // With conversationId === "" (which the rest of handleExport treats as
+      // unfiltered), workspace conversations should also be unfiltered. All
+      // four canonical conversation dirs should be present.
+      const conversationsDir = join(dir, "workspace", "conversations");
+      const entries = readdirSync(conversationsDir);
+      expect(entries).toContain("2025-01-10T00-00-00.000Z_conv-jan10");
+      expect(entries).toContain("2025-01-15T00-00-00.000Z_conv-jan15");
+      expect(entries).toContain("2025-01-20T00-00-00.000Z_conv-jan20");
+      expect(entries).toContain("2025-01-25T00-00-00.000Z_conv-jan25");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("treats startTime=0 and endTime=0 as no filter", async () => {
+    const res = await callExport({ startTime: 0, endTime: 0 });
+    const dir = await extractArchive(res);
+    try {
+      const conversationsDir = join(dir, "workspace", "conversations");
+      const entries = readdirSync(conversationsDir);
+      // All four canonical conversation dirs should be present (no filtering).
+      expect(entries).toContain("2025-01-10T00-00-00.000Z_conv-jan10");
+      expect(entries).toContain("2025-01-15T00-00-00.000Z_conv-jan15");
+      expect(entries).toContain("2025-01-20T00-00-00.000Z_conv-jan20");
+      expect(entries).toContain("2025-01-25T00-00-00.000Z_conv-jan25");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/assistant/src/memory/conversation-directories.ts
+++ b/assistant/src/memory/conversation-directories.ts
@@ -27,6 +27,33 @@ export function getConversationDirName(
 }
 
 /**
+ * Parse a canonical conversation directory name (`<ISO-with-dashes>_<id>`)
+ * back into its components. Returns null for names that don't match the
+ * canonical format — callers should treat null as "skip this entry"
+ * rather than as an error.
+ *
+ * Inverse of {@link getConversationDirName}. Does NOT parse the legacy
+ * `<id>_<ISO-with-dashes>` format.
+ */
+export function parseConversationDirName(
+  name: string,
+): { conversationId: string; createdAtMs: number } | null {
+  // Canonical format: YYYY-MM-DDTHH-MM-SS.sssZ_<uuid>
+  // The timestamp portion has 4 hyphens (date + time-component separators)
+  // and ends in `Z`. Anchor the regex to enforce that.
+  const match = name.match(
+    /^(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2}\.\d{1,9}Z)_(.+)$/,
+  );
+  if (!match) return null;
+  const [, datePart, hh, mm, ssAndMs, conversationId] = match;
+  const iso = `${datePart}T${hh}:${mm}:${ssAndMs}`;
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) return null;
+  if (!conversationId) return null;
+  return { conversationId, createdAtMs: ms };
+}
+
+/**
  * Return the absolute path to a conversation's timestamp-first disk-view
  * directory.
  */

--- a/assistant/src/memory/conversation-directories.ts
+++ b/assistant/src/memory/conversation-directories.ts
@@ -50,6 +50,18 @@ export function parseConversationDirName(
   const ms = Date.parse(iso);
   if (Number.isNaN(ms)) return null;
   if (!conversationId) return null;
+  // Reject conversation IDs that are path-traversal-shaped or contain
+  // path separators. These are never valid conversation IDs and would
+  // be a defense-in-depth concern if parsed.conversationId is later used
+  // to construct filesystem paths.
+  if (
+    conversationId === "." ||
+    conversationId === ".." ||
+    conversationId.includes("/") ||
+    conversationId.includes("\\")
+  ) {
+    return null;
+  }
   return { conversationId, createdAtMs: ms };
 }
 

--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -58,9 +58,10 @@ interface ExportRequestBody {
  * then package everything into a tar.gz archive.
  *
  * Archive layout:
- *   audit-data.json          — tool invocation records
- *   config-snapshot.json     — sanitized workspace config
- *   daemon-logs/<name>       — daemon log files
+ *   audit-data.json                 — tool invocation records
+ *   config-snapshot.json            — sanitized workspace config
+ *   daemon-logs/<name>              — daemon log files
+ *   workspace/conversations/<dir>/  — allowlisted workspace data (see ./log-export/AGENTS.md)
  */
 async function handleExport(body: ExportRequestBody): Promise<Response> {
   const staging = mkdtempSync(join(tmpdir(), "vellum-export-"));

--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -39,6 +39,7 @@ import { APP_VERSION, COMMIT_SHA } from "../../version.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 import { createTarGz } from "./archive-utils.js";
+import { collectWorkspaceData } from "./log-export/workspace-allowlist.js";
 
 const log = getLogger("log-export-routes");
 
@@ -241,6 +242,17 @@ async function handleExport(body: ExportRequestBody): Promise<Response> {
       }
     }
 
+    // --- Workspace allowlist ---
+    // Includes specific subpaths from <workspace>/ governed by the rules in
+    // ./log-export/AGENTS.md. Honors the same time + conversation filters as
+    // the rest of the export.
+    const workspaceResult = collectWorkspaceData({
+      staging,
+      conversationId: conversationId || undefined,
+      startTime: startTime || undefined,
+      endTime: endTime || undefined,
+    });
+
     // --- Sanitized config snapshot ---
     const configSnapshot = readSanitizedConfig();
     if (configSnapshot) {
@@ -281,6 +293,8 @@ async function handleExport(body: ExportRequestBody): Promise<Response> {
         totalBytes,
         hasConfig: configSnapshot !== undefined,
         conversationId: conversationId ?? null,
+        workspaceEntries: workspaceResult.entries.length,
+        workspaceBytes: workspaceResult.totalBytes,
       },
       "Export collected, creating tar.gz archive",
     );

--- a/assistant/src/runtime/routes/log-export/AGENTS.md
+++ b/assistant/src/runtime/routes/log-export/AGENTS.md
@@ -1,0 +1,84 @@
+# Log Export — Workspace Allowlist Rules
+
+`POST /v1/export` (handled by `log-export-routes.ts`) builds a tar.gz archive
+from audit DB rows, daemon logs under `<workspace>/data/logs/`, and a
+sanitized `config.json` snapshot. This directory
+(`assistant/src/runtime/routes/log-export/`) houses the allowlist module
+that governs which subpaths of the user's workspace directory
+(`~/.vellum/workspace/`) are permitted to flow into that archive.
+
+Workspace contents are **opt-in (allowlist), not opt-out**. The workspace
+contains arbitrary user files — skills, hooks, routes, conversations,
+credentials scaffolding, and other material the user has authored or
+installed locally. Accidentally bundling any of that into a support
+archive would exfiltrate data the user never intended to share. The
+default must therefore be "nothing from the workspace ships" and each
+individual entry that _does_ ship must be justified against the rules
+below.
+
+## Rule 1 — Prefer time-filterable data
+
+Only allowlist a workspace subpath if its contents can be narrowed to the
+`[startTime, endTime]` window carried on the export request.
+
+- When the data is organized as per-record files or per-record
+  directories whose **names encode a timestamp**, filter by parsing the
+  name. The canonical example is the per-conversation directory layout
+  where each directory is named `<ISO-with-dashes>_<conversationId>`
+  (the ISO date comes first so ordinary lexicographic comparison yields
+  chronological order, and colons in the ISO string are replaced with
+  `-` so the name is filesystem-safe). A time filter can be implemented
+  by parsing the prefix and comparing it to `startTime` / `endTime`
+  without reading file contents.
+- When the relevant time information lives **only inside files**, the
+  allowlist entry should err on the side of **not** being included —
+  unless the file is small, rarely changes, and its full contents are
+  acceptable to ship regardless of the requested window.
+
+## Rule 2 — Prefer conversation-filterable data
+
+When the export request carries a `conversationId`, every allowlisted
+subpath should narrow itself to that conversation **if at all possible**.
+
+- Data that is intrinsically global (i.e. not associated with a single
+  conversation) is acceptable to include **only** when Rule 1 alone is
+  sufficient and the request has no `conversationId` filter.
+- When a `conversationId` _is_ set and an entry cannot be scoped to it,
+  prefer omitting the entry for that particular export rather than
+  shipping unrelated conversation data.
+
+The `<ISO-with-dashes>_<conversationId>` directory naming is again the
+motivating example: the suffix lets us select exactly one
+per-conversation directory without scanning file contents.
+
+## Rule 3 — Default deny
+
+Anything in the workspace that is not explicitly added to the allowlist
+module must remain excluded from the export archive. Adding a new entry
+requires, in the same PR:
+
+1. Updating the allowlist module in this directory to teach it about the
+   new subpath (including its time filter, conversation filter, and
+   size cap).
+2. Updating this `AGENTS.md` to record the entry name, which filters it
+   honors, and its size cap under `## Allowlisted entries`.
+
+Review must confirm both updates landed together. A workspace subpath
+that is not mentioned in the registry below is, by definition, not
+allowed in the export archive.
+
+## Rule 4 — Bounded size
+
+Every allowlisted entry must enforce a byte cap so that a misbehaving
+workspace (e.g. a runaway log, a giant attachment, a pathological skill)
+cannot blow up the archive and defeat the export endpoint.
+
+The current convention is **10 MB** across the workspace allowlist,
+mirroring `MAX_LOG_PAYLOAD_BYTES` in `log-export-routes.ts`. Entries
+should track the number of bytes already consumed and stop adding files
+once the cap would be exceeded, preferring to include the newest /
+most-relevant records first.
+
+## Allowlisted entries
+
+- _(none yet — first entry will land in a follow-up PR)_

--- a/assistant/src/runtime/routes/log-export/AGENTS.md
+++ b/assistant/src/runtime/routes/log-export/AGENTS.md
@@ -81,4 +81,14 @@ most-relevant records first.
 
 ## Allowlisted entries
 
-- _(none yet — first entry will land in a follow-up PR)_
+- **`conversations/`**
+  - **Path**: `<workspace>/conversations/<ISO-with-dashes>_<conversationId>/`
+  - **Honors filters**: time (via the parsed timestamp prefix on each
+    directory name) and `conversationId` (exact match on the suffix — no
+    substring matching).
+  - **Cap**: shares the 10 MB workspace cap defined by
+    `MAX_WORKSPACE_PAYLOAD_BYTES` in `workspace-allowlist.ts`.
+  - **Notes**: Directory names that don't match the canonical
+    `<ISO-with-dashes>_<conversationId>` format are silently skipped
+    (Rule 3 — default deny). Legacy `<id>_<ISO>` directories are
+    intentionally excluded until they migrate to the canonical format.

--- a/assistant/src/runtime/routes/log-export/__tests__/workspace-allowlist-error-contract.test.ts
+++ b/assistant/src/runtime/routes/log-export/__tests__/workspace-allowlist-error-contract.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Regression test for the `result.entries` contract on `collectWorkspaceData`.
+ *
+ * Consumers and telemetry rely on `collectWorkspaceData` always returning at
+ * least one entry summary for the `conversations` allowlist entry — even when
+ * something throws partway through the candidate loop. This file pins that
+ * contract by mocking `parseConversationDirName` to return a malicious object
+ * whose `createdAtMs` getter throws. That throw escapes the inner per-iteration
+ * try/catch (it happens during sort + filter expression evaluation, not inside
+ * the wrapped parser call), bubbles up to the outer try/catch in
+ * `collectWorkspaceData`, and verifies that `result.entries` still contains
+ * exactly one `conversations` entry summary.
+ *
+ * Lives in its own file because `mock.module` is a global module override and
+ * we don't want it bleeding into the rest of the workspace-allowlist tests.
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../../../memory/conversation-directories.js", () => ({
+  parseConversationDirName: (_name: string) => {
+    // Return an object whose `createdAtMs` accessor throws. This bypasses the
+    // inner try/catch wrapping `parseConversationDirName(name)` (which only
+    // catches synchronous throws from the call itself, not from later property
+    // accesses) and triggers the unwrapped sort/filter comparisons further
+    // down in `collectConversations`.
+    return {
+      conversationId: "evil",
+      get createdAtMs(): number {
+        throw new Error("simulated parser corruption");
+      },
+    };
+  },
+}));
+
+import { getConversationsDir } from "../../../../util/platform.js";
+import { collectWorkspaceData } from "../workspace-allowlist.js";
+
+let staging: string;
+
+beforeEach(() => {
+  // Fresh staging directory for each test.
+  const conversationsDir = getConversationsDir();
+  rmSync(conversationsDir, { recursive: true, force: true });
+  mkdirSync(conversationsDir, { recursive: true });
+
+  staging = join(
+    process.env.VELLUM_WORKSPACE_DIR ?? "/tmp",
+    "ws-allowlist-error-staging",
+  );
+  rmSync(staging, { recursive: true, force: true });
+  mkdirSync(staging, { recursive: true });
+
+  // Seed a single canonical-looking dir so the loop has something to chew on.
+  const dirName = "2025-01-15T00-00-00.000Z_conv-jan15";
+  const dir = join(conversationsDir, dirName);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "meta.json"),
+    JSON.stringify({ name: dirName }),
+    "utf-8",
+  );
+});
+
+afterEach(() => {
+  try {
+    rmSync(staging, { recursive: true, force: true });
+  } catch {
+    /* best-effort cleanup */
+  }
+  try {
+    rmSync(getConversationsDir(), { recursive: true, force: true });
+  } catch {
+    /* best-effort cleanup */
+  }
+});
+
+describe("collectWorkspaceData — entry contract on unexpected error", () => {
+  test("synthesizes a conversations entry summary even when the loop throws", () => {
+    // The mocked parser returns a poisoned object whose `createdAtMs` accessor
+    // throws. The first read happens inside the time-filter checks in the
+    // candidate-collection loop, which is NOT wrapped in a per-iteration
+    // try/catch. The throw should propagate up to the outer try/catch in
+    // `collectWorkspaceData`, where it must be swallowed without dropping
+    // the entry summary.
+    const result = collectWorkspaceData({
+      staging,
+      // Force the time-filter branch to read `createdAtMs`.
+      startTime: 0,
+    });
+
+    // Contract: exactly one entry, named "conversations", regardless of error.
+    expect(result.entries).toHaveLength(1);
+    const [entry] = result.entries;
+    expect(entry.entry).toBe("conversations");
+    expect(entry.itemCount).toBe(0);
+    expect(entry.bytes).toBe(0);
+    expect(entry.skippedDueToCap).toBe(0);
+    expect(result.totalBytes).toBe(0);
+  });
+});

--- a/assistant/src/runtime/routes/log-export/__tests__/workspace-allowlist.test.ts
+++ b/assistant/src/runtime/routes/log-export/__tests__/workspace-allowlist.test.ts
@@ -1,0 +1,466 @@
+/**
+ * Tests for the workspace allowlist module used by `POST /v1/export`.
+ *
+ * Validates that `collectWorkspaceData` honors the time + conversationId
+ * filters, enforces the workspace cap, ignores malformed conversation
+ * directory names, and never throws.
+ *
+ * The shared `test-preload.ts` sets `VELLUM_WORKSPACE_DIR` to a per-file
+ * temp directory before any test code runs, so `getConversationsDir()`
+ * already resolves under our temp workspace. We just seed the
+ * `conversations/` subdirectory before each test and tear it down
+ * afterwards.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { getConversationsDir } from "../../../../util/platform.js";
+import { collectWorkspaceData } from "../workspace-allowlist.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CONV_DIRS = {
+  jan10: "2025-01-10T00-00-00.000Z_conv-jan10",
+  jan15: "2025-01-15T00-00-00.000Z_conv-jan15",
+  jan20: "2025-01-20T00-00-00.000Z_conv-jan20",
+  jan25: "2025-01-25T00-00-00.000Z_conv-jan25",
+  invalid: "not-a-valid-name",
+  jan15Attachments: "2025-01-15T00-00-00.000Z_conv-jan15-with-attachments",
+} as const;
+
+function seedConversations(): void {
+  const conversationsDir = getConversationsDir();
+  mkdirSync(conversationsDir, { recursive: true });
+
+  // Four canonical conversation dirs with a meta + messages file each.
+  for (const name of [
+    CONV_DIRS.jan10,
+    CONV_DIRS.jan15,
+    CONV_DIRS.jan20,
+    CONV_DIRS.jan25,
+  ]) {
+    const dir = join(conversationsDir, name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "meta.json"),
+      JSON.stringify({ name }, null, 2),
+      "utf-8",
+    );
+    writeFileSync(
+      join(dir, "messages.jsonl"),
+      `{"role":"user","content":"hi from ${name}"}\n`,
+      "utf-8",
+    );
+  }
+
+  // Malformed dir — should be skipped because parseConversationDirName
+  // returns null for it.
+  const invalidDir = join(conversationsDir, CONV_DIRS.invalid);
+  mkdirSync(invalidDir, { recursive: true });
+  writeFileSync(join(invalidDir, "junk.txt"), "should not be copied", "utf-8");
+
+  // A separate canonical conversation dir whose id is *not* an exact match
+  // for "conv-jan15" — used to verify that the conversationId filter does
+  // exact matching, not substring matching.
+  const attachmentsDir = join(conversationsDir, CONV_DIRS.jan15Attachments);
+  mkdirSync(join(attachmentsDir, "attachments"), { recursive: true });
+  writeFileSync(
+    join(attachmentsDir, "meta.json"),
+    JSON.stringify({ name: CONV_DIRS.jan15Attachments }, null, 2),
+    "utf-8",
+  );
+  writeFileSync(
+    join(attachmentsDir, "attachments", "photo.png"),
+    "PNGDATA",
+    "utf-8",
+  );
+}
+
+let staging: string;
+
+beforeEach(() => {
+  // Fresh staging directory for each test.
+  staging = mkdtempSync(join(tmpdir(), "ws-allowlist-staging-"));
+  // Reset the workspace's conversations dir between tests.
+  const conversationsDir = getConversationsDir();
+  rmSync(conversationsDir, { recursive: true, force: true });
+});
+
+afterEach(() => {
+  try {
+    rmSync(staging, { recursive: true, force: true });
+  } catch {
+    /* best-effort cleanup */
+  }
+  // Wipe the workspace's conversations dir so test files can't bleed into
+  // each other.
+  try {
+    rmSync(getConversationsDir(), { recursive: true, force: true });
+  } catch {
+    /* best-effort cleanup */
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("collectWorkspaceData — conversations entry", () => {
+  test("copies all valid conversation dirs when no filters are set", () => {
+    seedConversations();
+
+    const result = collectWorkspaceData({ staging });
+
+    expect(result.entries).toHaveLength(1);
+    const [entry] = result.entries;
+    expect(entry.entry).toBe("conversations");
+    // Four valid + one extra canonical (jan15-with-attachments) = 5
+    expect(entry.itemCount).toBe(5);
+    expect(entry.skippedDueToCap).toBe(0);
+    expect(entry.bytes).toBeGreaterThan(0);
+    expect(result.totalBytes).toBe(entry.bytes);
+
+    const copied = readdirSync(join(staging, "workspace", "conversations"));
+    expect(copied).toContain(CONV_DIRS.jan10);
+    expect(copied).toContain(CONV_DIRS.jan15);
+    expect(copied).toContain(CONV_DIRS.jan20);
+    expect(copied).toContain(CONV_DIRS.jan25);
+    expect(copied).toContain(CONV_DIRS.jan15Attachments);
+    // Malformed dir is skipped.
+    expect(copied).not.toContain(CONV_DIRS.invalid);
+  });
+
+  test("startTime filter excludes earlier conversations", () => {
+    seedConversations();
+    const startTime = Date.parse("2025-01-14T00:00:00Z");
+
+    const result = collectWorkspaceData({ staging, startTime });
+
+    const copied = readdirSync(join(staging, "workspace", "conversations"));
+    expect(copied).not.toContain(CONV_DIRS.jan10);
+    expect(copied).toContain(CONV_DIRS.jan15);
+    expect(copied).toContain(CONV_DIRS.jan20);
+    expect(copied).toContain(CONV_DIRS.jan25);
+    // jan15-with-attachments has the same timestamp as jan15 → still included.
+    expect(copied).toContain(CONV_DIRS.jan15Attachments);
+    expect(result.entries[0].itemCount).toBe(4);
+  });
+
+  test("endTime filter excludes later conversations", () => {
+    seedConversations();
+    const endTime = Date.parse("2025-01-22T00:00:00Z");
+
+    const result = collectWorkspaceData({ staging, endTime });
+
+    const copied = readdirSync(join(staging, "workspace", "conversations"));
+    expect(copied).toContain(CONV_DIRS.jan10);
+    expect(copied).toContain(CONV_DIRS.jan15);
+    expect(copied).toContain(CONV_DIRS.jan20);
+    expect(copied).not.toContain(CONV_DIRS.jan25);
+    expect(copied).toContain(CONV_DIRS.jan15Attachments);
+    expect(result.entries[0].itemCount).toBe(4);
+  });
+
+  test("startTime + endTime keeps only conversations inside the window", () => {
+    seedConversations();
+    const startTime = Date.parse("2025-01-14T00:00:00Z");
+    const endTime = Date.parse("2025-01-22T00:00:00Z");
+
+    const result = collectWorkspaceData({ staging, startTime, endTime });
+
+    const copied = readdirSync(join(staging, "workspace", "conversations"));
+    expect(copied).not.toContain(CONV_DIRS.jan10);
+    expect(copied).toContain(CONV_DIRS.jan15);
+    expect(copied).toContain(CONV_DIRS.jan20);
+    expect(copied).not.toContain(CONV_DIRS.jan25);
+    // jan15-with-attachments shares the Jan 15 timestamp → still included.
+    expect(copied).toContain(CONV_DIRS.jan15Attachments);
+    expect(result.entries[0].itemCount).toBe(3);
+  });
+
+  test("conversationId filter matches exactly (no substrings)", () => {
+    seedConversations();
+
+    const result = collectWorkspaceData({
+      staging,
+      conversationId: "conv-jan15",
+    });
+
+    const copied = readdirSync(join(staging, "workspace", "conversations"));
+    expect(copied).toEqual([CONV_DIRS.jan15]);
+    // Crucially, the substring-match attachments dir is NOT included.
+    expect(copied).not.toContain(CONV_DIRS.jan15Attachments);
+    expect(result.entries[0].itemCount).toBe(1);
+  });
+
+  test("conversationId + time filter intersection can be empty", () => {
+    seedConversations();
+
+    const result = collectWorkspaceData({
+      staging,
+      conversationId: "conv-jan15",
+      // Window that excludes Jan 15.
+      startTime: Date.parse("2025-01-16T00:00:00Z"),
+      endTime: Date.parse("2025-01-22T00:00:00Z"),
+    });
+
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].itemCount).toBe(0);
+    expect(result.entries[0].bytes).toBe(0);
+    expect(result.totalBytes).toBe(0);
+    // No directory should have been created because nothing was copied.
+    expect(existsSync(join(staging, "workspace", "conversations"))).toBe(false);
+  });
+
+  test("byte cap enforcement skips every conversation when too tight", () => {
+    seedConversations();
+
+    // 1 byte cap is impossible to fit any seeded dir into.
+    const result = collectWorkspaceData({ staging, maxBytes: 1 });
+
+    expect(result.entries).toHaveLength(1);
+    const [entry] = result.entries;
+    expect(entry.itemCount).toBe(0);
+    expect(entry.bytes).toBe(0);
+    expect(entry.skippedDueToCap).toBe(5);
+    expect(result.totalBytes).toBe(0);
+    expect(existsSync(join(staging, "workspace", "conversations"))).toBe(false);
+  });
+
+  test("byte cap keeps the newest conversations first", () => {
+    // Seed three dirs with distinct, non-trivial sizes and known
+    // timestamps. Use a padding file per dir so the per-dir byte total
+    // is predictable and large enough to push us past the cap after a
+    // couple entries have been copied.
+    const conversationsDir = getConversationsDir();
+    mkdirSync(conversationsDir, { recursive: true });
+
+    const PADDING_BYTES = 4000;
+    const padding = "a".repeat(PADDING_BYTES);
+    for (const name of [CONV_DIRS.jan10, CONV_DIRS.jan15, CONV_DIRS.jan20]) {
+      const dir = join(conversationsDir, name);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, "pad.txt"), padding, "utf-8");
+    }
+
+    // Each dir weighs ~PADDING_BYTES. A 10 KB cap fits exactly 2 dirs
+    // (but not the third).
+    const result = collectWorkspaceData({
+      staging,
+      maxBytes: PADDING_BYTES * 2 + 500,
+    });
+
+    expect(result.entries).toHaveLength(1);
+    const [entry] = result.entries;
+    expect(entry.itemCount).toBe(2);
+    expect(entry.skippedDueToCap).toBe(1);
+
+    // The two newest dirs (jan20 and jan15) should have been copied;
+    // jan10 (oldest) should be the one skipped due to the cap.
+    const copied = readdirSync(join(staging, "workspace", "conversations"));
+    expect(copied).toContain(CONV_DIRS.jan20);
+    expect(copied).toContain(CONV_DIRS.jan15);
+    expect(copied).not.toContain(CONV_DIRS.jan10);
+  });
+
+  test("non-directory entries with canonical-looking names are skipped", () => {
+    // Make sure the conversations dir exists and seed one valid dir so
+    // we can confirm the function still copies legit entries alongside
+    // the bogus regular file.
+    const conversationsDir = getConversationsDir();
+    mkdirSync(conversationsDir, { recursive: true });
+
+    // Seed a real canonical conversation dir so there's something to copy.
+    const validDir = join(conversationsDir, CONV_DIRS.jan20);
+    mkdirSync(validDir, { recursive: true });
+    writeFileSync(
+      join(validDir, "meta.json"),
+      JSON.stringify({ name: CONV_DIRS.jan20 }, null, 2),
+      "utf-8",
+    );
+
+    // Seed a REGULAR FILE whose name matches the canonical
+    // `<ISO>_<conversationId>` pattern. Fill it with data that is big
+    // enough to exceed the cap, to prove that the non-dir guard bails
+    // before `dirSizeWithinBudget`/`cpSync` could silently copy it.
+    const bogusName = "2025-01-15T00-00-00.000Z_conv-jan15-as-file";
+    const bogusPath = join(conversationsDir, bogusName);
+    writeFileSync(bogusPath, "x".repeat(1024 * 1024), "utf-8"); // 1 MB
+
+    // Use a tight cap (larger than the valid dir but smaller than the
+    // bogus file) to prove the bogus file is skipped before copying.
+    const result = collectWorkspaceData({
+      staging,
+      maxBytes: 100 * 1024, // 100 KB
+    });
+
+    expect(result.entries).toHaveLength(1);
+    const [entry] = result.entries;
+    // Only the real conversation dir should have been copied.
+    expect(entry.itemCount).toBe(1);
+    // skippedDueToCap should NOT include the bogus file — it's rejected
+    // by the non-dir guard, not by the cap.
+    expect(entry.skippedDueToCap).toBe(0);
+
+    const copied = readdirSync(join(staging, "workspace", "conversations"));
+    expect(copied).toEqual([CONV_DIRS.jan20]);
+    expect(copied).not.toContain(bogusName);
+  });
+
+  test("missing conversations dir returns an empty entry summary", () => {
+    // Do NOT seed — workspace has no conversations/ subdir.
+    const conversationsDir = getConversationsDir();
+    rmSync(conversationsDir, { recursive: true, force: true });
+    expect(existsSync(conversationsDir)).toBe(false);
+
+    const result = collectWorkspaceData({ staging });
+
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0]).toEqual({
+      entry: "conversations",
+      itemCount: 0,
+      bytes: 0,
+      skippedDueToCap: 0,
+    });
+    expect(result.totalBytes).toBe(0);
+    expect(existsSync(join(staging, "workspace"))).toBe(false);
+  });
+
+  test("recursive copy preserves nested attachments", () => {
+    seedConversations();
+
+    collectWorkspaceData({
+      staging,
+      conversationId: "conv-jan15-with-attachments",
+    });
+
+    const copied = readdirSync(join(staging, "workspace", "conversations"));
+    expect(copied).toEqual([CONV_DIRS.jan15Attachments]);
+    const photoPath = join(
+      staging,
+      "workspace",
+      "conversations",
+      CONV_DIRS.jan15Attachments,
+      "attachments",
+      "photo.png",
+    );
+    expect(existsSync(photoPath)).toBe(true);
+  });
+
+  test("skips symlinked directories to avoid infinite loops", () => {
+    // Symlink creation requires elevated permissions on Windows; skip
+    // there to avoid spurious failures in CI on Windows hosts.
+    if (process.platform === "win32") return;
+
+    // Seed a single canonical conversation directory and stick a
+    // symlink loop inside it (`loop -> .`). `dirSizeWithinBudget` uses
+    // `lstatSync` so that symlinks are skipped rather than dereferenced;
+    // without this, following the symlink would recurse infinitely and
+    // hang the export. We expect the function to return promptly and
+    // still process the conversation directory.
+    const conversationsDir = getConversationsDir();
+    mkdirSync(conversationsDir, { recursive: true });
+
+    const convDir = join(conversationsDir, CONV_DIRS.jan20);
+    mkdirSync(convDir, { recursive: true });
+    writeFileSync(
+      join(convDir, "meta.json"),
+      JSON.stringify({ name: CONV_DIRS.jan20 }, null, 2),
+      "utf-8",
+    );
+
+    // Create the loop: <conv-dir>/loop -> .
+    symlinkSync(".", join(convDir, "loop"), "dir");
+
+    const startMs = Date.now();
+    const result = collectWorkspaceData({ staging });
+    const elapsedMs = Date.now() - startMs;
+
+    // Sanity check: the call must complete quickly. The `lstatSync`
+    // guard is what keeps this from hanging — if the recursive walker
+    // were to dereference the symlink, the bun test runner would time
+    // out long before this assertion ever fired.
+    expect(elapsedMs).toBeLessThan(5000);
+
+    expect(result.entries).toHaveLength(1);
+    const [entry] = result.entries;
+    expect(entry.entry).toBe("conversations");
+    // The conversation directory should still be processed and copied;
+    // we don't care whether the symlink itself was reproduced in the
+    // copy — the key invariant is that the function completed.
+    expect(entry.itemCount).toBe(1);
+    expect(entry.skippedDueToCap).toBe(0);
+
+    const copied = readdirSync(join(staging, "workspace", "conversations"));
+    expect(copied).toContain(CONV_DIRS.jan20);
+  });
+
+  test("rejects top-level symlinks pointing outside the conversations dir", () => {
+    // Symlink creation requires elevated permissions on Windows; skip
+    // there to avoid spurious failures in CI on Windows hosts.
+    if (process.platform === "win32") return;
+
+    // Create a directory OUTSIDE `conversations/` that masquerades as a
+    // valid conversation dir (with a `meta.json`). The allowlist guard
+    // must not allow a symlink with a canonical name to escape the
+    // `conversations/` boundary by dereferencing into this external
+    // target.
+    const externalTarget = mkdtempSync(
+      join(tmpdir(), "ws-allowlist-external-"),
+    );
+    try {
+      writeFileSync(
+        join(externalTarget, "meta.json"),
+        JSON.stringify({ name: "evil" }, null, 2),
+        "utf-8",
+      );
+      writeFileSync(
+        join(externalTarget, "secret.txt"),
+        "should never be copied",
+        "utf-8",
+      );
+
+      // Seed the conversations dir and add a symlink with a canonical
+      // name pointing at the external target.
+      const conversationsDir = getConversationsDir();
+      mkdirSync(conversationsDir, { recursive: true });
+
+      const evilName = "2025-01-30T00-00-00.000Z_evil-target";
+      symlinkSync(externalTarget, join(conversationsDir, evilName), "dir");
+
+      const result = collectWorkspaceData({ staging });
+
+      // The symlink must be skipped by the top-level `lstatSync` guard.
+      // Nothing from the external target should land in the staging
+      // directory and the entry summary should not count it.
+      expect(result.entries).toHaveLength(1);
+      const [entry] = result.entries;
+      expect(entry.entry).toBe("conversations");
+      expect(entry.itemCount).toBe(0);
+      expect(entry.skippedDueToCap).toBe(0);
+      expect(entry.bytes).toBe(0);
+      expect(result.totalBytes).toBe(0);
+
+      // No staging directory should have been created because nothing
+      // qualified for copying.
+      expect(existsSync(join(staging, "workspace", "conversations"))).toBe(
+        false,
+      );
+    } finally {
+      rmSync(externalTarget, { recursive: true, force: true });
+    }
+  });
+});

--- a/assistant/src/runtime/routes/log-export/workspace-allowlist.ts
+++ b/assistant/src/runtime/routes/log-export/workspace-allowlist.ts
@@ -1,0 +1,297 @@
+/**
+ * Workspace allowlist module for the daemon log export endpoint.
+ *
+ * `POST /v1/export` collects audit DB rows, daemon logs, and a sanitized
+ * `config.json` snapshot. This module governs which subpaths of the user's
+ * workspace directory (`~/.vellum/workspace/`) are *opted in* to the export
+ * archive. The default is "nothing from the workspace ships" — every entry
+ * here must be justified against the rules in `./AGENTS.md`.
+ *
+ * The first allowlisted entry is `<workspace>/conversations/`, which honors
+ * both the time filter (via the parsed timestamp prefix on each conversation
+ * directory name) and the conversationId filter (via exact match on the id
+ * suffix). Directory names that don't match the canonical
+ * `<ISO-with-dashes>_<conversationId>` format are silently skipped (Rule 3).
+ */
+
+import { cpSync, existsSync, lstatSync, mkdirSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { parseConversationDirName } from "../../../memory/conversation-directories.js";
+import { getLogger } from "../../../util/logger.js";
+import { getConversationsDir } from "../../../util/platform.js";
+
+const log = getLogger("log-export-workspace");
+
+/**
+ * Maximum total bytes that the workspace allowlist may contribute to a
+ * single export archive. Mirrors `MAX_LOG_PAYLOAD_BYTES` in
+ * `log-export-routes.ts` so that the workspace section can never blow past
+ * the same 10 MB cap that already governs the daemon-logs section.
+ */
+export const MAX_WORKSPACE_PAYLOAD_BYTES = 10 * 1024 * 1024;
+
+export interface CollectWorkspaceDataOptions {
+  /** Absolute path of the export staging directory. */
+  staging: string;
+  /** When set, restrict allowlisted entries to this conversation. */
+  conversationId?: string;
+  /** Lower bound (epoch ms, inclusive). */
+  startTime?: number;
+  /** Upper bound (epoch ms, inclusive). */
+  endTime?: number;
+  /** Override the default 10 MB cap (used in tests). */
+  maxBytes?: number;
+}
+
+export interface CollectWorkspaceDataResult {
+  /** Allowlisted entries that were copied to staging/workspace/. */
+  entries: Array<{
+    /** Allowlist entry name (e.g. "conversations"). */
+    entry: string;
+    /** Number of items (files or subdirs) copied. */
+    itemCount: number;
+    /** Total bytes copied for this entry. */
+    bytes: number;
+    /** Items skipped because the cap would be exceeded. */
+    skippedDueToCap: number;
+  }>;
+  totalBytes: number;
+}
+
+/**
+ * Walk a directory recursively and sum the sizes of every regular file
+ * underneath it. Bails out early once the running total would push the
+ * workspace cap over `remainingBudget` bytes — that way we never burn
+ * cycles totalling a multi-gigabyte directory only to discard it.
+ *
+ * Returns `null` to signal "this directory is too big to fit in the
+ * remaining budget"; returns the exact byte total otherwise.
+ */
+function dirSizeWithinBudget(
+  rootDir: string,
+  remainingBudget: number,
+): number | null {
+  let total = 0;
+  const stack: string[] = [rootDir];
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    let entries: string[];
+    try {
+      entries = readdirSync(current);
+    } catch (err) {
+      log.warn(
+        { err, dir: current },
+        "Failed to read workspace directory while sizing; skipping",
+      );
+      continue;
+    }
+    for (const name of entries) {
+      const child = join(current, name);
+      let stat: ReturnType<typeof lstatSync>;
+      try {
+        // Use lstat (not stat) so symlinks are NOT dereferenced. Without
+        // this, a symlink cycle inside a conversation directory (e.g.
+        // `loop -> .`) would cause the walker to recurse forever and
+        // hang `collectWorkspaceData`. With lstat, symlinks show up as
+        // symlinks — neither `isDirectory()` nor `isFile()` is true on
+        // the lstat result, so they're naturally skipped below.
+        stat = lstatSync(child);
+      } catch (err) {
+        log.warn(
+          { err, path: child },
+          "Failed to stat workspace path while sizing; skipping",
+        );
+        continue;
+      }
+      if (stat.isDirectory()) {
+        stack.push(child);
+      } else if (stat.isFile()) {
+        total += stat.size;
+        if (total > remainingBudget) {
+          return null;
+        }
+      }
+    }
+  }
+  return total;
+}
+
+function collectConversations(
+  opts: CollectWorkspaceDataOptions,
+  result: CollectWorkspaceDataResult,
+): void {
+  const maxBytes = opts.maxBytes ?? MAX_WORKSPACE_PAYLOAD_BYTES;
+  const entry = {
+    entry: "conversations",
+    itemCount: 0,
+    bytes: 0,
+    skippedDueToCap: 0,
+  };
+
+  const sourceDir = getConversationsDir();
+  if (!existsSync(sourceDir)) {
+    result.entries.push(entry);
+    return;
+  }
+
+  let names: string[];
+  try {
+    names = readdirSync(sourceDir);
+  } catch (err) {
+    log.warn(
+      { err, sourceDir },
+      "Failed to read conversations directory; skipping conversations entry",
+    );
+    result.entries.push(entry);
+    return;
+  }
+
+  const destBase = join(opts.staging, "workspace", "conversations");
+
+  // First pass: parse + filter all names and collect the surviving
+  // candidates so we can sort them deterministically before applying the
+  // byte cap. Without this, `readdirSync` order determines which
+  // conversations are dropped on truncation, which both makes capped
+  // exports nondeterministic and can drop the newest conversations.
+  const candidates: Array<{
+    name: string;
+    parsed: { conversationId: string; createdAtMs: number };
+  }> = [];
+  for (const name of names) {
+    let parsed: ReturnType<typeof parseConversationDirName>;
+    try {
+      parsed = parseConversationDirName(name);
+    } catch (err) {
+      log.warn(
+        { err, name },
+        "Failed to parse conversation directory name; skipping",
+      );
+      continue;
+    }
+    if (!parsed) continue; // Rule 3 — default deny non-canonical names.
+
+    if (
+      opts.conversationId !== undefined &&
+      parsed.conversationId !== opts.conversationId
+    ) {
+      continue;
+    }
+    if (opts.startTime !== undefined && parsed.createdAtMs < opts.startTime) {
+      continue;
+    }
+    if (opts.endTime !== undefined && parsed.createdAtMs > opts.endTime) {
+      continue;
+    }
+
+    candidates.push({ name, parsed });
+  }
+
+  // Newest first so cap-truncation keeps the most recent conversations.
+  candidates.sort((a, b) => b.parsed.createdAtMs - a.parsed.createdAtMs);
+
+  for (const { name } of candidates) {
+    const srcPath = join(sourceDir, name);
+
+    // Guard: a canonical-looking entry must be a real directory under
+    // `conversations/`. Use `lstatSync` (not `statSync`) so symlinks are
+    // not dereferenced — a symlink with a canonical name pointing at an
+    // external directory must not be allowed to escape the allowlist
+    // boundary. Symlinks are rejected explicitly below; regular files
+    // (and anything else that isn't a directory) are also skipped so
+    // `dirSizeWithinBudget` and `cpSync` never see them.
+    let srcStat: ReturnType<typeof lstatSync>;
+    try {
+      srcStat = lstatSync(srcPath);
+    } catch (err) {
+      log.warn({ err, srcPath }, "Failed to stat conversation entry; skipping");
+      continue;
+    }
+    if (srcStat.isSymbolicLink()) {
+      log.warn(
+        { srcPath },
+        "Conversation entry is a symbolic link; skipping to preserve allowlist boundary",
+      );
+      continue;
+    }
+    if (!srcStat.isDirectory()) {
+      log.warn({ srcPath }, "Conversation entry is not a directory; skipping");
+      continue;
+    }
+
+    const remainingBudget = maxBytes - result.totalBytes;
+    let dirBytes: number | null;
+    try {
+      dirBytes = dirSizeWithinBudget(srcPath, remainingBudget);
+    } catch (err) {
+      log.warn(
+        { err, srcPath },
+        "Failed to compute conversation directory size; skipping",
+      );
+      continue;
+    }
+
+    if (dirBytes === null) {
+      // Including this directory would exceed the workspace cap.
+      entry.skippedDueToCap += 1;
+      continue;
+    }
+
+    try {
+      mkdirSync(destBase, { recursive: true });
+      cpSync(srcPath, join(destBase, name), { recursive: true });
+    } catch (err) {
+      log.warn(
+        { err, srcPath },
+        "Failed to copy conversation directory; skipping",
+      );
+      continue;
+    }
+
+    entry.itemCount += 1;
+    entry.bytes += dirBytes;
+    result.totalBytes += dirBytes;
+  }
+
+  result.entries.push(entry);
+}
+
+/**
+ * Collect allowlisted workspace data into `<staging>/workspace/`.
+ *
+ * Currently the only allowlisted entry is `conversations/`. Future entries
+ * should follow the rules in `./AGENTS.md` (time filter, conversation
+ * filter, byte cap, registry update). The function never throws — all
+ * filesystem errors are logged at warn level so the rest of the export
+ * pipeline can continue regardless.
+ */
+export function collectWorkspaceData(
+  opts: CollectWorkspaceDataOptions,
+): CollectWorkspaceDataResult {
+  const result: CollectWorkspaceDataResult = {
+    entries: [],
+    totalBytes: 0,
+  };
+
+  try {
+    collectConversations(opts, result);
+  } catch (err) {
+    log.warn(
+      { err },
+      "Unexpected error while collecting workspace conversations entry",
+    );
+  }
+
+  log.info(
+    {
+      entries: result.entries,
+      totalBytes: result.totalBytes,
+      conversationId: opts.conversationId ?? null,
+      startTime: opts.startTime ?? null,
+      endTime: opts.endTime ?? null,
+    },
+    "Workspace allowlist collection complete",
+  );
+
+  return result;
+}

--- a/assistant/src/runtime/routes/log-export/workspace-allowlist.ts
+++ b/assistant/src/runtime/routes/log-export/workspace-allowlist.ts
@@ -122,16 +122,22 @@ function collectConversations(
   result: CollectWorkspaceDataResult,
 ): void {
   const maxBytes = opts.maxBytes ?? MAX_WORKSPACE_PAYLOAD_BYTES;
+  // Initialize the entry summary and push it onto `result.entries`
+  // immediately so the conversations entry is always present in the
+  // result, even if the candidate loop below throws partway through.
+  // The array holds a reference to this object, so all later mutations
+  // to `entry.itemCount`, `entry.bytes`, and `entry.skippedDueToCap`
+  // are visible to consumers via `result.entries`.
   const entry = {
     entry: "conversations",
     itemCount: 0,
     bytes: 0,
     skippedDueToCap: 0,
   };
+  result.entries.push(entry);
 
   const sourceDir = getConversationsDir();
   if (!existsSync(sourceDir)) {
-    result.entries.push(entry);
     return;
   }
 
@@ -143,7 +149,6 @@ function collectConversations(
       { err, sourceDir },
       "Failed to read conversations directory; skipping conversations entry",
     );
-    result.entries.push(entry);
     return;
   }
 
@@ -252,8 +257,6 @@ function collectConversations(
     entry.bytes += dirBytes;
     result.totalBytes += dirBytes;
   }
-
-  result.entries.push(entry);
 }
 
 /**

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -21,6 +21,8 @@ private let log = Logger(
 /// - Multi-service logs via `POST /v1/logs/export` gateway HTTP API — the gateway orchestrates
 ///   collection from all services (gateway, daemon, CES), returning a combined archive that
 ///   includes gateway logs, CES logs, daemon logs, audit data, and sanitized config
+/// - `workspace/conversations/<dir>/` — allowlisted user conversation directories from the
+///   workspace, filtered by time and conversation when applicable
 /// - `~/.config/vellum/logs/` — CLI XDG logs (hatch.log, retire.log, etc.)
 /// - `~/.vellum.lock.json` — sanitized lockfile with assistant entries and resource ports (credentials stripped)
 /// - `user-defaults.json` — snapshot of app-relevant UserDefaults keys


### PR DESCRIPTION
## Summary

The daemon log export API at `POST /v1/export` now includes specific subpaths from `~/.vellum/workspace/` via an allowlist module governed by two principles documented in a new `AGENTS.md`: prefer time-filterable data, and prefer conversation-filterable data. The first allowlisted entry is `<workspace>/conversations/`, whose timestamp-prefixed directory names enable both filters cleanly.

## PRs merged into feature branch
- #23880: docs: add log-export module AGENTS.md describing workspace allowlist rules
- #23879: feat(memory): add parseConversationDirName as inverse of getConversationDirName
- #23883: feat(log-export): collect workspace conversations dirs via allowlist
- #23901: feat(log-export): include allowlisted workspace data in /v1/export archive

Part of plan: ws-export-allowlist.md

Self-review is starting. Results will be posted here when complete.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23905" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
