### PR TITLE
fix: scope stabilizationGeneration bump to mode-exit transitions only

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -477,8 +477,11 @@ final class MessageListScrollState {
             // transition(), so resetting here would clobber the new count,
             // causing the first endStabilization to prematurely exit.
             if case .stabilizing = newMode {
-                // Staying in stabilizing: preserve the window count.
+                // Staying in stabilizing: preserve the window count
+                // and generation so cancelled tasks from the old reason
+                // can still call endStabilization() to balance the count.
             } else {
+                stabilizationGeneration &+= 1
                 activeStabilizationCount = 0
             }
         default:
@@ -535,7 +538,6 @@ final class MessageListScrollState {
     }
 
     private func cancelStabilizationTasks() {
-        stabilizationGeneration &+= 1
         expansionTimeoutTask?.cancel()
         expansionTimeoutTask = nil
     }


### PR DESCRIPTION
Addresses review feedback on #23968. During cross-reason stabilization transitions (e.g. `.expansion` → `.resize`), the unconditional generation bump in `cancelStabilizationTasks()` prevented the cancelled expansion task from calling `endStabilization()`, leaving `activeStabilizationCount` permanently stuck at 1 and mode locked in `.stabilizing`. Now the generation only bumps when actually leaving stabilizing mode entirely.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23991" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
