### PR TITLE
Add <system_reminder> PKB nudge to every user turn

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -603,6 +603,7 @@ describe("applyRuntimeInjections — injection mode", () => {
     unifiedTurnContext:
       "<turn_context>\ntimestamp: 2026-03-04 (Tue) 12:00:00 +00:00 (UTC)\ninterface: telegram\n</turn_context>",
     nowScratchpad: "Current focus: shipping PR 3",
+    pkbContext: "essentials content here",
     isNonInteractive: true,
   };
 
@@ -620,6 +621,8 @@ describe("applyRuntimeInjections — injection mode", () => {
     expect(allText).toContain("<turn_context>");
     expect(allText).toContain("<non_interactive_context>");
     expect(allText).toContain("<NOW.md");
+    expect(allText).toContain("<system_reminder>");
+    expect(allText).toContain("<pkb>");
   });
 
   test("explicit mode: 'full' behaves the same as default", () => {
@@ -653,6 +656,8 @@ describe("applyRuntimeInjections — injection mode", () => {
     expect(allText).not.toContain("<channel_command_context>");
     expect(allText).not.toContain("<active_workspace>");
     expect(allText).not.toContain("<NOW.md");
+    expect(allText).not.toContain("<system_reminder>");
+    expect(allText).not.toContain("<pkb>");
   });
 
   test("minimal mode preserves safety-critical blocks", () => {

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -540,13 +540,12 @@ const AUTOINJECT_FILENAME = "_autoinject.md";
 /** Max buffer.md lines injected into prompts — keeps context bounded even when filing is off. */
 const MAX_BUFFER_LINES = 50;
 
-const PKB_NUDGE =
-  "\n\n---\n" +
-  "Your knowledge base has topic files beyond what's loaded here — " +
-  "INDEX.md is your table of contents. At the start of each conversation, " +
-  "read any topic files that might be relevant. " +
-  "Don't wait to be asked — look things up proactively. " +
-  "Use `remember` for every new fact you learn, immediately, no batching.";
+const PKB_SYSTEM_REMINDER =
+  "<system_reminder>" +
+  "\nProactively read any PKB topic files relevant to this conversation — " +
+  "INDEX.md is your table of contents. Don't wait to be asked. " +
+  "Use `remember` for every new fact you learn, immediately, no batching." +
+  "\n</system_reminder>";
 
 /**
  * Read `_autoinject.md` from the PKB directory and return the list of
@@ -610,7 +609,7 @@ export function readPkbContext(): string | null {
     }
   }
 
-  return parts.length > 0 ? parts.join("\n\n") + PKB_NUDGE : null;
+  return parts.length > 0 ? parts.join("\n\n") : null;
 }
 
 /**
@@ -1084,6 +1083,7 @@ const RUNTIME_INJECTION_PREFIXES = [
   "<NOW.md Always keep this up to date>",
   "<now_scratchpad>", // backward-compat: strip legacy blocks from pre-rename history
   "<pkb>",
+  "<system_reminder>",
   "<transport_hints>",
   "<system_notice>One or more tool calls returned an error.",
 ];
@@ -1215,6 +1215,24 @@ export function applyRuntimeInjections(
       result = [
         ...result.slice(0, -1),
         injectPkbContext(userTail, options.pkbContext),
+      ];
+    }
+  }
+
+  // PKB behavioral nudge — remind the assistant to read topic files and
+  // call `remember` aggressively.
+  if (mode === "full" && options.pkbContext) {
+    const userTail = result[result.length - 1];
+    if (userTail && userTail.role === "user") {
+      result = [
+        ...result.slice(0, -1),
+        {
+          ...userTail,
+          content: [
+            ...userTail.content,
+            { type: "text" as const, text: PKB_SYSTEM_REMINDER },
+          ],
+        },
       ];
     }
   }


### PR DESCRIPTION
## Summary
- Replace `PKB_NUDGE` constant (embedded inside `<pkb>` content) with a standalone `<system_reminder>` block injected as a separate text content block on every user turn
- Gated on `mode === "full" && options.pkbContext` — no wasted tokens when PKB isn't active
- Added `<system_reminder>` to `RUNTIME_INJECTION_PREFIXES` for compaction stripping

## Original prompt
Add a `<system_reminder>` nudge to every user turn that instructs the assistant to read any relevant PKB entries and to call remember aggressively