### PR TITLE
fix: honor empty _autoinject.md and revert migration 029 modification

### DIFF
--- a/assistant/src/__tests__/pkb-autoinject.test.ts
+++ b/assistant/src/__tests__/pkb-autoinject.test.ts
@@ -36,18 +36,18 @@ describe("readAutoinjectList", () => {
     expect(readAutoinjectList(pkbDir)).toBeNull();
   });
 
-  test("returns null when _autoinject.md is empty", () => {
+  test("returns empty array when _autoinject.md is empty", () => {
     writeFileSync(join(pkbDir, "_autoinject.md"), "", "utf-8");
-    expect(readAutoinjectList(pkbDir)).toBeNull();
+    expect(readAutoinjectList(pkbDir)).toEqual([]);
   });
 
-  test("returns null when _autoinject.md contains only comments", () => {
+  test("returns empty array when _autoinject.md contains only comments", () => {
     writeFileSync(
       join(pkbDir, "_autoinject.md"),
       "_ This is a comment\n_ Another comment\n",
       "utf-8",
     );
-    expect(readAutoinjectList(pkbDir)).toBeNull();
+    expect(readAutoinjectList(pkbDir)).toEqual([]);
   });
 
   test("parses standard default content", () => {

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -562,7 +562,7 @@ export function readAutoinjectList(pkbDir: string): string[] | null {
       .split("\n")
       .map((l) => l.trim())
       .filter((l) => l.length > 0);
-    return files.length > 0 ? files : null;
+    return files.length > 0 ? files : [];
   } catch {
     return null;
   }

--- a/assistant/src/workspace/migrations/029-seed-pkb.ts
+++ b/assistant/src/workspace/migrations/029-seed-pkb.ts
@@ -13,7 +13,7 @@ const INDEX_TEMPLATE = `_ Lines starting with _ are comments - they won't appear
 - essentials.md — Core facts, patterns, and biographical info
 - threads.md — Active commitments, follow-ups, and projects in progress
 - buffer.md — Inbox of recently learned facts (filed periodically)
-- _autoinject.md — Controls which files are loaded into every conversation
+
 
 ## Topics
 `;


### PR DESCRIPTION
Addresses review feedback on #23894. (1) readAutoinjectList() now returns an empty array when the file exists but has no entries, allowing users to disable all autoinjection. (2) Reverts the modification to released migration 029, since migration 030 already handles adding the _autoinject.md entry to INDEX.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23928" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
