### PR TITLE
feat(runtime): extend PendingInteraction kind with host_browser

### DIFF
--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -1,13 +1,15 @@
 /**
  * In-memory tracker that maps requestId to conversation info for pending
- * confirmation, secret, host_bash, host_file, and host_cu interactions.
+ * confirmation, secret, host_bash, host_file, host_cu, and host_browser
+ * interactions.
  *
  * When the agent loop emits a confirmation_request, secret_request,
- * host_bash_request, host_file_request, or host_cu_request, the onEvent
- * callback registers the interaction here. Standalone HTTP endpoints
- * (/v1/confirm, /v1/secret, /v1/trust-rules, /v1/host-bash-result,
- * /v1/host-file-result, /v1/host-cu-result) look up the conversation from this
- * tracker to resolve the interaction.
+ * host_bash_request, host_file_request, host_cu_request, or
+ * host_browser_request, the onEvent callback registers the interaction here.
+ * Standalone HTTP endpoints (/v1/confirm, /v1/secret, /v1/trust-rules,
+ * /v1/host-bash-result, /v1/host-file-result, /v1/host-cu-result,
+ * /v1/host-browser-result) look up the conversation from this tracker to
+ * resolve the interaction.
  */
 
 import type { Conversation } from "../daemon/conversation.js";
@@ -45,6 +47,7 @@ export interface PendingInteraction {
     | "host_bash"
     | "host_file"
     | "host_cu"
+    | "host_browser"
     | "acp_confirmation";
   confirmationDetails?: ConfirmationDetails;
   /** For ACP permissions: resolves directly without a Conversation object. */
@@ -100,12 +103,13 @@ export function getByConversation(
  * Remove pending confirmation and secret interactions for a given conversation.
  * Used when auto-denying all pending interactions (e.g. new user message).
  *
- * host_bash, host_file, and host_cu interactions are intentionally skipped
- * — they represent in-flight tool executions proxied to the client, not
- * confirmations to auto-deny. Removing them would orphan the request: the
- * client would POST to /v1/host-bash-result, /v1/host-file-result, or
- * /v1/host-cu-result after completing the operation, get a 404, and the
- * proxy timer would fire with a spurious timeout error.
+ * host_bash, host_file, host_cu, and host_browser interactions are
+ * intentionally skipped — they represent in-flight tool executions proxied to
+ * the client, not confirmations to auto-deny. Removing them would orphan the
+ * request: the client would POST to /v1/host-bash-result,
+ * /v1/host-file-result, /v1/host-cu-result, or /v1/host-browser-result after
+ * completing the operation, get a 404, and the proxy timer would fire with a
+ * spurious timeout error.
  */
 export function removeByConversation(conversation: Conversation): void {
   for (const [requestId, interaction] of pending) {
@@ -114,6 +118,7 @@ export function removeByConversation(conversation: Conversation): void {
       interaction.kind !== "host_bash" &&
       interaction.kind !== "host_file" &&
       interaction.kind !== "host_cu" &&
+      interaction.kind !== "host_browser" &&
       interaction.kind !== "acp_confirmation"
     ) {
       pending.delete(requestId);


### PR DESCRIPTION
## Summary
- Add `host_browser` to the `PendingInteraction.kind` union
- Extend `removeByConversation` skip list so in-flight browser requests are not auto-orphaned
- Update module and function docstrings to mention the new kind and `/v1/host-browser-result`

Part of plan: host-browser-proxy-phase1.md (PR 2 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23972" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
