### PR TITLE
feat: smart animated spacer that shrinks as assistant response grows

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -268,9 +268,9 @@ struct MessageListContentView: View, Equatable {
                 compactingIndicatorRow()
             }
 
-            // Dynamic spacer: ensures user message can reach top even with short assistant output
+            // Smart spacer: animates open on send, shrinks as assistant content grows
             Color.clear
-                .frame(height: max(0, viewportHeight - 100))
+                .frame(height: scrollState.spacerHeight)
                 .id("scroll-bottom-spacer")
 
             // Bottom anchor for explicit jumps

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -104,6 +104,20 @@ final class MessageListScrollState {
     /// from initial position). Used to gate initial auto-scroll behavior.
     @ObservationIgnored var hasBeenInteracted: Bool = false
 
+    // MARK: - Smart Spacer
+
+    /// The spacer height that the view reads. Observable so the view updates.
+    private(set) var spacerHeight: CGFloat = 0
+
+    /// Whether a send cycle is actively streaming.
+    @ObservationIgnored var isInSendCycle: Bool = false
+
+    /// Target spacer height (viewportHeight - estimated user msg height).
+    @ObservationIgnored var targetSpacerHeight: CGFloat = 0
+
+    /// Content height when send started, for computing growth delta.
+    @ObservationIgnored var contentHeightAtSendStart: CGFloat = 0
+
     // MARK: - Derived State Cache
 
     /// Non-observable cache for memoizing derived state computations.
@@ -219,6 +233,38 @@ final class MessageListScrollState {
         scrollLog.debug("Scroll to latest tapped — resetting near-bottom state")
     }
 
+    // MARK: - Smart Spacer Methods
+
+    /// Begins the spacer animation when a send cycle starts.
+    /// Animates the spacer from 0 to `viewportHeight - 150` (estimated user message height).
+    func startSpacerAnimation() {
+        isInSendCycle = true
+        contentHeightAtSendStart = contentHeight
+        targetSpacerHeight = max(0, viewportHeight - 150)
+        withAnimation(VAnimation.standard) {
+            spacerHeight = targetSpacerHeight
+        }
+    }
+
+    /// Shrinks the spacer proportionally as assistant content grows during streaming.
+    /// Throttled to 10pt changes to avoid excessive re-renders.
+    func updateSpacerForContentGrowth(newContentHeight: CGFloat) {
+        guard isInSendCycle else { return }
+        let growth = max(0, newContentHeight - contentHeightAtSendStart)
+        let newHeight = max(100, targetSpacerHeight - growth)
+        if abs(newHeight - spacerHeight) >= 10 {
+            spacerHeight = newHeight
+        }
+    }
+
+    /// Ends the send cycle and settles the spacer at the 100pt floor.
+    func endSendCycle() {
+        isInSendCycle = false
+        withAnimation(VAnimation.standard) {
+            spacerHeight = 100
+        }
+    }
+
     /// Resets all state for a conversation switch.
     func reset(for conversationId: UUID) {
         currentConversationId = conversationId
@@ -237,6 +283,10 @@ final class MessageListScrollState {
         lastAutoFocusedRequestId = nil
         bottomAnchorAppeared = false
         hasBeenInteracted = false
+        spacerHeight = 0
+        targetSpacerHeight = 0
+        isInSendCycle = false
+        contentHeightAtSendStart = 0
         derivedStateCache.reset()
 
         scrollLog.debug("Reset for conversation: \(conversationId)")

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -58,8 +58,11 @@ extension MessageListView {
                 }
                 scrollState.markSendAnchored()
             }
+            scrollState.startSpacerAnimation()
         } else {
-            // true → false transition: track first-message detection.
+            // true → false transition: end spacer send cycle.
+            scrollState.endSendCycle()
+            // Track first-message detection.
             if !hasEverSentMessage && messages.contains(where: { $0.role == .user }) {
                 hasEverSentMessage = true
                 UserDefaults.standard.set(true, forKey: "hasEverSentMessage")

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -16,6 +16,10 @@ extension MessageListView {
         scrollState.viewportHeight = newState.visibleRectHeight
         scrollState.updateNearBottom()
 
+        if scrollState.isInSendCycle {
+            scrollState.updateSpacerForContentGrowth(newContentHeight: newState.contentHeight)
+        }
+
         // Derive sentinel position from content offset (inverted sign to
         // match the old coordinate-space convention where minY is negative
         // when scrolled past the viewport top).


### PR DESCRIPTION
## Summary
- Spacer animates from 0 to (viewportHeight - 150) on send
- Shrinks proportionally as assistant content streams in (100pt floor)
- Resets on new send cycle or conversation switch
- 10pt throttle on updates to avoid excessive re-renders

Part of plan: user-msg-maxheight-smart-spacer.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24004" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
