### PR TITLE
test(macos): add JSONL detection contract regression test

### DIFF
--- a/clients/macos/vellum-assistantTests/SharedFileViewerComponentsTests.swift
+++ b/clients/macos/vellum-assistantTests/SharedFileViewerComponentsTests.swift
@@ -88,4 +88,36 @@ final class SharedFileViewerComponentsTests: XCTestCase {
     func testIsJSONLContentFalseForPlainText() {
         XCTAssertFalse(isJSONLContent(fileName: "notes.txt", mimeType: "text/plain"))
     }
+
+    // MARK: - Detection contract
+
+    func testJsonlDetectionContractIsConsistent() {
+        // FileContentView wires .tree mode to JSONTreeView with
+        // isJSONL: isJSONLContent(...). For the wiring to be coherent, every
+        // file that gets [.tree, .source] from JSONL detection must also be
+        // recognized by isJSONLContent — and vice versa.
+        let cases: [(String, String)] = [
+            ("messages.jsonl", ""),
+            ("events.ndjson", ""),
+            ("anything.txt", "application/jsonl"),
+            ("anything.txt", "application/x-ndjson"),
+            ("anything.txt", "application/x-jsonlines"),
+            ("anything.txt", "application/jsonlines"),
+        ]
+        for (name, mime) in cases {
+            XCTAssertTrue(
+                isJSONLContent(fileName: name, mimeType: mime),
+                "\(name) / \(mime) should be JSONL"
+            )
+            XCTAssertTrue(
+                availableViewModes(for: name, mimeType: mime).contains(.tree),
+                "\(name) / \(mime) should expose .tree mode"
+            )
+        }
+
+        // Inverse: regular JSON must NOT be flagged as JSONL even though it
+        // also gets [.tree, .source].
+        XCTAssertFalse(isJSONLContent(fileName: "data.json", mimeType: "application/json"))
+        XCTAssertTrue(availableViewModes(for: "data.json", mimeType: "application/json").contains(.tree))
+    }
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for macos-jsonl-viewer.md.

**Gap:** Missing `testJsonlDetectionContractIsConsistent` regression test
**What was expected:** A regression test that pins the invariant that `availableViewModes` and `isJSONLContent` stay in sync, so `FileContentView`'s wiring (which depends on both) never silently breaks due to future drift.
**What was found:** The test was specified in the original plan's PR 5 step 3 but was never added during execution (PR 5 was absorbed into PR 4 without this particular test).

Part of plan: macos-jsonl-viewer.md (post-review remediation)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23930" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
