### PR TITLE
Guard against empty archivable IDs in onArchiveAll

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -169,6 +169,7 @@ extension MainWindowView {
             },
             onArchiveAll: {
                 let archivableIds = conversations.filter { !$0.isChannelConversation }.map(\.id)
+                guard !archivableIds.isEmpty else { return }
                 archiveAllPending = ArchiveAllTarget(
                     displayName: group.name,
                     ids: archivableIds


### PR DESCRIPTION
Prevent showing 'Archive 0 conversations' alert when a group contains only channel conversations. Add early return when the filtered archivable ID list is empty. Addresses feedback from Codex (P3) and Devin on #23975. Part of #23949.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
