### PR TITLE
fix: scroll-to-latest and auto-follow target last message, not empty anchor

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -32,7 +32,11 @@ extension MessageListView {
                 flashHighlight(messageId: id)
                 anchorMessageId = nil
             } else if anchorMessageId == nil {
-                scrollProxy?.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                if let lastId = scrollState.lastMessageId {
+                    scrollProxy?.scrollTo(lastId, anchor: .bottom)
+                } else {
+                    scrollProxy?.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                }
             }
         }
     }
@@ -95,7 +99,11 @@ extension MessageListView {
 
         // --- Auto-follow on new messages ---
         if scrollState.shouldAutoFollow, scrollProxy != nil {
-            scrollProxy?.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+            if let lastId = scrollState.lastMessageId {
+                scrollProxy?.scrollTo(lastId, anchor: .bottom)
+            } else {
+                scrollProxy?.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+            }
         }
 
         // --- Confirmation focus handoff ---
@@ -108,7 +116,11 @@ extension MessageListView {
         if scrollState.isNearBottom {
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 100_000_000)
-                scrollProxy?.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                if let lastId = scrollState.lastMessageId {
+                    scrollProxy?.scrollTo(lastId, anchor: .bottom)
+                } else {
+                    scrollProxy?.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                }
             }
         }
     }
@@ -120,7 +132,11 @@ extension MessageListView {
         highlightedMessageId = nil
         // Seed lastMessageId for the new conversation.
         scrollState.lastMessageId = paginatedVisibleMessages.last?.id
-        scrollProxy?.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+        if let lastId = scrollState.lastMessageId {
+            scrollProxy?.scrollTo(lastId, anchor: .bottom)
+        } else {
+            scrollProxy?.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+        }
     }
 
     func handleAnchorMessageTask() async {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -123,14 +123,22 @@ struct MessageListView: View {
             } action: { _, newState in
                 handleScrollGeometryUpdate(newState)
                 if scrollState.canAutoFollow() {
-                    proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                    if let lastId = scrollState.lastMessageId {
+                        proxy.scrollTo(lastId, anchor: .bottom)
+                    } else {
+                        proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                    }
                 }
             }
             .scrollIndicators(scrollState.scrollIndicatorsHidden ? .hidden : .automatic)
             .overlay(alignment: .bottom) {
                 ScrollToLatestOverlayView(scrollState: scrollState) {
                     withAnimation(VAnimation.spring) {
-                        proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                        if let lastId = scrollState.lastMessageId {
+                            proxy.scrollTo(lastId, anchor: .bottom)
+                        } else {
+                            proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Scroll-to-latest button now scrolls to actual last message, not empty anchor after spacer
- Auto-follow during streaming targets last message content
- Falls back to bottom anchor only when no messages exist

Part of plan: scroll-to-latest-fix.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23912" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
