### PR TITLE
fix: guard NOW.md re-injection on actual history stripping

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1210,8 +1210,16 @@ export async function runAgentLoopImpl(
     // limit), incorporate those new messages into ctx.messages so the
     // convergence loop operates on the full (larger) history.
     if (state.contextTooLargeDetected) {
+      // Track whether ctx.messages was actually stripped so we know if
+      // NOW.md (and other injections) need to be re-injected.  When the
+      // provider rejects before adding any messages, the strip is skipped
+      // and ctx.messages still contains the previous injection — blindly
+      // re-injecting would duplicate the NOW.md block.
+      let convergenceStripped = false;
+
       if (updatedHistory.length > preRunHistoryLength) {
         ctx.messages = stripInjectionsForCompaction(updatedHistory);
+        convergenceStripped = true;
         preRepairMessages = updatedHistory;
         preRunHistoryLength = updatedHistory.length;
       }
@@ -1334,12 +1342,13 @@ export async function runAgentLoopImpl(
           shouldInjectWorkspace = true;
         }
 
-        // ctx.messages has been stripped (line 1206/1373) so NOW.md must
-        // always be re-injected regardless of whether compaction ran.
+        // Only re-inject NOW.md when ctx.messages was actually stripped;
+        // otherwise the existing NOW.md block is still present and
+        // re-injecting would duplicate it.
         runMessages = applyRuntimeInjections(ctx.messages, {
           ...injectionOpts,
           pkbContext: currentPkbContent,
-          nowScratchpad: currentNowContent,
+          nowScratchpad: convergenceStripped ? currentNowContent : null,
           workspaceTopLevelContext: shouldInjectWorkspace
             ? ctx.workspaceTopLevelContext
             : null,
@@ -1381,6 +1390,7 @@ export async function runAgentLoopImpl(
           // pre-rerun messages.
           if (updatedHistory.length > preRunHistoryLength) {
             ctx.messages = stripInjectionsForCompaction(updatedHistory);
+            convergenceStripped = true;
             preRepairMessages = updatedHistory;
             preRunHistoryLength = updatedHistory.length;
           }
@@ -1456,12 +1466,12 @@ export async function runAgentLoopImpl(
               shouldInjectWorkspace = true;
             }
 
-            // ctx.messages was already stripped before the convergence
-            // loop, so NOW.md must always be re-injected here.
+            // Only re-inject NOW.md when ctx.messages was actually stripped;
+            // otherwise the existing block is still present.
             runMessages = applyRuntimeInjections(ctx.messages, {
               ...injectionOpts,
               pkbContext: currentPkbContent,
-              nowScratchpad: currentNowContent,
+              nowScratchpad: convergenceStripped ? currentNowContent : null,
               workspaceTopLevelContext: shouldInjectWorkspace
                 ? ctx.workspaceTopLevelContext
                 : null,
@@ -1576,12 +1586,12 @@ export async function runAgentLoopImpl(
             shouldInjectWorkspace = true;
           }
 
-          // ctx.messages was already stripped before the convergence
-          // loop, so NOW.md must always be re-injected here.
+          // Only re-inject NOW.md when ctx.messages was actually stripped;
+          // otherwise the existing block is still present.
           runMessages = applyRuntimeInjections(ctx.messages, {
             ...injectionOpts,
             pkbContext: currentPkbContent,
-            nowScratchpad: currentNowContent,
+            nowScratchpad: convergenceStripped ? currentNowContent : null,
             workspaceTopLevelContext: shouldInjectWorkspace
               ? ctx.workspaceTopLevelContext
               : null,


### PR DESCRIPTION
Addresses review feedback on #23735. NOW.md re-injection is now gated on whether history stripping actually occurred, preventing duplication in the context_too_large convergence path where the strip condition is not met.

When the provider rejects with context_too_large before adding messages, `updatedHistory.length <= preRunHistoryLength` so the `stripInjectionsForCompaction()` call is skipped. Previously, the re-injection sites unconditionally passed `nowScratchpad: currentNowContent`, duplicating the existing NOW.md block on each convergence retry. Now a `convergenceStripped` flag tracks whether stripping actually ran, and all three convergence re-injection sites gate on it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23927" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
