### PR TITLE
docs(log-export): document workspace/conversations subtree in archive layout

### DIFF
--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -58,9 +58,10 @@ interface ExportRequestBody {
  * then package everything into a tar.gz archive.
  *
  * Archive layout:
- *   audit-data.json          — tool invocation records
- *   config-snapshot.json     — sanitized workspace config
- *   daemon-logs/<name>       — daemon log files
+ *   audit-data.json                 — tool invocation records
+ *   config-snapshot.json            — sanitized workspace config
+ *   daemon-logs/<name>              — daemon log files
+ *   workspace/conversations/<dir>/  — allowlisted workspace data (see ./log-export/AGENTS.md)
  */
 async function handleExport(body: ExportRequestBody): Promise<Response> {
   const staging = mkdtempSync(join(tmpdir(), "vellum-export-"));

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -21,6 +21,8 @@ private let log = Logger(
 /// - Multi-service logs via `POST /v1/logs/export` gateway HTTP API — the gateway orchestrates
 ///   collection from all services (gateway, daemon, CES), returning a combined archive that
 ///   includes gateway logs, CES logs, daemon logs, audit data, and sanitized config
+/// - `workspace/conversations/<dir>/` — allowlisted user conversation directories from the
+///   workspace, filtered by time and conversation when applicable
 /// - `~/.config/vellum/logs/` — CLI XDG logs (hatch.log, retire.log, etc.)
 /// - `~/.vellum.lock.json` — sanitized lockfile with assistant entries and resource ports (credentials stripped)
 /// - `user-defaults.json` — snapshot of app-relevant UserDefaults keys


### PR DESCRIPTION
## Summary
Update the archive layout doc comments in `log-export-routes.ts` and `LogExporter.swift` to list the `workspace/conversations/<dir>/` subtree that the daemon now ships when there are matching canonical conversation directories. Comments describe current behavior in present tense.

Fixes gap identified during plan review for ws-export-allowlist.md.
**Gap:** Archive layout change is not reflected in client-side documentation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
