### PR TITLE
fix: use portable C.UTF-8 locale instead of en_US.UTF-8 in sandbox env

### DIFF
--- a/assistant/src/__tests__/terminal-tools.test.ts
+++ b/assistant/src/__tests__/terminal-tools.test.ts
@@ -450,8 +450,8 @@ describe("buildSanitizedEnv", () => {
     delete process.env.LC_ALL;
 
     const env = buildSanitizedEnv();
-    expect(env.LANG).toBe("en_US.UTF-8");
-    expect(env.LC_ALL).toBe("en_US.UTF-8");
+    expect(env.LANG).toBe("C.UTF-8");
+    expect(env.LC_ALL).toBe("C.UTF-8");
   });
 
   test("injects INTERNAL_GATEWAY_BASE_URL from gateway config", () => {

--- a/assistant/src/tools/terminal/safe-env.ts
+++ b/assistant/src/tools/terminal/safe-env.ts
@@ -74,7 +74,7 @@ export function buildSanitizedEnv(): Record<string, string> {
   env.VELLUM_WORKSPACE_DIR = getWorkspaceDir();
   // Ensure UTF-8 locale so multi-byte characters (em dashes, curly quotes,
   // arrows, etc.) survive piping through tools like pbcopy without corruption.
-  if (!env.LANG) env.LANG = "en_US.UTF-8";
-  if (!env.LC_ALL) env.LC_ALL = "en_US.UTF-8";
+  if (!env.LANG) env.LANG = "C.UTF-8";
+  if (!env.LC_ALL) env.LC_ALL = "C.UTF-8";
   return env;
 }


### PR DESCRIPTION
PR #23994 hardcoded en_US.UTF-8 for LANG/LC_ALL defaults, but that locale may not exist in Linux/container environments without locale-gen. C.UTF-8 is universally available and achieves the same UTF-8 encoding goal.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24078" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
