### PR TITLE
fix: add 401 auth-retry to streaming post with progress

### DIFF
--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -172,6 +172,49 @@ public enum GatewayHTTPClient {
 
         logResponse(request, http: http, quiet: false)
 
+        // 401 retry for non-managed (bearer token) connections.
+        if http.statusCode == 401, !connection.isManaged {
+            // Drain the 401 response body before attempting credential refresh.
+            for try await _ in bytes {}
+
+            if await refreshBearerCredentials(connection: connection) {
+                // Rebuild with fresh credentials from the credential store.
+                let freshConnection = try resolveConnection()
+                var retryRequest = try buildRequest(path: path, params: params, method: "POST", timeout: timeout, connection: freshConnection)
+                retryRequest.httpBody = body
+                if let contentType {
+                    retryRequest.setValue(contentType, forHTTPHeaderField: "Content-Type")
+                }
+                logOutgoing(retryRequest, quiet: false)
+
+                let (retryBytes, retryResponse) = try await URLSession.shared.bytes(for: retryRequest)
+
+                guard let retryHttp = retryResponse as? HTTPURLResponse else {
+                    var collected = Data()
+                    for try await byte in retryBytes {
+                        collected.append(byte)
+                    }
+                    return Response(data: collected, statusCode: -1)
+                }
+
+                logResponse(retryRequest, http: retryHttp, quiet: false)
+
+                return try await collectStreamingResponse(bytes: retryBytes, http: retryHttp, onProgress: onProgress)
+            }
+
+            // Refresh failed — return the original 401 response.
+            return Response(data: Data(), statusCode: http.statusCode)
+        }
+
+        return try await collectStreamingResponse(bytes: bytes, http: http, onProgress: onProgress)
+    }
+
+    /// Collects a streaming byte response into `Data`, reporting progress via `onProgress`.
+    private static func collectStreamingResponse(
+        bytes: URLSession.AsyncBytes,
+        http: HTTPURLResponse,
+        onProgress: @escaping @MainActor (Double) -> Void
+    ) async throws -> Response {
         let totalBytes = http.expectedContentLength // -1 when unknown
 
         if totalBytes <= 0 {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for teleport-loading-bars.md.

**Gap:** No 401 auth-retry on streaming post overload
**What was expected:** 401 credential refresh like all other gateway methods
**What was found:** Direct URLSession call without retry logic
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24063" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
