### PR TITLE
fix: update stale comments in consolidation.ts after removing decay partition

### DIFF
--- a/assistant/src/memory/graph/consolidation.ts
+++ b/assistant/src/memory/graph/consolidation.ts
@@ -4,8 +4,7 @@
 // Runs daily (or on demand). Processes nodes in partitions:
 // 1. Recency: nodes from last 7 days — merge duplicates, initial narrative
 // 2. Significance: top N by significance — update narrative arcs
-// 3. Decay: nodes at faded/gist fidelity — candidates for merging or marking gone
-// 4. Random sample: cross-pollination and pattern detection
+// 3. Random sample: cross-pollination and pattern detection
 //
 // Each partition is a separate LLM call. The LLM produces a MemoryDiff
 // (same format as extraction) that is applied to the graph.
@@ -159,7 +158,7 @@ const CONSOLIDATE_TOOL_SCHEMA = {
       },
       delete_ids: {
         type: "array" as const,
-        description: "Node IDs to delete (merged duplicates, gone memories)",
+        description: "Node IDs to delete (merged duplicates only)",
         items: { type: "string" as const },
       },
       merge_edges: {


### PR DESCRIPTION
Addresses Devin's review feedback on #24045. Updates the file header comment to reflect the current partition set (removed Decay reference, renumbered) and fixes the stale delete_ids tool schema description that still referenced 'gone memories'.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
