### PR TITLE
Increase vTooltip default hover delay to 1s

### DIFF
--- a/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
+++ b/clients/shared/DesignSystem/Modifiers/NativeTooltipModifier.swift
@@ -89,7 +89,7 @@ private final class VTooltipCoordinator {
 /// ```
 public extension View {
     /// Attaches a floating tooltip that appears on hover after `delay` seconds.
-    func vTooltip(_ text: String, edge: Edge = .top, delay: TimeInterval = 0.2) -> some View {
+    func vTooltip(_ text: String, edge: Edge = .top, delay: TimeInterval = 1.0) -> some View {
         self.overlay(
                 VTooltipTracker(text: text, edge: edge, delay: delay)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -551,7 +551,7 @@ public extension View {
     }
 
     /// On non-macOS platforms, falls back to the standard `.help()` modifier.
-    func vTooltip(_ text: String, edge: Edge = .top, delay: TimeInterval = 0.2) -> some View {
+    func vTooltip(_ text: String, edge: Edge = .top, delay: TimeInterval = 1.0) -> some View {
         self.help(text)
     }
 }


### PR DESCRIPTION
## Summary
- Increase the default `delay` parameter for `.vTooltip()` from 0.2s to 1.0s, closer to the native macOS tooltip delay (~1.5s)
- Updated in both macOS and non-macOS declarations

## Original prompt
update it to 1s
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24092" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
