### PR TITLE
fix: ensure progress delegates are invalidated on all exit paths

### DIFF
--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -191,7 +191,10 @@ public enum GatewayHTTPClient {
     ) async throws -> (Response, HTTPURLResponse?) {
         let delegate = DownloadProgressDelegate(onProgress: onProgress)
         let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
-        defer { session.finishTasksAndInvalidate() }
+        defer {
+            delegate.invalidate()
+            session.finishTasksAndInvalidate()
+        }
 
         let (data, response) = try await session.data(for: request, delegate: delegate)
         let http = response as? HTTPURLResponse
@@ -201,12 +204,10 @@ public enum GatewayHTTPClient {
             logResponse(request, http: http, quiet: false)
         }
 
-        // Send final progress if we tracked determinately, then invalidate
-        // to prevent any queued Tasks from dispatching stale callbacks.
+        // Send final progress if we tracked determinately.
         if delegate.totalBytes > 0, delegate.lastReportedFraction < 1.0 {
             await MainActor.run { onProgress(1.0) }
         }
-        delegate.invalidate()
 
         return (Response(data: data, statusCode: statusCode), http)
     }

--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -138,7 +138,10 @@ public enum PlatformMigrationClient {
 
         let delegate = UploadProgressDelegate(onProgress: onProgress)
         let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
-        defer { session.finishTasksAndInvalidate() }
+        defer {
+            delegate.reset()
+            session.finishTasksAndInvalidate()
+        }
 
         let urlPath = logPath(from: uploadURL) ?? "signed-url-upload"
 


### PR DESCRIPTION
## Summary
- Move download delegate invalidation into defer so it runs on both success and error (throw) paths
- Add upload delegate reset in defer so queued callbacks are discarded after the upload completes or throws

Addresses review feedback on PR #24060.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
