### PR TITLE
fix: correct credentials command syntax in manual-token error message

### DIFF
--- a/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
@@ -690,7 +690,9 @@ describe("assistant oauth connect", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toContain("manual token configuration");
-    expect(parsed.error).toContain("credentials set --service");
+    expect(parsed.error).toContain("assistant credentials set");
+    expect(parsed.error).toContain("--service");
+    expect(parsed.error).toContain("--field");
   });
 
   // -------------------------------------------------------------------------

--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -342,7 +342,7 @@ Examples:
             if (providerRow.authUrl === "urn:manual-token") {
               writeError(
                 `"${provider}" uses manual token configuration, not an OAuth browser flow. ` +
-                  `Set credentials with 'assistant credentials set --service ${provider} --field <key> <value>'.`,
+                  `Set the token with: assistant credentials set <token_value> --service ${provider} --field <field_name>`,
               );
               return;
             }


### PR DESCRIPTION
Addresses review feedback on #23847. Updates the error message for manual-token providers to show valid, unambiguous CLI syntax for the `credentials set` command — puts the positional `<token_value>` arg right after `set` (matching the command definition) and uses distinct placeholder names (`<token_value>`, `<field_name>`) so users can distinguish the secret from the field flag.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23923" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
