### PR TITLE
feat: add conversation option to usage breakdown group-by picker

### DIFF
--- a/clients/shared/Features/Usage/UsageDashboardStore.swift
+++ b/clients/shared/Features/Usage/UsageDashboardStore.swift
@@ -101,6 +101,7 @@ public enum UsageGroupByDimension: String, CaseIterable, Sendable {
     case actor
     case provider
     case model
+    case conversation
 }
 
 // MARK: - Formatting Helpers


### PR DESCRIPTION
## Summary
- Add 'conversation' case to UsageGroupByDimension enum in shared store
- Automatically appears in macOS dropdown and iOS segmented picker via CaseIterable

Part of plan: conv-cost-breakdown.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24098" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
