### PR TITLE
chore: reduce default LLM request log retention from 7d to 1d

### DIFF
--- a/assistant/src/config/schemas/memory-lifecycle.ts
+++ b/assistant/src/config/schemas/memory-lifecycle.ts
@@ -80,7 +80,7 @@ export const MemoryCleanupConfigSchema = z
       .nonnegative(
         "memory.cleanup.llmRequestLogRetentionMs must be non-negative",
       )
-      .default(7 * 24 * 60 * 60 * 1000)
+      .default(1 * 24 * 60 * 60 * 1000)
       .describe(
         "Retention period for LLM request/response logs in milliseconds (0 disables pruning)",
       ),


### PR DESCRIPTION
## Summary
- Changes the default `llmRequestLogRetentionMs` from 7 days to 1 day in the schema
- Instances that need longer retention can override via `memory.cleanup.llmRequestLogRetentionMs` in their workspace config (set to `0` to disable pruning entirely)

## Original prompt
change the default to 1 day of retention. leave mine disabled (retain forever)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
