### PR TITLE
feat(daemon): wire HostBrowserProxy into Conversation

### DIFF
--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -104,6 +104,7 @@ import {
 } from "./conversation-tool-setup.js";
 import { refreshWorkspaceTopLevelContextIfNeeded as refreshWorkspaceImpl } from "./conversation-workspace.js";
 import { HostBashProxy } from "./host-bash-proxy.js";
+import { HostBrowserProxy } from "./host-browser-proxy.js";
 import type { CuObservationResult } from "./host-cu-proxy.js";
 import { HostCuProxy } from "./host-cu-proxy.js";
 import { HostFileProxy } from "./host-file-proxy.js";
@@ -180,6 +181,7 @@ export class Conversation {
   /** @internal */ taskRunId?: string;
   /** @internal */ callSessionId?: string;
   /** @internal */ hostBashProxy?: HostBashProxy;
+  /** @internal */ hostBrowserProxy?: HostBrowserProxy;
   /** @internal */ hostCuProxy?: HostCuProxy;
   /** @internal */ hostFileProxy?: HostFileProxy;
   /** @internal */ cesClient?: CesClient;
@@ -501,6 +503,7 @@ export class Conversation {
     this.traceEmitter.updateSender(sendToClient);
     if (!opts?.skipProxySenderUpdate) {
       this.hostBashProxy?.updateSender(sendToClient, !hasNoClient);
+      this.hostBrowserProxy?.updateSender(sendToClient, !hasNoClient);
       this.hostCuProxy?.updateSender(sendToClient, !hasNoClient);
       this.hostFileProxy?.updateSender(sendToClient, !hasNoClient);
     }
@@ -527,6 +530,7 @@ export class Conversation {
   /** Mark host proxies as unavailable so tool execution uses local fallback. */
   clearProxyAvailability(): void {
     this.hostBashProxy?.updateSender(this.sendToClient, false);
+    this.hostBrowserProxy?.updateSender(this.sendToClient, false);
     this.hostCuProxy?.updateSender(this.sendToClient, false);
     this.hostFileProxy?.updateSender(this.sendToClient, false);
   }
@@ -535,6 +539,7 @@ export class Conversation {
   restoreProxyAvailability(): void {
     if (!this.hasNoClient) {
       this.hostBashProxy?.updateSender(this.sendToClient, true);
+      this.hostBrowserProxy?.updateSender(this.sendToClient, true);
       this.hostCuProxy?.updateSender(this.sendToClient, true);
       this.hostFileProxy?.updateSender(this.sendToClient, true);
     }
@@ -570,6 +575,7 @@ export class Conversation {
   dispose(): void {
     approvalOverrides.clearMode(this.conversationId);
     this.hostBashProxy?.dispose();
+    this.hostBrowserProxy?.dispose();
     this.hostCuProxy?.dispose();
     this.hostFileProxy?.dispose();
     // CES client is owned by DaemonServer — just drop the reference.
@@ -866,6 +872,20 @@ export class Conversation {
       this.hostBashProxy.dispose();
     }
     this.hostBashProxy = proxy;
+  }
+
+  resolveHostBrowser(
+    requestId: string,
+    response: { content: string; isError: boolean },
+  ): void {
+    this.hostBrowserProxy?.resolve(requestId, response);
+  }
+
+  setHostBrowserProxy(proxy: HostBrowserProxy | undefined): void {
+    if (this.hostBrowserProxy && this.hostBrowserProxy !== proxy) {
+      this.hostBrowserProxy.dispose();
+    }
+    this.hostBrowserProxy = proxy;
   }
 
   resolveHostFile(


### PR DESCRIPTION
## Summary
- Add `hostBrowserProxy?:` field to the `Conversation` class
- Add `resolveHostBrowser()` and `setHostBrowserProxy()` public methods
- Propagate lifecycle (`updateSender`, `dispose`) to the new proxy alongside the existing three

Part of plan: host-browser-proxy-phase1.md (PR 4 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23996" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
