### PR TITLE
fix: seed ThinkingBlockView markdown cache for initiallyExpanded path

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ThinkingBlockView.swift
@@ -11,13 +11,20 @@ struct ThinkingBlockView: View {
     @State private var isExpanded: Bool
     /// Cached parsed markdown segments — parsed lazily only when the block is
     /// expanded, avoiding synchronous O(n) work while collapsed (the default).
-    @State private var cachedSegments: [MarkdownSegment] = []
-    @State private var cachedContent: String = ""
+    @State private var cachedSegments: [MarkdownSegment]
+    @State private var cachedContent: String
 
     init(content: String, isStreaming: Bool, initiallyExpanded: Bool = false) {
         self.content = content
         self.isStreaming = isStreaming
         _isExpanded = State(initialValue: initiallyExpanded)
+        if initiallyExpanded {
+            _cachedSegments = State(initialValue: parseMarkdownSegments(content))
+            _cachedContent = State(initialValue: content)
+        } else {
+            _cachedSegments = State(initialValue: [])
+            _cachedContent = State(initialValue: "")
+        }
     }
 
     var body: some View {


### PR DESCRIPTION
Addresses review feedback on #23965. When `initiallyExpanded: true`, the lazy markdown parsing via `onChange` handlers never fires on the initial render, leaving the block with empty content. This seeds the cache eagerly in `init` only when `initiallyExpanded` is true, preserving the lazy behavior for the default collapsed path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23990" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
