### PR TITLE
fix: detect actual NOW.md strip state instead of tracking mutation sites in convergence loop

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1213,12 +1213,12 @@ export async function runAgentLoopImpl(
     // limit), incorporate those new messages into ctx.messages so the
     // convergence loop operates on the full (larger) history.
     if (state.contextTooLargeDetected) {
-      // Track whether ctx.messages was actually stripped so we know if
-      // NOW.md (and other injections) need to be re-injected.  When the
-      // provider rejects before adding any messages, the strip is skipped
-      // and ctx.messages still contains the previous injection — blindly
-      // re-injecting would duplicate the NOW.md block.
-      let convergenceStripped = false;
+      // Detect whether ctx.messages currently lacks NOW.md so we know if
+      // it needs to be re-injected.  Mid-loop compaction (line ~1067) may
+      // have already stripped injections before escalating here, so we
+      // check actual message state rather than tracking mutation sites.
+      let convergenceStripped =
+        findLastInjectedNowContent(ctx.messages) === null;
 
       if (updatedHistory.length > preRunHistoryLength) {
         ctx.messages = stripInjectionsForCompaction(updatedHistory);


### PR DESCRIPTION
Addresses review feedback on #23927. `convergenceStripped` was initialized to `false` at the convergence loop entry, but `ctx.messages` may have already been stripped by mid-loop compaction. Now uses `findLastInjectedNowContent` to detect actual message state instead of tracking mutation sites.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23964" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
