### PR TITLE
feat(macos): move permission mode indicator from toolbar to composer bar

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -86,6 +86,11 @@ struct ChatView: View {
     var onDictateToggle: (() -> Void)? = nil
     var onVoiceModeToggle: (() -> Void)? = nil
 
+    // MARK: - Permission Mode (macOS only)
+
+    var connectionManager: GatewayConnectionManager? = nil
+    var permissionModeEnabled: Bool = false
+
     // MARK: - External State
 
     var watchSession: WatchSession?
@@ -412,7 +417,9 @@ struct ChatView: View {
                     isInteractionEnabled: isInteractionEnabled,
                     contextWindowFillRatio: viewModel.contextWindowFillRatio,
                     contextWindowTokens: viewModel.contextWindowTokens,
-                    contextWindowMaxTokens: viewModel.contextWindowMaxTokens
+                    contextWindowMaxTokens: viewModel.contextWindowMaxTokens,
+                    connectionManager: connectionManager,
+                    permissionModeEnabled: permissionModeEnabled
                 )
             }
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
@@ -32,6 +32,10 @@ struct ComposerSection: View {
     var contextWindowTokens: Int? = nil
     var contextWindowMaxTokens: Int? = nil
 
+    // MARK: - Permission Mode (macOS only)
+    var connectionManager: GatewayConnectionManager? = nil
+    var permissionModeEnabled: Bool = false
+
     var body: some View {
         VStack(spacing: 0) {
             if let watchSession, watchSession.state == .capturing {
@@ -69,7 +73,9 @@ struct ComposerSection: View {
                 isInteractionEnabled: isInteractionEnabled,
                 contextWindowFillRatio: contextWindowFillRatio,
                 contextWindowTokens: contextWindowTokens,
-                contextWindowMaxTokens: contextWindowMaxTokens
+                contextWindowMaxTokens: contextWindowMaxTokens,
+                connectionManager: connectionManager,
+                permissionModeEnabled: permissionModeEnabled
             )
         }
         .background(

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -66,6 +66,11 @@ struct ComposerView: View {
     var contextWindowTokens: Int? = nil
     var contextWindowMaxTokens: Int? = nil
 
+    // MARK: - Permission Mode (macOS only)
+    var connectionManager: GatewayConnectionManager? = nil
+    var permissionModeEnabled: Bool = false
+    @State private var showPermissionModePopover: Bool = false
+
     @Environment(\.cmdEnterToSend) private var cmdEnterToSend
     #if os(macOS)
     @Environment(\.dropActions) private var dropActions
@@ -462,6 +467,8 @@ struct ComposerView: View {
 
                 .vTooltip(micTooltipText)
 
+                permissionModeIndicatorButton
+
                 // Send button (always visible, disabled when empty)
                 VButton(
                     label: "Send message",
@@ -485,6 +492,8 @@ struct ComposerView: View {
                 )
 
                 .vTooltip(micTooltipText)
+
+                permissionModeIndicatorButton
 
                 // Send button
                 VButton(
@@ -518,6 +527,7 @@ struct ComposerView: View {
                     action: { (onDictateToggle ?? onMicrophoneToggle)() }
                 )
 
+                permissionModeIndicatorButton
 
                 VButton(
                     label: "Send message",
@@ -531,6 +541,56 @@ struct ComposerView: View {
                 }
             }
         }
+    }
+
+    // MARK: - Permission Mode Indicator
+
+    /// Shield icon reflecting the current permission mode state.
+    /// Only rendered when the feature flag is enabled and a mode is available.
+    @ViewBuilder
+    private var permissionModeIndicatorButton: some View {
+        if permissionModeEnabled, let cm = connectionManager, let mode = cm.permissionMode {
+            permissionModeButton(mode: mode, connectionManager: cm)
+        }
+    }
+
+    /// Builds the shield button for the given permission mode.
+    /// Extracted from @ViewBuilder to allow local `let` bindings.
+    private func permissionModeButton(mode: PermissionModeUpdateMessage, connectionManager cm: GatewayConnectionManager) -> some View {
+        let askBeforeActing = mode.askBeforeActing
+        let hostAccess = mode.hostAccess
+
+        let iconName: String
+        let iconColor: Color
+        let tooltip: String
+
+        if askBeforeActing && !hostAccess {
+            iconName = VIcon.shieldCheck.rawValue
+            iconColor = VColor.systemPositiveStrong
+            tooltip = "Protected: asks before acting, no computer access"
+        } else if hostAccess {
+            iconName = VIcon.shieldAlert.rawValue
+            iconColor = VColor.systemMidStrong
+            tooltip = "Computer access enabled"
+        } else {
+            iconName = VIcon.shieldOff.rawValue
+            iconColor = VColor.contentSecondary
+            tooltip = "Autonomous mode: acts without asking"
+        }
+
+        return VButton(
+            label: "Permission controls",
+            iconOnly: iconName,
+            style: .ghost,
+            iconSize: composerActionButtonSize
+        ) {
+            showPermissionModePopover.toggle()
+        }
+        .foregroundStyle(iconColor)
+        .popover(isPresented: $showPermissionModePopover, arrowEdge: .top) {
+            PermissionModeStatusView(connectionManager: cm)
+        }
+        .vTooltip(tooltip)
     }
 
     // MARK: - Dictation Inline Mode

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -85,9 +85,6 @@ struct MainWindowView: View {
     @State var assistantLoadingTimedOut = false
     /// Whether the main window is in native macOS fullscreen (traffic lights hidden).
     @State var isInFullscreen: Bool = false
-    /// Whether the permission mode popover is shown.
-    @State private var showPermissionModePopover: Bool = false
-
     init(conversationManager: ConversationManager, appListManager: AppListManager, zoomManager: ZoomManager, traceStore: TraceStore, usageDashboardStore: UsageDashboardStore, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, documentManager: DocumentManager, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager, updateManager: UpdateManager, onSendWakeUp: (() -> Void)? = nil) {
         self.conversationManager = conversationManager
         self.appListManager = appListManager
@@ -483,10 +480,6 @@ struct MainWindowView: View {
                 .animation(VAnimation.fast, value: updateManager.isServiceGroupUpdateAvailable)
                 .animation(VAnimation.fast, value: updateManager.isDeferredUpdateReady)
             }
-            if assistantFeatureFlagStore.isEnabled("permission-controls-v2"),
-               connectionManager.permissionMode != nil {
-                permissionModeIndicator
-            }
             if windowState.isConversationVisible {
                 TemporaryChatToggleWrapper(
                     activeConversation: conversationManager.activeConversation,
@@ -545,50 +538,6 @@ struct MainWindowView: View {
         }
         .frame(height: 48)
         .background(VColor.surfaceBase)
-    }
-
-    /// Toolbar status indicator for the two-axis permission mode.
-    ///
-    /// Shows a shield icon reflecting the current state:
-    /// - Shield-check when both protections are active (ask + no host access)
-    /// - Shield-alert when host access is granted
-    /// - Shield-off when autonomous mode is active
-    ///
-    /// Tapping opens the `PermissionModeStatusView` popover.
-    private var permissionModeIndicator: some View {
-        let askBeforeActing = connectionManager.permissionMode?.askBeforeActing ?? PermissionModeDefaults.askBeforeActing
-        let hostAccess = connectionManager.permissionMode?.hostAccess ?? PermissionModeDefaults.hostAccess
-
-        let iconName: String
-        let iconColor: Color
-        let tooltip: String
-
-        if askBeforeActing && !hostAccess {
-            iconName = VIcon.shieldCheck.rawValue
-            iconColor = VColor.systemPositiveStrong
-            tooltip = "Protected: asks before acting, no computer access"
-        } else if hostAccess {
-            iconName = VIcon.shieldAlert.rawValue
-            iconColor = VColor.systemMidStrong
-            tooltip = "Computer access enabled"
-        } else {
-            iconName = VIcon.shieldOff.rawValue
-            iconColor = VColor.contentSecondary
-            tooltip = "Autonomous mode: acts without asking"
-        }
-
-        return VButton(
-            label: "Permission controls",
-            iconOnly: iconName,
-            style: .ghost,
-            tooltip: tooltip
-        ) {
-            showPermissionModePopover.toggle()
-        }
-        .foregroundStyle(iconColor)
-        .popover(isPresented: $showPermissionModePopover, arrowEdge: .bottom) {
-            PermissionModeStatusView(connectionManager: connectionManager)
-        }
     }
 
     /// Core layout extracted to break up type-checker complexity.

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -427,6 +427,9 @@ extension MainWindowView {
             let isVoiceModeEnabled = assistantFeatureFlagStore.isEnabled(
                 "voice-mode"
             )
+            let isPermissionModeEnabled = assistantFeatureFlagStore.isEnabled(
+                "permission-controls-v2"
+            )
             ActiveChatViewWrapper(
                 viewModel: viewModel,
                 windowState: windowState,
@@ -452,7 +455,9 @@ extension MainWindowView {
                 } : nil,
                 conversationId: conversationManager.activeConversationId,
                 anchorMessageId: $conversationManager.pendingAnchorMessageId,
-                highlightedMessageId: $conversationManager.highlightedMessageId
+                highlightedMessageId: $conversationManager.highlightedMessageId,
+                connectionManager: connectionManager,
+                permissionModeEnabled: isPermissionModeEnabled
             )
         }
     }
@@ -623,6 +628,10 @@ struct ActiveChatViewWrapper: View {
     @Binding var anchorMessageId: UUID?
     @Binding var highlightedMessageId: UUID?
 
+    // MARK: - Permission Mode (macOS only)
+    var connectionManager: GatewayConnectionManager? = nil
+    var permissionModeEnabled: Bool = false
+
     @State private var inspectorMessageId: String? = nil
 
     /// Reads the persisted bootstrap state so the chat view can suppress
@@ -687,6 +696,8 @@ struct ActiveChatViewWrapper: View {
                 onEndVoiceMode: onEndVoiceMode,
                 onDictateToggle: onDictateToggle,
                 onVoiceModeToggle: onVoiceModeToggle,
+                connectionManager: connectionManager,
+                permissionModeEnabled: permissionModeEnabled,
                 watchSession: ambientAgent.activeWatchSession
             )
             .environment(\.cmdEnterToSend, settingsStore.cmdEnterToSend)


### PR DESCRIPTION
## Summary
- Move the permission mode shield indicator from the top toolbar to the chat composer action buttons area, between the mic button and send button
- Shield icon appears in all three composer states (empty, with text, pending confirmation)
- Same feature-flag gating and popover behavior, just in a more discoverable location near the user's input area

## Original prompt
Move the permission mode shield indicator from the top toolbar to the chat composer bar area. Place it to the right of the microphone icon, matching the sizing and styling of adjacent controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24069" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
