### PR TITLE
feat(teleport): add progress bars for export and upload steps

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -142,7 +142,7 @@ struct TeleportSection: View {
             } else if case .transferring(let step) = phase {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     HStack(spacing: VSpacing.sm) {
-                        if transferProgress == nil {
+                        if transferProgress == nil || (transferProgress ?? 0) < 0 {
                             ProgressView()
                                 .controlSize(.small)
                         }
@@ -150,7 +150,7 @@ struct TeleportSection: View {
                             .font(VFont.labelDefault)
                             .foregroundStyle(VColor.contentTertiary)
                     }
-                    if let transferProgress {
+                    if let transferProgress, transferProgress >= 0 {
                         ProgressView(value: transferProgress)
                             .progressViewStyle(.linear)
                             .tint(VColor.primaryBase)

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -97,6 +97,7 @@ struct TeleportSection: View {
     @State private var transferTask: Task<Void, Never>?
     @State private var originalAssistant: LockfileAssistant?
     @State private var targetAssistant: LockfileAssistant?
+    @State private var transferProgress: Double? = nil
 
     var body: some View {
         Group {
@@ -139,12 +140,22 @@ struct TeleportSection: View {
             if case .verifying = phase {
                 verifyingBanner
             } else if case .transferring(let step) = phase {
-                HStack(spacing: VSpacing.sm) {
-                    ProgressView()
-                        .controlSize(.small)
-                    Text(step)
-                        .font(VFont.labelDefault)
-                        .foregroundStyle(VColor.contentTertiary)
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    HStack(spacing: VSpacing.sm) {
+                        if transferProgress == nil {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                        Text(step)
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                    }
+                    if let transferProgress {
+                        ProgressView(value: transferProgress)
+                            .progressViewStyle(.linear)
+                            .tint(VColor.primaryBase)
+                            .frame(maxWidth: 240)
+                    }
                 }
             } else if case .failed(let error) = phase {
                 failedBanner(error: error)
@@ -239,6 +250,7 @@ struct TeleportSection: View {
                 label: "Try Again",
                 style: .outlined
             ) {
+                transferProgress = nil
                 phase = .idle
             }
         }
@@ -301,6 +313,7 @@ struct TeleportSection: View {
                 }
             }
         }
+        transferProgress = nil
         phase = .idle
         targetAssistant = nil
     }
@@ -322,6 +335,7 @@ struct TeleportSection: View {
                 throw TeleportError.invalidURL
             }
         } catch {
+            transferProgress = nil
             phase = .failed(error: "Teleport failed: \(error.localizedDescription)")
         }
     }
@@ -331,9 +345,10 @@ struct TeleportSection: View {
     private func teleportLocalToPlatform() async throws {
         // Step 1 — Export local assistant data
         phase = .transferring(step: "Exporting assistant data...")
-        let bundleData = try await exportAssistantBundle()
+        let bundleData = try await exportAssistantBundle(onProgress: { self.transferProgress = $0 })
 
         // Step 2 — Resolve and validate org ID before upload (upload reads org from UserDefaults)
+        transferProgress = nil
         phase = .transferring(step: "Resolving organization...")
         let organizationId = try await resolveOrganizationId()
 
@@ -342,7 +357,7 @@ struct TeleportSection: View {
         let bundleKey: String?
         do {
             let uploadInfo = try await PlatformMigrationClient.requestUploadUrl()
-            try await PlatformMigrationClient.uploadToSignedUrl(uploadInfo.uploadUrl, bundleData: bundleData)
+            try await PlatformMigrationClient.uploadToSignedUrl(uploadInfo.uploadUrl, bundleData: bundleData, onProgress: { self.transferProgress = $0 })
             bundleKey = uploadInfo.bundleKey
         } catch let error as PlatformMigrationClient.PlatformMigrationError {
             if case .signedUrlsNotAvailable = error {
@@ -353,6 +368,7 @@ struct TeleportSection: View {
         }
 
         // Step 4 — Ensure managed assistant exists on platform via direct hatch
+        transferProgress = nil
         phase = .transferring(step: "Setting up cloud assistant...")
         let hatchResult = try await AuthService.shared.hatchAssistant(organizationId: organizationId)
         let platformAssistant: PlatformAssistant
@@ -391,9 +407,10 @@ struct TeleportSection: View {
     private func teleportLocalToDocker() async throws {
         // Step 1 — Export local assistant data
         phase = .transferring(step: "Exporting assistant data...")
-        let bundleData = try await exportAssistantBundle()
+        let bundleData = try await exportAssistantBundle(onProgress: { self.transferProgress = $0 })
 
         // Step 2 — Ensure a docker assistant exists
+        transferProgress = nil
         phase = .transferring(step: "Preparing Docker assistant...")
         var dockerAssistant = LockfileAssistant.loadAll().first(where: { $0.isDocker })
         if dockerAssistant == nil {
@@ -468,9 +485,10 @@ struct TeleportSection: View {
     private func teleportDockerToPlatform() async throws {
         // Step 1 — Export docker assistant data
         phase = .transferring(step: "Exporting assistant data...")
-        let bundleData = try await exportAssistantBundle()
+        let bundleData = try await exportAssistantBundle(onProgress: { self.transferProgress = $0 })
 
         // Step 2 — Resolve and validate org ID before upload (upload reads org from UserDefaults)
+        transferProgress = nil
         phase = .transferring(step: "Resolving organization...")
         let organizationId = try await resolveOrganizationId()
 
@@ -479,7 +497,7 @@ struct TeleportSection: View {
         let bundleKey: String?
         do {
             let uploadInfo = try await PlatformMigrationClient.requestUploadUrl()
-            try await PlatformMigrationClient.uploadToSignedUrl(uploadInfo.uploadUrl, bundleData: bundleData)
+            try await PlatformMigrationClient.uploadToSignedUrl(uploadInfo.uploadUrl, bundleData: bundleData, onProgress: { self.transferProgress = $0 })
             bundleKey = uploadInfo.bundleKey
         } catch let error as PlatformMigrationClient.PlatformMigrationError {
             if case .signedUrlsNotAvailable = error {
@@ -490,6 +508,7 @@ struct TeleportSection: View {
         }
 
         // Step 4 — Ensure managed assistant exists on platform via direct hatch
+        transferProgress = nil
         phase = .transferring(step: "Setting up cloud assistant...")
         let hatchResult = try await AuthService.shared.hatchAssistant(organizationId: organizationId)
         let platformAssistant: PlatformAssistant
@@ -560,11 +579,20 @@ struct TeleportSection: View {
     }
 
     /// Exports the current assistant's data as a `.vbundle` binary archive.
-    private func exportAssistantBundle() async throws -> Data {
-        let response = try await GatewayHTTPClient.post(
-            path: "assistants/{assistantId}/migrations/export",
-            timeout: 60
-        )
+    private func exportAssistantBundle(onProgress: (@MainActor (Double) -> Void)? = nil) async throws -> Data {
+        let response: GatewayHTTPClient.Response
+        if let onProgress {
+            response = try await GatewayHTTPClient.post(
+                path: "assistants/{assistantId}/migrations/export",
+                timeout: 60,
+                onProgress: onProgress
+            )
+        } else {
+            response = try await GatewayHTTPClient.post(
+                path: "assistants/{assistantId}/migrations/export",
+                timeout: 60
+            )
+        }
         guard response.isSuccess else {
             throw TeleportError.exportFailed(statusCode: response.statusCode)
         }

--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -126,12 +126,12 @@ public enum GatewayHTTPClient {
     /// Performs an authenticated POST request that streams the response and
     /// reports download progress via an `onProgress` callback.
     ///
-    /// Uses `URLSession.bytes(for:)` to stream the response body. When the
-    /// server provides a `Content-Length` header, `onProgress` is called on
-    /// the main actor with a value between 0.0 and 1.0 representing
-    /// `bytesReceived / totalBytes`. When `Content-Length` is absent (e.g.
-    /// chunked transfer encoding), `onProgress` is called once with `-1` to
-    /// signal indeterminate progress.
+    /// Uses a custom `URLSessionDataDelegate` to receive the response body in
+    /// network-sized chunks and track progress. When the server provides a
+    /// `Content-Length` header, `onProgress` is called on the main actor with
+    /// a value between 0.0 and 1.0 representing `bytesReceived / totalBytes`.
+    /// When `Content-Length` is absent (e.g. chunked transfer encoding),
+    /// `onProgress` is called once with `-1` to signal indeterminate progress.
     ///
     /// - Parameters:
     ///   - path: Path segment after `/v1/`.
@@ -201,24 +201,35 @@ public enum GatewayHTTPClient {
             logResponse(request, http: http, quiet: false)
         }
 
-        // Send final progress if we tracked determinately.
+        // Send final progress if we tracked determinately, then invalidate
+        // to prevent any queued Tasks from dispatching stale callbacks.
         if delegate.totalBytes > 0, delegate.lastReportedFraction < 1.0 {
             await MainActor.run { onProgress(1.0) }
         }
+        delegate.invalidate()
 
         return (Response(data: data, statusCode: statusCode), http)
     }
 
     /// URLSessionDataDelegate that tracks download progress via `didReceive data:` chunks.
+    /// Uses a generation counter to prevent stale callbacks from firing after invalidation.
     private class DownloadProgressDelegate: NSObject, URLSessionDataDelegate {
         let onProgress: @MainActor (Double) -> Void
         var totalBytes: Int64 = -1
         var receivedBytes: Int64 = 0
         var lastReportedFraction: Double = 0.0
         private var reportedIndeterminate = false
+        private var generation: Int = 0
+        private var invalidated = false
 
         init(onProgress: @escaping @MainActor (Double) -> Void) {
             self.onProgress = onProgress
+        }
+
+        /// Prevents any further progress callbacks from being dispatched.
+        func invalidate() {
+            invalidated = true
+            generation += 1
         }
 
         func urlSession(
@@ -228,22 +239,30 @@ public enum GatewayHTTPClient {
             completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
         ) {
             totalBytes = response.expectedContentLength // -1 when unknown
-            if totalBytes <= 0, !reportedIndeterminate {
+            if totalBytes <= 0, !reportedIndeterminate, !invalidated {
                 reportedIndeterminate = true
                 let callback = self.onProgress
-                Task { await callback(-1) }
+                let gen = self.generation
+                Task { [weak self] in
+                    guard self?.generation == gen else { return }
+                    await callback(-1)
+                }
             }
             completionHandler(.allow)
         }
 
         func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
             receivedBytes += Int64(data.count)
-            guard totalBytes > 0 else { return }
+            guard totalBytes > 0, !invalidated else { return }
             let fraction = Double(receivedBytes) / Double(totalBytes)
             guard fraction - lastReportedFraction >= 0.01 || receivedBytes >= totalBytes else { return }
             lastReportedFraction = fraction
             let callback = self.onProgress
-            Task { await callback(min(fraction, 1.0)) }
+            let gen = self.generation
+            Task { [weak self] in
+                guard self?.generation == gen else { return }
+                await callback(min(fraction, 1.0))
+            }
         }
     }
 

--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -172,6 +172,49 @@ public enum GatewayHTTPClient {
 
         logResponse(request, http: http, quiet: false)
 
+        // 401 retry for non-managed (bearer token) connections.
+        if http.statusCode == 401, !connection.isManaged {
+            // Drain the 401 response body before attempting credential refresh.
+            for try await _ in bytes {}
+
+            if await refreshBearerCredentials(connection: connection) {
+                // Rebuild with fresh credentials from the credential store.
+                let freshConnection = try resolveConnection()
+                var retryRequest = try buildRequest(path: path, params: params, method: "POST", timeout: timeout, connection: freshConnection)
+                retryRequest.httpBody = body
+                if let contentType {
+                    retryRequest.setValue(contentType, forHTTPHeaderField: "Content-Type")
+                }
+                logOutgoing(retryRequest, quiet: false)
+
+                let (retryBytes, retryResponse) = try await URLSession.shared.bytes(for: retryRequest)
+
+                guard let retryHttp = retryResponse as? HTTPURLResponse else {
+                    var collected = Data()
+                    for try await byte in retryBytes {
+                        collected.append(byte)
+                    }
+                    return Response(data: collected, statusCode: -1)
+                }
+
+                logResponse(retryRequest, http: retryHttp, quiet: false)
+
+                return try await collectStreamingResponse(bytes: retryBytes, http: retryHttp, onProgress: onProgress)
+            }
+
+            // Refresh failed — return the original 401 response.
+            return Response(data: Data(), statusCode: http.statusCode)
+        }
+
+        return try await collectStreamingResponse(bytes: bytes, http: http, onProgress: onProgress)
+    }
+
+    /// Collects a streaming byte response into `Data`, reporting progress via `onProgress`.
+    private static func collectStreamingResponse(
+        bytes: URLSession.AsyncBytes,
+        http: HTTPURLResponse,
+        onProgress: @escaping @MainActor (Double) -> Void
+    ) async throws -> Response {
         let totalBytes = http.expectedContentLength // -1 when unknown
 
         if totalBytes <= 0 {

--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -191,7 +191,10 @@ public enum GatewayHTTPClient {
     ) async throws -> (Response, HTTPURLResponse?) {
         let delegate = DownloadProgressDelegate(onProgress: onProgress)
         let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
-        defer { session.finishTasksAndInvalidate() }
+        defer {
+            delegate.invalidate()
+            session.finishTasksAndInvalidate()
+        }
 
         let (data, response) = try await session.data(for: request, delegate: delegate)
         let http = response as? HTTPURLResponse
@@ -201,12 +204,10 @@ public enum GatewayHTTPClient {
             logResponse(request, http: http, quiet: false)
         }
 
-        // Send final progress if we tracked determinately, then invalidate
-        // to prevent any queued Tasks from dispatching stale callbacks.
+        // Send final progress if we tracked determinately.
         if delegate.totalBytes > 0, delegate.lastReportedFraction < 1.0 {
             await MainActor.run { onProgress(1.0) }
         }
-        delegate.invalidate()
 
         return (Response(data: data, statusCode: statusCode), http)
     }

--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -123,6 +123,78 @@ public enum GatewayHTTPClient {
         }
     }
 
+    /// Performs an authenticated POST request that streams the response and
+    /// reports download progress via an `onProgress` callback.
+    ///
+    /// Uses `URLSession.bytes(for:)` to stream the response body. When the
+    /// server provides a `Content-Length` header, `onProgress` is called on
+    /// the main actor with a value between 0.0 and 1.0 representing
+    /// `bytesReceived / totalBytes`. When `Content-Length` is absent (e.g.
+    /// chunked transfer encoding), `onProgress` is called once with `-1` to
+    /// signal indeterminate progress.
+    ///
+    /// - Parameters:
+    ///   - path: Path segment after `/v1/`.
+    ///   - body: Optional HTTP body data.
+    ///   - params: Optional query parameters.
+    ///   - contentType: Optional Content-Type header value.
+    ///   - timeout: Request timeout in seconds. Defaults to 30.
+    ///   - onProgress: Closure called on the main actor with the current
+    ///     download fraction (0.0–1.0), or `-1` for indeterminate.
+    /// - Returns: A `Response` with the raw data and HTTP status code.
+    /// - Throws: `ClientError` if the request cannot be constructed, or network errors from `URLSession`.
+    public static func post(
+        path: String,
+        body: Data? = nil,
+        params: [String: String]? = nil,
+        contentType: String? = nil,
+        timeout: TimeInterval = 30,
+        onProgress: @escaping @MainActor (Double) -> Void
+    ) async throws -> Response {
+        let connection = try resolveConnection()
+        var request = try buildRequest(path: path, params: params, method: "POST", timeout: timeout, connection: connection)
+        request.httpBody = body
+        if let contentType {
+            request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+        }
+        logOutgoing(request, quiet: false)
+
+        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+
+        guard let http = response as? HTTPURLResponse else {
+            // Non-HTTP response — collect all bytes without progress.
+            var collected = Data()
+            for try await byte in bytes {
+                collected.append(byte)
+            }
+            return Response(data: collected, statusCode: -1)
+        }
+
+        logResponse(request, http: http, quiet: false)
+
+        let totalBytes = http.expectedContentLength // -1 when unknown
+
+        if totalBytes <= 0 {
+            // Content-Length unavailable — signal indeterminate progress.
+            await MainActor.run { onProgress(-1) }
+        }
+
+        var collected = Data()
+        if totalBytes > 0 {
+            collected.reserveCapacity(Int(totalBytes))
+        }
+
+        for try await byte in bytes {
+            collected.append(byte)
+            if totalBytes > 0 {
+                let fraction = Double(collected.count) / Double(totalBytes)
+                await MainActor.run { onProgress(min(fraction, 1.0)) }
+            }
+        }
+
+        return Response(data: collected, statusCode: http.statusCode)
+    }
+
     /// Performs an authenticated PATCH request against the gateway.
     ///
     /// - Parameters:

--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -193,7 +193,7 @@ public enum GatewayHTTPClient {
         let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
         defer { session.finishTasksAndInvalidate() }
 
-        let (data, response) = try await session.data(for: request)
+        let (data, response) = try await session.data(for: request, delegate: delegate)
         let http = response as? HTTPURLResponse
         let statusCode = http?.statusCode ?? -1
 

--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -159,26 +159,11 @@ public enum GatewayHTTPClient {
         }
         logOutgoing(request, quiet: false)
 
-        let (bytes, response) = try await URLSession.shared.bytes(for: request)
-
-        guard let http = response as? HTTPURLResponse else {
-            // Non-HTTP response — collect all bytes without progress.
-            var collected = Data()
-            for try await byte in bytes {
-                collected.append(byte)
-            }
-            return Response(data: collected, statusCode: -1)
-        }
-
-        logResponse(request, http: http, quiet: false)
+        let (result, http) = try await performStreamingPost(request: request, onProgress: onProgress)
 
         // 401 retry for non-managed (bearer token) connections.
-        if http.statusCode == 401, !connection.isManaged {
-            // Drain the 401 response body before attempting credential refresh.
-            for try await _ in bytes {}
-
+        if result.statusCode == 401, !connection.isManaged {
             if await refreshBearerCredentials(connection: connection) {
-                // Rebuild with fresh credentials from the credential store.
                 let freshConnection = try resolveConnection()
                 var retryRequest = try buildRequest(path: path, params: params, method: "POST", timeout: timeout, connection: freshConnection)
                 retryRequest.httpBody = body
@@ -187,64 +172,79 @@ public enum GatewayHTTPClient {
                 }
                 logOutgoing(retryRequest, quiet: false)
 
-                let (retryBytes, retryResponse) = try await URLSession.shared.bytes(for: retryRequest)
-
-                guard let retryHttp = retryResponse as? HTTPURLResponse else {
-                    var collected = Data()
-                    for try await byte in retryBytes {
-                        collected.append(byte)
-                    }
-                    return Response(data: collected, statusCode: -1)
-                }
-
-                logResponse(retryRequest, http: retryHttp, quiet: false)
-
-                return try await collectStreamingResponse(bytes: retryBytes, http: retryHttp, onProgress: onProgress)
+                let (retryResult, _) = try await performStreamingPost(request: retryRequest, onProgress: onProgress)
+                return retryResult
             }
 
             // Refresh failed — return the original 401 response.
-            return Response(data: Data(), statusCode: http.statusCode)
+            return result
         }
 
-        return try await collectStreamingResponse(bytes: bytes, http: http, onProgress: onProgress)
+        return result
     }
 
-    /// Collects a streaming byte response into `Data`, reporting progress via `onProgress`.
-    private static func collectStreamingResponse(
-        bytes: URLSession.AsyncBytes,
-        http: HTTPURLResponse,
+    /// Performs a POST request with progress tracking using a delegate-based data task
+    /// that receives data in chunks (not byte-by-byte).
+    private static func performStreamingPost(
+        request: URLRequest,
         onProgress: @escaping @MainActor (Double) -> Void
-    ) async throws -> Response {
-        let totalBytes = http.expectedContentLength // -1 when unknown
+    ) async throws -> (Response, HTTPURLResponse?) {
+        let delegate = DownloadProgressDelegate(onProgress: onProgress)
+        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+        defer { session.finishTasksAndInvalidate() }
 
-        if totalBytes <= 0 {
-            // Content-Length unavailable — signal indeterminate progress.
-            await MainActor.run { onProgress(-1) }
+        let (data, response) = try await session.data(for: request)
+        let http = response as? HTTPURLResponse
+        let statusCode = http?.statusCode ?? -1
+
+        if let http {
+            logResponse(request, http: http, quiet: false)
         }
 
-        var collected = Data()
-        if totalBytes > 0 {
-            collected.reserveCapacity(Int(totalBytes))
-        }
-
-        var lastReportedFraction = 0.0
-        for try await byte in bytes {
-            collected.append(byte)
-            if totalBytes > 0 {
-                let fraction = Double(collected.count) / Double(totalBytes)
-                if fraction - lastReportedFraction >= 0.01 || collected.count == Int(totalBytes) {
-                    lastReportedFraction = fraction
-                    await MainActor.run { onProgress(min(fraction, 1.0)) }
-                }
-            }
-        }
-
-        // Ensure we always report completion when content length was known.
-        if totalBytes > 0, lastReportedFraction < 1.0 {
+        // Send final progress if we tracked determinately.
+        if delegate.totalBytes > 0, delegate.lastReportedFraction < 1.0 {
             await MainActor.run { onProgress(1.0) }
         }
 
-        return Response(data: collected, statusCode: http.statusCode)
+        return (Response(data: data, statusCode: statusCode), http)
+    }
+
+    /// URLSessionDataDelegate that tracks download progress via `didReceive data:` chunks.
+    private class DownloadProgressDelegate: NSObject, URLSessionDataDelegate {
+        let onProgress: @MainActor (Double) -> Void
+        var totalBytes: Int64 = -1
+        var receivedBytes: Int64 = 0
+        var lastReportedFraction: Double = 0.0
+        private var reportedIndeterminate = false
+
+        init(onProgress: @escaping @MainActor (Double) -> Void) {
+            self.onProgress = onProgress
+        }
+
+        func urlSession(
+            _ session: URLSession,
+            dataTask: URLSessionDataTask,
+            didReceive response: URLResponse,
+            completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+        ) {
+            totalBytes = response.expectedContentLength // -1 when unknown
+            if totalBytes <= 0, !reportedIndeterminate {
+                reportedIndeterminate = true
+                let callback = self.onProgress
+                Task { await callback(-1) }
+            }
+            completionHandler(.allow)
+        }
+
+        func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+            receivedBytes += Int64(data.count)
+            guard totalBytes > 0 else { return }
+            let fraction = Double(receivedBytes) / Double(totalBytes)
+            guard fraction - lastReportedFraction >= 0.01 || receivedBytes >= totalBytes else { return }
+            lastReportedFraction = fraction
+            let callback = self.onProgress
+            Task { await callback(min(fraction, 1.0)) }
+        }
     }
 
     /// Performs an authenticated PATCH request against the gateway.

--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -184,12 +184,21 @@ public enum GatewayHTTPClient {
             collected.reserveCapacity(Int(totalBytes))
         }
 
+        var lastReportedFraction = 0.0
         for try await byte in bytes {
             collected.append(byte)
             if totalBytes > 0 {
                 let fraction = Double(collected.count) / Double(totalBytes)
-                await MainActor.run { onProgress(min(fraction, 1.0)) }
+                if fraction - lastReportedFraction >= 0.01 || collected.count == Int(totalBytes) {
+                    lastReportedFraction = fraction
+                    await MainActor.run { onProgress(min(fraction, 1.0)) }
+                }
             }
+        }
+
+        // Ensure we always report completion when content length was known.
+        if totalBytes > 0, lastReportedFraction < 1.0 {
+            await MainActor.run { onProgress(1.0) }
         }
 
         return Response(data: collected, statusCode: http.statusCode)

--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -114,6 +114,58 @@ public enum PlatformMigrationClient {
         }
     }
 
+    /// Uploads binary bundle data to a GCS signed URL with progress tracking.
+    ///
+    /// - Parameters:
+    ///   - url: The signed upload URL from `requestUploadUrl()`.
+    ///   - bundleData: The raw bundle data to upload.
+    ///   - onProgress: A closure called on the main actor with values from 0.0 to 1.0
+    ///     representing the fraction of bytes uploaded.
+    /// - Throws: `PlatformMigrationError.uploadFailed` if the upload returns a non-2xx status.
+    public static func uploadToSignedUrl(
+        _ url: String,
+        bundleData: Data,
+        onProgress: @escaping (Double) -> Void
+    ) async throws {
+        guard let uploadURL = URL(string: url) else {
+            throw PlatformMigrationError.uploadFailed(statusCode: 0)
+        }
+
+        var request = URLRequest(url: uploadURL)
+        request.httpMethod = "PUT"
+        request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 600
+
+        let delegate = UploadProgressDelegate(onProgress: onProgress)
+        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+        defer { session.finishTasksAndInvalidate() }
+
+        let urlPath = logPath(from: uploadURL) ?? "signed-url-upload"
+
+        for attempt in 0...maxRetries {
+            log.info("PUT \(urlPath, privacy: .public)\(attempt > 0 ? " (retry \(attempt)/\(maxRetries))" : "")")
+            let (_, response) = try await session.upload(for: request, from: bundleData)
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            log.info("PUT \(urlPath, privacy: .public) → \(statusCode)")
+
+            if attempt < maxRetries
+                && retryableStatusCodes.contains(statusCode)
+            {
+                let delay = UInt64(pow(2.0, Double(attempt))) * 1_000_000_000
+                log.warning("Transient server error (\(statusCode)) — retrying in \(1 << attempt)s")
+                try await Task.sleep(nanoseconds: delay)
+                continue
+            }
+
+            guard (200..<300).contains(statusCode) else {
+                throw PlatformMigrationError.uploadFailed(statusCode: statusCode)
+            }
+            return
+        }
+
+        throw PlatformMigrationError.requestFailed(statusCode: 0, detail: "Unexpected retry loop exit")
+    }
+
     /// Triggers a GCS-based import on the platform after the bundle has been uploaded.
     ///
     /// - Parameter bundleKey: The bundle key returned by `requestUploadUrl()`.
@@ -226,6 +278,32 @@ public enum PlatformMigrationClient {
         }
         components.query = nil
         return components.path
+    }
+
+    // MARK: - Upload Progress Delegate
+
+    /// Tracks upload progress and dispatches progress updates to the main actor.
+    private class UploadProgressDelegate: NSObject, URLSessionTaskDelegate {
+        private let onProgress: (Double) -> Void
+
+        init(onProgress: @escaping (Double) -> Void) {
+            self.onProgress = onProgress
+        }
+
+        func urlSession(
+            _ session: URLSession,
+            task: URLSessionTask,
+            didSendBodyData bytesSent: Int64,
+            totalBytesSent: Int64,
+            totalBytesExpectedToSend: Int64
+        ) {
+            guard totalBytesExpectedToSend > 0 else { return }
+            let progress = Double(totalBytesSent) / Double(totalBytesExpectedToSend)
+            let callback = self.onProgress
+            Task { @MainActor in
+                callback(progress)
+            }
+        }
     }
 
     /// Resolves the platform base URL, session token, and org ID for authenticated requests.

--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -285,9 +285,11 @@ public enum PlatformMigrationClient {
     // MARK: - Upload Progress Delegate
 
     /// Tracks upload progress and dispatches throttled updates to the main actor.
+    /// Uses a generation counter to prevent stale callbacks from firing after reset.
     private class UploadProgressDelegate: NSObject, URLSessionTaskDelegate {
         private let onProgress: @MainActor (Double) -> Void
         private var lastReportedFraction: Double = 0.0
+        private var generation: Int = 0
 
         init(onProgress: @escaping @MainActor (Double) -> Void) {
             self.onProgress = onProgress
@@ -305,14 +307,18 @@ public enum PlatformMigrationClient {
             guard progress - lastReportedFraction >= 0.01 || progress >= 1.0 else { return }
             lastReportedFraction = progress
             let callback = self.onProgress
-            Task {
+            let gen = self.generation
+            Task { [weak self] in
+                guard self?.generation == gen else { return }
                 await callback(progress)
             }
         }
 
-        /// Resets the throttle so progress reports from 0 again (e.g. on retry).
+        /// Resets the throttle and increments the generation counter so any
+        /// in-flight callbacks from the previous attempt are discarded.
         func reset() {
             lastReportedFraction = 0.0
+            generation += 1
         }
     }
 

--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -144,7 +144,7 @@ public enum PlatformMigrationClient {
 
         for attempt in 0...maxRetries {
             log.info("PUT \(urlPath, privacy: .public)\(attempt > 0 ? " (retry \(attempt)/\(maxRetries))" : "")")
-            let (_, response) = try await session.upload(for: request, from: bundleData)
+            let (_, response) = try await session.upload(for: request, from: bundleData, delegate: delegate)
             let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
             log.info("PUT \(urlPath, privacy: .public) → \(statusCode)")
 

--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -154,6 +154,7 @@ public enum PlatformMigrationClient {
                 let delay = UInt64(pow(2.0, Double(attempt))) * 1_000_000_000
                 log.warning("Transient server error (\(statusCode)) — retrying in \(1 << attempt)s")
                 try await Task.sleep(nanoseconds: delay)
+                onProgress(0)
                 continue
             }
 

--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -154,7 +154,8 @@ public enum PlatformMigrationClient {
                 let delay = UInt64(pow(2.0, Double(attempt))) * 1_000_000_000
                 log.warning("Transient server error (\(statusCode)) — retrying in \(1 << attempt)s")
                 try await Task.sleep(nanoseconds: delay)
-                onProgress(0)
+                delegate.reset()
+                await onProgress(0)
                 continue
             }
 
@@ -283,9 +284,10 @@ public enum PlatformMigrationClient {
 
     // MARK: - Upload Progress Delegate
 
-    /// Tracks upload progress and dispatches progress updates to the main actor.
+    /// Tracks upload progress and dispatches throttled updates to the main actor.
     private class UploadProgressDelegate: NSObject, URLSessionTaskDelegate {
         private let onProgress: @MainActor (Double) -> Void
+        private var lastReportedFraction: Double = 0.0
 
         init(onProgress: @escaping @MainActor (Double) -> Void) {
             self.onProgress = onProgress
@@ -300,10 +302,17 @@ public enum PlatformMigrationClient {
         ) {
             guard totalBytesExpectedToSend > 0 else { return }
             let progress = Double(totalBytesSent) / Double(totalBytesExpectedToSend)
+            guard progress - lastReportedFraction >= 0.01 || progress >= 1.0 else { return }
+            lastReportedFraction = progress
             let callback = self.onProgress
             Task {
                 await callback(progress)
             }
+        }
+
+        /// Resets the throttle so progress reports from 0 again (e.g. on retry).
+        func reset() {
+            lastReportedFraction = 0.0
         }
     }
 

--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -125,7 +125,7 @@ public enum PlatformMigrationClient {
     public static func uploadToSignedUrl(
         _ url: String,
         bundleData: Data,
-        onProgress: @escaping (Double) -> Void
+        onProgress: @escaping @MainActor (Double) -> Void
     ) async throws {
         guard let uploadURL = URL(string: url) else {
             throw PlatformMigrationError.uploadFailed(statusCode: 0)
@@ -285,9 +285,9 @@ public enum PlatformMigrationClient {
 
     /// Tracks upload progress and dispatches progress updates to the main actor.
     private class UploadProgressDelegate: NSObject, URLSessionTaskDelegate {
-        private let onProgress: (Double) -> Void
+        private let onProgress: @MainActor (Double) -> Void
 
-        init(onProgress: @escaping (Double) -> Void) {
+        init(onProgress: @escaping @MainActor (Double) -> Void) {
             self.onProgress = onProgress
         }
 
@@ -301,8 +301,8 @@ public enum PlatformMigrationClient {
             guard totalBytesExpectedToSend > 0 else { return }
             let progress = Double(totalBytesSent) / Double(totalBytesExpectedToSend)
             let callback = self.onProgress
-            Task { @MainActor in
-                callback(progress)
+            Task {
+                await callback(progress)
             }
         }
     }

--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -138,7 +138,10 @@ public enum PlatformMigrationClient {
 
         let delegate = UploadProgressDelegate(onProgress: onProgress)
         let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
-        defer { session.finishTasksAndInvalidate() }
+        defer {
+            delegate.reset()
+            session.finishTasksAndInvalidate()
+        }
 
         let urlPath = logPath(from: uploadURL) ?? "signed-url-upload"
 


### PR DESCRIPTION
## Summary
Add determinate progress bars to the teleport flow's vbundle export and GCS upload steps. Previously the UI showed only an indeterminate spinner with step labels. Now users see a linear progress bar tracking byte-level progress during export download and upload, matching the existing `HatchingStepView` progress bar pattern.

## PRs merged into feature branch
- #24058: feat(teleport): add upload progress tracking to PlatformMigrationClient
- #24057: feat(teleport): add export download progress tracking to GatewayHTTPClient
- #24059: feat(teleport): show determinate progress bars during export and upload

Part of plan: teleport-loading-bars.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
