### PR TITLE
fix: normalize PKB text before dedup comparison

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -790,10 +790,13 @@ export async function runAgentLoopImpl(
     // Only inject PKB if it changed since the last injection in the
     // conversation.  Keeping the previous injection in place avoids mutating
     // historical user messages and preserves the cached prefix.
+    // Note: injectPkbContext escapes </pkb> sequences before writing to history,
+    // so we must apply the same escaping before comparing to avoid false mismatches.
     const currentPkbContent = readPkbContext();
     const lastInjectedPkb = findLastInjectedPkbContent(ctx.messages);
+    const escapedCurrentPkb = currentPkbContent?.replace(/<\/pkb\s*>/gi, "&lt;/pkb&gt;") ?? null;
     const pkbContext =
-      currentPkbContent !== lastInjectedPkb ? currentPkbContent : null;
+      escapedCurrentPkb !== lastInjectedPkb ? currentPkbContent : null;
 
     // Shared injection options — reused whenever we need to re-inject after reduction.
     const injectionOpts = {


### PR DESCRIPTION
Addresses review feedback on #23876. Applies the same escaping to current PKB content before comparing with the last injected block, preventing false mismatches when PKB contains </pkb> sequences.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
