### PR TITLE
fix: skip explicit-font runs in emphasis trait verification

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -627,7 +627,7 @@ struct MarkdownSegmentView: View, Equatable {
             }
         }
 
-        for emphRun in emphasisRuns where !emphRun.intent.contains(.code) && emphRun.utf16Length > 0 {
+        for emphRun in emphasisRuns where !emphRun.intent.contains(.code) && !emphRun.hasExplicitFont && emphRun.utf16Length > 0 {
             let nsRange = NSRange(location: emphRun.utf16Offset, length: emphRun.utf16Length)
             guard nsRange.location + nsRange.length <= ns.length else { continue }
             guard let actualFont = ns.attribute(.font, at: nsRange.location, effectiveRange: nil) as? NSFont else {


### PR DESCRIPTION
Addresses review feedback on #23737. The post-pass emphasis verification loop now skips runs with hasExplicitFont, matching the synthesis loop's filter. This prevents headings from being falsely counted as unresolved emphasis, which was disabling measurement caching and logging spurious warnings.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23917" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
