### PR TITLE
refactor: remove redundant HStack pin button from sidebar row

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarConversationItem.swift
@@ -121,53 +121,40 @@ struct SidebarConversationItem: View, Equatable {
         // Use a tap gesture instead of Button so .onDrag can coexist —
         // Button captures mouse-down and prevents drag initiation on macOS.
         HStack(spacing: VSpacing.xs) {
-            // Leading 20x20 slot: single render path.
-            // Hovered -> interactive pin button; not hovered -> status indicator.
-            if isHovered {
-                VButton(
-                    label: conversation.isPinned ? "Unpin \(conversation.title)" : "Pin \(conversation.title)",
-                    iconOnly: conversation.isPinned ? VIcon.pinOff.rawValue : VIcon.pin.rawValue,
-                    style: .ghost,
-                    iconSize: 20,
-                    tooltip: conversation.isPinned ? "Unpin" : "Pin",
-                    iconColor: VColor.contentSecondary,
-                    iconRotation: conversation.isPinned ? .degrees(0) : .degrees(-45)
-                ) {
-                    onTogglePin()
-                }
-                .transition(.opacity)
-            } else {
-                switch interactionState {
-                case .processing:
-                    VBusyIndicator()
+            // Leading 20x20 slot: always shows the status indicator.
+            // The pin button is rendered as a leading overlay (after .onTapGesture)
+            // so it has hit-test priority on macOS. When hovered, the overlay pin
+            // icon covers this slot visually.
+            switch interactionState {
+            case .processing:
+                VBusyIndicator()
+                    .frame(width: 20, height: 20)
+                    .nativeTooltip("Processing")
+                    .accessibilityLabel("Processing")
+            case .waitingForInput:
+                VIconView(.circleAlert, size: 12)
+                    .foregroundStyle(VColor.systemMidStrong)
+                    .frame(width: 20, height: 20)
+                    .nativeTooltip("Waiting for input")
+                    .accessibilityLabel("Waiting for input")
+            case .error:
+                VIconView(.circleAlert, size: 12)
+                    .foregroundStyle(VColor.systemNegativeStrong)
+                    .frame(width: 20, height: 20)
+                    .nativeTooltip("Error")
+                    .accessibilityLabel("Error")
+                    .transition(.opacity)
+            case .idle:
+                if conversation.hasUnseenLatestAssistantMessage {
+                    VBadge(style: .dot, color: VColor.systemMidStrong)
+                        .accessibilityLabel("Unread")
                         .frame(width: 20, height: 20)
-                        .nativeTooltip("Processing")
-                        .accessibilityLabel("Processing")
-                case .waitingForInput:
-                    VIconView(.circleAlert, size: 12)
-                        .foregroundStyle(VColor.systemMidStrong)
-                        .frame(width: 20, height: 20)
-                        .nativeTooltip("Waiting for input")
-                        .accessibilityLabel("Waiting for input")
-                case .error:
-                    VIconView(.circleAlert, size: 12)
-                        .foregroundStyle(VColor.systemNegativeStrong)
-                        .frame(width: 20, height: 20)
-                        .nativeTooltip("Error")
-                        .accessibilityLabel("Error")
+                        .nativeTooltip("Unread")
                         .transition(.opacity)
-                case .idle:
-                    if conversation.hasUnseenLatestAssistantMessage {
-                        VBadge(style: .dot, color: VColor.systemMidStrong)
-                            .accessibilityLabel("Unread")
-                            .frame(width: 20, height: 20)
-                            .nativeTooltip("Unread")
-                            .transition(.opacity)
-                    } else {
-                        Color.clear
-                            .frame(width: 20, height: 20)
-                            .accessibilityLabel(conversation.isPinned ? "Pinned" : "")
-                    }
+                } else {
+                    Color.clear
+                        .frame(width: 20, height: 20)
+                        .accessibilityLabel(conversation.isPinned ? "Pinned" : "")
                 }
             }
             if conversation.kind == .private {


### PR DESCRIPTION
## Summary
- Follow-up to #24096: now that the pin button lives in a leading overlay, remove the old `if isHovered { VButton(pin) } else { status }` conditional from the HStack
- The status indicator always renders in the leading 20x20 slot; the overlay pin icon covers it on hover
- Eliminates the duplicate pin button that was left behind by the previous PR

## Original prompt
Fix pin and unpin buttons not working in the macOS sidebar
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24097" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
