### PR TITLE
Remove transport_hints; move host env fields to workspace block

### DIFF
--- a/assistant/src/__tests__/top-level-renderer.test.ts
+++ b/assistant/src/__tests__/top-level-renderer.test.ts
@@ -1,10 +1,11 @@
+import { homedir, userInfo } from "node:os";
 import { describe, expect, test } from "bun:test";
 
 import { renderWorkspaceTopLevelContext } from "../workspace/top-level-renderer.js";
 import type { TopLevelSnapshot } from "../workspace/top-level-scanner.js";
 
 describe("renderWorkspaceTopLevelContext", () => {
-  test("renders basic snapshot with directories and files", () => {
+  test("renders basic snapshot with directories, files, and host env", () => {
     const snapshot: TopLevelSnapshot = {
       rootPath: "/sandbox",
       directories: ["lib", "src", "tests"],
@@ -19,6 +20,8 @@ describe("renderWorkspaceTopLevelContext", () => {
         "Root: /sandbox",
         "Directories: lib, src, tests",
         "Files: README.md, package.json",
+        `Host home directory: ${homedir()}`,
+        `Host username: ${userInfo().username}`,
         "</workspace>",
       ].join("\n"),
     );
@@ -65,6 +68,8 @@ describe("renderWorkspaceTopLevelContext", () => {
         "Root: /empty",
         "Directories: ",
         "Files: ",
+        `Host home directory: ${homedir()}`,
+        `Host username: ${userInfo().username}`,
         "</workspace>",
       ].join("\n"),
     );

--- a/assistant/src/__tests__/transport-hints-queue.test.ts
+++ b/assistant/src/__tests__/transport-hints-queue.test.ts
@@ -11,7 +11,7 @@ import { buildTransportHints } from "../daemon/transport-hints.js";
 // ---------------------------------------------------------------------------
 
 describe("buildTransportHints", () => {
-  test("produces correct hints for macOS transport", () => {
+  test("returns empty array for macOS transport without client hints", () => {
     const transport: MacosTransportMetadata = {
       channelId: "vellum",
       interfaceId: "macos",
@@ -21,13 +21,10 @@ describe("buildTransportHints", () => {
 
     const hints = buildTransportHints(transport);
 
-    expect(hints).toContain("User is messaging from interface: macos");
-    expect(hints).toContain("Host home directory: /Users/alice");
-    expect(hints).toContain("Host username: alice");
-    expect(hints).toHaveLength(3);
+    expect(hints).toHaveLength(0);
   });
 
-  test("produces correct hints for non-macOS transport", () => {
+  test("returns empty array for non-macOS transport without client hints", () => {
     const transport: NonMacosTransportMetadata = {
       channelId: "vellum",
       interfaceId: "ios",
@@ -35,14 +32,10 @@ describe("buildTransportHints", () => {
 
     const hints = buildTransportHints(transport);
 
-    expect(hints).toContain("User is messaging from interface: ios");
-    expect(hints).toHaveLength(1);
-    // Should not include host environment hints
-    expect(hints.some((h) => h.includes("Host home directory"))).toBe(false);
-    expect(hints.some((h) => h.includes("Host username"))).toBe(false);
+    expect(hints).toHaveLength(0);
   });
 
-  test("includes client-provided hints", () => {
+  test("forwards client-provided hints", () => {
     const transport: MacosTransportMetadata = {
       channelId: "vellum",
       interfaceId: "macos",
@@ -53,14 +46,10 @@ describe("buildTransportHints", () => {
 
     const hints = buildTransportHints(transport);
 
-    expect(hints).toContain("User is messaging from interface: macos");
-    expect(hints).toContain("Host home directory: /Users/bob");
-    expect(hints).toContain("Host username: bob");
-    expect(hints).toContain("custom hint");
-    expect(hints).toHaveLength(4);
+    expect(hints).toEqual(["custom hint"]);
   });
 
-  test("handles missing optional fields on macOS transport", () => {
+  test("returns empty array when no hints field present", () => {
     const transport: MacosTransportMetadata = {
       channelId: "vellum",
       interfaceId: "macos",
@@ -68,10 +57,6 @@ describe("buildTransportHints", () => {
 
     const hints = buildTransportHints(transport);
 
-    expect(hints).toContain("User is messaging from interface: macos");
-    // Without hostHomeDir and hostUsername, only the interface hint is present
-    expect(hints).toHaveLength(1);
-    expect(hints.some((h) => h.includes("Host home directory"))).toBe(false);
-    expect(hints.some((h) => h.includes("Host username"))).toBe(false);
+    expect(hints).toHaveLength(0);
   });
 });

--- a/assistant/src/daemon/transport-hints.ts
+++ b/assistant/src/daemon/transport-hints.ts
@@ -1,33 +1,14 @@
-import { parseInterfaceId } from "../channels/types.js";
 import type { ConversationTransportMetadata } from "./message-types/conversations.js";
 
 /**
- * Build enriched transport hints from conversation transport metadata.
+ * Build transport hints from conversation transport metadata.
  *
- * Interface ID first, then host environment (macOS only), then any
- * client-provided hints. Shared between the conversation creation path
- * (server.ts) and the queue drain path (conversation-process.ts).
+ * Only forwards client-provided hints. Interface identity is already
+ * covered by `<turn_context>`, and host environment fields (home dir,
+ * username) are rendered in the `<workspace>` block.
  */
 export function buildTransportHints(
   transport: ConversationTransportMetadata,
 ): string[] {
-  const hints: string[] = [];
-
-  const interfaceLabel = parseInterfaceId(transport.interfaceId) ?? "vellum";
-  hints.push(`User is messaging from interface: ${interfaceLabel}`);
-
-  if (transport.interfaceId === "macos") {
-    if (transport.hostHomeDir) {
-      hints.push(`Host home directory: ${transport.hostHomeDir}`);
-    }
-    if (transport.hostUsername) {
-      hints.push(`Host username: ${transport.hostUsername}`);
-    }
-  }
-
-  if (transport.hints) {
-    hints.push(...transport.hints);
-  }
-
-  return hints;
+  return transport.hints ? [...transport.hints] : [];
 }

--- a/assistant/src/workspace/top-level-renderer.ts
+++ b/assistant/src/workspace/top-level-renderer.ts
@@ -1,3 +1,5 @@
+import { homedir, userInfo } from "node:os";
+
 import type { TopLevelSnapshot } from "./top-level-scanner.js";
 
 export interface WorkspaceTopLevelRenderOptions {
@@ -24,6 +26,8 @@ export function renderWorkspaceTopLevelContext(
   if (snapshot.truncated) {
     lines.push("(list truncated — more entries exist)");
   }
+  lines.push(`Host home directory: ${homedir()}`);
+  lines.push(`Host username: ${userInfo().username}`);
   lines.push("</workspace>");
   return lines.join("\n");
 }


### PR DESCRIPTION
## Summary
- Stripped generated fields from `buildTransportHints()` (interface label, host home dir, host username) — it now only forwards client-provided `transport.hints`
- Added `Host home directory` and `Host username` to the `<workspace>` block in `top-level-renderer.ts` using `os.homedir()` and `os.userInfo().username`
- Updated tests for both changes