### PR TITLE
fix: preserve pending local messages during stripped history reload

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2090,7 +2090,13 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
             self.reconnectLatchTimeoutTask?.cancel()
             self.isReconnectHistoryLoading = false
             refreshModelMetadataIfNeeded(hasModelCommand)
-        } else if messages.contains(where: { $0.role == .user && !$0.isContentStripped }) {
+        } else if messages.contains(where: {
+            $0.role == .user && (
+                !$0.isContentStripped
+                || pendingMessageIds.contains($0.id)
+                || $0.status == .pendingOffline
+            )
+        }) {
             // History arrived after the user already sent messages.
             // The history payload includes ALL persisted messages — including
             // ones the user sent (and any assistant replies) before the
@@ -2099,7 +2105,10 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
             // existing message.
             // Content-stripped messages (from trimForBackground) are excluded
             // from this check — they should be fully replaced by fresh server
-            // data, not preserved with their heavy content cleared.
+            // data, not preserved with their heavy content cleared. However,
+            // pending/unsent local messages must be preserved even if stripped,
+            // since the server doesn't have them yet and a full replace would
+            // drop them.
             let earliestExisting = self.messages.map(\.timestamp).min()
             let uniqueHistory: [ChatMessage]
             if let earliest = earliestExisting {


### PR DESCRIPTION
## Summary
- Refines the stripped-message check in `ChatViewModel.populateFromHistory` to also consider whether a message is pending (in `pendingMessageIds` or has `.pendingOffline` status)
- Previously, `trimForBackground()` marking all messages as content-stripped caused the dedup path to be skipped entirely, dropping pending local messages during reconnect races
- Pending/unsent local messages are now preserved even when content-stripped, since the server doesn't have them yet

## Test plan
- [ ] Verify that pending messages are preserved after returning from background during a reconnect
- [ ] Verify that non-pending stripped messages are still fully replaced by server data

Addresses review feedback on #23852.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23921" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
