### PR TITLE
fix: render sidebar pin button as overlay for hit-test priority

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -209,6 +209,28 @@ struct SidebarConversationItem: View, Equatable {
             selectConversation()
             onSelect?()
         }
+        .overlay(alignment: .leading) {
+            // Pin button rendered as an overlay so it sits above .onTapGesture
+            // in the hit-test chain. Without this, .contentShape(Rectangle()) +
+            // .onTapGesture on the parent intercepts clicks before they reach
+            // child Button views on macOS (same pattern as the trailing
+            // "More options" overlay below).
+            if isHovered {
+                VButton(
+                    label: conversation.isPinned ? "Unpin \(conversation.title)" : "Pin \(conversation.title)",
+                    iconOnly: conversation.isPinned ? VIcon.pinOff.rawValue : VIcon.pin.rawValue,
+                    style: .ghost,
+                    iconSize: 20,
+                    tooltip: conversation.isPinned ? "Unpin" : "Pin",
+                    iconColor: VColor.contentSecondary,
+                    iconRotation: conversation.isPinned ? .degrees(0) : .degrees(-45)
+                ) {
+                    onTogglePin()
+                }
+                .padding(.leading, VSpacing.xs)
+                .transition(.opacity)
+            }
+        }
         .accessibilityAddTraits(.isButton)
         .accessibilityLabel("Conversation: \(conversation.title)")
         .accessibilityAction(.default) {


### PR DESCRIPTION
## Summary
- The pin/unpin button in the sidebar was unclickable because `.contentShape(Rectangle())` + `.onTapGesture` on the parent row intercepted clicks before they reached the child `Button` on macOS
- Add the pin button as a `.overlay(alignment: .leading)` after `.onTapGesture`, matching the existing pattern used by the trailing "More options" button which already works
- The overlay approach gives the pin button higher z-order in the hit-test chain so it receives clicks first

## Original prompt
Fix pin and unpin buttons not working in the macOS sidebar
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24096" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
