### PR TITLE
fix: use array offset for breakdown ForEach identity to avoid duplicates

### DIFF
--- a/clients/ios/Views/UsageDashboardView.swift
+++ b/clients/ios/Views/UsageDashboardView.swift
@@ -146,7 +146,7 @@ struct UsageDashboardView: View {
                     Text("No data for selected range")
                         .foregroundStyle(.secondary)
                 } else {
-                    ForEach(breakdown.breakdown, id: \.group) { entry in
+                    ForEach(Array(breakdown.breakdown.enumerated()), id: \.offset) { _, entry in
                         VStack(alignment: .leading, spacing: 4) {
                             Text(entry.group)
                                 .font(.subheadline.weight(.medium))

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -352,7 +352,7 @@ struct UsageDashboardPanel: View {
             .padding(.horizontal, VSpacing.md)
             .padding(.vertical, VSpacing.sm)
 
-            ForEach(Array(entries.enumerated()), id: \.element.group) { index, entry in
+            ForEach(Array(entries.enumerated()), id: \.offset) { index, entry in
                 Divider().background(VColor.borderBase)
                 breakdownRow(entry)
             }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for conv-cost-breakdown.md.

**Gap:** Duplicate ForEach identity when conversations share titles
**What was expected:** ForEach should handle duplicate group names without rendering issues
**What was found:** ForEach used group string as identity, which breaks with duplicate conversation titles