### PR TITLE
fix: scope expansion timeout cleanup to correct stabilization generation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -436,6 +436,14 @@ final class MessageListScrollState {
     /// the increment (matching the resize/pagination cleanup pattern).
     @ObservationIgnored private var activeStabilizationCount = 0
 
+    /// Monotonically increasing counter, bumped each time
+    /// `cancelStabilizationTasks()` is called. Expansion timeout tasks
+    /// capture the current generation before sleeping. After waking,
+    /// cancelled tasks only call `endStabilization()` if the generation
+    /// is unchanged — preventing stale tasks from acting on a new
+    /// stabilization cycle that started after the cancellation.
+    @ObservationIgnored private var stabilizationGeneration: UInt64 = 0
+
     // MARK: - Deep-Link Anchor Tracking
 
     @ObservationIgnored var anchorSetTime: Date?
@@ -527,15 +535,25 @@ final class MessageListScrollState {
     }
 
     private func cancelStabilizationTasks() {
+        stabilizationGeneration &+= 1
         expansionTimeoutTask?.cancel()
         expansionTimeoutTask = nil
     }
 
     private func scheduleExpansionTimeout() {
         expansionTimeoutTask?.cancel()
+        let capturedGeneration = stabilizationGeneration
         expansionTimeoutTask = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: 200_000_000)
             guard let self else { return }
+            if Task.isCancelled {
+                // Cancelled within the same stabilization cycle (e.g. cross-reason
+                // transition from .expansion to .resize): balance the count so the
+                // superseding reason's endStabilization() can reach zero.
+                // If a new cycle started (generation changed), a stale task must NOT
+                // call endStabilization — it would act on the new cycle's state.
+                guard capturedGeneration == self.stabilizationGeneration else { return }
+            }
             self.endStabilization()
         }
     }


### PR DESCRIPTION
Addresses review feedback on #23922. Adds a `stabilizationGeneration` counter to prevent stale cancelled timeout tasks from prematurely ending subsequent stabilization cycles.

**The race condition:**
1. Mode is `.stabilizing(.expansion)`, count = 1, timeout A running
2. User scrolls up → `transition(to: .freeBrowsing)`: cancels A, count = 0
3. Content expansion → `beginStabilization(.expansion)`: count = 1, timeout B scheduled
4. Cancelled A's continuation runs: `endStabilization()` → mode IS `.stabilizing` → count = 0 → premature restore

**The fix:**
- `cancelStabilizationTasks()` increments `stabilizationGeneration`
- `scheduleExpansionTimeout` captures the generation before sleep
- After sleep, cancelled tasks only call `endStabilization()` if the generation hasn't changed
- Non-cancelled tasks (normal completion) always call `endStabilization()`

This preserves the cross-reason count balancing from #23922 (cancelled tasks within the same generation still clean up) while preventing stale tasks from acting on new cycles (different generation → early return).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23968" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
