### PR TITLE
fix: balance expansion timeout endStabilization on cancellation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -431,10 +431,9 @@ final class MessageListScrollState {
     /// Tracks overlapping stabilization windows. Stabilization only ends
     /// when all active windows have completed, so concurrent reasons
     /// (e.g. resize during pagination) don't prematurely restore the mode.
-    /// Re-entering the same reason increments the count like any other entry.
-    /// Callers are structured so that each `beginStabilization` has a matching
-    /// `endStabilization` (cancelled task cleanup for resize, preceding
-    /// `endStabilization` in `suppressAutoScroll` for expansion).
+    /// Same-reason expansion re-entry increments the count and resets the
+    /// timer; the cancelled timeout calls `endStabilization()` to balance
+    /// the increment (matching the resize/pagination cleanup pattern).
     @ObservationIgnored private var activeStabilizationCount = 0
 
     // MARK: - Deep-Link Anchor Tracking
@@ -495,6 +494,7 @@ final class MessageListScrollState {
             previousMode = prev
             if activeReason == reason {
                 if reason == .expansion {
+                    activeStabilizationCount += 1
                     scheduleExpansionTimeout()
                 }
                 return
@@ -535,7 +535,7 @@ final class MessageListScrollState {
         expansionTimeoutTask?.cancel()
         expansionTimeoutTask = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: 200_000_000)
-            guard !Task.isCancelled, let self else { return }
+            guard let self else { return }
             self.endStabilization()
         }
     }


### PR DESCRIPTION
Addresses review feedback on #23731. When the expansion timeout is cancelled due to same-reason re-entry, the cancelled task now calls endStabilization() before returning (matching the resize/pagination cleanup pattern). This ensures activeStabilizationCount stays balanced and stabilization doesn't get permanently stuck.

Changes:
- Same-reason expansion re-entry now increments activeStabilizationCount (balancing the endStabilization from the cancelled timeout)
- Cancelled expansion timeout calls endStabilization() instead of silently returning (matching resize/pagination patterns)
- Updated comment to accurately describe the balanced count behavior
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23922" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
