### PR TITLE
fix: cache markdown segments in ThinkingBlockView to avoid reparsing on every render

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
@@ -9,11 +9,18 @@ struct ThinkingBlockView: View {
     let isStreaming: Bool
 
     @State private var isExpanded: Bool
+    /// Cached parsed markdown segments — updated only when `content` changes,
+    /// not on every SwiftUI body evaluation. Avoids synchronous O(n) reparsing
+    /// on each token update while streaming with the block expanded.
+    @State private var cachedSegments: [MarkdownSegment]
+    @State private var cachedContent: String
 
     init(content: String, isStreaming: Bool, initiallyExpanded: Bool = false) {
         self.content = content
         self.isStreaming = isStreaming
         _isExpanded = State(initialValue: initiallyExpanded)
+        _cachedSegments = State(initialValue: parseMarkdownSegments(content))
+        _cachedContent = State(initialValue: content)
     }
 
     static func makeMarkdownView(content: String, isStreaming: Bool) -> MarkdownSegmentView {
@@ -38,7 +45,17 @@ struct ThinkingBlockView: View {
                 Divider()
                     .padding(.horizontal, VSpacing.sm)
 
-                Self.makeMarkdownView(content: content, isStreaming: isStreaming)
+                MarkdownSegmentView(
+                    segments: cachedSegments,
+                    isStreaming: isStreaming,
+                    maxContentWidth: nil,
+                    textColor: VColor.contentSecondary,
+                    secondaryTextColor: VColor.contentTertiary,
+                    mutedTextColor: VColor.contentTertiary,
+                    tintColor: VColor.primaryBase,
+                    codeTextColor: VColor.contentDefault,
+                    codeBackgroundColor: VColor.surfaceBase
+                )
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(VSpacing.sm)
                 .transition(.opacity)
@@ -46,6 +63,11 @@ struct ThinkingBlockView: View {
         }
         .background(VColor.surfaceOverlay)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .onChange(of: content) { _, newContent in
+            guard newContent != cachedContent else { return }
+            cachedContent = newContent
+            cachedSegments = parseMarkdownSegments(newContent)
+        }
     }
 
     // MARK: - Header


### PR DESCRIPTION
Addresses review feedback on #23915. Adds segment caching to ThinkingBlockView so parseMarkdownSegments is only called when content changes, matching the pattern used by ChatBubbleTextContent.cachedSegments.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23940" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
