### PR TITLE
vTooltip: Screen edge clamping, max width, accessibility, and dismiss fixes

### DIFF
--- a/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
@@ -310,16 +310,29 @@ private final class VTooltipTrackerView: NSView {
         p.hasShadow = true
         p.ignoresMouseEvents = true
 
-        let host = NSHostingView(rootView: VTooltipContent(text: tooltipText))
-        // Use sizeThatFits(in:) — Apple's recommended API for measuring
-        // NSHostingView with a proposed size. fittingSize doesn't pass a
-        // width proposal, so .fixedSize(horizontal: false) would wrap text
-        // at zero width and return an incorrect (very tall) size.
-        let panelSize = host.sizeThatFits(
-            NSSize(width: 280, height: CGFloat.greatestFiniteMagnitude)
-        )
-        host.frame.size = panelSize
-        p.contentView = host
+        // Two-pass sizing: first measure unconstrained with .fixedSize()
+        // (which gives correct fittingSize), then if the tooltip exceeds the
+        // max width, re-measure with a fixed wrapping width.
+        // .fixedSize(horizontal: false) breaks NSHostingView.fittingSize
+        // because fittingSize has no way to pass a width proposal, causing
+        // text to wrap at zero width and return an incorrect height.
+        let maxTooltipWidth: CGFloat = 280
+        let measureHost = NSHostingView(rootView: VTooltipContent(text: tooltipText))
+        let idealSize = measureHost.fittingSize
+
+        let panelSize: NSSize
+        if idealSize.width > maxTooltipWidth {
+            let wrappedHost = NSHostingView(
+                rootView: VTooltipContent(text: tooltipText, wrapWidth: maxTooltipWidth)
+            )
+            panelSize = wrappedHost.fittingSize
+            wrappedHost.frame.size = panelSize
+            p.contentView = wrappedHost
+        } else {
+            panelSize = idealSize
+            measureHost.frame.size = panelSize
+            p.contentView = measureHost
+        }
         p.setContentSize(panelSize)
 
         // Use AppKit's native coordinate conversion — works on any display.
@@ -407,20 +420,31 @@ private final class VTooltipTrackerView: NSView {
 
 private struct VTooltipContent: View {
     let text: String
+    /// When set, the text wraps at this fixed width instead of using its
+    /// natural single-line width. Used by `showTooltip()` in the two-pass
+    /// sizing flow when the unconstrained tooltip exceeds the max width.
+    var wrapWidth: CGFloat? = nil
 
     var body: some View {
-        Text(text)
-            .fixedSize(horizontal: false, vertical: true)
-            .frame(maxWidth: 280, alignment: .leading)
-            .font(VFont.labelDefault)
-            .foregroundStyle(VColor.contentDefault)
-            .padding(.horizontal, VSpacing.sm)
-            .padding(.vertical, VSpacing.xs)
-            .background(VColor.surfaceLift)
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-            .shadow(color: VColor.auxBlack.opacity(0.12), radius: 4, y: 2)
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel(text)
+        Group {
+            if let wrapWidth {
+                Text(text)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(width: wrapWidth, alignment: .leading)
+            } else {
+                Text(text)
+                    .fixedSize()
+            }
+        }
+        .font(VFont.labelDefault)
+        .foregroundStyle(VColor.contentDefault)
+        .padding(.horizontal, VSpacing.sm)
+        .padding(.vertical, VSpacing.xs)
+        .background(VColor.surfaceLift)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+        .shadow(color: VColor.auxBlack.opacity(0.12), radius: 4, y: 2)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(text)
     }
 }
 

--- a/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
@@ -311,9 +311,12 @@ private final class VTooltipTrackerView: NSView {
         p.ignoresMouseEvents = true
 
         let host = NSHostingView(rootView: VTooltipContent(text: tooltipText))
-        // Capture fittingSize once before setting the frame — subsequent calls
-        // may return different values because .fixedSize(horizontal: false)
-        // allows the layout to change based on the proposed width.
+        // Pre-set the frame to the max tooltip width so the SwiftUI layout
+        // receives a reasonable width proposal. Without this, the initial
+        // frame is zero, causing .fixedSize(horizontal: false) to wrap
+        // text at zero width and return a very tall fittingSize.
+        let maxTooltipWidth: CGFloat = 280
+        host.frame.size = NSSize(width: maxTooltipWidth, height: 10000)
         let panelSize = host.fittingSize
         host.frame.size = panelSize
         p.contentView = host

--- a/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
@@ -403,7 +403,7 @@ private final class VTooltipTrackerView: NSView {
         // because fittingSize has no way to pass a width proposal, causing
         // text to wrap at zero width and return an incorrect height.
         let maxTooltipWidth: CGFloat = 280
-        let tooltipHorizontalPadding: CGFloat = 16 // VSpacing.sm (8) × 2
+        let tooltipHorizontalPadding: CGFloat = VSpacing.sm * 2
         let measureHost = NSHostingView(rootView: VTooltipContent(text: tooltipText))
         let idealSize = measureHost.fittingSize
 

--- a/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
@@ -307,9 +307,14 @@ private final class VTooltipTrackerView: NSView {
         mouseDownMonitor = NSEvent.addLocalMonitorForEvents(
             matching: [.leftMouseDown, .rightMouseDown, .otherMouseDown]
         ) { [weak self] event in
-            self?.showTimer?.invalidate()
-            self?.showTimer = nil
-            self?.hideTooltip()
+            // Defer dismissal to the next run-loop cycle so the mouse-down
+            // event finishes processing first. Synchronous removeChildWindow
+            // during mouse-down interferes with drag gesture recognition.
+            DispatchQueue.main.async {
+                self?.showTimer?.invalidate()
+                self?.showTimer = nil
+                self?.hideTooltip()
+            }
             return event
         }
         keyDownMonitor = NSEvent.addLocalMonitorForEvents(

--- a/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
@@ -403,13 +403,19 @@ private final class VTooltipTrackerView: NSView {
         // because fittingSize has no way to pass a width proposal, causing
         // text to wrap at zero width and return an incorrect height.
         let maxTooltipWidth: CGFloat = 280
+        let tooltipHorizontalPadding: CGFloat = 16 // VSpacing.sm (8) × 2
         let measureHost = NSHostingView(rootView: VTooltipContent(text: tooltipText))
         let idealSize = measureHost.fittingSize
 
         let panelSize: NSSize
         if idealSize.width > maxTooltipWidth {
+            // Subtract horizontal padding so the total panel width
+            // (text + padding) respects maxTooltipWidth.
             let wrappedHost = NSHostingView(
-                rootView: VTooltipContent(text: tooltipText, wrapWidth: maxTooltipWidth)
+                rootView: VTooltipContent(
+                    text: tooltipText,
+                    wrapWidth: maxTooltipWidth - tooltipHorizontalPadding
+                )
             )
             panelSize = wrappedHost.fittingSize
             wrappedHost.frame.size = panelSize
@@ -451,6 +457,7 @@ private final class VTooltipTrackerView: NSView {
                 p.animator().alphaValue = 1
             }
             panel = p
+            installInteractionMonitors()
             return
         }
 

--- a/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
@@ -402,7 +402,8 @@ private struct VTooltipContent: View {
 
     var body: some View {
         Text(text)
-            .fixedSize()
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: 280, alignment: .leading)
             .font(VFont.labelDefault)
             .foregroundStyle(VColor.contentDefault)
             .padding(.horizontal, VSpacing.sm)

--- a/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
@@ -314,16 +314,58 @@ private final class VTooltipTrackerView: NSView {
         p.contentView = host
         p.setContentSize(host.fittingSize)
 
-        // Use AppKit's native coordinate conversion — works on any display
+        // Use AppKit's native coordinate conversion — works on any display.
+        // Pre-compute both edge anchors so the flip logic can use the opposite edge.
         let viewFrameInWindow = convert(bounds, to: nil)
-        let anchorY = tooltipEdge == .bottom ? viewFrameInWindow.minY : viewFrameInWindow.maxY
-        let screenPoint = window.convertPoint(toScreen: NSPoint(
-            x: viewFrameInWindow.midX,
-            y: anchorY
+        let topScreenPoint = window.convertPoint(toScreen: NSPoint(
+            x: viewFrameInWindow.midX, y: viewFrameInWindow.maxY
         ))
+        let bottomScreenPoint = window.convertPoint(toScreen: NSPoint(
+            x: viewFrameInWindow.midX, y: viewFrameInWindow.minY
+        ))
+        let screenPoint = tooltipEdge == .bottom ? bottomScreenPoint : topScreenPoint
 
-        let x = screenPoint.x - host.fittingSize.width / 2
-        let y = tooltipEdge == .bottom ? screenPoint.y - host.fittingSize.height - 4 : screenPoint.y + 4
+        let panelWidth = host.fittingSize.width
+        let panelHeight = host.fittingSize.height
+        let edgeInset: CGFloat = 4
+
+        // Find the screen containing the anchor point (fall back to main display)
+        let screen = NSScreen.screens.first(where: { $0.frame.contains(screenPoint) }) ?? NSScreen.main
+        guard let visibleFrame = screen?.visibleFrame else {
+            // No screen found — fall back to unclamped positioning
+            p.setFrameOrigin(NSPoint(
+                x: screenPoint.x - panelWidth / 2,
+                y: tooltipEdge == .bottom ? screenPoint.y - panelHeight - edgeInset : screenPoint.y + edgeInset
+            ))
+            p.alphaValue = 0
+            window.addChildWindow(p, ordered: .above)
+            NSAnimationContext.runAnimationGroup { ctx in
+                ctx.duration = 0.12
+                p.animator().alphaValue = 1
+            }
+            panel = p
+            return
+        }
+
+        // Compute initial position centered on the anchor
+        var x = screenPoint.x - panelWidth / 2
+        var y = tooltipEdge == .bottom
+            ? screenPoint.y - panelHeight - edgeInset
+            : screenPoint.y + edgeInset
+
+        // If the tooltip would be clipped on the preferred edge, flip using the opposite anchor
+        if tooltipEdge == .bottom, y < visibleFrame.minY + edgeInset {
+            y = topScreenPoint.y + edgeInset
+        } else if tooltipEdge != .bottom, y + panelHeight > visibleFrame.maxY - edgeInset {
+            y = bottomScreenPoint.y - panelHeight - edgeInset
+        }
+
+        // Clamp horizontally within the visible screen bounds
+        x = max(visibleFrame.minX + edgeInset, min(x, visibleFrame.maxX - panelWidth - edgeInset))
+
+        // Clamp vertically within the visible screen bounds
+        y = max(visibleFrame.minY + edgeInset, min(y, visibleFrame.maxY - panelHeight - edgeInset))
+
         p.setFrameOrigin(NSPoint(x: x, y: y))
 
         p.alphaValue = 0

--- a/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
@@ -311,9 +311,13 @@ private final class VTooltipTrackerView: NSView {
         p.ignoresMouseEvents = true
 
         let host = NSHostingView(rootView: VTooltipContent(text: tooltipText))
-        host.frame.size = host.fittingSize
+        // Capture fittingSize once before setting the frame — subsequent calls
+        // may return different values because .fixedSize(horizontal: false)
+        // allows the layout to change based on the proposed width.
+        let panelSize = host.fittingSize
+        host.frame.size = panelSize
         p.contentView = host
-        p.setContentSize(host.fittingSize)
+        p.setContentSize(panelSize)
 
         // Use AppKit's native coordinate conversion — works on any display.
         // Pre-compute both edge anchors so the flip logic can use the opposite edge.
@@ -326,8 +330,8 @@ private final class VTooltipTrackerView: NSView {
         ))
         let screenPoint = tooltipEdge == .bottom ? bottomScreenPoint : topScreenPoint
 
-        let panelWidth = host.fittingSize.width
-        let panelHeight = host.fittingSize.height
+        let panelWidth = panelSize.width
+        let panelHeight = panelSize.height
         let edgeInset: CGFloat = 4
 
         // Find the screen containing the anchor point (fall back to main display)

--- a/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
@@ -140,6 +140,10 @@ private final class VTooltipTrackerView: NSView {
     private var scrollObserver: NSObjectProtocol?
     private var scrollEndObserver: NSObjectProtocol?
     private var appDeactivationObserver: NSObjectProtocol?
+    private var mouseDownMonitor: Any?
+    private var keyDownMonitor: Any?
+    private var windowMovedObserver: NSObjectProtocol?
+    private var windowResizedObserver: NSObjectProtocol?
 
     /// Suppresses synthetic mouseEntered events during and briefly after scroll.
     /// Static because the re-entry can hit a different VTooltipTrackerView instance
@@ -177,6 +181,8 @@ private final class VTooltipTrackerView: NSView {
         showTimer?.invalidate()
         stopObservingScroll()
         stopObservingAppDeactivation()
+        stopObservingWindowGeometry()
+        removeInteractionMonitors()
         hideTooltip()
         super.removeFromSuperview()
     }
@@ -186,10 +192,13 @@ private final class VTooltipTrackerView: NSView {
         if window != nil {
             startObservingScroll()
             startObservingAppDeactivation()
+            startObservingWindowGeometry()
         } else {
             showTimer?.invalidate()
             stopObservingScroll()
             stopObservingAppDeactivation()
+            stopObservingWindowGeometry()
+            removeInteractionMonitors()
             hideTooltip()
         }
     }
@@ -249,6 +258,78 @@ private final class VTooltipTrackerView: NSView {
         if let observer = appDeactivationObserver {
             NotificationCenter.default.removeObserver(observer)
             appDeactivationObserver = nil
+        }
+    }
+
+    // MARK: - Dismiss on window move/resize
+
+    private func startObservingWindowGeometry() {
+        guard windowMovedObserver == nil, let window else { return }
+        windowMovedObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didMoveNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            self?.showTimer?.invalidate()
+            self?.showTimer = nil
+            self?.hideTooltip()
+        }
+        windowResizedObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didResizeNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            self?.showTimer?.invalidate()
+            self?.showTimer = nil
+            self?.hideTooltip()
+        }
+    }
+
+    private func stopObservingWindowGeometry() {
+        if let observer = windowMovedObserver {
+            NotificationCenter.default.removeObserver(observer)
+            windowMovedObserver = nil
+        }
+        if let observer = windowResizedObserver {
+            NotificationCenter.default.removeObserver(observer)
+            windowResizedObserver = nil
+        }
+    }
+
+    // MARK: - Dismiss on mouse-down / key-down
+
+    /// Installs local event monitors that dismiss the tooltip on any
+    /// mouse-down (fixes tooltip persisting during drag) or key-down.
+    /// Monitors are installed when the tooltip appears and removed when
+    /// it hides, so there is zero overhead when no tooltip is visible.
+    private func installInteractionMonitors() {
+        guard mouseDownMonitor == nil else { return }
+        mouseDownMonitor = NSEvent.addLocalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown, .otherMouseDown]
+        ) { [weak self] event in
+            self?.showTimer?.invalidate()
+            self?.showTimer = nil
+            self?.hideTooltip()
+            return event
+        }
+        keyDownMonitor = NSEvent.addLocalMonitorForEvents(
+            matching: .keyDown
+        ) { [weak self] event in
+            self?.showTimer?.invalidate()
+            self?.showTimer = nil
+            self?.hideTooltip()
+            return event
+        }
+    }
+
+    private func removeInteractionMonitors() {
+        if let monitor = mouseDownMonitor {
+            NSEvent.removeMonitor(monitor)
+            mouseDownMonitor = nil
+        }
+        if let monitor = keyDownMonitor {
+            NSEvent.removeMonitor(monitor)
+            keyDownMonitor = nil
         }
     }
 
@@ -399,11 +480,13 @@ private final class VTooltipTrackerView: NSView {
             p.animator().alphaValue = 1
         }
         panel = p
+        installInteractionMonitors()
     }
 
     private func hideTooltip() {
         guard let p = panel else { return }
         panel = nil
+        removeInteractionMonitors()
         // Detach from parent window before hiding.
         if let parentWindow = p.parent {
             parentWindow.removeChildWindow(p)

--- a/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
@@ -91,10 +91,11 @@ public extension View {
     /// Attaches a floating tooltip that appears on hover after `delay` seconds.
     func vTooltip(_ text: String, edge: Edge = .top, delay: TimeInterval = 0.2) -> some View {
         self.overlay(
-            VTooltipTracker(text: text, edge: edge, delay: delay)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .allowsHitTesting(false)
-        )
+                VTooltipTracker(text: text, edge: edge, delay: delay)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .allowsHitTesting(false)
+                    .accessibilityHidden(true)
+            )
     }
 }
 
@@ -411,6 +412,8 @@ private struct VTooltipContent: View {
             .background(VColor.surfaceLift)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
             .shadow(color: VColor.auxBlack.opacity(0.12), radius: 4, y: 2)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(text)
     }
 }
 

--- a/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
@@ -311,13 +311,13 @@ private final class VTooltipTrackerView: NSView {
         p.ignoresMouseEvents = true
 
         let host = NSHostingView(rootView: VTooltipContent(text: tooltipText))
-        // Pre-set the frame to the max tooltip width so the SwiftUI layout
-        // receives a reasonable width proposal. Without this, the initial
-        // frame is zero, causing .fixedSize(horizontal: false) to wrap
-        // text at zero width and return a very tall fittingSize.
-        let maxTooltipWidth: CGFloat = 280
-        host.frame.size = NSSize(width: maxTooltipWidth, height: 10000)
-        let panelSize = host.fittingSize
+        // Use sizeThatFits(in:) — Apple's recommended API for measuring
+        // NSHostingView with a proposed size. fittingSize doesn't pass a
+        // width proposal, so .fixedSize(horizontal: false) would wrap text
+        // at zero width and return an incorrect (very tall) size.
+        let panelSize = host.sizeThatFits(
+            NSSize(width: 280, height: CGFloat.greatestFiniteMagnitude)
+        )
         host.frame.size = panelSize
         p.contentView = host
         p.setContentSize(panelSize)


### PR DESCRIPTION
## Summary
Address behavioral gaps in the `.vTooltip()` implementation compared to native macOS tooltips:
- Tooltips stay fully visible when source view is near screen edges (multi-display aware)
- Long tooltip text wraps at ~280pt max width instead of producing arbitrarily wide panels
- Tooltip content is exposed to VoiceOver via accessibility attributes
- Tooltips dismiss on mouse-down, key-down, and window move/resize

## Changes

### Screen edge clamping
- `showTooltip()` queries `NSScreen.screens` to find the correct display
- Clamps the tooltip panel within `visibleFrame` with 4pt inset
- Flips to the opposite edge (using the correct anchor point) when clipped

### Max width & text wrapping
- Two-pass sizing: measure unconstrained with `.fixedSize()` first, then re-measure with `.frame(width: 280)` if too wide
- Short text sizes to content naturally; long text wraps at 280pt
- Uses `VTooltipContent(wrapWidth:)` parameter to switch between modes

### Accessibility
- Added `.accessibilityElement(children: .ignore)` and `.accessibilityLabel(text)` to `VTooltipContent`
- Tracker overlay marked `.accessibilityHidden(true)` to avoid duplicate announcements

### Dismiss behaviors
- **Mouse-down**: dismisses tooltip immediately (fixes tooltip persisting during drag)
- **Key-down**: dismisses tooltip on any keystroke
- **Window move/resize**: observes `NSWindow.didMoveNotification` / `didResizeNotification`
- Event monitors installed only while a tooltip is visible (zero overhead otherwise)

## Milestone PRs (merged into feature branch)
- #24005: M1 — Screen edge clamping
- #24011: M2 — Max width and text wrapping
- #24017: M3 — VoiceOver accessibility

## Post-merge fixes (pushed directly to feature branch)
- Fix: use opposite anchor point when edge-flipping tooltip
- Fix: two-pass tooltip sizing to fix positioning regression
- Fix: dismiss on mouse-down, key-down, and window move/resize

## Project issue
Closes #23999

## Test plan
- [ ] Hover over a tooltip near each screen edge — should stay fully visible
- [ ] Hover over a tooltip on a secondary display — clamping uses that display's bounds
- [ ] Apply `.vTooltip()` with a 100+ character string — text wraps at ~280pt
- [ ] Short tooltip text ("Copy", "Send") sizes to content naturally
- [ ] Enable VoiceOver and hover over a view with `.vTooltip()` — tooltip text announced
- [ ] Click while tooltip is visible — tooltip dismisses immediately
- [ ] Press any key while tooltip is visible — tooltip dismisses
- [ ] Move or resize the window while tooltip is visible — tooltip dismisses
- [ ] Drag from a view with `.vTooltip()` — tooltip does not persist during drag