### PR TITLE
feat: apply minHeight to assistant turn content for user-message-at-top

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -165,6 +165,7 @@ struct MessageListContentView: View, Equatable {
     // MARK: - Body
 
     var body: some View {
+        let turnMinHeight: CGFloat = max(0, viewportHeight - 150)
         LazyVStack(alignment: .leading, spacing: VSpacing.md) {
             if isLoadingMoreMessages {
                 HStack {
@@ -235,6 +236,7 @@ struct MessageListContentView: View, Equatable {
                     providerCatalogHash: providerCatalogHash
                 )
                 .equatable()
+                .frame(minHeight: isLatestAssistant ? turnMinHeight : nil, alignment: .top)
             }
 
             ForEach(state.orphanSubagents) { subagent in
@@ -250,28 +252,28 @@ struct MessageListContentView: View, Equatable {
             }
 
             if state.shouldShowThinkingIndicator && state.anchoredThinkingIndex == nil {
-                if isCompacting {
-                    compactingIndicatorRow()
-                } else {
-                    thinkingIndicatorRow(hasUserMessage: state.hasUserMessage)
+                VStack(alignment: .leading, spacing: VSpacing.md) {
+                    if isCompacting {
+                        compactingIndicatorRow()
+                    } else {
+                        thinkingIndicatorRow(hasUserMessage: state.hasUserMessage)
+                    }
+                    thinkingAvatarRow
                 }
-                thinkingAvatarRow
+                .frame(minHeight: turnMinHeight, alignment: .top)
             } else if state.isStreamingWithoutText {
                 HStack {
                     TypingIndicatorView()
                     Spacer()
                 }
                 .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
+                .frame(minHeight: turnMinHeight, alignment: .top)
                 .id("streaming-without-text-indicator")
                 .transition(.opacity.combined(with: .move(edge: .bottom)))
             } else if isCompacting && !state.shouldShowThinkingIndicator && !state.canInlineProcessing {
                 compactingIndicatorRow()
+                    .frame(minHeight: turnMinHeight, alignment: .top)
             }
-
-            // Smart spacer: animates open on send, shrinks as assistant content grows
-            Color.clear
-                .frame(height: scrollState.spacerHeight)
-                .id("scroll-bottom-spacer")
 
             // Bottom anchor for explicit jumps
             Color.clear

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -104,20 +104,6 @@ final class MessageListScrollState {
     /// from initial position). Used to gate initial auto-scroll behavior.
     @ObservationIgnored var hasBeenInteracted: Bool = false
 
-    // MARK: - Smart Spacer
-
-    /// The spacer height that the view reads. Observable so the view updates.
-    private(set) var spacerHeight: CGFloat = 0
-
-    /// Whether a send cycle is actively streaming.
-    @ObservationIgnored var isInSendCycle: Bool = false
-
-    /// Target spacer height (viewportHeight - estimated user msg height).
-    @ObservationIgnored var targetSpacerHeight: CGFloat = 0
-
-    /// Content height when send started, for computing growth delta.
-    @ObservationIgnored var contentHeightAtSendStart: CGFloat = 0
-
     // MARK: - Derived State Cache
 
     /// Non-observable cache for memoizing derived state computations.
@@ -233,38 +219,6 @@ final class MessageListScrollState {
         scrollLog.debug("Scroll to latest tapped — resetting near-bottom state")
     }
 
-    // MARK: - Smart Spacer Methods
-
-    /// Begins the spacer animation when a send cycle starts.
-    /// Animates the spacer from 0 to `viewportHeight - 150` (estimated user message height).
-    func startSpacerAnimation() {
-        isInSendCycle = true
-        contentHeightAtSendStart = contentHeight
-        targetSpacerHeight = max(0, viewportHeight - 150)
-        withAnimation(VAnimation.standard) {
-            spacerHeight = targetSpacerHeight
-        }
-    }
-
-    /// Shrinks the spacer proportionally as assistant content grows during streaming.
-    /// Throttled to 10pt changes to avoid excessive re-renders.
-    func updateSpacerForContentGrowth(newContentHeight: CGFloat) {
-        guard isInSendCycle else { return }
-        let growth = max(0, newContentHeight - contentHeightAtSendStart)
-        let newHeight = max(100, targetSpacerHeight - growth)
-        if abs(newHeight - spacerHeight) >= 10 {
-            spacerHeight = newHeight
-        }
-    }
-
-    /// Ends the send cycle and settles the spacer at the 100pt floor.
-    func endSendCycle() {
-        isInSendCycle = false
-        withAnimation(VAnimation.standard) {
-            spacerHeight = 100
-        }
-    }
-
     /// Resets all state for a conversation switch.
     func reset(for conversationId: UUID) {
         currentConversationId = conversationId
@@ -283,10 +237,6 @@ final class MessageListScrollState {
         lastAutoFocusedRequestId = nil
         bottomAnchorAppeared = false
         hasBeenInteracted = false
-        spacerHeight = 0
-        targetSpacerHeight = 0
-        isInSendCycle = false
-        contentHeightAtSendStart = 0
         derivedStateCache.reset()
 
         scrollLog.debug("Reset for conversation: \(conversationId)")

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+Lifecycle.swift
@@ -58,10 +58,8 @@ extension MessageListView {
                 }
                 scrollState.markSendAnchored()
             }
-            scrollState.startSpacerAnimation()
         } else {
-            // true → false transition: end spacer send cycle.
-            scrollState.endSendCycle()
+            // true → false transition.
             // Track first-message detection.
             if !hasEverSentMessage && messages.contains(where: { $0.role == .user }) {
                 hasEverSentMessage = true

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+ScrollHandling.swift
@@ -16,10 +16,6 @@ extension MessageListView {
         scrollState.viewportHeight = newState.visibleRectHeight
         scrollState.updateNearBottom()
 
-        if scrollState.isInSendCycle {
-            scrollState.updateSpacerForContentGrowth(newContentHeight: newState.contentHeight)
-        }
-
         // Derive sentinel position from content offset (inverted sign to
         // match the old coordinate-space convention where minY is negative
         // when scrolled past the viewport top).


### PR DESCRIPTION
## Summary
- Apply frame(minHeight: viewportHeight - 150, alignment: .top) to last assistant message, thinking indicator, and streaming indicator
- Remove bottom spacer entirely — no synthetic empty space
- Remove smart spacer state from MessageListScrollState
- Content aligns to top within minHeight frame; exceeds it naturally as response grows

Part of plan: assistant-turn-minheight.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24026" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
