### PR TITLE
feat(chrome-extension): add standalone CDP proxy module

### DIFF
--- a/clients/chrome-extension/background/cdp-proxy.ts
+++ b/clients/chrome-extension/background/cdp-proxy.ts
@@ -8,6 +8,28 @@
  * standalone lets us write unit tests against an injectable ChromeDebuggerApi
  * mock without pulling in the service worker's lifecycle concerns.
  *
+ * Flat-session handling
+ * ---------------------
+ * The chrome.debugger API does not expose a `sessionId` argument on either
+ * `sendCommand` or `onEvent` — sessions created via `Target.attachToTarget`
+ * with `flatten: true` are addressed by stuffing the `sessionId` into the
+ * command/event `params` object. This proxy mirrors that contract:
+ *
+ *   - `send()`: when `frame.sessionId` is provided, it is folded into the
+ *     params object as `params.sessionId` before being passed to
+ *     `api.sendCommand`. Callers should populate `frame.sessionId` rather
+ *     than mutating params themselves.
+ *
+ *   - `onEvent()`: when an event arrives whose `params` contains a
+ *     `sessionId` field, that value is hoisted onto the emitted
+ *     `CdpEventFrame.sessionId` so consumers can route events without
+ *     having to peek into params.
+ *
+ * Errors from the underlying chrome.debugger callbacks are read through
+ * `api.runtime.lastError` (rather than the global `chrome.runtime.lastError`)
+ * so that tests passing a mocked `ChromeDebuggerApi` can simulate failures
+ * by toggling `runtime.lastError` on the mock.
+ *
  * XXX(host-browser-ph2/pr-6): A unit test file
  *   `clients/chrome-extension/background/__tests__/cdp-proxy.test.ts`
  * is not included in this PR because `clients/chrome-extension/` does not
@@ -18,7 +40,10 @@
  * runner is introduced for the Chrome extension package. The public surface
  * (CdpRequestFrame / CdpResultFrame / CdpEventFrame / CdpTarget / CdpProxy /
  * ChromeDebuggerApi / createCdpProxy) is designed for injectable mocking so
- * adding tests in a follow-up PR is trivial once a runner exists.
+ * adding tests in a follow-up PR is trivial once a runner exists. Now that
+ * `runtime.lastError` is part of the injectable `ChromeDebuggerApi`, mocked
+ * tests can fully exercise both success and error paths without depending
+ * on a real `chrome` global.
  */
 
 /** Raw CDP frame as received from the runtime over the relay. */
@@ -26,7 +51,12 @@ export interface CdpRequestFrame {
   id: number;
   method: string;
   params?: Record<string, unknown>;
-  /** Optional CDP session id for nested flat sessions. */
+  /**
+   * Optional CDP session id for nested flat sessions. The chrome.debugger
+   * `sendCommand` API does not accept a sessionId argument; this proxy folds
+   * the value into `params.sessionId` before dispatch (see the module
+   * docstring for the flat-session contract).
+   */
   sessionId?: string;
 }
 
@@ -69,7 +99,18 @@ export interface CdpProxy {
   dispose(): void;
 }
 
-/** Inject the chrome.debugger API so tests can pass a mock. */
+/**
+ * Inject the chrome.debugger API (plus the slice of `chrome.runtime` we read
+ * `lastError` from) so tests can pass a mock. The shape is intentionally
+ * source-compatible with the real `chrome.debugger` namespace plus a
+ * `runtime.lastError` field — at runtime we satisfy this by composing
+ * `chrome.debugger` and `chrome.runtime` (see the default in `createCdpProxy`).
+ *
+ * Reading `lastError` through the injected `api.runtime.lastError` (rather
+ * than the global `chrome.runtime.lastError`) is what makes the proxy
+ * properly testable: a mocked `ChromeDebuggerApi` can simulate failure paths
+ * by toggling `runtime.lastError` on the mock between callback invocations.
+ */
 export interface ChromeDebuggerApi {
   attach(target: CdpDebuggee, requiredVersion: string, callback?: () => void): void;
   detach(target: CdpDebuggee, callback?: () => void): void;
@@ -99,6 +140,15 @@ export interface ChromeDebuggerApi {
     addListener(callback: (source: CdpDebuggee, reason: string) => void): void;
     removeListener(callback: (source: CdpDebuggee, reason: string) => void): void;
   };
+  /**
+   * Mirror of `chrome.runtime.lastError`. The chrome.debugger callbacks
+   * report errors by setting `chrome.runtime.lastError` synchronously inside
+   * the callback. We thread the `runtime` reference through the injectable
+   * api so that mocked tests do not need to set anything on a global `chrome`.
+   */
+  runtime: {
+    lastError?: { message?: string };
+  };
 }
 
 /**
@@ -109,13 +159,32 @@ export interface ChromeDebuggerApi {
  * be removed — the shapes are source-compatible with the real types.
  */
 declare const chrome: {
-  debugger: ChromeDebuggerApi;
+  debugger: Omit<ChromeDebuggerApi, "runtime">;
   runtime: {
-    lastError?: { message: string };
+    lastError?: { message?: string };
   };
 };
 
-export function createCdpProxy(api: ChromeDebuggerApi = chrome.debugger): CdpProxy {
+/**
+ * Compose a default `ChromeDebuggerApi` from the real `chrome` global. We
+ * splice `chrome.runtime` onto `chrome.debugger` so that the merged object
+ * satisfies the `ChromeDebuggerApi` interface (which now includes a
+ * `runtime.lastError` field). The runtime reference is read live on every
+ * access — `chrome.runtime.lastError` is set by the browser synchronously
+ * during callback invocation, so we expose it via a getter rather than
+ * snapshotting at module load.
+ */
+function defaultChromeDebuggerApi(): ChromeDebuggerApi {
+  const api = chrome.debugger as ChromeDebuggerApi;
+  return new Proxy(api, {
+    get(target, prop, receiver) {
+      if (prop === "runtime") return chrome.runtime;
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+}
+
+export function createCdpProxy(api: ChromeDebuggerApi = defaultChromeDebuggerApi()): CdpProxy {
   const eventHandlers = new Set<(event: CdpEventFrame) => void>();
 
   const onEventListener = (
@@ -123,8 +192,12 @@ export function createCdpProxy(api: ChromeDebuggerApi = chrome.debugger): CdpPro
     method: string,
     params?: unknown,
   ) => {
-    const event: CdpEventFrame = { method, params };
-    // chrome.debugger.onEvent does not surface sessionId; flat sessions land in params.sessionId.
+    // chrome.debugger.onEvent does not surface sessionId as a separate
+    // argument; for flat sessions Chrome stuffs the value into
+    // `params.sessionId`. Hoist it onto the emitted CdpEventFrame so that
+    // downstream consumers can route events without poking into params.
+    const sessionId = (params as { sessionId?: string } | undefined)?.sessionId;
+    const event: CdpEventFrame = { method, params, sessionId };
     for (const h of eventHandlers) {
       try {
         h(event);
@@ -145,8 +218,8 @@ export function createCdpProxy(api: ChromeDebuggerApi = chrome.debugger): CdpPro
     attach(target, requiredVersion) {
       return new Promise<void>((resolve, reject) => {
         api.attach(targetToDebuggee(target), requiredVersion, () => {
-          const err = chrome.runtime.lastError;
-          if (err) reject(new Error(err.message));
+          const err = api.runtime.lastError;
+          if (err) reject(new Error(err.message ?? "chrome.debugger.attach failed"));
           else resolve();
         });
       });
@@ -154,18 +227,33 @@ export function createCdpProxy(api: ChromeDebuggerApi = chrome.debugger): CdpPro
     detach(target) {
       return new Promise<void>((resolve, reject) => {
         api.detach(targetToDebuggee(target), () => {
-          const err = chrome.runtime.lastError;
-          if (err) reject(new Error(err.message));
+          const err = api.runtime.lastError;
+          if (err) reject(new Error(err.message ?? "chrome.debugger.detach failed"));
           else resolve();
         });
       });
     },
+    /**
+     * Dispatch a CDP command. The chrome.debugger `sendCommand` API does not
+     * accept a sessionId argument: for flat sessions (created via
+     * `Target.attachToTarget` with `flatten: true`) the sessionId is passed
+     * by stuffing it into the command params object. When `frame.sessionId`
+     * is provided we fold it into a shallow copy of `frame.params` before
+     * dispatch so callers do not have to manage that themselves. See the
+     * module docstring for the full flat-session contract.
+     */
     send(target, frame) {
       return new Promise<CdpResultFrame>((resolve) => {
-        api.sendCommand(targetToDebuggee(target), frame.method, frame.params, (result) => {
-          const err = chrome.runtime.lastError;
+        const paramsWithSession = frame.sessionId
+          ? { ...(frame.params ?? {}), sessionId: frame.sessionId }
+          : frame.params;
+        api.sendCommand(targetToDebuggee(target), frame.method, paramsWithSession, (result) => {
+          const err = api.runtime.lastError;
           if (err) {
-            resolve({ id: frame.id, error: { code: -32000, message: err.message } });
+            resolve({
+              id: frame.id,
+              error: { code: -32000, message: err.message ?? "chrome.debugger.sendCommand failed" },
+            });
           } else {
             resolve({ id: frame.id, result });
           }

--- a/clients/chrome-extension/background/cdp-proxy.ts
+++ b/clients/chrome-extension/background/cdp-proxy.ts
@@ -1,0 +1,186 @@
+/**
+ * Standalone CDP JSON-RPC proxy that wraps `chrome.debugger`.
+ *
+ * This module is deliberately decoupled from worker.ts and from any WebSocket
+ * relay — its only responsibility is to provide a typed attach/detach/send/
+ * onEvent surface over the chrome.debugger API. It will be consumed by the
+ * host-browser dispatcher in a follow-up PR (Phase 2 / PR 9). Keeping it
+ * standalone lets us write unit tests against an injectable ChromeDebuggerApi
+ * mock without pulling in the service worker's lifecycle concerns.
+ *
+ * XXX(host-browser-ph2/pr-6): A unit test file
+ *   `clients/chrome-extension/background/__tests__/cdp-proxy.test.ts`
+ * is not included in this PR because `clients/chrome-extension/` does not
+ * yet have a `package.json`, `tsconfig.json`, or any configured test runner
+ * (neither vitest nor bun:test is wired up — the extension is built via
+ * `bun build` from `build.sh`, which does not type-check or run tests).
+ * Per the PR 6 plan instructions, the test file is deferred until a test
+ * runner is introduced for the Chrome extension package. The public surface
+ * (CdpRequestFrame / CdpResultFrame / CdpEventFrame / CdpTarget / CdpProxy /
+ * ChromeDebuggerApi / createCdpProxy) is designed for injectable mocking so
+ * adding tests in a follow-up PR is trivial once a runner exists.
+ */
+
+/** Raw CDP frame as received from the runtime over the relay. */
+export interface CdpRequestFrame {
+  id: number;
+  method: string;
+  params?: Record<string, unknown>;
+  /** Optional CDP session id for nested flat sessions. */
+  sessionId?: string;
+}
+
+/** Raw CDP result frame that the extension sends back. */
+export interface CdpResultFrame {
+  id: number;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+/** CDP event frame forwarded from chrome.debugger.onEvent. */
+export interface CdpEventFrame {
+  method: string;
+  params?: unknown;
+  sessionId?: string;
+}
+
+/**
+ * Target identifier passed to chrome.debugger.attach. Mirrors the shape of
+ * `chrome.debugger.Debuggee` from `@types/chrome` so that when those types
+ * are added to the Chrome extension package in a later PR the cast between
+ * the two is a no-op.
+ */
+export interface CdpDebuggee {
+  tabId?: number;
+  extensionId?: string;
+  targetId?: string;
+}
+
+export interface CdpTarget {
+  tabId?: number;
+  targetId?: string;
+}
+
+export interface CdpProxy {
+  attach(target: CdpTarget, requiredVersion: string): Promise<void>;
+  detach(target: CdpTarget): Promise<void>;
+  send(target: CdpTarget, frame: CdpRequestFrame): Promise<CdpResultFrame>;
+  onEvent(handler: (event: CdpEventFrame) => void): () => void; // returns unsubscribe
+  dispose(): void;
+}
+
+/** Inject the chrome.debugger API so tests can pass a mock. */
+export interface ChromeDebuggerApi {
+  attach(target: CdpDebuggee, requiredVersion: string, callback?: () => void): void;
+  detach(target: CdpDebuggee, callback?: () => void): void;
+  sendCommand(
+    target: CdpDebuggee,
+    method: string,
+    params?: Record<string, unknown>,
+    callback?: (result?: unknown) => void,
+  ): void;
+  onEvent: {
+    addListener(
+      callback: (
+        source: CdpDebuggee,
+        method: string,
+        params?: unknown,
+      ) => void,
+    ): void;
+    removeListener(
+      callback: (
+        source: CdpDebuggee,
+        method: string,
+        params?: unknown,
+      ) => void,
+    ): void;
+  };
+  onDetach: {
+    addListener(callback: (source: CdpDebuggee, reason: string) => void): void;
+    removeListener(callback: (source: CdpDebuggee, reason: string) => void): void;
+  };
+}
+
+/**
+ * Minimal ambient view of the parts of the `chrome` global that this module
+ * touches. Declared locally so the module does not depend on `@types/chrome`
+ * and can compile standalone under a tsconfig that only includes this file.
+ * When `@types/chrome` lands in the extension package these declarations can
+ * be removed — the shapes are source-compatible with the real types.
+ */
+declare const chrome: {
+  debugger: ChromeDebuggerApi;
+  runtime: {
+    lastError?: { message: string };
+  };
+};
+
+export function createCdpProxy(api: ChromeDebuggerApi = chrome.debugger): CdpProxy {
+  const eventHandlers = new Set<(event: CdpEventFrame) => void>();
+
+  const onEventListener = (
+    _source: CdpDebuggee,
+    method: string,
+    params?: unknown,
+  ) => {
+    const event: CdpEventFrame = { method, params };
+    // chrome.debugger.onEvent does not surface sessionId; flat sessions land in params.sessionId.
+    for (const h of eventHandlers) {
+      try {
+        h(event);
+      } catch (err) {
+        console.error("[cdp-proxy] event handler threw", err);
+      }
+    }
+  };
+  api.onEvent.addListener(onEventListener);
+
+  function targetToDebuggee(target: CdpTarget): CdpDebuggee {
+    if (target.targetId) return { targetId: target.targetId };
+    if (target.tabId !== undefined) return { tabId: target.tabId };
+    throw new Error("CdpTarget must have either tabId or targetId");
+  }
+
+  return {
+    attach(target, requiredVersion) {
+      return new Promise<void>((resolve, reject) => {
+        api.attach(targetToDebuggee(target), requiredVersion, () => {
+          const err = chrome.runtime.lastError;
+          if (err) reject(new Error(err.message));
+          else resolve();
+        });
+      });
+    },
+    detach(target) {
+      return new Promise<void>((resolve, reject) => {
+        api.detach(targetToDebuggee(target), () => {
+          const err = chrome.runtime.lastError;
+          if (err) reject(new Error(err.message));
+          else resolve();
+        });
+      });
+    },
+    send(target, frame) {
+      return new Promise<CdpResultFrame>((resolve) => {
+        api.sendCommand(targetToDebuggee(target), frame.method, frame.params, (result) => {
+          const err = chrome.runtime.lastError;
+          if (err) {
+            resolve({ id: frame.id, error: { code: -32000, message: err.message } });
+          } else {
+            resolve({ id: frame.id, result });
+          }
+        });
+      });
+    },
+    onEvent(handler) {
+      eventHandlers.add(handler);
+      return () => {
+        eventHandlers.delete(handler);
+      };
+    },
+    dispose() {
+      eventHandlers.clear();
+      api.onEvent.removeListener(onEventListener);
+    },
+  };
+}

--- a/clients/chrome-extension/background/cdp-proxy.ts
+++ b/clients/chrome-extension/background/cdp-proxy.ts
@@ -1,49 +1,34 @@
 /**
  * Standalone CDP JSON-RPC proxy that wraps `chrome.debugger`.
  *
- * This module is deliberately decoupled from worker.ts and from any WebSocket
- * relay — its only responsibility is to provide a typed attach/detach/send/
- * onEvent surface over the chrome.debugger API. It will be consumed by the
- * host-browser dispatcher in a follow-up PR (Phase 2 / PR 9). Keeping it
- * standalone lets us write unit tests against an injectable ChromeDebuggerApi
- * mock without pulling in the service worker's lifecycle concerns.
+ * Provides a typed attach/detach/send/onEvent surface over the chrome.debugger
+ * API. The module is decoupled from the service worker lifecycle and from any
+ * relay transport so it can be consumed by a host-browser dispatcher and
+ * exercised in isolation. The `ChromeDebuggerApi` interface is injectable so
+ * tests can drive both success and error paths against a mock; tests will be
+ * added once a test runner is configured for this package.
  *
  * Flat-session handling
  * ---------------------
- * The chrome.debugger API does not expose a `sessionId` argument on either
- * `sendCommand` or `onEvent` — sessions created via `Target.attachToTarget`
- * with `flatten: true` are addressed by stuffing the `sessionId` into the
- * command/event `params` object. This proxy mirrors that contract:
+ * Chrome 125+ supports flat sessions created via `Target.attachToTarget` with
+ * `flatten: true`. For flat sessions the child `sessionId` is addressed via
+ * the `target` (DebuggerSession) argument to `chrome.debugger.sendCommand` —
+ * NOT by smuggling the value into the command params object. This proxy
+ * mirrors that contract:
  *
- *   - `send()`: when `frame.sessionId` is provided, it is folded into the
- *     params object as `params.sessionId` before being passed to
- *     `api.sendCommand`. Callers should populate `frame.sessionId` rather
- *     than mutating params themselves.
+ *   - `send()`: when `frame.sessionId` is provided, the value is attached to
+ *     the `DebuggerSession` target passed to `api.sendCommand`. Command params
+ *     are forwarded as-is.
  *
- *   - `onEvent()`: when an event arrives whose `params` contains a
- *     `sessionId` field, that value is hoisted onto the emitted
- *     `CdpEventFrame.sessionId` so consumers can route events without
- *     having to peek into params.
+ *   - `onEvent()`: the `source: DebuggerSession` argument supplied by Chrome
+ *     identifies the originating session. The proxy reads `source.sessionId`
+ *     and hoists it onto the emitted `CdpEventFrame.sessionId` so consumers
+ *     can route events without having to inspect the source object.
  *
  * Errors from the underlying chrome.debugger callbacks are read through
  * `api.runtime.lastError` (rather than the global `chrome.runtime.lastError`)
  * so that tests passing a mocked `ChromeDebuggerApi` can simulate failures
  * by toggling `runtime.lastError` on the mock.
- *
- * XXX(host-browser-ph2/pr-6): A unit test file
- *   `clients/chrome-extension/background/__tests__/cdp-proxy.test.ts`
- * is not included in this PR because `clients/chrome-extension/` does not
- * yet have a `package.json`, `tsconfig.json`, or any configured test runner
- * (neither vitest nor bun:test is wired up — the extension is built via
- * `bun build` from `build.sh`, which does not type-check or run tests).
- * Per the PR 6 plan instructions, the test file is deferred until a test
- * runner is introduced for the Chrome extension package. The public surface
- * (CdpRequestFrame / CdpResultFrame / CdpEventFrame / CdpTarget / CdpProxy /
- * ChromeDebuggerApi / createCdpProxy) is designed for injectable mocking so
- * adding tests in a follow-up PR is trivial once a runner exists. Now that
- * `runtime.lastError` is part of the injectable `ChromeDebuggerApi`, mocked
- * tests can fully exercise both success and error paths without depending
- * on a real `chrome` global.
  */
 
 /** Raw CDP frame as received from the runtime over the relay. */
@@ -52,10 +37,9 @@ export interface CdpRequestFrame {
   method: string;
   params?: Record<string, unknown>;
   /**
-   * Optional CDP session id for nested flat sessions. The chrome.debugger
-   * `sendCommand` API does not accept a sessionId argument; this proxy folds
-   * the value into `params.sessionId` before dispatch (see the module
-   * docstring for the flat-session contract).
+   * Optional CDP session id for nested flat sessions. Routed via the
+   * `DebuggerSession` target argument of `chrome.debugger.sendCommand` (see
+   * the module docstring for the flat-session contract).
    */
   sessionId?: string;
 }
@@ -86,6 +70,16 @@ export interface CdpDebuggee {
   targetId?: string;
 }
 
+/**
+ * `DebuggerSession` is the Chrome 125+ shape that `chrome.debugger.sendCommand`
+ * (and the `onEvent` `source` argument) accept: a `Debuggee` plus an optional
+ * `sessionId` that addresses a child flat session created via
+ * `Target.attachToTarget` with `flatten: true`.
+ */
+export interface DebuggerSession extends CdpDebuggee {
+  sessionId?: string;
+}
+
 export interface CdpTarget {
   tabId?: number;
   targetId?: string;
@@ -96,6 +90,7 @@ export interface CdpProxy {
   detach(target: CdpTarget): Promise<void>;
   send(target: CdpTarget, frame: CdpRequestFrame): Promise<CdpResultFrame>;
   onEvent(handler: (event: CdpEventFrame) => void): () => void; // returns unsubscribe
+  onDetach(handler: (target: CdpDebuggee, reason: string) => void): () => void; // returns unsubscribe
   dispose(): void;
 }
 
@@ -106,16 +101,20 @@ export interface CdpProxy {
  * `runtime.lastError` field — at runtime we satisfy this by composing
  * `chrome.debugger` and `chrome.runtime` (see the default in `createCdpProxy`).
  *
+ * `attach` / `detach` / `sendCommand` / `onEvent` all accept a
+ * `DebuggerSession` so that flat-session child commands and events can be
+ * routed via the target's `sessionId` field, matching Chrome 125+ semantics.
+ *
  * Reading `lastError` through the injected `api.runtime.lastError` (rather
  * than the global `chrome.runtime.lastError`) is what makes the proxy
  * properly testable: a mocked `ChromeDebuggerApi` can simulate failure paths
  * by toggling `runtime.lastError` on the mock between callback invocations.
  */
 export interface ChromeDebuggerApi {
-  attach(target: CdpDebuggee, requiredVersion: string, callback?: () => void): void;
-  detach(target: CdpDebuggee, callback?: () => void): void;
+  attach(target: DebuggerSession, requiredVersion: string, callback?: () => void): void;
+  detach(target: DebuggerSession, callback?: () => void): void;
   sendCommand(
-    target: CdpDebuggee,
+    target: DebuggerSession,
     method: string,
     params?: Record<string, unknown>,
     callback?: (result?: unknown) => void,
@@ -123,14 +122,14 @@ export interface ChromeDebuggerApi {
   onEvent: {
     addListener(
       callback: (
-        source: CdpDebuggee,
+        source: DebuggerSession,
         method: string,
         params?: unknown,
       ) => void,
     ): void;
     removeListener(
       callback: (
-        source: CdpDebuggee,
+        source: DebuggerSession,
         method: string,
         params?: unknown,
       ) => void,
@@ -186,18 +185,18 @@ function defaultChromeDebuggerApi(): ChromeDebuggerApi {
 
 export function createCdpProxy(api: ChromeDebuggerApi = defaultChromeDebuggerApi()): CdpProxy {
   const eventHandlers = new Set<(event: CdpEventFrame) => void>();
+  const detachHandlers = new Set<(target: CdpDebuggee, reason: string) => void>();
 
   const onEventListener = (
-    _source: CdpDebuggee,
+    source: DebuggerSession,
     method: string,
     params?: unknown,
   ) => {
-    // chrome.debugger.onEvent does not surface sessionId as a separate
-    // argument; for flat sessions Chrome stuffs the value into
-    // `params.sessionId`. Hoist it onto the emitted CdpEventFrame so that
-    // downstream consumers can route events without poking into params.
-    const sessionId = (params as { sessionId?: string } | undefined)?.sessionId;
-    const event: CdpEventFrame = { method, params, sessionId };
+    // For flat sessions Chrome 125+ surfaces the originating session id on
+    // the `source` DebuggerSession (NOT inside `params`). Hoist it onto the
+    // emitted CdpEventFrame so downstream consumers can route events without
+    // having to inspect the source object.
+    const event: CdpEventFrame = { method, params, sessionId: source.sessionId };
     for (const h of eventHandlers) {
       try {
         h(event);
@@ -207,6 +206,17 @@ export function createCdpProxy(api: ChromeDebuggerApi = defaultChromeDebuggerApi
     }
   };
   api.onEvent.addListener(onEventListener);
+
+  const onDetachListener = (source: CdpDebuggee, reason: string) => {
+    for (const h of detachHandlers) {
+      try {
+        h(source, reason);
+      } catch (err) {
+        console.error("[cdp-proxy] detach handler threw", err);
+      }
+    }
+  };
+  api.onDetach.addListener(onDetachListener);
 
   function targetToDebuggee(target: CdpTarget): CdpDebuggee {
     if (target.targetId) return { targetId: target.targetId };
@@ -234,20 +244,19 @@ export function createCdpProxy(api: ChromeDebuggerApi = defaultChromeDebuggerApi
       });
     },
     /**
-     * Dispatch a CDP command. The chrome.debugger `sendCommand` API does not
-     * accept a sessionId argument: for flat sessions (created via
-     * `Target.attachToTarget` with `flatten: true`) the sessionId is passed
-     * by stuffing it into the command params object. When `frame.sessionId`
-     * is provided we fold it into a shallow copy of `frame.params` before
-     * dispatch so callers do not have to manage that themselves. See the
-     * module docstring for the full flat-session contract.
+     * Dispatch a CDP command. For flat sessions (created via
+     * `Target.attachToTarget` with `flatten: true`) Chrome 125+ routes the
+     * child `sessionId` via the `target` (DebuggerSession) argument — not
+     * via the command params object. When `frame.sessionId` is provided we
+     * attach it to the DebuggerSession passed to `api.sendCommand`; params
+     * are forwarded as-is.
      */
     send(target, frame) {
       return new Promise<CdpResultFrame>((resolve) => {
-        const paramsWithSession = frame.sessionId
-          ? { ...(frame.params ?? {}), sessionId: frame.sessionId }
-          : frame.params;
-        api.sendCommand(targetToDebuggee(target), frame.method, paramsWithSession, (result) => {
+        const debuggerSession: DebuggerSession = frame.sessionId
+          ? { ...targetToDebuggee(target), sessionId: frame.sessionId }
+          : targetToDebuggee(target);
+        api.sendCommand(debuggerSession, frame.method, frame.params, (result) => {
           const err = api.runtime.lastError;
           if (err) {
             resolve({
@@ -266,9 +275,17 @@ export function createCdpProxy(api: ChromeDebuggerApi = defaultChromeDebuggerApi
         eventHandlers.delete(handler);
       };
     },
+    onDetach(handler) {
+      detachHandlers.add(handler);
+      return () => {
+        detachHandlers.delete(handler);
+      };
+    },
     dispose() {
       eventHandlers.clear();
+      detachHandlers.clear();
       api.onEvent.removeListener(onEventListener);
+      api.onDetach.removeListener(onDetachListener);
     },
   };
 }

--- a/clients/chrome-extension/background/cdp-proxy.ts
+++ b/clients/chrome-extension/background/cdp-proxy.ts
@@ -166,21 +166,29 @@ declare const chrome: {
 
 /**
  * Compose a default `ChromeDebuggerApi` from the real `chrome` global. We
- * splice `chrome.runtime` onto `chrome.debugger` so that the merged object
- * satisfies the `ChromeDebuggerApi` interface (which now includes a
- * `runtime.lastError` field). The runtime reference is read live on every
- * access — `chrome.runtime.lastError` is set by the browser synchronously
- * during callback invocation, so we expose it via a getter rather than
- * snapshotting at module load.
+ * build a plain object with `chrome.debugger`'s methods explicitly bound to
+ * `chrome.debugger`, plus a live `runtime` getter that reads `chrome.runtime`
+ * on every access. Methods MUST be bound: Chrome's native bindings check
+ * `this` to be the original `chrome.debugger` object and will throw
+ * "Illegal invocation" otherwise. The `onEvent` / `onDetach` event objects
+ * are forwarded as-is — `chrome.events.Event` instances expose
+ * `addListener` / `removeListener` that don't depend on the surrounding
+ * receiver. The `runtime` getter (rather than a snapshot) is required because
+ * `chrome.runtime.lastError` is set by the browser synchronously during
+ * callback invocation.
  */
 function defaultChromeDebuggerApi(): ChromeDebuggerApi {
-  const api = chrome.debugger as ChromeDebuggerApi;
-  return new Proxy(api, {
-    get(target, prop, receiver) {
-      if (prop === "runtime") return chrome.runtime;
-      return Reflect.get(target, prop, receiver);
+  const d = chrome.debugger;
+  return {
+    attach: d.attach.bind(d),
+    detach: d.detach.bind(d),
+    sendCommand: d.sendCommand.bind(d),
+    onEvent: d.onEvent,
+    onDetach: d.onDetach,
+    get runtime() {
+      return chrome.runtime;
     },
-  });
+  };
 }
 
 export function createCdpProxy(api: ChromeDebuggerApi = defaultChromeDebuggerApi()): CdpProxy {

--- a/clients/chrome-extension/tsconfig.json
+++ b/clients/chrome-extension/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["ES2022", "DOM"],
+    "noEmit": true
+  },
+  "include": [
+    "background/cdp-proxy.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- New standalone module clients/chrome-extension/background/cdp-proxy.ts wrapping chrome.debugger
- Generic attach/detach/sendCommand/onEvent interface decoupled from the WebSocket relay
- Not yet imported by worker.ts — integration lands in a later PR

Part of plan: host-browser-proxy-phase-2.md (PR 6 of 16)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
