### PR TITLE
Update Vellum Cloud hosting copy to highlight 24/7 availability

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -61,7 +61,7 @@ final class OnboardingState {
 
         var subtitle: String {
             switch self {
-            case .vellumCloud: return "Ready out of the box. Runs entirely on Vellum's secure infrastructure."
+            case .vellumCloud: return "Always on, 24/7, even when your Mac is asleep. Runs on Vellum's secure infrastructure."
             case .local: return "Your machine, your data. Nothing leaves your Mac."
             case .docker: return "Same privacy as local, but sandboxed using Docker."
             case .oldLocal: return "Legacy local mode without Docker."


### PR DESCRIPTION
## Summary
- Update Vellum Cloud subtitle in onboarding hosting step to emphasize always-on, 24/7 availability
- New copy: "Always on, 24/7, even when your Mac is asleep. Runs on Vellum's secure infrastructure."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24022" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
