### PR TITLE
fix: add generation counter to scroll geometry dispatcher to reject stale drains

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
@@ -59,6 +59,7 @@ final class ScrollGeometryUpdateDispatcher {
 
     private var pendingSnapshots: [ObjectIdentifier: ScrollGeometrySnapshot] = [:]
     private var scheduledKeys: Set<ObjectIdentifier> = []
+    private var generations: [ObjectIdentifier: Int] = [:]
 
     func enqueue(
         for owner: MessageListScrollState,
@@ -68,29 +69,40 @@ final class ScrollGeometryUpdateDispatcher {
         let key = ObjectIdentifier(owner)
         pendingSnapshots[key] = snapshot
         guard scheduledKeys.insert(key).inserted else { return }
-        scheduleDrain(for: key, owner: owner, handler: handler)
+        let generation = nextGeneration(for: key)
+        scheduleDrain(for: key, owner: owner, generation: generation, handler: handler)
     }
 
     func cancel(for owner: MessageListScrollState) {
         let key = ObjectIdentifier(owner)
         scheduledKeys.remove(key)
         pendingSnapshots[key] = nil
+        nextGeneration(for: key)
+    }
+
+    @discardableResult
+    private func nextGeneration(for key: ObjectIdentifier) -> Int {
+        let next = (generations[key] ?? 0) + 1
+        generations[key] = next
+        return next
     }
 
     private func scheduleDrain(
         for key: ObjectIdentifier,
         owner: MessageListScrollState,
+        generation: Int,
         handler: @escaping @MainActor (ScrollGeometrySnapshot) -> Void
     ) {
         DispatchQueue.main.async { [weak self, weak owner] in
             Task { @MainActor [weak self, weak owner] in
                 guard let self else { return }
+                guard self.generations[key] == generation else { return }
                 guard let owner else {
                     self.pendingSnapshots[key] = nil
                     self.scheduledKeys.remove(key)
                     return
                 }
-                self.drainNext(for: key, owner: owner, handler: handler)
+                self.drainNext(for: key, owner: owner, generation: generation, handler: handler)
             }
         }
     }
@@ -98,8 +110,10 @@ final class ScrollGeometryUpdateDispatcher {
     private func drainNext(
         for key: ObjectIdentifier,
         owner: MessageListScrollState,
+        generation: Int,
         handler: @escaping @MainActor (ScrollGeometrySnapshot) -> Void
     ) {
+        guard generations[key] == generation else { return }
         guard let latest = pendingSnapshots[key] else {
             scheduledKeys.remove(key)
             return
@@ -113,7 +127,7 @@ final class ScrollGeometryUpdateDispatcher {
             return
         }
 
-        scheduleDrain(for: key, owner: owner, handler: handler)
+        scheduleDrain(for: key, owner: owner, generation: generation, handler: handler)
     }
 }
 


### PR DESCRIPTION
Addresses review feedback on #23899. Adds a per-owner generation counter that increments on cancel and enqueue. Stale DispatchQueue.main.async drain blocks check the generation before processing, rejecting outdated drains that could apply geometry decisions with a stale handler.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23924" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
