### PR TITLE
feat(teleport): show determinate progress bars during export and upload

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -97,6 +97,7 @@ struct TeleportSection: View {
     @State private var transferTask: Task<Void, Never>?
     @State private var originalAssistant: LockfileAssistant?
     @State private var targetAssistant: LockfileAssistant?
+    @State private var transferProgress: Double? = nil
 
     var body: some View {
         Group {
@@ -139,12 +140,22 @@ struct TeleportSection: View {
             if case .verifying = phase {
                 verifyingBanner
             } else if case .transferring(let step) = phase {
-                HStack(spacing: VSpacing.sm) {
-                    ProgressView()
-                        .controlSize(.small)
-                    Text(step)
-                        .font(VFont.labelDefault)
-                        .foregroundStyle(VColor.contentTertiary)
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    HStack(spacing: VSpacing.sm) {
+                        if transferProgress == nil {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                        Text(step)
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                    }
+                    if let transferProgress {
+                        ProgressView(value: transferProgress)
+                            .progressViewStyle(.linear)
+                            .tint(VColor.primaryBase)
+                            .frame(maxWidth: 240)
+                    }
                 }
             } else if case .failed(let error) = phase {
                 failedBanner(error: error)
@@ -239,6 +250,7 @@ struct TeleportSection: View {
                 label: "Try Again",
                 style: .outlined
             ) {
+                transferProgress = nil
                 phase = .idle
             }
         }
@@ -301,6 +313,7 @@ struct TeleportSection: View {
                 }
             }
         }
+        transferProgress = nil
         phase = .idle
         targetAssistant = nil
     }
@@ -322,6 +335,7 @@ struct TeleportSection: View {
                 throw TeleportError.invalidURL
             }
         } catch {
+            transferProgress = nil
             phase = .failed(error: "Teleport failed: \(error.localizedDescription)")
         }
     }
@@ -331,9 +345,10 @@ struct TeleportSection: View {
     private func teleportLocalToPlatform() async throws {
         // Step 1 — Export local assistant data
         phase = .transferring(step: "Exporting assistant data...")
-        let bundleData = try await exportAssistantBundle()
+        let bundleData = try await exportAssistantBundle(onProgress: { self.transferProgress = $0 })
 
         // Step 2 — Resolve and validate org ID before upload (upload reads org from UserDefaults)
+        transferProgress = nil
         phase = .transferring(step: "Resolving organization...")
         let organizationId = try await resolveOrganizationId()
 
@@ -342,7 +357,7 @@ struct TeleportSection: View {
         let bundleKey: String?
         do {
             let uploadInfo = try await PlatformMigrationClient.requestUploadUrl()
-            try await PlatformMigrationClient.uploadToSignedUrl(uploadInfo.uploadUrl, bundleData: bundleData)
+            try await PlatformMigrationClient.uploadToSignedUrl(uploadInfo.uploadUrl, bundleData: bundleData, onProgress: { self.transferProgress = $0 })
             bundleKey = uploadInfo.bundleKey
         } catch let error as PlatformMigrationClient.PlatformMigrationError {
             if case .signedUrlsNotAvailable = error {
@@ -353,6 +368,7 @@ struct TeleportSection: View {
         }
 
         // Step 4 — Ensure managed assistant exists on platform via direct hatch
+        transferProgress = nil
         phase = .transferring(step: "Setting up cloud assistant...")
         let hatchResult = try await AuthService.shared.hatchAssistant(organizationId: organizationId)
         let platformAssistant: PlatformAssistant
@@ -391,9 +407,10 @@ struct TeleportSection: View {
     private func teleportLocalToDocker() async throws {
         // Step 1 — Export local assistant data
         phase = .transferring(step: "Exporting assistant data...")
-        let bundleData = try await exportAssistantBundle()
+        let bundleData = try await exportAssistantBundle(onProgress: { self.transferProgress = $0 })
 
         // Step 2 — Ensure a docker assistant exists
+        transferProgress = nil
         phase = .transferring(step: "Preparing Docker assistant...")
         var dockerAssistant = LockfileAssistant.loadAll().first(where: { $0.isDocker })
         if dockerAssistant == nil {
@@ -468,9 +485,10 @@ struct TeleportSection: View {
     private func teleportDockerToPlatform() async throws {
         // Step 1 — Export docker assistant data
         phase = .transferring(step: "Exporting assistant data...")
-        let bundleData = try await exportAssistantBundle()
+        let bundleData = try await exportAssistantBundle(onProgress: { self.transferProgress = $0 })
 
         // Step 2 — Resolve and validate org ID before upload (upload reads org from UserDefaults)
+        transferProgress = nil
         phase = .transferring(step: "Resolving organization...")
         let organizationId = try await resolveOrganizationId()
 
@@ -479,7 +497,7 @@ struct TeleportSection: View {
         let bundleKey: String?
         do {
             let uploadInfo = try await PlatformMigrationClient.requestUploadUrl()
-            try await PlatformMigrationClient.uploadToSignedUrl(uploadInfo.uploadUrl, bundleData: bundleData)
+            try await PlatformMigrationClient.uploadToSignedUrl(uploadInfo.uploadUrl, bundleData: bundleData, onProgress: { self.transferProgress = $0 })
             bundleKey = uploadInfo.bundleKey
         } catch let error as PlatformMigrationClient.PlatformMigrationError {
             if case .signedUrlsNotAvailable = error {
@@ -490,6 +508,7 @@ struct TeleportSection: View {
         }
 
         // Step 4 — Ensure managed assistant exists on platform via direct hatch
+        transferProgress = nil
         phase = .transferring(step: "Setting up cloud assistant...")
         let hatchResult = try await AuthService.shared.hatchAssistant(organizationId: organizationId)
         let platformAssistant: PlatformAssistant
@@ -560,11 +579,20 @@ struct TeleportSection: View {
     }
 
     /// Exports the current assistant's data as a `.vbundle` binary archive.
-    private func exportAssistantBundle() async throws -> Data {
-        let response = try await GatewayHTTPClient.post(
-            path: "assistants/{assistantId}/migrations/export",
-            timeout: 60
-        )
+    private func exportAssistantBundle(onProgress: (@MainActor (Double) -> Void)? = nil) async throws -> Data {
+        let response: GatewayHTTPClient.Response
+        if let onProgress {
+            response = try await GatewayHTTPClient.post(
+                path: "assistants/{assistantId}/migrations/export",
+                timeout: 60,
+                onProgress: onProgress
+            )
+        } else {
+            response = try await GatewayHTTPClient.post(
+                path: "assistants/{assistantId}/migrations/export",
+                timeout: 60
+            )
+        }
         guard response.isSuccess else {
             throw TeleportError.exportFailed(statusCode: response.statusCode)
         }


### PR DESCRIPTION
## Summary
- Show determinate linear progress bar during vbundle export and GCS upload steps
- Fall back to indeterminate spinner for steps without progress data
- Apply progress tracking to all three teleport paths (local→platform, docker→platform, local→docker)

Part of plan: teleport-loading-bars.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24059" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
