### PR TITLE
M1: Screen edge clamping for vTooltip (#24000)

### DIFF
--- a/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
@@ -328,7 +328,21 @@ private final class VTooltipTrackerView: NSView {
 
         // Find the screen containing the anchor point (fall back to main display)
         let screen = NSScreen.screens.first(where: { $0.frame.contains(screenPoint) }) ?? NSScreen.main
-        let visibleFrame = screen?.visibleFrame ?? NSRect(x: 0, y: 0, width: .infinity, height: .infinity)
+        guard let visibleFrame = screen?.visibleFrame else {
+            // No screen found — fall back to unclamped positioning
+            p.setFrameOrigin(NSPoint(
+                x: screenPoint.x - panelWidth / 2,
+                y: tooltipEdge == .bottom ? screenPoint.y - panelHeight - edgeInset : screenPoint.y + edgeInset
+            ))
+            p.alphaValue = 0
+            window.addChildWindow(p, ordered: .above)
+            NSAnimationContext.runAnimationGroup { ctx in
+                ctx.duration = 0.12
+                p.animator().alphaValue = 1
+            }
+            panel = p
+            return
+        }
 
         // Compute initial position centered on the anchor
         var x = screenPoint.x - panelWidth / 2

--- a/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
@@ -314,13 +314,16 @@ private final class VTooltipTrackerView: NSView {
         p.contentView = host
         p.setContentSize(host.fittingSize)
 
-        // Use AppKit's native coordinate conversion — works on any display
+        // Use AppKit's native coordinate conversion — works on any display.
+        // Pre-compute both edge anchors so the flip logic can use the opposite edge.
         let viewFrameInWindow = convert(bounds, to: nil)
-        let anchorY = tooltipEdge == .bottom ? viewFrameInWindow.minY : viewFrameInWindow.maxY
-        let screenPoint = window.convertPoint(toScreen: NSPoint(
-            x: viewFrameInWindow.midX,
-            y: anchorY
+        let topScreenPoint = window.convertPoint(toScreen: NSPoint(
+            x: viewFrameInWindow.midX, y: viewFrameInWindow.maxY
         ))
+        let bottomScreenPoint = window.convertPoint(toScreen: NSPoint(
+            x: viewFrameInWindow.midX, y: viewFrameInWindow.minY
+        ))
+        let screenPoint = tooltipEdge == .bottom ? bottomScreenPoint : topScreenPoint
 
         let panelWidth = host.fittingSize.width
         let panelHeight = host.fittingSize.height
@@ -350,11 +353,11 @@ private final class VTooltipTrackerView: NSView {
             ? screenPoint.y - panelHeight - edgeInset
             : screenPoint.y + edgeInset
 
-        // If the tooltip would be clipped on the preferred edge, flip to the opposite edge
+        // If the tooltip would be clipped on the preferred edge, flip using the opposite anchor
         if tooltipEdge == .bottom, y < visibleFrame.minY + edgeInset {
-            y = screenPoint.y + edgeInset
+            y = topScreenPoint.y + edgeInset
         } else if tooltipEdge != .bottom, y + panelHeight > visibleFrame.maxY - edgeInset {
-            y = screenPoint.y - panelHeight - edgeInset
+            y = bottomScreenPoint.y - panelHeight - edgeInset
         }
 
         // Clamp horizontally within the visible screen bounds

--- a/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
@@ -322,8 +322,33 @@ private final class VTooltipTrackerView: NSView {
             y: anchorY
         ))
 
-        let x = screenPoint.x - host.fittingSize.width / 2
-        let y = tooltipEdge == .bottom ? screenPoint.y - host.fittingSize.height - 4 : screenPoint.y + 4
+        let panelWidth = host.fittingSize.width
+        let panelHeight = host.fittingSize.height
+        let edgeInset: CGFloat = 4
+
+        // Find the screen containing the anchor point (fall back to main display)
+        let screen = NSScreen.screens.first(where: { $0.frame.contains(screenPoint) }) ?? NSScreen.main
+        let visibleFrame = screen?.visibleFrame ?? NSRect(x: 0, y: 0, width: .infinity, height: .infinity)
+
+        // Compute initial position centered on the anchor
+        var x = screenPoint.x - panelWidth / 2
+        var y = tooltipEdge == .bottom
+            ? screenPoint.y - panelHeight - edgeInset
+            : screenPoint.y + edgeInset
+
+        // If the tooltip would be clipped on the preferred edge, flip to the opposite edge
+        if tooltipEdge == .bottom, y < visibleFrame.minY + edgeInset {
+            y = screenPoint.y + edgeInset
+        } else if tooltipEdge != .bottom, y + panelHeight > visibleFrame.maxY - edgeInset {
+            y = screenPoint.y - panelHeight - edgeInset
+        }
+
+        // Clamp horizontally within the visible screen bounds
+        x = max(visibleFrame.minX + edgeInset, min(x, visibleFrame.maxX - panelWidth - edgeInset))
+
+        // Clamp vertically within the visible screen bounds
+        y = max(visibleFrame.minY + edgeInset, min(y, visibleFrame.maxY - panelHeight - edgeInset))
+
         p.setFrameOrigin(NSPoint(x: x, y: y))
 
         p.alphaValue = 0


### PR DESCRIPTION
## Summary
- Clamp tooltip panel position within the visible screen frame so tooltips near screen edges stay fully visible
- Uses `NSScreen.screens` to find the correct display containing the anchor point, falling back to `NSScreen.main`
- Applies a 4pt inset margin and flips the tooltip to the opposite edge if it would be clipped on the preferred side

## Test plan
- [ ] Hover over a tooltip source near the left edge of the screen — tooltip should stay within bounds
- [ ] Hover over a tooltip source near the right edge — tooltip should not overflow
- [ ] Hover over a tooltip source near the top edge (menu bar) — tooltip should flip below if needed
- [ ] Hover over a tooltip source near the bottom edge (dock) — tooltip should flip above if needed
- [ ] Verify normal centered tooltips still appear correctly in the middle of the screen
- [ ] Test on multi-monitor setup — tooltip should respect the correct screen's visible frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
