### PR TITLE
chore: reduce default memory injection counts

### DIFF
--- a/assistant/src/config/schemas/memory-retrieval.ts
+++ b/assistant/src/config/schemas/memory-retrieval.ts
@@ -195,7 +195,7 @@ const MemoryContextLoadInjectionSchema = z
       .positive(
         "memory.retrieval.injection.contextLoad.maxNodes must be a positive integer",
       )
-      .default(40)
+      .default(25)
       .describe("Maximum number of memory nodes to load at conversation start"),
     serendipitySlots: z
       .number({
@@ -208,7 +208,7 @@ const MemoryContextLoadInjectionSchema = z
       .nonnegative(
         "memory.retrieval.injection.contextLoad.serendipitySlots must be non-negative",
       )
-      .default(10)
+      .default(5)
       .describe("Number of random wildcard memory picks at conversation start"),
     capabilityReserve: z
       .number({
@@ -238,7 +238,7 @@ const MemoryPerTurnInjectionSchema = z
       .positive(
         "memory.retrieval.injection.perTurn.maxNodes must be a positive integer",
       )
-      .default(8)
+      .default(6)
       .describe(
         "Maximum total memory nodes injected per turn (general + capability + serendipity)",
       ),
@@ -266,7 +266,7 @@ const MemoryPerTurnInjectionSchema = z
       .nonnegative(
         "memory.retrieval.injection.perTurn.capabilityReserve must be non-negative",
       )
-      .default(3)
+      .default(2)
       .describe("Reserved slots for skill/CLI capability nodes per turn"),
   })
   .describe("Memory injection limits for mid-conversation turns");


### PR DESCRIPTION
## Summary
- contextLoad: 40/10/5 → 25/5/5 (maxNodes/serendipitySlots/capabilityReserve)
- perTurn: 6/1/2 (maxNodes/serendipitySlots/capabilityReserve, was 8/1/3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24029" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
