### PR TITLE
fix: align naming — rename proceduralReserve to capabilityReserve

### DIFF
--- a/assistant/src/config/schemas/memory-retrieval.ts
+++ b/assistant/src/config/schemas/memory-retrieval.ts
@@ -188,18 +188,15 @@ const MemoryContextLoadInjectionSchema = z
   .object({
     maxNodes: z
       .number({
-        error: "memory.retrieval.injection.contextLoad.maxNodes must be a number",
+        error:
+          "memory.retrieval.injection.contextLoad.maxNodes must be a number",
       })
-      .int(
-        "memory.retrieval.injection.contextLoad.maxNodes must be an integer",
-      )
+      .int("memory.retrieval.injection.contextLoad.maxNodes must be an integer")
       .positive(
         "memory.retrieval.injection.contextLoad.maxNodes must be a positive integer",
       )
       .default(40)
-      .describe(
-        "Maximum number of memory nodes to load at conversation start",
-      ),
+      .describe("Maximum number of memory nodes to load at conversation start"),
     serendipitySlots: z
       .number({
         error:
@@ -212,9 +209,7 @@ const MemoryContextLoadInjectionSchema = z
         "memory.retrieval.injection.contextLoad.serendipitySlots must be non-negative",
       )
       .default(10)
-      .describe(
-        "Number of random wildcard memory picks at conversation start",
-      ),
+      .describe("Number of random wildcard memory picks at conversation start"),
     capabilityReserve: z
       .number({
         error:
@@ -240,16 +235,12 @@ const MemoryPerTurnInjectionSchema = z
         error:
           "memory.retrieval.injection.perTurn.maxInjected must be a number",
       })
-      .int(
-        "memory.retrieval.injection.perTurn.maxInjected must be an integer",
-      )
+      .int("memory.retrieval.injection.perTurn.maxInjected must be an integer")
       .positive(
         "memory.retrieval.injection.perTurn.maxInjected must be a positive integer",
       )
       .default(4)
-      .describe(
-        "Maximum general memories injected mid-conversation per turn",
-      ),
+      .describe("Maximum general memories injected mid-conversation per turn"),
     serendipitySlots: z
       .number({
         error:
@@ -263,21 +254,19 @@ const MemoryPerTurnInjectionSchema = z
       )
       .default(1)
       .describe("Number of random wildcard memory picks per turn"),
-    proceduralReserve: z
+    capabilityReserve: z
       .number({
         error:
-          "memory.retrieval.injection.perTurn.proceduralReserve must be a number",
+          "memory.retrieval.injection.perTurn.capabilityReserve must be a number",
       })
       .int(
-        "memory.retrieval.injection.perTurn.proceduralReserve must be an integer",
+        "memory.retrieval.injection.perTurn.capabilityReserve must be an integer",
       )
       .nonnegative(
-        "memory.retrieval.injection.perTurn.proceduralReserve must be non-negative",
+        "memory.retrieval.injection.perTurn.capabilityReserve must be non-negative",
       )
       .default(3)
-      .describe(
-        "Reserved slots for skill/CLI capability nodes per turn",
-      ),
+      .describe("Reserved slots for skill/CLI capability nodes per turn"),
   })
   .describe("Memory injection limits for mid-conversation turns");
 

--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -989,7 +989,7 @@ export async function retrieveForTurn(
   // Sourced from vector search candidates — only semantically relevant
   // capabilities compete for reserved slots.
   const perTurnCfg = opts.config.memory.retrieval.injection.perTurn;
-  const proceduralReserve = perTurnCfg.proceduralReserve;
+  const capabilityReserve = perTurnCfg.capabilityReserve;
 
   const proceduralCandidates = capabilityCandidates
     .filter(({ node }) => !opts.tracker.isInContext(node.id))
@@ -1008,7 +1008,7 @@ export async function retrieveForTurn(
       }
       return true;
     })
-    .slice(0, proceduralReserve);
+    .slice(0, capabilityReserve);
 
   const proceduralScored: ScoredNode[] = rankedProcedural.map(({ node, sim }) =>
     scoreCandidate(


### PR DESCRIPTION
## Summary
- Rename `perTurn.proceduralReserve` to `perTurn.capabilityReserve` in the memory injection config schema and retriever
- Both `contextLoad` and `perTurn` now use the same `capabilityReserve` key for reserved skill/CLI slots
- "Capability" is the user-facing concept; "procedural" is an internal node type detail that shouldn't leak into config

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24016" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
