### PR TITLE
test: add cancel-invalidates-pending-drain test for ScrollGeometryUpdateDispatcher

### DIFF
--- a/clients/macos/vellum-assistantTests/MessageListScrollGeometryDispatcherTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollGeometryDispatcherTests.swift
@@ -79,4 +79,30 @@ final class MessageListScrollGeometryDispatcherTests: XCTestCase {
         await fulfillment(of: [markerReached, secondDelivery], timeout: 1.0)
         XCTAssertEqual(trace, ["first-start", "first-end", "marker", "second"])
     }
+
+    func testCancelInvalidatesPendingDrain() async {
+        let dispatcher = ScrollGeometryUpdateDispatcher()
+        let owner = MessageListScrollState()
+
+        let snapshot = ScrollGeometrySnapshot(
+            contentOffsetY: 5,
+            contentHeight: 200,
+            containerHeight: 100,
+            visibleRectHeight: 100
+        )
+
+        var handlerCalled = false
+        dispatcher.enqueue(for: owner, snapshot: snapshot) { _ in
+            handlerCalled = true
+        }
+        dispatcher.cancel(for: owner)
+
+        // Allow the run loop to drain so the scheduled DispatchQueue.main.async
+        // block executes (it should see a mismatched generation and bail out).
+        let drained = expectation(description: "run loop drained")
+        DispatchQueue.main.async { drained.fulfill() }
+        await fulfillment(of: [drained], timeout: 1.0)
+
+        XCTAssertFalse(handlerCalled, "Handler must not be invoked after cancel(for:) invalidates the pending drain")
+    }
 }


### PR DESCRIPTION
Addresses review feedback on #23924. Adds a test that verifies calling cancel(for:) after enqueue prevents the handler from being invoked, directly validating the generation counter mechanism.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23938" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
