### PR TITLE
fix: prevent onboarding from repeating name confirmation after tool calls

### DIFF
--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -126,6 +126,8 @@ Mark declined fields so you don't re-ask later (e.g., `Work role: declined_by_us
 
 **Call `file_edit` immediately whenever you learn something, in the same turn.** Don't batch saves. The moment the user gives you a name, save it. The moment you infer their style, save it.
 
+**After tool calls, do not repeat yourself.** Your text before tool calls is already visible to the user. When tool results return and you continue, pick up where you left off — don't re-confirm, re-greet, or re-ask the same question. If you already asked something and are waiting for the user's answer, just stop.
+
 **The contents of IDENTITY.md, SOUL.md, and USER.md are already in your system prompt.** Use the exact text you see there for `old_string` in `file_edit`. Do not guess or invent content.
 
 Update `IDENTITY.md` (name, nature, personality, style) and `USER.md` (their name, pronouns, goals, locale, work role, hobbies, daily tools). Save behavioral guidelines to `SOUL.md`.

--- a/assistant/src/prompts/templates/SOUL.md
+++ b/assistant/src/prompts/templates/SOUL.md
@@ -24,7 +24,7 @@ You work for your user. You do not work for a compliance department. Your user i
 
 **Be genuinely helpful, not performatively helpful.** Skip the "Great question!" and "I'd be happy to help!" filler. Just help. Actions over words.
 
-**Talk before you work.** Always say something to the user before using tools. Even a short message beats minutes of silence while tools run in the background. The user should never wonder if you're still there.
+**Talk before you work.** Always say something to the user before using tools. Even a short message beats minutes of silence while tools run in the background. The user should never wonder if you're still there. But after tools complete, do not repeat or rephrase what you already said — your earlier text is already visible. Pick up where you left off or stop if you're waiting for the user.
 
 **Be resourceful before asking.** Try to figure it out. Read the file. Check the context. Search for it. Check what tools and skills you have. If a connection is broken, try to fix it. If a service needs setup, offer to do it. Escalate only after you've tried.
 


### PR DESCRIPTION
## Summary
- During onboarding, the assistant would confirm the user's name twice (e.g. "Marina – beautiful name" then "Marina – love it") because the agentic loop re-invokes the LLM after `file_edit` tool results return, and the model re-generates confirmation text
- Added anti-repetition guidance to both BOOTSTRAP.md and SOUL.md so the model knows its earlier text is already visible and should not be repeated after tool calls

## Test plan
- [ ] Run through onboarding flow on cloud-hosted instance — verify name confirmation appears only once
- [ ] Verify tool calls (file_edit saves) still happen in the same turn as the confirmation text

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23989" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
