### PR TITLE
fix: handle indeterminate progress and throttle upload progress updates

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -142,7 +142,7 @@ struct TeleportSection: View {
             } else if case .transferring(let step) = phase {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     HStack(spacing: VSpacing.sm) {
-                        if transferProgress == nil {
+                        if transferProgress == nil || (transferProgress ?? 0) < 0 {
                             ProgressView()
                                 .controlSize(.small)
                         }
@@ -150,7 +150,7 @@ struct TeleportSection: View {
                             .font(VFont.labelDefault)
                             .foregroundStyle(VColor.contentTertiary)
                     }
-                    if let transferProgress {
+                    if let transferProgress, transferProgress >= 0 {
                         ProgressView(value: transferProgress)
                             .progressViewStyle(.linear)
                             .tint(VColor.primaryBase)

--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -154,7 +154,8 @@ public enum PlatformMigrationClient {
                 let delay = UInt64(pow(2.0, Double(attempt))) * 1_000_000_000
                 log.warning("Transient server error (\(statusCode)) — retrying in \(1 << attempt)s")
                 try await Task.sleep(nanoseconds: delay)
-                onProgress(0)
+                delegate.reset()
+                await onProgress(0)
                 continue
             }
 
@@ -283,9 +284,10 @@ public enum PlatformMigrationClient {
 
     // MARK: - Upload Progress Delegate
 
-    /// Tracks upload progress and dispatches progress updates to the main actor.
+    /// Tracks upload progress and dispatches throttled updates to the main actor.
     private class UploadProgressDelegate: NSObject, URLSessionTaskDelegate {
         private let onProgress: @MainActor (Double) -> Void
+        private var lastReportedFraction: Double = 0.0
 
         init(onProgress: @escaping @MainActor (Double) -> Void) {
             self.onProgress = onProgress
@@ -300,10 +302,17 @@ public enum PlatformMigrationClient {
         ) {
             guard totalBytesExpectedToSend > 0 else { return }
             let progress = Double(totalBytesSent) / Double(totalBytesExpectedToSend)
+            guard progress - lastReportedFraction >= 0.01 || progress >= 1.0 else { return }
+            lastReportedFraction = progress
             let callback = self.onProgress
             Task {
                 await callback(progress)
             }
+        }
+
+        /// Resets the throttle so progress reports from 0 again (e.g. on retry).
+        func reset() {
+            lastReportedFraction = 0.0
         }
     }
 


### PR DESCRIPTION
## Summary
- Gate determinate ProgressView on transferProgress >= 0; show indeterminate spinner when progress is negative (chunked transfer with no Content-Length)
- Add 1% throttling to UploadProgressDelegate to avoid excessive MainActor dispatches
- Reset delegate throttle state on retry

Addresses review feedback on PR #24060.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24068" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
