### PR TITLE
fix: soft-delete graph nodes instead of hard-deleting

### DIFF
--- a/assistant/src/memory/graph/store.test.ts
+++ b/assistant/src/memory/graph/store.test.ts
@@ -179,10 +179,12 @@ describe("node CRUD", () => {
     expect(updated!.eventDate).toBeNull();
   });
 
-  test("deleteNode removes the node", () => {
+  test("deleteNode soft-deletes the node by setting fidelity to gone", () => {
     const node = createNode(makeNewNode());
     deleteNode(node.id);
-    expect(getNode(node.id)).toBeNull();
+    const deleted = getNode(node.id);
+    expect(deleted).not.toBeNull();
+    expect(deleted!.fidelity).toBe("gone");
   });
 });
 

--- a/assistant/src/memory/graph/store.ts
+++ b/assistant/src/memory/graph/store.ts
@@ -6,6 +6,7 @@ import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "../db.js";
+import { enqueueMemoryJob } from "../jobs-store.js";
 import {
   memoryGraphEdges,
   memoryGraphNodeEdits,
@@ -270,7 +271,14 @@ export function updateNode(
 
 export function deleteNode(id: string): void {
   const db = getDb();
-  db.delete(memoryGraphNodes).where(eq(memoryGraphNodes.id, id)).run();
+  db.update(memoryGraphNodes)
+    .set({ fidelity: "gone", lastAccessed: Date.now() })
+    .where(eq(memoryGraphNodes.id, id))
+    .run();
+  enqueueMemoryJob("delete_qdrant_vectors", {
+    targetType: "graph_node",
+    targetId: id,
+  });
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Changed `deleteNode()` to set `fidelity='gone'` instead of hard `DELETE`, making consolidation deletions recoverable without re-bootstrapping from raw segments
- Added Qdrant vector cleanup job on soft-delete (matching `deleteCapabilityNode()` pattern)
- Updated test to verify soft-delete behavior

## Original prompt

Soft-delete graph nodes instead of hard-deleting so that memory loss is recoverable without re-bootstrapping.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24043" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
