### PR TITLE
fix: clear pending async text apply when switching to sync path in SelectableTextView

### DIFF
--- a/clients/shared/DesignSystem/Components/Display/SelectableTextView.swift
+++ b/clients/shared/DesignSystem/Components/Display/SelectableTextView.swift
@@ -160,6 +160,7 @@ public struct VSelectableTextView: NSViewRepresentable {
         if useExternalSizing {
             coordinator.scheduleAttributedStringApply(attributedString, lineSpacing: lineSpacing, to: textView)
         } else {
+            coordinator.cancelPendingApply()
             coordinator.applyAttributedString(attributedString, lineSpacing: lineSpacing, to: textView)
         }
     }
@@ -207,6 +208,12 @@ public struct VSelectableTextView: NSViewRepresentable {
             pendingLineSpacing = nil
             pendingTextView = nil
             hasScheduledApply = false
+        }
+
+        func cancelPendingApply() {
+            pendingAttributedString = nil
+            pendingLineSpacing = nil
+            pendingTextView = nil
         }
 
         func scheduleAttributedStringApply(


### PR DESCRIPTION
Addresses review feedback on #23918. Cancels any pending async text apply when the synchronous code path is taken, preventing stale content from being re-applied by a previously queued callback.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23937" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
