### PR TITLE
fix: restore conversation starters auto-refresh after graph extraction

### DIFF
--- a/assistant/src/__tests__/conversation-starters-cadence.test.ts
+++ b/assistant/src/__tests__/conversation-starters-cadence.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { v4 as uuid } from "uuid";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { getSqlite, initializeDb } from "../memory/db.js";
+import { maybeEnqueueConversationStartersJob } from "../memory/conversation-starters-cadence.js";
+
+initializeDb();
+
+function clearTables() {
+  getSqlite().run("DELETE FROM memory_graph_nodes");
+  getSqlite().run("DELETE FROM memory_jobs");
+  getSqlite().run("DELETE FROM memory_checkpoints");
+}
+
+function insertMemoryNode(scopeId = "default") {
+  const now = Date.now();
+  getSqlite().run(
+    `INSERT INTO memory_graph_nodes (
+      id, content, type, created, last_accessed, last_consolidated,
+      emotional_charge, fidelity, confidence, significance,
+      stability, reinforcement_count, last_reinforced,
+      source_conversations, source_type, scope_id
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, 'vivid', 0.8, 0.5, 14, 0, ?, '[]', 'inferred', ?)`,
+    [
+      uuid(),
+      "test statement",
+      "semantic",
+      now,
+      now,
+      now,
+      '{"valence":0,"intensity":0.1,"decayCurve":"linear","decayRate":0.05,"originalIntensity":0.1}',
+      now,
+      scopeId,
+    ],
+  );
+}
+
+function setCheckpoint(key: string, value: string) {
+  getSqlite().run(
+    `INSERT OR REPLACE INTO memory_checkpoints (key, value, updated_at) VALUES (?, ?, ?)`,
+    [key, value, Date.now()],
+  );
+}
+
+function getPendingJobs(): Array<{ type: string }> {
+  return getSqlite()
+    .prepare(
+      `SELECT type FROM memory_jobs WHERE type = 'generate_conversation_starters' AND status = 'pending'`,
+    )
+    .all() as Array<{ type: string }>;
+}
+
+beforeEach(() => {
+  clearTables();
+});
+
+describe("maybeEnqueueConversationStartersJob", () => {
+  test("no-op when zero memory nodes", () => {
+    maybeEnqueueConversationStartersJob("default");
+    expect(getPendingJobs()).toHaveLength(0);
+  });
+
+  test("enqueues when threshold exceeded (<=10 nodes, threshold=1)", () => {
+    insertMemoryNode();
+    insertMemoryNode();
+
+    maybeEnqueueConversationStartersJob("default");
+    expect(getPendingJobs()).toHaveLength(1);
+  });
+
+  test("no-op when delta below threshold", () => {
+    for (let i = 0; i < 5; i++) insertMemoryNode();
+
+    // Set checkpoint to current count — no new items since last gen
+    setCheckpoint("conversation_starters:item_count_at_last_gen:default", "5");
+
+    maybeEnqueueConversationStartersJob("default");
+    expect(getPendingJobs()).toHaveLength(0);
+  });
+
+  test("uses higher threshold for larger memory counts (>50 nodes, threshold=10)", () => {
+    for (let i = 0; i < 55; i++) insertMemoryNode();
+
+    // Set checkpoint so delta is only 4 (below threshold of 10)
+    setCheckpoint(
+      "conversation_starters:item_count_at_last_gen:default",
+      "51",
+    );
+
+    maybeEnqueueConversationStartersJob("default");
+    expect(getPendingJobs()).toHaveLength(0);
+
+    // Add more to exceed threshold
+    for (let i = 0; i < 6; i++) insertMemoryNode();
+
+    maybeEnqueueConversationStartersJob("default");
+    expect(getPendingJobs()).toHaveLength(1);
+  });
+
+  test("dedup prevents double-enqueue", () => {
+    insertMemoryNode();
+    insertMemoryNode();
+
+    maybeEnqueueConversationStartersJob("default");
+    expect(getPendingJobs()).toHaveLength(1);
+
+    // Call again — should not create a second job
+    maybeEnqueueConversationStartersJob("default");
+    expect(getPendingJobs()).toHaveLength(1);
+  });
+
+  test("scopes are independent", () => {
+    insertMemoryNode("scope-a");
+    insertMemoryNode("scope-b");
+
+    maybeEnqueueConversationStartersJob("scope-a");
+    maybeEnqueueConversationStartersJob("scope-b");
+
+    const jobs = getSqlite()
+      .prepare(
+        `SELECT payload FROM memory_jobs WHERE type = 'generate_conversation_starters' AND status = 'pending'`,
+      )
+      .all() as Array<{ payload: string }>;
+
+    expect(jobs).toHaveLength(2);
+    const payloads = jobs.map((j) => JSON.parse(j.payload).scopeId).sort();
+    expect(payloads).toEqual(["scope-a", "scope-b"]);
+  });
+});

--- a/assistant/src/memory/conversation-starters-cadence.ts
+++ b/assistant/src/memory/conversation-starters-cadence.ts
@@ -1,0 +1,74 @@
+/**
+ * Cadence logic for conversation starters generation.
+ *
+ * Decides whether a new generation job should be enqueued based on how many
+ * active memory items have accumulated since the last generation.
+ */
+
+import { and, eq, inArray, like } from "drizzle-orm";
+
+import { getLogger } from "../util/logger.js";
+import { getDb } from "./db.js";
+import { enqueueMemoryJob } from "./jobs-store.js";
+import { rawGet } from "./raw-query.js";
+import { memoryCheckpoints, memoryJobs } from "./schema.js";
+
+const log = getLogger("conversation-starters-cadence");
+
+/**
+ * Check whether enough new memory items have accumulated to justify
+ * generating a fresh batch of conversation starters.
+ */
+export function maybeEnqueueConversationStartersJob(scopeId: string): void {
+  const db = getDb();
+
+  // Count total active memory items
+  const countRow = rawGet<{ c: number }>(
+    `SELECT COUNT(*) AS c FROM memory_graph_nodes WHERE fidelity != 'gone' AND scope_id = ?`,
+    scopeId,
+  );
+  const totalActive = countRow?.c ?? 0;
+  if (totalActive === 0) return;
+
+  // Read checkpoint: item count at last generation (scoped so each scope tracks independently)
+  const checkpointKey = `conversation_starters:item_count_at_last_gen:${scopeId}`;
+  const checkpoint = db
+    .select({ value: memoryCheckpoints.value })
+    .from(memoryCheckpoints)
+    .where(eq(memoryCheckpoints.key, checkpointKey))
+    .get();
+  const lastCount = checkpoint ? parseInt(checkpoint.value, 10) : 0;
+
+  // Cadence formula
+  let threshold: number;
+  if (totalActive <= 10) {
+    threshold = 1;
+  } else if (totalActive <= 50) {
+    threshold = 5;
+  } else {
+    threshold = 10;
+  }
+
+  const delta = totalActive - lastCount;
+  if (delta < threshold) return;
+
+  // Dedup: don't enqueue if a pending/running job for this scope already exists
+  const existing = db
+    .select({ id: memoryJobs.id })
+    .from(memoryJobs)
+    .where(
+      and(
+        eq(memoryJobs.type, "generate_conversation_starters"),
+        inArray(memoryJobs.status, ["pending", "running"]),
+        like(memoryJobs.payload, `%"scopeId":"${scopeId}"%`),
+      ),
+    )
+    .get();
+  if (existing) return;
+
+  enqueueMemoryJob("generate_conversation_starters", { scopeId });
+  log.info(
+    { totalActive, lastCount, delta, threshold, scopeId },
+    "Enqueued conversation starters generation job",
+  );
+}

--- a/assistant/src/memory/graph/extraction-job.ts
+++ b/assistant/src/memory/graph/extraction-job.ts
@@ -9,6 +9,7 @@
 import type { AssistantConfig } from "../../config/types.js";
 import { getLogger } from "../../util/logger.js";
 import { getMemoryCheckpoint, setMemoryCheckpoint } from "../checkpoints.js";
+import { maybeEnqueueConversationStartersJob } from "../conversation-starters-cadence.js";
 import { asString } from "../job-utils.js";
 import type { MemoryJob } from "../jobs-store.js";
 import { runGraphExtraction } from "./extraction.js";
@@ -64,6 +65,20 @@ export async function graphExtractJob(
       },
       "Graph extraction job complete",
     );
+
+    try {
+      maybeEnqueueConversationStartersJob(scopeId);
+    } catch (cadenceErr) {
+      log.warn(
+        {
+          err:
+            cadenceErr instanceof Error
+              ? cadenceErr.message
+              : String(cadenceErr),
+        },
+        "Conversation starters cadence check failed (non-fatal)",
+      );
+    }
   } catch (err) {
     log.error(
       { conversationId, err: err instanceof Error ? err.message : String(err) },


### PR DESCRIPTION
## Summary
- Restores `conversation-starters-cadence.ts` (deleted in 577bd54c2 as "unused" — its call site was removed in the memory graph migration)
- Wires `maybeEnqueueConversationStartersJob()` into `graphExtractJob()` so starters regenerate when enough new memory nodes accumulate
- Adds tests for the cadence logic (threshold tiers, dedup, scope isolation)

## Original prompt
Conversation starter suggestions on the home screen are stale and never update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
