### PR TITLE
fix: annotate PlatformMigrationClient onProgress with @MainActor

### DIFF
--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -125,7 +125,7 @@ public enum PlatformMigrationClient {
     public static func uploadToSignedUrl(
         _ url: String,
         bundleData: Data,
-        onProgress: @escaping (Double) -> Void
+        onProgress: @escaping @MainActor (Double) -> Void
     ) async throws {
         guard let uploadURL = URL(string: url) else {
             throw PlatformMigrationError.uploadFailed(statusCode: 0)
@@ -284,9 +284,9 @@ public enum PlatformMigrationClient {
 
     /// Tracks upload progress and dispatches progress updates to the main actor.
     private class UploadProgressDelegate: NSObject, URLSessionTaskDelegate {
-        private let onProgress: (Double) -> Void
+        private let onProgress: @MainActor (Double) -> Void
 
-        init(onProgress: @escaping (Double) -> Void) {
+        init(onProgress: @escaping @MainActor (Double) -> Void) {
             self.onProgress = onProgress
         }
 
@@ -300,8 +300,8 @@ public enum PlatformMigrationClient {
             guard totalBytesExpectedToSend > 0 else { return }
             let progress = Double(totalBytesSent) / Double(totalBytesExpectedToSend)
             let callback = self.onProgress
-            Task { @MainActor in
-                callback(progress)
+            Task {
+                await callback(progress)
             }
         }
     }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for teleport-loading-bars.md.

**Gap:** onProgress not @MainActor-annotated in PlatformMigrationClient
**What was expected:** @MainActor annotation matching GatewayHTTPClient pattern
**What was found:** Plain closure without actor isolation annotation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24064" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
