### PR TITLE
fix: restore outer try-catch in markSurfaceCompleted for DB error resilience

### DIFF
--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -65,32 +65,36 @@ export function markSurfaceCompleted(
   }
 
   // Persist to DB.
-  const rows = getMessages(ctx.conversationId);
-  for (let r = rows.length - 1; r >= 0; r--) {
-    let parsed: unknown[];
-    try {
-      const result = JSON.parse(rows[r].content);
-      if (!Array.isArray(result)) continue;
-      parsed = result;
-    } catch {
-      // Some rows store plain text content (e.g. notification seeding) —
-      // skip them and keep scanning.
-      continue;
-    }
-    let found = false;
-    for (const pb of parsed) {
-      const rb = pb as Record<string, unknown>;
-      if (rb.type === "ui_surface" && rb.surfaceId === surfaceId) {
-        rb.completed = true;
-        rb.completionSummary = summary;
-        found = true;
-        break;
+  try {
+    const rows = getMessages(ctx.conversationId);
+    for (let r = rows.length - 1; r >= 0; r--) {
+      let parsed: unknown[];
+      try {
+        const result = JSON.parse(rows[r].content);
+        if (!Array.isArray(result)) continue;
+        parsed = result;
+      } catch {
+        // Some rows store plain text content (e.g. notification seeding) —
+        // skip them and keep scanning.
+        continue;
+      }
+      let found = false;
+      for (const pb of parsed) {
+        const rb = pb as Record<string, unknown>;
+        if (rb.type === "ui_surface" && rb.surfaceId === surfaceId) {
+          rb.completed = true;
+          rb.completionSummary = summary;
+          found = true;
+          break;
+        }
+      }
+      if (found) {
+        updateMessageContent(rows[r].id, JSON.stringify(parsed));
+        return;
       }
     }
-    if (found) {
-      updateMessageContent(rows[r].id, JSON.stringify(parsed));
-      return;
-    }
+  } catch (err) {
+    log.warn({ err, surfaceId }, "Failed to persist surface completion to DB");
   }
 }
 const TASK_PROGRESS_TEMPLATE_FIELDS = ["title", "status", "steps"] as const;


### PR DESCRIPTION
## Summary
- PR #23865 correctly added per-row JSON.parse error handling but removed the outer try-catch that guarded `getMessages()` and `updateMessageContent()` DB calls.
- This restores the outer error guard so transient DB failures (SQLite lock contention, corruption, uninitialized DB) degrade gracefully with a warning log instead of crashing callers.
- The inner per-row JSON.parse try-catch is preserved as-is since that improvement is correct.

## Test plan
- [x] Verified `log` is already imported and available in the module
- [x] The outer try-catch wraps the full DB persistence block (getMessages through updateMessageContent)
- [x] The inner per-row JSON.parse try-catch remains unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
