### PR TITLE
M3: Client data layer — HomeFeedStore & SSE

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/FeedItem.swift
+++ b/clients/macos/vellum-assistant/Features/Home/FeedItem.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// A single item in the home feed.
+struct FeedItem: Codable, Identifiable, Sendable {
+
+    let id: String
+    let type: FeedItemType
+    var status: FeedItemStatus
+    let title: String
+    let body: String?
+    let conversationId: String?
+    let createdAt: Date
+    let actions: [FeedAction]
+
+    struct FeedAction: Codable, Identifiable, Sendable {
+        let id: String
+        let label: String
+        let style: String?
+    }
+
+    enum FeedItemType: String, Codable, Sendable {
+        case nudge
+        case digest
+        case action
+        case thread
+    }
+
+    enum FeedItemStatus: String, Codable, Sendable {
+        case new
+        case seen
+        case actedOn = "acted_on"
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedStore.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedStore.swift
@@ -38,6 +38,11 @@ final class HomeFeedStore {
 
     // MARK: - Init
 
+    /// Creates a new store and starts listening for SSE and foreground events.
+    ///
+    /// The store does **not** perform an initial fetch — the caller is expected to
+    /// call ``fetch()`` when the view appears (e.g. in `onAppear`), matching the
+    /// pattern used by `DirectoryStore` and the home feed spec's `onAppear` trigger.
     init(eventStreamClient: EventStreamClient) {
         self.eventStreamClient = eventStreamClient
         startSSESubscription()
@@ -61,7 +66,7 @@ final class HomeFeedStore {
 
         do {
             let (decoded, response): ([FeedItem]?, GatewayHTTPClient.Response) =
-                try await GatewayHTTPClient.get(path: "home/feed") { decoder in
+                try await GatewayHTTPClient.get(path: "assistants/{assistantId}/home/feed") { decoder in
                     decoder.dateDecodingStrategy = .iso8601
                     decoder.keyDecodingStrategy = .convertFromSnakeCase
                 }
@@ -85,7 +90,7 @@ final class HomeFeedStore {
     func markSeen(_ id: String) async {
         do {
             let response = try await GatewayHTTPClient.patch(
-                path: "home/feed/\(id)",
+                path: "assistants/{assistantId}/home/feed/\(id)",
                 json: ["status": "seen"]
             )
             if response.isSuccess {
@@ -104,7 +109,7 @@ final class HomeFeedStore {
     func dismiss(_ id: String) async {
         do {
             let response = try await GatewayHTTPClient.patch(
-                path: "home/feed/\(id)",
+                path: "assistants/{assistantId}/home/feed/\(id)",
                 json: ["status": "acted_on"]
             )
             if response.isSuccess {
@@ -123,7 +128,7 @@ final class HomeFeedStore {
     func triggerAction(itemId: String, actionId: String) async {
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "home/feed/\(itemId)/actions/\(actionId)",
+                path: "assistants/{assistantId}/home/feed/\(itemId)/actions/\(actionId)",
                 json: [:]
             )
             if response.isSuccess {
@@ -141,10 +146,10 @@ final class HomeFeedStore {
 
     private func startSSESubscription() {
         sseTask = Task { [weak self] in
-            guard let self else { return }
-            let stream = self.eventStreamClient.subscribe()
+            guard let eventStreamClient = self?.eventStreamClient else { return }
+            let stream = eventStreamClient.subscribe()
             for await message in stream {
-                guard !Task.isCancelled else { break }
+                guard let self, !Task.isCancelled else { break }
                 if case .homeFeedUpdated = message {
                     await self.fetch()
                 }

--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedStore.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedStore.swift
@@ -1,0 +1,173 @@
+import AppKit
+import Foundation
+import Observation
+import os
+import VellumAssistantShared
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "HomeFeedStore")
+
+/// Observable store that owns home feed state and refreshes on SSE events
+/// or app foreground transitions.
+///
+/// Uses `GatewayHTTPClient` (stateless enum) for HTTP requests and subscribes
+/// to the gateway's `EventStreamClient` for real-time `home_feed_updated` pushes.
+@MainActor
+@Observable
+final class HomeFeedStore {
+
+    // MARK: - Observable State
+
+    var items: [FeedItem] = []
+    var lastUpdated: Date?
+    var isLoading = false
+    var error: String?
+
+    // MARK: - Filtered Views
+
+    var nudges: [FeedItem] { items.filter { $0.type == .nudge && $0.status != .actedOn } }
+    var digests: [FeedItem] { items.filter { $0.type == .digest } }
+    var actions: [FeedItem] { items.filter { $0.type == .action } }
+    var threads: [FeedItem] { items.filter { $0.type == .thread } }
+    var newCount: Int { items.filter { $0.status == .new }.count }
+
+    // MARK: - Dependencies
+
+    @ObservationIgnored private let eventStreamClient: EventStreamClient
+    @ObservationIgnored private var sseTask: Task<Void, Never>?
+    @ObservationIgnored private var foregroundObserver: NSObjectProtocol?
+
+    // MARK: - Init
+
+    init(eventStreamClient: EventStreamClient) {
+        self.eventStreamClient = eventStreamClient
+        startSSESubscription()
+        startForegroundObserver()
+    }
+
+    deinit {
+        sseTask?.cancel()
+        if let observer = foregroundObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(observer)
+        }
+    }
+
+    // MARK: - HTTP Methods
+
+    /// Fetch the full feed from the gateway.
+    func fetch() async {
+        isLoading = true
+        error = nil
+        defer { isLoading = false }
+
+        do {
+            let (decoded, response): ([FeedItem]?, GatewayHTTPClient.Response) =
+                try await GatewayHTTPClient.get(path: "home/feed") { decoder in
+                    decoder.dateDecodingStrategy = .iso8601
+                    decoder.keyDecodingStrategy = .convertFromSnakeCase
+                }
+
+            if response.isSuccess, let decoded {
+                items = decoded
+                lastUpdated = Date()
+            } else {
+                let msg = "Failed to fetch feed (HTTP \(response.statusCode))"
+                log.error("\(msg)")
+                error = msg
+            }
+        } catch {
+            let msg = "Feed fetch error: \(error.localizedDescription)"
+            log.error("\(msg)")
+            self.error = msg
+        }
+    }
+
+    /// Mark a feed item as seen.
+    func markSeen(_ id: String) async {
+        do {
+            let response = try await GatewayHTTPClient.patch(
+                path: "home/feed/\(id)",
+                json: ["status": "seen"]
+            )
+            if response.isSuccess {
+                if let idx = items.firstIndex(where: { $0.id == id }) {
+                    items[idx].status = .seen
+                }
+            } else {
+                log.error("markSeen failed (HTTP \(response.statusCode)) for item \(id)")
+            }
+        } catch {
+            log.error("markSeen error: \(error.localizedDescription)")
+        }
+    }
+
+    /// Dismiss a feed item (mark as acted_on).
+    func dismiss(_ id: String) async {
+        do {
+            let response = try await GatewayHTTPClient.patch(
+                path: "home/feed/\(id)",
+                json: ["status": "acted_on"]
+            )
+            if response.isSuccess {
+                if let idx = items.firstIndex(where: { $0.id == id }) {
+                    items[idx].status = .actedOn
+                }
+            } else {
+                log.error("dismiss failed (HTTP \(response.statusCode)) for item \(id)")
+            }
+        } catch {
+            log.error("dismiss error: \(error.localizedDescription)")
+        }
+    }
+
+    /// Trigger a specific action on a feed item.
+    func triggerAction(itemId: String, actionId: String) async {
+        do {
+            let response = try await GatewayHTTPClient.post(
+                path: "home/feed/\(itemId)/actions/\(actionId)",
+                json: [:]
+            )
+            if response.isSuccess {
+                // Refresh to pick up any server-side status changes
+                await fetch()
+            } else {
+                log.error("triggerAction failed (HTTP \(response.statusCode)) for item \(itemId) action \(actionId)")
+            }
+        } catch {
+            log.error("triggerAction error: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - SSE Subscription
+
+    private func startSSESubscription() {
+        sseTask = Task { [weak self] in
+            guard let self else { return }
+            let stream = self.eventStreamClient.subscribe()
+            for await message in stream {
+                guard !Task.isCancelled else { break }
+                if case .homeFeedUpdated = message {
+                    await self.fetch()
+                }
+            }
+        }
+    }
+
+    // MARK: - App Foreground Observer
+
+    private func startForegroundObserver() {
+        foregroundObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            // Only refresh when *our* app comes to the foreground
+            guard let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,
+                  app.bundleIdentifier == Bundle.appBundleIdentifier else {
+                return
+            }
+            Task { @MainActor [weak self] in
+                await self?.fetch()
+            }
+        }
+    }
+}

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -53,6 +53,8 @@ import Foundation
 // │                                 │ decoded from flat fields               │
 // │ SkillsshOriginMeta             │ Payload struct for skillssh origin;    │
 // │                                 │ decoded from flat fields               │
+// │ HomeFeedUpdatedMessage          │ New SSE event; not yet in generated    │
+// │                                 │ contract                               │
 // └─────────────────────────────────┴──────────────────────────────────────────┘
 //
 // **Do not add new manual structs** without documenting the reason here.
@@ -2284,6 +2286,7 @@ public enum ServerMessage: Decodable, Sendable {
     case serviceGroupUpdateStarting(ServiceGroupUpdateStartingMessage)
     case serviceGroupUpdateProgress(ServiceGroupUpdateProgressMessage)
     case serviceGroupUpdateComplete(ServiceGroupUpdateCompleteMessage)
+    case homeFeedUpdated(HomeFeedUpdatedMessage)
     case conversationIdResolved(localId: String, serverId: String)
     case pong
     case unknown(String)
@@ -2748,6 +2751,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "service_group_update_complete":
             let message = try ServiceGroupUpdateCompleteMessage(from: decoder)
             self = .serviceGroupUpdateComplete(message)
+        case "home_feed_updated":
+            let message = try HomeFeedUpdatedMessage(from: decoder)
+            self = .homeFeedUpdated(message)
         case "pong":
             self = .pong
         default:
@@ -2756,6 +2762,13 @@ public enum ServerMessage: Decodable, Sendable {
     }
 }
 
+
+// MARK: - Home Feed
+
+/// Sent by the daemon when the home feed has new or updated items.
+public struct HomeFeedUpdatedMessage: Codable, Sendable {
+    public let conversationId: String?
+}
 
 // MARK: - Permission Mode
 


### PR DESCRIPTION
## Summary
- Create `HomeFeedStore` — @Observable store with fetch/markSeen/dismiss/triggerAction methods and filtered computed properties
- Add `home_feed_updated` SSE event type to MessageTypes.swift
- Wire store to refresh on SSE events and app foreground

Part of #23956
Part of JARVIS-447

## Test plan
- [ ] HomeFeedStore compiles and follows existing store patterns
- [ ] SSE event type parses correctly
- [ ] Store refreshes on home_feed_updated events
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23981" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
