### PR TITLE
feat: render server_tool_use and web_search_tool_result blocks in conversation history

### DIFF
--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -344,6 +344,59 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
       }
       continue;
     }
+    if (block.type === "server_tool_use") {
+      finalizeSegment();
+      const name = typeof block.name === "string" ? block.name : "unknown";
+      const input = isRecord(block.input)
+        ? (block.input as Record<string, unknown>)
+        : {};
+      const id = typeof block.id === "string" ? block.id : "";
+      const entry: HistoryToolCall = { name, input };
+      toolCalls.push(entry);
+      if (id) pendingToolUses.set(id, entry);
+      contentOrder.push(`tool:${toolCalls.length - 1}`);
+      if (!seenToolUse) {
+        seenToolUse = true;
+        if (!seenText) toolCallsBeforeText = true;
+      }
+      continue;
+    }
+    if (block.type === "web_search_tool_result") {
+      const toolUseId =
+        typeof block.tool_use_id === "string" ? block.tool_use_id : "";
+      const isError =
+        isRecord(block.content) &&
+        (block.content as { type?: string }).type ===
+          "web_search_tool_result_error";
+
+      // Format search results into readable text.
+      let resultContent = "";
+      if (Array.isArray(block.content)) {
+        resultContent = (block.content as unknown[])
+          .filter(
+            (r): r is { type: string; title: string; url: string } =>
+              typeof r === "object" &&
+              r != null &&
+              (r as { type?: string }).type === "web_search_result",
+          )
+          .map((r) => `${r.title}\n${r.url}`)
+          .join("\n\n");
+      }
+
+      const matched = toolUseId ? pendingToolUses.get(toolUseId) : null;
+      if (matched) {
+        matched.result = resultContent;
+        matched.isError = isError;
+      } else {
+        toolCalls.push({
+          name: "web_search",
+          input: {},
+          result: resultContent,
+          isError,
+        });
+      }
+      continue;
+    }
     if (block.type === "tool_result") {
       const toolUseId =
         typeof block.tool_use_id === "string" ? block.tool_use_id : "";


### PR DESCRIPTION
## Summary
- Handle `server_tool_use` blocks in `renderHistoryContent()` — creates `HistoryToolCall` entries with name/input, registers in `pendingToolUses` for pairing
- Handle `web_search_tool_result` blocks — pairs with `server_tool_use` by `tool_use_id`, formats search results as title+URL text into the `result` field
- Web search steps now appear correctly in conversation history with query and results

Part of plan: web-search-display.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24035" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
