### PR TITLE
Add code & tooling changes item to analyze prompt

### DIFF
--- a/assistant/src/runtime/routes/conversation-analysis-routes.ts
+++ b/assistant/src/runtime/routes/conversation-analysis-routes.ts
@@ -111,6 +111,7 @@ Analyze the conversation above. Provide a structured self-assessment:
 3. **What went wrong**: Errors, unnecessary tool calls, incorrect assumptions, wasted turns, misunderstandings.
 4. **Root causes**: Why did failures happen? Missing context? Wrong approach? Tool limitations?
 5. **Recommendations**: Specific, actionable improvements for similar conversations next time.
+6. **Code & tooling changes**: Are there any changes to files you should make based on these learnings? Are there any skills or scripts that are worth creating or modifying? Don't make these changes yet — just provide your analysis.
 
 Be honest and specific. Reference particular moments in the transcript. Focus on patterns that generalize beyond this specific conversation.
 


### PR DESCRIPTION
## Summary
- Adds item 6 ("Code & tooling changes") to the conversation analysis prompt in `conversation-analysis-routes.ts`
- Prompts the assistant to identify actionable file, skill, or script changes based on analysis learnings without making them yet

## Original prompt
The analyze prompt should include another item like this: Are there any changes to files you should make based on these learnings? Are there any skills or scripts that are worth creating or modifying? Don't make these changes yet just provide your analysis.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24082" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
