### PR TITLE
fix: replace deprecated assistant.vellum.ai domain in test fixture

### DIFF
--- a/gateway/src/__tests__/remote-feature-flag-sync.test.ts
+++ b/gateway/src/__tests__/remote-feature-flag-sync.test.ts
@@ -60,7 +60,7 @@ function fakeCredentialCache(
 
 function defaultCredentials(): Record<string, string> {
   return {
-    "credential/vellum/platform_base_url": "https://assistant.vellum.ai",
+    "credential/vellum/platform_base_url": "https://vellum.ai",
     "credential/vellum/platform_assistant_id": "asst-123",
     "credential/vellum/assistant_api_key": "test-api-key",
   };

--- a/gateway/src/__tests__/remote-feature-flag-sync.test.ts
+++ b/gateway/src/__tests__/remote-feature-flag-sync.test.ts
@@ -60,7 +60,7 @@ function fakeCredentialCache(
 
 function defaultCredentials(): Record<string, string> {
   return {
-    "credential/vellum/platform_base_url": "https://vellum.ai",
+    "credential/vellum/platform_base_url": "https://platform.vellum.ai",
     "credential/vellum/platform_assistant_id": "asst-123",
     "credential/vellum/assistant_api_key": "test-api-key",
   };


### PR DESCRIPTION
## Summary
- Replace `assistant.vellum.ai` with `vellum.ai` in the remote feature flag sync test fixture, as the `assistant.vellum.ai` production domain is being retired

## Original prompt
fix the above
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23997" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
