### PR TITLE
feat(browser-session): add BrowserSessionManager scaffold with extension backend stub

### DIFF
--- a/assistant/src/browser-session/__tests__/manager.test.ts
+++ b/assistant/src/browser-session/__tests__/manager.test.ts
@@ -124,4 +124,47 @@ describe("BrowserSessionManager", () => {
     expect(state.disposed).toBe(true);
     expect(manager.getSession(session.id)).toBeUndefined();
   });
+
+  test("send with a known sessionId routes through the matching backend", async () => {
+    const expectedResult: CdpResult = { result: { routed: true } };
+    const state: MockBackendState = {
+      available: true,
+      disposed: false,
+      sendImpl: async () => expectedResult,
+    };
+    const manager = new BrowserSessionManager({
+      backends: [createMockExtensionBackend(state)],
+    });
+    const session = manager.createSession();
+    const result = await manager.send(session.id, {
+      method: "Browser.getVersion",
+    });
+    expect(result).toEqual(expectedResult);
+    expect(state.lastCommand).toEqual({ method: "Browser.getVersion" });
+  });
+
+  test("send with an unknown sessionId throws", async () => {
+    const state: MockBackendState = { available: true, disposed: false };
+    const manager = new BrowserSessionManager({
+      backends: [createMockExtensionBackend(state)],
+    });
+    await expect(
+      manager.send("does-not-exist", { method: "Browser.getVersion" }),
+    ).rejects.toThrow("Unknown browser session: does-not-exist");
+    // The mock backend should not have received the command.
+    expect(state.lastCommand).toBeUndefined();
+  });
+
+  test("send with a sessionId of a disposed session throws", async () => {
+    const state: MockBackendState = { available: true, disposed: false };
+    const manager = new BrowserSessionManager({
+      backends: [createMockExtensionBackend(state)],
+    });
+    const session = manager.createSession();
+    manager.disposeSession(session.id);
+    await expect(
+      manager.send(session.id, { method: "Browser.getVersion" }),
+    ).rejects.toThrow(`Unknown browser session: ${session.id}`);
+    expect(state.lastCommand).toBeUndefined();
+  });
 });

--- a/assistant/src/browser-session/__tests__/manager.test.ts
+++ b/assistant/src/browser-session/__tests__/manager.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
-import { createExtensionBackend } from "../backends/extension.js";
-import { BrowserSessionManager } from "../manager.js";
-import type { BrowserBackend, CdpCommand, CdpResult } from "../types.js";
+import {
+  type BrowserBackend,
+  BrowserSessionManager,
+  type CdpCommand,
+  type CdpResult,
+  createExtensionBackend,
+} from "../index.js";
 
 interface MockBackendState {
   available: boolean;

--- a/assistant/src/browser-session/__tests__/manager.test.ts
+++ b/assistant/src/browser-session/__tests__/manager.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+
+import { createExtensionBackend } from "../backends/extension.js";
+import { BrowserSessionManager } from "../manager.js";
+import type { BrowserBackend, CdpCommand, CdpResult } from "../types.js";
+
+interface MockBackendState {
+  available: boolean;
+  disposed: boolean;
+  lastCommand?: CdpCommand;
+  lastSignal?: AbortSignal;
+  sendImpl?: (command: CdpCommand, signal?: AbortSignal) => Promise<CdpResult>;
+}
+
+function createMockExtensionBackend(state: MockBackendState): BrowserBackend {
+  return createExtensionBackend({
+    isAvailable: () => state.available,
+    sendCdp: async (command, signal) => {
+      state.lastCommand = command;
+      state.lastSignal = signal;
+      if (state.sendImpl) return state.sendImpl(command, signal);
+      return { result: { ok: true } };
+    },
+    dispose: () => {
+      state.disposed = true;
+    },
+  });
+}
+
+describe("BrowserSessionManager", () => {
+  test("selectBackend throws when no backend is available", () => {
+    const state: MockBackendState = { available: false, disposed: false };
+    const manager = new BrowserSessionManager({
+      backends: [createMockExtensionBackend(state)],
+    });
+    expect(() => manager.selectBackend()).toThrow(
+      "No available browser backend",
+    );
+  });
+
+  test("selectBackend returns the extension backend when available", () => {
+    const state: MockBackendState = { available: true, disposed: false };
+    const backend = createMockExtensionBackend(state);
+    const manager = new BrowserSessionManager({ backends: [backend] });
+    const selected = manager.selectBackend();
+    expect(selected.kind).toBe("extension");
+    expect(selected).toBe(backend);
+  });
+
+  test("createSession returns a session with a new uuid stored in the map", () => {
+    const state: MockBackendState = { available: true, disposed: false };
+    const manager = new BrowserSessionManager({
+      backends: [createMockExtensionBackend(state)],
+    });
+    const session = manager.createSession();
+    expect(session.id).toBeTruthy();
+    expect(session.backendKind).toBe("extension");
+    // Lookup round-trips.
+    expect(manager.getSession(session.id)).toEqual(session);
+    // Two sessions get unique ids.
+    const another = manager.createSession();
+    expect(another.id).not.toBe(session.id);
+  });
+
+  test("send delegates to backend.send and returns the CDP result", async () => {
+    const expectedResult: CdpResult = { result: { value: 42 } };
+    const state: MockBackendState = {
+      available: true,
+      disposed: false,
+      sendImpl: async () => expectedResult,
+    };
+    const manager = new BrowserSessionManager({
+      backends: [createMockExtensionBackend(state)],
+    });
+    const result = await manager.send(undefined, {
+      method: "Browser.getVersion",
+      params: { foo: "bar" },
+    });
+    expect(result).toEqual(expectedResult);
+    expect(state.lastCommand).toEqual({
+      method: "Browser.getVersion",
+      params: { foo: "bar" },
+    });
+  });
+
+  test("send with an aborted signal propagates the abort", async () => {
+    const state: MockBackendState = {
+      available: true,
+      disposed: false,
+      sendImpl: async (_command, signal) => {
+        if (signal?.aborted) {
+          throw new Error("aborted");
+        }
+        return { result: { ok: true } };
+      },
+    };
+    const manager = new BrowserSessionManager({
+      backends: [createMockExtensionBackend(state)],
+    });
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      manager.send(
+        undefined,
+        { method: "Browser.getVersion" },
+        controller.signal,
+      ),
+    ).rejects.toThrow("aborted");
+    expect(state.lastSignal).toBe(controller.signal);
+  });
+
+  test("disposeAll calls backend.dispose and clears the session map", () => {
+    const state: MockBackendState = { available: true, disposed: false };
+    const manager = new BrowserSessionManager({
+      backends: [createMockExtensionBackend(state)],
+    });
+    const session = manager.createSession();
+    expect(manager.getSession(session.id)).toBeDefined();
+    manager.disposeAll();
+    expect(state.disposed).toBe(true);
+    expect(manager.getSession(session.id)).toBeUndefined();
+  });
+});

--- a/assistant/src/browser-session/backends/extension.ts
+++ b/assistant/src/browser-session/backends/extension.ts
@@ -1,0 +1,25 @@
+import type { BrowserBackend, CdpCommand, CdpResult } from "../types.js";
+
+/**
+ * Extension backend stub. Phase 2 Wave 2 will wire this to the runtime's
+ * chrome-extension WebSocket connection registry. For now this is a pure
+ * interface implementation so BrowserSessionManager and its tests can be
+ * written without depending on runtime internals.
+ */
+export interface ExtensionBackendDeps {
+  /** Sends a CDP command to an attached chrome extension and returns the CDP result. */
+  sendCdp(command: CdpCommand, signal?: AbortSignal): Promise<CdpResult>;
+  isAvailable(): boolean;
+  dispose(): void;
+}
+
+export function createExtensionBackend(
+  deps: ExtensionBackendDeps,
+): BrowserBackend {
+  return {
+    kind: "extension",
+    isAvailable: deps.isAvailable,
+    send: deps.sendCdp,
+    dispose: deps.dispose,
+  };
+}

--- a/assistant/src/browser-session/index.ts
+++ b/assistant/src/browser-session/index.ts
@@ -1,0 +1,3 @@
+export * from "./backends/extension.js";
+export * from "./manager.js";
+export * from "./types.js";

--- a/assistant/src/browser-session/manager.ts
+++ b/assistant/src/browser-session/manager.ts
@@ -1,0 +1,60 @@
+import { v4 as uuid } from "uuid";
+
+import type {
+  BrowserBackend,
+  BrowserSession,
+  CdpCommand,
+  CdpResult,
+} from "./types.js";
+
+export interface BrowserSessionManagerOptions {
+  /** Ordered list of backends to try; first available wins. Phase 2 only has extension. */
+  backends: BrowserBackend[];
+}
+
+export class BrowserSessionManager {
+  private backends: BrowserBackend[];
+  private sessions = new Map<string, BrowserSession>();
+
+  constructor(opts: BrowserSessionManagerOptions) {
+    this.backends = opts.backends;
+  }
+
+  /** Pick an available backend or throw. */
+  selectBackend(): BrowserBackend {
+    const b = this.backends.find((x) => x.isAvailable());
+    if (!b) throw new Error("No available browser backend");
+    return b;
+  }
+
+  createSession(): BrowserSession {
+    const backend = this.selectBackend();
+    const session: BrowserSession = { id: uuid(), backendKind: backend.kind };
+    this.sessions.set(session.id, session);
+    return session;
+  }
+
+  getSession(id: string): BrowserSession | undefined {
+    return this.sessions.get(id);
+  }
+
+  async send(
+    sessionId: string | undefined,
+    command: CdpCommand,
+    signal?: AbortSignal,
+  ): Promise<CdpResult> {
+    // For now, session is advisory — all extension-backend commands route through the same connection.
+    // Phase 4 will use sessionId to route to specific targets when multi-tab multiplexing lands.
+    const backend = this.selectBackend();
+    return backend.send(command, signal);
+  }
+
+  disposeSession(id: string): void {
+    this.sessions.delete(id);
+  }
+
+  disposeAll(): void {
+    for (const b of this.backends) b.dispose();
+    this.sessions.clear();
+  }
+}

--- a/assistant/src/browser-session/manager.ts
+++ b/assistant/src/browser-session/manager.ts
@@ -38,14 +38,40 @@ export class BrowserSessionManager {
     return this.sessions.get(id);
   }
 
+  /**
+   * Dispatch a CDP command.
+   *
+   * - If `sessionId` is provided, the session must exist in the manager; otherwise this throws.
+   *   The command is routed through the backend whose `kind` matches the session's `backendKind`,
+   *   ensuring per-session backend isolation and making `disposeSession()` an actual enforcement
+   *   boundary against stale ids.
+   * - If `sessionId` is `undefined`, the first available backend is selected (legacy advisory
+   *   behavior used for one-off commands without a session handle).
+   *
+   * Phase 2 only has the extension backend so routing is effectively a no-op, but Phase 4 will
+   * rely on this contract once multi-backend / multi-tab multiplexing lands.
+   */
   async send(
     sessionId: string | undefined,
     command: CdpCommand,
     signal?: AbortSignal,
   ): Promise<CdpResult> {
-    // For now, session is advisory — all extension-backend commands route through the same connection.
-    // Phase 4 will use sessionId to route to specific targets when multi-tab multiplexing lands.
-    const backend = this.selectBackend();
+    let backend: BrowserBackend;
+    if (sessionId !== undefined) {
+      const session = this.sessions.get(sessionId);
+      if (!session) {
+        throw new Error(`Unknown browser session: ${sessionId}`);
+      }
+      const matched = this.backends.find((b) => b.kind === session.backendKind);
+      if (!matched) {
+        throw new Error(
+          `No backend available for session kind: ${session.backendKind}`,
+        );
+      }
+      backend = matched;
+    } else {
+      backend = this.selectBackend();
+    }
     return backend.send(command, signal);
   }
 

--- a/assistant/src/browser-session/types.ts
+++ b/assistant/src/browser-session/types.ts
@@ -1,0 +1,28 @@
+export type BrowserBackendKind = "extension"; // Phase 4/5 will add "cdp-inspect", "playwright".
+
+export interface CdpCommand {
+  method: string;
+  params?: Record<string, unknown>;
+  sessionId?: string;
+}
+
+export interface CdpResult {
+  /** Raw CDP result object; opaque to the manager. */
+  result?: unknown;
+  /** CDP error envelope if the command failed. */
+  error?: { code: number; message: string; data?: unknown };
+}
+
+export interface BrowserSession {
+  id: string;
+  backendKind: BrowserBackendKind;
+  /** Opaque target/sessionId from the backend. Omitted for "most-recent-tab" commands. */
+  targetId?: string;
+}
+
+export interface BrowserBackend {
+  kind: BrowserBackendKind;
+  isAvailable(): boolean;
+  send(command: CdpCommand, signal?: AbortSignal): Promise<CdpResult>;
+  dispose(): void;
+}


### PR DESCRIPTION
## Summary
- New standalone module at assistant/src/browser-session/ with no daemon or runtime dependencies
- BrowserSessionManager selects the first available backend, tracks sessions, and routes CDP commands
- Extension backend stub will be wired up in a later PR; the cloud runtime will be able to import this module

Part of plan: host-browser-proxy-phase-2.md (PR 5 of 16)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
