### PR TITLE
fix: add bottom spacer for user-message-at-top spacing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -268,6 +268,13 @@ struct MessageListContentView: View, Equatable {
                 compactingIndicatorRow()
             }
 
+            // Bottom fill: ensures content area is tall enough for user message
+            // to reach viewport top. Since scroll targets go to lastMessageId
+            // (not the anchor), this space is only visible at absolute bottom.
+            Color.clear
+                .frame(height: max(0, viewportHeight - 100))
+                .allowsHitTesting(false)
+
             // Bottom anchor for explicit jumps
             Color.clear
                 .frame(height: 1)
@@ -288,7 +295,6 @@ struct MessageListContentView: View, Equatable {
         .padding(.top, VSpacing.md)
         .padding(.bottom, VSpacing.md)
         .frame(maxWidth: VSpacing.chatColumnMaxWidth)
-        .frame(minHeight: viewportHeight, alignment: .top)
         .frame(maxWidth: .infinity)
         .environment(\.bubbleMaxWidth, containerWidth > 0
             ? min(VSpacing.chatBubbleMaxWidth, max(containerWidth - 2 * VSpacing.xl, 0))


### PR DESCRIPTION
## Summary
- Remove non-functional frame(minHeight:) on LazyVStack
- Add explicit bottom spacer (viewportHeight - 100) before anchor
- Scroll targets go to lastMessageId so spacer is never the scroll destination

Part of plan: scroll-polish-fixes.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23946" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
