### PR TITLE
fix: apply text synchronously for intrinsic sizing in SelectableTextView

### DIFF
--- a/clients/shared/DesignSystem/Components/Display/SelectableTextView.swift
+++ b/clients/shared/DesignSystem/Components/Display/SelectableTextView.swift
@@ -157,7 +157,11 @@ public struct VSelectableTextView: NSViewRepresentable {
         let coordinator = context.coordinator
         guard coordinator.lastAttributedString != attributedString
             || coordinator.lastLineSpacing != lineSpacing else { return }
-        coordinator.scheduleAttributedStringApply(attributedString, lineSpacing: lineSpacing, to: textView)
+        if useExternalSizing {
+            coordinator.scheduleAttributedStringApply(attributedString, lineSpacing: lineSpacing, to: textView)
+        } else {
+            coordinator.applyAttributedString(attributedString, lineSpacing: lineSpacing, to: textView)
+        }
     }
 
     /// When `useExternalSizing` is `true`, returns `nil` so SwiftUI uses


### PR DESCRIPTION
Addresses review feedback on #23874. When useExternalSizing is false, text is applied synchronously to avoid stale measurements during sizeThatFits. The deferred path is only used when useExternalSizing is true, where reentrancy is the actual concern.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
