### PR TITLE
fix(macos): silence unused-result warning in syncAllKeysToDaemon

### DIFF
--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -192,6 +192,7 @@ enum APIKeyManager {
 
     /// Write a key to the daemon's secret store via the gateway API.
     /// Performs server-side validation and returns the result.
+    @discardableResult
     static func setKey(_ key: String, for provider: String) async -> SetKeyResult {
         do {
             let body: [String: Any] = ["type": "api_key", "name": provider, "value": key]


### PR DESCRIPTION
## Summary
- Mark the async `APIKeyManager.setKey(_:for:)` overload as `@discardableResult` to silence the `#no-usage` warning emitted from `SettingsStore.syncAllKeysToDaemon`, where the result is intentionally fire-and-forget during reconnect re-sync.
- Matches the existing `@discardableResult` annotation on the async `deleteKey(for:)` overload for consistency.

## Original prompt
help me fix these build warnings:

\`\`\`
clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift:1199:41: warning: result of call to 'setKey(_:for:)' is unused [#no-usage]
1197 |             for provider in APIKeyManager.allSyncableProviders {
1198 |                 if let key = APIKeyManager.getKey(for: provider) {
1199 |                     await APIKeyManager.setKey(key, for: provider)
     |                                         \`- warning: result of call to 'setKey(_:for:)' is unused [#no-usage]
1200 |                 }
1201 |             }
\`\`\`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23945" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
