### PR TITLE
fix: scope system_notice stripping to runtime-injected blocks only

### DIFF
--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1081,7 +1081,7 @@ const RUNTIME_INJECTION_PREFIXES = [
   "<now_scratchpad>", // backward-compat: strip legacy blocks from pre-rename history
   "<pkb>",
   "<transport_hints>",
-  "<system_notice>",
+  "<system_notice>One or more tool calls returned an error.",
 ];
 
 /**

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -722,15 +722,12 @@ function mergeToolResultsIntoAssistantMessages(
       }
     }
 
-    // No tool results → pass through unless the message is purely system notices.
+    // No tool results → pass through unchanged. System notices are only
+    // injected alongside tool results in the agent loop, so a pure user
+    // message (no tool_result blocks) should never be filtered — even if
+    // the user's text happens to look like a system_notice tag.
     if (toolResultBlocks.length === 0) {
-      const hasRealContent = blocks.some((block) => {
-        if (typeof block !== "object" || block === null) return true;
-        return !isSystemNoticeText(block as Record<string, unknown>);
-      });
-      if (hasRealContent) {
-        result.push(msg);
-      }
+      result.push(msg);
       continue;
     }
 


### PR DESCRIPTION
## Summary
Addresses review feedback on #23900. Scopes system_notice filtering to runtime-injected blocks only, preventing user-authored text starting with `<system_notice>` from being stripped during compaction or dropped from history API responses.

- **conversation-routes.ts**: Removed the `isSystemNoticeText` filter from the no-tool-results branch. Since system notices are only injected alongside tool results in the agent loop, pure user messages (no tool_result blocks) are now passed through unchanged — even if the user's text happens to look like a system_notice tag.
- **conversation-runtime-assembly.ts**: Replaced the broad `"<system_notice>"` prefix in `RUNTIME_INJECTION_PREFIXES` with the specific text the runtime actually injects (`"<system_notice>One or more tool calls returned an error."`), so `stripInjectionsForCompaction` won't match arbitrary user text that starts with `<system_notice>`.

## Test plan
- [ ] Verify that user-authored messages containing `<system_notice>` text are preserved in conversation history API output
- [ ] Verify that runtime-injected system notices (tool error nudges) are still properly stripped during compaction
- [ ] Verify that tool-result merging still works correctly for messages with system_notice + tool_result blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23929" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
