### PR TITLE
fix: sort imports in conversation-starters-cadence test

### DIFF
--- a/assistant/src/__tests__/conversation-starters-cadence.test.ts
+++ b/assistant/src/__tests__/conversation-starters-cadence.test.ts
@@ -9,8 +9,8 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-import { getSqlite, initializeDb } from "../memory/db.js";
 import { maybeEnqueueConversationStartersJob } from "../memory/conversation-starters-cadence.js";
+import { getSqlite, initializeDb } from "../memory/db.js";
 
 initializeDb();
 


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error in `conversation-starters-cadence.test.ts` by sorting imports alphabetically

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24096664230/job/70296903924
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24040" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
