### PR TITLE
fix: explicitly reset upload progress to 0 before retry

### DIFF
--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -154,6 +154,7 @@ public enum PlatformMigrationClient {
                 let delay = UInt64(pow(2.0, Double(attempt))) * 1_000_000_000
                 log.warning("Transient server error (\(statusCode)) — retrying in \(1 << attempt)s")
                 try await Task.sleep(nanoseconds: delay)
+                onProgress(0)
                 continue
             }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for teleport-loading-bars.md.

**Gap:** Upload progress resets to 0 on retry without notifying the UI
**What was expected:** Clean progress bar reset signal on retry
**What was found:** Progress jumps from intermediate value back to 0 without explicit reset