### PR TITLE
fix: replace stripped non-pending messages with fresh server data during history reload

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2116,7 +2116,21 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
             } else {
                 uniqueHistory = chatMessages
             }
-            var mergedMessages = uniqueHistory + self.messages
+            // Replace stripped non-pending messages with fresh server copies.
+            // Pending messages are kept as-is since the server doesn't have
+            // them yet, but stripped messages that already exist on the server
+            // should be refreshed with their full content.
+            let freshById = Dictionary(chatMessages.map { ($0.id, $0) }, uniquingKeysWith: { _, latest in latest })
+            let refreshedExisting = self.messages.map { msg -> ChatMessage in
+                if msg.isContentStripped
+                    && !pendingMessageIds.contains(msg.id)
+                    && msg.status != .pendingOffline,
+                   let fresh = freshById[msg.id] {
+                    return fresh
+                }
+                return msg
+            }
+            var mergedMessages = uniqueHistory + refreshedExisting
             mergedMessages.sort { $0.timestamp < $1.timestamp }
             let hasModelCommand = applyHistoryResponseMarkers(to: &mergedMessages)
             self.messages = mergedMessages


### PR DESCRIPTION
Addresses review feedback on #23921. When the prepend path is taken due to pending messages, stripped non-pending messages are now replaced with their fresh server copies instead of being kept in their stripped state.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23941" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
