### PR TITLE
fix: update config-schema test for 1-day log retention default

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -166,7 +166,7 @@ describe("AssistantConfigSchema", () => {
       enqueueIntervalMs: 6 * 60 * 60 * 1000,
       supersededItemRetentionMs: 30 * 24 * 60 * 60 * 1000,
       conversationRetentionDays: 0,
-      llmRequestLogRetentionMs: 7 * 24 * 60 * 60 * 1000,
+      llmRequestLogRetentionMs: 1 * 24 * 60 * 60 * 1000,
     });
   });
 


### PR DESCRIPTION
## Summary
- Update `config-schema.test.ts` to expect `llmRequestLogRetentionMs` of 1 day (86400000ms) instead of 7 days (604800000ms), matching the default changed in d6173724c

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24092533891/job/70282495258
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
