### PR TITLE
fix: only show dynamic bottom spacer during active streaming

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -55,6 +55,7 @@ struct MessageListContentView: View, Equatable {
             && lhs.highlightedMessageId == rhs.highlightedMessageId
             && lhs.mediaEmbedSettings == rhs.mediaEmbedSettings
             && lhs.hasEverSentMessage == rhs.hasEverSentMessage
+            && lhs.isSending == rhs.isSending
             && lhs.showInspectButton == rhs.showInspectButton
             && lhs.isTTSEnabled == rhs.isTTSEnabled
             && lhs.selectedModel == rhs.selectedModel
@@ -77,6 +78,7 @@ struct MessageListContentView: View, Equatable {
     let highlightedMessageId: UUID?
     let mediaEmbedSettings: MediaEmbedResolverSettings?
     let hasEverSentMessage: Bool
+    let isSending: Bool
     let showInspectButton: Bool
     let isTTSEnabled: Bool
     let selectedModel: String
@@ -269,9 +271,11 @@ struct MessageListContentView: View, Equatable {
             }
 
             // Dynamic spacer: ensures user message can reach top even with short assistant output
-            Color.clear
-                .frame(height: max(0, viewportHeight - 100))
-                .id("scroll-bottom-spacer")
+            if isSending {
+                Color.clear
+                    .frame(height: max(0, viewportHeight - 100))
+                    .id("scroll-bottom-spacer")
+            }
 
             // Bottom anchor for explicit jumps
             Color.clear

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
@@ -374,6 +374,7 @@ extension MessageListView {
             highlightedMessageId: highlightedMessageId,
             mediaEmbedSettings: mediaEmbedSettings,
             hasEverSentMessage: hasEverSentMessage,
+            isSending: isSending,
             showInspectButton: showInspectButton,
             isTTSEnabled: isTTSEnabled,
             selectedModel: selectedModel,


### PR DESCRIPTION
## Summary
- Make dynamic bottom spacer conditional on isSending
- No empty gap below last message when conversation is idle
- Spacer appears during streaming for user message top-anchor guarantee

Part of plan: scroll-to-latest-fix.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23911" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
