### PR TITLE
fix(menu): keep Share Feedback modal on top when opening dropdown

### DIFF
--- a/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
@@ -27,6 +27,13 @@ public class VMenuPanel: NSPanel {
     ///
     /// - Parameters:
     ///   - screenPoint: Cursor position in screen coordinates.
+    ///   - sourceWindow: The window the menu was opened from. When provided, this is
+    ///     used as the parent window for `addChildWindow(_:ordered:)`. When `nil`,
+    ///     the source window is inferred from the topmost window containing
+    ///     `screenPoint` (front-to-back via `NSApp.orderedWindows`). Callers that
+    ///     already know which window owns the trigger (e.g. `VDropdown`) should
+    ///     pass it explicitly to avoid the geometric heuristic picking the wrong
+    ///     window when multiple app windows overlap the click point.
     ///   - sourceAppearance: The source window's appearance for correct color resolution.
     ///   - content: The SwiftUI view to display (typically a `VMenu`).
     ///   - onDismiss: Called when the panel is dismissed for any reason.
@@ -34,6 +41,7 @@ public class VMenuPanel: NSPanel {
     @discardableResult
     public static func show<Content: View>(
         at screenPoint: CGPoint,
+        sourceWindow: NSWindow? = nil,
         sourceAppearance: NSAppearance? = nil,
         excludeRect: CGRect? = nil,
         @ViewBuilder content: () -> Content,
@@ -99,21 +107,29 @@ public class VMenuPanel: NSPanel {
         let origin = clampedOrigin(for: menuSize, cursorAt: screenPoint)
         panel.setFrame(CGRect(origin: origin, size: menuSize), display: true)
 
-        // Detect the source window before ordering the panel to avoid
-        // picking up the panel itself in the window list.
-        let sourceWindow = NSApp.windows.first(where: { $0.frame.contains(screenPoint) && !($0 is VMenuPanel) })
+        // Resolve the parent window for child-window attachment. Prefer the
+        // explicit `sourceWindow` passed by the caller — they know which
+        // window owns the trigger. Fall back to a front-to-back geometric
+        // search when no source is provided (e.g. `vContextMenu`). We use
+        // `orderedWindows` (z-order) rather than `windows` (creation order)
+        // so the topmost window containing the click point wins; otherwise
+        // an older window stacked behind a newer modal would be picked up
+        // and `addChildWindow` would shove the modal behind it.
+        let resolvedSourceWindow: NSWindow? = sourceWindow ?? NSApp.orderedWindows.first(where: {
+            $0.isVisible && $0.frame.contains(screenPoint) && !($0 is VMenuPanel)
+        })
 
         panel.makeKeyAndOrderFront(nil)
 
         // Attach as a child window so the menu stays grouped with its
         // parent and doesn't float above unrelated windows from other apps.
         // See: https://developer.apple.com/documentation/appkit/nswindow/addchildwindow(_:ordered:)
-        if let sourceWindow {
-            sourceWindow.addChildWindow(panel, ordered: .above)
+        if let resolvedSourceWindow {
+            resolvedSourceWindow.addChildWindow(panel, ordered: .above)
         }
 
         // Register with coordinator — it installs the unified click monitor
-        coordinator.registerRootPanel(panel, sourceWindow: sourceWindow, excludeRect: excludeRect, onDismiss: onDismiss)
+        coordinator.registerRootPanel(panel, sourceWindow: resolvedSourceWindow, excludeRect: excludeRect, onDismiss: onDismiss)
 
         // Notify VoiceOver that a new menu appeared so it navigates into it.
         DispatchQueue.main.async {
@@ -363,9 +379,12 @@ private struct VContextMenuModifier<MenuContent: View>: ViewModifier {
                 panelRef.value = nil
                 oldPanel?.close()
 
-                // Capture appearance from the window under the cursor at click time
-                let appearance = NSApp.windows
-                    .first(where: { $0.frame.contains(screenPoint) })?
+                // Capture appearance from the window under the cursor at click time.
+                // Use `orderedWindows` (front-to-back z-order) so we pick the topmost
+                // window the click landed in — `NSApp.windows` is creation order and
+                // can return an older window stacked behind a newer one.
+                let appearance = NSApp.orderedWindows
+                    .first(where: { $0.isVisible && $0.frame.contains(screenPoint) })?
                     .effectiveAppearance
 
                 let newPanel = VMenuPanel.show(

--- a/clients/shared/DesignSystem/Core/Inputs/VDropdown.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VDropdown.swift
@@ -210,7 +210,14 @@ public struct VDropdown<T: Hashable>: View {
         )
 
         let appearance = window.effectiveAppearance
-        activePanel = VMenuPanel.show(at: screenPoint, sourceAppearance: appearance, excludeRect: triggerScreenRect) {
+        // Pass the resolved source window explicitly so VMenuPanel attaches the
+        // popup as a child of the trigger's window. Without this, VMenuPanel
+        // would fall back to a geometric search and could pick up the wrong
+        // window when the trigger lives in a modal that overlaps a larger
+        // window behind it (e.g. the Share Feedback modal over the main app
+        // window) — attaching to the wrong parent shoves the modal behind via
+        // `addChildWindow`.
+        activePanel = VMenuPanel.show(at: screenPoint, sourceWindow: window, sourceAppearance: appearance, excludeRect: triggerScreenRect) {
             VMenu(width: menuWidth) {
                 ForEach(optionList) { option in
                     VMenuItem(


### PR DESCRIPTION
## Summary

- Fix Share Feedback modal getting pushed behind the main app window when its time-range dropdown is opened. Root cause: `VMenuPanel.show()` resolved the popup's parent window via `NSApp.windows.first(where: frame.contains)`, but `NSApp.windows` is creation order — so the older main window (which also overlaps the click point) was picked over the newer Share Feedback modal, and `addChildWindow` shoved the modal behind.
- Add an optional `sourceWindow:` parameter to `VMenuPanel.show()` so callers that already know the trigger's window can pass it explicitly. `VDropdown` now does this — it had already resolved the right window via `NSApp.keyWindow` for screen-point math but never threaded it through.
- For callers that don't pass an explicit source window (e.g. `vContextMenu`), fall back to `NSApp.orderedWindows` (front-to-back z-order) instead of `NSApp.windows`, so the topmost window containing the click point wins. Same fix applied to `VContextMenuModifier`'s appearance lookup.

## Original prompt

the fix
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
