### PR TITLE
fix: widen breakdown group column for conversation titles

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -325,6 +325,10 @@ struct UsageDashboardPanel: View {
         )
     }
 
+    private var groupColumnWidth: CGFloat {
+        store.selectedGroupBy == .conversation ? 200 : 130
+    }
+
     private let breakdownTableWidth: CGFloat = 500
 
     @ViewBuilder
@@ -335,7 +339,7 @@ struct UsageDashboardPanel: View {
                 Text("Group")
                     .font(VFont.labelDefault)
                     .foregroundStyle(VColor.contentTertiary)
-                    .frame(width: 130, alignment: .leading)
+                    .frame(width: groupColumnWidth, alignment: .leading)
                 Text("Tokens")
                     .font(VFont.labelDefault)
                     .foregroundStyle(VColor.contentTertiary)
@@ -362,8 +366,8 @@ struct UsageDashboardPanel: View {
             Text(entry.group)
                 .font(VFont.bodyMediumLighter)
                 .foregroundStyle(VColor.contentDefault)
-                .frame(width: 130, alignment: .leading)
-                .lineLimit(1)
+                .frame(width: groupColumnWidth, alignment: .leading)
+                .lineLimit(store.selectedGroupBy == .conversation ? 2 : 1)
             Text(UsageFormatting.formatBreakdownSummary(entry))
                 .font(VFont.labelDefault)
                 .foregroundStyle(VColor.contentSecondary)


### PR DESCRIPTION
## Summary
- Add dynamic group column width: 200pt for conversation grouping, 130pt for others
- Allow 2-line wrapping for conversation titles in breakdown table

Part of plan: conv-cost-breakdown.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
