### PR TITLE
fix(daemon): wire HostBrowserProxy through conversation handler sibling code path

### DIFF
--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -31,6 +31,7 @@ import { summarizeToolInput } from "../../tools/tool-input-summary.js";
 import { truncate } from "../../util/truncate.js";
 import type { Conversation } from "../conversation.js";
 import { HostBashProxy } from "../host-bash-proxy.js";
+import { HostBrowserProxy } from "../host-browser-proxy.js";
 import { HostCuProxy } from "../host-cu-proxy.js";
 import { HostFileProxy } from "../host-file-proxy.js";
 import type {
@@ -131,6 +132,12 @@ export function makeEventSender(params: {
         conversation,
         conversationId,
         kind: "host_bash",
+      });
+    } else if (event.type === "host_browser_request") {
+      pendingInteractions.register(event.requestId, {
+        conversation,
+        conversationId,
+        kind: "host_browser",
       });
     } else if (event.type === "host_file_request") {
       pendingInteractions.register(event.requestId, {
@@ -307,6 +314,10 @@ export async function handleConversationCreate(
         pendingInteractions.resolve(requestId);
       });
       conversationObj.setHostBashProxy(proxy);
+      const browserProxy = new HostBrowserProxy(sendEvent, (requestId) => {
+        pendingInteractions.resolve(requestId);
+      });
+      conversationObj.setHostBrowserProxy(browserProxy);
       const fileProxy = new HostFileProxy(sendEvent, (requestId) => {
         pendingInteractions.resolve(requestId);
       });


### PR DESCRIPTION
## Summary
Self-review gap: `daemon/handlers/conversations.ts` has a sibling code path (the conversation-creation handler + `makeEventSender`) that instantiates bash/file/cu proxies and registers their events, but the Phase 1 plan only wired `HostBrowserProxy` through `conversation-routes.ts:handleSendMessage`. When a client creates a new conversation with an initial message, the conversation-creation handler runs instead of `handleSendMessage`, so `host_browser_request` events were silently dropped on this code path.

- Add `HostBrowserProxy` import and instantiation in the `supportsHostProxy(transportInterface)` branch
- Register `host_browser_request` in the event dispatch chain

Fix for plan: host-browser-proxy-phase1.md (self-review round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24027" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
