### PR TITLE
fix(file-browser): address self-review gaps from unify-file-browsers plan

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
@@ -48,10 +48,12 @@ struct SkillDetailView: View {
         .onChange(of: skillsManager.selectedSkillFiles?.files.map(\.path)) {
             // 1. Rebuild the browser node tree from the latest file list (moved out of
             //    view body per clients/AGENTS.md: no heavy transformation in body).
+            let textFiles: [SkillFileEntry]
             if let files = skillsManager.selectedSkillFiles?.files {
-                let textFiles = files.filter { !$0.isBinary && $0.content != nil }
+                textFiles = files.filter { !$0.isBinary && $0.content != nil }
                 browserNodes = Self.buildSkillNodeTree(from: textFiles)
             } else {
+                textFiles = []
                 browserNodes = []
             }
 
@@ -66,12 +68,18 @@ struct SkillDetailView: View {
                 }
             }
 
-            // 3. Expand every directory in the tree so nested files are visible by
-            //    default. This preserves the previous flat-list behavior where all
-            //    files were immediately visible. Also union the selected file's
-            //    ancestors as a defensive no-op (already a subset of the above).
-            if let files = skillsManager.selectedSkillFiles?.files {
-                var newExpanded = Self.allDirectoryPaths(in: files)
+            // 3. On first load only, expand every directory in the tree so nested
+            //    files are visible by default — this preserves the pre-tree flat-list
+            //    behavior where all files were immediately visible. On subsequent
+            //    refetches (e.g. files re-fetched after an edit), keep the user's
+            //    existing expansion state so manual collapses aren't clobbered.
+            //    `expandedPaths` is reset to `[]` in `.onDisappear`, so navigating
+            //    to a different skill re-triggers the initial seeding.
+            //    Compute `allDirectoryPaths` from the filtered text files (not the
+            //    raw file list) so directories that only contain binaries — which
+            //    don't appear in the tree — don't leak into `expandedPaths`.
+            if expandedPaths.isEmpty && !textFiles.isEmpty {
+                var newExpanded = Self.allDirectoryPaths(in: textFiles)
                 if let selectedPath = expandedFilePath {
                     newExpanded.formUnion(Self.ancestorPaths(of: selectedPath))
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -138,6 +138,7 @@ struct WorkspacePanel: View {
             expandedPaths: $state.expandedDirs,
             selectedPath: $state.selectedFilePath,
             sidebarWidth: sidebarWidth,
+            isLoading: state.isLoadingTree,
             onExpand: { node in
                 if state.directoryCache[node.path] == nil {
                     await state.refreshDirectory(node.path, using: workspaceClient)
@@ -286,7 +287,17 @@ struct WorkspacePanel: View {
             TextField("Name", text: $state.renamingText)
             Button("Cancel", role: .cancel) {}
             Button("Rename") {
-                Task { await renameItem() }
+                // Capture state synchronously BEFORE creating the Task.
+                // SwiftUI dismisses the alert on button tap, which fires the
+                // binding setter above that clears `state.renamingPath`. The
+                // setter runs before the Task body executes, so if we read
+                // `state.renamingPath` from inside the Task it's already nil
+                // and the rename silently no-ops. Capturing synchronously here
+                // guarantees the rename still has the values the user entered.
+                guard let oldPath = state.renamingPath else { return }
+                let newName = state.renamingText
+                state.renamingPath = nil
+                Task { await renameItem(oldPath: oldPath, newName: newName) }
             }
         }
     }
@@ -522,12 +533,12 @@ struct WorkspacePanel: View {
 
     // MARK: - Rename
 
-    /// Renames the item currently referenced by `state.renamingPath` to the
-    /// name in `state.renamingText`. Preserves all expandedDirs/directoryCache
-    /// migration semantics from the former inline rename implementation.
-    private func renameItem() async {
-        guard let oldPath = state.renamingPath else { return }
-        let newName = state.renamingText
+    /// Renames `oldPath` to a sibling with `newName`. `oldPath` and `newName`
+    /// are captured synchronously by the alert button so this function doesn't
+    /// read them from `state` — if it did, the alert's binding setter would
+    /// have already cleared `state.renamingPath` by the time the Task body
+    /// runs, causing a silent no-op.
+    private func renameItem(oldPath: String, newName: String) async {
         let parentPath = parentDirectory(of: oldPath)
         let newPath = parentPath.isEmpty ? newName : "\(parentPath)/\(newName)"
 
@@ -592,7 +603,6 @@ struct WorkspacePanel: View {
                 }
             }
         }
-        state.renamingPath = nil
     }
 
     private func parentDirectory(of path: String) -> String {
@@ -655,17 +665,11 @@ private struct WorkspaceFileViewer: View {
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if let detail = state.selectedFileDetail {
+                // VFileBrowser.rightPane provides the outer card (bordered
+                // RoundedRectangle with surfaceLift background). Render the
+                // file content edge-to-edge so it doesn't duplicate that
+                // chrome with an inner card.
                 fileContent(detail)
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                    .background(
-                        RoundedRectangle(cornerRadius: VRadius.md)
-                            .fill(VColor.surfaceBase)
-                    )
-                    .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.md)
-                            .strokeBorder(VColor.borderBase, lineWidth: 1)
-                    )
-                    .padding(.horizontal, VSpacing.md)
             } else {
                 emptyState
             }

--- a/clients/shared/DesignSystem/Components/Display/VFileBrowser.swift
+++ b/clients/shared/DesignSystem/Components/Display/VFileBrowser.swift
@@ -67,6 +67,7 @@ public struct VFileBrowser<
     @Binding var selectedPath: String?
     let searchPlaceholder: String
     let sidebarWidth: CGFloat
+    let isLoading: Bool
     let onExpand: ((VFileBrowserNode) async -> Void)?
     let onSelect: ((VFileBrowserNode) -> Void)?
     let onDrop: ((VFileBrowserNode?, [NSItemProvider]) -> Bool)?
@@ -78,6 +79,7 @@ public struct VFileBrowser<
 
     @State private var searchText: String = ""
     @State private var isDropTargeted: Bool = false
+    @State private var cachedVisibleRowData: VisibleRowData = VisibleRowData(rows: [], forcedExpanded: [])
 
     public init(
         title: String = "Files",
@@ -86,6 +88,7 @@ public struct VFileBrowser<
         selectedPath: Binding<String?>,
         searchPlaceholder: String = "Search files",
         sidebarWidth: CGFloat = 280,
+        isLoading: Bool = false,
         onExpand: ((VFileBrowserNode) async -> Void)? = nil,
         onSelect: ((VFileBrowserNode) -> Void)? = nil,
         onDrop: ((VFileBrowserNode?, [NSItemProvider]) -> Bool)? = nil,
@@ -101,6 +104,7 @@ public struct VFileBrowser<
         self._selectedPath = selectedPath
         self.searchPlaceholder = searchPlaceholder
         self.sidebarWidth = sidebarWidth
+        self.isLoading = isLoading
         self.onExpand = onExpand
         self.onSelect = onSelect
         self.onDrop = onDrop
@@ -186,26 +190,41 @@ public struct VFileBrowser<
         }
     }
 
+    @ViewBuilder
     private var treeScrollView: some View {
-        let data = visibleRowData
-        return ScrollView {
-            LazyVStack(spacing: 0) {
-                ForEach(data.rows, id: \.node.path) { row in
-                    VFileBrowserTreeRow(
-                        node: row.node,
-                        depth: row.depth,
-                        isSelected: selectedPath == row.node.path,
-                        isExpanded: expandedPaths.contains(row.node.path) || data.forcedExpanded.contains(row.node.path),
-                        onTap: { handleTap(row.node) },
-                        rowContextMenu: rowContextMenu,
-                        onDrop: onDrop
-                    )
-                }
+        if isLoading && rootNodes.isEmpty {
+            VStack {
+                Spacer()
+                ProgressView()
+                    .controlSize(.small)
+                Spacer()
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.vertical, VSpacing.xs)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(rootDropTarget)
+        } else {
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(cachedVisibleRowData.rows, id: \.id) { row in
+                        VFileBrowserTreeRow(
+                            node: row.node,
+                            depth: row.depth,
+                            isSelected: selectedPath == row.node.path,
+                            isExpanded: expandedPaths.contains(row.node.path) || cachedVisibleRowData.forcedExpanded.contains(row.node.path),
+                            onTap: { handleTap(row.node) },
+                            rowContextMenu: rowContextMenu,
+                            onDrop: onDrop
+                        )
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, VSpacing.xs)
+            }
+            .background(rootDropTarget)
+            .onAppear { recomputeVisibleRowData() }
+            .onChange(of: searchText) { recomputeVisibleRowData() }
+            .onChange(of: expandedPaths) { recomputeVisibleRowData() }
+            .onChange(of: rootNodes) { recomputeVisibleRowData() }
         }
-        .background(rootDropTarget)
     }
 
     @ViewBuilder
@@ -238,6 +257,13 @@ public struct VFileBrowser<
 
     private func handleTap(_ node: VFileBrowserNode) {
         if node.isDirectory {
+            // When search is active the tree is force-expanded to show matches
+            // and their ancestors. Directory taps must be no-ops in that mode
+            // so they don't silently mutate the persistent expansion state —
+            // without this guard, tapping a directory during search removes it
+            // from `expandedPaths` with no visible feedback, and the collapse
+            // is only revealed after the user clears the search bar.
+            guard searchText.isEmpty else { return }
             let wasExpanded = expandedPaths.contains(node.path)
             withAnimation(VAnimation.fast) {
                 if wasExpanded {
@@ -271,33 +297,51 @@ public struct VFileBrowser<
 
     // MARK: - Tree flattening / search
 
-    private struct VisibleRowData {
-        let rows: [(node: VFileBrowserNode, depth: Int)]
+    private struct VisibleRow: Identifiable, Equatable {
+        let node: VFileBrowserNode
+        let depth: Int
+        var id: String { node.path }
+    }
+
+    private struct VisibleRowData: Equatable {
+        let rows: [VisibleRow]
         let forcedExpanded: Set<String>
     }
 
-    /// When search is active, the tree is filtered to matches and their ancestors,
-    /// and ALL ancestor directories are forcibly rendered as expanded regardless of
-    /// `expandedPaths`. This means clicking a directory during search appears to do
-    /// nothing — a deliberate UX choice so users always see the matches.
-    private var visibleRowData: VisibleRowData {
+    /// Recomputes the cached visible row set from the current `rootNodes`,
+    /// `expandedPaths`, and `searchText`. Called from `.onAppear` and from
+    /// `.onChange` handlers on the three inputs instead of being evaluated
+    /// inside the view body — per `clients/AGENTS.md` § "View Bodies and
+    /// Rendering", tree flattening and filtering is too heavy for body eval.
+    ///
+    /// When search is active, the tree is filtered to matches and their
+    /// ancestors, and ALL ancestor directories are forcibly rendered as
+    /// expanded regardless of `expandedPaths`. Directory taps are ignored
+    /// during search (see `handleTap`) so the persistent expansion state is
+    /// preserved.
+    private func recomputeVisibleRowData() {
+        let newData: VisibleRowData
         if searchText.isEmpty {
             let rows = Self.flattenTree(rootNodes, depth: 0, expanded: expandedPaths)
-            return VisibleRowData(rows: rows, forcedExpanded: [])
+            newData = VisibleRowData(rows: rows, forcedExpanded: [])
+        } else {
+            let result = Self.filterTreeForSearch(rootNodes, query: searchText)
+            let rows = Self.flattenTree(result.nodes, depth: 0, expanded: result.forcedExpanded)
+            newData = VisibleRowData(rows: rows, forcedExpanded: result.forcedExpanded)
         }
-        let result = Self.filterTreeForSearch(rootNodes, query: searchText)
-        let rows = Self.flattenTree(result.nodes, depth: 0, expanded: result.forcedExpanded)
-        return VisibleRowData(rows: rows, forcedExpanded: result.forcedExpanded)
+        if newData != cachedVisibleRowData {
+            cachedVisibleRowData = newData
+        }
     }
 
     private static func flattenTree(
         _ nodes: [VFileBrowserNode],
         depth: Int,
         expanded: Set<String>
-    ) -> [(node: VFileBrowserNode, depth: Int)] {
-        var result: [(VFileBrowserNode, Int)] = []
+    ) -> [VisibleRow] {
+        var result: [VisibleRow] = []
         for node in nodes {
-            result.append((node, depth))
+            result.append(VisibleRow(node: node, depth: depth))
             if node.isDirectory && expanded.contains(node.path) {
                 result.append(contentsOf: flattenTree(node.children, depth: depth + 1, expanded: expanded))
             }
@@ -365,6 +409,7 @@ where
         selectedPath: Binding<String?>,
         searchPlaceholder: String = "Search files",
         sidebarWidth: CGFloat = 280,
+        isLoading: Bool = false,
         onExpand: ((VFileBrowserNode) async -> Void)? = nil,
         onSelect: ((VFileBrowserNode) -> Void)? = nil,
         onDrop: ((VFileBrowserNode?, [NSItemProvider]) -> Bool)? = nil,
@@ -377,6 +422,7 @@ where
             selectedPath: selectedPath,
             searchPlaceholder: searchPlaceholder,
             sidebarWidth: sidebarWidth,
+            isLoading: isLoading,
             onExpand: onExpand,
             onSelect: onSelect,
             onDrop: onDrop,
@@ -409,6 +455,23 @@ private struct VFileBrowserTreeRow<RowContextMenu: View>: View {
     let onDrop: ((VFileBrowserNode?, [NSItemProvider]) -> Bool)?
 
     @State private var isDropTargeted = false
+    @State private var isHovered = false
+
+    /// Selected state always wins over hovered state, and drop-targeted state
+    /// wins over hover so the user gets the strongest feedback for the action
+    /// they're performing.
+    private var rowBackground: Color {
+        if isSelected {
+            return VColor.surfaceActive
+        }
+        if isDropTargeted {
+            return VColor.surfaceBase
+        }
+        if isHovered {
+            return VColor.surfaceBase
+        }
+        return Color.clear
+    }
 
     var body: some View {
         Button(action: onTap) {
@@ -455,13 +518,15 @@ private struct VFileBrowserTreeRow<RowContextMenu: View>: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: VRadius.sm)
-                    .fill(isSelected ? VColor.surfaceActive : (isDropTargeted ? VColor.surfaceBase : Color.clear))
+                    .fill(rowBackground)
             )
             .opacity(node.isDimmed ? 0.6 : 1.0)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .pointerCursor()
+        .onHover { isHovered = $0 }
+        .animation(VAnimation.fast, value: isHovered)
         .accessibilityLabel(node.name)
         .accessibilityHint(
             isSelected ? "Selected"


### PR DESCRIPTION
## Summary

Addresses gaps found during the self-review of the unify-file-browsers plan:

- **Rename flow** (CRITICAL): Capture state synchronously in the alert button so renames don't silently no-op
- **Loading spinner**: Add additive `isLoading` parameter to VFileBrowser; restore loading feedback for Workspace
- **Double border**: Remove WorkspaceFileViewer's inner card chrome now that VFileBrowser provides the outer card
- **Directory taps during search**: Gate handleTap on searchText.isEmpty so persistent expansion state isn't silently mutated
- **Body perf**: Cache visibleRowData via @State + onChange instead of recomputing on every body eval
- **Skills allDirectoryPaths**: Compute from filtered text files; only seed expandedPaths on first load
- **Skills hover state**: Restore the per-row hover highlight that the old VFileBrowserRow had

Fixes gaps identified during plan review for unify-file-browsers.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
