### PR TITLE
fix: clear stale connectedAssistantId during re-hatch

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -372,13 +372,13 @@ struct OnboardingFlowView: View {
         state.hasExistingManagedAssistant = false
         log.info("Beginning managed assistant bootstrap")
 
-        // When re-hatching, clear the stored assistant ID so
+        // When re-hatching, clear the active assistant in the lockfile so
         // ensureManagedAssistant() doesn't short-circuit by fetching the
         // old assistant. Without this, the hatch endpoint is never called
         // and the user ends up reconnected to their previous assistant.
         if state.isRehatch {
-            log.info("Re-hatch: clearing connectedAssistantId to force hatch endpoint")
-            UserDefaults.standard.removeObject(forKey: "connectedAssistantId")
+            log.info("Re-hatch: clearing activeAssistant to force hatch endpoint")
+            LockfileAssistant.setActiveAssistantId(nil)
         }
 
         do {

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -372,6 +372,15 @@ struct OnboardingFlowView: View {
         state.hasExistingManagedAssistant = false
         log.info("Beginning managed assistant bootstrap")
 
+        // When re-hatching, clear the stored assistant ID so
+        // ensureManagedAssistant() doesn't short-circuit by fetching the
+        // old assistant. Without this, the hatch endpoint is never called
+        // and the user ends up reconnected to their previous assistant.
+        if state.isRehatch {
+            log.info("Re-hatch: clearing connectedAssistantId to force hatch endpoint")
+            UserDefaults.standard.removeObject(forKey: "connectedAssistantId")
+        }
+
         do {
             let activation = try await ManagedAssistantConnectionCoordinator().activateManagedAssistant()
             let assistant = activation.assistant


### PR DESCRIPTION
## Summary
- When re-hatching a managed assistant, `ensureManagedAssistant()` short-circuits on the stale `connectedAssistantId` (still pointing to the old assistant), fetching the old assistant instead of calling the hatch endpoint to create a new one
- Clear `connectedAssistantId` at the start of `performManagedBootstrap()` when `isRehatch` is true, consistent with Emily's source-of-truth pattern from #14774 / #21001
- Safe because the onboarding flow has no active gateway connection (main window is hidden), and `persistManagedAssistant()` restores the ID to the new assistant immediately after hatch returns

## Original prompt
that (and branch your worktree off of main, not our current branch). first make sure to check Emily (emmie)'s recent commits and make sure this doesnt reintroduce old patterns, she's doing some refactoring right now around this area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24088" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
