### PR TITLE
chore(macos): remove dead connectedAssistantId KVO property

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -78,12 +78,6 @@ extension UserDefaults {
         }
         return string(forKey: "popOutShortcut") ?? ""
     }
-    /// Legacy KVO-observable property. No longer used by SettingsStore
-    /// (which now subscribes to `LockfileAssistant.activeAssistantDidChange`)
-    /// but retained for any remaining KVO observers.
-    @objc dynamic var connectedAssistantId: String? {
-        return string(forKey: "connectedAssistantId")
-    }
     @objc dynamic var connectedOrganizationId: String? {
         return string(forKey: "connectedOrganizationId")
     }


### PR DESCRIPTION
## Summary
- Remove the legacy \`@objc dynamic var connectedAssistantId\` KVO shim on \`UserDefaults\` in \`AppDelegate+InputMonitors.swift\`.
- The underlying \`connectedAssistantId\` UserDefaults key is now cleared by the one-time lockfile migration, and a grep for KVO observers (\`\\.connectedAssistantId\`, \`publisher(for:\`, \`observe(\`) found zero remaining call sites — the doc comment said it was retained "for any remaining KVO observers" but there are none.
- Leaves \`connectedOrganizationId\` untouched.

## Original prompt
Remove dead KVO property \`@objc dynamic var connectedAssistantId\` from clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift (around line 84). It reads the legacy \`connectedAssistantId\` UserDefaults key which is now cleared by the lockfile migration, and a grep for KVO observers found zero remaining observers. The comment above it says "retained for any remaining KVO observers" — but there are none. Just delete the property (lines ~81-86 including the doc comment). Leave \`connectedOrganizationId\` directly below it alone.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24077" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
