### PR TITLE
feat(daemon): add host_browser_request message types

### DIFF
--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -23,6 +23,7 @@ export * from "./message-types/diagnostics.js";
 export * from "./message-types/documents.js";
 export * from "./message-types/guardian-actions.js";
 export * from "./message-types/host-bash.js";
+export * from "./message-types/host-browser.js";
 export * from "./message-types/host-cu.js";
 export * from "./message-types/host-file.js";
 export * from "./message-types/inbox.js";
@@ -77,6 +78,7 @@ import type {
   _GuardianActionsServerMessages,
 } from "./message-types/guardian-actions.js";
 import type { _HostBashServerMessages } from "./message-types/host-bash.js";
+import type { _HostBrowserServerMessages } from "./message-types/host-browser.js";
 import type { _HostCuServerMessages } from "./message-types/host-cu.js";
 import type { _HostFileServerMessages } from "./message-types/host-file.js";
 import type {
@@ -186,6 +188,7 @@ export type ServerMessage =
   | _DocumentsServerMessages
   | _GuardianActionsServerMessages
   | _HostBashServerMessages
+  | _HostBrowserServerMessages
   | _HostCuServerMessages
   | _HostFileServerMessages
   | _MemoryServerMessages

--- a/assistant/src/daemon/message-types/host-browser.ts
+++ b/assistant/src/daemon/message-types/host-browser.ts
@@ -1,0 +1,30 @@
+// Host browser proxy types.
+// Enables proxying CDP commands to the desktop client (host machine)
+// when running as a managed assistant.
+
+// === Server → Client ===
+
+export interface HostBrowserRequest {
+  type: "host_browser_request";
+  requestId: string;
+  conversationId: string;
+  /** CDP method name, e.g. "Page.navigate", "Runtime.evaluate", "Accessibility.getFullAXTree". */
+  cdpMethod: string;
+  /** Opaque JSON params object forwarded verbatim to CDP. */
+  cdpParams?: Record<string, unknown>;
+  /** Optional CDP target/session ID; omitted = "most-recently-active tab". */
+  cdpSessionId?: string;
+  /** Client-side timeout hint; defaults to 30s in the proxy. */
+  timeout_seconds?: number;
+}
+
+export interface HostBrowserCancelRequest {
+  type: "host_browser_cancel";
+  requestId: string;
+}
+
+// --- Domain-level union aliases (consumed by the barrel file) ---
+
+export type _HostBrowserServerMessages =
+  | HostBrowserRequest
+  | HostBrowserCancelRequest;


### PR DESCRIPTION
## Summary
- Add `HostBrowserRequest` and `HostBrowserCancelRequest` message interfaces with CDP method/params envelope fields
- Register `_HostBrowserServerMessages` in the aggregate `ServerMessage` union
- Mirrors the existing host_bash/host_file/host_cu message-type pattern

Part of plan: host-browser-proxy-phase1.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23973" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
