### PR TITLE
M3: VoiceOver accessibility for vTooltip (#24002)

### DIFF
--- a/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
@@ -90,9 +90,7 @@ private final class VTooltipCoordinator {
 public extension View {
     /// Attaches a floating tooltip that appears on hover after `delay` seconds.
     func vTooltip(_ text: String, edge: Edge = .top, delay: TimeInterval = 0.2) -> some View {
-        self
-            .accessibilityHint(text)
-            .overlay(
+        self.overlay(
                 VTooltipTracker(text: text, edge: edge, delay: delay)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .allowsHitTesting(false)

--- a/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
@@ -90,11 +90,14 @@ private final class VTooltipCoordinator {
 public extension View {
     /// Attaches a floating tooltip that appears on hover after `delay` seconds.
     func vTooltip(_ text: String, edge: Edge = .top, delay: TimeInterval = 0.2) -> some View {
-        self.overlay(
-            VTooltipTracker(text: text, edge: edge, delay: delay)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .allowsHitTesting(false)
-        )
+        self
+            .accessibilityHint(text)
+            .overlay(
+                VTooltipTracker(text: text, edge: edge, delay: delay)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .allowsHitTesting(false)
+                    .accessibilityHidden(true)
+            )
     }
 }
 
@@ -411,6 +414,8 @@ private struct VTooltipContent: View {
             .background(VColor.surfaceLift)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
             .shadow(color: VColor.auxBlack.opacity(0.12), radius: 4, y: 2)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(text)
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `accessibilityElement(children: .ignore)` and `accessibilityLabel(text)` to `VTooltipContent` so VoiceOver reads the tooltip panel text
- Add `accessibilityHint(text)` to the source view in `.vTooltip()` so the tooltip text is announced as a hint
- Mark the invisible `VTooltipTracker` overlay as `accessibilityHidden(true)` to prevent duplicate VoiceOver announcements

## Test plan
- [ ] Enable VoiceOver on macOS and hover over a view with `.vTooltip()`
- [ ] Verify VoiceOver announces the tooltip text as a hint on the source view
- [ ] Verify VoiceOver reads the tooltip panel content when it appears
- [ ] Verify the invisible tracker overlay is not announced by VoiceOver

Closes #24002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24017" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
