### PR TITLE
Inject PKB/NOW.md on first turn only; PKB nudge every turn

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -604,6 +604,7 @@ describe("applyRuntimeInjections — injection mode", () => {
       "<turn_context>\ntimestamp: 2026-03-04 (Tue) 12:00:00 +00:00 (UTC)\ninterface: telegram\n</turn_context>",
     nowScratchpad: "Current focus: shipping PR 3",
     pkbContext: "essentials content here",
+    pkbActive: true,
     isNonInteractive: true,
   };
 

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -102,7 +102,6 @@ import {
   applyRuntimeInjections,
   buildUnifiedTurnContextBlock,
   findLastInjectedNowContent,
-  findLastInjectedPkbContent,
   inboundActorContextFromTrust,
   inboundActorContextFromTrustContext,
   readNowScratchpad,
@@ -779,24 +778,15 @@ export async function runAgentLoopImpl(
     const isInteractiveResolved =
       options?.isInteractive ?? (!ctx.hasNoClient && !ctx.headlessLock);
 
-    // Only inject NOW.md if it changed since the last injection in the
-    // conversation.  Keeping the previous injection in place avoids mutating
-    // historical user messages and preserves the cached prefix.
+    // Inject NOW.md and PKB content only on the first turn (or after
+    // compaction re-strips them).  Old injections persist in history and
+    // are never stripped on normal turns — this preserves the cached prefix.
     const currentNowContent = readNowScratchpad();
-    const lastInjectedNow = findLastInjectedNowContent(ctx.messages);
-    const nowScratchpad =
-      currentNowContent !== lastInjectedNow ? currentNowContent : null;
+    const nowScratchpad = isFirstMessage ? currentNowContent : null;
 
-    // Only inject PKB if it changed since the last injection in the
-    // conversation.  Keeping the previous injection in place avoids mutating
-    // historical user messages and preserves the cached prefix.
-    // Note: injectPkbContext escapes </pkb> sequences before writing to history,
-    // so we must apply the same escaping before comparing to avoid false mismatches.
     const currentPkbContent = readPkbContext();
-    const lastInjectedPkb = findLastInjectedPkbContent(ctx.messages);
-    const escapedCurrentPkb = currentPkbContent?.replace(/<\/pkb\s*>/gi, "&lt;/pkb&gt;") ?? null;
-    const pkbContext =
-      escapedCurrentPkb !== lastInjectedPkb ? currentPkbContent : null;
+    const pkbContext = isFirstMessage ? currentPkbContent : null;
+    const pkbActive = currentPkbContent !== null;
 
     // Shared injection options — reused whenever we need to re-inject after reduction.
     const injectionOpts = {
@@ -808,6 +798,7 @@ export async function runAgentLoopImpl(
       channelCommandContext: ctx.commandIntent ?? null,
       unifiedTurnContext: unifiedTurnContextStr,
       pkbContext,
+      pkbActive,
       nowScratchpad,
       voiceCallControlPrompt: ctx.voiceCallControlPrompt ?? null,
       transportHints: ctx.transportHints ?? null,

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1121,28 +1121,6 @@ export function findLastInjectedNowContent(messages: Message[]): string | null {
 }
 
 /**
- * Extract the most recently injected PKB content from the message history.
- * Returns null if no PKB injection is found.
- */
-export function findLastInjectedPkbContent(
-  messages: Message[],
-): string | null {
-  const prefix = "<pkb>\n";
-  const suffix = "\n</pkb>";
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i];
-    if (msg.role !== "user") continue;
-    for (const block of msg.content) {
-      if (block.type === "text" && block.text.startsWith(prefix)) {
-        const end = block.text.lastIndexOf(suffix);
-        if (end > prefix.length) return block.text.slice(prefix.length, end);
-      }
-    }
-  }
-  return null;
-}
-
-/**
  * Controls which runtime injections are applied.
  *
  * - `'full'` (default): all injections are applied.
@@ -1169,6 +1147,7 @@ export function applyRuntimeInjections(
     unifiedTurnContext?: string | null;
     voiceCallControlPrompt?: string | null;
     pkbContext?: string | null;
+    pkbActive?: boolean;
     nowScratchpad?: string | null;
     isNonInteractive?: boolean;
     transportHints?: string[] | null;
@@ -1219,9 +1198,9 @@ export function applyRuntimeInjections(
     }
   }
 
-  // PKB behavioral nudge — remind the assistant to read topic files and
-  // call `remember` aggressively.
-  if (mode === "full" && options.pkbContext) {
+  // PKB behavioral nudge — injected on every turn when PKB is active so
+  // the model keeps reading topic files and calling `remember`.
+  if (mode === "full" && options.pkbActive) {
     const userTail = result[result.length - 1];
     if (userTail && userTail.role === "user") {
       result = [


### PR DESCRIPTION
## Summary
- PKB and NOW.md content are now injected only on the first user turn (or first after compaction), replacing the per-change deduplication logic that re-injected whenever content changed
- PKB system nudge (`<system_reminder>`) is decoupled from `pkbContext` and injected on every turn via a new `pkbActive` flag — ensuring the model always sees the nudge regardless of whether PKB content was injected this turn
- Removed dead `findLastInjectedPkbContent` function

## Original prompt
First turn (or first turn after compaction): Workspace, Transport hints, Turn context, NOW.md, Full context memory graph injection, PKB, PKB system nudge. All other turns: Transport hints, Turn context, Turn memory graph injection, PKB system nudge. Never strip except during compaction.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
