### PR TITLE
fix: don't overwrite LLM-written source files in app_create scaffold

### DIFF
--- a/assistant/src/__tests__/app-builder-tool-scripts.test.ts
+++ b/assistant/src/__tests__/app-builder-tool-scripts.test.ts
@@ -25,6 +25,7 @@ function makeMockStore(overrides: Partial<AppStore> = {}): AppStore {
   return {
     getApp: () => makeApp(),
     listApps: () => [makeApp()],
+    appFileExists: () => false,
     createApp: (params) =>
       makeApp({ name: params.name, description: params.description }),
     updateApp: (id, updates) => makeApp({ id, ...updates }),

--- a/assistant/src/__tests__/app-executors.test.ts
+++ b/assistant/src/__tests__/app-executors.test.ts
@@ -56,6 +56,7 @@ function mockStore(
   return {
     getApp: (id: string) => (id === app.id ? app : null),
     listApps: () => [app],
+    appFileExists: (_appId: string, path: string) => path in files,
     createApp: () => app,
     updateApp: () => app,
     deleteApp: () => {},

--- a/assistant/src/memory/app-store.ts
+++ b/assistant/src/memory/app-store.ts
@@ -75,7 +75,10 @@ export function inlineDistAssets(appDir: string, html: string): string {
   // Inline main.js
   const jsPath = join(distDir, "main.js");
   if (existsSync(jsPath)) {
-    const js = readFileSync(jsPath, "utf-8").replace(/<\/script>/g, "<\\/script>");
+    const js = readFileSync(jsPath, "utf-8").replace(
+      /<\/script>/g,
+      "<\\/script>",
+    );
     html = html.replace(
       /<script\s+type="module"\s+src="main\.js"\s*><\/script>/,
       () => `<script type="module">${js}</script>`,
@@ -816,6 +819,16 @@ export function listAppFiles(appId: string): string[] {
 
   walk(appDir);
   return results.sort();
+}
+
+/**
+ * Check whether a file exists in the app directory.
+ * Path is validated to prevent traversal.
+ */
+export function appFileExists(appId: string, path: string): boolean {
+  validateId(appId);
+  const resolved = validateFilePath(appId, path);
+  return existsSync(resolved);
 }
 
 /**

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -8,6 +8,9 @@
  * ToolDefinition or ToolContext types.
  */
 
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
 import { compileApp } from "../../bundler/app-compiler.js";
 import { generateAppIcon } from "../../media/app-icon-generator.js";
 import type { AppDefinition } from "../../memory/app-store.js";
@@ -183,11 +186,19 @@ function App() {
 render(<App />, document.getElementById('app')!);
 `;
 
-    store.writeAppFile(app.id, "src/index.html", indexHtml);
-    store.writeAppFile(app.id, "src/main.tsx", mainTsx);
+    // Only write scaffold files when they don't already exist on disk.
+    // The LLM may have written custom source files via file_write before
+    // calling app_create, and overwriting them would destroy the real app
+    // content, leaving only the scaffold placeholder.
+    const appDir = getAppDirPath(app.id);
+    if (!existsSync(join(appDir, "src", "index.html"))) {
+      store.writeAppFile(app.id, "src/index.html", indexHtml);
+    }
+    if (!existsSync(join(appDir, "src", "main.tsx"))) {
+      store.writeAppFile(app.id, "src/main.tsx", mainTsx);
+    }
 
     // Compile src/ → dist/
-    const appDir = getAppDirPath(app.id);
     const compileResult = await compileApp(appDir);
     if (!compileResult.ok) {
       return {

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -8,9 +8,6 @@
  * ToolDefinition or ToolContext types.
  */
 
-import { existsSync } from "node:fs";
-import { join } from "node:path";
-
 import { compileApp } from "../../bundler/app-compiler.js";
 import { generateAppIcon } from "../../media/app-icon-generator.js";
 import type { AppDefinition } from "../../memory/app-store.js";
@@ -35,6 +32,7 @@ export interface ExecutorResult {
 export interface AppStoreReader {
   getApp(id: string): AppDefinition | null;
   listApps(): AppDefinition[];
+  appFileExists(appId: string, path: string): boolean;
 }
 
 export interface AppStoreWriter {
@@ -190,15 +188,15 @@ render(<App />, document.getElementById('app')!);
     // The LLM may have written custom source files via file_write before
     // calling app_create, and overwriting them would destroy the real app
     // content, leaving only the scaffold placeholder.
-    const appDir = getAppDirPath(app.id);
-    if (!existsSync(join(appDir, "src", "index.html"))) {
+    if (!store.appFileExists(app.id, "src/index.html")) {
       store.writeAppFile(app.id, "src/index.html", indexHtml);
     }
-    if (!existsSync(join(appDir, "src", "main.tsx"))) {
+    if (!store.appFileExists(app.id, "src/main.tsx")) {
       store.writeAppFile(app.id, "src/main.tsx", mainTsx);
     }
 
     // Compile src/ → dist/
+    const appDir = getAppDirPath(app.id);
     const compileResult = await compileApp(appDir);
     if (!compileResult.ok) {
       return {


### PR DESCRIPTION
## Summary

- `executeAppCreate` unconditionally wrote scaffold `src/index.html` and `src/main.tsx` during multifile app creation, even when the LLM had already written custom source files via `file_write`
- This caused the compiled output to show a placeholder ("Hello, AppName!") instead of the actual app — the preview image captured before the overwrite was correct, but opening the app served the scaffold version
- Scaffold files are now only written when they don't already exist on disk

## Original prompt
Fix app_create overwriting LLM-written source files with scaffold defaults, causing built apps to show placeholder content instead of the real UI.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24065" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
