### PR TITLE
feat: format web search results for client display in server_tool_complete handler

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -932,10 +932,25 @@ export async function dispatchAgentEvent(
           "assistant_turn",
           deps.reqId,
         );
+
+        // Format web search results into a human-readable string for the client.
+        let resultText = "";
+        if (Array.isArray(event.content) && event.content.length > 0) {
+          resultText = (event.content as unknown[])
+            .filter(
+              (r): r is { type: string; title: string; url: string } =>
+                typeof r === "object" &&
+                r != null &&
+                (r as { type?: string }).type === "web_search_result",
+            )
+            .map((r) => `${r.title}\n${r.url}`)
+            .join("\n\n");
+        }
+
         deps.onEvent({
           type: "tool_result",
-          toolName: "",
-          result: "",
+          toolName: "web_search",
+          result: resultText,
           isError: event.isError,
           conversationId: deps.ctx.conversationId,
           toolUseId: event.toolUseId,


### PR DESCRIPTION
## Summary
- Format web search results as `title\nurl` pairs in the `server_tool_complete` handler
- Set `toolName: "web_search"` (was empty string) so the client renders proper labels
- Set `result` to formatted text (was empty string) so the client shows search results in step details

Part of plan: web-search-display.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24037" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
