### PR TITLE
feat: add content field to server_tool_complete event type

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -82,7 +82,7 @@ export type AgentEvent =
       toolUseId: string;
       input: Record<string, unknown>;
     }
-  | { type: "server_tool_complete"; toolUseId: string; isError: boolean }
+  | { type: "server_tool_complete"; toolUseId: string; isError: boolean; content?: unknown[] }
   | { type: "error"; error: Error }
   | {
       type: "usage";

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -126,7 +126,7 @@ export type ProviderEvent =
       toolUseId: string;
       input: Record<string, unknown>;
     }
-  | { type: "server_tool_complete"; toolUseId: string; isError: boolean };
+  | { type: "server_tool_complete"; toolUseId: string; isError: boolean; content?: unknown[] };
 
 export interface SendMessageConfig {
   model?: string;


### PR DESCRIPTION
## Summary
- Add optional `content?: unknown[]` field to `server_tool_complete` variant of `ProviderEvent` in types.ts
- Add matching field to `server_tool_complete` variant of `AgentEvent` in loop.ts

Part of plan: web-search-display.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24034" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
