### PR TITLE
fix: pass delegate to URLSession async methods for progress callbacks

### DIFF
--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -193,7 +193,7 @@ public enum GatewayHTTPClient {
         let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
         defer { session.finishTasksAndInvalidate() }
 
-        let (data, response) = try await session.data(for: request)
+        let (data, response) = try await session.data(for: request, delegate: delegate)
         let http = response as? HTTPURLResponse
         let statusCode = http?.statusCode ?? -1
 

--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -144,7 +144,7 @@ public enum PlatformMigrationClient {
 
         for attempt in 0...maxRetries {
             log.info("PUT \(urlPath, privacy: .public)\(attempt > 0 ? " (retry \(attempt)/\(maxRetries))" : "")")
-            let (_, response) = try await session.upload(for: request, from: bundleData)
+            let (_, response) = try await session.upload(for: request, from: bundleData, delegate: delegate)
             let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
             log.info("PUT \(urlPath, privacy: .public) → \(statusCode)")
 


### PR DESCRIPTION
## Summary
- Pass delegate parameter to `session.data(for:delegate:)` in `performStreamingPost` so `DownloadProgressDelegate` receives `didReceive data:` callbacks
- Pass delegate parameter to `session.upload(for:from:delegate:)` in `uploadToSignedUrl` so `UploadProgressDelegate` receives `didSendBodyData` callbacks
- Without the explicit `delegate:` parameter, the async URLSession methods don't deliver task-specific delegate callbacks

Addresses review feedback on PR #24060.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24085" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
