### PR TITLE
fix: add canInlineProcessing guard to streaming-without-text indicator

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -254,7 +254,7 @@ struct MessageListContentView: View, Equatable {
                     thinkingIndicatorRow(hasUserMessage: state.hasUserMessage)
                 }
                 thinkingAvatarRow
-            } else if state.isStreamingWithoutText {
+            } else if state.isStreamingWithoutText && !state.canInlineProcessing {
                 HStack {
                     TypingIndicatorView()
                     Spacer()


### PR DESCRIPTION
Addresses review feedback on #23877. Adds `!state.canInlineProcessing` guard to the `isStreamingWithoutText` branch to prevent showing typing dots when the message cell already shows an inline processing indicator.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
