### PR TITLE
fix(file-browser): eliminate first-render flash and harden Skills first-load gate

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
@@ -10,6 +10,7 @@ struct SkillDetailView: View {
 
     @State private var expandedFilePath: String?
     @State private var expandedPaths: Set<String> = []
+    @State private var didSeedExpandedPaths: Bool = false
     @State private var skillFileViewMode: FileViewMode = .source
     @State private var browserNodes: [VFileBrowserNode] = []
 
@@ -68,22 +69,26 @@ struct SkillDetailView: View {
                 }
             }
 
-            // 3. On first load only, expand every directory in the tree so nested
-            //    files are visible by default — this preserves the pre-tree flat-list
-            //    behavior where all files were immediately visible. On subsequent
-            //    refetches (e.g. files re-fetched after an edit), keep the user's
-            //    existing expansion state so manual collapses aren't clobbered.
-            //    `expandedPaths` is reset to `[]` in `.onDisappear`, so navigating
+            // 3. On the first fetch for this skill view, expand every directory in
+            //    the tree so nested files are visible by default — this preserves
+            //    the pre-tree flat-list behavior where all files were immediately
+            //    visible. On subsequent refetches (e.g. files re-fetched after an
+            //    edit, a refresh button, or a file watcher), the `didSeedExpandedPaths`
+            //    flag prevents re-seeding so manual collapses aren't clobbered —
+            //    even if the user has collapsed every directory (which would defeat
+            //    a naive `expandedPaths.isEmpty` predicate). `didSeedExpandedPaths`
+            //    is reset in `.onDisappear` alongside `expandedPaths`, so navigating
             //    to a different skill re-triggers the initial seeding.
             //    Compute `allDirectoryPaths` from the filtered text files (not the
             //    raw file list) so directories that only contain binaries — which
             //    don't appear in the tree — don't leak into `expandedPaths`.
-            if expandedPaths.isEmpty && !textFiles.isEmpty {
+            if !didSeedExpandedPaths && !textFiles.isEmpty {
                 var newExpanded = Self.allDirectoryPaths(in: textFiles)
                 if let selectedPath = expandedFilePath {
                     newExpanded.formUnion(Self.ancestorPaths(of: selectedPath))
                 }
                 expandedPaths = newExpanded
+                didSeedExpandedPaths = true
             }
         }
         .onChange(of: expandedFilePath) {
@@ -98,6 +103,7 @@ struct SkillDetailView: View {
         .onDisappear {
             expandedFilePath = nil
             expandedPaths = []
+            didSeedExpandedPaths = false
             browserNodes = []
             skillsManager.clearSkillDetail()
         }

--- a/clients/shared/DesignSystem/Components/Display/VFileBrowser.swift
+++ b/clients/shared/DesignSystem/Components/Display/VFileBrowser.swift
@@ -202,14 +202,15 @@ public struct VFileBrowser<
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(rootDropTarget)
         } else {
+            let data = visibleRowData
             ScrollView {
                 LazyVStack(spacing: 0) {
-                    ForEach(cachedVisibleRowData.rows, id: \.id) { row in
+                    ForEach(data.rows, id: \.id) { row in
                         VFileBrowserTreeRow(
                             node: row.node,
                             depth: row.depth,
                             isSelected: selectedPath == row.node.path,
-                            isExpanded: expandedPaths.contains(row.node.path) || cachedVisibleRowData.forcedExpanded.contains(row.node.path),
+                            isExpanded: expandedPaths.contains(row.node.path) || data.forcedExpanded.contains(row.node.path),
                             onTap: { handleTap(row.node) },
                             rowContextMenu: rowContextMenu,
                             onDrop: onDrop
@@ -225,6 +226,24 @@ public struct VFileBrowser<
             .onChange(of: expandedPaths) { recomputeVisibleRowData() }
             .onChange(of: rootNodes) { recomputeVisibleRowData() }
         }
+    }
+
+    /// Optimistic memo accessor for the flattened visible row set.
+    ///
+    /// The `cachedVisibleRowData` state property is updated by `.onAppear` and
+    /// `.onChange` callbacks, but SwiftUI evaluates the view body BEFORE those
+    /// callbacks fire. On the very first render after `rootNodes` transitions
+    /// from empty to non-empty, the cache is still the empty initial value,
+    /// which would produce a sub-frame "empty tree" flash before the
+    /// recomputation lands. To prevent that, fall back to computing the row
+    /// set inline when the cache is stale (empty rows but non-empty
+    /// `rootNodes`). The next `.onChange`/`.onAppear` tick will populate the
+    /// cache so subsequent body evaluations take the fast path.
+    private var visibleRowData: VisibleRowData {
+        if !cachedVisibleRowData.rows.isEmpty || rootNodes.isEmpty {
+            return cachedVisibleRowData
+        }
+        return computeVisibleRowData()
     }
 
     @ViewBuilder
@@ -308,27 +327,36 @@ public struct VFileBrowser<
         let forcedExpanded: Set<String>
     }
 
-    /// Recomputes the cached visible row set from the current `rootNodes`,
-    /// `expandedPaths`, and `searchText`. Called from `.onAppear` and from
-    /// `.onChange` handlers on the three inputs instead of being evaluated
-    /// inside the view body — per `clients/AGENTS.md` § "View Bodies and
-    /// Rendering", tree flattening and filtering is too heavy for body eval.
+    /// Computes the visible row set from the current `rootNodes`,
+    /// `expandedPaths`, and `searchText` without mutating state. Used by both
+    /// the memoized `recomputeVisibleRowData()` writer (which stores the
+    /// result in `cachedVisibleRowData`) and the `visibleRowData` computed
+    /// property's fallback path (which needs a correct row set during a body
+    /// evaluation where the cache hasn't been populated yet).
     ///
     /// When search is active, the tree is filtered to matches and their
     /// ancestors, and ALL ancestor directories are forcibly rendered as
     /// expanded regardless of `expandedPaths`. Directory taps are ignored
     /// during search (see `handleTap`) so the persistent expansion state is
     /// preserved.
-    private func recomputeVisibleRowData() {
-        let newData: VisibleRowData
+    private func computeVisibleRowData() -> VisibleRowData {
         if searchText.isEmpty {
             let rows = Self.flattenTree(rootNodes, depth: 0, expanded: expandedPaths)
-            newData = VisibleRowData(rows: rows, forcedExpanded: [])
-        } else {
-            let result = Self.filterTreeForSearch(rootNodes, query: searchText)
-            let rows = Self.flattenTree(result.nodes, depth: 0, expanded: result.forcedExpanded)
-            newData = VisibleRowData(rows: rows, forcedExpanded: result.forcedExpanded)
+            return VisibleRowData(rows: rows, forcedExpanded: [])
         }
+        let result = Self.filterTreeForSearch(rootNodes, query: searchText)
+        let rows = Self.flattenTree(result.nodes, depth: 0, expanded: result.forcedExpanded)
+        return VisibleRowData(rows: rows, forcedExpanded: result.forcedExpanded)
+    }
+
+    /// Recomputes the cached visible row set and writes it to
+    /// `cachedVisibleRowData`. Called from `.onAppear` and `.onChange`
+    /// handlers on `rootNodes`, `expandedPaths`, and `searchText` instead of
+    /// being evaluated inside the view body — per `clients/AGENTS.md` §
+    /// "View Bodies and Rendering", tree flattening and filtering is too
+    /// heavy for body eval.
+    private func recomputeVisibleRowData() {
+        let newData = computeVisibleRowData()
         if newData != cachedVisibleRowData {
             cachedVisibleRowData = newData
         }


### PR DESCRIPTION
## Summary

- VFileBrowser now falls back to inline visible-row computation when the @State cache is empty but rootNodes is populated, eliminating the sub-frame empty-tree flash on first render.
- SkillDetailView's first-load expansion gate now uses a dedicated didSeedExpandedPaths flag instead of relying on the brittle 'expandedPaths.isEmpty' check, so future refetch paths can't silently clobber a user's manual collapses.

Fixes round 2 self-review gaps for unify-file-browsers.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
