### PR TITLE
M3: Wire group archive-all in sidebar + confirmation alert

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -167,6 +167,12 @@ extension MainWindowView {
                     groupToDelete = group
                 }
             },
+            onArchiveAll: {
+                archiveAllPending = ArchiveAllTarget(
+                    displayName: group.name,
+                    ids: conversations.map(\.id)
+                )
+            },
             selectedConversationId: conversationManager.activeConversationId,
             onToggleExpand: { sidebar.toggleSection(group.id) },
             onToggleShowAll: { sidebar.toggleShowAll(group.id) },
@@ -418,6 +424,23 @@ extension MainWindowView {
                         groupToDelete = nil
                     }
                 )
+            }
+            .alert(
+                archiveAllPending.map { "Archive \($0.ids.count) conversation\($0.ids.count == 1 ? "" : "s") in \"\($0.displayName)\"?" } ?? "",
+                isPresented: Binding(
+                    get: { archiveAllPending != nil },
+                    set: { if !$0 { archiveAllPending = nil } }
+                )
+            ) {
+                Button("Cancel", role: .cancel) { archiveAllPending = nil }
+                Button("Archive All", role: .destructive) {
+                    if let pending = archiveAllPending {
+                        archiveAllPending = nil
+                        conversationManager.archiveAllConversations(ids: pending.ids)
+                    }
+                }
+            } message: {
+                Text("This will archive all conversations in this group. You can restore them from Settings \u{203A} Archive.")
             }
             .background(GeometryReader { scrollGeo in
                 Color.clear.preference(

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -168,9 +168,10 @@ extension MainWindowView {
                 }
             },
             onArchiveAll: {
+                let archivableIds = conversations.filter { !$0.isChannelConversation }.map(\.id)
                 archiveAllPending = ArchiveAllTarget(
                     displayName: group.name,
-                    ids: conversations.map(\.id)
+                    ids: archivableIds
                 )
             },
             selectedConversationId: conversationManager.activeConversationId,

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -3,6 +3,12 @@ import SwiftUI
 import VellumAssistantShared
 import UniformTypeIdentifiers
 
+/// Target for the "Archive All" confirmation alert.
+struct ArchiveAllTarget {
+    let displayName: String
+    let ids: [UUID]
+}
+
 struct MainWindowView: View {
     @Bindable var conversationManager: ConversationManager
     let appListManager: AppListManager
@@ -65,6 +71,7 @@ struct MainWindowView: View {
     @State var showEarnCreditsModal = false
     @State var conversationSwitcherTriggerFrame: CGRect = .zero
     @State var groupToDelete: ConversationGroup?
+    @State var archiveAllPending: ArchiveAllTarget?
 
     /// Cached assistant display name, refreshed when the daemon emits an identity change event.
     @State var cachedAssistantName: String = "Your Assistant"


### PR DESCRIPTION
## Summary
- Add `ArchiveAllTarget` struct to `MainWindowView.swift` for tracking pending archive-all confirmations
- Wire `onArchiveAll` callback in `makeSectionView` for ALL group headers (system and custom) — captures group name and conversation IDs
- Add confirmation `.alert` on the sidebar ScrollView that shows conversation count and group name before bulk archiving via `conversationManager.archiveAllConversations(ids:)`

## Test plan
- [ ] Verify "Archive All" appears in the context menu for both system groups (All, Pinned, etc.) and custom groups
- [ ] Confirm clicking "Archive All" shows a confirmation alert with correct count and group name
- [ ] Confirm "Cancel" dismisses the alert without archiving
- [ ] Confirm "Archive All" in the alert archives all conversations in that group
- [ ] Verify archived conversations can be restored from Settings > Archive

Part of #23949.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23975" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
