### PR TITLE
fix: update conversation analysis test to match #23967 behavior

### DIFF
--- a/assistant/src/__tests__/conversation-analysis-routes.test.ts
+++ b/assistant/src/__tests__/conversation-analysis-routes.test.ts
@@ -121,7 +121,7 @@ describe("POST /v1/conversations/:id/analyze", () => {
     );
   });
 
-  test("marks analysis interactive when a matching subscriber is already connected", async () => {
+  test("keeps analysis non-interactive even when a matching subscriber is connected", async () => {
     const conversation = makeConversation();
     const assistantEventHub = new AssistantEventHub();
     assistantEventHub.subscribe(
@@ -163,7 +163,7 @@ describe("POST /v1/conversations/:id/analyze", () => {
       expect.any(String),
       "msg-1",
       expect.any(Function),
-      expect.objectContaining({ isInteractive: true, isUserMessage: true }),
+      expect.objectContaining({ isInteractive: false, isUserMessage: true }),
     );
   });
 });


### PR DESCRIPTION
## Summary
- Updates the second test in `conversation-analysis-routes.test.ts` to expect `isInteractive: false` even when a subscriber is connected, matching the route change from #23967 that hardcoded `isInteractive: false` to prevent unresolvable approval prompts in analysis loops.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24087523621/job/70264497233
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23974" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
