### PR TITLE
fix: harden conversation analysis trust and tool access

### DIFF
--- a/assistant/src/__tests__/assistant-event-hub.test.ts
+++ b/assistant/src/__tests__/assistant-event-hub.test.ts
@@ -102,6 +102,36 @@ describe("AssistantEventHub — fanout", () => {
     const hub = new AssistantEventHub();
     await expect(hub.publish(makeEvent())).resolves.toBeUndefined();
   });
+
+  test("hasSubscribersForEvent returns true for assistant-wide subscribers", () => {
+    const hub = new AssistantEventHub();
+    hub.subscribe({ assistantId: "ast_1" }, () => {});
+
+    expect(
+      hub.hasSubscribersForEvent({
+        assistantId: "ast_1",
+        conversationId: "sess_A",
+      }),
+    ).toBe(true);
+  });
+
+  test("hasSubscribersForEvent honors conversation scoping", () => {
+    const hub = new AssistantEventHub();
+    hub.subscribe({ assistantId: "ast_1", conversationId: "sess_A" }, () => {});
+
+    expect(
+      hub.hasSubscribersForEvent({
+        assistantId: "ast_1",
+        conversationId: "sess_A",
+      }),
+    ).toBe(true);
+    expect(
+      hub.hasSubscribersForEvent({
+        assistantId: "ast_1",
+        conversationId: "sess_B",
+      }),
+    ).toBe(false);
+  });
 });
 
 // ── Unsubscribe / cleanup ────────────────────────────────────────────────────

--- a/assistant/src/__tests__/conversation-analysis-routes.test.ts
+++ b/assistant/src/__tests__/conversation-analysis-routes.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+const mockResolveConversationId = mock((id: string) => id);
+const mockGetConversation = mock(() => ({
+  id: "conv-1",
+  title: "Source",
+  conversationType: "normal",
+}));
+const mockGetMessages = mock(() => [{ id: "m-source" }]);
+const mockCreateConversation = mock(() => ({ id: "analysis-1" }));
+const mockAddMessage = mock(async () => ({ id: "msg-1" }));
+
+mock.module("../memory/conversation-key-store.js", () => ({
+  resolveConversationId: mockResolveConversationId,
+}));
+
+mock.module("../memory/conversation-crud.js", () => ({
+  getConversation: mockGetConversation,
+  getMessages: mockGetMessages,
+  createConversation: mockCreateConversation,
+  addMessage: mockAddMessage,
+}));
+
+mock.module("../export/transcript-formatter.js", () => ({
+  buildAnalysisTranscript: () => "user: hi",
+}));
+
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
+import { AssistantEventHub } from "../runtime/assistant-event-hub.js";
+import type { SendMessageDeps } from "../runtime/http-types.js";
+import { conversationAnalysisRouteDefinitions } from "../runtime/routes/conversation-analysis-routes.js";
+
+beforeEach(() => {
+  mockResolveConversationId.mockClear();
+  mockGetConversation.mockClear();
+  mockGetMessages.mockClear();
+  mockCreateConversation.mockClear();
+  mockAddMessage.mockClear();
+});
+
+function getAnalyzeRoute() {
+  const routes = conversationAnalysisRouteDefinitions({
+    sendMessageDeps: null as never,
+    buildConversationDetailResponse: () => ({ id: "analysis-1" }),
+  });
+  const route = routes.find(
+    (r) => r.method === "POST" && r.endpoint === "conversations/:id/analyze",
+  );
+  if (!route) throw new Error("analyze route missing");
+  return route;
+}
+
+function makeConversation() {
+  return {
+    setTrustContext: mock(() => {}),
+    ensureActorScopedHistory: mock(() => Promise.resolve()),
+    setSubagentAllowedTools: mock(() => {}),
+    updateClient: mock(() => {}),
+    processing: false,
+    abortController: null as AbortController | null,
+    currentRequestId: null as string | null,
+    runAgentLoop: mock(() => Promise.resolve()),
+  };
+}
+
+describe("POST /v1/conversations/:id/analyze", () => {
+  test("runs headless analysis with unknown trust and no tools when no subscriber is present", async () => {
+    const conversation = makeConversation();
+    const assistantEventHub = new AssistantEventHub();
+    const sendMessageDeps = {
+      getOrCreateConversation: mock(async () => conversation),
+      assistantEventHub,
+      resolveAttachments: () => [],
+    } as unknown as SendMessageDeps;
+
+    const routes = conversationAnalysisRouteDefinitions({
+      sendMessageDeps,
+      buildConversationDetailResponse: () => ({ id: "analysis-1" }),
+    });
+    const route = routes.find(
+      (r) => r.method === "POST" && r.endpoint === "conversations/:id/analyze",
+    );
+    if (!route) throw new Error("analyze route missing");
+
+    const req = new Request("http://localhost/v1/conversations/conv-1/analyze", {
+      method: "POST",
+    });
+
+    const res = await route.handler({
+      req,
+      url: new URL(req.url),
+      server: null as never,
+      authContext: {} as never,
+      params: { id: "conv-1" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockAddMessage).toHaveBeenCalledWith(
+      "analysis-1",
+      "user",
+      expect.any(String),
+      { provenanceTrustClass: "unknown" },
+    );
+    expect(conversation.setTrustContext).toHaveBeenCalledWith({
+      trustClass: "unknown",
+      sourceChannel: "vellum",
+    });
+    expect(conversation.ensureActorScopedHistory).toHaveBeenCalledTimes(1);
+    expect(conversation.setSubagentAllowedTools).toHaveBeenCalledTimes(1);
+    const allowedTools = (
+      conversation.setSubagentAllowedTools.mock.calls as unknown as Array<
+        [Set<string> | undefined]
+      >
+    )[0]?.[0];
+    expect(allowedTools).toBeInstanceOf(Set);
+    expect(allowedTools?.size).toBe(0);
+    expect(conversation.updateClient).toHaveBeenCalledWith(
+      expect.any(Function),
+      true,
+    );
+    expect(conversation.runAgentLoop).toHaveBeenCalledWith(
+      expect.any(String),
+      "msg-1",
+      expect.any(Function),
+      expect.objectContaining({ isInteractive: false, isUserMessage: true }),
+    );
+  });
+
+  test("marks analysis interactive when a matching subscriber is already connected", async () => {
+    const conversation = makeConversation();
+    const assistantEventHub = new AssistantEventHub();
+    assistantEventHub.subscribe(
+      { assistantId: DAEMON_INTERNAL_ASSISTANT_ID },
+      () => {},
+    );
+    const sendMessageDeps = {
+      getOrCreateConversation: mock(async () => conversation),
+      assistantEventHub,
+      resolveAttachments: () => [],
+    } as unknown as SendMessageDeps;
+
+    const routes = conversationAnalysisRouteDefinitions({
+      sendMessageDeps,
+      buildConversationDetailResponse: () => ({ id: "analysis-1" }),
+    });
+    const route = routes.find(
+      (r) => r.method === "POST" && r.endpoint === "conversations/:id/analyze",
+    );
+    if (!route) throw new Error("analyze route missing");
+
+    const req = new Request("http://localhost/v1/conversations/conv-1/analyze", {
+      method: "POST",
+    });
+
+    await route.handler({
+      req,
+      url: new URL(req.url),
+      server: null as never,
+      authContext: {} as never,
+      params: { id: "conv-1" },
+    });
+
+    expect(conversation.updateClient).toHaveBeenCalledWith(
+      expect.any(Function),
+      false,
+    );
+    expect(conversation.runAgentLoop).toHaveBeenCalledWith(
+      expect.any(String),
+      "msg-1",
+      expect.any(Function),
+      expect.objectContaining({ isInteractive: true, isUserMessage: true }),
+    );
+  });
+});

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -156,6 +156,28 @@ export class AssistantEventHub {
     }
   }
 
+  /**
+   * Returns true when at least one active subscriber would receive the given
+   * event based on the same assistant/conversation matching rules as publish().
+   */
+  hasSubscribersForEvent(
+    event: Pick<AssistantEvent, "assistantId" | "conversationId">,
+  ): boolean {
+    for (const entry of this.subscribers) {
+      if (!entry.active) continue;
+      if (entry.filter.assistantId !== event.assistantId) continue;
+      if (
+        event.conversationId != null &&
+        entry.filter.conversationId != null &&
+        entry.filter.conversationId !== event.conversationId
+      ) {
+        continue;
+      }
+      return true;
+    }
+    return false;
+  }
+
   /** Number of currently active subscribers (useful for tests and caps). */
   subscriberCount(): number {
     return this.subscribers.size;

--- a/assistant/src/runtime/routes/conversation-analysis-routes.ts
+++ b/assistant/src/runtime/routes/conversation-analysis-routes.ts
@@ -19,7 +19,6 @@ import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 import type { SendMessageDeps } from "../http-types.js";
-import { resolveLocalTrustContext } from "../local-actor-identity.js";
 
 const log = getLogger("conversation-analysis-routes");
 
@@ -115,22 +114,34 @@ Analyze the conversation above. Provide a structured self-assessment:
 
 Be honest and specific. Reference particular moments in the transcript. Focus on patterns that generalize beyond this specific conversation.
 
-If you identify insights worth remembering for future conversations, use your memory tools to save them.`;
+Do not use tools during analysis. If you identify insights worth remembering for future conversations, include them in the response as explicit memory candidates instead of saving them directly.`;
 
         // h. Persist the user message
         const message = await addMessage(
           newConv.id,
           "user",
           JSON.stringify([{ type: "text", text: prompt }]),
-          { provenanceTrustClass: "guardian" as const },
+          { provenanceTrustClass: "unknown" as const },
         );
         const messageId = message.id;
 
-        // i. Load the conversation into memory and set guardian trust context
+        // i. Load the conversation into memory with untrusted analysis context
         const analysisConversation =
           await deps.sendMessageDeps.getOrCreateConversation(newConv.id);
-        analysisConversation.setTrustContext(resolveLocalTrustContext("vellum"));
+        analysisConversation.setTrustContext({
+          trustClass: "unknown",
+          sourceChannel: "vellum",
+        });
         await analysisConversation.ensureActorScopedHistory();
+        // Analysis runs over attacker-influenced transcript content, so do not
+        // expose any tools, even when a live client is available.
+        analysisConversation.setSubagentAllowedTools(new Set<string>());
+
+        const hasLiveSubscriber =
+          deps.sendMessageDeps.assistantEventHub.hasSubscribersForEvent({
+            assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+            conversationId: newConv.id,
+          });
 
         // j. Build onEvent using inline hub publisher
         const onEvent = (msg: ServerMessage) => {
@@ -138,6 +149,7 @@ If you identify insights worth remembering for future conversations, use your me
             buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, msg, newConv.id),
           );
         };
+        analysisConversation.updateClient(onEvent, !hasLiveSubscriber);
 
         // k. Set up processing state (required by runAgentLoop guard)
         analysisConversation.processing = true;
@@ -147,7 +159,7 @@ If you identify insights worth remembering for future conversations, use your me
         // l. Fire-and-forget the agent loop
         analysisConversation
           .runAgentLoop(prompt, messageId, onEvent, {
-            isInteractive: false,
+            isInteractive: hasLiveSubscriber,
             isUserMessage: true,
           })
           .catch((err) => {


### PR DESCRIPTION
## Summary
- Downgrade conversation analysis from guardian trust to unknown trust class with no tool access, since the analysis prompt includes attacker-influenced transcript content
- Add `hasSubscribersForEvent()` to `AssistantEventHub` to detect live SSE subscribers, making analysis interactive only when a client is connected
- Add comprehensive tests for the hardened analysis route and the new event hub method

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23934" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
