### PR TITLE
M4: Add archive-all context menu to subgroup disclosure headers

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -174,6 +174,12 @@ extension MainWindowView {
                     ids: archivableIds
                 )
             },
+            onArchiveAllInSubGroup: { subGroupLabel, ids in
+                archiveAllPending = ArchiveAllTarget(
+                    displayName: subGroupLabel,
+                    ids: ids
+                )
+            },
             selectedConversationId: conversationManager.activeConversationId,
             onToggleExpand: { sidebar.toggleSection(group.id) },
             onToggleShowAll: { sidebar.toggleShowAll(group.id) },

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -324,10 +324,11 @@ struct SidebarSectionView: View {
         .buttonStyle(.plain)
         .pointerCursor()
         .vContextMenu {
+            let archivable = subGroup.conversations.filter { !$0.isChannelConversation }
             VMenuItem(icon: VIcon.archive.rawValue, label: "Archive All\u{2026}") {
-                onArchiveAllInSubGroup?(subGroup.label, subGroup.conversations.filter { !$0.isChannelConversation }.map(\.id))
+                onArchiveAllInSubGroup?(subGroup.label, archivable.map(\.id))
             }
-            .disabled(subGroup.conversations.isEmpty)
+            .disabled(archivable.isEmpty)
         }
 
         if isSubGroupExpanded {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -29,6 +29,7 @@ struct SidebarSectionView: View {
     var onCancelRename: (() -> Void)?
     var onDelete: (() -> Void)?
     var onArchiveAll: (() -> Void)? = nil
+    var onArchiveAllInSubGroup: ((String, [UUID]) -> Void)? = nil
 
     /// The currently selected conversation ID. Passed through so that SwiftUI
     /// re-evaluates this view's body (and thus re-calls makeRow) when selection changes.
@@ -322,6 +323,12 @@ struct SidebarSectionView: View {
         }
         .buttonStyle(.plain)
         .pointerCursor()
+        .vContextMenu {
+            VMenuItem(icon: VIcon.archive.rawValue, label: "Archive All\u{2026}") {
+                onArchiveAllInSubGroup?(subGroup.label, subGroup.conversations.filter { !$0.isChannelConversation }.map(\.id))
+            }
+            .disabled(subGroup.conversations.isEmpty)
+        }
 
         if isSubGroupExpanded {
             let subGroupShowAll = showAllInSubGroup.contains(subGroup.key)


### PR DESCRIPTION
## Summary
- Add `onArchiveAllInSubGroup` callback property to `SidebarSectionView`
- Add `.vContextMenu` with "Archive All…" to the subgroup disclosure header button (shared by both schedule and background subgroups)
- Wire the callback in `makeSectionView` to reuse the existing `ArchiveAllTarget` + confirmation alert from M3
- Channel conversations are filtered out of the archive list

## Test plan
- [ ] Right-click a multi-conversation schedule subgroup disclosure header and verify "Archive All…" appears
- [ ] Right-click a multi-conversation background subgroup disclosure header and verify "Archive All…" appears
- [ ] Click "Archive All…" and verify the confirmation alert shows with correct subgroup name and count
- [ ] Confirm archive and verify conversations are archived
- [ ] Verify single-conversation subgroups (rendered as plain rows) do NOT show the subgroup archive menu

Part of #23949.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23977" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
