### PR TITLE
fix: filter gone-node edges, update applyDiff to soft-delete, remove duplicate Qdrant cleanup

### DIFF
--- a/assistant/src/memory/graph/store.test.ts
+++ b/assistant/src/memory/graph/store.test.ts
@@ -757,7 +757,9 @@ describe("applyDiff", () => {
       reinforceNodeIds: [],
     });
     expect(result.nodesDeleted).toBe(1);
-    expect(getNode(node.id)).toBeNull();
+    const deleted = getNode(node.id);
+    expect(deleted).not.toBeNull();
+    expect(deleted!.fidelity).toBe("gone");
   });
 
   test("updates nodes", () => {

--- a/assistant/src/memory/graph/store.ts
+++ b/assistant/src/memory/graph/store.ts
@@ -404,12 +404,19 @@ export function getEdgesForNode(
   direction?: "incoming" | "outgoing",
 ): MemoryEdge[] {
   const db = getDb();
-  const condition =
+  const dirCondition =
     direction === "outgoing"
       ? eq(memoryGraphEdges.sourceNodeId, nodeId)
       : direction === "incoming"
         ? eq(memoryGraphEdges.targetNodeId, nodeId)
         : sql`${memoryGraphEdges.sourceNodeId} = ${nodeId} OR ${memoryGraphEdges.targetNodeId} = ${nodeId}`;
+
+  // Exclude edges where either endpoint has fidelity='gone' (soft-deleted)
+  const condition = and(
+    dirCondition,
+    sql`NOT EXISTS (SELECT 1 FROM ${memoryGraphNodes} WHERE ${memoryGraphNodes.id} = ${memoryGraphEdges.sourceNodeId} AND ${memoryGraphNodes.fidelity} = 'gone')`,
+    sql`NOT EXISTS (SELECT 1 FROM ${memoryGraphNodes} WHERE ${memoryGraphNodes.id} = ${memoryGraphEdges.targetNodeId} AND ${memoryGraphNodes.fidelity} = 'gone')`,
+  );
 
   return db
     .select()
@@ -622,9 +629,18 @@ export function applyDiff(
   };
 
   db.transaction((tx) => {
-    // Delete nodes first (cascades edges + triggers)
+    // Soft-delete nodes (set fidelity='gone' and enqueue Qdrant cleanup)
     for (const id of diff.deleteNodeIds) {
-      tx.delete(memoryGraphNodes).where(eq(memoryGraphNodes.id, id)).run();
+      tx.update(memoryGraphNodes)
+        .set({ fidelity: "gone", lastAccessed: Date.now() })
+        .where(eq(memoryGraphNodes.id, id))
+        .run();
+      enqueueMemoryJob(
+        "delete_qdrant_vectors",
+        { targetType: "graph_node", targetId: id },
+        Date.now(),
+        tx,
+      );
       result.nodesDeleted++;
     }
 

--- a/assistant/src/runtime/routes/memory-item-routes.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.ts
@@ -712,14 +712,8 @@ export async function handleDeleteMemoryItem(
     return httpError("NOT_FOUND", "Memory item not found", 404);
   }
 
-  // Hard-delete the node (cascades to edges and triggers via FK)
+  // Soft-delete the node (deleteNode sets fidelity='gone' and enqueues Qdrant cleanup)
   deleteNode(id);
-
-  // Clean up Qdrant vectors asynchronously
-  enqueueMemoryJob("delete_qdrant_vectors", {
-    targetType: "graph_node",
-    targetId: id,
-  });
 
   return new Response(null, { status: 204 });
 }


### PR DESCRIPTION
Addresses review feedback on #24043. Filters edges touching gone nodes from activation spread, updates applyDiff to soft-delete consistently, and removes the duplicate delete_qdrant_vectors enqueue in handleDeleteMemoryItem.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24055" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
