### PR TITLE
fix: throttle download progress updates to avoid per-byte MainActor dispatch

### DIFF
--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -184,12 +184,21 @@ public enum GatewayHTTPClient {
             collected.reserveCapacity(Int(totalBytes))
         }
 
+        var lastReportedFraction = 0.0
         for try await byte in bytes {
             collected.append(byte)
             if totalBytes > 0 {
                 let fraction = Double(collected.count) / Double(totalBytes)
-                await MainActor.run { onProgress(min(fraction, 1.0)) }
+                if fraction - lastReportedFraction >= 0.01 || collected.count == Int(totalBytes) {
+                    lastReportedFraction = fraction
+                    await MainActor.run { onProgress(min(fraction, 1.0)) }
+                }
             }
+        }
+
+        // Ensure we always report completion when content length was known.
+        if totalBytes > 0, lastReportedFraction < 1.0 {
+            await MainActor.run { onProgress(1.0) }
         }
 
         return Response(data: collected, statusCode: http.statusCode)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for teleport-loading-bars.md.

**Gap:** Per-byte MainActor.run dispatch causes extreme UI thread contention
**What was expected:** Progress updates at reasonable granularity
**What was found:** onProgress called on every byte, causing millions of MainActor dispatches
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24061" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
