### PR TITLE
feat(runtime): add /v1/host-browser-result route

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -3836,6 +3836,43 @@ paths:
               required:
                 - requestId
               additionalProperties: false
+  /v1/host-browser-result:
+    post:
+      operationId: hostbrowserresult_post
+      summary: Submit host browser result
+      description: Resolve a pending host browser request by requestId.
+      tags:
+        - host
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accepted:
+                    type: boolean
+                required:
+                  - accepted
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                requestId:
+                  type: string
+                  description: Pending browser request ID
+                content:
+                  type: string
+                isError:
+                  type: boolean
+              required:
+                - requestId
+              additionalProperties: false
   /v1/host-cu-result:
     post:
       operationId: hostcuresult_post

--- a/assistant/src/__tests__/host-browser-routes.test.ts
+++ b/assistant/src/__tests__/host-browser-routes.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Unit tests for the /v1/host-browser-result route handler.
+ *
+ * Tests handleHostBrowserResult directly with mocked AuthContext, Request,
+ * and a stub Conversation whose resolveHostBrowser method records calls.
+ */
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { Conversation } from "../daemon/conversation.js";
+import type { AuthContext } from "../runtime/auth/types.js";
+
+// ── Module mocks ─────────────────────────────────────────────────────
+
+let fakeHttpAuthDisabled = true;
+
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => fakeHttpAuthDisabled,
+  hasUngatedHttpAuthDisabled: () => false,
+}));
+
+// ── Real imports (after mocks) ───────────────────────────────────────
+
+import * as pendingInteractions from "../runtime/pending-interactions.js";
+import { handleHostBrowserResult } from "../runtime/routes/host-browser-routes.js";
+
+afterAll(() => {
+  mock.restore();
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+interface ResolveHostBrowserCall {
+  requestId: string;
+  response: { content: string; isError: boolean };
+}
+
+function makeStubConversation(spy: ResolveHostBrowserCall[]): Conversation {
+  return {
+    resolveHostBrowser(
+      requestId: string,
+      response: { content: string; isError: boolean },
+    ) {
+      spy.push({ requestId, response });
+    },
+  } as unknown as Conversation;
+}
+
+const AUTHED_CONTEXT: AuthContext = {
+  subject: "actor:test",
+  principalType: "actor",
+  assistantId: "test-assistant",
+  actorPrincipalId: "actor-principal-1",
+  scopeProfile: "actor_client_v1",
+  scopes: new Set(),
+  policyEpoch: 0,
+};
+
+const UNAUTHED_CONTEXT: AuthContext = {
+  subject: "actor:test",
+  principalType: "actor",
+  assistantId: "test-assistant",
+  // actorPrincipalId intentionally absent
+  scopeProfile: "actor_client_v1",
+  scopes: new Set(),
+  policyEpoch: 0,
+};
+
+function makeJsonRequest(body: unknown): Request {
+  return new Request("http://localhost/v1/host-browser-result", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("handleHostBrowserResult", () => {
+  beforeEach(() => {
+    pendingInteractions.clear();
+    fakeHttpAuthDisabled = true;
+  });
+
+  test("happy path: resolves a pending host_browser interaction", async () => {
+    const spy: ResolveHostBrowserCall[] = [];
+    const conversation = makeStubConversation(spy);
+    const requestId = "browser-req-happy";
+
+    pendingInteractions.register(requestId, {
+      conversation,
+      conversationId: "conv-1",
+      kind: "host_browser",
+    });
+
+    const req = makeJsonRequest({
+      requestId,
+      content: "ok",
+      isError: false,
+    });
+
+    const res = await handleHostBrowserResult(req, AUTHED_CONTEXT);
+    const body = (await res.json()) as { accepted: boolean };
+
+    expect(res.status).toBe(200);
+    expect(body.accepted).toBe(true);
+    expect(spy).toHaveLength(1);
+    expect(spy[0].requestId).toBe(requestId);
+    expect(spy[0].response).toEqual({ content: "ok", isError: false });
+
+    // Pending interaction should be consumed
+    expect(pendingInteractions.get(requestId)).toBeUndefined();
+  });
+
+  test("unauthorized: returns 403 when actor is not guardian-bound", async () => {
+    fakeHttpAuthDisabled = false;
+
+    const req = makeJsonRequest({
+      requestId: "browser-req-unauth",
+      content: "anything",
+      isError: false,
+    });
+
+    const res = await handleHostBrowserResult(req, UNAUTHED_CONTEXT);
+    expect(res.status).toBe(403);
+  });
+
+  test("missing requestId: returns 400", async () => {
+    const req = makeJsonRequest({ content: "x" });
+
+    const res = await handleHostBrowserResult(req, AUTHED_CONTEXT);
+    expect(res.status).toBe(400);
+  });
+
+  test("unknown requestId: returns 404", async () => {
+    const req = makeJsonRequest({
+      requestId: "00000000-0000-0000-0000-000000000000",
+      content: "x",
+      isError: false,
+    });
+
+    const res = await handleHostBrowserResult(req, AUTHED_CONTEXT);
+    expect(res.status).toBe(404);
+  });
+
+  test("wrong kind: returns 409 with mismatch message", async () => {
+    const spy: ResolveHostBrowserCall[] = [];
+    const conversation = makeStubConversation(spy);
+    const requestId = "browser-req-wrong-kind";
+
+    pendingInteractions.register(requestId, {
+      conversation,
+      conversationId: "conv-1",
+      kind: "host_bash",
+    });
+
+    const req = makeJsonRequest({
+      requestId,
+      content: "x",
+      isError: false,
+    });
+
+    const res = await handleHostBrowserResult(req, AUTHED_CONTEXT);
+    expect(res.status).toBe(409);
+
+    const body = (await res.json()) as {
+      error: { message: string; code?: string };
+    };
+    expect(body.error.message).toContain('"host_bash"');
+    expect(body.error.message).toContain('"host_browser"');
+
+    // Pending interaction should NOT have been consumed
+    expect(pendingInteractions.get(requestId)).toBeDefined();
+    expect(spy).toHaveLength(0);
+  });
+
+  test("defaults: missing content/isError default to '' and false", async () => {
+    const spy: ResolveHostBrowserCall[] = [];
+    const conversation = makeStubConversation(spy);
+    const requestId = "browser-req-defaults";
+
+    pendingInteractions.register(requestId, {
+      conversation,
+      conversationId: "conv-1",
+      kind: "host_browser",
+    });
+
+    const req = makeJsonRequest({ requestId });
+
+    const res = await handleHostBrowserResult(req, AUTHED_CONTEXT);
+    const body = (await res.json()) as { accepted: boolean };
+
+    expect(res.status).toBe(200);
+    expect(body.accepted).toBe(true);
+    expect(spy).toHaveLength(1);
+    expect(spy[0].requestId).toBe(requestId);
+    expect(spy[0].response).toEqual({ content: "", isError: false });
+  });
+});

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -148,6 +148,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "secret", scopes: ["approval.write"] },
   { endpoint: "trust-rules", scopes: ["approval.write"] },
   { endpoint: "host-bash-result", scopes: ["approval.write"] },
+  { endpoint: "host-browser-result", scopes: ["approval.write"] },
   { endpoint: "host-cu-result", scopes: ["approval.write"] },
   { endpoint: "host-file-result", scopes: ["approval.write"] },
   { endpoint: "pending-interactions", scopes: ["approval.read"] },

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -147,6 +147,7 @@ import { handleGuardianBootstrap } from "./routes/guardian-bootstrap-routes.js";
 import { handleGuardianRefresh } from "./routes/guardian-refresh-routes.js";
 import { heartbeatRouteDefinitions } from "./routes/heartbeat-routes.js";
 import { hostBashRouteDefinitions } from "./routes/host-bash-routes.js";
+import { hostBrowserRouteDefinitions } from "./routes/host-browser-routes.js";
 import { hostCuRouteDefinitions } from "./routes/host-cu-routes.js";
 import { hostFileRouteDefinitions } from "./routes/host-file-routes.js";
 import {
@@ -1209,6 +1210,7 @@ export class RuntimeHttpServer {
       ...globalSearchRouteDefinitions(),
       ...approvalRouteDefinitions(),
       ...hostBashRouteDefinitions(),
+      ...hostBrowserRouteDefinitions(),
       ...hostCuRouteDefinitions(),
       ...hostFileRouteDefinitions(),
       ...(this.getSkillContext

--- a/assistant/src/runtime/routes/host-browser-routes.ts
+++ b/assistant/src/runtime/routes/host-browser-routes.ts
@@ -1,0 +1,92 @@
+/**
+ * Route handler for host browser result submissions.
+ *
+ * Resolves pending host browser proxy requests by requestId when the desktop
+ * client returns CDP results via HTTP.
+ */
+import { z } from "zod";
+
+import { requireBoundGuardian } from "../auth/require-bound-guardian.js";
+import type { AuthContext } from "../auth/types.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+import * as pendingInteractions from "../pending-interactions.js";
+
+/**
+ * POST /v1/host-browser-result — resolve a pending host browser request by requestId.
+ * Requires AuthContext with guardian-bound actor.
+ */
+export async function handleHostBrowserResult(
+  req: Request,
+  authContext: AuthContext,
+): Promise<Response> {
+  const authError = requireBoundGuardian(authContext);
+  if (authError) return authError;
+
+  const body = (await req.json()) as {
+    requestId?: string;
+    content?: string;
+    isError?: boolean;
+  };
+
+  const { requestId, content, isError } = body;
+
+  if (!requestId || typeof requestId !== "string") {
+    return httpError("BAD_REQUEST", "requestId is required", 400);
+  }
+
+  // Peek first (non-destructive) so we can validate the interaction kind
+  // without accidentally consuming a confirmation or secret interaction.
+  const peeked = pendingInteractions.get(requestId);
+  if (!peeked) {
+    return httpError(
+      "NOT_FOUND",
+      "No pending interaction found for this requestId",
+      404,
+    );
+  }
+
+  if (peeked.kind !== "host_browser") {
+    return httpError(
+      "CONFLICT",
+      `Pending interaction is of kind "${peeked.kind}", expected "host_browser"`,
+      409,
+    );
+  }
+
+  // Validation passed — consume the pending interaction.
+  const interaction = pendingInteractions.resolve(requestId)!;
+
+  interaction.conversation!.resolveHostBrowser(requestId, {
+    content: content ?? "",
+    isError: isError ?? false,
+  });
+
+  return Response.json({ accepted: true });
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function hostBrowserRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "host-browser-result",
+      method: "POST",
+      summary: "Submit host browser result",
+      description: "Resolve a pending host browser request by requestId.",
+      tags: ["host"],
+      requestBody: z.object({
+        requestId: z.string().describe("Pending browser request ID"),
+        content: z.string().optional(),
+        isError: z.boolean().optional(),
+      }),
+      responseBody: z.object({
+        accepted: z.boolean(),
+      }),
+      handler: async ({ req, authContext }) =>
+        handleHostBrowserResult(req, authContext),
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Add `POST /v1/host-browser-result` route handler following the host_bash/host_file/host_cu pattern
- Validates guardian-bound JWT, `requestId`, and `kind === "host_browser"` before resolving
- Mirror tests for happy path, auth, missing/unknown requestId, wrong kind, and defaults

Part of plan: host-browser-proxy-phase1.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
