### PR TITLE
M1: Add archiveAllConversations(ids:) to ConversationManager

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -694,6 +694,69 @@ final class ConversationManager: ConversationRestorerDelegate {
         log.info("Archived conversation \(id)")
     }
 
+    func archiveAllConversations(ids: [UUID]) {
+        guard !ids.isEmpty else { return }
+
+        var needsReorder = false
+        var newlyArchivedServerIds = Set<String>()
+        let idsSet = Set(ids)
+
+        for i in listStore.conversations.indices where idsSet.contains(listStore.conversations[i].id) {
+            if listStore.conversations[i].displayOrder != nil {
+                needsReorder = true
+            }
+            listStore.conversations[i].isArchived = true
+            listStore.conversations[i].displayOrder = nil
+            if let cid = listStore.conversations[i].conversationId {
+                newlyArchivedServerIds.insert(cid)
+            }
+        }
+
+        if !newlyArchivedServerIds.isEmpty {
+            var archived = listStore.archivedConversationIds
+            archived.formUnion(newlyArchivedServerIds)
+            listStore.archivedConversationIds = archived
+        }
+
+        for id in ids {
+            guard listStore.conversations.contains(where: { $0.id == id }) else { continue }
+
+            AppDelegate.shared?.threadWindowManager?.closeThread(conversationLocalId: id)
+            selectionStore.pinnedViewModelIds.remove(id)
+
+            if let convIndex = listStore.conversations.firstIndex(where: { $0.id == id }) {
+                if listStore.conversations[convIndex].conversationId != nil {
+                    selectionStore.chatViewModels[id]?.stopGenerating()
+                    selectionStore.removeChatViewModel(for: id)
+                } else if selectionStore.chatViewModels[id]?.messages.contains(where: { $0.role == .user }) != true
+                            && selectionStore.chatViewModels[id]?.isBootstrapping != true {
+                    selectionStore.chatViewModels[id]?.stopGenerating()
+                    selectionStore.removeChatViewModel(for: id)
+                } else {
+                    selectionStore.chatViewModels[id]?.cancelPendingMessage()
+                }
+            }
+        }
+
+        if let activeId = selectionStore.activeConversationId, idsSet.contains(activeId) {
+            if listStore.visibleConversations.isEmpty {
+                enterDraftMode()
+            } else if let firstVisibleId = listStore.visibleConversations.first?.id {
+                selectionStore.performActivation(for: firstVisibleId)
+            }
+        } else if listStore.visibleConversations.isEmpty {
+            enterDraftMode()
+        }
+
+        ConversationSelectionStore.clearRenderCaches()
+
+        if needsReorder {
+            listStore.sendReorderConversations()
+        }
+
+        log.info("Archived \(ids.count) conversations")
+    }
+
     func unarchiveConversation(id: UUID) {
         guard let index = listStore.conversations.firstIndex(where: { $0.id == id }) else { return }
         listStore.conversations[index].isArchived = false

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -701,16 +701,18 @@ final class ConversationManager: ConversationRestorerDelegate {
         var newlyArchivedServerIds = Set<String>()
         let idsSet = Set(ids)
 
-        for i in listStore.conversations.indices where idsSet.contains(listStore.conversations[i].id) {
-            if listStore.conversations[i].displayOrder != nil {
+        var draft = listStore.conversations
+        for i in draft.indices where idsSet.contains(draft[i].id) {
+            if draft[i].displayOrder != nil {
                 needsReorder = true
             }
-            listStore.conversations[i].isArchived = true
-            listStore.conversations[i].displayOrder = nil
-            if let cid = listStore.conversations[i].conversationId {
+            draft[i].isArchived = true
+            draft[i].displayOrder = nil
+            if let cid = draft[i].conversationId {
                 newlyArchivedServerIds.insert(cid)
             }
         }
+        listStore.conversations = draft
 
         if !newlyArchivedServerIds.isEmpty {
             var archived = listStore.archivedConversationIds


### PR DESCRIPTION
## Summary
- Add a new `archiveAllConversations(ids: [UUID])` method to `ConversationManager` that bulk-archives a batch of conversations without deleting any group
- Mirrors the archive loop from `deleteGroupAndArchiveConversations` but skips group deletion and group-ID reassignment
- Handles batch update of `archivedConversationIds`, active conversation fallback, render cache clearing, and conditional reorder signaling

## Test plan
- [ ] Verify bulk archiving multiple conversations marks them all as archived
- [ ] Verify active conversation fallback works when the active conversation is among those archived
- [ ] Verify `sendReorderConversations` is only called when at least one archived conversation had a non-nil `displayOrder`
- [ ] Verify empty array input returns immediately with no side effects

Part of #23949.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23954" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
