### PR TITLE
Archive All Conversations in Group/Subgroup Context Menu

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -694,6 +694,71 @@ final class ConversationManager: ConversationRestorerDelegate {
         log.info("Archived conversation \(id)")
     }
 
+    func archiveAllConversations(ids: [UUID]) {
+        guard !ids.isEmpty else { return }
+
+        var needsReorder = false
+        var newlyArchivedServerIds = Set<String>()
+        let idsSet = Set(ids)
+
+        var draft = listStore.conversations
+        for i in draft.indices where idsSet.contains(draft[i].id) {
+            if draft[i].displayOrder != nil {
+                needsReorder = true
+            }
+            draft[i].isArchived = true
+            draft[i].displayOrder = nil
+            if let cid = draft[i].conversationId {
+                newlyArchivedServerIds.insert(cid)
+            }
+        }
+        listStore.conversations = draft
+
+        if !newlyArchivedServerIds.isEmpty {
+            var archived = listStore.archivedConversationIds
+            archived.formUnion(newlyArchivedServerIds)
+            listStore.archivedConversationIds = archived
+        }
+
+        for id in ids {
+            guard listStore.conversations.contains(where: { $0.id == id }) else { continue }
+
+            AppDelegate.shared?.threadWindowManager?.closeThread(conversationLocalId: id)
+            selectionStore.pinnedViewModelIds.remove(id)
+
+            if let convIndex = listStore.conversations.firstIndex(where: { $0.id == id }) {
+                if listStore.conversations[convIndex].conversationId != nil {
+                    selectionStore.chatViewModels[id]?.stopGenerating()
+                    selectionStore.removeChatViewModel(for: id)
+                } else if selectionStore.chatViewModels[id]?.messages.contains(where: { $0.role == .user }) != true
+                            && selectionStore.chatViewModels[id]?.isBootstrapping != true {
+                    selectionStore.chatViewModels[id]?.stopGenerating()
+                    selectionStore.removeChatViewModel(for: id)
+                } else {
+                    selectionStore.chatViewModels[id]?.cancelPendingMessage()
+                }
+            }
+        }
+
+        if let activeId = selectionStore.activeConversationId, idsSet.contains(activeId) {
+            if listStore.visibleConversations.isEmpty {
+                enterDraftMode()
+            } else if let firstVisibleId = listStore.visibleConversations.first?.id {
+                selectionStore.performActivation(for: firstVisibleId)
+            }
+        } else if listStore.visibleConversations.isEmpty {
+            enterDraftMode()
+        }
+
+        ConversationSelectionStore.clearRenderCaches()
+
+        if needsReorder {
+            listStore.sendReorderConversations()
+        }
+
+        log.info("Archived \(ids.count) conversations")
+    }
+
     func unarchiveConversation(id: UUID) {
         guard let index = listStore.conversations.firstIndex(where: { $0.id == id }) else { return }
         listStore.conversations[index].isArchived = false

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -169,6 +169,7 @@ extension MainWindowView {
             },
             onArchiveAll: {
                 let archivableIds = conversations.filter { !$0.isChannelConversation }.map(\.id)
+                guard !archivableIds.isEmpty else { return }
                 archiveAllPending = ArchiveAllTarget(
                     displayName: group.name,
                     ids: archivableIds

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -174,6 +174,12 @@ extension MainWindowView {
                     ids: archivableIds
                 )
             },
+            onArchiveAllInSubGroup: { subGroupLabel, ids in
+                archiveAllPending = ArchiveAllTarget(
+                    displayName: subGroupLabel,
+                    ids: ids
+                )
+            },
             selectedConversationId: conversationManager.activeConversationId,
             onToggleExpand: { sidebar.toggleSection(group.id) },
             onToggleShowAll: { sidebar.toggleShowAll(group.id) },

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -167,6 +167,13 @@ extension MainWindowView {
                     groupToDelete = group
                 }
             },
+            onArchiveAll: {
+                let archivableIds = conversations.filter { !$0.isChannelConversation }.map(\.id)
+                archiveAllPending = ArchiveAllTarget(
+                    displayName: group.name,
+                    ids: archivableIds
+                )
+            },
             selectedConversationId: conversationManager.activeConversationId,
             onToggleExpand: { sidebar.toggleSection(group.id) },
             onToggleShowAll: { sidebar.toggleShowAll(group.id) },
@@ -418,6 +425,23 @@ extension MainWindowView {
                         groupToDelete = nil
                     }
                 )
+            }
+            .alert(
+                archiveAllPending.map { "Archive \($0.ids.count) conversation\($0.ids.count == 1 ? "" : "s") in \"\($0.displayName)\"?" } ?? "",
+                isPresented: Binding(
+                    get: { archiveAllPending != nil },
+                    set: { if !$0 { archiveAllPending = nil } }
+                )
+            ) {
+                Button("Cancel", role: .cancel) { archiveAllPending = nil }
+                Button("Archive All", role: .destructive) {
+                    if let pending = archiveAllPending {
+                        archiveAllPending = nil
+                        conversationManager.archiveAllConversations(ids: pending.ids)
+                    }
+                }
+            } message: {
+                Text("This will archive all conversations in this group. You can restore them from Settings \u{203A} Archive.")
             }
             .background(GeometryReader { scrollGeo in
                 Color.clear.preference(

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -3,6 +3,12 @@ import SwiftUI
 import VellumAssistantShared
 import UniformTypeIdentifiers
 
+/// Target for the "Archive All" confirmation alert.
+struct ArchiveAllTarget {
+    let displayName: String
+    let ids: [UUID]
+}
+
 struct MainWindowView: View {
     @Bindable var conversationManager: ConversationManager
     let appListManager: AppListManager
@@ -65,6 +71,7 @@ struct MainWindowView: View {
     @State var showEarnCreditsModal = false
     @State var conversationSwitcherTriggerFrame: CGRect = .zero
     @State var groupToDelete: ConversationGroup?
+    @State var archiveAllPending: ArchiveAllTarget?
 
     /// Cached assistant display name, refreshed when the daemon emits an identity change event.
     @State var cachedAssistantName: String = "Your Assistant"

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionHeader.swift
@@ -32,6 +32,7 @@ struct SidebarSectionHeader: View {
     var onCommitRename: ((String) -> Void)?
     var onCancelRename: (() -> Void)?
     var onDelete: (() -> Void)?
+    var onArchiveAll: (() -> Void)? = nil
     var sidebar: SidebarInteractionState?
 
     @FocusState private var isRenameFocused: Bool
@@ -142,6 +143,7 @@ struct SidebarSectionHeader: View {
         .modifier(ConditionalGroupContextMenu(
             onRename: onRename.map { rename in { rename(group.name) } },
             onDelete: onDelete,
+            onArchiveAll: onArchiveAll,
             hasConversations: conversationCount > 0
         ))
         .conditionalOnDrag(enabled: !group.isSystemGroup) {
@@ -154,15 +156,26 @@ struct SidebarSectionHeader: View {
 // MARK: - Conditional context menu modifier
 
 /// Only attaches a `.vContextMenu` when at least one action is available.
-/// System groups (where onRename and onDelete are both nil) get no context menu.
+/// System groups (where onRename and onDelete are both nil) get no context menu
+/// unless onArchiveAll is provided.
 private struct ConditionalGroupContextMenu: ViewModifier {
     let onRename: (() -> Void)?
     let onDelete: (() -> Void)?
+    let onArchiveAll: (() -> Void)?
     let hasConversations: Bool
 
     func body(content: Content) -> some View {
-        if onRename != nil || onDelete != nil {
+        if onRename != nil || onDelete != nil || onArchiveAll != nil {
             content.vContextMenu {
+                if let onArchiveAll {
+                    VMenuItem(icon: VIcon.archive.rawValue, label: "Archive All\u{2026}") {
+                        onArchiveAll()
+                    }
+                    .disabled(!hasConversations)
+                }
+                if onArchiveAll != nil && (onRename != nil || onDelete != nil) {
+                    VMenuDivider()
+                }
                 if let onRename {
                     VMenuItem(icon: VIcon.pencil.rawValue, label: "Rename") { onRename() }
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -29,6 +29,7 @@ struct SidebarSectionView: View {
     var onCancelRename: (() -> Void)?
     var onDelete: (() -> Void)?
     var onArchiveAll: (() -> Void)? = nil
+    var onArchiveAllInSubGroup: ((String, [UUID]) -> Void)? = nil
 
     /// The currently selected conversation ID. Passed through so that SwiftUI
     /// re-evaluates this view's body (and thus re-calls makeRow) when selection changes.
@@ -322,6 +323,13 @@ struct SidebarSectionView: View {
         }
         .buttonStyle(.plain)
         .pointerCursor()
+        .vContextMenu {
+            let archivable = subGroup.conversations.filter { !$0.isChannelConversation }
+            VMenuItem(icon: VIcon.archive.rawValue, label: "Archive All\u{2026}") {
+                onArchiveAllInSubGroup?(subGroup.label, archivable.map(\.id))
+            }
+            .disabled(archivable.isEmpty)
+        }
 
         if isSubGroupExpanded {
             let subGroupShowAll = showAllInSubGroup.contains(subGroup.key)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarSectionView.swift
@@ -28,6 +28,7 @@ struct SidebarSectionView: View {
     var onCommitRename: ((String) -> Void)?
     var onCancelRename: (() -> Void)?
     var onDelete: (() -> Void)?
+    var onArchiveAll: (() -> Void)? = nil
 
     /// The currently selected conversation ID. Passed through so that SwiftUI
     /// re-evaluates this view's body (and thus re-calls makeRow) when selection changes.
@@ -116,6 +117,7 @@ struct SidebarSectionView: View {
             onCommitRename: onCommitRename,
             onCancelRename: onCancelRename,
             onDelete: onDelete,
+            onArchiveAll: onArchiveAll,
             sidebar: sidebar
         )
         .modifier(SectionHeaderDropModifier(


### PR DESCRIPTION
## Summary
Add the ability to right-click on any group or subgroup (including system groups like Pinned, Scheduled, Background, Recents) in the sidebar and select "Archive All Conversations" to bulk-archive all conversations under that group or subgroup. A confirmation alert is shown before archiving.

## Changes
- **ConversationManager**: New `archiveAllConversations(ids:)` bulk archive method using copy-mutate-writeback pattern for optimal performance
- **SidebarSectionHeader**: Extended `ConditionalGroupContextMenu` to support `onArchiveAll` callback, enabling context menus on system groups (which previously had none)
- **SidebarSectionView**: Added `onArchiveAll` and `onArchiveAllInSubGroup` callbacks, with `.vContextMenu` on subgroup disclosure headers
- **MainWindowView**: Added `ArchiveAllTarget` struct and `archiveAllPending` state for confirmation alert
- **MainWindowView+Sidebar**: Wired `onArchiveAll` for all groups and `onArchiveAllInSubGroup` for schedule/background subgroups, with channel conversation filtering

## Milestone PRs (merged into feature branch)
- #23954: M1: Add archiveAllConversations(ids:) to ConversationManager
- #23963: M2: Add onArchiveAll callback to SidebarSectionHeader and SidebarSectionView
- #23975: M3: Wire group archive-all in sidebar + confirmation alert
- #23977: M4: Add archive-all context menu to subgroup disclosure headers
- #23978: Guard against empty archivable IDs in onArchiveAll

## Project issue
Closes #23949

## Test plan
- [ ] Right-click on a custom group with conversations → "Archive All…" appears → confirm → all conversations archived
- [ ] Right-click on system groups (Pinned, Recents, Scheduled, Background) → "Archive All…" appears and works
- [ ] Right-click on a schedule subgroup → "Archive All…" appears → confirm → subgroup conversations archived
- [ ] Right-click on an empty group → "Archive All…" is disabled
- [ ] Groups with only channel conversations → "Archive All…" is effectively a no-op (guard prevents alert)
- [ ] Confirmation alert shows correct count and group name
- [ ] Active conversation handling: if current conversation is in archived group, app switches to first visible or draft mode
- [ ] Archived conversations appear in Settings → Archive and can be unarchived
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
