### PR TITLE
fix: adjust near-bottom detection to account for conditional spacer

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -104,6 +104,10 @@ final class MessageListScrollState {
     /// from initial position). Used to gate initial auto-scroll behavior.
     @ObservationIgnored var hasBeenInteracted: Bool = false
 
+    /// Whether a message is currently being sent/streamed.
+    /// Used to subtract the conditional spacer height from `distanceFromBottom`.
+    @ObservationIgnored var isSending: Bool = false
+
     // MARK: - Derived State Cache
 
     /// Non-observable cache for memoizing derived state computations.
@@ -114,8 +118,15 @@ final class MessageListScrollState {
     // MARK: - Computed Properties
 
     /// Distance from the bottom of the scrollable content.
+    /// When sending, subtracts the conditional spacer height so that
+    /// near-bottom detection is based on actual content, not the spacer.
     var distanceFromBottom: CGFloat {
-        contentHeight - contentOffsetY - viewportHeight
+        let raw = contentHeight - contentOffsetY - viewportHeight
+        if isSending {
+            let spacerHeight = max(0, viewportHeight - 100)
+            return raw - spacerHeight
+        }
+        return raw
     }
 
     /// Whether auto-follow should engage: near bottom and not yet anchored
@@ -237,6 +248,7 @@ final class MessageListScrollState {
         lastAutoFocusedRequestId = nil
         bottomAnchorAppeared = false
         hasBeenInteracted = false
+        isSending = false
         derivedStateCache.reset()
 
         scrollLog.debug("Reset for conversation: \(conversationId)")

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -14,6 +14,7 @@ extension MessageListView {
         scrollState.contentOffsetY = newState.contentOffsetY
         scrollState.contentHeight = newState.contentHeight
         scrollState.viewportHeight = newState.visibleRectHeight
+        scrollState.isSending = isSending
         scrollState.updateNearBottom()
 
         // Derive sentinel position from content offset (inverted sign to


### PR DESCRIPTION
## Summary
- Subtract spacer height from distanceFromBottom when isSending
- Near-bottom detection and scroll-to-latest show/hide based on actual content distance
- Prevents false positives during streaming

Part of plan: scroll-to-latest-fix.md (PR 3 of 3)

## Test plan
- [ ] During streaming, verify "Scroll to latest" does not appear when user is already at the bottom
- [ ] After scrolling up during streaming, verify "Scroll to latest" appears correctly
- [ ] When not streaming, verify behavior is unchanged
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23914" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
