### PR TITLE
Refactor WorkspaceBrowserState view-mode helper and add JSONL test coverage

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -38,6 +38,22 @@ final class WorkspaceBrowserState {
     var showHiddenFiles: Bool = UserDefaults.standard.bool(forKey: "showHiddenFiles")
     var hiddenFilesToggleRequestId: UInt64 = 0
 
+    /// Picks the initial view mode for a freshly-loaded file based on its
+    /// extension and the user's stored preference. Pure function so it can be
+    /// unit tested without spinning up a real workspace client. Called from
+    /// `loadFile(path:using:)`.
+    static func defaultViewMode(forExtension ext: String, prefersSource: Bool) -> FileViewMode {
+        if prefersSource { return .source }
+        switch ext {
+        case "md", "markdown":
+            return .preview
+        case "json", "jsonl", "ndjson":
+            return .tree
+        default:
+            return .source
+        }
+    }
+
     func refreshDirectory(_ dirPath: String, using workspaceClient: any WorkspaceClientProtocol) async {
         if let response = await workspaceClient.fetchWorkspaceTree(path: dirPath, showHidden: showHiddenFiles) {
             directoryCache[dirPath] = response.entries
@@ -48,15 +64,7 @@ final class WorkspaceBrowserState {
         selectedFilePath = targetPath
         let ext = (targetPath as NSString).pathExtension.lowercased()
         let prefersSource = UserDefaults.standard.string(forKey: "fileViewerPreferredMode") == "source"
-        if prefersSource {
-            viewMode = .source
-        } else if ext == "md" || ext == "markdown" {
-            viewMode = .preview
-        } else if ext == "json" || ext == "jsonl" || ext == "ndjson" {
-            viewMode = .tree
-        } else {
-            viewMode = .source
-        }
+        viewMode = Self.defaultViewMode(forExtension: ext, prefersSource: prefersSource)
         isLoadingFile = true
         selectedFileDetail = nil
         isDirty = false

--- a/clients/macos/vellum-assistantTests/WorkspaceBrowserStateJSONLTests.swift
+++ b/clients/macos/vellum-assistantTests/WorkspaceBrowserStateJSONLTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class WorkspaceBrowserStateJSONLTests: XCTestCase {
+
+    // MARK: - JSON / JSONL / NDJSON default to tree
+
+    func testJsonDefaultsToTree() {
+        XCTAssertEqual(
+            WorkspaceBrowserState.defaultViewMode(forExtension: "json", prefersSource: false),
+            .tree
+        )
+    }
+
+    func testJsonlDefaultsToTree() {
+        XCTAssertEqual(
+            WorkspaceBrowserState.defaultViewMode(forExtension: "jsonl", prefersSource: false),
+            .tree
+        )
+    }
+
+    func testNdjsonDefaultsToTree() {
+        XCTAssertEqual(
+            WorkspaceBrowserState.defaultViewMode(forExtension: "ndjson", prefersSource: false),
+            .tree
+        )
+    }
+
+    // MARK: - Markdown defaults to preview
+
+    func testMarkdownDefaultsToPreview() {
+        XCTAssertEqual(
+            WorkspaceBrowserState.defaultViewMode(forExtension: "md", prefersSource: false),
+            .preview
+        )
+    }
+
+    func testMarkdownLongExtensionDefaultsToPreview() {
+        XCTAssertEqual(
+            WorkspaceBrowserState.defaultViewMode(forExtension: "markdown", prefersSource: false),
+            .preview
+        )
+    }
+
+    // MARK: - Unknown defaults to source
+
+    func testUnknownDefaultsToSource() {
+        XCTAssertEqual(
+            WorkspaceBrowserState.defaultViewMode(forExtension: "txt", prefersSource: false),
+            .source
+        )
+    }
+
+    func testEmptyExtensionDefaultsToSource() {
+        XCTAssertEqual(
+            WorkspaceBrowserState.defaultViewMode(forExtension: "", prefersSource: false),
+            .source
+        )
+    }
+
+    // MARK: - prefersSource overrides everything
+
+    func testPrefersSourceForcesSourceForJsonl() {
+        XCTAssertEqual(
+            WorkspaceBrowserState.defaultViewMode(forExtension: "jsonl", prefersSource: true),
+            .source
+        )
+    }
+
+    func testPrefersSourceForcesSourceForNdjson() {
+        XCTAssertEqual(
+            WorkspaceBrowserState.defaultViewMode(forExtension: "ndjson", prefersSource: true),
+            .source
+        )
+    }
+
+    func testPrefersSourceForcesSourceForJson() {
+        XCTAssertEqual(
+            WorkspaceBrowserState.defaultViewMode(forExtension: "json", prefersSource: true),
+            .source
+        )
+    }
+
+    func testPrefersSourceForcesSourceForMarkdown() {
+        XCTAssertEqual(
+            WorkspaceBrowserState.defaultViewMode(forExtension: "md", prefersSource: true),
+            .source
+        )
+    }
+
+    func testPrefersSourceForcesSourceForUnknown() {
+        XCTAssertEqual(
+            WorkspaceBrowserState.defaultViewMode(forExtension: "txt", prefersSource: true),
+            .source
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Extract the inline view-mode-decision chain into a static `defaultViewMode(forExtension:prefersSource:)` helper for unit testability
- Add 12 new tests covering JSON/JSONL/NDJSON/markdown/unknown extensions and the prefers-source override

Part of plan: macos-jsonl-viewer.md (PR 6 of 6)