### PR TITLE
fix: bump stabilizationGeneration in reset() and cancelAll() paths

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListScrollState.swift
@@ -436,12 +436,13 @@ final class MessageListScrollState {
     /// the increment (matching the resize/pagination cleanup pattern).
     @ObservationIgnored private var activeStabilizationCount = 0
 
-    /// Monotonically increasing counter, bumped each time
-    /// `cancelStabilizationTasks()` is called. Expansion timeout tasks
-    /// capture the current generation before sleeping. After waking,
-    /// cancelled tasks only call `endStabilization()` if the generation
-    /// is unchanged — preventing stale tasks from acting on a new
-    /// stabilization cycle that started after the cancellation.
+    /// Monotonically increasing counter, bumped when leaving the
+    /// `.stabilizing` mode — either via `transition(to:)` (to a
+    /// non-stabilizing mode), `reset()`, or `cancelAll()`. Expansion
+    /// timeout tasks capture the current generation before sleeping.
+    /// After waking, cancelled tasks only call `endStabilization()` if
+    /// the generation is unchanged — preventing stale tasks from acting
+    /// on a new stabilization cycle that started after the cancellation.
     @ObservationIgnored private var stabilizationGeneration: UInt64 = 0
 
     // MARK: - Deep-Link Anchor Tracking
@@ -779,6 +780,7 @@ final class MessageListScrollState {
     /// Resets state for a conversation switch.
     func reset(for newConversationId: UUID?) {
         cancelStabilizationTasks()
+        stabilizationGeneration &+= 1
         paginationTask?.cancel()
         paginationTask = nil
         ScrollGeometryUpdateDispatcher.shared.cancel(for: self)
@@ -825,6 +827,7 @@ final class MessageListScrollState {
     /// Cancel all tasks and reset mode. Called from `onDisappear`.
     func cancelAll() {
         cancelStabilizationTasks()
+        stabilizationGeneration &+= 1
         uiSyncTask?.cancel()
         uiSyncTask = nil
         scrollRestoreTask?.cancel()


### PR DESCRIPTION
Addresses review feedback on #23991. The stabilizationGeneration bump was moved to transition(to:) but reset() and cancelAll() bypass transition(), leaving stale cancelled tasks able to interfere with new stabilization cycles. Adds generation bumps in both paths and updates the stale doc comment.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24052" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
