### PR TITLE
fix: prevent analysis route from setting isInteractive to avoid unresolvable approval prompts

### DIFF
--- a/assistant/src/runtime/routes/conversation-analysis-routes.ts
+++ b/assistant/src/runtime/routes/conversation-analysis-routes.ts
@@ -159,7 +159,7 @@ Do not use tools during analysis. If you identify insights worth remembering for
         // l. Fire-and-forget the agent loop
         analysisConversation
           .runAgentLoop(prompt, messageId, onEvent, {
-            isInteractive: hasLiveSubscriber,
+            isInteractive: false,
             isUserMessage: true,
           })
           .catch((err) => {


### PR DESCRIPTION
Addresses review feedback on #23934. The analysis route was setting isInteractive based on SSE subscribers, which could trigger context-overflow approval prompts that the client can't resolve (no confirmation_request registration). Analysis runs now always use isInteractive=false to auto-compress without prompting.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23967" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
