### PR TITLE
M2: Add onArchiveAll callback to SidebarSectionHeader and SidebarSectionView

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
@@ -32,6 +32,7 @@ struct SidebarSectionHeader: View {
     var onCommitRename: ((String) -> Void)?
     var onCancelRename: (() -> Void)?
     var onDelete: (() -> Void)?
+    var onArchiveAll: (() -> Void)?
     var sidebar: SidebarInteractionState?
 
     @FocusState private var isRenameFocused: Bool
@@ -142,6 +143,7 @@ struct SidebarSectionHeader: View {
         .modifier(ConditionalGroupContextMenu(
             onRename: onRename.map { rename in { rename(group.name) } },
             onDelete: onDelete,
+            onArchiveAll: onArchiveAll,
             hasConversations: conversationCount > 0
         ))
         .conditionalOnDrag(enabled: !group.isSystemGroup) {
@@ -154,15 +156,26 @@ struct SidebarSectionHeader: View {
 // MARK: - Conditional context menu modifier
 
 /// Only attaches a `.vContextMenu` when at least one action is available.
-/// System groups (where onRename and onDelete are both nil) get no context menu.
+/// System groups (where onRename and onDelete are both nil) get no context menu
+/// unless onArchiveAll is provided.
 private struct ConditionalGroupContextMenu: ViewModifier {
     let onRename: (() -> Void)?
     let onDelete: (() -> Void)?
+    let onArchiveAll: (() -> Void)?
     let hasConversations: Bool
 
     func body(content: Content) -> some View {
-        if onRename != nil || onDelete != nil {
+        if onRename != nil || onDelete != nil || onArchiveAll != nil {
             content.vContextMenu {
+                if let onArchiveAll {
+                    VMenuItem(icon: VIcon.archive.rawValue, label: "Archive All\u{2026}") {
+                        onArchiveAll()
+                    }
+                    .disabled(!hasConversations)
+                }
+                if onArchiveAll != nil && (onRename != nil || onDelete != nil) {
+                    VMenuDivider()
+                }
                 if let onRename {
                     VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename") { onRename() }
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
@@ -32,7 +32,7 @@ struct SidebarSectionHeader: View {
     var onCommitRename: ((String) -> Void)?
     var onCancelRename: (() -> Void)?
     var onDelete: (() -> Void)?
-    var onArchiveAll: (() -> Void)?
+    var onArchiveAll: (() -> Void)? = nil
     var sidebar: SidebarInteractionState?
 
     @FocusState private var isRenameFocused: Bool

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -28,7 +28,7 @@ struct SidebarSectionView: View {
     var onCommitRename: ((String) -> Void)?
     var onCancelRename: (() -> Void)?
     var onDelete: (() -> Void)?
-    var onArchiveAll: (() -> Void)?
+    var onArchiveAll: (() -> Void)? = nil
 
     /// The currently selected conversation ID. Passed through so that SwiftUI
     /// re-evaluates this view's body (and thus re-calls makeRow) when selection changes.

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -28,6 +28,7 @@ struct SidebarSectionView: View {
     var onCommitRename: ((String) -> Void)?
     var onCancelRename: (() -> Void)?
     var onDelete: (() -> Void)?
+    var onArchiveAll: (() -> Void)?
 
     /// The currently selected conversation ID. Passed through so that SwiftUI
     /// re-evaluates this view's body (and thus re-calls makeRow) when selection changes.
@@ -116,6 +117,7 @@ struct SidebarSectionView: View {
             onCommitRename: onCommitRename,
             onCancelRename: onCancelRename,
             onDelete: onDelete,
+            onArchiveAll: onArchiveAll,
             sidebar: sidebar
         )
         .modifier(SectionHeaderDropModifier(


### PR DESCRIPTION
Add optional onArchiveAll closure to sidebar header and section views. Update ConditionalGroupContextMenu to show 'Archive All…' menu item and enable context menus on system groups (which previously had none). Part of #23949.

## Summary
- Add `onArchiveAll: (() -> Void)?` property to `SidebarSectionHeader` and `SidebarSectionView`
- Update `ConditionalGroupContextMenu` guard to also check `onArchiveAll != nil`, enabling context menus on system groups
- Add "Archive All…" menu item at top of context menu with archive icon, disabled when group has 0 conversations
- Add `VMenuDivider()` between Archive All and Rename/Delete sections when both exist
- Pass `onArchiveAll` through from `SidebarSectionView` to `SidebarSectionHeader`

## Test plan
- [ ] Verify custom groups still show Rename and Delete in their context menu
- [ ] Verify system groups gain a context menu when onArchiveAll is wired (M3)
- [ ] Verify "Archive All…" is disabled when conversationCount is 0
- [ ] Verify divider appears between Archive All and Rename/Delete for custom groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
