### PR TITLE
docs: remove stale nudge-path reference from stripOldImageBlocks JSDoc

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -709,10 +709,10 @@ export function compactAxTreeHistory(messages: Message[]): Message[] {
  * once by the LLM on the turn it was captured, then replaced with a text
  * placeholder on subsequent turns.
  *
- * We look for the last user message with tool_results (not just the last user
- * message) because the empty-response nudge path appends a text-only user
- * message after the tool results. Preserving images in that case ensures
- * the model still sees the screenshot on the retry.
+ * We target the last user message with tool_results (not just the last user
+ * message) because a plain-text user message may follow the tool-result
+ * turn. Using the last user message unconditionally would leave the most
+ * recent tool screenshots unprotected from stripping.
  */
 function stripOldImageBlocks(history: Message[]): Message[] {
   // Find the last user message that contains tool_result blocks.


### PR DESCRIPTION
Addresses review feedback on #23925. Removes the paragraph in stripOldImageBlocks JSDoc that references the removed empty-response nudge path, per the AGENTS.md rule against referencing removed code in comments.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
