### PR TITLE
fix: default LANG/LC_ALL to UTF-8 in sandbox environment

### DIFF
--- a/assistant/src/__tests__/terminal-tools.test.ts
+++ b/assistant/src/__tests__/terminal-tools.test.ts
@@ -445,6 +445,15 @@ describe("buildSanitizedEnv", () => {
     expect(env.LC_CTYPE).toBe("UTF-8");
   });
 
+  test("defaults LANG and LC_ALL to UTF-8 when unset", () => {
+    delete process.env.LANG;
+    delete process.env.LC_ALL;
+
+    const env = buildSanitizedEnv();
+    expect(env.LANG).toBe("en_US.UTF-8");
+    expect(env.LC_ALL).toBe("en_US.UTF-8");
+  });
+
   test("injects INTERNAL_GATEWAY_BASE_URL from gateway config", () => {
     process.env.GATEWAY_PORT = "9000";
     const env = buildSanitizedEnv();

--- a/assistant/src/tools/terminal/safe-env.ts
+++ b/assistant/src/tools/terminal/safe-env.ts
@@ -71,5 +71,9 @@ export function buildSanitizedEnv(): Record<string, string> {
   // Expose the workspace directory so skills and child processes can read/write
   // workspace-scoped files (e.g. avatar traits, user data).
   env.VELLUM_WORKSPACE_DIR = getWorkspaceDir();
+  // Ensure UTF-8 locale so multi-byte characters (em dashes, curly quotes,
+  // arrows, etc.) survive piping through tools like pbcopy without corruption.
+  if (!env.LANG) env.LANG = "en_US.UTF-8";
+  if (!env.LC_ALL) env.LC_ALL = "en_US.UTF-8";
   return env;
 }


### PR DESCRIPTION
## Summary
- Default `LANG` and `LC_ALL` to `en_US.UTF-8` in `buildSanitizedEnv()` when not already set in the process environment
- Fixes multi-byte UTF-8 characters (em dashes, curly quotes, arrows) corrupting when piped through tools like `pbcopy` in the bash sandbox

## Test plan
- [x] Existing `buildSanitizedEnv` tests pass (8/8)
- [x] New test verifies UTF-8 defaults are applied when `LANG`/`LC_ALL` are unset
- [x] Existing test confirms explicit locale values are preserved when set

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23994" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
