### PR TITLE
fix: use minHeight pattern for scroll spacer instead of conditional spacer

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -55,7 +55,6 @@ struct MessageListContentView: View, Equatable {
             && lhs.highlightedMessageId == rhs.highlightedMessageId
             && lhs.mediaEmbedSettings == rhs.mediaEmbedSettings
             && lhs.hasEverSentMessage == rhs.hasEverSentMessage
-            && lhs.isSending == rhs.isSending
             && lhs.showInspectButton == rhs.showInspectButton
             && lhs.isTTSEnabled == rhs.isTTSEnabled
             && lhs.selectedModel == rhs.selectedModel
@@ -78,7 +77,6 @@ struct MessageListContentView: View, Equatable {
     let highlightedMessageId: UUID?
     let mediaEmbedSettings: MediaEmbedResolverSettings?
     let hasEverSentMessage: Bool
-    let isSending: Bool
     let showInspectButton: Bool
     let isTTSEnabled: Bool
     let selectedModel: String
@@ -270,13 +268,6 @@ struct MessageListContentView: View, Equatable {
                 compactingIndicatorRow()
             }
 
-            // Dynamic spacer: ensures user message can reach top even with short assistant output
-            if isSending {
-                Color.clear
-                    .frame(height: max(0, viewportHeight - 100))
-                    .id("scroll-bottom-spacer")
-            }
-
             // Bottom anchor for explicit jumps
             Color.clear
                 .frame(height: 1)
@@ -297,6 +288,7 @@ struct MessageListContentView: View, Equatable {
         .padding(.top, VSpacing.md)
         .padding(.bottom, VSpacing.md)
         .frame(maxWidth: VSpacing.chatColumnMaxWidth)
+        .frame(minHeight: viewportHeight, alignment: .top)
         .frame(maxWidth: .infinity)
         .environment(\.bubbleMaxWidth, containerWidth > 0
             ? min(VSpacing.chatBubbleMaxWidth, max(containerWidth - 2 * VSpacing.xl, 0))

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -104,10 +104,6 @@ final class MessageListScrollState {
     /// from initial position). Used to gate initial auto-scroll behavior.
     @ObservationIgnored var hasBeenInteracted: Bool = false
 
-    /// Whether a message is currently being sent/streamed.
-    /// Used to subtract the conditional spacer height from `distanceFromBottom`.
-    @ObservationIgnored var isSending: Bool = false
-
     // MARK: - Derived State Cache
 
     /// Non-observable cache for memoizing derived state computations.
@@ -118,15 +114,8 @@ final class MessageListScrollState {
     // MARK: - Computed Properties
 
     /// Distance from the bottom of the scrollable content.
-    /// When sending, subtracts the conditional spacer height so that
-    /// near-bottom detection is based on actual content, not the spacer.
     var distanceFromBottom: CGFloat {
-        let raw = contentHeight - contentOffsetY - viewportHeight
-        if isSending {
-            let spacerHeight = max(0, viewportHeight - 100)
-            return raw - spacerHeight
-        }
-        return raw
+        contentHeight - contentOffsetY - viewportHeight
     }
 
     /// Whether auto-follow should engage: near bottom and not yet anchored
@@ -248,7 +237,6 @@ final class MessageListScrollState {
         lastAutoFocusedRequestId = nil
         bottomAnchorAppeared = false
         hasBeenInteracted = false
-        isSending = false
         derivedStateCache.reset()
 
         scrollLog.debug("Reset for conversation: \(conversationId)")

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
@@ -374,7 +374,6 @@ extension MessageListView {
             highlightedMessageId: highlightedMessageId,
             mediaEmbedSettings: mediaEmbedSettings,
             hasEverSentMessage: hasEverSentMessage,
-            isSending: isSending,
             showInspectButton: showInspectButton,
             isTTSEnabled: isTTSEnabled,
             selectedModel: selectedModel,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -14,7 +14,6 @@ extension MessageListView {
         scrollState.contentOffsetY = newState.contentOffsetY
         scrollState.contentHeight = newState.contentHeight
         scrollState.viewportHeight = newState.visibleRectHeight
-        scrollState.isSending = isSending
         scrollState.updateNearBottom()
 
         // Derive sentinel position from content offset (inverted sign to


### PR DESCRIPTION
## Summary
- Replace conditional isSending spacer with frame(minHeight: viewportHeight, alignment: .top)
- Content naturally fills from top; no empty gap below last message
- Remove isSending plumbing from ContentView, ScrollState, and ScrollHandling
- Simplify distanceFromBottom back to basic subtraction

Part of plan: spacer-minheight-fix.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23933" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
