### PR TITLE
docs: update readAutoinjectList docstring to reflect null vs empty array semantics

### DIFF
--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -550,8 +550,12 @@ const PKB_NUDGE =
 
 /**
  * Read `_autoinject.md` from the PKB directory and return the list of
- * filenames to inject. Returns `null` when the file is missing, empty,
- * or unreadable — callers should fall back to the hardcoded defaults.
+ * filenames to inject.
+ *
+ * - Returns `null` when the file is missing or unreadable — callers
+ *   should fall back to the hardcoded defaults.
+ * - Returns `[]` when the file exists but has no entries (empty or
+ *   comments only) — an explicit opt-out meaning "inject nothing."
  */
 export function readAutoinjectList(pkbDir: string): string[] | null {
   const filePath = join(pkbDir, AUTOINJECT_FILENAME);


### PR DESCRIPTION
Addresses review feedback on #23928. Updates the readAutoinjectList docstring to accurately document that null means missing/unreadable (triggers default fallback) while an empty array means the file exists but has no entries (explicit opt-out).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
