### PR TITLE
feat: render thinking block content as markdown

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
@@ -1,6 +1,3 @@
-#if os(macOS)
-import AppKit
-#endif
 import SwiftUI
 import VellumAssistantShared
 
@@ -11,7 +8,27 @@ struct ThinkingBlockView: View {
     let content: String
     let isStreaming: Bool
 
-    @State private var isExpanded: Bool = false
+    @State private var isExpanded: Bool
+
+    init(content: String, isStreaming: Bool, initiallyExpanded: Bool = false) {
+        self.content = content
+        self.isStreaming = isStreaming
+        _isExpanded = State(initialValue: initiallyExpanded)
+    }
+
+    static func makeMarkdownView(content: String, isStreaming: Bool) -> MarkdownSegmentView {
+        MarkdownSegmentView(
+            segments: parseMarkdownSegments(content),
+            isStreaming: isStreaming,
+            maxContentWidth: nil,
+            textColor: VColor.contentSecondary,
+            secondaryTextColor: VColor.contentTertiary,
+            mutedTextColor: VColor.contentTertiary,
+            tintColor: VColor.primaryBase,
+            codeTextColor: VColor.contentDefault,
+            codeBackgroundColor: VColor.surfaceBase
+        )
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -21,28 +38,10 @@ struct ThinkingBlockView: View {
                 Divider()
                     .padding(.horizontal, VSpacing.sm)
 
-                #if os(macOS)
-                VSelectableTextView(
-                    attributedString: NSAttributedString(
-                        string: content,
-                        attributes: [
-                            .font: VFont.nsBodyMediumDefault,
-                            .foregroundColor: NSColor(VColor.contentSecondary),
-                        ]
-                    ),
-                    lineSpacing: 0
-                )
+                Self.makeMarkdownView(content: content, isStreaming: isStreaming)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(VSpacing.sm)
                 .transition(.opacity)
-                #else
-                Text(content)
-                    .font(VFont.bodyMediumDefault)
-                    .foregroundStyle(VColor.contentSecondary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(VSpacing.sm)
-                    .transition(.opacity)
-                #endif
             }
         }
         .background(VColor.surfaceOverlay)

--- a/clients/macos/vellum-assistantTests/ThinkingBlockViewTests.swift
+++ b/clients/macos/vellum-assistantTests/ThinkingBlockViewTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class ThinkingBlockViewTests: XCTestCase {
+    func testMakeMarkdownViewParsesMarkdownContent() {
+        let markdownView = ThinkingBlockView.makeMarkdownView(
+            content: "*italic* and **bold**",
+            isStreaming: false
+        )
+
+        XCTAssertEqual(markdownView.segments, parseMarkdownSegments("*italic* and **bold**"))
+        XCTAssertFalse(markdownView.isStreaming)
+    }
+
+    func testExpandedThinkingBlockBodyDoesNotCrashWithMarkdown() {
+        let view = ThinkingBlockView(
+            content: """
+            *gasps against the fabric*
+
+            *muffled, breathless*
+            """,
+            isStreaming: false,
+            initiallyExpanded: true
+        )
+
+        _ = view.body
+    }
+}


### PR DESCRIPTION
## Summary
- Replace plain-text `VSelectableTextView`/`Text` rendering in `ThinkingBlockView` with `MarkdownSegmentView` for rich formatting support
- Remove platform-specific `#if os(macOS)` branching in favor of unified cross-platform implementation
- Add `ThinkingBlockViewTests` covering the new markdown rendering path
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23915" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
