### PR TITLE
fix(memory): reject path-traversal-shaped conversation IDs in parseConversationDirName

### DIFF
--- a/assistant/src/__tests__/conversation-directories-parse.test.ts
+++ b/assistant/src/__tests__/conversation-directories-parse.test.ts
@@ -69,6 +69,28 @@ describe("parseConversationDirName", () => {
     test("returns null for random garbage", () => {
       expect(parseConversationDirName("drafts/foo")).toBeNull();
     });
+
+    test("returns null when the conversation id is '.'", () => {
+      expect(parseConversationDirName("2025-01-15T00-00-00.000Z_.")).toBeNull();
+    });
+
+    test("returns null when the conversation id is '..'", () => {
+      expect(
+        parseConversationDirName("2025-01-15T00-00-00.000Z_.."),
+      ).toBeNull();
+    });
+
+    test("returns null when the conversation id contains a forward slash", () => {
+      expect(
+        parseConversationDirName("2025-01-15T00-00-00.000Z_foo/bar"),
+      ).toBeNull();
+    });
+
+    test("returns null when the conversation id contains a backslash", () => {
+      expect(
+        parseConversationDirName("2025-01-15T00-00-00.000Z_foo\\bar"),
+      ).toBeNull();
+    });
   });
 
   describe("ids containing underscores", () => {

--- a/assistant/src/memory/conversation-directories.ts
+++ b/assistant/src/memory/conversation-directories.ts
@@ -50,6 +50,18 @@ export function parseConversationDirName(
   const ms = Date.parse(iso);
   if (Number.isNaN(ms)) return null;
   if (!conversationId) return null;
+  // Reject conversation IDs that are path-traversal-shaped or contain
+  // path separators. These are never valid conversation IDs and would
+  // be a defense-in-depth concern if parsed.conversationId is later used
+  // to construct filesystem paths.
+  if (
+    conversationId === "." ||
+    conversationId === ".." ||
+    conversationId.includes("/") ||
+    conversationId.includes("\\")
+  ) {
+    return null;
+  }
   return { conversationId, createdAtMs: ms };
 }
 


### PR DESCRIPTION
## Summary
Add an explicit rejection in `parseConversationDirName` for conversation IDs that are `.`, `..`, or contain path separators (`/`, `\\`). These are never valid IDs and would be a defense-in-depth concern if a parsed ID were later used to construct filesystem paths. Add unit tests for each rejection case.

Fixes gap identified during plan review for ws-export-allowlist.md.
**Gap:** parseConversationDirName accepts `.` and `..` as conversation IDs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23907" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
