### PR TITLE
M5: Daemon feed writer & action proxy

### DIFF
--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -22,6 +22,7 @@ export * from "./message-types/conversations.js";
 export * from "./message-types/diagnostics.js";
 export * from "./message-types/documents.js";
 export * from "./message-types/guardian-actions.js";
+export * from "./message-types/home.js";
 export * from "./message-types/host-bash.js";
 export * from "./message-types/host-cu.js";
 export * from "./message-types/host-file.js";
@@ -76,6 +77,7 @@ import type {
   _GuardianActionsClientMessages,
   _GuardianActionsServerMessages,
 } from "./message-types/guardian-actions.js";
+import type { _HomeServerMessages } from "./message-types/home.js";
 import type { _HostBashServerMessages } from "./message-types/host-bash.js";
 import type { _HostCuServerMessages } from "./message-types/host-cu.js";
 import type { _HostFileServerMessages } from "./message-types/host-file.js";
@@ -185,6 +187,7 @@ export type ServerMessage =
   | _SubagentsServerMessages
   | _DocumentsServerMessages
   | _GuardianActionsServerMessages
+  | _HomeServerMessages
   | _HostBashServerMessages
   | _HostCuServerMessages
   | _HostFileServerMessages

--- a/assistant/src/daemon/message-types/home.ts
+++ b/assistant/src/daemon/message-types/home.ts
@@ -1,0 +1,12 @@
+// Home feed: events for feed updates pushed to connected clients.
+
+// === Server → Client ===
+
+/** Sent by the daemon when the home feed JSON file has been updated. */
+export interface HomeFeedUpdated {
+  type: "home_feed_updated";
+}
+
+// --- Domain-level union aliases (consumed by the barrel file) ---
+
+export type _HomeServerMessages = HomeFeedUpdated;

--- a/assistant/src/home/__tests__/feed-writer.test.ts
+++ b/assistant/src/home/__tests__/feed-writer.test.ts
@@ -1,0 +1,127 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+import type { FeedItem } from "../feed-writer.js";
+import { readFeedItems, writeFeedItems } from "../feed-writer.js";
+
+// ---------------------------------------------------------------------------
+// Temp directory scaffold
+// ---------------------------------------------------------------------------
+
+let testDir: string;
+
+beforeAll(() => {
+  testDir = mkdtempSync(join(tmpdir(), "feed-writer-test-"));
+});
+
+afterAll(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+// Each test gets its own workspace subdirectory to avoid cross-contamination
+let wsCounter = 0;
+function freshWorkspace(): string {
+  wsCounter++;
+  const ws = join(testDir, `ws-${wsCounter}`);
+  mkdirSync(ws, { recursive: true });
+  return ws;
+}
+
+// ---------------------------------------------------------------------------
+// Sample data
+// ---------------------------------------------------------------------------
+
+function sampleItem(overrides?: Partial<FeedItem>): FeedItem {
+  return {
+    id: "item-1",
+    type: "nudge",
+    priority: 50,
+    title: "Test nudge",
+    summary: "A test feed item",
+    timestamp: "2026-04-07T12:00:00.000Z",
+    status: "new",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("readFeedItems", () => {
+  test("returns empty feed when file does not exist", async () => {
+    const ws = freshWorkspace();
+    const result = await readFeedItems(ws);
+    expect(result).toEqual({ version: 1, lastUpdated: "", items: [] });
+  });
+});
+
+describe("writeFeedItems", () => {
+  test("write + read roundtrip preserves data", async () => {
+    const ws = freshWorkspace();
+    const items: FeedItem[] = [
+      sampleItem(),
+      sampleItem({
+        id: "item-2",
+        type: "digest",
+        priority: 80,
+        title: "Digest item",
+        summary: "Another item",
+        status: "seen",
+        actions: [{ id: "act-1", label: "Open" }],
+      }),
+    ];
+
+    await writeFeedItems(ws, items);
+    const result = await readFeedItems(ws);
+
+    expect(result.version).toBe(1);
+    expect(result.lastUpdated).toBeTruthy();
+    expect(result.items).toHaveLength(2);
+    expect(result.items[0].id).toBe("item-1");
+    expect(result.items[1].id).toBe("item-2");
+    expect(result.items[1].actions).toEqual([{ id: "act-1", label: "Open" }]);
+  });
+
+  test("creates data/ directory if missing", async () => {
+    const ws = freshWorkspace();
+    const dataDir = join(ws, "data");
+
+    expect(existsSync(dataDir)).toBe(false);
+
+    await writeFeedItems(ws, [sampleItem()]);
+
+    expect(existsSync(dataDir)).toBe(true);
+    expect(existsSync(join(dataDir, "home-feed.json"))).toBe(true);
+  });
+
+  test("atomic write uses temp file + rename (no leftover temp files)", async () => {
+    const ws = freshWorkspace();
+
+    await writeFeedItems(ws, [sampleItem()]);
+
+    const dataDir = join(ws, "data");
+    const files = readdirSync(dataDir);
+    // Only the final file should remain — no .tmp-* files
+    expect(files).toEqual(["home-feed.json"]);
+  });
+
+  test("overwrites existing feed file", async () => {
+    const ws = freshWorkspace();
+
+    await writeFeedItems(ws, [sampleItem({ id: "first" })]);
+    await writeFeedItems(ws, [sampleItem({ id: "second" })]);
+
+    const result = await readFeedItems(ws);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].id).toBe("second");
+  });
+});

--- a/assistant/src/home/feed-writer.ts
+++ b/assistant/src/home/feed-writer.ts
@@ -1,0 +1,129 @@
+/**
+ * Home Feed Writer — reads and writes the home-feed.json file.
+ *
+ * The feed file lives at `{workspaceDir}/data/home-feed.json` and is
+ * written atomically (temp file + rename) to prevent partial reads.
+ * After each write, an `home_feed_updated` SSE event is emitted so
+ * connected clients can refresh.
+ */
+
+import { randomUUID } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+import { buildAssistantEvent } from "../runtime/assistant-event.js";
+import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("feed-writer");
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface FeedAction {
+  id: string;
+  label: string;
+}
+
+export interface FeedItem {
+  id: string;
+  type: "nudge" | "digest" | "action" | "thread";
+  priority: number;
+  title: string;
+  summary: string;
+  source?: string;
+  timestamp: string;
+  status: "new" | "seen" | "acted_on";
+  ttl?: string;
+  minTimeAway?: number;
+  actions?: FeedAction[];
+}
+
+export interface HomeFeedFile {
+  version: 1;
+  lastUpdated: string;
+  items: FeedItem[];
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function feedFilePath(workspaceDir: string): string {
+  return join(workspaceDir, "data", "home-feed.json");
+}
+
+function emptyFeed(): HomeFeedFile {
+  return { version: 1, lastUpdated: "", items: [] };
+}
+
+function atomicWriteFile(filePath: string, content: string): void {
+  const dir = dirname(filePath);
+  const tmpPath = join(dir, `.tmp-${randomUUID()}`);
+  writeFileSync(tmpPath, content, "utf-8");
+  renameSync(tmpPath, filePath);
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Read and parse the home feed file.
+ * Returns an empty feed structure if the file doesn't exist.
+ */
+export async function readFeedItems(
+  workspaceDir: string,
+): Promise<HomeFeedFile> {
+  const filePath = feedFilePath(workspaceDir);
+  if (!existsSync(filePath)) {
+    return emptyFeed();
+  }
+  try {
+    const raw = readFileSync(filePath, "utf-8");
+    const data = JSON.parse(raw) as HomeFeedFile;
+    return data;
+  } catch (err) {
+    log.warn({ err }, "Failed to read home feed file, returning empty feed");
+    return emptyFeed();
+  }
+}
+
+/**
+ * Write feed items atomically and emit an SSE event.
+ *
+ * Creates the `data/` directory if it doesn't exist. Writes to a temp
+ * file first, then renames for atomicity.
+ */
+export async function writeFeedItems(
+  workspaceDir: string,
+  items: FeedItem[],
+): Promise<void> {
+  const filePath = feedFilePath(workspaceDir);
+  const dir = dirname(filePath);
+
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+
+  const feed: HomeFeedFile = {
+    version: 1,
+    lastUpdated: new Date().toISOString(),
+    items,
+  };
+
+  atomicWriteFile(filePath, JSON.stringify(feed, null, 2));
+
+  // Emit SSE event to notify connected clients
+  assistantEventHub
+    .publish(
+      buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, {
+        type: "home_feed_updated",
+      }),
+    )
+    .catch((err: unknown) => {
+      log.warn({ err }, "Failed to publish home_feed_updated event");
+    });
+}

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -485,6 +485,9 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   // Permission mode
   { endpoint: "permission-mode:GET", scopes: ["settings.read"] },
   { endpoint: "permission-mode", scopes: ["settings.write"] },
+
+  // Home feed
+  { endpoint: "internal/home/feed/actions", scopes: ["chat.write"] },
 ];
 
 for (const { endpoint, scopes } of ACTOR_ENDPOINTS) {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -146,6 +146,7 @@ import { guardianActionRouteDefinitions } from "./routes/guardian-action-routes.
 import { handleGuardianBootstrap } from "./routes/guardian-bootstrap-routes.js";
 import { handleGuardianRefresh } from "./routes/guardian-refresh-routes.js";
 import { heartbeatRouteDefinitions } from "./routes/heartbeat-routes.js";
+import { homeFeedRouteDefinitions } from "./routes/home-feed-routes.js";
 import { hostBashRouteDefinitions } from "./routes/host-bash-routes.js";
 import { hostCuRouteDefinitions } from "./routes/host-cu-routes.js";
 import { hostFileRouteDefinitions } from "./routes/host-file-routes.js";
@@ -960,6 +961,7 @@ export class RuntimeHttpServer {
       ...scheduleRouteDefinitions({
         sendMessageDeps: this.sendMessageDeps,
       }),
+      ...homeFeedRouteDefinitions(),
       ...heartbeatRouteDefinitions({
         getHeartbeatService: this.getHeartbeatService,
       }),

--- a/assistant/src/runtime/routes/home-feed-routes.ts
+++ b/assistant/src/runtime/routes/home-feed-routes.ts
@@ -45,15 +45,21 @@ export function homeFeedRouteDefinitions(): RouteDefinition[] {
 
         // TODO: Create a new conversation with context about the action.
         // This requires wiring SendMessageDeps into the route, which is
-        // deferred to a follow-up PR. For now, return a stub response.
-        const conversationId = `stub-${itemId}-${actionId}`;
+        // deferred to a follow-up PR.
 
         log.info(
           { itemId, actionId, label: action.label, title: item.title },
-          "Feed action triggered (stub)",
+          "Feed action triggered (not yet implemented)",
         );
 
-        return Response.json({ ok: true, conversationId });
+        return Response.json(
+          {
+            error: "Not implemented",
+            message:
+              "Conversation creation for feed actions is not yet implemented",
+          },
+          { status: 501 },
+        );
       },
     },
   ];

--- a/assistant/src/runtime/routes/home-feed-routes.ts
+++ b/assistant/src/runtime/routes/home-feed-routes.ts
@@ -1,0 +1,60 @@
+/**
+ * Internal home feed routes.
+ *
+ * Provides an action proxy endpoint that lets clients trigger feed
+ * item actions. The endpoint reads the feed file, validates the
+ * item/action pair, and creates a new conversation with context.
+ */
+
+import { readFeedItems } from "../../home/feed-writer.js";
+import { getLogger } from "../../util/logger.js";
+import { getWorkspaceDir } from "../../util/platform.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+
+const log = getLogger("home-feed-routes");
+
+export function homeFeedRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "internal/home/feed/:itemId/actions/:actionId",
+      method: "POST",
+      summary: "Trigger a feed item action",
+      description:
+        "Look up a feed item and action, then create a conversation with context about the user tapping that action.",
+      tags: ["home"],
+      handler: async ({ params }) => {
+        const { itemId, actionId } = params;
+
+        const workspaceDir = getWorkspaceDir();
+        const feed = await readFeedItems(workspaceDir);
+
+        const item = feed.items.find((i) => i.id === itemId);
+        if (!item) {
+          return httpError("NOT_FOUND", `Feed item '${itemId}' not found`, 404);
+        }
+
+        const action = item.actions?.find((a) => a.id === actionId);
+        if (!action) {
+          return httpError(
+            "NOT_FOUND",
+            `Action '${actionId}' not found on feed item '${itemId}'`,
+            404,
+          );
+        }
+
+        // TODO: Create a new conversation with context about the action.
+        // This requires wiring SendMessageDeps into the route, which is
+        // deferred to a follow-up PR. For now, return a stub response.
+        const conversationId = `stub-${itemId}-${actionId}`;
+
+        log.info(
+          { itemId, actionId, label: action.label, title: item.title },
+          "Feed action triggered (stub)",
+        );
+
+        return Response.json({ ok: true, conversationId });
+      },
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Create `feed-writer.ts` with read/write functions for home-feed.json (atomic writes, SSE event emission)
- Create `feed-writer.test.ts` with tests for read, write, roundtrip, and directory creation
- Add internal action proxy endpoint for feed item actions
- Add `home_feed_updated` message type to the wire protocol

Part of #23956
Part of JARVIS-447

## Test plan
- [ ] `bun test src/home/__tests__/feed-writer.test.ts` passes
- [ ] Feed writer creates data/ directory if missing
- [ ] Atomic write pattern (temp + rename)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/23998" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
