### PR TITLE
feat(daemon): add HostBrowserProxy class

### DIFF
--- a/assistant/src/__tests__/host-browser-proxy.test.ts
+++ b/assistant/src/__tests__/host-browser-proxy.test.ts
@@ -318,4 +318,49 @@ describe("HostBrowserProxy", () => {
       });
     });
   });
+
+  describe("sender throws synchronously", () => {
+    test("rejects the promise, clears pending state and timer, invokes onInternalResolve", async () => {
+      const resolvedIds: string[] = [];
+      sentMessages = [];
+      sendToClient = () => {
+        throw new Error("transport down");
+      };
+      proxy = new HostBrowserProxy(sendToClient, (id) => resolvedIds.push(id));
+
+      // request() synchronously calls sendToClient inside the Promise
+      // executor. A throw there surfaces as a rejected promise.
+      const resultPromise = proxy.request(
+        { cdpMethod: "Page.navigate", cdpParams: { url: "https://x.test" } },
+        "session-1",
+      );
+
+      await expect(resultPromise).rejects.toThrow("transport down");
+
+      // No entries should have leaked into the pending map.
+      // (We can't assert against a specific requestId because the sender
+      // threw before any message was observed, so there's nothing to read
+      // the id from. We can instead assert the internal resolve fired once
+      // and that no pending entries remain for any id we issue next.)
+      expect(resolvedIds).toHaveLength(1);
+
+      // Issue a new request on a fresh (non-throwing) sender and verify
+      // the proxy is still functional — no stale timers or bookkeeping
+      // from the failed request.
+      sentMessages = [];
+      proxy.updateSender((msg) => sentMessages.push(msg), true);
+      const okPromise = proxy.request(
+        { cdpMethod: "Page.reload" },
+        "session-1",
+      );
+      expect(sentMessages).toHaveLength(1);
+      const okRequestId = (sentMessages[0] as Record<string, unknown>)
+        .requestId as string;
+      expect(proxy.hasPendingRequest(okRequestId)).toBe(true);
+      proxy.resolve(okRequestId, { content: "reloaded", isError: false });
+      const okResult = await okPromise;
+      expect(okResult.content).toBe("reloaded");
+      expect(okResult.isError).toBe(false);
+    });
+  });
 });

--- a/assistant/src/__tests__/host-browser-proxy.test.ts
+++ b/assistant/src/__tests__/host-browser-proxy.test.ts
@@ -254,7 +254,7 @@ describe("HostBrowserProxy", () => {
   });
 
   describe("dispose", () => {
-    test("rejects all pending requests, emits cancels, invokes onInternalResolve", () => {
+    test("rejects all pending requests, emits cancels, invokes onInternalResolve", async () => {
       const resolvedIds: string[] = [];
       setup((id) => resolvedIds.push(id));
 
@@ -266,8 +266,10 @@ describe("HostBrowserProxy", () => {
         { cdpMethod: "Page.navigate", cdpParams: { url: "https://b.test" } },
         "session-1",
       );
-      p1.catch(() => {}); // Expected rejection on dispose.
-      p2.catch(() => {}); // Expected rejection on dispose.
+      // Attach rejection handlers immediately so Bun doesn't flag the
+      // promises as unhandled before the awaited assertions run.
+      const p1Swallowed = p1.catch(() => {});
+      const p2Swallowed = p2.catch(() => {});
 
       const requestIds = (sentMessages as Array<Record<string, unknown>>).map(
         (m) => m.requestId as string,
@@ -283,8 +285,11 @@ describe("HostBrowserProxy", () => {
       expect(proxy.hasPendingRequest(requestIds[1]!)).toBe(false);
 
       // Both promises should reject with AssistantError message.
-      expect(p1).rejects.toThrow("Host browser proxy disposed");
-      expect(p2).rejects.toThrow("Host browser proxy disposed");
+      await expect(p1).rejects.toThrow("Host browser proxy disposed");
+      await expect(p2).rejects.toThrow("Host browser proxy disposed");
+      // Drain the swallowed copies so the unhandled-rejection guard clears.
+      await p1Swallowed;
+      await p2Swallowed;
 
       // After the 2 request messages, dispose should have sent 2 cancel messages.
       const cancelMessages = sentMessages

--- a/assistant/src/__tests__/host-browser-proxy.test.ts
+++ b/assistant/src/__tests__/host-browser-proxy.test.ts
@@ -320,33 +320,55 @@ describe("HostBrowserProxy", () => {
   });
 
   describe("abort listener lifecycle", () => {
+    // Helper that wraps an AbortSignal to observe add/removeEventListener
+    // invocations without tripping over tsc's strict overload matching on
+    // AbortSignal itself.
+    type Spied = {
+      signal: AbortSignal;
+      addCalls: string[];
+      removeCalls: string[];
+    };
+    function spySignal(source: AbortSignal): Spied {
+      const addCalls: string[] = [];
+      const removeCalls: string[] = [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const s = source as any;
+      const origAdd = source.addEventListener.bind(source);
+      const origRemove = source.removeEventListener.bind(source);
+      s.addEventListener = (
+        type: string,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...rest: any[]
+      ) => {
+        addCalls.push(type);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (origAdd as any)(type, ...rest);
+      };
+      s.removeEventListener = (
+        type: string,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...rest: any[]
+      ) => {
+        removeCalls.push(type);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (origRemove as any)(type, ...rest);
+      };
+      return { signal: source, addCalls, removeCalls };
+    }
+
     test("removes abort listener from signal after resolve completes", async () => {
       setup();
       const controller = new AbortController();
-      const signal = controller.signal;
-
-      // Spy on addEventListener / removeEventListener.
-      const addCalls: string[] = [];
-      const removeCalls: string[] = [];
-      const origAdd = signal.addEventListener.bind(signal);
-      const origRemove = signal.removeEventListener.bind(signal);
-      signal.addEventListener = ((type: string, ...rest: unknown[]) => {
-        addCalls.push(type);
-        return origAdd(type, ...(rest as Parameters<typeof origAdd>));
-      }) as typeof signal.addEventListener;
-      signal.removeEventListener = ((type: string, ...rest: unknown[]) => {
-        removeCalls.push(type);
-        return origRemove(type, ...(rest as Parameters<typeof origRemove>));
-      }) as typeof signal.removeEventListener;
+      const spy = spySignal(controller.signal);
 
       const resultPromise = proxy.request(
         { cdpMethod: "Page.reload" },
         "session-1",
-        signal,
+        spy.signal,
       );
 
-      expect(addCalls).toEqual(["abort"]);
-      expect(removeCalls).toEqual([]);
+      expect(spy.addCalls).toEqual(["abort"]);
+      expect(spy.removeCalls).toEqual([]);
 
       const requestId = (sentMessages[0] as Record<string, unknown>)
         .requestId as string;
@@ -354,7 +376,7 @@ describe("HostBrowserProxy", () => {
       await resultPromise;
 
       // Listener is detached after normal completion.
-      expect(removeCalls).toEqual(["abort"]);
+      expect(spy.removeCalls).toEqual(["abort"]);
 
       // Subsequent aborts are harmless no-ops (no side effects on the proxy).
       controller.abort();
@@ -365,25 +387,18 @@ describe("HostBrowserProxy", () => {
     test("removes abort listener from signal after dispose", () => {
       setup();
       const controller = new AbortController();
-      const signal = controller.signal;
-
-      const removeCalls: string[] = [];
-      const origRemove = signal.removeEventListener.bind(signal);
-      signal.removeEventListener = ((type: string, ...rest: unknown[]) => {
-        removeCalls.push(type);
-        return origRemove(type, ...(rest as Parameters<typeof origRemove>));
-      }) as typeof signal.removeEventListener;
+      const spy = spySignal(controller.signal);
 
       const p = proxy.request(
         { cdpMethod: "Page.reload" },
         "session-1",
-        signal,
+        spy.signal,
       );
       p.catch(() => {}); // Swallow expected rejection.
 
       proxy.dispose();
 
-      expect(removeCalls).toEqual(["abort"]);
+      expect(spy.removeCalls).toEqual(["abort"]);
     });
   });
 

--- a/assistant/src/__tests__/host-browser-proxy.test.ts
+++ b/assistant/src/__tests__/host-browser-proxy.test.ts
@@ -319,6 +319,74 @@ describe("HostBrowserProxy", () => {
     });
   });
 
+  describe("abort listener lifecycle", () => {
+    test("removes abort listener from signal after resolve completes", async () => {
+      setup();
+      const controller = new AbortController();
+      const signal = controller.signal;
+
+      // Spy on addEventListener / removeEventListener.
+      const addCalls: string[] = [];
+      const removeCalls: string[] = [];
+      const origAdd = signal.addEventListener.bind(signal);
+      const origRemove = signal.removeEventListener.bind(signal);
+      signal.addEventListener = ((type: string, ...rest: unknown[]) => {
+        addCalls.push(type);
+        return origAdd(type, ...(rest as Parameters<typeof origAdd>));
+      }) as typeof signal.addEventListener;
+      signal.removeEventListener = ((type: string, ...rest: unknown[]) => {
+        removeCalls.push(type);
+        return origRemove(type, ...(rest as Parameters<typeof origRemove>));
+      }) as typeof signal.removeEventListener;
+
+      const resultPromise = proxy.request(
+        { cdpMethod: "Page.reload" },
+        "session-1",
+        signal,
+      );
+
+      expect(addCalls).toEqual(["abort"]);
+      expect(removeCalls).toEqual([]);
+
+      const requestId = (sentMessages[0] as Record<string, unknown>)
+        .requestId as string;
+      proxy.resolve(requestId, { content: "ok", isError: false });
+      await resultPromise;
+
+      // Listener is detached after normal completion.
+      expect(removeCalls).toEqual(["abort"]);
+
+      // Subsequent aborts are harmless no-ops (no side effects on the proxy).
+      controller.abort();
+      // No additional emitted envelopes from the late abort.
+      expect(sentMessages).toHaveLength(1);
+    });
+
+    test("removes abort listener from signal after dispose", () => {
+      setup();
+      const controller = new AbortController();
+      const signal = controller.signal;
+
+      const removeCalls: string[] = [];
+      const origRemove = signal.removeEventListener.bind(signal);
+      signal.removeEventListener = ((type: string, ...rest: unknown[]) => {
+        removeCalls.push(type);
+        return origRemove(type, ...(rest as Parameters<typeof origRemove>));
+      }) as typeof signal.removeEventListener;
+
+      const p = proxy.request(
+        { cdpMethod: "Page.reload" },
+        "session-1",
+        signal,
+      );
+      p.catch(() => {}); // Swallow expected rejection.
+
+      proxy.dispose();
+
+      expect(removeCalls).toEqual(["abort"]);
+    });
+  });
+
   describe("sender throws synchronously", () => {
     test("rejects the promise, clears pending state and timer, invokes onInternalResolve", async () => {
       const resolvedIds: string[] = [];

--- a/assistant/src/__tests__/host-browser-proxy.test.ts
+++ b/assistant/src/__tests__/host-browser-proxy.test.ts
@@ -1,0 +1,316 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+const { HostBrowserProxy } = await import("../daemon/host-browser-proxy.js");
+
+describe("HostBrowserProxy", () => {
+  let proxy: InstanceType<typeof HostBrowserProxy>;
+  let sentMessages: unknown[];
+  let sendToClient: (msg: unknown) => void;
+
+  function setup(onInternalResolve?: (requestId: string) => void) {
+    sentMessages = [];
+    sendToClient = (msg: unknown) => sentMessages.push(msg);
+    proxy = new HostBrowserProxy(sendToClient, onInternalResolve);
+  }
+
+  afterEach(() => {
+    proxy?.dispose();
+  });
+
+  describe("request/resolve lifecycle (happy path)", () => {
+    test("sends host_browser_request and resolves with content", async () => {
+      setup();
+
+      const resultPromise = proxy.request(
+        {
+          cdpMethod: "Page.navigate",
+          cdpParams: { url: "https://example.com" },
+        },
+        "session-1",
+      );
+
+      // Verify the request was sent to the client
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.type).toBe("host_browser_request");
+      expect(sent.conversationId).toBe("session-1");
+      expect(sent.cdpMethod).toBe("Page.navigate");
+      expect(sent.cdpParams).toEqual({ url: "https://example.com" });
+      expect(typeof sent.requestId).toBe("string");
+
+      const requestId = sent.requestId as string;
+      expect(proxy.hasPendingRequest(requestId)).toBe(true);
+
+      // Simulate client response
+      proxy.resolve(requestId, {
+        content: "ok",
+        isError: false,
+      });
+
+      const result = await resultPromise;
+      expect(result.content).toBe("ok");
+      expect(result.isError).toBe(false);
+      expect(proxy.hasPendingRequest(requestId)).toBe(false);
+    });
+
+    test("forwards cdpParams and cdpSessionId on the emitted envelope", async () => {
+      setup();
+
+      const resultPromise = proxy.request(
+        {
+          cdpMethod: "Runtime.evaluate",
+          cdpParams: { expression: "document.title", returnByValue: true },
+          cdpSessionId: "session-abc",
+        },
+        "session-1",
+      );
+
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.type).toBe("host_browser_request");
+      expect(sent.cdpMethod).toBe("Runtime.evaluate");
+      expect(sent.cdpParams).toEqual({
+        expression: "document.title",
+        returnByValue: true,
+      });
+      expect(sent.cdpSessionId).toBe("session-abc");
+
+      const requestId = sent.requestId as string;
+      proxy.resolve(requestId, {
+        content: "Example Domain",
+        isError: false,
+      });
+
+      await resultPromise;
+    });
+
+    test("resolves error responses correctly", async () => {
+      setup();
+
+      const resultPromise = proxy.request(
+        { cdpMethod: "Page.navigate", cdpParams: { url: "invalid://" } },
+        "session-1",
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+
+      proxy.resolve(requestId, {
+        content: "Navigation failed",
+        isError: true,
+      });
+
+      const result = await resultPromise;
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("Navigation failed");
+    });
+  });
+
+  describe("pending tracking", () => {
+    test("hasPendingRequest returns true after request and false after resolve", async () => {
+      setup();
+
+      const resultPromise = proxy.request(
+        { cdpMethod: "Page.navigate", cdpParams: { url: "https://a.test" } },
+        "session-1",
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+      expect(proxy.hasPendingRequest(requestId)).toBe(true);
+
+      proxy.resolve(requestId, { content: "ok", isError: false });
+
+      expect(proxy.hasPendingRequest(requestId)).toBe(false);
+      await resultPromise;
+    });
+  });
+
+  describe("timeout", () => {
+    test("resolves with timeout error when proxy timeout fires", async () => {
+      const resolvedIds: string[] = [];
+      setup((id) => resolvedIds.push(id));
+
+      const resultPromise = proxy.request(
+        {
+          cdpMethod: "Page.navigate",
+          cdpParams: { url: "https://slow.test" },
+          // Sub-second timeout to trigger the timer quickly.
+          timeout_seconds: 0.01,
+        },
+        "session-1",
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+      expect(proxy.hasPendingRequest(requestId)).toBe(true);
+
+      // Wait long enough for the timer (10ms) to fire.
+      await new Promise((r) => setTimeout(r, 50));
+
+      const result = await resultPromise;
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("Host browser proxy timed out");
+      expect(proxy.hasPendingRequest(requestId)).toBe(false);
+      expect(resolvedIds).toEqual([requestId]);
+    });
+  });
+
+  describe("abort signal", () => {
+    test("returns immediately if signal already aborted", async () => {
+      setup();
+
+      const controller = new AbortController();
+      controller.abort();
+
+      const result = await proxy.request(
+        { cdpMethod: "Page.navigate", cdpParams: { url: "https://a.test" } },
+        "session-1",
+        controller.signal,
+      );
+
+      expect(result.content).toBe("Aborted");
+      expect(result.isError).toBe(true);
+      expect(sentMessages).toHaveLength(0); // No envelope emitted.
+    });
+
+    test("mid-flight abort resolves with Aborted and emits host_browser_cancel", async () => {
+      const resolvedIds: string[] = [];
+      setup((id) => resolvedIds.push(id));
+
+      const controller = new AbortController();
+      const resultPromise = proxy.request(
+        { cdpMethod: "Page.navigate", cdpParams: { url: "https://a.test" } },
+        "session-1",
+        controller.signal,
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+      expect(proxy.hasPendingRequest(requestId)).toBe(true);
+
+      controller.abort();
+
+      const result = await resultPromise;
+      expect(result.content).toBe("Aborted");
+      expect(result.isError).toBe(true);
+      expect(proxy.hasPendingRequest(requestId)).toBe(false);
+
+      // Second message should be the cancel envelope.
+      expect(sentMessages).toHaveLength(2);
+      const cancelMsg = sentMessages[1] as Record<string, unknown>;
+      expect(cancelMsg.type).toBe("host_browser_cancel");
+      expect(cancelMsg.requestId).toBe(requestId);
+
+      // onInternalResolve should have been invoked.
+      expect(resolvedIds).toEqual([requestId]);
+    });
+  });
+
+  describe("isAvailable", () => {
+    test("returns false by default (no client connected)", () => {
+      setup();
+      expect(proxy.isAvailable()).toBe(false);
+    });
+
+    test("returns true after updateSender with clientConnected=true", () => {
+      setup();
+      proxy.updateSender(sendToClient, true);
+      expect(proxy.isAvailable()).toBe(true);
+    });
+
+    test("returns false after updateSender with clientConnected=false", () => {
+      setup();
+      proxy.updateSender(sendToClient, true);
+      expect(proxy.isAvailable()).toBe(true);
+      proxy.updateSender(sendToClient, false);
+      expect(proxy.isAvailable()).toBe(false);
+    });
+  });
+
+  describe("updateSender", () => {
+    test("uses updated sender for new requests", async () => {
+      setup();
+
+      const newMessages: unknown[] = [];
+      proxy.updateSender((msg) => newMessages.push(msg), true);
+
+      const resultPromise = proxy.request(
+        { cdpMethod: "Page.navigate", cdpParams: { url: "https://a.test" } },
+        "session-1",
+      );
+
+      expect(sentMessages).toHaveLength(0); // Old sender not used.
+      expect(newMessages).toHaveLength(1); // New sender used.
+
+      const sent = newMessages[0] as Record<string, unknown>;
+      proxy.resolve(sent.requestId as string, {
+        content: "ok",
+        isError: false,
+      });
+
+      await resultPromise;
+    });
+  });
+
+  describe("dispose", () => {
+    test("rejects all pending requests, emits cancels, invokes onInternalResolve", () => {
+      const resolvedIds: string[] = [];
+      setup((id) => resolvedIds.push(id));
+
+      const p1 = proxy.request(
+        { cdpMethod: "Page.navigate", cdpParams: { url: "https://a.test" } },
+        "session-1",
+      );
+      const p2 = proxy.request(
+        { cdpMethod: "Page.navigate", cdpParams: { url: "https://b.test" } },
+        "session-1",
+      );
+      p1.catch(() => {}); // Expected rejection on dispose.
+      p2.catch(() => {}); // Expected rejection on dispose.
+
+      const requestIds = (sentMessages as Array<Record<string, unknown>>).map(
+        (m) => m.requestId as string,
+      );
+      expect(requestIds).toHaveLength(2);
+      expect(proxy.hasPendingRequest(requestIds[0]!)).toBe(true);
+      expect(proxy.hasPendingRequest(requestIds[1]!)).toBe(true);
+
+      proxy.dispose();
+
+      // Both pending requests should no longer be tracked.
+      expect(proxy.hasPendingRequest(requestIds[0]!)).toBe(false);
+      expect(proxy.hasPendingRequest(requestIds[1]!)).toBe(false);
+
+      // Both promises should reject with AssistantError message.
+      expect(p1).rejects.toThrow("Host browser proxy disposed");
+      expect(p2).rejects.toThrow("Host browser proxy disposed");
+
+      // After the 2 request messages, dispose should have sent 2 cancel messages.
+      const cancelMessages = sentMessages
+        .slice(2)
+        .filter(
+          (m) => (m as Record<string, unknown>).type === "host_browser_cancel",
+        ) as Array<Record<string, unknown>>;
+      expect(cancelMessages).toHaveLength(2);
+      expect(cancelMessages.map((m) => m.requestId)).toContain(requestIds[0]);
+      expect(cancelMessages.map((m) => m.requestId)).toContain(requestIds[1]);
+
+      // onInternalResolve fired for each pending request on dispose.
+      expect(resolvedIds).toHaveLength(2);
+      expect(resolvedIds).toContain(requestIds[0]!);
+      expect(resolvedIds).toContain(requestIds[1]!);
+    });
+  });
+
+  describe("resolve with unknown requestId", () => {
+    test("silently ignores unknown requestId", () => {
+      setup();
+      // Should not throw.
+      proxy.resolve("nonexistent", {
+        content: "stale",
+        isError: false,
+      });
+    });
+  });
+});

--- a/assistant/src/daemon/host-browser-proxy.ts
+++ b/assistant/src/daemon/host-browser-proxy.ts
@@ -23,6 +23,8 @@ interface PendingRequest {
   resolve: (result: ToolExecutionResult) => void;
   reject: (err: Error) => void;
   timer: ReturnType<typeof setTimeout>;
+  /** Detach the abort listener from the caller's signal. No-op when no signal was passed. */
+  detachAbort: () => void;
 }
 
 export class HostBrowserProxy {
@@ -61,8 +63,14 @@ export class HostBrowserProxy {
     return new Promise<ToolExecutionResult>((resolve, reject) => {
       // CDP operations should be fast — 30 second default timeout matches host_file.
       const timeoutSec = input.timeout_seconds ?? 30;
+
+      // Declared up-front so onAbort (defined before detachAbort is assigned)
+      // can close over a stable reference once it's wired below.
+      let detachAbort: () => void = () => {};
+
       const timer = setTimeout(() => {
         this.pending.delete(requestId);
+        detachAbort();
         this.onInternalResolve?.(requestId);
         log.warn(
           { requestId, cdpMethod: input.cdpMethod },
@@ -74,13 +82,14 @@ export class HostBrowserProxy {
         });
       }, timeoutSec * 1000);
 
-      this.pending.set(requestId, { resolve, reject, timer });
-
       if (signal) {
         const onAbort = () => {
           if (this.pending.has(requestId)) {
             clearTimeout(timer);
             this.pending.delete(requestId);
+            // Abort fired — nothing to detach, but call the no-op for symmetry
+            // so callers can rely on detachAbort being idempotent.
+            detachAbort();
             this.onInternalResolve?.(requestId);
             try {
               this.sendToClient({
@@ -94,7 +103,10 @@ export class HostBrowserProxy {
           }
         };
         signal.addEventListener("abort", onAbort, { once: true });
+        detachAbort = () => signal.removeEventListener("abort", onAbort);
       }
+
+      this.pending.set(requestId, { resolve, reject, timer, detachAbort });
 
       try {
         this.sendToClient({
@@ -109,6 +121,7 @@ export class HostBrowserProxy {
         // leak an in-flight entry that nothing will ever resolve.
         clearTimeout(timer);
         this.pending.delete(requestId);
+        detachAbort();
         this.onInternalResolve?.(requestId);
         log.warn(
           { requestId, cdpMethod: input.cdpMethod, err },
@@ -129,6 +142,7 @@ export class HostBrowserProxy {
       return;
     }
     clearTimeout(entry.timer);
+    entry.detachAbort();
     this.pending.delete(requestId);
     entry.resolve({ content: response.content, isError: response.isError });
   }
@@ -144,6 +158,7 @@ export class HostBrowserProxy {
   dispose(): void {
     for (const [requestId, entry] of this.pending) {
       clearTimeout(entry.timer);
+      entry.detachAbort();
       this.onInternalResolve?.(requestId);
       try {
         this.sendToClient({

--- a/assistant/src/daemon/host-browser-proxy.ts
+++ b/assistant/src/daemon/host-browser-proxy.ts
@@ -96,12 +96,26 @@ export class HostBrowserProxy {
         signal.addEventListener("abort", onAbort, { once: true });
       }
 
-      this.sendToClient({
-        ...input,
-        type: "host_browser_request",
-        requestId,
-        conversationId,
-      } as ServerMessage);
+      try {
+        this.sendToClient({
+          ...input,
+          type: "host_browser_request",
+          requestId,
+          conversationId,
+        } as ServerMessage);
+      } catch (err) {
+        // Sender threw synchronously (e.g. client transport error during
+        // event emission). Clean up pending state and timer so we don't
+        // leak an in-flight entry that nothing will ever resolve.
+        clearTimeout(timer);
+        this.pending.delete(requestId);
+        this.onInternalResolve?.(requestId);
+        log.warn(
+          { requestId, cdpMethod: input.cdpMethod, err },
+          "Host browser proxy send failed",
+        );
+        reject(err instanceof Error ? err : new Error(String(err)));
+      }
     });
   }
 

--- a/assistant/src/daemon/host-browser-proxy.ts
+++ b/assistant/src/daemon/host-browser-proxy.ts
@@ -1,0 +1,151 @@
+import { v4 as uuid } from "uuid";
+
+import type { ToolExecutionResult } from "../tools/types.js";
+import { AssistantError, ErrorCode } from "../util/errors.js";
+import { getLogger } from "../util/logger.js";
+import type { ServerMessage } from "./message-protocol.js";
+import type { HostBrowserRequest } from "./message-types/host-browser.js";
+
+/** Distributive omit that preserves union variant fields. */
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown
+  ? Omit<T, K>
+  : never;
+
+/** Clean input type for callers — transport envelope fields are added by the proxy. */
+export type HostBrowserInput = DistributiveOmit<
+  HostBrowserRequest,
+  "type" | "requestId" | "conversationId"
+>;
+
+const log = getLogger("host-browser-proxy");
+
+interface PendingRequest {
+  resolve: (result: ToolExecutionResult) => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+export class HostBrowserProxy {
+  private pending = new Map<string, PendingRequest>();
+  private sendToClient: (msg: ServerMessage) => void;
+  private onInternalResolve?: (requestId: string) => void;
+  private clientConnected = false;
+
+  constructor(
+    sendToClient: (msg: ServerMessage) => void,
+    onInternalResolve?: (requestId: string) => void,
+  ) {
+    this.sendToClient = sendToClient;
+    this.onInternalResolve = onInternalResolve;
+  }
+
+  updateSender(
+    sendToClient: (msg: ServerMessage) => void,
+    clientConnected: boolean,
+  ): void {
+    this.sendToClient = sendToClient;
+    this.clientConnected = clientConnected;
+  }
+
+  request(
+    input: HostBrowserInput,
+    conversationId: string,
+    signal?: AbortSignal,
+  ): Promise<ToolExecutionResult> {
+    if (signal?.aborted) {
+      return Promise.resolve({ content: "Aborted", isError: true });
+    }
+
+    const requestId = uuid();
+
+    return new Promise<ToolExecutionResult>((resolve, reject) => {
+      // CDP operations should be fast — 30 second default timeout matches host_file.
+      const timeoutSec = input.timeout_seconds ?? 30;
+      const timer = setTimeout(() => {
+        this.pending.delete(requestId);
+        this.onInternalResolve?.(requestId);
+        log.warn(
+          { requestId, cdpMethod: input.cdpMethod },
+          "Host browser proxy request timed out",
+        );
+        resolve({
+          content: "Host browser proxy timed out waiting for client response",
+          isError: true,
+        });
+      }, timeoutSec * 1000);
+
+      this.pending.set(requestId, { resolve, reject, timer });
+
+      if (signal) {
+        const onAbort = () => {
+          if (this.pending.has(requestId)) {
+            clearTimeout(timer);
+            this.pending.delete(requestId);
+            this.onInternalResolve?.(requestId);
+            try {
+              this.sendToClient({
+                type: "host_browser_cancel",
+                requestId,
+              } as ServerMessage);
+            } catch {
+              // Best-effort cancel notification — connection may already be closed.
+            }
+            resolve({ content: "Aborted", isError: true });
+          }
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
+
+      this.sendToClient({
+        ...input,
+        type: "host_browser_request",
+        requestId,
+        conversationId,
+      } as ServerMessage);
+    });
+  }
+
+  resolve(
+    requestId: string,
+    response: { content: string; isError: boolean },
+  ): void {
+    const entry = this.pending.get(requestId);
+    if (!entry) {
+      log.warn({ requestId }, "No pending host browser request for response");
+      return;
+    }
+    clearTimeout(entry.timer);
+    this.pending.delete(requestId);
+    entry.resolve({ content: response.content, isError: response.isError });
+  }
+
+  hasPendingRequest(requestId: string): boolean {
+    return this.pending.has(requestId);
+  }
+
+  isAvailable(): boolean {
+    return this.clientConnected;
+  }
+
+  dispose(): void {
+    for (const [requestId, entry] of this.pending) {
+      clearTimeout(entry.timer);
+      this.onInternalResolve?.(requestId);
+      try {
+        this.sendToClient({
+          type: "host_browser_cancel",
+          requestId,
+        } as ServerMessage);
+      } catch {
+        // Best-effort cancel notification — connection may already be closed.
+      }
+      entry.reject(
+        new AssistantError(
+          "Host browser proxy disposed",
+          ErrorCode.INTERNAL_ERROR,
+        ),
+      );
+    }
+    this.pending.clear();
+  }
+}


### PR DESCRIPTION
## Summary
- Add `HostBrowserProxy` class mirroring `HostFileProxy` for CDP JSON-RPC command tunneling
- Export `HostBrowserInput` helper type using `DistributiveOmit` over the envelope fields
- Unit tests cover happy path, input spread, pending tracking, timeout, abort, dispose, updateSender, and unknown-requestId paths

Part of plan: host-browser-proxy-phase1.md (PR 3 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
