### PR TITLE
feat(chrome-extension-native-host): add native messaging helper scaffold

### DIFF
--- a/clients/chrome-extension-native-host/README.md
+++ b/clients/chrome-extension-native-host/README.md
@@ -1,0 +1,161 @@
+# @vellum/chrome-extension-native-host
+
+A tiny Node CLI binary that bridges the Vellum Chrome extension and the
+locally-running Vellum assistant via [Chrome Native Messaging][cnm]. It
+exists so the extension can bootstrap a scoped capability token for the
+self-hosted (local-daemon) transport without ever shipping a long-lived
+secret in the extension package itself.
+
+This package is **scaffolding only** in this PR. It is not yet wired into
+the extension or the macOS installer — those land in PR 12 (manifest +
+installer) and PR 13 (extension self-hosted bootstrap flow). The runtime
+HTTP endpoint it talks to (`/v1/browser-extension-pair`) lands in PR 11.
+
+[cnm]: https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging
+
+## Why a separate binary?
+
+Chrome only allows extensions to talk to native code through the native
+messaging protocol: a stdio pipe with a 4-byte little-endian length prefix
+and a UTF-8 JSON body. The host binary is registered with Chrome via a
+JSON manifest installed in a well-known location, and Chrome enforces an
+allowlist of extension IDs in that manifest before it will spawn the
+binary at all.
+
+Keeping the helper as its own package gives us:
+
+- A clean security boundary: the helper has zero imports from the
+  extension or the assistant daemon, and verifies the calling extension
+  ID against a hard-coded allowlist before doing any work.
+- A small, auditable surface: ~200 lines of TypeScript that compile to a
+  single Node CLI entry point.
+- Simple distribution: the macOS installer (PR 12) just drops the
+  compiled `dist/index.js` and a manifest into `~/Library/Application
+  Support/Google/Chrome/NativeMessagingHosts/`.
+
+## Stdio contract
+
+The helper speaks a single request/response exchange per spawn. Chrome
+re-spawns it on every `chrome.runtime.connectNative("com.vellum.daemon")`
+call, so there is no long-lived session state.
+
+### Frame format
+
+Every message in either direction is framed as:
+
+```
++--------+----------------------------+
+| u32 LE |   UTF-8 JSON (len bytes)   |
+| length |                            |
++--------+----------------------------+
+```
+
+`encodeFrame(payload)` and `decodeFrames(buf)` in `src/protocol.ts` are
+the canonical implementations. They are pure functions — no I/O — and are
+covered by `src/__tests__/protocol.test.ts`.
+
+### Messages
+
+The extension sends:
+
+```json
+{ "type": "request_token" }
+```
+
+On success, the helper writes:
+
+```json
+{
+  "type": "token_response",
+  "token": "<scoped capability token>",
+  "expiresAt": "<ISO-8601 timestamp>"
+}
+```
+
+On any failure, the helper writes:
+
+```json
+{ "type": "error", "message": "<reason>" }
+```
+
+…and exits with a non-zero status code. Possible `message` values
+include `unauthorized_origin`, `unsupported_frame_type`,
+`unexpected_additional_frame`, and any error string surfaced by the
+underlying `fetch` to the daemon (`failed to reach daemon at …`,
+`daemon pair request failed with HTTP 503`, etc.).
+
+## Origin allowlist
+
+Chrome appends the calling extension's origin (e.g.
+`chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/`) as the first
+positional argument when launching the host. The helper parses this,
+extracts the bare extension ID, and rejects anything not in
+`ALLOWED_EXTENSION_IDS` in `src/index.ts` before reading any stdin
+bytes.
+
+Today the allowlist contains a single dev placeholder ID. The production
+ID will be added before release — see the `// TODO: production id before
+release` comment in `src/index.ts`.
+
+## Daemon port resolution
+
+The helper looks up the daemon's HTTP port by reading
+`~/.vellum/runtime-port` (a single integer written by the assistant on
+startup). If the file is missing, unreadable, or doesn't contain a valid
+port number, it falls back to the well-known default port `7821`. The
+subsequent HTTP request will surface a clear connection error if the
+daemon isn't actually listening there.
+
+## Building
+
+```bash
+cd clients/chrome-extension-native-host
+bun install
+bun run build       # produces dist/index.js
+```
+
+`bun run build` is a thin wrapper around `tsc -p tsconfig.json`. The
+output is a single ES module file under `dist/` that can be invoked
+directly with `node dist/index.js`.
+
+## Testing
+
+```bash
+cd clients/chrome-extension-native-host
+bun test src/__tests__/protocol.test.ts
+```
+
+The current test suite covers the framing protocol (round-trips,
+multi-frame buffers, partial frames, empty buffers). The CLI itself does
+not yet have integration tests — those land alongside PR 13 when the
+extension-side bootstrap flow is wired up.
+
+## Local manual smoke test
+
+Once the daemon is running and exposing `/v1/browser-extension-pair`
+(PR 11), you can exercise the helper end-to-end without Chrome by piping
+a framed request to it on stdin. Add the extension ID you want to test
+to `ALLOWED_EXTENSION_IDS` in `src/index.ts` (or use the existing dev
+placeholder), then:
+
+```bash
+node -e "
+  const { encodeFrame } = require('./dist/protocol.js');
+  process.stdout.write(encodeFrame({ type: 'request_token' }));
+" | node dist/index.js "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/"
+```
+
+The helper will write a single `token_response` frame to stdout and
+exit `0`, or an `error` frame and exit `1`.
+
+## Related PRs
+
+- **PR 11** — Daemon `/v1/browser-extension-pair` endpoint that mints
+  the capability token this helper requests.
+- **PR 12** — macOS installer changes that drop the compiled binary and
+  the native messaging host manifest into Chrome's well-known
+  `NativeMessagingHosts` directory.
+- **PR 13** — Chrome extension changes that call
+  `chrome.runtime.connectNative("com.vellum.daemon")`, send a
+  `request_token` frame, and persist the response in
+  `chrome.storage.local`.

--- a/clients/chrome-extension-native-host/README.md
+++ b/clients/chrome-extension-native-host/README.md
@@ -80,9 +80,13 @@ On any failure, the helper writes:
 
 …and exits with a non-zero status code. Possible `message` values
 include `unauthorized_origin`, `unsupported_frame_type`,
-`unexpected_additional_frame`, and any error string surfaced by the
-underlying `fetch` to the daemon (`failed to reach daemon at …`,
-`daemon pair request failed with HTTP 503`, etc.).
+`unexpected_additional_frame`, `protocol_error: malformed_frame_json: …`
+(returned when stdin contains a frame whose body is not valid JSON), and
+any error string surfaced by the underlying `fetch` to the assistant
+(`failed to reach assistant at …`, `assistant pair request failed with
+HTTP 503`, etc.). Per the project-wide terminology rule in `AGENTS.md`,
+all user-visible strings refer to the local process as the "assistant"
+even though the binary is internally talking to the daemon HTTP server.
 
 ## Origin allowlist
 
@@ -97,14 +101,34 @@ Today the allowlist contains a single dev placeholder ID. The production
 ID will be added before release — see the `// TODO: production id before
 release` comment in `src/index.ts`.
 
-## Daemon port resolution
+## Assistant port resolution
 
-The helper looks up the daemon's HTTP port by reading
-`~/.vellum/runtime-port` (a single integer written by the assistant on
-startup). If the file is missing, unreadable, or doesn't contain a valid
-port number, it falls back to the well-known default port `7821`. The
-subsequent HTTP request will surface a clear connection error if the
-daemon isn't actually listening there.
+The helper looks up the assistant daemon's HTTP port using the following
+precedence (highest first):
+
+1. **`--assistant-port <port>`** CLI flag — accepts either
+   `--assistant-port 7822` or `--assistant-port=7822`. This exists so a
+   wrapper script registered in Chrome's `NativeMessagingHosts` manifest
+   can pin the helper to a known port for non-default installs (e.g.
+   named local instances spawned by `cli/src/lib/local.ts` which set
+   `RUNTIME_HTTP_PORT` from `resources.daemonPort`).
+2. **`~/.vellum/runtime-port`** lockfile — a single integer written by
+   the assistant on startup. *Note: this lockfile is not yet written by
+   the daemon — see the TODO below.* Once it is, default installs will
+   not need any manifest-side configuration.
+3. **`7821`** — the well-known default port.
+
+If a step fails (file missing, parse error, etc.), resolution falls
+through to the next step. The subsequent HTTP request will surface a
+clear connection error if the assistant isn't actually listening on the
+resolved port.
+
+> **TODO (follow-up):** Have the assistant daemon write its active HTTP
+> port to `~/.vellum/runtime-port` on startup so the lockfile branch
+> above starts working without requiring `--assistant-port`. This was
+> intentionally left out of the scaffold PR (PR 7) to keep the change
+> surface small. Until then, multi-instance installs should rely on the
+> CLI flag via a wrapper script in the native messaging manifest.
 
 ## Building
 
@@ -147,6 +171,17 @@ node -e "
 
 The helper will write a single `token_response` frame to stdout and
 exit `0`, or an `error` frame and exit `1`.
+
+To target a non-default assistant port (e.g. a named local instance):
+
+```bash
+node -e "
+  const { encodeFrame } = require('./dist/protocol.js');
+  process.stdout.write(encodeFrame({ type: 'request_token' }));
+" | node dist/index.js \
+    "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/" \
+    --assistant-port 7822
+```
 
 ## Related PRs
 

--- a/clients/chrome-extension-native-host/README.md
+++ b/clients/chrome-extension-native-host/README.md
@@ -3,7 +3,7 @@
 A tiny Node CLI binary that bridges the Vellum Chrome extension and the
 locally-running Vellum assistant via [Chrome Native Messaging][cnm]. It
 exists so the extension can bootstrap a scoped capability token for the
-self-hosted (local-daemon) transport without ever shipping a long-lived
+self-hosted (local-assistant) transport without ever shipping a long-lived
 secret in the extension package itself.
 
 This package is **scaffolding only** in this PR. It is not yet wired into
@@ -25,7 +25,7 @@ binary at all.
 Keeping the helper as its own package gives us:
 
 - A clean security boundary: the helper has zero imports from the
-  extension or the assistant daemon, and verifies the calling extension
+  extension or the assistant, and verifies the calling extension
   ID against a hard-coded allowlist before doing any work.
 - A small, auditable surface: ~200 lines of TypeScript that compile to a
   single Node CLI entry point.
@@ -85,8 +85,7 @@ include `unauthorized_origin`, `unsupported_frame_type`,
 any error string surfaced by the underlying `fetch` to the assistant
 (`failed to reach assistant at …`, `assistant pair request failed with
 HTTP 503`, etc.). Per the project-wide terminology rule in `AGENTS.md`,
-all user-visible strings refer to the local process as the "assistant"
-even though the binary is internally talking to the daemon HTTP server.
+all user-visible strings refer to the local process as the "assistant".
 
 ## Origin allowlist
 
@@ -103,7 +102,7 @@ release` comment in `src/index.ts`.
 
 ## Assistant port resolution
 
-The helper looks up the assistant daemon's HTTP port using the following
+The helper looks up the assistant's HTTP port using the following
 precedence (highest first):
 
 1. **`--assistant-port <port>`** CLI flag — accepts either
@@ -114,8 +113,8 @@ precedence (highest first):
    `RUNTIME_HTTP_PORT` from `resources.daemonPort`).
 2. **`~/.vellum/runtime-port`** lockfile — a single integer written by
    the assistant on startup. *Note: this lockfile is not yet written by
-   the daemon — see the TODO below.* Once it is, default installs will
-   not need any manifest-side configuration.
+   the assistant — see the TODO below.* Once it is, default installs
+   will not need any manifest-side configuration.
 3. **`7821`** — the well-known default port.
 
 If a step fails (file missing, parse error, etc.), resolution falls
@@ -123,9 +122,9 @@ through to the next step. The subsequent HTTP request will surface a
 clear connection error if the assistant isn't actually listening on the
 resolved port.
 
-> **TODO (follow-up):** Have the assistant daemon write its active HTTP
-> port to `~/.vellum/runtime-port` on startup so the lockfile branch
-> above starts working without requiring `--assistant-port`. This was
+> **TODO (follow-up):** Have the assistant write its active HTTP port
+> to `~/.vellum/runtime-port` on startup so the lockfile branch above
+> starts working without requiring `--assistant-port`. This was
 > intentionally left out of the scaffold PR (PR 7) to keep the change
 > surface small. Until then, multi-instance installs should rely on the
 > CLI flag via a wrapper script in the native messaging manifest.
@@ -156,18 +155,22 @@ extension-side bootstrap flow is wired up.
 
 ## Local manual smoke test
 
-Once the daemon is running and exposing `/v1/browser-extension-pair`
+Once the assistant is running and exposing `/v1/browser-extension-pair`
 (PR 11), you can exercise the helper end-to-end without Chrome by piping
 a framed request to it on stdin. Add the extension ID you want to test
 to `ALLOWED_EXTENSION_IDS` in `src/index.ts` (or use the existing dev
 placeholder), then:
 
 ```bash
-node -e "
-  const { encodeFrame } = require('./dist/protocol.js');
+node --input-type=module -e "
+  import { encodeFrame } from './dist/protocol.js';
   process.stdout.write(encodeFrame({ type: 'request_token' }));
 " | node dist/index.js "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/"
 ```
+
+(The package is ESM — `"type": "module"` in `package.json` — so the
+inline snippet uses `--input-type=module` and dynamic `import()` rather
+than `require()`, which would fail with `ERR_REQUIRE_ESM`.)
 
 The helper will write a single `token_response` frame to stdout and
 exit `0`, or an `error` frame and exit `1`.
@@ -175,8 +178,8 @@ exit `0`, or an `error` frame and exit `1`.
 To target a non-default assistant port (e.g. a named local instance):
 
 ```bash
-node -e "
-  const { encodeFrame } = require('./dist/protocol.js');
+node --input-type=module -e "
+  import { encodeFrame } from './dist/protocol.js';
   process.stdout.write(encodeFrame({ type: 'request_token' }));
 " | node dist/index.js \
     "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/" \
@@ -185,7 +188,7 @@ node -e "
 
 ## Related PRs
 
-- **PR 11** — Daemon `/v1/browser-extension-pair` endpoint that mints
+- **PR 11** — Assistant `/v1/browser-extension-pair` endpoint that mints
   the capability token this helper requests.
 - **PR 12** — macOS installer changes that drop the compiled binary and
   the native messaging host manifest into Chrome's well-known

--- a/clients/chrome-extension-native-host/bun.lock
+++ b/clients/chrome-extension-native-host/bun.lock
@@ -1,0 +1,20 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@vellum/chrome-extension-native-host",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.5.0",
+      },
+    },
+  },
+  "packages": {
+    "@types/node": ["@types/node@20.19.39", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+  }
+}

--- a/clients/chrome-extension-native-host/package.json
+++ b/clients/chrome-extension-native-host/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@vellum/chrome-extension-native-host",
+  "version": "0.1.0",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "bin": {
+    "vellum-chrome-native-host": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "bunx tsc --noEmit",
+    "test": "bun test src/"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/clients/chrome-extension-native-host/src/__tests__/protocol.test.ts
+++ b/clients/chrome-extension-native-host/src/__tests__/protocol.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for the Chrome native messaging stdio framing in protocol.ts.
+ *
+ * Run with `bun test src/__tests__/protocol.test.ts` from the package root.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { decodeFrames, encodeFrame } from "../protocol.js";
+
+describe("encodeFrame / decodeFrames", () => {
+  test("round-trips a simple object through encode/decode", () => {
+    const payload = { type: "request_token", origin: "chrome-extension://abc/" };
+    const frame = encodeFrame(payload);
+
+    // Frame layout: 4-byte LE length prefix followed by JSON body.
+    expect(frame.length).toBeGreaterThan(4);
+    const expectedLen = Buffer.from(JSON.stringify(payload), "utf8").length;
+    expect(frame.readUInt32LE(0)).toBe(expectedLen);
+
+    const { frames, remainder } = decodeFrames(frame);
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toEqual(payload);
+    expect(remainder.length).toBe(0);
+  });
+
+  test("decodes multiple frames in one buffer", () => {
+    const a = { type: "first", n: 1 };
+    const b = { type: "second", n: 2 };
+    const c = { type: "third", nested: { ok: true } };
+    const combined = Buffer.concat([encodeFrame(a), encodeFrame(b), encodeFrame(c)]);
+
+    const { frames, remainder } = decodeFrames(combined);
+    expect(frames).toHaveLength(3);
+    expect(frames[0]).toEqual(a);
+    expect(frames[1]).toEqual(b);
+    expect(frames[2]).toEqual(c);
+    expect(remainder.length).toBe(0);
+  });
+
+  test("leaves a partial frame in the remainder", () => {
+    const payload = { type: "request_token" };
+    const frame = encodeFrame(payload);
+    // Slice off the last 3 bytes of the JSON body so the frame is incomplete.
+    const truncated = frame.subarray(0, frame.length - 3);
+
+    const { frames, remainder } = decodeFrames(truncated);
+    expect(frames).toHaveLength(0);
+    // Remainder should equal the truncated input verbatim so the caller can
+    // append the next chunk and try again.
+    expect(remainder.equals(truncated)).toBe(true);
+  });
+
+  test("leaves a partial length prefix in the remainder", () => {
+    // Less than 4 bytes — not even enough for the length field.
+    const partial = Buffer.from([0x01, 0x02]);
+    const { frames, remainder } = decodeFrames(partial);
+    expect(frames).toHaveLength(0);
+    expect(remainder.equals(partial)).toBe(true);
+  });
+
+  test("decodes a complete frame followed by a partial frame", () => {
+    const complete = { type: "complete" };
+    const partialPayload = { type: "partial" };
+    const combined = Buffer.concat([
+      encodeFrame(complete),
+      encodeFrame(partialPayload).subarray(0, 5),
+    ]);
+
+    const { frames, remainder } = decodeFrames(combined);
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toEqual(complete);
+    expect(remainder.length).toBe(5);
+  });
+
+  test("handles an empty buffer", () => {
+    const { frames, remainder } = decodeFrames(Buffer.alloc(0));
+    expect(frames).toHaveLength(0);
+    expect(remainder.length).toBe(0);
+  });
+});

--- a/clients/chrome-extension-native-host/src/__tests__/protocol.test.ts
+++ b/clients/chrome-extension-native-host/src/__tests__/protocol.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { decodeFrames, encodeFrame } from "../protocol.js";
+import { decodeFrames, encodeFrame, FrameDecodeError } from "../protocol.js";
 
 describe("encodeFrame / decodeFrames", () => {
   test("round-trips a simple object through encode/decode", () => {
@@ -77,5 +77,50 @@ describe("encodeFrame / decodeFrames", () => {
     const { frames, remainder } = decodeFrames(Buffer.alloc(0));
     expect(frames).toHaveLength(0);
     expect(remainder.length).toBe(0);
+  });
+
+  test("throws FrameDecodeError when a complete frame body is invalid JSON", () => {
+    // Hand-craft a frame: 4-byte LE length prefix + a body that is not
+    // valid JSON. The decoder should reach the JSON.parse step (because
+    // the buffer has a full frame's worth of bytes) and throw, rather
+    // than crashing the host with an uncaught SyntaxError.
+    const body = Buffer.from("not-json{", "utf8");
+    const len = Buffer.alloc(4);
+    len.writeUInt32LE(body.length, 0);
+    const malformed = Buffer.concat([len, body]);
+
+    expect(() => decodeFrames(malformed)).toThrow(FrameDecodeError);
+    expect(() => decodeFrames(malformed)).toThrow(/malformed_frame_json/);
+  });
+
+  test("FrameDecodeError preserves the underlying SyntaxError as cause", () => {
+    const body = Buffer.from("{not-valid", "utf8");
+    const len = Buffer.alloc(4);
+    len.writeUInt32LE(body.length, 0);
+    const malformed = Buffer.concat([len, body]);
+
+    let caught: unknown;
+    try {
+      decodeFrames(malformed);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(FrameDecodeError);
+    expect((caught as FrameDecodeError).cause).toBeInstanceOf(SyntaxError);
+  });
+
+  test("a malformed frame after a valid one still throws (does not silently drop the valid one)", () => {
+    // Buffer layout: [valid frame][malformed frame]. The decoder iterates
+    // in order and throws on the second frame. The current contract is
+    // "fail loud on the first malformed frame" — we don't try to return
+    // any frames decoded before the failure, since the caller should
+    // surface a protocol_error and exit anyway.
+    const valid = encodeFrame({ type: "request_token" });
+    const badBody = Buffer.from("definitely not json", "utf8");
+    const badLen = Buffer.alloc(4);
+    badLen.writeUInt32LE(badBody.length, 0);
+    const combined = Buffer.concat([valid, badLen, badBody]);
+
+    expect(() => decodeFrames(combined)).toThrow(FrameDecodeError);
   });
 });

--- a/clients/chrome-extension-native-host/src/index.ts
+++ b/clients/chrome-extension-native-host/src/index.ts
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+/**
+ * Vellum chrome-extension native messaging helper.
+ *
+ * This binary is spawned by Chrome when the Vellum browser extension calls
+ * `chrome.runtime.connectNative("com.vellum.daemon")`. It speaks the Chrome
+ * native messaging stdio protocol (4-byte little-endian length prefix +
+ * UTF-8 JSON) on stdin/stdout.
+ *
+ * Responsibilities:
+ *
+ *   1. Verify that the calling extension's origin (passed by Chrome as the
+ *      first command-line argument, e.g. `chrome-extension://<id>/`) is on a
+ *      hard-coded allowlist of known Vellum extension IDs.
+ *   2. Listen on stdin for `{ type: "request_token" }` frames.
+ *   3. POST the calling extension's origin to the running daemon's
+ *      `/v1/browser-extension-pair` endpoint (port resolved from
+ *      `~/.vellum/runtime-port` or defaulting to 7821).
+ *   4. Echo the daemon's response back to Chrome as a
+ *      `{ type: "token_response", token, expiresAt }` frame.
+ *   5. On any unrecoverable error, write a `{ type: "error", message }` frame
+ *      and exit with a non-zero status.
+ *
+ * The helper deliberately does NOT persist tokens — the extension is
+ * responsible for storing the returned token in `chrome.storage.local`.
+ *
+ * See PR 11 (`/v1/browser-extension-pair` endpoint) and PR 12 (native
+ * messaging host manifest + macOS installer wiring) for the rest of the
+ * pairing flow.
+ */
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { decodeFrames, encodeFrame } from "./protocol.js";
+
+/**
+ * Allowlist of Chrome extension IDs that are permitted to spawn this helper.
+ *
+ * Chrome passes the calling extension's origin as the first positional
+ * argument, e.g. `chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/`.
+ * Anything not on this list is rejected before any further processing.
+ */
+const ALLOWED_EXTENSION_IDS: ReadonlySet<string> = new Set<string>([
+  // Dev placeholder — replaced when the unpacked extension is loaded locally.
+  // TODO: production id before release
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+]);
+
+const DEFAULT_DAEMON_PORT = 7821;
+const RUNTIME_PORT_FILE = join(homedir(), ".vellum", "runtime-port");
+
+interface TokenResponse {
+  token: string;
+  expiresAt: string;
+}
+
+/**
+ * Resolve the daemon's HTTP port. The Mac app writes the active port to
+ * `~/.vellum/runtime-port` on startup; if the file is missing or unreadable
+ * we fall back to the well-known default. Any parse failure also falls back
+ * rather than crashing — the daemon is the ultimate source of truth and the
+ * subsequent HTTP call will surface a clear connection error.
+ */
+function resolveDaemonPort(): number {
+  try {
+    const raw = readFileSync(RUNTIME_PORT_FILE, "utf8").trim();
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isFinite(parsed) && parsed > 0 && parsed < 65536) {
+      return parsed;
+    }
+  } catch {
+    // Fall through to the default. This is expected on first launch and in
+    // dev environments where the port file hasn't been written yet.
+  }
+  return DEFAULT_DAEMON_PORT;
+}
+
+/**
+ * Extract the bare extension id from a `chrome-extension://<id>/` origin.
+ * Returns `null` if the input doesn't match the expected shape.
+ */
+function parseExtensionId(origin: string | undefined): string | null {
+  if (!origin) return null;
+  const match = origin.match(/^chrome-extension:\/\/([a-p]{32})\/?$/);
+  return match ? match[1]! : null;
+}
+
+/**
+ * Write a single native-messaging frame to stdout. Uses the synchronous
+ * write path so the caller can `process.exit()` immediately after without
+ * losing the frame in a buffered queue.
+ */
+function writeFrame(payload: unknown): void {
+  process.stdout.write(encodeFrame(payload));
+}
+
+/**
+ * Emit an `error` frame and exit with a non-zero status. Also logs the
+ * underlying message to stderr so an operator running the binary by hand
+ * (or a Chrome extension developer inspecting the host's stderr stream)
+ * can see what went wrong.
+ */
+function fail(message: string, code = 1): never {
+  process.stderr.write(`vellum-chrome-native-host: ${message}\n`);
+  try {
+    writeFrame({ type: "error", message });
+  } catch {
+    // If even writing the error frame fails (e.g. stdout already closed),
+    // there's nothing useful to do — just exit.
+  }
+  process.exit(code);
+}
+
+/**
+ * POST the extension origin to the daemon's pair endpoint and return the
+ * issued capability token. Surfaces a uniform error message on failure so
+ * the caller can wrap it in a native-messaging error frame.
+ */
+async function requestToken(extensionOrigin: string): Promise<TokenResponse> {
+  const port = resolveDaemonPort();
+  const url = `http://127.0.0.1:${port}/v1/browser-extension-pair`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ extensionOrigin }),
+    });
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(`failed to reach daemon at ${url}: ${detail}`);
+  }
+
+  if (!response.ok) {
+    throw new Error(`daemon pair request failed with HTTP ${response.status}`);
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(`daemon pair response was not valid JSON: ${detail}`);
+  }
+
+  if (
+    !body ||
+    typeof body !== "object" ||
+    typeof (body as { token?: unknown }).token !== "string" ||
+    typeof (body as { expiresAt?: unknown }).expiresAt !== "string"
+  ) {
+    throw new Error("daemon pair response missing token / expiresAt");
+  }
+
+  const { token, expiresAt } = body as TokenResponse;
+  return { token, expiresAt };
+}
+
+async function main(): Promise<void> {
+  // Chrome passes the calling extension's origin (e.g.
+  // `chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/`) as the first
+  // positional argument when it spawns the native messaging host.
+  //
+  // Where that lands in `process.argv` depends on how the manifest's `path`
+  // is set up: if it points directly at a compiled binary, the origin shows
+  // up at `argv[1]`; if it points at a wrapper shell script that re-execs
+  // `node dist/index.js "$@"`, the origin lands at `argv[2]` (because Node
+  // takes argv[0] = node and argv[1] = the script path). To stay robust
+  // across both deployment shapes we scan all post-argv[0] arguments for
+  // the first one that looks like a `chrome-extension://` URL.
+  const extensionOrigin = process.argv
+    .slice(1)
+    .find((arg) => arg.startsWith("chrome-extension://"));
+  const extensionId = parseExtensionId(extensionOrigin);
+
+  if (!extensionId || !ALLOWED_EXTENSION_IDS.has(extensionId)) {
+    process.stderr.write(
+      `vellum-chrome-native-host: unauthorized_origin (got ${extensionOrigin ?? "<none>"})\n`,
+    );
+    try {
+      writeFrame({ type: "error", message: "unauthorized_origin" });
+    } catch {
+      // Ignore — exit code is the authoritative signal here.
+    }
+    process.exit(1);
+  }
+
+  // Reading stdin in 4-byte-framed chunks. Chrome may deliver a single
+  // request across multiple `data` events, so we accumulate into a buffer
+  // and let `decodeFrames` peel off whole messages as they arrive.
+  let pending: Buffer = Buffer.alloc(0);
+  let handling = false;
+
+  process.stdin.on("data", async (chunk: Buffer) => {
+    pending = Buffer.concat([pending, chunk]);
+    const { frames, remainder } = decodeFrames(pending);
+    pending = remainder;
+
+    for (const frame of frames) {
+      if (handling) {
+        // We only support a single in-flight request per spawn — Chrome
+        // re-spawns the helper on every `connectNative` call. Anything
+        // beyond the first frame is treated as a protocol error.
+        fail("unexpected_additional_frame");
+      }
+      handling = true;
+
+      if (
+        !frame ||
+        typeof frame !== "object" ||
+        (frame as { type?: unknown }).type !== "request_token"
+      ) {
+        fail("unsupported_frame_type");
+      }
+
+      try {
+        const { token, expiresAt } = await requestToken(extensionOrigin!);
+        writeFrame({ type: "token_response", token, expiresAt });
+        process.exit(0);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        fail(message);
+      }
+    }
+  });
+
+  process.stdin.on("end", () => {
+    if (!handling) {
+      // Chrome closed the pipe without sending a request — treat as a
+      // clean no-op exit so we don't pollute logs with bogus errors.
+      process.exit(0);
+    }
+  });
+
+  process.stdin.on("error", (err) => {
+    fail(`stdin_error: ${err.message}`);
+  });
+}
+
+main().catch((err) => {
+  const message = err instanceof Error ? err.message : String(err);
+  fail(message);
+});

--- a/clients/chrome-extension-native-host/src/index.ts
+++ b/clients/chrome-extension-native-host/src/index.ts
@@ -132,12 +132,29 @@ function parseExtensionId(origin: string | undefined): string | null {
 }
 
 /**
- * Write a single native-messaging frame to stdout. Uses the synchronous
- * write path so the caller can `process.exit()` immediately after without
- * losing the frame in a buffered queue.
+ * Write a single native-messaging frame to stdout and exit the process
+ * once the underlying write has actually been flushed.
+ *
+ * Chrome native messaging hosts communicate over a pipe-backed stdout.
+ * `process.stdout.write()` may buffer data internally and flush
+ * asynchronously, so calling `process.exit()` immediately after a write
+ * can tear the process down before the frame ever reaches Chrome — the
+ * extension then sees a disconnect instead of the intended response or
+ * error frame. Using the callback form of `write()` defers `exit()` until
+ * the buffer has been handed off, which is what we want here.
+ *
+ * The function never returns to the caller (declared as `never`), so it
+ * is safe to use in code paths whose control flow assumes the process
+ * has terminated.
  */
-function writeFrame(payload: unknown): void {
-  process.stdout.write(encodeFrame(payload));
+function writeFrameAndExit(payload: unknown, exitCode: number): never {
+  process.stdout.write(encodeFrame(payload), () => {
+    process.exit(exitCode);
+  });
+  // The callback above will fire on the next tick of the event loop and
+  // terminate the process. We block here forever so callers can rely on
+  // a `never` return type without us racing the callback.
+  return new Promise<never>(() => {}) as unknown as never;
 }
 
 /**
@@ -145,16 +162,19 @@ function writeFrame(payload: unknown): void {
  * underlying message to stderr so an operator running the binary by hand
  * (or a Chrome extension developer inspecting the host's stderr stream)
  * can see what went wrong.
+ *
+ * Uses `writeFrameAndExit` so the error frame is actually flushed to
+ * Chrome before the process terminates.
  */
 function fail(message: string, code = 1): never {
   process.stderr.write(`vellum-chrome-native-host: ${message}\n`);
   try {
-    writeFrame({ type: "error", message });
+    return writeFrameAndExit({ type: "error", message }, code);
   } catch {
-    // If even writing the error frame fails (e.g. stdout already closed),
+    // If even queuing the error frame fails (e.g. stdout already closed),
     // there's nothing useful to do — just exit.
+    process.exit(code);
   }
-  process.exit(code);
 }
 
 /**
@@ -235,11 +255,11 @@ async function main(): Promise<void> {
       `vellum-chrome-native-host: unauthorized_origin (got ${extensionOrigin ?? "<none>"})\n`,
     );
     try {
-      writeFrame({ type: "error", message: "unauthorized_origin" });
+      writeFrameAndExit({ type: "error", message: "unauthorized_origin" }, 1);
     } catch {
       // Ignore — exit code is the authoritative signal here.
+      process.exit(1);
     }
-    process.exit(1);
   }
 
   // Reading stdin in 4-byte-framed chunks. Chrome may deliver a single
@@ -282,8 +302,10 @@ async function main(): Promise<void> {
             extensionOrigin!,
             process.argv,
           );
-          writeFrame({ type: "token_response", token, expiresAt });
-          process.exit(0);
+          writeFrameAndExit(
+            { type: "token_response", token, expiresAt },
+            0,
+          );
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           fail(message);

--- a/clients/chrome-extension-native-host/src/index.ts
+++ b/clients/chrome-extension-native-host/src/index.ts
@@ -13,11 +13,11 @@
  *      first command-line argument, e.g. `chrome-extension://<id>/`) is on a
  *      hard-coded allowlist of known Vellum extension IDs.
  *   2. Listen on stdin for `{ type: "request_token" }` frames.
- *   3. POST the calling extension's origin to the running daemon's
+ *   3. POST the calling extension's origin to the running assistant's
  *      `/v1/browser-extension-pair` endpoint (port resolved from
  *      `--assistant-port`, then `~/.vellum/runtime-port`, then defaulting to
  *      7821).
- *   4. Echo the daemon's response back to Chrome as a
+ *   4. Echo the assistant's response back to Chrome as a
  *      `{ type: "token_response", token, expiresAt }` frame.
  *   5. On any unrecoverable error, write a `{ type: "error", message }` frame
  *      and exit with a non-zero status.
@@ -49,7 +49,7 @@ const ALLOWED_EXTENSION_IDS: ReadonlySet<string> = new Set<string>([
   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 ]);
 
-const DEFAULT_DAEMON_PORT = 7821;
+const DEFAULT_ASSISTANT_PORT = 7821;
 const RUNTIME_PORT_FILE = join(homedir(), ".vellum", "runtime-port");
 
 interface TokenResponse {
@@ -89,23 +89,23 @@ function parseAssistantPortArg(argv: readonly string[]): number | null {
 }
 
 /**
- * Resolve the assistant daemon's HTTP port. Resolution order:
+ * Resolve the assistant's HTTP port. Resolution order:
  *
  *   1. `--assistant-port <port>` CLI flag (highest precedence). This exists
  *      so a wrapper script registered in Chrome's NativeMessagingHosts
  *      manifest can pin the helper to a known port without relying on a
  *      lockfile.
  *   2. `~/.vellum/runtime-port` lockfile (a single integer). This file is
- *      not yet written by the daemon — see the TODO in this package's
+ *      not yet written by the assistant — see the TODO in this package's
  *      README. Once it is, no manifest changes are needed for default
  *      installs.
  *   3. The well-known default port `7821`.
  *
  * Any read or parse failure on the lockfile silently falls through to the
- * default rather than crashing — the daemon is the ultimate source of truth
- * and the subsequent HTTP call will surface a clear connection error.
+ * default rather than crashing — the assistant is the ultimate source of
+ * truth and the subsequent HTTP call will surface a clear connection error.
  */
-function resolveDaemonPort(argv: readonly string[]): number {
+function resolveAssistantPort(argv: readonly string[]): number {
   const fromArg = parseAssistantPortArg(argv);
   if (fromArg !== null) return fromArg;
   try {
@@ -118,7 +118,7 @@ function resolveDaemonPort(argv: readonly string[]): number {
     // Fall through to the default. This is expected on first launch and in
     // dev environments where the port file hasn't been written yet.
   }
-  return DEFAULT_DAEMON_PORT;
+  return DEFAULT_ASSISTANT_PORT;
 }
 
 /**
@@ -158,7 +158,7 @@ function fail(message: string, code = 1): never {
 }
 
 /**
- * POST the extension origin to the daemon's pair endpoint and return the
+ * POST the extension origin to the assistant's pair endpoint and return the
  * issued capability token. Surfaces a uniform error message on failure so
  * the caller can wrap it in a native-messaging error frame.
  *
@@ -171,7 +171,7 @@ async function requestToken(
   extensionOrigin: string,
   argv: readonly string[],
 ): Promise<TokenResponse> {
-  const port = resolveDaemonPort(argv);
+  const port = resolveAssistantPort(argv);
   const url = `http://127.0.0.1:${port}/v1/browser-extension-pair`;
 
   let response: Response;

--- a/clients/chrome-extension-native-host/src/index.ts
+++ b/clients/chrome-extension-native-host/src/index.ts
@@ -15,7 +15,8 @@
  *   2. Listen on stdin for `{ type: "request_token" }` frames.
  *   3. POST the calling extension's origin to the running daemon's
  *      `/v1/browser-extension-pair` endpoint (port resolved from
- *      `~/.vellum/runtime-port` or defaulting to 7821).
+ *      `--assistant-port`, then `~/.vellum/runtime-port`, then defaulting to
+ *      7821).
  *   4. Echo the daemon's response back to Chrome as a
  *      `{ type: "token_response", token, expiresAt }` frame.
  *   5. On any unrecoverable error, write a `{ type: "error", message }` frame
@@ -33,7 +34,7 @@ import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-import { decodeFrames, encodeFrame } from "./protocol.js";
+import { decodeFrames, encodeFrame, FrameDecodeError } from "./protocol.js";
 
 /**
  * Allowlist of Chrome extension IDs that are permitted to spawn this helper.
@@ -57,13 +58,56 @@ interface TokenResponse {
 }
 
 /**
- * Resolve the daemon's HTTP port. The Mac app writes the active port to
- * `~/.vellum/runtime-port` on startup; if the file is missing or unreadable
- * we fall back to the well-known default. Any parse failure also falls back
- * rather than crashing — the daemon is the ultimate source of truth and the
- * subsequent HTTP call will surface a clear connection error.
+ * Parse a `--assistant-port <number>` (or `--assistant-port=<number>`)
+ * argument out of `process.argv`. Returns the parsed port if present and
+ * valid, otherwise `null`.
+ *
+ * This is intentionally a tiny hand-rolled parser rather than a full CLI
+ * library: the helper is invoked by Chrome's native messaging runtime which
+ * has a fixed argv shape, and pulling in a CLI dependency would bloat the
+ * audited surface for no real gain.
  */
-function resolveDaemonPort(): number {
+function parseAssistantPortArg(argv: readonly string[]): number | null {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    let raw: string | undefined;
+    if (arg === "--assistant-port") {
+      raw = argv[i + 1];
+    } else if (arg.startsWith("--assistant-port=")) {
+      raw = arg.slice("--assistant-port=".length);
+    } else {
+      continue;
+    }
+    if (raw === undefined) return null;
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isFinite(parsed) && parsed > 0 && parsed < 65536) {
+      return parsed;
+    }
+    return null;
+  }
+  return null;
+}
+
+/**
+ * Resolve the assistant daemon's HTTP port. Resolution order:
+ *
+ *   1. `--assistant-port <port>` CLI flag (highest precedence). This exists
+ *      so a wrapper script registered in Chrome's NativeMessagingHosts
+ *      manifest can pin the helper to a known port without relying on a
+ *      lockfile.
+ *   2. `~/.vellum/runtime-port` lockfile (a single integer). This file is
+ *      not yet written by the daemon — see the TODO in this package's
+ *      README. Once it is, no manifest changes are needed for default
+ *      installs.
+ *   3. The well-known default port `7821`.
+ *
+ * Any read or parse failure on the lockfile silently falls through to the
+ * default rather than crashing — the daemon is the ultimate source of truth
+ * and the subsequent HTTP call will surface a clear connection error.
+ */
+function resolveDaemonPort(argv: readonly string[]): number {
+  const fromArg = parseAssistantPortArg(argv);
+  if (fromArg !== null) return fromArg;
   try {
     const raw = readFileSync(RUNTIME_PORT_FILE, "utf8").trim();
     const parsed = Number.parseInt(raw, 10);
@@ -117,9 +161,17 @@ function fail(message: string, code = 1): never {
  * POST the extension origin to the daemon's pair endpoint and return the
  * issued capability token. Surfaces a uniform error message on failure so
  * the caller can wrap it in a native-messaging error frame.
+ *
+ * Note: error messages here are user-visible (they get propagated to Chrome
+ * as `{ type: "error", message }` frames and surfaced in the extension UI),
+ * so per AGENTS.md they refer to the local process as the "assistant" rather
+ * than the internal "daemon" name.
  */
-async function requestToken(extensionOrigin: string): Promise<TokenResponse> {
-  const port = resolveDaemonPort();
+async function requestToken(
+  extensionOrigin: string,
+  argv: readonly string[],
+): Promise<TokenResponse> {
+  const port = resolveDaemonPort(argv);
   const url = `http://127.0.0.1:${port}/v1/browser-extension-pair`;
 
   let response: Response;
@@ -131,11 +183,13 @@ async function requestToken(extensionOrigin: string): Promise<TokenResponse> {
     });
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
-    throw new Error(`failed to reach daemon at ${url}: ${detail}`);
+    throw new Error(`failed to reach assistant at ${url}: ${detail}`);
   }
 
   if (!response.ok) {
-    throw new Error(`daemon pair request failed with HTTP ${response.status}`);
+    throw new Error(
+      `assistant pair request failed with HTTP ${response.status}`,
+    );
   }
 
   let body: unknown;
@@ -143,7 +197,7 @@ async function requestToken(extensionOrigin: string): Promise<TokenResponse> {
     body = await response.json();
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
-    throw new Error(`daemon pair response was not valid JSON: ${detail}`);
+    throw new Error(`assistant pair response was not valid JSON: ${detail}`);
   }
 
   if (
@@ -152,7 +206,7 @@ async function requestToken(extensionOrigin: string): Promise<TokenResponse> {
     typeof (body as { token?: unknown }).token !== "string" ||
     typeof (body as { expiresAt?: unknown }).expiresAt !== "string"
   ) {
-    throw new Error("daemon pair response missing token / expiresAt");
+    throw new Error("assistant pair response missing token / expiresAt");
   }
 
   const { token, expiresAt } = body as TokenResponse;
@@ -195,35 +249,60 @@ async function main(): Promise<void> {
   let handling = false;
 
   process.stdin.on("data", async (chunk: Buffer) => {
-    pending = Buffer.concat([pending, chunk]);
-    const { frames, remainder } = decodeFrames(pending);
-    pending = remainder;
+    // The entire handler body is wrapped in a try/catch so that any
+    // unexpected exception (most notably `FrameDecodeError` from a
+    // malformed JSON body, but also any synchronous error before the
+    // request reaches `requestToken`) is translated into a protocol-level
+    // `error` frame instead of bubbling up to Node's unhandled-rejection
+    // path and silently exit-1'ing the process.
+    try {
+      pending = Buffer.concat([pending, chunk]);
+      const { frames, remainder } = decodeFrames(pending);
+      pending = remainder;
 
-    for (const frame of frames) {
-      if (handling) {
-        // We only support a single in-flight request per spawn — Chrome
-        // re-spawns the helper on every `connectNative` call. Anything
-        // beyond the first frame is treated as a protocol error.
-        fail("unexpected_additional_frame");
-      }
-      handling = true;
+      for (const frame of frames) {
+        if (handling) {
+          // We only support a single in-flight request per spawn — Chrome
+          // re-spawns the helper on every `connectNative` call. Anything
+          // beyond the first frame is treated as a protocol error.
+          fail("unexpected_additional_frame");
+        }
+        handling = true;
 
-      if (
-        !frame ||
-        typeof frame !== "object" ||
-        (frame as { type?: unknown }).type !== "request_token"
-      ) {
-        fail("unsupported_frame_type");
-      }
+        if (
+          !frame ||
+          typeof frame !== "object" ||
+          (frame as { type?: unknown }).type !== "request_token"
+        ) {
+          fail("unsupported_frame_type");
+        }
 
-      try {
-        const { token, expiresAt } = await requestToken(extensionOrigin!);
-        writeFrame({ type: "token_response", token, expiresAt });
-        process.exit(0);
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        fail(message);
+        try {
+          const { token, expiresAt } = await requestToken(
+            extensionOrigin!,
+            process.argv,
+          );
+          writeFrame({ type: "token_response", token, expiresAt });
+          process.exit(0);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          fail(message);
+        }
       }
+    } catch (err) {
+      // `FrameDecodeError` is the most likely culprit here (malformed JSON
+      // body in a stdin frame), but we deliberately funnel any synchronous
+      // exception thrown out of `decodeFrames` or the dispatch loop above
+      // through this single catch so the helper always gets a chance to
+      // emit a structured `error` frame instead of dying with an
+      // unhandled exception.
+      const detail =
+        err instanceof FrameDecodeError
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      fail(`protocol_error: ${detail}`);
     }
   });
 

--- a/clients/chrome-extension-native-host/src/protocol.ts
+++ b/clients/chrome-extension-native-host/src/protocol.ts
@@ -9,6 +9,21 @@
  */
 
 /**
+ * Thrown by `decodeFrames` when a complete frame body is not valid JSON.
+ *
+ * The caller is expected to translate this into a protocol-level error frame
+ * (e.g. via the helper's `fail()` path) rather than letting it propagate as an
+ * uncaught exception, which would crash the host without surfacing a
+ * structured error response to Chrome.
+ */
+export class FrameDecodeError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "FrameDecodeError";
+  }
+}
+
+/**
  * Encode an arbitrary JSON-serializable payload as a single native-messaging
  * frame: 4-byte little-endian length prefix followed by the UTF-8 JSON body.
  */
@@ -27,6 +42,10 @@ export function encodeFrame(payload: unknown): Buffer {
  * The decoder is intentionally tolerant of partial reads — Chrome may deliver
  * a single message across multiple `data` events, and multiple messages may
  * arrive coalesced in one event.
+ *
+ * If a complete frame body fails to parse as JSON, this function throws a
+ * `FrameDecodeError`. Callers should catch it and translate it into a
+ * protocol-level error frame rather than letting it crash the host.
  */
 export function decodeFrames(buf: Buffer): {
   frames: unknown[];
@@ -38,7 +57,16 @@ export function decodeFrames(buf: Buffer): {
     const len = buf.readUInt32LE(offset);
     if (buf.length - offset - 4 < len) break;
     const body = buf.subarray(offset + 4, offset + 4 + len);
-    frames.push(JSON.parse(body.toString("utf8")));
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(body.toString("utf8"));
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new FrameDecodeError(`malformed_frame_json: ${detail}`, {
+        cause: err,
+      });
+    }
+    frames.push(parsed);
     offset += 4 + len;
   }
   return { frames, remainder: buf.subarray(offset) };

--- a/clients/chrome-extension-native-host/src/protocol.ts
+++ b/clients/chrome-extension-native-host/src/protocol.ts
@@ -1,0 +1,45 @@
+/**
+ * Chrome Native Messaging stdio framing.
+ *
+ * Each message exchanged between Chrome and the native host is prefixed with a
+ * 32-bit unsigned little-endian length, followed by a UTF-8 JSON payload of
+ * exactly that length.
+ *
+ * See: https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging#native-messaging-host-protocol
+ */
+
+/**
+ * Encode an arbitrary JSON-serializable payload as a single native-messaging
+ * frame: 4-byte little-endian length prefix followed by the UTF-8 JSON body.
+ */
+export function encodeFrame(payload: unknown): Buffer {
+  const json = Buffer.from(JSON.stringify(payload), "utf8");
+  const len = Buffer.alloc(4);
+  len.writeUInt32LE(json.length, 0);
+  return Buffer.concat([len, json]);
+}
+
+/**
+ * Decode as many complete frames as possible from a buffer accumulated from
+ * stdin. Returns the parsed frames plus any unconsumed bytes (a partial frame
+ * that should be carried into the next read).
+ *
+ * The decoder is intentionally tolerant of partial reads — Chrome may deliver
+ * a single message across multiple `data` events, and multiple messages may
+ * arrive coalesced in one event.
+ */
+export function decodeFrames(buf: Buffer): {
+  frames: unknown[];
+  remainder: Buffer;
+} {
+  const frames: unknown[] = [];
+  let offset = 0;
+  while (buf.length - offset >= 4) {
+    const len = buf.readUInt32LE(offset);
+    if (buf.length - offset - 4 < len) break;
+    const body = buf.subarray(offset + 4, offset + 4 + len);
+    frames.push(JSON.parse(body.toString("utf8")));
+    offset += 4 + len;
+  }
+  return { frames, remainder: buf.subarray(offset) };
+}

--- a/clients/chrome-extension-native-host/tsconfig.json
+++ b/clients/chrome-extension-native-host/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/__tests__/**"]
+}


### PR DESCRIPTION
## Summary
- New clients/chrome-extension-native-host/ package builds to a CLI entry point
- Implements Chrome native messaging stdio framing (4-byte LE length prefix + UTF-8 JSON)
- CLI validates calling extension origin, POSTs to the daemon /v1/browser-extension-pair endpoint, and returns the capability token via native-messaging stdio
- Not yet wired into the extension or installer — that's PRs 12 and 13

Part of plan: host-browser-proxy-phase-2.md (PR 7 of 16)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
