### PR TITLE
M2: Max width and text wrapping for vTooltip (#24001)

### DIFF
--- a/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
@@ -402,7 +402,8 @@ private struct VTooltipContent: View {
 
     var body: some View {
         Text(text)
-            .fixedSize()
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: 280, alignment: .leading)
             .font(VFont.labelDefault)
             .foregroundStyle(VColor.contentDefault)
             .padding(.horizontal, VSpacing.sm)


### PR DESCRIPTION
Replace `.fixedSize()` with constrained max width (280pt) and vertical-only fixed sizing so long tooltip text wraps instead of producing arbitrarily wide panels. Closes #24001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24011" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
