### PR TITLE
fix: align perTurn.maxInjected to perTurn.maxNodes as total budget

### DIFF
--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -370,7 +370,8 @@ export const AssistantConfigSchema = z
           "memory.retrieval.dynamicBudget.minInjectTokens must be <= memory.retrieval.dynamicBudget.maxInjectTokens",
       });
     }
-    const ctxLoad = config.memory?.retrieval?.injection?.contextLoad;
+    const injection = config.memory?.retrieval?.injection;
+    const ctxLoad = injection?.contextLoad;
     if (
       ctxLoad &&
       ctxLoad.capabilityReserve + ctxLoad.serendipitySlots >= ctxLoad.maxNodes
@@ -380,6 +381,18 @@ export const AssistantConfigSchema = z
         path: ["memory", "retrieval", "injection", "contextLoad"],
         message:
           "memory.retrieval.injection.contextLoad.capabilityReserve + serendipitySlots must be less than maxNodes",
+      });
+    }
+    const perTurn = injection?.perTurn;
+    if (
+      perTurn &&
+      perTurn.capabilityReserve + perTurn.serendipitySlots >= perTurn.maxNodes
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["memory", "retrieval", "injection", "perTurn"],
+        message:
+          "memory.retrieval.injection.perTurn.capabilityReserve + serendipitySlots must be less than maxNodes",
       });
     }
   });

--- a/assistant/src/config/schemas/memory-retrieval.ts
+++ b/assistant/src/config/schemas/memory-retrieval.ts
@@ -230,17 +230,18 @@ const MemoryContextLoadInjectionSchema = z
 
 const MemoryPerTurnInjectionSchema = z
   .object({
-    maxInjected: z
+    maxNodes: z
       .number({
-        error:
-          "memory.retrieval.injection.perTurn.maxInjected must be a number",
+        error: "memory.retrieval.injection.perTurn.maxNodes must be a number",
       })
-      .int("memory.retrieval.injection.perTurn.maxInjected must be an integer")
+      .int("memory.retrieval.injection.perTurn.maxNodes must be an integer")
       .positive(
-        "memory.retrieval.injection.perTurn.maxInjected must be a positive integer",
+        "memory.retrieval.injection.perTurn.maxNodes must be a positive integer",
       )
-      .default(4)
-      .describe("Maximum general memories injected mid-conversation per turn"),
+      .default(8)
+      .describe(
+        "Maximum total memory nodes injected per turn (general + capability + serendipity)",
+      ),
     serendipitySlots: z
       .number({
         error:

--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -1036,7 +1036,12 @@ export async function retrieveForTurn(
   scored.sort((a, b) => b.score - a.score);
   const INJECTION_THRESHOLD = 0.3;
   const PRE_DEDUP_POOL = 20;
-  const maxInjected = perTurnCfg.maxInjected;
+  const maxGeneralNodes = Math.max(
+    0,
+    perTurnCfg.maxNodes -
+      perTurnCfg.serendipitySlots -
+      proceduralInjected.length,
+  );
   const pool = scored
     .filter((s) => s.score >= INJECTION_THRESHOLD)
     .slice(0, PRE_DEDUP_POOL);
@@ -1044,8 +1049,12 @@ export async function retrieveForTurn(
   // Dedup + rerank with a fast model when the pool is large enough to warrant it
   let injected: ScoredNode[];
   let llmDedupApplied = false;
-  if (pool.length > maxInjected) {
-    const result = await dedupForTurn(pool, maxInjected, opts.userLastMessage);
+  if (pool.length > maxGeneralNodes) {
+    const result = await dedupForTurn(
+      pool,
+      maxGeneralNodes,
+      opts.userLastMessage,
+    );
     injected = result.nodes;
     llmDedupApplied = result.llmApplied;
   } else {
@@ -1056,17 +1065,17 @@ export async function retrieveForTurn(
   const generalInjected = injected.filter((s) => !proceduralIds.has(s.node.id));
 
   // Backfill vacated general slots from the remaining pool so we always
-  // return up to the configured max general memories when eligible candidates exist.
+  // return up to maxGeneralNodes when eligible candidates exist.
   // Only skip backfill when LLM dedup genuinely ran — it intentionally rejected
   // items as duplicates/irrelevant. When dedupForTurn fell back to a plain
   // top-N slice (no provider, tool call failure), backfill is still appropriate.
-  if (generalInjected.length < maxInjected && !llmDedupApplied) {
+  if (generalInjected.length < maxGeneralNodes && !llmDedupApplied) {
     const usedIds = new Set([
       ...generalInjected.map((s) => s.node.id),
       ...proceduralIds,
     ]);
     const backfillCandidates = pool.filter((s) => !usedIds.has(s.node.id));
-    const needed = maxInjected - generalInjected.length;
+    const needed = maxGeneralNodes - generalInjected.length;
     for (let i = 0; i < Math.min(needed, backfillCandidates.length); i++) {
       generalInjected.push(backfillCandidates[i]);
     }


### PR DESCRIPTION
## Summary
- Rename `perTurn.maxInjected` → `perTurn.maxNodes` (default 8 = 4 general + 3 capability + 1 serendipity) to match the `contextLoad.maxNodes` pattern
- General slots now derived as `maxNodes - serendipitySlots - actualCapabilityCount`, same as context load
- Add per-turn validation that reserves don't exceed total budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24023" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
