### PR TITLE
feat(tools): thread hostBrowserProxy through tool context

### DIFF
--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -106,6 +106,8 @@ export interface ToolSetupContext extends SurfaceConversationContext {
   callSessionId?: string;
   /** Optional proxy for delegating host_bash execution to a connected client. */
   hostBashProxy?: import("./host-bash-proxy.js").HostBashProxy;
+  /** Optional proxy for delegating CDP commands to a connected client (managed/cloud-hosted mode). */
+  hostBrowserProxy?: import("./host-browser-proxy.js").HostBrowserProxy;
   /** Optional proxy for delegating host_file_read/write/edit execution to a connected client. */
   hostFileProxy?: import("./host-file-proxy.js").HostFileProxy;
   /** CES RPC client for credential execution operations. Injected when CES tools are enabled and the CES process is available. */
@@ -190,6 +192,7 @@ export function createToolExecutor(
       forcePromptSideEffects: ctx.memoryPolicy.strictSideEffects,
       toolUseId,
       hostBashProxy: ctx.hostBashProxy,
+      hostBrowserProxy: ctx.hostBrowserProxy,
       hostFileProxy: ctx.hostFileProxy,
       isPlatformHosted: getIsPlatform(),
       cesClient: ctx.cesClient,

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -176,6 +176,8 @@ export interface ToolContext {
   toolUseId?: string;
   /** Optional proxy for delegating host_bash execution to a connected client (managed/cloud-hosted mode). */
   hostBashProxy?: import("../daemon/host-bash-proxy.js").HostBashProxy;
+  /** Optional proxy for delegating CDP commands to a connected client (managed/cloud-hosted mode). */
+  hostBrowserProxy?: import("../daemon/host-browser-proxy.js").HostBrowserProxy;
   /** Optional proxy for delegating host_file_read/write/edit execution to a connected client (managed/cloud-hosted mode). */
   hostFileProxy?: import("../daemon/host-file-proxy.js").HostFileProxy;
   /** True when the assistant is running as a platform-managed remote instance. Used to auto-approve sandboxed bash tools. */


### PR DESCRIPTION
## Summary
- Add `hostBrowserProxy?:` field to `ToolContext` and `ToolSetupContext`
- Propagate the proxy through `createToolExecutor` alongside the existing three host proxies
- Pure plumbing — no tool currently consumes the proxy; a CDP tool will be added in a later phase

Part of plan: host-browser-proxy-phase1.md (PR 5 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23995" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
