### PR TITLE
M1: Feature flag & data model

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedItem.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedItem.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+// MARK: - Feed Item Type
+
+/// The category of a feed item.
+public enum FeedItemType: String, Codable, Sendable {
+    case nudge
+    case digest
+    case action
+    case thread
+}
+
+// MARK: - Feed Item Status
+
+/// Lifecycle status of a feed item.
+public enum FeedItemStatus: String, Codable, Sendable {
+    case new
+    case seen
+    case actedOn = "acted_on"
+}
+
+// MARK: - Feed Action
+
+/// An actionable button presented on a feed item.
+public struct FeedAction: Codable, Identifiable, Sendable {
+    public let id: String
+    public let label: String
+
+    public init(id: String, label: String) {
+        self.id = id
+        self.label = label
+    }
+}
+
+// MARK: - Feed Item
+
+/// A single entry in the Home feed.
+public struct FeedItem: Codable, Identifiable, Sendable {
+    public let id: String
+    public let type: FeedItemType
+    public let priority: Int
+    public let title: String
+    public let summary: String
+    public let source: String?
+    public let timestamp: Date
+    public let status: FeedItemStatus
+    public let ttl: Date?
+    public let minTimeAway: TimeInterval?
+    public let actions: [FeedAction]?
+
+    public init(
+        id: String,
+        type: FeedItemType,
+        priority: Int,
+        title: String,
+        summary: String,
+        source: String? = nil,
+        timestamp: Date,
+        status: FeedItemStatus,
+        ttl: Date? = nil,
+        minTimeAway: TimeInterval? = nil,
+        actions: [FeedAction]? = nil
+    ) {
+        self.id = id
+        self.type = type
+        self.priority = priority
+        self.title = title
+        self.summary = summary
+        self.source = source
+        self.timestamp = timestamp
+        self.status = status
+        self.ttl = ttl
+        self.minTimeAway = minTimeAway
+        self.actions = actions
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case type
+        case priority
+        case title
+        case summary
+        case source
+        case timestamp
+        case status
+        case ttl
+        case minTimeAway = "min_time_away"
+        case actions
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedItem.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedItem.swift
@@ -73,18 +73,4 @@ public struct FeedItem: Codable, Identifiable, Sendable {
         self.minTimeAway = minTimeAway
         self.actions = actions
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case type
-        case priority
-        case title
-        case summary
-        case source
-        case timestamp
-        case status
-        case ttl
-        case minTimeAway = "min_time_away"
-        case actions
-    }
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -288,6 +288,14 @@
       "label": "Permission Controls V2",
       "description": "Replace risk-level permission system with two independent controls: 'Ask before acting' (LLM behavior toggle) and 'Host access' (system-enforced gate)",
       "defaultEnabled": false
+    },
+    {
+      "id": "home-feed",
+      "scope": "macos",
+      "key": "home-feed",
+      "label": "Home Feed",
+      "description": "Show the Home feed as the primary navigation destination in the sidebar, with a gateway-served feed API",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Register `home-feed` feature flag (macos scope, disabled by default) in both registry locations
- Create `HomeFeedItem.swift` with FeedItem, FeedAction, FeedItemType, and FeedItemStatus types

Part of #23956
Part of JARVIS-447

## Test plan
- [ ] Verify flag appears in both registry JSON files
- [ ] Verify Swift types compile (SPM build)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23962" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
