### PR TITLE
docs(conversation-routes): update makeHubPublisher JSDoc for all host proxy kinds

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -799,9 +799,9 @@ function mergeToolResultsIntoAssistantMessages(
  * assistant event hub, maintaining ordered delivery through a serial chain.
  *
  * Also registers pending interactions when confirmation_request,
- * secret_request, host_bash_request, or host_file_request events flow
- * through, so standalone approval/result endpoints can look up the conversation
- * by requestId.
+ * secret_request, host_bash_request, host_browser_request, host_file_request,
+ * or host_cu_request events flow through, so standalone approval/result
+ * endpoints can look up the conversation by requestId.
  */
 function makeHubPublisher(
   deps: SendMessageDeps,


### PR DESCRIPTION
## Summary
Self-review round 2 gap: the JSDoc on `makeHubPublisher` in `conversation-routes.ts` listed only `host_bash_request` and `host_file_request`, but the body now also handles `host_browser_request` and `host_cu_request`. Update the comment to describe the current state, per assistant/CLAUDE.md.

This is the exact analog of the stale comment that was fixed in `daemon/server.ts:makePendingInteractionRegistrar` during round 1.

Fix for plan: host-browser-proxy-phase1.md (self-review round 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24030" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
