### PR TITLE
chore: regenerate openapi.yaml for conversation groupBy dimension

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -7709,7 +7709,7 @@ paths:
     get:
       operationId: usage_breakdown_get
       summary: Get usage breakdown
-      description: Return grouped usage breakdown (by actor, provider, or model).
+      description: Return grouped usage breakdown (by actor, provider, model, or conversation).
       tags:
         - usage
       responses:
@@ -7745,7 +7745,7 @@ paths:
           required: false
           schema:
             type: string
-          description: "Group by: actor, provider, or model (required)"
+          description: "Group by: actor, provider, model, or conversation (required)"
   /v1/usage/daily:
     get:
       operationId: usage_daily_get


### PR DESCRIPTION
## Summary
Regenerates openapi.yaml to include the conversation groupBy dimension in usage breakdown route descriptions.

Fixes stale openapi.yaml detected during plan review for conv-cost-breakdown.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
