### PR TITLE
feat: forward web search result content through provider and agent loop

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -344,6 +344,7 @@ export class AgentLoop {
                   type: "server_tool_complete",
                   toolUseId: event.toolUseId,
                   isError: event.isError,
+                  ...(event.content ? { content: event.content } : {}),
                 });
               }
             },

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -982,6 +982,7 @@ export class AnthropicProvider implements Provider {
               type: "server_tool_complete",
               toolUseId: block.tool_use_id,
               isError: !!isError,
+              ...(Array.isArray(block.content) ? { content: block.content } : {}),
             });
           }
           if (event.type === "content_block_stop") {


### PR DESCRIPTION
## Summary
- Forward `block.content` (web search results array) in the `server_tool_complete` event from the Anthropic provider
- Relay the `content` field through the agent loop event pipeline

Part of plan: web-search-display.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24036" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
