### PR TITLE
fix: restrict closing-tag skip to exact memory_image tag

### DIFF
--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -628,7 +628,7 @@ export function injectPkbContext(message: Message, content: string): Message {
     if (
       block.type === "text" &&
       (block.text.startsWith("<memory") ||
-        block.text.startsWith("</memory") ||
+        block.text.startsWith("</memory_image>") ||
         block.text.startsWith("<memory_context"))
     ) {
       insertIdx = i + 1;


### PR DESCRIPTION
Addresses review feedback on #23875. Narrows the closing-tag check from startsWith("</memory") to startsWith("</memory_image>") to avoid matching user-authored XML content.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23919" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
