### PR TITLE
feat(log-export): include conversations with in-window message activity

### DIFF
--- a/assistant/src/runtime/routes/log-export/AGENTS.md
+++ b/assistant/src/runtime/routes/log-export/AGENTS.md
@@ -83,9 +83,19 @@ most-relevant records first.
 
 - **`conversations/`**
   - **Path**: `<workspace>/conversations/<ISO-with-dashes>_<conversationId>/`
-  - **Honors filters**: time (via the parsed timestamp prefix on each
-    directory name) and `conversationId` (exact match on the suffix — no
-    substring matching).
+  - **Honors filters**: time (union of parsed `createdAt` prefix _and_
+    per-message `ts` inside `messages.jsonl`) and `conversationId`
+    (exact match on the directory-name suffix — no substring matching).
+  - **Time semantics**: A conversation directory is included if EITHER
+    its `createdAt` (parsed from the directory name) falls in the
+    requested window OR `messages.jsonl` contains at least one message
+    whose `ts` falls in the window. The cheap directory-name check runs
+    first; the per-message scan only runs as a fallback when the cheap
+    check failed, so the common in-window case stays IO-free. This is
+    the "support bundle" union — false positives are cheaper than false
+    negatives because the user almost always wants the conversations
+    they were _active in_ during the window, not just the ones they
+    _started_ during it.
   - **Cap**: shares the 10 MB workspace cap defined by
     `MAX_WORKSPACE_PAYLOAD_BYTES` in `workspace-allowlist.ts`.
   - **Notes**: Directory names that don't match the canonical

--- a/assistant/src/runtime/routes/log-export/__tests__/workspace-allowlist.test.ts
+++ b/assistant/src/runtime/routes/log-export/__tests__/workspace-allowlist.test.ts
@@ -340,6 +340,104 @@ describe("collectWorkspaceData — conversations entry", () => {
     expect(existsSync(join(staging, "workspace", "conversations"))).toBe(false);
   });
 
+  test("canonical-named symlinks are rejected before the message-window scan runs", () => {
+    // Symlink creation requires elevated permissions on Windows; skip
+    // there to avoid spurious failures in CI on Windows hosts.
+    if (process.platform === "win32") return;
+
+    // Create an external directory containing a messages.jsonl whose
+    // single message timestamp falls inside the requested window. If
+    // the message-window scan ever follows the symlink, it would
+    // mistakenly include the symlink because the in-window message
+    // would "match". The boundary guard must reject the symlink first
+    // so the scan never reads outside `conversations/`.
+    const externalTarget = mkdtempSync(
+      join(tmpdir(), "ws-allowlist-symlink-msg-"),
+    );
+    try {
+      writeFileSync(
+        join(externalTarget, "meta.json"),
+        JSON.stringify({ name: "evil" }, null, 2),
+        "utf-8",
+      );
+      writeFileSync(
+        join(externalTarget, "messages.jsonl"),
+        '{"role":"user","ts":"2025-01-18T12:00:00.000Z","content":"in window"}\n',
+        "utf-8",
+      );
+
+      const conversationsDir = getConversationsDir();
+      mkdirSync(conversationsDir, { recursive: true });
+
+      // Canonical name with createdAt OUTSIDE the window so the cheap
+      // check fails and the message-window fallback would normally fire.
+      const evilName = "2025-01-10T00-00-00.000Z_evil-target";
+      symlinkSync(externalTarget, join(conversationsDir, evilName), "dir");
+
+      const result = collectWorkspaceData({
+        staging,
+        startTime: Date.parse("2025-01-14T00:00:00Z"),
+        endTime: Date.parse("2025-01-22T00:00:00Z"),
+      });
+
+      // The boundary guard must reject the symlink before the message
+      // scan ever opens the external messages.jsonl. Nothing must land
+      // in the staging directory.
+      expect(result.entries).toHaveLength(1);
+      const [entry] = result.entries;
+      expect(entry.itemCount).toBe(0);
+      expect(entry.bytes).toBe(0);
+      expect(entry.skippedDueToCap).toBe(0);
+      expect(existsSync(join(staging, "workspace", "conversations"))).toBe(
+        false,
+      );
+    } finally {
+      rmSync(externalTarget, { recursive: true, force: true });
+    }
+  });
+
+  test("streaming scan finds an in-window message in a large messages.jsonl", () => {
+    // Build a messages.jsonl that's large enough to span multiple
+    // 64 KB read chunks. Padding messages have an out-of-window ts; a
+    // single in-window message is buried near the end so the scan must
+    // actually traverse most of the file to find it. This exercises
+    // the streaming + UTF-8 boundary handling without ever loading
+    // the whole file into a single string.
+    const conversationsDir = getConversationsDir();
+    mkdirSync(conversationsDir, { recursive: true });
+    const dir = join(conversationsDir, CONV_DIRS.jan10);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "meta.json"),
+      JSON.stringify({ name: CONV_DIRS.jan10 }, null, 2),
+      "utf-8",
+    );
+
+    const padLine = `{"role":"user","ts":"2025-01-10T00:00:00.000Z","content":"${"x".repeat(500)}"}`;
+    const matchLine =
+      '{"role":"user","ts":"2025-01-18T12:00:00.000Z","content":"hit"}';
+    // ~500 padding lines + 1 match line ≈ 250 KB, well over a single
+    // 64 KB chunk.
+    const lines: string[] = [];
+    for (let i = 0; i < 500; i++) lines.push(padLine);
+    lines.push(matchLine);
+    writeFileSync(
+      join(dir, "messages.jsonl"),
+      lines.join("\n") + "\n",
+      "utf-8",
+    );
+
+    const result = collectWorkspaceData({
+      staging,
+      startTime: Date.parse("2025-01-14T00:00:00Z"),
+      endTime: Date.parse("2025-01-22T00:00:00Z"),
+    });
+
+    expect(result.entries[0].itemCount).toBe(1);
+    const copied = readdirSync(join(staging, "workspace", "conversations"));
+    expect(copied).toEqual([CONV_DIRS.jan10]);
+  });
+
   test("malformed messages.jsonl lines are silently skipped during the window scan", () => {
     // Conversation created on Jan 10 (out of window). messages.jsonl
     // has garbage on most lines but ONE valid line whose ts is in

--- a/assistant/src/runtime/routes/log-export/__tests__/workspace-allowlist.test.ts
+++ b/assistant/src/runtime/routes/log-export/__tests__/workspace-allowlist.test.ts
@@ -225,6 +225,158 @@ describe("collectWorkspaceData — conversations entry", () => {
     expect(existsSync(join(staging, "workspace", "conversations"))).toBe(false);
   });
 
+  test("includes conversation when createdAt is outside window but a message ts is inside", () => {
+    // Conversation was created on Jan 10 but received a message on
+    // Jan 18. With a [Jan 14, Jan 22] window, the directory-name parse
+    // says "out of window" but the message scan should keep it.
+    const conversationsDir = getConversationsDir();
+    mkdirSync(conversationsDir, { recursive: true });
+    const dir = join(conversationsDir, CONV_DIRS.jan10);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "meta.json"),
+      JSON.stringify({ name: CONV_DIRS.jan10 }, null, 2),
+      "utf-8",
+    );
+    writeFileSync(
+      join(dir, "messages.jsonl"),
+      [
+        '{"role":"user","ts":"2025-01-10T00:00:00.000Z","content":"created"}',
+        '{"role":"user","ts":"2025-01-18T12:00:00.000Z","content":"in window"}',
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const result = collectWorkspaceData({
+      staging,
+      startTime: Date.parse("2025-01-14T00:00:00Z"),
+      endTime: Date.parse("2025-01-22T00:00:00Z"),
+    });
+
+    expect(result.entries[0].itemCount).toBe(1);
+    const copied = readdirSync(join(staging, "workspace", "conversations"));
+    expect(copied).toEqual([CONV_DIRS.jan10]);
+  });
+
+  test("excludes conversation when createdAt and every message ts are outside the window", () => {
+    // Conversation created on Jan 10 with messages only before/after the
+    // [Jan 14, Jan 22] window. Both filters miss → directory must be skipped.
+    const conversationsDir = getConversationsDir();
+    mkdirSync(conversationsDir, { recursive: true });
+    const dir = join(conversationsDir, CONV_DIRS.jan10);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "meta.json"),
+      JSON.stringify({ name: CONV_DIRS.jan10 }, null, 2),
+      "utf-8",
+    );
+    writeFileSync(
+      join(dir, "messages.jsonl"),
+      [
+        '{"role":"user","ts":"2025-01-10T00:00:00.000Z","content":"too early"}',
+        '{"role":"user","ts":"2025-01-12T00:00:00.000Z","content":"still early"}',
+        '{"role":"user","ts":"2025-01-25T00:00:00.000Z","content":"too late"}',
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const result = collectWorkspaceData({
+      staging,
+      startTime: Date.parse("2025-01-14T00:00:00Z"),
+      endTime: Date.parse("2025-01-22T00:00:00Z"),
+    });
+
+    expect(result.entries[0].itemCount).toBe(0);
+    expect(existsSync(join(staging, "workspace", "conversations"))).toBe(false);
+  });
+
+  test("includes conversation when createdAt is in window even if messages.jsonl is missing", () => {
+    // Conversation created on Jan 15 with no messages.jsonl yet (e.g.
+    // brand-new conversation). The cheap createdAt check is enough; we
+    // should never even open messages.jsonl.
+    const conversationsDir = getConversationsDir();
+    mkdirSync(conversationsDir, { recursive: true });
+    const dir = join(conversationsDir, CONV_DIRS.jan15);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "meta.json"),
+      JSON.stringify({ name: CONV_DIRS.jan15 }, null, 2),
+      "utf-8",
+    );
+
+    const result = collectWorkspaceData({
+      staging,
+      startTime: Date.parse("2025-01-14T00:00:00Z"),
+      endTime: Date.parse("2025-01-22T00:00:00Z"),
+    });
+
+    expect(result.entries[0].itemCount).toBe(1);
+    const copied = readdirSync(join(staging, "workspace", "conversations"));
+    expect(copied).toEqual([CONV_DIRS.jan15]);
+  });
+
+  test("excludes conversation when createdAt is out of window and messages.jsonl is missing", () => {
+    // Conversation created on Jan 10 (out of window) with no
+    // messages.jsonl at all. Both checks miss → skip.
+    const conversationsDir = getConversationsDir();
+    mkdirSync(conversationsDir, { recursive: true });
+    const dir = join(conversationsDir, CONV_DIRS.jan10);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "meta.json"),
+      JSON.stringify({ name: CONV_DIRS.jan10 }, null, 2),
+      "utf-8",
+    );
+
+    const result = collectWorkspaceData({
+      staging,
+      startTime: Date.parse("2025-01-14T00:00:00Z"),
+      endTime: Date.parse("2025-01-22T00:00:00Z"),
+    });
+
+    expect(result.entries[0].itemCount).toBe(0);
+    expect(existsSync(join(staging, "workspace", "conversations"))).toBe(false);
+  });
+
+  test("malformed messages.jsonl lines are silently skipped during the window scan", () => {
+    // Conversation created on Jan 10 (out of window). messages.jsonl
+    // has garbage on most lines but ONE valid line whose ts is in
+    // window — that single valid line should be enough to keep the dir.
+    const conversationsDir = getConversationsDir();
+    mkdirSync(conversationsDir, { recursive: true });
+    const dir = join(conversationsDir, CONV_DIRS.jan10);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "meta.json"),
+      JSON.stringify({ name: CONV_DIRS.jan10 }, null, 2),
+      "utf-8",
+    );
+    writeFileSync(
+      join(dir, "messages.jsonl"),
+      [
+        "not json at all",
+        '{"role":"user"}', // missing ts
+        '{"role":"user","ts":"not-a-date"}', // ts isn't parseable
+        '{"role":"user","ts":42}', // ts is wrong type
+        '{"role":"user","ts":"2025-01-18T12:00:00.000Z","content":"valid"}',
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const result = collectWorkspaceData({
+      staging,
+      startTime: Date.parse("2025-01-14T00:00:00Z"),
+      endTime: Date.parse("2025-01-22T00:00:00Z"),
+    });
+
+    expect(result.entries[0].itemCount).toBe(1);
+    const copied = readdirSync(join(staging, "workspace", "conversations"));
+    expect(copied).toEqual([CONV_DIRS.jan10]);
+  });
+
   test("byte cap enforcement skips every conversation when too tight", () => {
     seedConversations();
 

--- a/assistant/src/runtime/routes/log-export/workspace-allowlist.ts
+++ b/assistant/src/runtime/routes/log-export/workspace-allowlist.ts
@@ -14,7 +14,14 @@
  * `<ISO-with-dashes>_<conversationId>` format are silently skipped (Rule 3).
  */
 
-import { cpSync, existsSync, lstatSync, mkdirSync, readdirSync } from "node:fs";
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+} from "node:fs";
 import { join } from "node:path";
 
 import { parseConversationDirName } from "../../../memory/conversation-directories.js";
@@ -117,6 +124,64 @@ function dirSizeWithinBudget(
   return total;
 }
 
+/**
+ * Scan a conversation's `messages.jsonl` file and report whether any
+ * message's `ts` (an ISO 8601 string written by `conversation-disk-view`)
+ * falls inside the `[startTime, endTime]` window.
+ *
+ * Returns:
+ *   - `true`  if at least one message timestamp lies in the window.
+ *   - `false` otherwise (including: file is missing, file is empty, every
+ *     line fails to parse, or no parsed line lands in the window).
+ *
+ * Lines that fail to parse as JSON or whose `ts` is not a parseable date
+ * are silently skipped — they shouldn't be able to make the function
+ * throw, since the export pipeline must never crash on a malformed
+ * conversation file.
+ *
+ * The scan bails out as soon as it finds the first matching message, so
+ * the worst case for an in-window conversation is "one early hit", and
+ * the worst case for an out-of-window conversation is "read the whole
+ * file once". Files are bounded by the workspace cap so this is safe.
+ */
+function conversationHasMessageInWindow(
+  conversationDir: string,
+  startTime: number | undefined,
+  endTime: number | undefined,
+): boolean {
+  // No window means every message trivially "matches", but the only
+  // caller (`collectConversations`) already short-circuits in that case
+  // and never invokes this helper. Defensive check kept so the helper is
+  // safe to reuse.
+  if (startTime === undefined && endTime === undefined) return true;
+
+  const messagesPath = join(conversationDir, "messages.jsonl");
+  let raw: string;
+  try {
+    raw = readFileSync(messagesPath, "utf-8");
+  } catch {
+    // Missing or unreadable messages file → no in-window evidence.
+    return false;
+  }
+
+  for (const line of raw.split("\n")) {
+    if (!line) continue;
+    let record: { ts?: unknown };
+    try {
+      record = JSON.parse(line) as { ts?: unknown };
+    } catch {
+      continue;
+    }
+    if (typeof record.ts !== "string") continue;
+    const ms = Date.parse(record.ts);
+    if (Number.isNaN(ms)) continue;
+    if (startTime !== undefined && ms < startTime) continue;
+    if (endTime !== undefined && ms > endTime) continue;
+    return true;
+  }
+  return false;
+}
+
 function collectConversations(
   opts: CollectWorkspaceDataOptions,
   result: CollectWorkspaceDataResult,
@@ -182,11 +247,41 @@ function collectConversations(
     ) {
       continue;
     }
-    if (opts.startTime !== undefined && parsed.createdAtMs < opts.startTime) {
-      continue;
-    }
-    if (opts.endTime !== undefined && parsed.createdAtMs > opts.endTime) {
-      continue;
+
+    // Time-window filter: keep the conversation if EITHER its createdAt
+    // (parsed from the directory name) OR any individual message inside
+    // `messages.jsonl` falls in the requested window. This is the union
+    // semantics — a conversation that was started before the window but
+    // received messages during it should still ship, since the user
+    // running an export almost always wants to see the activity that
+    // happened during the window, not just conversations that were
+    // _created_ in it.
+    if (opts.startTime !== undefined || opts.endTime !== undefined) {
+      const createdAtInWindow =
+        (opts.startTime === undefined ||
+          parsed.createdAtMs >= opts.startTime) &&
+        (opts.endTime === undefined || parsed.createdAtMs <= opts.endTime);
+      if (!createdAtInWindow) {
+        // Fall back to scanning messages.jsonl for in-window activity.
+        // This is more expensive than the directory-name parse, so we
+        // only do it when the cheap check failed.
+        const conversationDir = join(sourceDir, name);
+        let hasMessageInWindow: boolean;
+        try {
+          hasMessageInWindow = conversationHasMessageInWindow(
+            conversationDir,
+            opts.startTime,
+            opts.endTime,
+          );
+        } catch (err) {
+          log.warn(
+            { err, conversationDir },
+            "Failed to scan messages.jsonl for window match; skipping",
+          );
+          continue;
+        }
+        if (!hasMessageInWindow) continue;
+      }
     }
 
     candidates.push({ name, parsed });

--- a/assistant/src/runtime/routes/log-export/workspace-allowlist.ts
+++ b/assistant/src/runtime/routes/log-export/workspace-allowlist.ts
@@ -15,14 +15,17 @@
  */
 
 import {
+  closeSync,
   cpSync,
   existsSync,
   lstatSync,
   mkdirSync,
+  openSync,
   readdirSync,
-  readFileSync,
+  readSync,
 } from "node:fs";
 import { join } from "node:path";
+import { StringDecoder } from "node:string_decoder";
 
 import { parseConversationDirName } from "../../../memory/conversation-directories.js";
 import { getLogger } from "../../../util/logger.js";
@@ -125,6 +128,41 @@ function dirSizeWithinBudget(
 }
 
 /**
+ * Chunk size used by the streaming `messages.jsonl` reader. 64 KB is
+ * large enough to amortize syscall overhead but small enough to keep
+ * the synchronous read path off the event loop for any meaningful
+ * stretch.
+ */
+const MESSAGES_SCAN_CHUNK_BYTES = 64 * 1024;
+
+/**
+ * Check whether a single JSONL line records a message whose `ts` falls
+ * in the `[startTime, endTime]` window. Returns `false` for malformed
+ * lines, missing/wrong-typed `ts` fields, and dates outside the window.
+ * Pulled out as a helper so the streaming reader can call it on each
+ * decoded line without duplicating the parsing logic.
+ */
+function lineMatchesWindow(
+  line: string,
+  startTime: number | undefined,
+  endTime: number | undefined,
+): boolean {
+  if (!line) return false;
+  let record: { ts?: unknown };
+  try {
+    record = JSON.parse(line) as { ts?: unknown };
+  } catch {
+    return false;
+  }
+  if (typeof record.ts !== "string") return false;
+  const ms = Date.parse(record.ts);
+  if (Number.isNaN(ms)) return false;
+  if (startTime !== undefined && ms < startTime) return false;
+  if (endTime !== undefined && ms > endTime) return false;
+  return true;
+}
+
+/**
  * Scan a conversation's `messages.jsonl` file and report whether any
  * message's `ts` (an ISO 8601 string written by `conversation-disk-view`)
  * falls inside the `[startTime, endTime]` window.
@@ -139,10 +177,13 @@ function dirSizeWithinBudget(
  * throw, since the export pipeline must never crash on a malformed
  * conversation file.
  *
- * The scan bails out as soon as it finds the first matching message, so
- * the worst case for an in-window conversation is "one early hit", and
- * the worst case for an out-of-window conversation is "read the whole
- * file once". Files are bounded by the workspace cap so this is safe.
+ * The reader streams the file in fixed-size chunks (`MESSAGES_SCAN_CHUNK_BYTES`)
+ * via `readSync` and decodes UTF-8 across chunk boundaries with
+ * `StringDecoder`. It bails out as soon as it finds the first matching
+ * line, so the worst case for an in-window conversation is "one early
+ * hit", and the worst case for an out-of-window conversation is "read
+ * the whole file once" — without ever holding more than one chunk plus
+ * one in-progress line in memory.
  */
 function conversationHasMessageInWindow(
   conversationDir: string,
@@ -156,28 +197,41 @@ function conversationHasMessageInWindow(
   if (startTime === undefined && endTime === undefined) return true;
 
   const messagesPath = join(conversationDir, "messages.jsonl");
-  let raw: string;
+  let fd: number;
   try {
-    raw = readFileSync(messagesPath, "utf-8");
+    fd = openSync(messagesPath, "r");
   } catch {
     // Missing or unreadable messages file → no in-window evidence.
     return false;
   }
 
-  for (const line of raw.split("\n")) {
-    if (!line) continue;
-    let record: { ts?: unknown };
-    try {
-      record = JSON.parse(line) as { ts?: unknown };
-    } catch {
-      continue;
+  const buffer = Buffer.alloc(MESSAGES_SCAN_CHUNK_BYTES);
+  const decoder = new StringDecoder("utf8");
+  let leftover = "";
+  try {
+    while (true) {
+      const bytesRead = readSync(fd, buffer, 0, buffer.length, null);
+      if (bytesRead === 0) break;
+      const text = leftover + decoder.write(buffer.subarray(0, bytesRead));
+      const lines = text.split("\n");
+      // The last segment may be a partial line — hold it back for the
+      // next chunk to complete.
+      leftover = lines.pop() ?? "";
+      for (const line of lines) {
+        if (lineMatchesWindow(line, startTime, endTime)) return true;
+      }
     }
-    if (typeof record.ts !== "string") continue;
-    const ms = Date.parse(record.ts);
-    if (Number.isNaN(ms)) continue;
-    if (startTime !== undefined && ms < startTime) continue;
-    if (endTime !== undefined && ms > endTime) continue;
-    return true;
+    // Drain any partial UTF-8 sequence the decoder is still holding,
+    // then check the final unterminated line (the file may not end with
+    // a newline).
+    const tail = leftover + decoder.end();
+    if (lineMatchesWindow(tail, startTime, endTime)) return true;
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+      /* best-effort close */
+    }
   }
   return false;
 }
@@ -219,11 +273,16 @@ function collectConversations(
 
   const destBase = join(opts.staging, "workspace", "conversations");
 
-  // First pass: parse + filter all names and collect the surviving
-  // candidates so we can sort them deterministically before applying the
-  // byte cap. Without this, `readdirSync` order determines which
-  // conversations are dropped on truncation, which both makes capped
-  // exports nondeterministic and can drop the newest conversations.
+  // First pass: parse the name, apply the conversationId filter, validate
+  // that the entry is a real directory (not a symlink, not a regular
+  // file), then apply the time-window filter (which may need to read
+  // `messages.jsonl`). Collect surviving candidates so we can sort them
+  // deterministically before applying the byte cap.
+  //
+  // The non-directory / symlink validation happens BEFORE the message
+  // scan so a canonical-named symlink can never coerce
+  // `conversationHasMessageInWindow` into reading from outside the
+  // `conversations/` boundary.
   const candidates: Array<{
     name: string;
     parsed: { conversationId: string; createdAtMs: number };
@@ -248,58 +307,16 @@ function collectConversations(
       continue;
     }
 
-    // Time-window filter: keep the conversation if EITHER its createdAt
-    // (parsed from the directory name) OR any individual message inside
-    // `messages.jsonl` falls in the requested window. This is the union
-    // semantics — a conversation that was started before the window but
-    // received messages during it should still ship, since the user
-    // running an export almost always wants to see the activity that
-    // happened during the window, not just conversations that were
-    // _created_ in it.
-    if (opts.startTime !== undefined || opts.endTime !== undefined) {
-      const createdAtInWindow =
-        (opts.startTime === undefined ||
-          parsed.createdAtMs >= opts.startTime) &&
-        (opts.endTime === undefined || parsed.createdAtMs <= opts.endTime);
-      if (!createdAtInWindow) {
-        // Fall back to scanning messages.jsonl for in-window activity.
-        // This is more expensive than the directory-name parse, so we
-        // only do it when the cheap check failed.
-        const conversationDir = join(sourceDir, name);
-        let hasMessageInWindow: boolean;
-        try {
-          hasMessageInWindow = conversationHasMessageInWindow(
-            conversationDir,
-            opts.startTime,
-            opts.endTime,
-          );
-        } catch (err) {
-          log.warn(
-            { err, conversationDir },
-            "Failed to scan messages.jsonl for window match; skipping",
-          );
-          continue;
-        }
-        if (!hasMessageInWindow) continue;
-      }
-    }
-
-    candidates.push({ name, parsed });
-  }
-
-  // Newest first so cap-truncation keeps the most recent conversations.
-  candidates.sort((a, b) => b.parsed.createdAtMs - a.parsed.createdAtMs);
-
-  for (const { name } of candidates) {
     const srcPath = join(sourceDir, name);
 
-    // Guard: a canonical-looking entry must be a real directory under
-    // `conversations/`. Use `lstatSync` (not `statSync`) so symlinks are
-    // not dereferenced — a symlink with a canonical name pointing at an
-    // external directory must not be allowed to escape the allowlist
-    // boundary. Symlinks are rejected explicitly below; regular files
-    // (and anything else that isn't a directory) are also skipped so
-    // `dirSizeWithinBudget` and `cpSync` never see them.
+    // Boundary guard: a canonical-looking entry must be a real directory
+    // under `conversations/`. Use `lstatSync` (not `statSync`) so
+    // symlinks are not dereferenced — a symlink with a canonical name
+    // pointing at an external directory must not be allowed to escape
+    // the allowlist boundary, neither for the time-window message scan
+    // below nor for the eventual `cpSync` copy. Symlinks and regular
+    // files are rejected explicitly here so the message scan and the
+    // copy loop only ever see real directories.
     let srcStat: ReturnType<typeof lstatSync>;
     try {
       srcStat = lstatSync(srcPath);
@@ -318,6 +335,52 @@ function collectConversations(
       log.warn({ srcPath }, "Conversation entry is not a directory; skipping");
       continue;
     }
+
+    // Time-window filter: keep the conversation if EITHER its createdAt
+    // (parsed from the directory name) OR any individual message inside
+    // `messages.jsonl` falls in the requested window. This is the union
+    // semantics — a conversation that was started before the window but
+    // received messages during it should still ship, since the user
+    // running an export almost always wants to see the activity that
+    // happened during the window, not just conversations that were
+    // _created_ in it.
+    if (opts.startTime !== undefined || opts.endTime !== undefined) {
+      const createdAtInWindow =
+        (opts.startTime === undefined ||
+          parsed.createdAtMs >= opts.startTime) &&
+        (opts.endTime === undefined || parsed.createdAtMs <= opts.endTime);
+      if (!createdAtInWindow) {
+        // Fall back to scanning messages.jsonl for in-window activity.
+        // This is more expensive than the directory-name parse, so we
+        // only do it when the cheap check failed. The boundary guard
+        // above guarantees `srcPath` is a real in-allowlist directory,
+        // so the file path the scanner reads stays inside the allowlist.
+        let hasMessageInWindow: boolean;
+        try {
+          hasMessageInWindow = conversationHasMessageInWindow(
+            srcPath,
+            opts.startTime,
+            opts.endTime,
+          );
+        } catch (err) {
+          log.warn(
+            { err, srcPath },
+            "Failed to scan messages.jsonl for window match; skipping",
+          );
+          continue;
+        }
+        if (!hasMessageInWindow) continue;
+      }
+    }
+
+    candidates.push({ name, parsed });
+  }
+
+  // Newest first so cap-truncation keeps the most recent conversations.
+  candidates.sort((a, b) => b.parsed.createdAtMs - a.parsed.createdAtMs);
+
+  for (const { name } of candidates) {
+    const srcPath = join(sourceDir, name);
 
     const remainingBudget = maxBytes - result.totalBytes;
     let dirBytes: number | null;


### PR DESCRIPTION
## Summary
- The workspace allowlist time filter now keeps a conversation directory if EITHER its `createdAt` (parsed from the directory name) OR any individual message's `ts` inside `messages.jsonl` falls in the requested `[startTime, endTime]` window.
- Adds a new `conversationHasMessageInWindow` helper that scans `messages.jsonl` only as a fallback when the cheap directory-name check fails, so the common in-window case stays IO-free. Bails on first match.
- Updates `assistant/src/runtime/routes/log-export/AGENTS.md` to document the union semantics and 5 new tests in `workspace-allowlist.test.ts` covering: in-window message rescues an out-of-window createdAt, all-out-of-window misses, missing messages.jsonl with in-window createdAt, missing messages.jsonl with out-of-window createdAt, and malformed JSONL lines being silently skipped.

## Original prompt
Option 2

(Switch the workspace-allowlist conversation time filter from "createdAt only" to "union of createdAt and any in-window message ts" so a conversation started before the window but messaged during it still ships in the support bundle.)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23932" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
