### PR TITLE
fix: guard bootstrap Step 5 fallback when no Step 3 answer exists

### DIFF
--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -98,7 +98,9 @@ After the task is done, don't pivot to setup. Build on what just happened.
 
 The follow-up should feel like a coworker saying "while we're at it..." — not a product tour.
 
-**Fallback: plant a hook for next time.** If the task was a dead-end (photo edit, one-off question), reach back to Step 3. Pick up something from their "what's on your mind" answer and offer to work on it: "You mentioned [X] earlier — I can dig into that and have something ready next time you open this."
+**Fallback: plant a hook for next time.** If the task was a dead-end (photo edit, one-off question):
+- *If Step 3 produced a real answer* (the user shared something on their mind), reach back to it. Offer to work on that topic: "You mentioned [X] earlier — I can dig into that and have something ready next time you open this."
+- *If Step 3 was skipped* (user said "nothing," declined, or moved on), don't reference it. Instead, offer something forward-looking: "I'm here whenever you need me — just open this up and tell me what you're working on."
 
 If they engage, do it. If they decline or wrap up, move on. One offer, no pressure.
 


### PR DESCRIPTION
## Summary
- The Step 5 fallback in BOOTSTRAP.md assumed Step 3 always produced usable content
- When a user skips Step 3 (says "nothing", declines, moves on), referencing their non-existent answer could cause the assistant to invent prior context — a trust-breaking behavior
- The fallback is now conditional: uses the Step 3 answer when available, otherwise offers a neutral forward-looking alternative

## Test plan
- [ ] Verify the BOOTSTRAP.md template reads correctly with the conditional fallback
- [ ] No code changes — prompt template only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24079" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
