### PR TITLE
refactor(oauth): rename 5 provider fields to match platform naming

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5012,16 +5012,16 @@ paths:
       responses:
         "200":
           description: Successful response
-  /v1/oauth/providers/{providerKey}:
+  /v1/oauth/providers/{provider}:
     get:
-      operationId: oauth_providers_by_providerKey_get
+      operationId: oauth_providers_by_provider_get
       tags:
         - oauth-providers
       responses:
         "200":
           description: Successful response
       parameters:
-        - name: providerKey
+        - name: provider
           in: path
           required: true
           schema:

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5012,16 +5012,16 @@ paths:
       responses:
         "200":
           description: Successful response
-  /v1/oauth/providers/{provider}:
+  /v1/oauth/providers/{providerKey}:
     get:
-      operationId: oauth_providers_by_provider_get
+      operationId: oauth_providers_by_providerKey_get
       tags:
         - oauth-providers
       responses:
         "200":
           description: Successful response
       parameters:
-        - name: provider
+        - name: providerKey
           in: path
           required: true
           schema:

--- a/assistant/src/__tests__/credential-vault-unit.test.ts
+++ b/assistant/src/__tests__/credential-vault-unit.test.ts
@@ -60,11 +60,11 @@ let slackChannelConfigCalls: Array<{
 }> = [];
 
 mock.module("../oauth/manual-token-connection.js", () => ({
-  syncManualTokenConnection: async (providerKey: string) => {
+  syncManualTokenConnection: async (provider: string) => {
     const { credentialKey } = await import("../security/credential-key.js");
     const { getSecureKeyAsync } = await import("../security/secure-keys.js");
 
-    if (providerKey === "slack_channel") {
+    if (provider === "slack_channel") {
       const hasBotToken = !!(await getSecureKeyAsync(
         credentialKey("slack_channel", "bot_token"),
       ));
@@ -72,9 +72,9 @@ mock.module("../oauth/manual-token-connection.js", () => ({
         credentialKey("slack_channel", "app_token"),
       ));
       if (hasBotToken && hasAppToken) {
-        manualConnectionStore[providerKey] = "active";
+        manualConnectionStore[provider] = "active";
       } else {
-        delete manualConnectionStore[providerKey];
+        delete manualConnectionStore[provider];
       }
     }
   },

--- a/assistant/src/__tests__/credential-vault.test.ts
+++ b/assistant/src/__tests__/credential-vault.test.ts
@@ -74,7 +74,7 @@ const mockConnections = new Map<
   string,
   {
     id: string;
-    providerKey: string;
+    provider: string;
     oauthAppId: string;
     expiresAt: number | null;
   }
@@ -83,7 +83,7 @@ const mockApps = new Map<
   string,
   {
     id: string;
-    providerKey: string;
+    provider: string;
     clientId: string;
     clientSecretCredentialPath: string;
   }
@@ -92,21 +92,21 @@ const mockProviders = new Map<
   string,
   {
     key: string;
-    tokenUrl: string;
+    tokenExchangeUrl: string;
     tokenEndpointAuthMethod?: string;
   }
 >();
 
 let mockDisconnectOAuthProvider: ReturnType<
   typeof mock<
-    (providerKey: string) => Promise<"disconnected" | "not-found" | "error">
+    (provider: string) => Promise<"disconnected" | "not-found" | "error">
   >
 >;
 
 mock.module("../oauth/oauth-store.js", () => {
-  mockDisconnectOAuthProvider = mock((providerKey: string) =>
+  mockDisconnectOAuthProvider = mock((provider: string) =>
     Promise.resolve(
-      mockConnections.has(providerKey)
+      mockConnections.has(provider)
         ? ("disconnected" as const)
         : ("not-found" as const),
     ),
@@ -746,7 +746,7 @@ describe("credential_store tool", () => {
       // Simulate an active OAuth connection for this service
       mockConnections.set("google", {
         id: "conn-gmail",
-        providerKey: "google",
+        provider: "google",
         oauthAppId: "app-gmail",
         expiresAt: Date.now() + 3600_000,
       });
@@ -1303,7 +1303,7 @@ describe("withValidToken refresh deduplication", () => {
    * Helper: set up a service with an access token, refresh token, and
    * mock DB data so that token refresh can proceed through doRefresh().
    *
-   * OAuth-specific fields (tokenUrl, clientId, expiresAt) are now stored
+   * OAuth-specific fields (tokenExchangeUrl, clientId, expiresAt) are now stored
    * in the SQLite oauth-store. The mock maps simulate the DB layer.
    */
   async function setupService(
@@ -1324,17 +1324,17 @@ describe("withValidToken refresh deduplication", () => {
     );
     mockProviders.set(service, {
       key: service,
-      tokenUrl: "https://oauth.example.com/token",
+      tokenExchangeUrl: "https://oauth.example.com/token",
     });
     mockApps.set(appId, {
       id: appId,
-      providerKey: service,
+      provider: service,
       clientId: "test-client-id",
       clientSecretCredentialPath: `oauth_app/${appId}/client_secret`,
     });
     mockConnections.set(service, {
       id: connId,
-      providerKey: service,
+      provider: service,
       oauthAppId: appId,
       expiresAt: opts?.expired
         ? Date.now() - 60_000 // expired 1 minute ago
@@ -1428,7 +1428,7 @@ describe("withValidToken refresh deduplication", () => {
     let refreshCallCount = 0;
     mockRefreshOAuth2Token.mockImplementation(() => {
       refreshCallCount++;
-      // Both services use the same tokenUrl in this test, so we track by
+      // Both services use the same tokenExchangeUrl in this test, so we track by
       // call order to return the correct deferred promise.
       if (refreshCallCount === 1) return gmailPromise;
       return slackPromise;

--- a/assistant/src/__tests__/credentials-cli.test.ts
+++ b/assistant/src/__tests__/credentials-cli.test.ts
@@ -148,9 +148,9 @@ let disconnectOAuthProviderResult: "disconnected" | "not-found" | "error" =
 
 mock.module("../oauth/oauth-store.js", () => ({
   disconnectOAuthProvider: async (
-    providerKey: string,
+    provider: string,
   ): Promise<"disconnected" | "not-found" | "error"> => {
-    disconnectOAuthProviderCalls.push(providerKey);
+    disconnectOAuthProviderCalls.push(provider);
     return disconnectOAuthProviderResult;
   },
   getConnectionByProvider: (): undefined => undefined,

--- a/assistant/src/__tests__/integration-status.test.ts
+++ b/assistant/src/__tests__/integration-status.test.ts
@@ -21,17 +21,16 @@ mock.module("../config/loader.js", () => ({
 }));
 
 mock.module("../oauth/oauth-store.js", () => ({
-  isProviderConnected: (providerKey: string) =>
-    connectedProviders.has(providerKey),
-  getConnectionByProvider: (providerKey: string) =>
-    connectedProviders.has(providerKey)
-      ? { id: `conn-${providerKey}`, status: "active" }
+  isProviderConnected: (provider: string) => connectedProviders.has(provider),
+  getConnectionByProvider: (provider: string) =>
+    connectedProviders.has(provider)
+      ? { id: `conn-${provider}`, status: "active" }
       : undefined,
 }));
 
 /** Mark a provider as fully connected (active row + access token). */
-function setOAuthConnected(providerKey: string): void {
-  connectedProviders.add(providerKey);
+function setOAuthConnected(provider: string): void {
+  connectedProviders.add(provider);
 }
 
 const { getIntegrationSummary, formatIntegrationSummary, hasCapability } =

--- a/assistant/src/__tests__/oauth-apps-routes.test.ts
+++ b/assistant/src/__tests__/oauth-apps-routes.test.ts
@@ -2,14 +2,14 @@ import { describe, expect, mock, test } from "bun:test";
 
 const mockGetApp = mock((_appId: string) => ({
   id: "app-1",
-  providerKey: "google",
+  provider: "google",
   clientId: "client-1",
 }));
 
 const mockListConnections = mock(() => [
   {
     id: "conn-1",
-    providerKey: "google",
+    provider: "google",
     accountInfo: '{"email":"alice@example.com"}',
     grantedScopes: '["email","profile"]',
     status: "active",
@@ -20,7 +20,7 @@ const mockListConnections = mock(() => [
   },
   {
     id: "conn-2",
-    providerKey: "google",
+    provider: "google",
     accountInfo: null,
     grantedScopes: [],
     status: "active",
@@ -37,24 +37,24 @@ mock.module("../oauth/oauth-store.js", () => ({
   getApp: mockGetApp,
   getAppClientSecret: mock(() => Promise.resolve(undefined)),
   getConnection: mock(() => undefined),
-  getProvider: mock((providerKey: string) =>
-    providerKey === "google"
+  getProvider: mock((provider: string) =>
+    provider === "google"
       ? {
-          providerKey: "google",
-          displayName: "Google",
+          provider: "google",
+          displayLabel: "Google",
           description: "Google OAuth provider",
           dashboardUrl: "https://console.cloud.google.com/apis/credentials",
           clientIdPlaceholder: null,
           requiresClientSecret: 1,
           managedServiceConfigKey: "google-oauth",
-          authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-          tokenUrl: "https://oauth2.googleapis.com/token",
+          authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+          tokenExchangeUrl: "https://oauth2.googleapis.com/token",
           tokenEndpointAuthMethod: null,
           userinfoUrl: null,
           baseUrl: null,
           defaultScopes: "[]",
           scopePolicy: "[]",
-          extraParams: null,
+          authorizeParams: null,
           pingUrl: null,
           pingMethod: null,
           pingHeaders: null,
@@ -80,7 +80,7 @@ mock.module("../oauth/oauth-store.js", () => ({
   upsertApp: mock(() =>
     Promise.resolve({
       id: "app-1",
-      providerKey: "google",
+      provider: "google",
       clientId: "client-1",
       createdAt: 1735689500000,
       updatedAt: 1735689550000,

--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -37,7 +37,7 @@ let mockUpsertAppCalls: Array<{
 }> = [];
 let mockUpsertAppResult: Record<string, unknown> = {
   id: "app-upsert-1",
-  providerKey: "test",
+  provider: "test",
   clientId: "test-client-id",
   createdAt: 1700000000000,
   updatedAt: 1700000000000,
@@ -58,18 +58,18 @@ let mockOrchestrateOAuthConnect: (
   opts: Record<string, unknown>,
 ) => Promise<Record<string, unknown>>;
 let mockGetAppByProviderAndClientId: (
-  providerKey: string,
+  provider: string,
   clientId: string,
 ) => Record<string, unknown> | undefined = () => undefined;
 let mockGetMostRecentAppByProvider: (
-  providerKey: string,
+  provider: string,
 ) => Record<string, unknown> | undefined = () => undefined;
 let mockGetProvider: (
-  providerKey: string,
+  provider: string,
 ) => Record<string, unknown> | undefined = () => undefined;
 let mockGetSecureKey: (account: string) => string | undefined = () => undefined;
 let mockResolveOAuthConnection: (
-  providerKey: string,
+  provider: string,
   options?: Record<string, unknown>,
 ) => Promise<{
   request: (req: Record<string, unknown>) => Promise<{
@@ -79,7 +79,7 @@ let mockResolveOAuthConnection: (
   }>;
   withToken: <T>(fn: (token: string) => Promise<T>) => Promise<T>;
   id: string;
-  providerKey: string;
+  provider: string;
   accountInfo: string | null;
 }> = async () => {
   throw new Error("resolveOAuthConnection not configured in test");
@@ -120,9 +120,9 @@ mock.module("../security/token-manager.js", () => ({
 
 mock.module("../oauth/oauth-store.js", () => ({
   disconnectOAuthProvider: async (
-    providerKey: string,
+    provider: string,
   ): Promise<"disconnected" | "not-found" | "error"> => {
-    disconnectOAuthProviderCalls.push(providerKey);
+    disconnectOAuthProviderCalls.push(provider);
     return disconnectOAuthProviderResult;
   },
   getConnection: () => undefined,
@@ -145,13 +145,13 @@ mock.module("../oauth/oauth-store.js", () => ({
     return mockUpsertAppResult;
   },
   getApp: () => undefined,
-  getAppByProviderAndClientId: (providerKey: string, clientId: string) =>
-    mockGetAppByProviderAndClientId(providerKey, clientId),
-  getMostRecentAppByProvider: (providerKey: string) =>
-    mockGetMostRecentAppByProvider(providerKey),
+  getAppByProviderAndClientId: (provider: string, clientId: string) =>
+    mockGetAppByProviderAndClientId(provider, clientId),
+  getMostRecentAppByProvider: (provider: string) =>
+    mockGetMostRecentAppByProvider(provider),
   listApps: () => [],
   deleteApp: async () => false,
-  getProvider: (providerKey: string) => mockGetProvider(providerKey),
+  getProvider: (provider: string) => mockGetProvider(provider),
   listProviders: () => mockListProviders(),
   registerProvider: () => ({}),
   updateProvider: () => undefined,
@@ -229,9 +229,9 @@ mock.module("../oauth/seed-providers.js", () => ({
 
 mock.module("../oauth/connection-resolver.js", () => ({
   resolveOAuthConnection: (
-    providerKey: string,
+    provider: string,
     options?: Record<string, unknown>,
-  ) => mockResolveOAuthConnection(providerKey, options),
+  ) => mockResolveOAuthConnection(provider, options),
 }));
 
 // ---------------------------------------------------------------------------
@@ -439,45 +439,45 @@ describe("assistant oauth token <provider-key>", () => {
 describe("assistant oauth providers list", () => {
   const fakeProviders = [
     {
-      providerKey: "google",
-      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-      tokenUrl: "https://oauth2.googleapis.com/token",
+      provider: "google",
+      authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenExchangeUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: "[]",
       scopePolicy: "{}",
-      extraParams: null,
+      authorizeParams: null,
       managedServiceConfigKey: "google-oauth",
       createdAt: "2025-01-01T00:00:00.000Z",
       updatedAt: "2025-01-01T00:00:00.000Z",
     },
     {
-      providerKey: "google-calendar",
-      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-      tokenUrl: "https://oauth2.googleapis.com/token",
+      provider: "google-calendar",
+      authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenExchangeUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: "[]",
       scopePolicy: "{}",
-      extraParams: null,
+      authorizeParams: null,
       managedServiceConfigKey: "google-calendar-oauth",
       createdAt: "2025-01-01T00:00:00.000Z",
       updatedAt: "2025-01-01T00:00:00.000Z",
     },
     {
-      providerKey: "slack",
-      authUrl: "https://slack.com/oauth/v2/authorize",
-      tokenUrl: "https://slack.com/api/oauth.v2.access",
+      provider: "slack",
+      authorizeUrl: "https://slack.com/oauth/v2/authorize",
+      tokenExchangeUrl: "https://slack.com/api/oauth.v2.access",
       defaultScopes: "[]",
       scopePolicy: "{}",
-      extraParams: null,
+      authorizeParams: null,
       managedServiceConfigKey: null,
       createdAt: "2025-01-01T00:00:00.000Z",
       updatedAt: "2025-01-01T00:00:00.000Z",
     },
     {
-      providerKey: "twitter",
-      authUrl: "https://twitter.com/i/oauth2/authorize",
-      tokenUrl: "https://api.twitter.com/2/oauth2/token",
+      provider: "twitter",
+      authorizeUrl: "https://twitter.com/i/oauth2/authorize",
+      tokenExchangeUrl: "https://api.twitter.com/2/oauth2/token",
       defaultScopes: "[]",
       scopePolicy: "{}",
-      extraParams: null,
+      authorizeParams: null,
       managedServiceConfigKey: null,
       createdAt: "2025-01-01T00:00:00.000Z",
       updatedAt: "2025-01-01T00:00:00.000Z",
@@ -494,7 +494,7 @@ describe("assistant oauth providers list", () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(4);
-    const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
+    const keys = parsed.map((p: { provider: string }) => p.provider);
     expect(keys).toContain("google");
     expect(keys).toContain("google-calendar");
     expect(keys).toContain("slack");
@@ -512,7 +512,7 @@ describe("assistant oauth providers list", () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(1);
-    expect(parsed[0].providerKey).toBe("slack");
+    expect(parsed[0].provider).toBe("slack");
   });
 
   test("filters by comma-separated OR values", async () => {
@@ -526,7 +526,7 @@ describe("assistant oauth providers list", () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(3);
-    const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
+    const keys = parsed.map((p: { provider: string }) => p.provider);
     expect(keys).toContain("google");
     expect(keys).toContain("google-calendar");
     expect(keys).toContain("slack");
@@ -556,7 +556,7 @@ describe("assistant oauth providers list", () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(3);
-    const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
+    const keys = parsed.map((p: { provider: string }) => p.provider);
     expect(keys).toContain("google");
     expect(keys).toContain("google-calendar");
     expect(keys).toContain("slack");
@@ -573,7 +573,7 @@ describe("assistant oauth providers list", () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(3);
-    const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
+    const keys = parsed.map((p: { provider: string }) => p.provider);
     expect(keys).toContain("google");
     expect(keys).toContain("google-calendar");
     expect(keys).toContain("slack");
@@ -589,7 +589,7 @@ describe("assistant oauth providers list", () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(2);
-    const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
+    const keys = parsed.map((p: { provider: string }) => p.provider);
     expect(keys).toContain("google");
     expect(keys).toContain("google-calendar");
     expect(keys).not.toContain("slack");
@@ -610,7 +610,7 @@ describe("assistant oauth providers list", () => {
     // Both google and google-calendar match --provider-key "google" AND have
     // managedServiceConfigKey set, so both are returned.
     expect(parsed).toHaveLength(2);
-    const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
+    const keys = parsed.map((p: { provider: string }) => p.provider);
     expect(keys).toContain("google");
     expect(keys).toContain("google-calendar");
   });
@@ -620,7 +620,7 @@ describe("assistant oauth providers list", () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(4);
-    const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
+    const keys = parsed.map((p: { provider: string }) => p.provider);
     expect(keys).toContain("google");
     expect(keys).toContain("google-calendar");
     expect(keys).toContain("slack");
@@ -638,7 +638,7 @@ describe("assistant oauth apps upsert --client-secret-credential-path", () => {
     mockUpsertAppCalls = [];
     mockUpsertAppResult = {
       id: "app-upsert-1",
-      providerKey: "google",
+      provider: "google",
       clientId: "abc123",
       createdAt: 1700000000000,
       updatedAt: 1700000000000,
@@ -890,19 +890,19 @@ describe("assistant oauth ping <provider-key>", () => {
 
   test("returns ok when ping endpoint returns 200", async () => {
     mockGetProvider = () => ({
-      providerKey: "google",
+      provider: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
-      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-      tokenUrl: "https://oauth2.googleapis.com/token",
+      authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenExchangeUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: "[]",
       scopePolicy: "{}",
-      extraParams: null,
+      authorizeParams: null,
       createdAt: Date.now(),
       updatedAt: Date.now(),
     });
     mockResolveOAuthConnection = async () => ({
       id: "conn-1",
-      providerKey: "google",
+      provider: "google",
       accountInfo: null,
       request: async () => ({ status: 200, headers: {}, body: {} }),
       withToken: async (fn) => fn("mock-access-token-xyz"),
@@ -925,13 +925,13 @@ describe("assistant oauth ping <provider-key>", () => {
 
   test("exits 1 when no ping URL configured", async () => {
     mockGetProvider = () => ({
-      providerKey: "telegram",
+      provider: "telegram",
       pingUrl: null,
-      authUrl: "urn:manual-token",
-      tokenUrl: "urn:manual-token",
+      authorizeUrl: "urn:manual-token",
+      tokenExchangeUrl: "urn:manual-token",
       defaultScopes: "[]",
       scopePolicy: "{}",
-      extraParams: null,
+      authorizeParams: null,
       createdAt: Date.now(),
       updatedAt: Date.now(),
     });
@@ -944,19 +944,19 @@ describe("assistant oauth ping <provider-key>", () => {
 
   test("exits 1 when ping endpoint returns non-2xx", async () => {
     mockGetProvider = () => ({
-      providerKey: "google",
+      provider: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
-      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-      tokenUrl: "https://oauth2.googleapis.com/token",
+      authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenExchangeUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: "[]",
       scopePolicy: "{}",
-      extraParams: null,
+      authorizeParams: null,
       createdAt: Date.now(),
       updatedAt: Date.now(),
     });
     mockResolveOAuthConnection = async () => ({
       id: "conn-1",
-      providerKey: "google",
+      provider: "google",
       accountInfo: null,
       request: async () => ({ status: 403, headers: {}, body: "Forbidden" }),
       withToken: async (fn) => fn("mock-access-token-xyz"),
@@ -970,13 +970,13 @@ describe("assistant oauth ping <provider-key>", () => {
 
   test("exits 1 when no connection can be resolved", async () => {
     mockGetProvider = () => ({
-      providerKey: "google",
+      provider: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
-      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-      tokenUrl: "https://oauth2.googleapis.com/token",
+      authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenExchangeUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: "[]",
       scopePolicy: "{}",
-      extraParams: null,
+      authorizeParams: null,
       createdAt: Date.now(),
       updatedAt: Date.now(),
     });
@@ -1023,12 +1023,12 @@ describe("assistant oauth connect managed mode — platform 401/403 errors", () 
     // Set up managed mode: provider has managedServiceConfigKey, config
     // returns the matching service with mode "managed".
     mockGetProvider = () => ({
-      providerKey: "google",
-      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-      tokenUrl: "https://oauth2.googleapis.com/token",
+      provider: "google",
+      authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenExchangeUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: "[]",
       scopePolicy: "{}",
-      extraParams: null,
+      authorizeParams: null,
       managedServiceConfigKey: "google-oauth",
       createdAt: Date.now(),
       updatedAt: Date.now(),
@@ -1249,12 +1249,12 @@ describe("assistant oauth mode", () => {
   beforeEach(() => {
     mockWithValidToken = async (_service, cb) => cb("mock-access-token-xyz");
     mockGetProvider = () => ({
-      providerKey: "google",
-      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-      tokenUrl: "https://oauth2.googleapis.com/token",
+      provider: "google",
+      authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenExchangeUrl: "https://oauth2.googleapis.com/token",
       defaultScopes: "[]",
       scopePolicy: "{}",
-      extraParams: null,
+      authorizeParams: null,
       managedServiceConfigKey: "google-oauth",
       createdAt: Date.now(),
       updatedAt: Date.now(),

--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -494,7 +494,7 @@ describe("assistant oauth providers list", () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(4);
-    const keys = parsed.map((p: { provider: string }) => p.provider);
+    const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
     expect(keys).toContain("google");
     expect(keys).toContain("google-calendar");
     expect(keys).toContain("slack");
@@ -526,7 +526,7 @@ describe("assistant oauth providers list", () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(3);
-    const keys = parsed.map((p: { provider: string }) => p.provider);
+    const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
     expect(keys).toContain("google");
     expect(keys).toContain("google-calendar");
     expect(keys).toContain("slack");
@@ -556,7 +556,7 @@ describe("assistant oauth providers list", () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(3);
-    const keys = parsed.map((p: { provider: string }) => p.provider);
+    const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
     expect(keys).toContain("google");
     expect(keys).toContain("google-calendar");
     expect(keys).toContain("slack");
@@ -573,7 +573,7 @@ describe("assistant oauth providers list", () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(3);
-    const keys = parsed.map((p: { provider: string }) => p.provider);
+    const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
     expect(keys).toContain("google");
     expect(keys).toContain("google-calendar");
     expect(keys).toContain("slack");
@@ -589,7 +589,7 @@ describe("assistant oauth providers list", () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(2);
-    const keys = parsed.map((p: { provider: string }) => p.provider);
+    const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
     expect(keys).toContain("google");
     expect(keys).toContain("google-calendar");
     expect(keys).not.toContain("slack");
@@ -610,7 +610,7 @@ describe("assistant oauth providers list", () => {
     // Both google and google-calendar match --provider-key "google" AND have
     // managedServiceConfigKey set, so both are returned.
     expect(parsed).toHaveLength(2);
-    const keys = parsed.map((p: { provider: string }) => p.provider);
+    const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
     expect(keys).toContain("google");
     expect(keys).toContain("google-calendar");
   });
@@ -620,7 +620,7 @@ describe("assistant oauth providers list", () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(4);
-    const keys = parsed.map((p: { provider: string }) => p.provider);
+    const keys = parsed.map((p: { providerKey: string }) => p.providerKey);
     expect(keys).toContain("google");
     expect(keys).toContain("google-calendar");
     expect(keys).toContain("slack");

--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -512,7 +512,7 @@ describe("assistant oauth providers list", () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveLength(1);
-    expect(parsed[0].provider).toBe("slack");
+    expect(parsed[0].providerKey).toBe("slack");
   });
 
   test("filters by comma-separated OR values", async () => {

--- a/assistant/src/__tests__/oauth-connect-orchestrator.test.ts
+++ b/assistant/src/__tests__/oauth-connect-orchestrator.test.ts
@@ -13,7 +13,7 @@ let lastStartArgs: {
 } | null = null;
 
 let mockPrepareResult: {
-  authUrl: string;
+  authorizeUrl: string;
   state: string;
   completion: Promise<{
     tokens: { accessToken: string; refreshToken?: string };
@@ -21,7 +21,7 @@ let mockPrepareResult: {
     rawTokenResponse: Record<string, unknown>;
   }>;
 } = {
-  authUrl: "https://provider.example.com/authorize?prepared",
+  authorizeUrl: "https://provider.example.com/authorize?prepared",
   state: "mock-state-123",
   completion: new Promise(() => {}), // never resolves by default
 };
@@ -86,21 +86,21 @@ mock.module("../oauth/scope-policy.js", () => ({
 
 // Provider store mock — configurable per test
 type ProviderRow = {
-  providerKey: string;
-  authUrl: string;
-  tokenUrl: string;
+  provider: string;
+  authorizeUrl: string;
+  tokenExchangeUrl: string;
   tokenEndpointAuthMethod: string | null;
   userinfoUrl: string | null;
   baseUrl: string | null;
   defaultScopes: string;
   scopePolicy: string;
-  extraParams: string | null;
+  authorizeParams: string | null;
   pingUrl: string | null;
   pingMethod: string | null;
   pingHeaders: string | null;
   pingBody: string | null;
   managedServiceConfigKey: string | null;
-  displayName: string | null;
+  displayLabel: string | null;
   description: string | null;
   dashboardUrl: string | null;
   clientIdPlaceholder: string | null;
@@ -157,25 +157,25 @@ import { orchestrateOAuthConnect } from "../oauth/connect-orchestrator.js";
 // ---------------------------------------------------------------------------
 
 function makeProviderRow(
-  overrides: Partial<ProviderRow> & { providerKey: string },
+  overrides: Partial<ProviderRow> & { provider: string },
 ): ProviderRow {
   const now = Date.now();
   return {
-    authUrl: "https://provider.example.com/authorize",
-    tokenUrl: "https://provider.example.com/token",
+    authorizeUrl: "https://provider.example.com/authorize",
+    tokenExchangeUrl: "https://provider.example.com/token",
     tokenEndpointAuthMethod: null,
     userinfoUrl: null,
     baseUrl: null,
     defaultScopes: '["openid","email"]',
     scopePolicy:
       '{"allowAdditionalScopes":false,"allowedOptionalScopes":[],"forbiddenScopes":[]}',
-    extraParams: null,
+    authorizeParams: null,
     pingUrl: null,
     pingMethod: null,
     pingHeaders: null,
     pingBody: null,
     managedServiceConfigKey: null,
-    displayName: null,
+    displayLabel: null,
     description: null,
     dashboardUrl: null,
     clientIdPlaceholder: null,
@@ -200,19 +200,21 @@ function makeProviderRow(
 
 // Shared provider definitions used across tests
 const GOOGLE_PROVIDER = makeProviderRow({
-  providerKey: "google",
-  authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-  tokenUrl: "https://oauth2.googleapis.com/token",
+  provider: "google",
+  authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenExchangeUrl: "https://oauth2.googleapis.com/token",
   loopbackPort: 17332,
-  displayName: "Google",
+  displayLabel: "Google",
 });
 
 const OUTLOOK_PROVIDER = makeProviderRow({
-  providerKey: "outlook",
-  authUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
-  tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+  provider: "outlook",
+  authorizeUrl:
+    "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+  tokenExchangeUrl:
+    "https://login.microsoftonline.com/common/oauth2/v2.0/token",
   loopbackPort: 17334,
-  displayName: "Outlook",
+  displayLabel: "Outlook",
 });
 
 // ---------------------------------------------------------------------------
@@ -227,7 +229,7 @@ beforeEach(() => {
   mockProviderStore = {};
 
   mockPrepareResult = {
-    authUrl: "https://provider.example.com/authorize?prepared",
+    authorizeUrl: "https://provider.example.com/authorize?prepared",
     state: "mock-state-123",
     completion: new Promise(() => {}),
   };
@@ -689,7 +691,7 @@ describe("orchestrateOAuthConnect — transport selection", () => {
   describe("provider without loopbackPort", () => {
     test("loopback transport passes undefined loopbackPort when provider has none", async () => {
       mockProviderStore["custom"] = makeProviderRow({
-        providerKey: "custom",
+        provider: "custom",
         loopbackPort: null, // no fixed port
       });
 

--- a/assistant/src/__tests__/oauth-provider-serializer.test.ts
+++ b/assistant/src/__tests__/oauth-provider-serializer.test.ts
@@ -10,21 +10,21 @@ import {
 function makeRow(overrides: Partial<OAuthProviderRow> = {}): OAuthProviderRow {
   const now = Date.now();
   return {
-    providerKey: "test-provider",
-    authUrl: "https://auth.example.com/authorize",
-    tokenUrl: "https://auth.example.com/token",
+    provider: "test-provider",
+    authorizeUrl: "https://auth.example.com/authorize",
+    tokenExchangeUrl: "https://auth.example.com/token",
     tokenEndpointAuthMethod: null,
     userinfoUrl: null,
     baseUrl: null,
     defaultScopes: "[]",
     scopePolicy: "{}",
-    extraParams: null,
+    authorizeParams: null,
     pingUrl: null,
     pingMethod: null,
     pingHeaders: null,
     pingBody: null,
     managedServiceConfigKey: null,
-    displayName: null,
+    displayLabel: null,
     description: null,
     dashboardUrl: null,
     clientIdPlaceholder: null,
@@ -52,7 +52,7 @@ describe("serializeProvider", () => {
     const row = makeRow({
       defaultScopes: JSON.stringify(["openid", "email"]),
       scopePolicy: JSON.stringify({ required: ["openid"] }),
-      extraParams: JSON.stringify({ access_type: "offline" }),
+      authorizeParams: JSON.stringify({ access_type: "offline" }),
       pingHeaders: JSON.stringify({ "X-Api-Version": "2" }),
       pingBody: JSON.stringify({ query: "{ me { id } }" }),
       injectionTemplates: JSON.stringify([
@@ -73,7 +73,7 @@ describe("serializeProvider", () => {
 
     expect(result.defaultScopes).toEqual(["openid", "email"]);
     expect(result.scopePolicy).toEqual({ required: ["openid"] });
-    expect(result.extraParams).toEqual({ access_type: "offline" });
+    expect(result.authorizeParams).toEqual({ access_type: "offline" });
     expect(result.pingHeaders).toEqual({ "X-Api-Version": "2" });
     expect(result.pingBody).toEqual({ query: "{ me { id } }" });
     expect(result.injectionTemplates).toEqual([
@@ -96,7 +96,7 @@ describe("serializeProvider", () => {
 
     expect(result.defaultScopes).toEqual([]);
     expect(result.scopePolicy).toEqual({});
-    expect(result.extraParams).toBeNull();
+    expect(result.authorizeParams).toBeNull();
     expect(result.pingHeaders).toBeNull();
     expect(result.pingBody).toBeNull();
     expect(result.injectionTemplates).toBeNull();
@@ -172,8 +172,8 @@ describe("serializeProvider", () => {
 describe("serializeProviderSummary", () => {
   test("returns the expected subset of fields in snake_case", () => {
     const row = makeRow({
-      providerKey: "google",
-      displayName: "Google",
+      provider: "google",
+      displayLabel: "Google",
       description: "Google OAuth 2.0",
       dashboardUrl: "https://console.cloud.google.com",
       clientIdPlaceholder: "your-client-id.apps.googleusercontent.com",
@@ -197,7 +197,7 @@ describe("serializeProviderSummary", () => {
 
   test("nullifies missing optional fields", () => {
     const row = makeRow({
-      displayName: null,
+      displayLabel: null,
       description: null,
       dashboardUrl: null,
       clientIdPlaceholder: null,

--- a/assistant/src/__tests__/oauth-provider-serializer.test.ts
+++ b/assistant/src/__tests__/oauth-provider-serializer.test.ts
@@ -73,7 +73,7 @@ describe("serializeProvider", () => {
 
     expect(result.defaultScopes).toEqual(["openid", "email"]);
     expect(result.scopePolicy).toEqual({ required: ["openid"] });
-    expect(result.authorizeParams).toEqual({ access_type: "offline" });
+    expect(result.extraParams).toEqual({ access_type: "offline" });
     expect(result.pingHeaders).toEqual({ "X-Api-Version": "2" });
     expect(result.pingBody).toEqual({ query: "{ me { id } }" });
     expect(result.injectionTemplates).toEqual([
@@ -96,7 +96,7 @@ describe("serializeProvider", () => {
 
     expect(result.defaultScopes).toEqual([]);
     expect(result.scopePolicy).toEqual({});
-    expect(result.authorizeParams).toBeNull();
+    expect(result.extraParams).toBeNull();
     expect(result.pingHeaders).toBeNull();
     expect(result.pingBody).toBeNull();
     expect(result.injectionTemplates).toBeNull();

--- a/assistant/src/__tests__/oauth-provider-visibility.test.ts
+++ b/assistant/src/__tests__/oauth-provider-visibility.test.ts
@@ -51,18 +51,16 @@ describe("isProviderVisible", () => {
   test("returns true when featureFlag is null", () => {
     seedProviders([
       {
-        providerKey: "no-flag-provider",
-        authUrl: "https://example.com/auth",
-        tokenUrl: "https://example.com/token",
+        provider: "no-flag-provider",
+        authorizeUrl: "https://example.com/auth",
+        tokenExchangeUrl: "https://example.com/token",
         defaultScopes: ["read"],
         scopePolicy: {},
       },
     ]);
 
     const providers = listProviders();
-    const provider = providers.find(
-      (p) => p.providerKey === "no-flag-provider",
-    );
+    const provider = providers.find((p) => p.provider === "no-flag-provider");
     expect(provider).toBeDefined();
     expect(provider!.featureFlag).toBeNull();
 
@@ -75,9 +73,9 @@ describe("isProviderVisible", () => {
 
     seedProviders([
       {
-        providerKey: "gated-provider",
-        authUrl: "https://example.com/auth",
-        tokenUrl: "https://example.com/token",
+        provider: "gated-provider",
+        authorizeUrl: "https://example.com/auth",
+        tokenExchangeUrl: "https://example.com/token",
         defaultScopes: ["read"],
         scopePolicy: {},
         featureFlag: "test-gate",
@@ -85,7 +83,7 @@ describe("isProviderVisible", () => {
     ]);
 
     const providers = listProviders();
-    const provider = providers.find((p) => p.providerKey === "gated-provider");
+    const provider = providers.find((p) => p.provider === "gated-provider");
     expect(provider).toBeDefined();
     expect(provider!.featureFlag).toBe("test-gate");
 
@@ -98,9 +96,9 @@ describe("isProviderVisible", () => {
 
     seedProviders([
       {
-        providerKey: "gated-provider",
-        authUrl: "https://example.com/auth",
-        tokenUrl: "https://example.com/token",
+        provider: "gated-provider",
+        authorizeUrl: "https://example.com/auth",
+        tokenExchangeUrl: "https://example.com/token",
         defaultScopes: ["read"],
         scopePolicy: {},
         featureFlag: "test-gate",
@@ -108,7 +106,7 @@ describe("isProviderVisible", () => {
     ]);
 
     const providers = listProviders();
-    const provider = providers.find((p) => p.providerKey === "gated-provider");
+    const provider = providers.find((p) => p.provider === "gated-provider");
     expect(provider).toBeDefined();
 
     const config = makeConfig();
@@ -120,16 +118,16 @@ describe("isProviderVisible", () => {
 
     seedProviders([
       {
-        providerKey: "visible-provider",
-        authUrl: "https://example.com/auth",
-        tokenUrl: "https://example.com/token",
+        provider: "visible-provider",
+        authorizeUrl: "https://example.com/auth",
+        tokenExchangeUrl: "https://example.com/token",
         defaultScopes: ["read"],
         scopePolicy: {},
       },
       {
-        providerKey: "gated-provider",
-        authUrl: "https://gated.example.com/auth",
-        tokenUrl: "https://gated.example.com/token",
+        provider: "gated-provider",
+        authorizeUrl: "https://gated.example.com/auth",
+        tokenExchangeUrl: "https://gated.example.com/token",
         defaultScopes: ["read"],
         scopePolicy: {},
         featureFlag: "test-gate",
@@ -144,6 +142,6 @@ describe("isProviderVisible", () => {
       isProviderVisible(p, config),
     );
     expect(visibleProviders).toHaveLength(1);
-    expect(visibleProviders[0]!.providerKey).toBe("visible-provider");
+    expect(visibleProviders[0]!.provider).toBe("visible-provider");
   });
 });

--- a/assistant/src/__tests__/oauth-providers-routes.test.ts
+++ b/assistant/src/__tests__/oauth-providers-routes.test.ts
@@ -211,16 +211,16 @@ describe("GET /v1/oauth/providers", () => {
   });
 });
 
-describe("GET /v1/oauth/providers/:provider", () => {
+describe("GET /v1/oauth/providers/:providerKey", () => {
   test("returns the correct provider", async () => {
     const req = new Request("http://localhost/v1/oauth/providers/google");
     const url = new URL(req.url);
-    const res = await getRoute("GET", "oauth/providers/:provider").handler({
+    const res = await getRoute("GET", "oauth/providers/:providerKey").handler({
       req,
       url,
       server: null as never,
       authContext: null as never,
-      params: { provider: "google" },
+      params: { providerKey: "google" },
     });
 
     expect(res.status).toBe(200);
@@ -245,12 +245,12 @@ describe("GET /v1/oauth/providers/:provider", () => {
   test("returns 404 for unknown provider", async () => {
     const req = new Request("http://localhost/v1/oauth/providers/nonexistent");
     const url = new URL(req.url);
-    const res = await getRoute("GET", "oauth/providers/:provider").handler({
+    const res = await getRoute("GET", "oauth/providers/:providerKey").handler({
       req,
       url,
       server: null as never,
       authContext: null as never,
-      params: { provider: "nonexistent" },
+      params: { providerKey: "nonexistent" },
     });
 
     expect(res.status).toBe(404);

--- a/assistant/src/__tests__/oauth-providers-routes.test.ts
+++ b/assistant/src/__tests__/oauth-providers-routes.test.ts
@@ -2,21 +2,21 @@ import { describe, expect, mock, test } from "bun:test";
 
 const mockListProviders = mock(() => [
   {
-    providerKey: "google",
-    displayName: "Google",
+    provider: "google",
+    displayLabel: "Google",
     description: "Google OAuth provider",
     dashboardUrl: "https://console.cloud.google.com/apis/credentials",
     clientIdPlaceholder: null,
     requiresClientSecret: 1,
     managedServiceConfigKey: "google-oauth",
-    authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-    tokenUrl: "https://oauth2.googleapis.com/token",
+    authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+    tokenExchangeUrl: "https://oauth2.googleapis.com/token",
     tokenEndpointAuthMethod: null,
     userinfoUrl: null,
     baseUrl: null,
     defaultScopes: "[]",
     scopePolicy: "[]",
-    extraParams: null,
+    authorizeParams: null,
 
     pingUrl: null,
     pingMethod: null,
@@ -38,21 +38,21 @@ const mockListProviders = mock(() => [
     updatedAt: 1735689550000,
   },
   {
-    providerKey: "github",
-    displayName: "GitHub",
+    provider: "github",
+    displayLabel: "GitHub",
     description: "GitHub OAuth provider",
     dashboardUrl: "https://github.com/settings/developers",
     clientIdPlaceholder: null,
     requiresClientSecret: 1,
     managedServiceConfigKey: null,
-    authUrl: "https://github.com/login/oauth/authorize",
-    tokenUrl: "https://github.com/login/oauth/access_token",
+    authorizeUrl: "https://github.com/login/oauth/authorize",
+    tokenExchangeUrl: "https://github.com/login/oauth/access_token",
     tokenEndpointAuthMethod: null,
     userinfoUrl: null,
     baseUrl: null,
     defaultScopes: "[]",
     scopePolicy: "[]",
-    extraParams: null,
+    authorizeParams: null,
 
     pingUrl: null,
     pingMethod: null,
@@ -75,9 +75,9 @@ const mockListProviders = mock(() => [
   },
 ]);
 
-const mockGetProvider = mock((providerKey: string) => {
+const mockGetProvider = mock((provider: string) => {
   const all = mockListProviders();
-  return all.find((p) => p.providerKey === providerKey) ?? undefined;
+  return all.find((p) => p.provider === provider) ?? undefined;
 });
 
 mock.module("../oauth/oauth-store.js", () => ({
@@ -211,16 +211,16 @@ describe("GET /v1/oauth/providers", () => {
   });
 });
 
-describe("GET /v1/oauth/providers/:providerKey", () => {
+describe("GET /v1/oauth/providers/:provider", () => {
   test("returns the correct provider", async () => {
     const req = new Request("http://localhost/v1/oauth/providers/google");
     const url = new URL(req.url);
-    const res = await getRoute("GET", "oauth/providers/:providerKey").handler({
+    const res = await getRoute("GET", "oauth/providers/:provider").handler({
       req,
       url,
       server: null as never,
       authContext: null as never,
-      params: { providerKey: "google" },
+      params: { provider: "google" },
     });
 
     expect(res.status).toBe(200);
@@ -245,12 +245,12 @@ describe("GET /v1/oauth/providers/:providerKey", () => {
   test("returns 404 for unknown provider", async () => {
     const req = new Request("http://localhost/v1/oauth/providers/nonexistent");
     const url = new URL(req.url);
-    const res = await getRoute("GET", "oauth/providers/:providerKey").handler({
+    const res = await getRoute("GET", "oauth/providers/:provider").handler({
       req,
       url,
       server: null as never,
       authContext: null as never,
-      params: { providerKey: "nonexistent" },
+      params: { provider: "nonexistent" },
     });
 
     expect(res.status).toBe(404);

--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -49,12 +49,12 @@ import {
 initializeDb();
 
 /** Seed a minimal provider row for FK satisfaction. */
-function seedTestProvider(providerKey = "github"): void {
+function seedTestProvider(provider = "github"): void {
   seedProviders([
     {
-      providerKey,
-      authUrl: `https://${providerKey}.example.com/authorize`,
-      tokenUrl: `https://${providerKey}.example.com/token`,
+      provider,
+      authorizeUrl: `https://${provider}.example.com/authorize`,
+      tokenExchangeUrl: `https://${provider}.example.com/token`,
       defaultScopes: ["read"],
       scopePolicy: {},
     },
@@ -62,9 +62,9 @@ function seedTestProvider(providerKey = "github"): void {
 }
 
 /** Create an app linked to the given provider. Returns the app row. */
-async function createTestApp(providerKey = "github", clientId = "client-1") {
-  seedTestProvider(providerKey);
-  return await upsertApp(providerKey, clientId);
+async function createTestApp(provider = "github", clientId = "client-1") {
+  seedTestProvider(provider);
+  return await upsertApp(provider, clientId);
 }
 
 beforeEach(() => {
@@ -89,34 +89,36 @@ describe("provider operations", () => {
     test("creates rows for new providers", () => {
       seedProviders([
         {
-          providerKey: "github",
-          authUrl: "https://github.com/login/oauth/authorize",
-          tokenUrl: "https://github.com/login/oauth/access_token",
+          provider: "github",
+          authorizeUrl: "https://github.com/login/oauth/authorize",
+          tokenExchangeUrl: "https://github.com/login/oauth/access_token",
           defaultScopes: ["repo", "user"],
           scopePolicy: { required: ["repo"] },
         },
         {
-          providerKey: "google",
-          authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-          tokenUrl: "https://oauth2.googleapis.com/token",
+          provider: "google",
+          authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+          tokenExchangeUrl: "https://oauth2.googleapis.com/token",
           defaultScopes: ["openid", "email"],
           scopePolicy: {},
-          extraParams: { access_type: "offline" },
+          authorizeParams: { access_type: "offline" },
         },
       ]);
 
       const gh = getProvider("github");
       expect(gh).toBeDefined();
-      expect(gh!.providerKey).toBe("github");
-      expect(gh!.authUrl).toBe("https://github.com/login/oauth/authorize");
-      expect(gh!.tokenUrl).toBe("https://github.com/login/oauth/access_token");
+      expect(gh!.provider).toBe("github");
+      expect(gh!.authorizeUrl).toBe("https://github.com/login/oauth/authorize");
+      expect(gh!.tokenExchangeUrl).toBe(
+        "https://github.com/login/oauth/access_token",
+      );
       expect(JSON.parse(gh!.defaultScopes)).toEqual(["repo", "user"]);
       expect(JSON.parse(gh!.scopePolicy)).toEqual({ required: ["repo"] });
 
       const goog = getProvider("google");
       expect(goog).toBeDefined();
-      expect(goog!.providerKey).toBe("google");
-      expect(JSON.parse(goog!.extraParams!)).toEqual({
+      expect(goog!.provider).toBe("google");
+      expect(JSON.parse(goog!.authorizeParams!)).toEqual({
         access_type: "offline",
       });
     });
@@ -124,9 +126,9 @@ describe("provider operations", () => {
     test("updates implementation fields while preserving user-customizable fields on re-seed", () => {
       seedProviders([
         {
-          providerKey: "github",
-          authUrl: "https://github.com/login/oauth/authorize",
-          tokenUrl: "https://github.com/login/oauth/access_token",
+          provider: "github",
+          authorizeUrl: "https://github.com/login/oauth/authorize",
+          tokenExchangeUrl: "https://github.com/login/oauth/access_token",
           defaultScopes: ["repo"],
           scopePolicy: {},
           baseUrl: "https://api.github.com",
@@ -141,9 +143,9 @@ describe("provider operations", () => {
       // Re-seed with corrected values (simulates a code fix deployed on upgrade)
       seedProviders([
         {
-          providerKey: "github",
-          authUrl: "https://github.com/login/oauth/authorize-v2",
-          tokenUrl: "https://github.com/login/oauth/access_token-v2",
+          provider: "github",
+          authorizeUrl: "https://github.com/login/oauth/authorize-v2",
+          tokenExchangeUrl: "https://github.com/login/oauth/access_token-v2",
           defaultScopes: ["repo", "user"],
           scopePolicy: { required: ["repo"] },
           baseUrl: "https://api.github.com/v2",
@@ -153,8 +155,10 @@ describe("provider operations", () => {
       const row = getProvider("github");
       expect(row).toBeDefined();
       // Implementation fields should be overwritten by the re-seed
-      expect(row!.authUrl).toBe("https://github.com/login/oauth/authorize-v2");
-      expect(row!.tokenUrl).toBe(
+      expect(row!.authorizeUrl).toBe(
+        "https://github.com/login/oauth/authorize-v2",
+      );
+      expect(row!.tokenExchangeUrl).toBe(
         "https://github.com/login/oauth/access_token-v2",
       );
       // User-customizable fields (baseUrl, defaultScopes, scopePolicy) are
@@ -169,9 +173,9 @@ describe("provider operations", () => {
     test("persists pingUrl when provided", () => {
       seedProviders([
         {
-          providerKey: "github",
-          authUrl: "https://github.com/authorize",
-          tokenUrl: "https://github.com/token",
+          provider: "github",
+          authorizeUrl: "https://github.com/authorize",
+          tokenExchangeUrl: "https://github.com/token",
           defaultScopes: ["repo"],
           scopePolicy: {},
           pingUrl: "https://api.github.com/user",
@@ -184,9 +188,9 @@ describe("provider operations", () => {
     test("pingUrl defaults to null when omitted", () => {
       seedProviders([
         {
-          providerKey: "github",
-          authUrl: "https://github.com/authorize",
-          tokenUrl: "https://github.com/token",
+          provider: "github",
+          authorizeUrl: "https://github.com/authorize",
+          tokenExchangeUrl: "https://github.com/token",
           defaultScopes: ["repo"],
           scopePolicy: {},
         },
@@ -199,15 +203,15 @@ describe("provider operations", () => {
       // Initial seed with all fields
       seedProviders([
         {
-          providerKey: "github",
-          authUrl: "https://github.com/authorize",
-          tokenUrl: "https://github.com/token",
+          provider: "github",
+          authorizeUrl: "https://github.com/authorize",
+          tokenExchangeUrl: "https://github.com/token",
           tokenEndpointAuthMethod: "client_secret_post",
           defaultScopes: ["repo"],
           scopePolicy: { required: ["repo"] },
           userinfoUrl: "https://api.github.com/user",
           baseUrl: "https://api.github.com",
-          extraParams: { prompt: "consent" },
+          authorizeParams: { prompt: "consent" },
 
           pingUrl: "https://api.github.com/user",
         },
@@ -224,7 +228,7 @@ describe("provider operations", () => {
           }),
           baseUrl: "https://custom.github.com/api",
         })
-        .where(eq(oauthProviders.providerKey, "github"))
+        .where(eq(oauthProviders.provider, "github"))
         .run();
 
       // Verify the manual updates took effect
@@ -239,15 +243,15 @@ describe("provider operations", () => {
       // Re-seed with updated implementation fields
       seedProviders([
         {
-          providerKey: "github",
-          authUrl: "https://github.com/authorize-v2",
-          tokenUrl: "https://github.com/token-v2",
+          provider: "github",
+          authorizeUrl: "https://github.com/authorize-v2",
+          tokenExchangeUrl: "https://github.com/token-v2",
           tokenEndpointAuthMethod: "client_secret_basic",
           defaultScopes: ["repo-only"],
           scopePolicy: {},
           userinfoUrl: "https://api.github.com/user-v2",
           baseUrl: "https://api.github.com/v2",
-          extraParams: { prompt: "login" },
+          authorizeParams: { prompt: "login" },
 
           pingUrl: "https://api.github.com/user-v2",
         },
@@ -265,11 +269,11 @@ describe("provider operations", () => {
       expect(row!.baseUrl).toBe("https://custom.github.com/api");
 
       // Implementation fields should be overwritten from the seed data
-      expect(row!.authUrl).toBe("https://github.com/authorize-v2");
-      expect(row!.tokenUrl).toBe("https://github.com/token-v2");
+      expect(row!.authorizeUrl).toBe("https://github.com/authorize-v2");
+      expect(row!.tokenExchangeUrl).toBe("https://github.com/token-v2");
       expect(row!.tokenEndpointAuthMethod).toBe("client_secret_basic");
       expect(row!.userinfoUrl).toBe("https://api.github.com/user-v2");
-      expect(JSON.parse(row!.extraParams!)).toEqual({ prompt: "login" });
+      expect(JSON.parse(row!.authorizeParams!)).toEqual({ prompt: "login" });
       expect(row!.pingUrl).toBe("https://api.github.com/user-v2");
     });
   });
@@ -278,9 +282,9 @@ describe("provider operations", () => {
     test("returns the correct row", () => {
       seedProviders([
         {
-          providerKey: "github",
-          authUrl: "https://github.com/authorize",
-          tokenUrl: "https://github.com/token",
+          provider: "github",
+          authorizeUrl: "https://github.com/authorize",
+          tokenExchangeUrl: "https://github.com/token",
           defaultScopes: ["repo"],
           scopePolicy: {},
         },
@@ -288,7 +292,7 @@ describe("provider operations", () => {
 
       const row = getProvider("github");
       expect(row).toBeDefined();
-      expect(row!.providerKey).toBe("github");
+      expect(row!.provider).toBe("github");
     });
 
     test("returns undefined for unknown keys", () => {
@@ -299,35 +303,35 @@ describe("provider operations", () => {
   describe("registerProvider", () => {
     test("creates a new row", () => {
       const row = registerProvider({
-        providerKey: "linear",
-        authUrl: "https://linear.app/oauth/authorize",
-        tokenUrl: "https://api.linear.app/oauth/token",
+        provider: "linear",
+        authorizeUrl: "https://linear.app/oauth/authorize",
+        tokenExchangeUrl: "https://api.linear.app/oauth/token",
         defaultScopes: ["read"],
         scopePolicy: {},
       });
 
-      expect(row.providerKey).toBe("linear");
-      expect(row.authUrl).toBe("https://linear.app/oauth/authorize");
+      expect(row.provider).toBe("linear");
+      expect(row.authorizeUrl).toBe("https://linear.app/oauth/authorize");
 
       const fetched = getProvider("linear");
       expect(fetched).toBeDefined();
-      expect(fetched!.providerKey).toBe("linear");
+      expect(fetched!.provider).toBe("linear");
     });
 
     test("throws for duplicate provider_key", () => {
       registerProvider({
-        providerKey: "linear",
-        authUrl: "https://linear.app/oauth/authorize",
-        tokenUrl: "https://api.linear.app/oauth/token",
+        provider: "linear",
+        authorizeUrl: "https://linear.app/oauth/authorize",
+        tokenExchangeUrl: "https://api.linear.app/oauth/token",
         defaultScopes: ["read"],
         scopePolicy: {},
       });
 
       expect(() =>
         registerProvider({
-          providerKey: "linear",
-          authUrl: "https://linear.app/oauth/authorize",
-          tokenUrl: "https://api.linear.app/oauth/token",
+          provider: "linear",
+          authorizeUrl: "https://linear.app/oauth/authorize",
+          tokenExchangeUrl: "https://api.linear.app/oauth/token",
           defaultScopes: ["read"],
           scopePolicy: {},
         }),
@@ -351,13 +355,13 @@ describe("app operations", () => {
       expect(app.id).toMatch(
         /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
       );
-      expect(app.providerKey).toBe("github");
+      expect(app.provider).toBe("github");
       expect(app.clientId).toBe("client-abc");
       expect(app.createdAt).toBeGreaterThan(0);
       expect(app.updatedAt).toBeGreaterThan(0);
     });
 
-    test("returns the existing app when called again with same (providerKey, clientId)", async () => {
+    test("returns the existing app when called again with same (provider, clientId)", async () => {
       seedTestProvider("github");
       const first = await upsertApp("github", "client-abc");
       const second = await upsertApp("github", "client-abc");
@@ -476,7 +480,7 @@ describe("app operations", () => {
 
       expect(fetched).toBeDefined();
       expect(fetched!.id).toBe(app.id);
-      expect(fetched!.providerKey).toBe("github");
+      expect(fetched!.provider).toBe("github");
       expect(fetched!.clientId).toBe("client-1");
     });
 
@@ -564,7 +568,7 @@ describe("connection operations", () => {
       const app = await createTestApp("github", "client-1");
       const conn = createConnection({
         oauthAppId: app.id,
-        providerKey: "github",
+        provider: "github",
         grantedScopes: ["repo", "user"],
         hasRefreshToken: true,
         accountInfo: "user@example.com",
@@ -574,7 +578,7 @@ describe("connection operations", () => {
 
       expect(conn.id).toBeTruthy();
       expect(conn.oauthAppId).toBe(app.id);
-      expect(conn.providerKey).toBe("github");
+      expect(conn.provider).toBe("github");
       expect(conn.status).toBe("active");
       expect(JSON.parse(conn.grantedScopes)).toEqual(["repo", "user"]);
       expect(conn.hasRefreshToken).toBe(1);
@@ -590,7 +594,7 @@ describe("connection operations", () => {
       const app = await createTestApp("github", "client-1");
       const conn = createConnection({
         oauthAppId: app.id,
-        providerKey: "github",
+        provider: "github",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
       });
@@ -598,7 +602,7 @@ describe("connection operations", () => {
       const fetched = getConnection(conn.id);
       expect(fetched).toBeDefined();
       expect(fetched!.id).toBe(conn.id);
-      expect(fetched!.providerKey).toBe("github");
+      expect(fetched!.provider).toBe("github");
     });
 
     test("returns undefined for unknown id", () => {
@@ -612,7 +616,7 @@ describe("connection operations", () => {
 
       createConnection({
         oauthAppId: app.id,
-        providerKey: "github",
+        provider: "github",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
         createdAt: 1000,
@@ -620,7 +624,7 @@ describe("connection operations", () => {
 
       const conn2 = createConnection({
         oauthAppId: app.id,
-        providerKey: "github",
+        provider: "github",
         grantedScopes: ["repo", "user"],
         hasRefreshToken: true,
         createdAt: 2000,
@@ -636,7 +640,7 @@ describe("connection operations", () => {
 
       const conn1 = createConnection({
         oauthAppId: app.id,
-        providerKey: "github",
+        provider: "github",
         accountInfo: "user1@example.com",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
@@ -645,7 +649,7 @@ describe("connection operations", () => {
 
       createConnection({
         oauthAppId: app.id,
-        providerKey: "github",
+        provider: "github",
         accountInfo: "user2@example.com",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
@@ -665,7 +669,7 @@ describe("connection operations", () => {
 
       const conn1 = createConnection({
         oauthAppId: app1.id,
-        providerKey: "github",
+        provider: "github",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
         createdAt: 1000,
@@ -673,7 +677,7 @@ describe("connection operations", () => {
 
       createConnection({
         oauthAppId: app2.id,
-        providerKey: "github",
+        provider: "github",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
         createdAt: 2000,
@@ -689,7 +693,7 @@ describe("connection operations", () => {
 
       createConnection({
         oauthAppId: app.id,
-        providerKey: "github",
+        provider: "github",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
       });
@@ -705,7 +709,7 @@ describe("connection operations", () => {
 
       const conn = createConnection({
         oauthAppId: app.id,
-        providerKey: "github",
+        provider: "github",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
       });
@@ -727,7 +731,7 @@ describe("connection operations", () => {
       // Create two connections with explicit timestamps so ordering is deterministic
       createConnection({
         oauthAppId: app.id,
-        providerKey: "github",
+        provider: "github",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
         createdAt: 1000,
@@ -735,7 +739,7 @@ describe("connection operations", () => {
 
       const conn2 = createConnection({
         oauthAppId: app.id,
-        providerKey: "github",
+        provider: "github",
         grantedScopes: ["repo", "user"],
         hasRefreshToken: true,
         createdAt: 2000,
@@ -751,14 +755,14 @@ describe("connection operations", () => {
 
       const conn1 = createConnection({
         oauthAppId: app.id,
-        providerKey: "github",
+        provider: "github",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
       });
 
       const conn2 = createConnection({
         oauthAppId: app.id,
-        providerKey: "github",
+        provider: "github",
         grantedScopes: ["repo", "user"],
         hasRefreshToken: true,
       });
@@ -776,7 +780,7 @@ describe("connection operations", () => {
 
       const conn = createConnection({
         oauthAppId: app.id,
-        providerKey: "github",
+        provider: "github",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
       });
@@ -798,7 +802,7 @@ describe("connection operations", () => {
 
       const conn1 = createConnection({
         oauthAppId: app.id,
-        providerKey: "github",
+        provider: "github",
         accountInfo: "user1@example.com",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
@@ -807,7 +811,7 @@ describe("connection operations", () => {
 
       createConnection({
         oauthAppId: app.id,
-        providerKey: "github",
+        provider: "github",
         accountInfo: "user2@example.com",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
@@ -827,7 +831,7 @@ describe("connection operations", () => {
 
       const conn = createConnection({
         oauthAppId: app.id,
-        providerKey: "github",
+        provider: "github",
         accountInfo: "user@example.com",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
@@ -843,7 +847,7 @@ describe("connection operations", () => {
 
       createConnection({
         oauthAppId: app.id,
-        providerKey: "github",
+        provider: "github",
         accountInfo: "user@example.com",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
@@ -861,7 +865,7 @@ describe("connection operations", () => {
 
       const conn = createConnection({
         oauthAppId: app.id,
-        providerKey: "github",
+        provider: "github",
         accountInfo: "user@example.com",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
@@ -882,7 +886,7 @@ describe("connection operations", () => {
 
       createConnection({
         oauthAppId: app.id,
-        providerKey: "github",
+        provider: "github",
         accountInfo: "user1@example.com",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
@@ -890,7 +894,7 @@ describe("connection operations", () => {
 
       createConnection({
         oauthAppId: app.id,
-        providerKey: "github",
+        provider: "github",
         accountInfo: "user2@example.com",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
@@ -905,7 +909,7 @@ describe("connection operations", () => {
 
       createConnection({
         oauthAppId: app.id,
-        providerKey: "github",
+        provider: "github",
         accountInfo: "user1@example.com",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
@@ -913,7 +917,7 @@ describe("connection operations", () => {
 
       const conn2 = createConnection({
         oauthAppId: app.id,
-        providerKey: "github",
+        provider: "github",
         accountInfo: "user2@example.com",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
@@ -936,7 +940,7 @@ describe("connection operations", () => {
       const app = await createTestApp("github", "client-1");
       const conn = createConnection({
         oauthAppId: app.id,
-        providerKey: "github",
+        provider: "github",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
       });
@@ -950,7 +954,7 @@ describe("connection operations", () => {
       const app = await createTestApp("github", "client-1");
       createConnection({
         oauthAppId: app.id,
-        providerKey: "github",
+        provider: "github",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
       });
@@ -967,7 +971,7 @@ describe("connection operations", () => {
       const app = await createTestApp("github", "client-1");
       const conn = createConnection({
         oauthAppId: app.id,
-        providerKey: "github",
+        provider: "github",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
       });
@@ -984,7 +988,7 @@ describe("connection operations", () => {
       const app = await createTestApp("github", "client-1");
       const conn = createConnection({
         oauthAppId: app.id,
-        providerKey: "github",
+        provider: "github",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
       });
@@ -1021,7 +1025,7 @@ describe("connection operations", () => {
 
       const conn = createConnection({
         oauthAppId: app1.id,
-        providerKey: "github",
+        provider: "github",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
       });
@@ -1051,13 +1055,13 @@ describe("connection operations", () => {
 
       createConnection({
         oauthAppId: ghApp.id,
-        providerKey: "github",
+        provider: "github",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
       });
       createConnection({
         oauthAppId: googApp.id,
-        providerKey: "google",
+        provider: "google",
         grantedScopes: ["email"],
         hasRefreshToken: true,
       });
@@ -1073,24 +1077,24 @@ describe("connection operations", () => {
 
       createConnection({
         oauthAppId: ghApp.id,
-        providerKey: "github",
+        provider: "github",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
       });
       createConnection({
         oauthAppId: googApp.id,
-        providerKey: "google",
+        provider: "google",
         grantedScopes: ["email"],
         hasRefreshToken: true,
       });
 
       const ghConns = listConnections("github");
       expect(ghConns).toHaveLength(1);
-      expect(ghConns[0].providerKey).toBe("github");
+      expect(ghConns[0].provider).toBe("github");
 
       const googConns = listConnections("google");
       expect(googConns).toHaveLength(1);
-      expect(googConns[0].providerKey).toBe("google");
+      expect(googConns[0].provider).toBe("google");
     });
 
     test("returns empty array when no connections exist", () => {
@@ -1103,7 +1107,7 @@ describe("connection operations", () => {
       const app = await createTestApp("github", "client-1");
       const conn = createConnection({
         oauthAppId: app.id,
-        providerKey: "github",
+        provider: "github",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
       });
@@ -1134,7 +1138,7 @@ describe("disconnectOAuthProvider", () => {
     const app = await createTestApp("github", "client-1");
     const conn = createConnection({
       oauthAppId: app.id,
-      providerKey: "github",
+      provider: "github",
       grantedScopes: ["repo"],
       hasRefreshToken: true,
     });
@@ -1172,7 +1176,7 @@ describe("FK constraints", () => {
     expect(() =>
       createConnection({
         oauthAppId: "nonexistent-app-id",
-        providerKey: "github",
+        provider: "github",
         grantedScopes: ["repo"],
         hasRefreshToken: false,
       }),

--- a/assistant/src/__tests__/oauth2-gateway-transport.test.ts
+++ b/assistant/src/__tests__/oauth2-gateway-transport.test.ts
@@ -138,8 +138,8 @@ globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
 import { type OAuth2Config, startOAuth2Flow } from "../security/oauth2.js";
 
 const BASE_OAUTH_CONFIG: OAuth2Config = {
-  authUrl: "https://provider.example.com/authorize",
-  tokenUrl: "https://provider.example.com/token",
+  authorizeUrl: "https://provider.example.com/authorize",
+  tokenExchangeUrl: "https://provider.example.com/token",
   scopes: ["read", "write"],
   clientId: "test-client-id",
 };
@@ -219,9 +219,9 @@ describe("OAuth2 gateway transport", () => {
       expect(capturedAuthUrl).toContain(encodeURIComponent("/oauth/callback"));
 
       // Extract the redirect_uri and simulate the callback
-      const authUrl = new URL(capturedAuthUrl);
-      const redirectUri = authUrl.searchParams.get("redirect_uri")!;
-      const state = authUrl.searchParams.get("state")!;
+      const authorizeUrl = new URL(capturedAuthUrl);
+      const redirectUri = authorizeUrl.searchParams.get("redirect_uri")!;
+      const state = authorizeUrl.searchParams.get("state")!;
 
       // Make a request to the loopback server with the auth code
       const callbackUrl = `${redirectUri}?code=loopback-auth-code&state=${state}`;
@@ -282,9 +282,9 @@ describe("OAuth2 gateway transport", () => {
       expect(capturedAuthUrl).not.toContain("gw.example.com");
 
       // Simulate callback to loopback server
-      const authUrl = new URL(capturedAuthUrl);
-      const redirectUri = authUrl.searchParams.get("redirect_uri")!;
-      const state = authUrl.searchParams.get("state")!;
+      const authorizeUrl = new URL(capturedAuthUrl);
+      const redirectUri = authorizeUrl.searchParams.get("redirect_uri")!;
+      const state = authorizeUrl.searchParams.get("state")!;
       await fetch(`${redirectUri}?code=explicit-loopback-code&state=${state}`);
 
       const result = await flowPromise;
@@ -405,9 +405,9 @@ describe("OAuth2 gateway transport", () => {
       expect(capturedAuthUrl).toContain("code_challenge=");
       expect(capturedAuthUrl).toContain("code_challenge_method=S256");
 
-      const authUrl = new URL(capturedAuthUrl);
-      const redirectUri = authUrl.searchParams.get("redirect_uri")!;
-      const state = authUrl.searchParams.get("state")!;
+      const authorizeUrl = new URL(capturedAuthUrl);
+      const redirectUri = authorizeUrl.searchParams.get("redirect_uri")!;
+      const state = authorizeUrl.searchParams.get("state")!;
 
       const resp = await fetch(
         `${redirectUri}?code=loopback-code&state=${state}`,
@@ -440,9 +440,9 @@ describe("OAuth2 gateway transport", () => {
 
       await urlReadyPromise;
 
-      const authUrl = new URL(capturedAuthUrl);
-      const redirectUri = authUrl.searchParams.get("redirect_uri")!;
-      const state = authUrl.searchParams.get("state")!;
+      const authorizeUrl = new URL(capturedAuthUrl);
+      const redirectUri = authorizeUrl.searchParams.get("redirect_uri")!;
+      const state = authorizeUrl.searchParams.get("state")!;
 
       // Fire callback without awaiting — immediately check flowPromise rejection
       fetch(`${redirectUri}?error=access_denied&state=${state}`).catch(
@@ -473,8 +473,8 @@ describe("OAuth2 gateway transport", () => {
 
       await urlReadyPromise;
 
-      const authUrl = new URL(capturedAuthUrl);
-      const redirectUri = authUrl.searchParams.get("redirect_uri")!;
+      const authorizeUrl = new URL(capturedAuthUrl);
+      const redirectUri = authorizeUrl.searchParams.get("redirect_uri")!;
 
       // Send callback with wrong state
       const resp = await fetch(
@@ -484,7 +484,7 @@ describe("OAuth2 gateway transport", () => {
 
       // The flow should still be waiting (not resolved)
       // Send the correct callback to clean up
-      const state = authUrl.searchParams.get("state")!;
+      const state = authorizeUrl.searchParams.get("state")!;
       await fetch(`${redirectUri}?code=correct-code&state=${state}`);
 
       const result = await flowPromise;
@@ -516,9 +516,9 @@ describe("OAuth2 gateway transport", () => {
 
       await urlReadyPromise;
 
-      const authUrl = new URL(capturedAuthUrl);
-      const redirectUri = authUrl.searchParams.get("redirect_uri")!;
-      const state = authUrl.searchParams.get("state")!;
+      const authorizeUrl = new URL(capturedAuthUrl);
+      const redirectUri = authorizeUrl.searchParams.get("redirect_uri")!;
+      const state = authorizeUrl.searchParams.get("state")!;
 
       // Fire callback without awaiting — immediately check flowPromise rejection
       fetch(`${redirectUri}?code=code-that-fails&state=${state}`).catch(

--- a/assistant/src/__tests__/outlook-categories.test.ts
+++ b/assistant/src/__tests__/outlook-categories.test.ts
@@ -15,7 +15,7 @@ const mockListMasterCategories = mock(() =>
   }),
 );
 const mockResolveOAuthConnection = mock(() =>
-  Promise.resolve({ id: "conn-1", providerKey: "outlook" }),
+  Promise.resolve({ id: "conn-1", provider: "outlook" }),
 );
 
 mock.module("../messaging/providers/outlook/client.js", () => ({

--- a/assistant/src/__tests__/outlook-client-automation.test.ts
+++ b/assistant/src/__tests__/outlook-client-automation.test.ts
@@ -25,7 +25,7 @@ function createMockConnection(
 ): OAuthConnection {
   return {
     id: "outlook-conn-1",
-    providerKey: "outlook",
+    provider: "outlook",
     accountInfo: "test@outlook.com",
     request: mock(() =>
       Promise.resolve({ status, headers: {}, body: responseBody }),

--- a/assistant/src/__tests__/outlook-compose-tools.test.ts
+++ b/assistant/src/__tests__/outlook-compose-tools.test.ts
@@ -56,7 +56,7 @@ const createForwardDraftMock = mock(
 
 const fakeConnection = {
   id: "conn-1",
-  providerKey: "microsoft",
+  provider: "microsoft",
   accountInfo: "user@outlook.com",
 } as unknown as OAuthConnection;
 

--- a/assistant/src/__tests__/outlook-email-watcher.test.ts
+++ b/assistant/src/__tests__/outlook-email-watcher.test.ts
@@ -40,7 +40,7 @@ mock.module("../messaging/providers/outlook/client.js", () => ({
 }));
 
 const mockResolveOAuthConnection =
-  mock<(providerKey: string) => Promise<unknown>>();
+  mock<(provider: string) => Promise<unknown>>();
 
 mock.module("../oauth/connection-resolver.js", () => ({
   resolveOAuthConnection: mockResolveOAuthConnection,

--- a/assistant/src/__tests__/outlook-follow-up.test.ts
+++ b/assistant/src/__tests__/outlook-follow-up.test.ts
@@ -24,7 +24,7 @@ const mockListMessages = mock(() =>
   }),
 );
 const mockResolveOAuthConnection = mock(() =>
-  Promise.resolve({ id: "conn-1", providerKey: "outlook" }),
+  Promise.resolve({ id: "conn-1", provider: "outlook" }),
 );
 
 mock.module("../messaging/providers/outlook/client.js", () => ({

--- a/assistant/src/__tests__/outlook-messaging-provider.test.ts
+++ b/assistant/src/__tests__/outlook-messaging-provider.test.ts
@@ -164,7 +164,7 @@ import {
 function createMockConnection(): OAuthConnection {
   return {
     id: "outlook-conn-1",
-    providerKey: "outlook",
+    provider: "outlook",
     accountInfo: "test@outlook.com",
     request: mock(() =>
       Promise.resolve({ status: 200, headers: {}, body: {} }),
@@ -884,7 +884,7 @@ describe("Outlook client functions", () => {
   ): OAuthConnection {
     return {
       id: "outlook-conn-1",
-      providerKey: "outlook",
+      provider: "outlook",
       accountInfo: "test@outlook.com",
       request: mock(() =>
         Promise.resolve({ status, headers: {}, body: responseBody }),

--- a/assistant/src/__tests__/outlook-trash.test.ts
+++ b/assistant/src/__tests__/outlook-trash.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, mock, test } from "bun:test";
 
 const mockTrashMessage = mock(() => Promise.resolve({}));
 const mockResolveOAuthConnection = mock(() =>
-  Promise.resolve({ id: "conn-1", providerKey: "outlook" }),
+  Promise.resolve({ id: "conn-1", provider: "outlook" }),
 );
 
 mock.module("../messaging/providers/outlook/client.js", () => ({

--- a/assistant/src/__tests__/outlook-unsubscribe.test.ts
+++ b/assistant/src/__tests__/outlook-unsubscribe.test.ts
@@ -57,7 +57,7 @@ const { run } =
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-const fakeConnection = { id: "outlook-conn-1", providerKey: "outlook" };
+const fakeConnection = { id: "outlook-conn-1", provider: "outlook" };
 
 function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
   return {

--- a/assistant/src/__tests__/slack-channel-config.test.ts
+++ b/assistant/src/__tests__/slack-channel-config.test.ts
@@ -82,8 +82,8 @@ let oauthConnectionStore: Record<
 > = {};
 
 mock.module("../oauth/oauth-store.js", () => ({
-  getConnectionByProvider: (providerKey: string) =>
-    oauthConnectionStore[providerKey] ?? undefined,
+  getConnectionByProvider: (provider: string) =>
+    oauthConnectionStore[provider] ?? undefined,
   createConnection: () => ({ id: "test-conn-id" }),
   updateConnection: () => true,
   deleteConnection: (id: string) => {
@@ -101,24 +101,21 @@ mock.module("../oauth/oauth-store.js", () => ({
 // Mock manual-token-connection
 mock.module("../oauth/manual-token-connection.js", () => ({
   ensureManualTokenConnection: async (
-    providerKey: string,
+    provider: string,
     accountInfo?: string,
   ) => {
-    oauthConnectionStore[providerKey] = {
-      id: `conn-${providerKey}`,
+    oauthConnectionStore[provider] = {
+      id: `conn-${provider}`,
       status: "active",
       accountInfo: accountInfo ?? null,
     };
   },
-  removeManualTokenConnection: (providerKey: string) => {
-    delete oauthConnectionStore[providerKey];
+  removeManualTokenConnection: (provider: string) => {
+    delete oauthConnectionStore[provider];
   },
-  syncManualTokenConnection: async (
-    providerKey: string,
-    accountInfo?: string,
-  ) => {
+  syncManualTokenConnection: async (provider: string, accountInfo?: string) => {
     const { getSecureKeyAsync } = await import("../security/secure-keys.js");
-    if (providerKey !== "slack_channel") return;
+    if (provider !== "slack_channel") return;
     const hasBotToken = !!(await getSecureKeyAsync(
       credentialKey("slack_channel", "bot_token"),
     ));
@@ -126,14 +123,14 @@ mock.module("../oauth/manual-token-connection.js", () => ({
       credentialKey("slack_channel", "app_token"),
     ));
     if (hasBotToken && hasAppToken) {
-      oauthConnectionStore[providerKey] = {
-        id: `conn-${providerKey}`,
+      oauthConnectionStore[provider] = {
+        id: `conn-${provider}`,
         status: "active",
         accountInfo: accountInfo ?? null,
       };
       return;
     }
-    delete oauthConnectionStore[providerKey];
+    delete oauthConnectionStore[provider];
   },
 }));
 

--- a/assistant/src/__tests__/telegram-config.test.ts
+++ b/assistant/src/__tests__/telegram-config.test.ts
@@ -7,7 +7,7 @@ let oauthConnectionStore: Record<
   string,
   { id: string; status: string; accountInfo?: string | null }
 > = {};
-const syncCalls: Array<{ providerKey: string; accountInfo?: string }> = [];
+const syncCalls: Array<{ provider: string; accountInfo?: string }> = [];
 
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({ telegram: {}, ui: {} }),
@@ -49,32 +49,29 @@ mock.module("../security/secure-keys.js", () => ({
 }));
 
 mock.module("../oauth/oauth-store.js", () => ({
-  getConnectionByProvider: (providerKey: string) =>
-    oauthConnectionStore[providerKey] ?? undefined,
+  getConnectionByProvider: (provider: string) =>
+    oauthConnectionStore[provider] ?? undefined,
 }));
 
 mock.module("../oauth/manual-token-connection.js", () => ({
   ensureManualTokenConnection: async () => {},
   removeManualTokenConnection: () => {},
-  syncManualTokenConnection: async (
-    providerKey: string,
-    accountInfo?: string,
-  ) => {
-    syncCalls.push({ providerKey, accountInfo });
-    if (providerKey !== "telegram") return;
+  syncManualTokenConnection: async (provider: string, accountInfo?: string) => {
+    syncCalls.push({ provider, accountInfo });
+    if (provider !== "telegram") return;
     const hasBotToken =
       !!secureKeyStore[credentialKey("telegram", "bot_token")];
     const hasWebhookSecret =
       !!secureKeyStore[credentialKey("telegram", "webhook_secret")];
     if (hasBotToken && hasWebhookSecret) {
-      oauthConnectionStore[providerKey] = {
-        id: `conn-${providerKey}`,
+      oauthConnectionStore[provider] = {
+        id: `conn-${provider}`,
         status: "active",
         accountInfo: accountInfo ?? null,
       };
       return;
     }
-    delete oauthConnectionStore[providerKey];
+    delete oauthConnectionStore[provider];
   },
 }));
 
@@ -114,7 +111,7 @@ describe("Telegram config handler", () => {
     expect(result.botUsername).toBe("testbot");
     expect(result.connected).toBe(true);
     expect(syncCalls).toEqual([
-      { providerKey: "telegram", accountInfo: "@testbot" },
+      { provider: "telegram", accountInfo: "@testbot" },
     ]);
     expect(oauthConnectionStore["telegram"]?.accountInfo).toBe("@testbot");
   });

--- a/assistant/src/cli/commands/credentials.ts
+++ b/assistant/src/cli/commands/credentials.ts
@@ -312,7 +312,7 @@ Examples:
           });
         }
 
-        // Build a lookup of oauth connections keyed by providerKey for enrichment.
+        // Build a lookup of oauth connections keyed by provider for enrichment.
         // listConnections() returns rows in no guaranteed order, so we compare
         // createdAt to keep the most recent active connection per provider —
         // matching the behaviour of getConnectionByProvider() used by inspect.
@@ -320,9 +320,9 @@ Examples:
         const connectionsByProvider = new Map<string, OAuthConnectionRow>();
         for (const conn of allConnections) {
           if (conn.status !== "active") continue;
-          const existing = connectionsByProvider.get(conn.providerKey);
+          const existing = connectionsByProvider.get(conn.provider);
           if (!existing || conn.createdAt > existing.createdAt) {
-            connectionsByProvider.set(conn.providerKey, conn);
+            connectionsByProvider.set(conn.provider, conn);
           }
         }
 

--- a/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
@@ -391,7 +391,7 @@ describe("assistant oauth connect", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(true);
     expect(parsed.deferred).toBe(true);
-    expect(parsed.authorizeUrl).toBe(
+    expect(parsed.authUrl).toBe(
       "https://accounts.google.com/o/oauth2/v2/auth?state=abc",
     );
     expect(parsed.service).toBe("google");
@@ -545,7 +545,7 @@ describe("assistant oauth connect", () => {
   // JSON output format for deferred case (BYO)
   // -------------------------------------------------------------------------
 
-  test("JSON output for deferred case includes ok, deferred, authorizeUrl, service", async () => {
+  test("JSON output for deferred case includes ok, deferred, authUrl, service", async () => {
     mockGetProvider = () => ({
       provider: "slack",
       authorizeUrl: "https://slack.com/oauth/v2/authorize",
@@ -581,7 +581,7 @@ describe("assistant oauth connect", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveProperty("ok", true);
     expect(parsed).toHaveProperty("deferred", true);
-    expect(parsed).toHaveProperty("authorizeUrl");
+    expect(parsed).toHaveProperty("authUrl");
     expect(parsed).toHaveProperty("service", "slack");
   });
 

--- a/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/connect.test.ts
@@ -264,9 +264,9 @@ describe("assistant oauth connect", () => {
 
   test("managed mode with --no-browser: prints connect URL", async () => {
     mockGetProvider = () => ({
-      providerKey: "google",
-      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-      tokenUrl: "https://oauth2.googleapis.com/token",
+      provider: "google",
+      authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenExchangeUrl: "https://oauth2.googleapis.com/token",
       managedServiceConfigKey: "google-oauth",
     });
     mockIsManagedMode = () => true;
@@ -301,9 +301,9 @@ describe("assistant oauth connect", () => {
 
   test("managed mode default: opens browser and polls for new connection", async () => {
     mockGetProvider = () => ({
-      providerKey: "google",
-      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-      tokenUrl: "https://oauth2.googleapis.com/token",
+      provider: "google",
+      authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenExchangeUrl: "https://oauth2.googleapis.com/token",
       managedServiceConfigKey: "google-oauth",
     });
     mockIsManagedMode = () => true;
@@ -357,9 +357,9 @@ describe("assistant oauth connect", () => {
 
   test("BYO mode with --no-browser: prints auth URL", async () => {
     mockGetProvider = () => ({
-      providerKey: "google",
-      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-      tokenUrl: "https://oauth2.googleapis.com/token",
+      provider: "google",
+      authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenExchangeUrl: "https://oauth2.googleapis.com/token",
       managedServiceConfigKey: null,
     });
     mockIsManagedMode = () => false;
@@ -368,7 +368,7 @@ describe("assistant oauth connect", () => {
       id: "app-1",
       clientId: "byo-client-id",
       clientSecretCredentialPath: "oauth_app/app-1/client_secret",
-      providerKey: "google",
+      provider: "google",
       createdAt: 0,
       updatedAt: 0,
     });
@@ -376,7 +376,7 @@ describe("assistant oauth connect", () => {
     mockOrchestrateOAuthConnect = async () => ({
       success: true,
       deferred: true,
-      authUrl: "https://accounts.google.com/o/oauth2/v2/auth?state=abc",
+      authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth?state=abc",
       state: "abc",
       service: "google",
     });
@@ -391,7 +391,7 @@ describe("assistant oauth connect", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(true);
     expect(parsed.deferred).toBe(true);
-    expect(parsed.authUrl).toBe(
+    expect(parsed.authorizeUrl).toBe(
       "https://accounts.google.com/o/oauth2/v2/auth?state=abc",
     );
     expect(parsed.service).toBe("google");
@@ -403,9 +403,9 @@ describe("assistant oauth connect", () => {
 
   test("BYO mode default calls orchestrator with isInteractive: true", async () => {
     mockGetProvider = () => ({
-      providerKey: "google",
-      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-      tokenUrl: "https://oauth2.googleapis.com/token",
+      provider: "google",
+      authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenExchangeUrl: "https://oauth2.googleapis.com/token",
       managedServiceConfigKey: null,
     });
     mockIsManagedMode = () => false;
@@ -414,7 +414,7 @@ describe("assistant oauth connect", () => {
       id: "app-1",
       clientId: "test-id",
       clientSecretCredentialPath: "oauth_app/app-1/client_secret",
-      providerKey: "google",
+      provider: "google",
       createdAt: 0,
       updatedAt: 0,
     });
@@ -455,9 +455,9 @@ describe("assistant oauth connect", () => {
 
   test("BYO mode: missing app with --client-id returns error with hint", async () => {
     mockGetProvider = () => ({
-      providerKey: "google",
-      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-      tokenUrl: "https://oauth2.googleapis.com/token",
+      provider: "google",
+      authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenExchangeUrl: "https://oauth2.googleapis.com/token",
       managedServiceConfigKey: null,
     });
     mockIsManagedMode = () => false;
@@ -483,9 +483,9 @@ describe("assistant oauth connect", () => {
 
   test("BYO mode: no client_id found returns error with hint", async () => {
     mockGetProvider = () => ({
-      providerKey: "google",
-      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-      tokenUrl: "https://oauth2.googleapis.com/token",
+      provider: "google",
+      authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenExchangeUrl: "https://oauth2.googleapis.com/token",
       managedServiceConfigKey: null,
     });
     mockIsManagedMode = () => false;
@@ -509,9 +509,9 @@ describe("assistant oauth connect", () => {
 
   test("--client-id is silently ignored in managed mode", async () => {
     mockGetProvider = () => ({
-      providerKey: "google",
-      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-      tokenUrl: "https://oauth2.googleapis.com/token",
+      provider: "google",
+      authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenExchangeUrl: "https://oauth2.googleapis.com/token",
       managedServiceConfigKey: "google-oauth",
     });
     mockIsManagedMode = () => true;
@@ -545,11 +545,11 @@ describe("assistant oauth connect", () => {
   // JSON output format for deferred case (BYO)
   // -------------------------------------------------------------------------
 
-  test("JSON output for deferred case includes ok, deferred, authUrl, service", async () => {
+  test("JSON output for deferred case includes ok, deferred, authorizeUrl, service", async () => {
     mockGetProvider = () => ({
-      providerKey: "slack",
-      authUrl: "https://slack.com/oauth/v2/authorize",
-      tokenUrl: "https://slack.com/api/oauth.v2.access",
+      provider: "slack",
+      authorizeUrl: "https://slack.com/oauth/v2/authorize",
+      tokenExchangeUrl: "https://slack.com/api/oauth.v2.access",
       managedServiceConfigKey: null,
     });
     mockIsManagedMode = () => false;
@@ -558,7 +558,7 @@ describe("assistant oauth connect", () => {
       id: "app-slack",
       clientId: "slack-client-id",
       clientSecretCredentialPath: "oauth_app/app-slack/client_secret",
-      providerKey: "slack",
+      provider: "slack",
       createdAt: 0,
       updatedAt: 0,
     });
@@ -566,7 +566,7 @@ describe("assistant oauth connect", () => {
     mockOrchestrateOAuthConnect = async () => ({
       success: true,
       deferred: true,
-      authUrl: "https://slack.com/oauth/v2/authorize?state=xyz",
+      authorizeUrl: "https://slack.com/oauth/v2/authorize?state=xyz",
       state: "xyz",
       service: "slack",
     });
@@ -581,7 +581,7 @@ describe("assistant oauth connect", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed).toHaveProperty("ok", true);
     expect(parsed).toHaveProperty("deferred", true);
-    expect(parsed).toHaveProperty("authUrl");
+    expect(parsed).toHaveProperty("authorizeUrl");
     expect(parsed).toHaveProperty("service", "slack");
   });
 
@@ -591,9 +591,9 @@ describe("assistant oauth connect", () => {
 
   test("JSON output for completed case includes ok, grantedScopes, accountInfo", async () => {
     mockGetProvider = () => ({
-      providerKey: "google",
-      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-      tokenUrl: "https://oauth2.googleapis.com/token",
+      provider: "google",
+      authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenExchangeUrl: "https://oauth2.googleapis.com/token",
       managedServiceConfigKey: null,
     });
     mockIsManagedMode = () => false;
@@ -602,7 +602,7 @@ describe("assistant oauth connect", () => {
       id: "app-1",
       clientId: "completed-client-id",
       clientSecretCredentialPath: "oauth_app/app-1/client_secret",
-      providerKey: "google",
+      provider: "google",
       createdAt: 0,
       updatedAt: 0,
     });
@@ -635,9 +635,9 @@ describe("assistant oauth connect", () => {
 
   test("BYO mode: client_secret required but missing returns error with hint", async () => {
     mockGetProvider = () => ({
-      providerKey: "google",
-      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-      tokenUrl: "https://oauth2.googleapis.com/token",
+      provider: "google",
+      authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenExchangeUrl: "https://oauth2.googleapis.com/token",
       tokenEndpointAuthMethod: "client_secret_post",
       managedServiceConfigKey: null,
       requiresClientSecret: 1,
@@ -648,7 +648,7 @@ describe("assistant oauth connect", () => {
       id: "app-1",
       clientId: "test-id",
       clientSecretCredentialPath: "oauth_app/app-1/client_secret",
-      providerKey: "google",
+      provider: "google",
       createdAt: 0,
       updatedAt: 0,
     });
@@ -674,9 +674,9 @@ describe("assistant oauth connect", () => {
 
   test("manual-token provider returns error directing to credentials command", async () => {
     mockGetProvider = () => ({
-      providerKey: "slack_channel",
-      authUrl: "urn:manual-token",
-      tokenUrl: "urn:manual-token",
+      provider: "slack_channel",
+      authorizeUrl: "urn:manual-token",
+      tokenExchangeUrl: "urn:manual-token",
       managedServiceConfigKey: null,
     });
     mockIsManagedMode = () => false;
@@ -701,9 +701,9 @@ describe("assistant oauth connect", () => {
 
   test("BYO mode: orchestrator error propagates correctly", async () => {
     mockGetProvider = () => ({
-      providerKey: "google",
-      authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-      tokenUrl: "https://oauth2.googleapis.com/token",
+      provider: "google",
+      authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenExchangeUrl: "https://oauth2.googleapis.com/token",
       managedServiceConfigKey: null,
     });
     mockIsManagedMode = () => false;
@@ -712,7 +712,7 @@ describe("assistant oauth connect", () => {
       id: "app-1",
       clientId: "client-id",
       clientSecretCredentialPath: "oauth_app/app-1/client_secret",
-      providerKey: "google",
+      provider: "google",
       createdAt: 0,
       updatedAt: 0,
     });

--- a/assistant/src/cli/commands/oauth/__tests__/disconnect.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/disconnect.test.ts
@@ -15,19 +15,19 @@ let mockGetConnection: (
 ) => Record<string, unknown> | undefined = () => undefined;
 
 let mockGetActiveConnection: (
-  providerKey: string,
+  provider: string,
   opts?: { account?: string },
 ) => Record<string, unknown> | undefined = () => undefined;
 
 let mockListActiveConnectionsByProvider: (
-  providerKey: string,
+  provider: string,
 ) => Array<Record<string, unknown>> = () => [];
 
 let mockDisconnectOAuthProviderResult: "disconnected" | "not-found" | "error" =
   "disconnected";
 
 let mockDisconnectOAuthProviderCalls: Array<{
-  providerKey: string;
+  provider: string;
   account: string | undefined;
   connectionId: string | undefined;
 }> = [];
@@ -64,17 +64,17 @@ mock.module("../../../../config/loader.js", () => ({
 mock.module("../../../../oauth/oauth-store.js", () => ({
   getProvider: (key: string) => mockGetProvider(key),
   getConnection: (id: string) => mockGetConnection(id),
-  getActiveConnection: (providerKey: string, opts?: { account?: string }) =>
-    mockGetActiveConnection(providerKey, opts),
-  listActiveConnectionsByProvider: (providerKey: string) =>
-    mockListActiveConnectionsByProvider(providerKey),
+  getActiveConnection: (provider: string, opts?: { account?: string }) =>
+    mockGetActiveConnection(provider, opts),
+  listActiveConnectionsByProvider: (provider: string) =>
+    mockListActiveConnectionsByProvider(provider),
   disconnectOAuthProvider: async (
-    providerKey: string,
+    provider: string,
     account?: string,
     connectionId?: string,
   ) => {
     mockDisconnectOAuthProviderCalls.push({
-      providerKey,
+      provider,
       account,
       connectionId,
     });
@@ -295,7 +295,7 @@ describe("assistant oauth disconnect", () => {
 
   test("both --account and --connection-id returns error", async () => {
     mockGetProvider = () => ({
-      providerKey: "google",
+      provider: "google",
       managedServiceConfigKey: null,
     });
 
@@ -323,7 +323,7 @@ describe("assistant oauth disconnect", () => {
   describe("managed mode", () => {
     beforeEach(() => {
       mockGetProvider = () => ({
-        providerKey: "google",
+        provider: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockIsManagedMode = () => true;
@@ -484,7 +484,7 @@ describe("assistant oauth disconnect", () => {
   describe("BYO mode", () => {
     beforeEach(() => {
       mockGetProvider = () => ({
-        providerKey: "google",
+        provider: "google",
         managedServiceConfigKey: null,
       });
       mockIsManagedMode = () => false;
@@ -494,7 +494,7 @@ describe("assistant oauth disconnect", () => {
       mockListActiveConnectionsByProvider = () => [
         {
           id: "conn-1",
-          providerKey: "google",
+          provider: "google",
           accountInfo: "user@gmail.com",
           status: "active",
         },
@@ -514,16 +514,16 @@ describe("assistant oauth disconnect", () => {
 
       // Verify disconnectOAuthProvider was called
       expect(mockDisconnectOAuthProviderCalls).toHaveLength(1);
-      expect(mockDisconnectOAuthProviderCalls[0].providerKey).toBe("google");
+      expect(mockDisconnectOAuthProviderCalls[0].provider).toBe("google");
       expect(mockDisconnectOAuthProviderCalls[0].connectionId).toBe("conn-1");
     });
 
     test("--account matches accountInfo", async () => {
-      mockGetActiveConnection = (providerKey, opts) => {
+      mockGetActiveConnection = (_provider, opts) => {
         if (opts?.account === "user@gmail.com") {
           return {
             id: "conn-1",
-            providerKey: "google",
+            provider: "google",
             accountInfo: "user@gmail.com",
             status: "active",
           };
@@ -567,7 +567,7 @@ describe("assistant oauth disconnect", () => {
         if (id === "conn-123") {
           return {
             id: "conn-123",
-            providerKey: "google",
+            provider: "google",
             accountInfo: "user@gmail.com",
             status: "active",
           };
@@ -593,7 +593,7 @@ describe("assistant oauth disconnect", () => {
         if (id === "conn-slack") {
           return {
             id: "conn-slack",
-            providerKey: "slack",
+            provider: "slack",
             accountInfo: null,
             status: "active",
           };
@@ -619,13 +619,13 @@ describe("assistant oauth disconnect", () => {
       mockListActiveConnectionsByProvider = () => [
         {
           id: "conn-1",
-          providerKey: "google",
+          provider: "google",
           accountInfo: "user1@gmail.com",
           status: "active",
         },
         {
           id: "conn-2",
-          providerKey: "google",
+          provider: "google",
           accountInfo: "user2@gmail.com",
           status: "active",
         },
@@ -666,7 +666,7 @@ describe("assistant oauth disconnect", () => {
       mockListActiveConnectionsByProvider = () => [
         {
           id: "conn-1",
-          providerKey: "google",
+          provider: "google",
           accountInfo: null,
           status: "active",
         },

--- a/assistant/src/cli/commands/oauth/__tests__/mode.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/mode.test.ts
@@ -11,7 +11,7 @@ let mockGetProvider: (
 ) => Record<string, unknown> | undefined = () => undefined;
 
 let mockListActiveConnectionsByProvider: (
-  providerKey: string,
+  provider: string,
 ) => Array<Record<string, unknown>> = () => [];
 
 let mockGetManagedServiceConfigKey: (key: string) => string | null = () => null;
@@ -71,8 +71,8 @@ mock.module("../../../../config/loader.js", () => ({
 
 mock.module("../../../../oauth/oauth-store.js", () => ({
   getProvider: (key: string) => mockGetProvider(key),
-  listActiveConnectionsByProvider: (providerKey: string) =>
-    mockListActiveConnectionsByProvider(providerKey),
+  listActiveConnectionsByProvider: (provider: string) =>
+    mockListActiveConnectionsByProvider(provider),
   listConnections: () => [],
   getConnection: () => undefined,
   getConnectionByProvider: () => undefined,
@@ -276,7 +276,7 @@ describe("assistant oauth mode", () => {
 
     test("provider without managedServiceConfigKey returns your-own with managedModeSupported: false", async () => {
       mockGetProvider = () => ({
-        providerKey: "slack",
+        provider: "slack",
         managedServiceConfigKey: null,
       });
       mockGetManagedServiceConfigKey = () => null;
@@ -296,7 +296,7 @@ describe("assistant oauth mode", () => {
 
     test("provider in managed mode returns mode: managed with managedModeSupported: true", async () => {
       mockGetProvider = () => ({
-        providerKey: "google",
+        provider: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockGetManagedServiceConfigKey = () => "google-oauth";
@@ -319,7 +319,7 @@ describe("assistant oauth mode", () => {
 
     test("provider in your-own mode returns mode: your-own with managedModeSupported: true", async () => {
       mockGetProvider = () => ({
-        providerKey: "google",
+        provider: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockGetManagedServiceConfigKey = () => "google-oauth";
@@ -348,7 +348,7 @@ describe("assistant oauth mode", () => {
   describe("set mode", () => {
     test("invalid mode value returns error listing valid values", async () => {
       mockGetProvider = () => ({
-        providerKey: "google",
+        provider: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockGetManagedServiceConfigKey = () => "google-oauth";
@@ -370,7 +370,7 @@ describe("assistant oauth mode", () => {
 
     test("provider without managedServiceConfigKey returns error about managed mode not available when --set managed", async () => {
       mockGetProvider = () => ({
-        providerKey: "slack",
+        provider: "slack",
         managedServiceConfigKey: null,
       });
       mockGetManagedServiceConfigKey = () => null;
@@ -391,7 +391,7 @@ describe("assistant oauth mode", () => {
 
     test("provider without managedServiceConfigKey treats --set your-own as successful no-op", async () => {
       mockGetProvider = () => ({
-        providerKey: "slack",
+        provider: "slack",
         managedServiceConfigKey: null,
       });
       mockGetManagedServiceConfigKey = () => null;
@@ -414,7 +414,7 @@ describe("assistant oauth mode", () => {
 
     test("set to same mode returns changed: false", async () => {
       mockGetProvider = () => ({
-        providerKey: "google",
+        provider: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockGetManagedServiceConfigKey = () => "google-oauth";
@@ -440,7 +440,7 @@ describe("assistant oauth mode", () => {
 
     test("switch managed -> your-own with active managed connections and no BYO connections includes hint", async () => {
       mockGetProvider = () => ({
-        providerKey: "google",
+        provider: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockGetManagedServiceConfigKey = () => "google-oauth";
@@ -483,7 +483,7 @@ describe("assistant oauth mode", () => {
 
     test("switch your-own -> managed with active BYO connections and no managed connections includes hint", async () => {
       mockGetProvider = () => ({
-        providerKey: "google",
+        provider: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockGetManagedServiceConfigKey = () => "google-oauth";
@@ -496,7 +496,7 @@ describe("assistant oauth mode", () => {
       mockListActiveConnectionsByProvider = () => [
         {
           id: "conn-local-1",
-          providerKey: "google",
+          provider: "google",
           status: "active",
         },
       ];
@@ -526,7 +526,7 @@ describe("assistant oauth mode", () => {
 
     test("switch mode with connections on both sides has no hint", async () => {
       mockGetProvider = () => ({
-        providerKey: "google",
+        provider: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockGetManagedServiceConfigKey = () => "google-oauth";
@@ -549,7 +549,7 @@ describe("assistant oauth mode", () => {
       mockListActiveConnectionsByProvider = () => [
         {
           id: "conn-local-1",
-          providerKey: "google",
+          provider: "google",
           status: "active",
         },
       ];
@@ -571,7 +571,7 @@ describe("assistant oauth mode", () => {
 
     test("switch mode with no connections on either side has no hint", async () => {
       mockGetProvider = () => ({
-        providerKey: "google",
+        provider: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockGetManagedServiceConfigKey = () => "google-oauth";
@@ -604,7 +604,7 @@ describe("assistant oauth mode", () => {
 
     test("saveRawConfig is called with the correct nested path", async () => {
       mockGetProvider = () => ({
-        providerKey: "google",
+        provider: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockGetManagedServiceConfigKey = () => "google-oauth";

--- a/assistant/src/cli/commands/oauth/__tests__/ping.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/ping.test.ts
@@ -15,7 +15,7 @@ let mockResolveOAuthConnectionResult:
   | Error = new Error("not configured");
 
 let mockResolveOAuthConnectionCalls: Array<{
-  providerKey: string;
+  provider: string;
   options?: Record<string, unknown>;
 }> = [];
 
@@ -53,10 +53,10 @@ mock.module("../../../../oauth/oauth-store.js", () => ({
 
 mock.module("../../../../oauth/connection-resolver.js", () => ({
   resolveOAuthConnection: async (
-    providerKey: string,
+    provider: string,
     options?: Record<string, unknown>,
   ) => {
-    mockResolveOAuthConnectionCalls.push({ providerKey, options });
+    mockResolveOAuthConnectionCalls.push({ provider, options });
     if (mockResolveOAuthConnectionResult instanceof Error) {
       throw mockResolveOAuthConnectionResult;
     }
@@ -186,7 +186,7 @@ describe("assistant oauth ping", () => {
 
   test("no ping URL configured returns error", async () => {
     mockGetProvider = () => ({
-      providerKey: "google",
+      provider: "google",
       pingUrl: null,
     });
 
@@ -205,7 +205,7 @@ describe("assistant oauth ping", () => {
   describe("BYO mode", () => {
     beforeEach(() => {
       mockGetProvider = () => ({
-        providerKey: "google",
+        provider: "google",
         pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
         managedServiceConfigKey: null,
       });
@@ -307,7 +307,7 @@ describe("assistant oauth ping", () => {
   describe("managed mode", () => {
     beforeEach(() => {
       mockGetProvider = () => ({
-        providerKey: "google",
+        provider: "google",
         pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
         managedServiceConfigKey: "google-oauth",
       });
@@ -363,7 +363,7 @@ describe("assistant oauth ping", () => {
 
   test("connection resolution failure (no active connection) with recovery hint", async () => {
     mockGetProvider = () => ({
-      providerKey: "google",
+      provider: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
     });
 
@@ -386,7 +386,7 @@ describe("assistant oauth ping", () => {
 
   test("--account option passed through to connection resolution", async () => {
     mockGetProvider = () => ({
-      providerKey: "google",
+      provider: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
     });
 
@@ -419,7 +419,7 @@ describe("assistant oauth ping", () => {
 
   test("--client-id option passed through to connection resolution", async () => {
     mockGetProvider = () => ({
-      providerKey: "google",
+      provider: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
     });
 
@@ -452,7 +452,7 @@ describe("assistant oauth ping", () => {
 
   test("JSON output mode returns structured response", async () => {
     mockGetProvider = () => ({
-      providerKey: "google",
+      provider: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
     });
 
@@ -480,7 +480,7 @@ describe("assistant oauth ping", () => {
 
   test("human output mode logs to stderr on success", async () => {
     mockGetProvider = () => ({
-      providerKey: "google",
+      provider: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
     });
 
@@ -508,7 +508,7 @@ describe("assistant oauth ping", () => {
 
   test("uses configured pingMethod for POST providers", async () => {
     mockGetProvider = () => ({
-      providerKey: "dropbox",
+      provider: "dropbox",
       pingUrl: "https://api.dropboxapi.com/2/users/get_current_account",
       pingMethod: "POST",
       pingHeaders: null,
@@ -530,7 +530,7 @@ describe("assistant oauth ping", () => {
 
   test("uses configured pingHeaders", async () => {
     mockGetProvider = () => ({
-      providerKey: "notion",
+      provider: "notion",
       pingUrl: "https://api.notion.com/v1/users/me",
       pingMethod: null,
       pingHeaders: '{"Notion-Version":"2022-06-28"}',
@@ -554,7 +554,7 @@ describe("assistant oauth ping", () => {
 
   test("uses configured pingBody for GraphQL providers", async () => {
     mockGetProvider = () => ({
-      providerKey: "linear",
+      provider: "linear",
       pingUrl: "https://api.linear.app/graphql",
       pingMethod: "POST",
       pingHeaders: '{"Content-Type":"application/json"}',
@@ -582,7 +582,7 @@ describe("assistant oauth ping", () => {
 
   test("defaults to GET with no extra headers/body when ping config is null", async () => {
     mockGetProvider = () => ({
-      providerKey: "google",
+      provider: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
       pingMethod: null,
       pingHeaders: null,
@@ -610,7 +610,7 @@ describe("assistant oauth ping", () => {
 
   test("network failure returns error with recovery hint", async () => {
     mockGetProvider = () => ({
-      providerKey: "google",
+      provider: "google",
       pingUrl: "https://www.googleapis.com/oauth2/v1/tokeninfo",
     });
 

--- a/assistant/src/cli/commands/oauth/__tests__/providers-delete.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/providers-delete.test.ts
@@ -20,7 +20,7 @@ let mockDeleteAppCalls: string[] = [];
 let mockDeleteAppResult = true;
 
 let mockDisconnectCalls: Array<{
-  providerKey: string;
+  provider: string;
   clientId: string | undefined;
   connectionId: string | undefined;
 }> = [];
@@ -47,11 +47,9 @@ mock.module("../../../../oauth/oauth-store.js", () => ({
   getProvider: (key: string) => mockGetProvider(key),
   deleteProvider: () => mockDeleteProviderResult,
   listApps: () => mockListAppsResult,
-  listConnections: (providerKey?: string) => {
-    if (providerKey) {
-      return mockListConnectionsResult.filter(
-        (c) => c.providerKey === providerKey,
-      );
+  listConnections: (provider?: string) => {
+    if (provider) {
+      return mockListConnectionsResult.filter((c) => c.provider === provider);
     }
     return mockListConnectionsResult;
   },
@@ -60,11 +58,11 @@ mock.module("../../../../oauth/oauth-store.js", () => ({
     return mockDeleteAppResult;
   },
   disconnectOAuthProvider: async (
-    providerKey: string,
+    provider: string,
     clientId?: string,
     connectionId?: string,
   ) => {
-    mockDisconnectCalls.push({ providerKey, clientId, connectionId });
+    mockDisconnectCalls.push({ provider, clientId, connectionId });
     return mockDisconnectResult;
   },
   listProviders: () => [],
@@ -210,20 +208,20 @@ describe("assistant oauth providers delete", () => {
   test("provider with dependents and no --force returns exit code 1 with counts", async () => {
     mockGetProvider = (key) =>
       key === "custom-api"
-        ? { providerKey: "custom-api", authUrl: "https://example.com/auth" }
+        ? { provider: "custom-api", authorizeUrl: "https://example.com/auth" }
         : undefined;
 
     mockListAppsResult = [
       {
         id: "app-1",
-        providerKey: "custom-api",
+        provider: "custom-api",
         clientId: "c1",
         createdAt: Date.now(),
         updatedAt: Date.now(),
       },
       {
         id: "app-2",
-        providerKey: "custom-api",
+        provider: "custom-api",
         clientId: "c2",
         createdAt: Date.now(),
         updatedAt: Date.now(),
@@ -233,19 +231,19 @@ describe("assistant oauth providers delete", () => {
     mockListConnectionsResult = [
       {
         id: "conn-1",
-        providerKey: "custom-api",
+        provider: "custom-api",
         oauthAppId: "app-1",
         status: "active",
       },
       {
         id: "conn-2",
-        providerKey: "custom-api",
+        provider: "custom-api",
         oauthAppId: "app-1",
         status: "active",
       },
       {
         id: "conn-3",
-        providerKey: "custom-api",
+        provider: "custom-api",
         oauthAppId: "app-2",
         status: "active",
       },
@@ -272,13 +270,13 @@ describe("assistant oauth providers delete", () => {
   test("provider with dependents and --force cascades deletion and returns summary", async () => {
     mockGetProvider = (key) =>
       key === "custom-api"
-        ? { providerKey: "custom-api", authUrl: "https://example.com/auth" }
+        ? { provider: "custom-api", authorizeUrl: "https://example.com/auth" }
         : undefined;
 
     mockListAppsResult = [
       {
         id: "app-1",
-        providerKey: "custom-api",
+        provider: "custom-api",
         clientId: "c1",
         clientSecretCredentialPath: "cred/app-1",
         createdAt: Date.now(),
@@ -286,7 +284,7 @@ describe("assistant oauth providers delete", () => {
       },
       {
         id: "app-other",
-        providerKey: "other-provider",
+        provider: "other-provider",
         clientId: "c3",
         clientSecretCredentialPath: "cred/app-other",
         createdAt: Date.now(),
@@ -297,13 +295,13 @@ describe("assistant oauth providers delete", () => {
     mockListConnectionsResult = [
       {
         id: "conn-1",
-        providerKey: "custom-api",
+        provider: "custom-api",
         oauthAppId: "app-1",
         status: "active",
       },
       {
         id: "conn-2",
-        providerKey: "custom-api",
+        provider: "custom-api",
         oauthAppId: "app-1",
         status: "active",
       },
@@ -326,12 +324,12 @@ describe("assistant oauth providers delete", () => {
     // Verify disconnectOAuthProvider was called for each connection
     expect(mockDisconnectCalls).toEqual([
       {
-        providerKey: "custom-api",
+        provider: "custom-api",
         clientId: undefined,
         connectionId: "conn-1",
       },
       {
-        providerKey: "custom-api",
+        provider: "custom-api",
         clientId: undefined,
         connectionId: "conn-2",
       },
@@ -348,7 +346,7 @@ describe("assistant oauth providers delete", () => {
   test("provider with no dependents and no --force deletes cleanly", async () => {
     mockGetProvider = (key) =>
       key === "custom-api"
-        ? { providerKey: "custom-api", authUrl: "https://example.com/auth" }
+        ? { provider: "custom-api", authorizeUrl: "https://example.com/auth" }
         : undefined;
 
     mockListAppsResult = [];
@@ -379,13 +377,13 @@ describe("assistant oauth providers delete", () => {
   test("built-in provider with --force succeeds and logs warning about re-creation", async () => {
     mockGetProvider = (key) =>
       key === "google"
-        ? { providerKey: "google", authUrl: "https://accounts.google.com" }
+        ? { provider: "google", authorizeUrl: "https://accounts.google.com" }
         : undefined;
 
     mockListAppsResult = [
       {
         id: "app-g",
-        providerKey: "google",
+        provider: "google",
         clientId: "goog-client",
         clientSecretCredentialPath: "cred/app-g",
         createdAt: Date.now(),
@@ -396,7 +394,7 @@ describe("assistant oauth providers delete", () => {
     mockListConnectionsResult = [
       {
         id: "conn-g",
-        providerKey: "google",
+        provider: "google",
         oauthAppId: "app-g",
         status: "active",
       },
@@ -430,7 +428,7 @@ describe("assistant oauth providers delete", () => {
   test("built-in provider without --force and no dependents logs warning and deletes", async () => {
     mockGetProvider = (key) =>
       key === "google"
-        ? { providerKey: "google", authUrl: "https://accounts.google.com" }
+        ? { provider: "google", authorizeUrl: "https://accounts.google.com" }
         : undefined;
 
     mockListAppsResult = [];
@@ -461,13 +459,13 @@ describe("assistant oauth providers delete", () => {
   test("token cleanup error logs warning but continues cascade delete", async () => {
     mockGetProvider = (key) =>
       key === "custom-api"
-        ? { providerKey: "custom-api", authUrl: "https://example.com/auth" }
+        ? { provider: "custom-api", authorizeUrl: "https://example.com/auth" }
         : undefined;
 
     mockListAppsResult = [
       {
         id: "app-1",
-        providerKey: "custom-api",
+        provider: "custom-api",
         clientId: "c1",
         createdAt: Date.now(),
         updatedAt: Date.now(),
@@ -477,7 +475,7 @@ describe("assistant oauth providers delete", () => {
     mockListConnectionsResult = [
       {
         id: "conn-1",
-        providerKey: "custom-api",
+        provider: "custom-api",
         oauthAppId: "app-1",
         status: "active",
       },
@@ -518,13 +516,13 @@ describe("assistant oauth providers delete", () => {
   test("token cleanup error calls deleteConnection as fallback to avoid FK violation", async () => {
     mockGetProvider = (key) =>
       key === "custom-api"
-        ? { providerKey: "custom-api", authUrl: "https://example.com/auth" }
+        ? { provider: "custom-api", authorizeUrl: "https://example.com/auth" }
         : undefined;
 
     mockListAppsResult = [
       {
         id: "app-1",
-        providerKey: "custom-api",
+        provider: "custom-api",
         clientId: "c1",
         createdAt: Date.now(),
         updatedAt: Date.now(),
@@ -534,13 +532,13 @@ describe("assistant oauth providers delete", () => {
     mockListConnectionsResult = [
       {
         id: "conn-1",
-        providerKey: "custom-api",
+        provider: "custom-api",
         oauthAppId: "app-1",
         status: "active",
       },
       {
         id: "conn-2",
-        providerKey: "custom-api",
+        provider: "custom-api",
         oauthAppId: "app-1",
         status: "active",
       },

--- a/assistant/src/cli/commands/oauth/__tests__/providers-update.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/providers-update.test.ts
@@ -137,21 +137,21 @@ async function runCommand(
 // ---------------------------------------------------------------------------
 
 const sampleProviderRow = {
-  providerKey: "custom-api",
-  authUrl: "https://custom-api.example.com/oauth/authorize",
-  tokenUrl: "https://custom-api.example.com/oauth/token",
+  provider: "custom-api",
+  authorizeUrl: "https://custom-api.example.com/oauth/authorize",
+  tokenExchangeUrl: "https://custom-api.example.com/oauth/token",
   tokenEndpointAuthMethod: null,
   userinfoUrl: null,
   baseUrl: null,
   defaultScopes: "[]",
   scopePolicy: "{}",
-  extraParams: null,
+  authorizeParams: null,
   managedServiceConfigKey: null,
   pingUrl: null,
   pingMethod: null,
   pingHeaders: null,
   pingBody: null,
-  displayName: null,
+  displayLabel: null,
   description: null,
   dashboardUrl: null,
   clientIdPlaceholder: null,
@@ -214,7 +214,7 @@ describe("assistant oauth providers update", () => {
   test("built-in provider returns error suggesting register", async () => {
     mockGetProvider = () => ({
       ...sampleProviderRow,
-      providerKey: "google",
+      provider: "google",
     });
 
     const { exitCode, stdout } = await runCommand([
@@ -259,7 +259,7 @@ describe("assistant oauth providers update", () => {
     mockGetProvider = () => ({ ...sampleProviderRow });
     mockUpdateProvider = (_key, _params) => ({
       ...sampleProviderRow,
-      displayName: "New Name",
+      displayLabel: "New Name",
       updatedAt: Date.now(),
     });
 
@@ -273,8 +273,8 @@ describe("assistant oauth providers update", () => {
     ]);
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
-    expect(parsed.providerKey).toBe("custom-api");
-    expect(parsed.displayName).toBe("New Name");
+    expect(parsed.provider).toBe("custom-api");
+    expect(parsed.displayLabel).toBe("New Name");
   });
 
   // -------------------------------------------------------------------------
@@ -285,9 +285,9 @@ describe("assistant oauth providers update", () => {
     mockGetProvider = () => ({ ...sampleProviderRow });
     mockUpdateProvider = (_key, _params) => ({
       ...sampleProviderRow,
-      displayName: "My API",
+      displayLabel: "My API",
       defaultScopes: '["read","write"]',
-      authUrl: "https://new.example.com/auth",
+      authorizeUrl: "https://new.example.com/auth",
       updatedAt: Date.now(),
     });
 
@@ -305,15 +305,15 @@ describe("assistant oauth providers update", () => {
     ]);
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
-    expect(parsed.providerKey).toBe("custom-api");
+    expect(parsed.provider).toBe("custom-api");
 
     // Verify updateProvider was called with the correct params
     expect(mockUpdateProviderCalls).toHaveLength(1);
     expect(mockUpdateProviderCalls[0].key).toBe("custom-api");
     expect(mockUpdateProviderCalls[0].params).toEqual({
-      displayName: "My API",
+      displayLabel: "My API",
       defaultScopes: ["read", "write"],
-      authUrl: "https://new.example.com/auth",
+      authorizeUrl: "https://new.example.com/auth",
     });
   });
 
@@ -381,7 +381,7 @@ describe("assistant oauth providers update", () => {
     ]);
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
-    expect(parsed.providerKey).toBe("custom-api");
+    expect(parsed.provider).toBe("custom-api");
 
     // Verify the new fields are present in the output (parsed from JSON strings)
     expect(parsed.loopbackPort).toBe(17400);

--- a/assistant/src/cli/commands/oauth/__tests__/providers-update.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/providers-update.test.ts
@@ -273,8 +273,8 @@ describe("assistant oauth providers update", () => {
     ]);
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
-    expect(parsed.provider).toBe("custom-api");
-    expect(parsed.displayLabel).toBe("New Name");
+    expect(parsed.providerKey).toBe("custom-api");
+    expect(parsed.displayName).toBe("New Name");
   });
 
   // -------------------------------------------------------------------------
@@ -305,7 +305,7 @@ describe("assistant oauth providers update", () => {
     ]);
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
-    expect(parsed.provider).toBe("custom-api");
+    expect(parsed.providerKey).toBe("custom-api");
 
     // Verify updateProvider was called with the correct params
     expect(mockUpdateProviderCalls).toHaveLength(1);
@@ -381,7 +381,7 @@ describe("assistant oauth providers update", () => {
     ]);
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
-    expect(parsed.provider).toBe("custom-api");
+    expect(parsed.providerKey).toBe("custom-api");
 
     // Verify the new fields are present in the output (parsed from JSON strings)
     expect(parsed.loopbackPort).toBe(17400);

--- a/assistant/src/cli/commands/oauth/__tests__/status.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/status.test.ts
@@ -11,7 +11,7 @@ let mockGetProvider: (
 ) => Record<string, unknown> | undefined = () => undefined;
 
 let mockListConnections: (
-  providerKey: string,
+  provider: string,
 ) => Array<Record<string, unknown>> = () => [];
 
 let mockIsManagedMode: (key: string) => boolean = () => false;
@@ -35,7 +35,7 @@ mock.module("../../../../config/loader.js", () => ({
 
 mock.module("../../../../oauth/oauth-store.js", () => ({
   getProvider: (key: string) => mockGetProvider(key),
-  listConnections: (providerKey: string) => mockListConnections(providerKey),
+  listConnections: (provider: string) => mockListConnections(provider),
   getConnection: () => undefined,
   getConnectionByProvider: () => undefined,
   getActiveConnection: () => undefined,
@@ -235,7 +235,7 @@ describe("assistant oauth status", () => {
   describe("managed mode", () => {
     beforeEach(() => {
       mockGetProvider = () => ({
-        providerKey: "google",
+        provider: "google",
         managedServiceConfigKey: "google-oauth",
       });
       mockIsManagedMode = () => true;
@@ -360,7 +360,7 @@ describe("assistant oauth status", () => {
   describe("BYO mode", () => {
     beforeEach(() => {
       mockGetProvider = () => ({
-        providerKey: "google",
+        provider: "google",
         managedServiceConfigKey: null,
       });
       mockIsManagedMode = () => false;
@@ -371,7 +371,7 @@ describe("assistant oauth status", () => {
       mockListConnections = () => [
         {
           id: "conn-local-1",
-          providerKey: "google",
+          provider: "google",
           accountInfo: "localuser@gmail.com",
           grantedScopes: '["email","profile"]',
           expiresAt,
@@ -405,7 +405,7 @@ describe("assistant oauth status", () => {
       mockListConnections = () => [
         {
           id: "conn-local-2",
-          providerKey: "google",
+          provider: "google",
           accountInfo: null,
           grantedScopes: "[]",
           expiresAt: null,
@@ -432,7 +432,7 @@ describe("assistant oauth status", () => {
       mockListConnections = () => [
         {
           id: "conn-active",
-          providerKey: "google",
+          provider: "google",
           accountInfo: "user@gmail.com",
           grantedScopes: "[]",
           expiresAt: null,
@@ -441,7 +441,7 @@ describe("assistant oauth status", () => {
         },
         {
           id: "conn-revoked",
-          providerKey: "google",
+          provider: "google",
           accountInfo: "old@gmail.com",
           grantedScopes: "[]",
           expiresAt: null,
@@ -489,7 +489,7 @@ describe("assistant oauth status", () => {
       mockListConnections = () => [
         {
           id: "conn-structure",
-          providerKey: "google",
+          provider: "google",
           accountInfo: "check@gmail.com",
           grantedScopes: '["scope1"]',
           expiresAt: Date.now() + 60_000,
@@ -527,7 +527,7 @@ describe("assistant oauth status", () => {
       mockListConnections = () => [
         {
           id: "conn-bad-scopes",
-          providerKey: "google",
+          provider: "google",
           accountInfo: null,
           grantedScopes: "not-valid-json",
           expiresAt: null,

--- a/assistant/src/cli/commands/oauth/__tests__/token.test.ts
+++ b/assistant/src/cli/commands/oauth/__tests__/token.test.ts
@@ -9,7 +9,7 @@ import { Command } from "commander";
 let mockIsManagedMode: (key: string) => boolean = () => false;
 
 let mockGetActiveConnection: (
-  providerKey: string,
+  provider: string,
   options?: { clientId?: string; account?: string },
 ) => Record<string, unknown> | undefined = () => undefined;
 
@@ -34,9 +34,9 @@ mock.module("../../../../oauth/oauth-store.js", () => ({
   getConnection: () => undefined,
   getConnectionByProvider: () => undefined,
   getActiveConnection: (
-    providerKey: string,
+    provider: string,
     options?: { clientId?: string; account?: string },
-  ) => mockGetActiveConnection(providerKey, options),
+  ) => mockGetActiveConnection(provider, options),
   listActiveConnectionsByProvider: () => [],
   disconnectOAuthProvider: async () => "not-found" as const,
   upsertApp: async () => ({}),
@@ -265,11 +265,11 @@ describe("assistant oauth token", () => {
 
   describe("--account option", () => {
     test("resolves connection by account and uses connectionId", async () => {
-      mockGetActiveConnection = (_providerKey, options) => {
+      mockGetActiveConnection = (_provider, options) => {
         if (options?.account === "user@gmail.com") {
           return {
             id: "conn-abc-123",
-            providerKey: "google",
+            provider: "google",
             accountInfo: "user@gmail.com",
             status: "active",
           };
@@ -322,11 +322,11 @@ describe("assistant oauth token", () => {
 
   describe("--client-id option", () => {
     test("resolves connection by client-id and uses connectionId", async () => {
-      mockGetActiveConnection = (_providerKey, options) => {
+      mockGetActiveConnection = (_provider, options) => {
         if (options?.clientId === "my-client-id") {
           return {
             id: "conn-client-456",
-            providerKey: "google",
+            provider: "google",
             accountInfo: null,
             status: "active",
           };

--- a/assistant/src/cli/commands/oauth/apps.ts
+++ b/assistant/src/cli/commands/oauth/apps.ts
@@ -48,7 +48,10 @@ function formatAppRow(row: {
 }) {
   return {
     id: row.id,
-    provider: row.provider,
+    // Wire key stays `providerKey` for backward compatibility with existing
+    // CLI script consumers of `assistant oauth apps list/get/upsert --json`;
+    // the internal Drizzle TS-side field is `provider`.
+    providerKey: row.provider,
     clientId: row.clientId,
     createdAt: new Date(row.createdAt).toISOString(),
     updatedAt: new Date(row.updatedAt).toISOString(),
@@ -110,7 +113,7 @@ Examples:
         let rows = listApps().map(formatAppRow);
 
         if (opts.providerKey) {
-          rows = rows.filter((r) => r.provider === opts.providerKey);
+          rows = rows.filter((r) => r.providerKey === opts.providerKey);
         }
 
         if (!shouldOutputJson(cmd)) {

--- a/assistant/src/cli/commands/oauth/apps.ts
+++ b/assistant/src/cli/commands/oauth/apps.ts
@@ -41,14 +41,14 @@ const log = getCliLogger("cli");
 /** Format an app row for output, converting timestamps to ISO strings. */
 function formatAppRow(row: {
   id: string;
-  providerKey: string;
+  provider: string;
   clientId: string;
   createdAt: number;
   updatedAt: number;
 }) {
   return {
     id: row.id,
-    providerKey: row.providerKey,
+    provider: row.provider,
     clientId: row.clientId,
     createdAt: new Date(row.createdAt).toISOString(),
     updatedAt: new Date(row.updatedAt).toISOString(),
@@ -94,7 +94,7 @@ Examples:
 Returns registered OAuth apps with their provider key, client ID, and
 timestamps. Output is an array of app objects.
 
-When --provider-key is specified, only apps whose providerKey exactly matches
+When --provider-key is specified, only apps whose provider exactly matches
 the given value are returned. Without the flag, all apps are listed.
 
 In JSON mode (--json), returns the array directly. In human mode, logs a
@@ -110,7 +110,7 @@ Examples:
         let rows = listApps().map(formatAppRow);
 
         if (opts.providerKey) {
-          rows = rows.filter((r) => r.providerKey === opts.providerKey);
+          rows = rows.filter((r) => r.provider === opts.providerKey);
         }
 
         if (!shouldOutputJson(cmd)) {
@@ -288,7 +288,7 @@ Examples:
           );
 
           if (!shouldOutputJson(cmd)) {
-            log.info(`Upserted app: ${row.id} (provider: ${row.providerKey})`);
+            log.info(`Upserted app: ${row.id} (provider: ${row.provider})`);
           }
 
           writeOutput(cmd, formatAppRow(row));

--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -339,7 +339,7 @@ Examples:
             // Manual-token providers (slack_channel, telegram) don't use
             // OAuth2 browser flows — credentials are configured via
             // `assistant credentials` or chat setup instead.
-            if (providerRow.authUrl === "urn:manual-token") {
+            if (providerRow.authorizeUrl === "urn:manual-token") {
               writeError(
                 `"${provider}" uses manual token configuration, not an OAuth browser flow. ` +
                   `Set the token with: assistant credentials set <token_value> --service ${provider} --field <field_name>`,
@@ -414,12 +414,12 @@ Examples:
                 writeOutput(cmd, {
                   ok: true,
                   deferred: true,
-                  authUrl: result.authUrl,
+                  authorizeUrl: result.authorizeUrl,
                   service: result.service,
                 });
               } else {
                 process.stdout.write(
-                  `\nAuthorize with ${provider}:\n\n${result.authUrl}\n\nThe connection will complete automatically once you authorize.\n`,
+                  `\nAuthorize with ${provider}:\n\n${result.authorizeUrl}\n\nThe connection will complete automatically once you authorize.\n`,
                 );
               }
               return;

--- a/assistant/src/cli/commands/oauth/connect.ts
+++ b/assistant/src/cli/commands/oauth/connect.ts
@@ -414,7 +414,10 @@ Examples:
                 writeOutput(cmd, {
                   ok: true,
                   deferred: true,
-                  authorizeUrl: result.authorizeUrl,
+                  // Wire key stays `authUrl` for backward compatibility with
+                  // existing CLI script consumers; the internal field on
+                  // `result` is `authorizeUrl`.
+                  authUrl: result.authorizeUrl,
                   service: result.service,
                 });
               } else {

--- a/assistant/src/cli/commands/oauth/disconnect.ts
+++ b/assistant/src/cli/commands/oauth/disconnect.ts
@@ -212,7 +212,7 @@ Examples:
               accountLabel = conn.accountInfo ?? undefined;
             } else if (opts.connectionId) {
               const conn = getConnection(opts.connectionId);
-              if (!conn || conn.providerKey !== provider) {
+              if (!conn || conn.provider !== provider) {
                 writeError(
                   `Connection "${opts.connectionId}" is not an active ${provider} connection.\n\n` +
                     `Run 'assistant oauth status ${provider}' to see active connections.`,

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -127,7 +127,7 @@ Examples:
               (r) =>
                 r &&
                 needles.some((needle) =>
-                  r.provider.toLowerCase().includes(needle),
+                  r.providerKey.toLowerCase().includes(needle),
                 ),
             );
           }

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -127,7 +127,7 @@ Examples:
               (r) =>
                 r &&
                 needles.some((needle) =>
-                  r.providerKey.toLowerCase().includes(needle),
+                  r.provider.toLowerCase().includes(needle),
                 ),
             );
           }
@@ -171,14 +171,14 @@ Examples:
   $ assistant oauth providers get google
   $ assistant oauth providers get twitter --json`,
     )
-    .action((providerKey: string, _opts: unknown, cmd: Command) => {
+    .action((provider: string, _opts: unknown, cmd: Command) => {
       try {
-        const row = getProvider(providerKey);
+        const row = getProvider(provider);
 
         if (!row) {
           writeOutput(cmd, {
             ok: false,
-            error: `Provider not found: "${providerKey}". Run 'assistant oauth providers list' to see all registered providers. To register a custom provider, run 'assistant oauth providers register --help'.`,
+            error: `Provider not found: "${provider}". Run 'assistant oauth providers list' to see all registered providers. To register a custom provider, run 'assistant oauth providers register --help'.`,
           });
           process.exitCode = 1;
           return;
@@ -187,7 +187,7 @@ Examples:
         if (!isProviderVisible(row, loadConfig())) {
           writeOutput(cmd, {
             ok: false,
-            error: `Provider not found: "${providerKey}". Run 'assistant oauth providers list' to see all registered providers. To register a custom provider, run 'assistant oauth providers register --help'.`,
+            error: `Provider not found: "${provider}". Run 'assistant oauth providers list' to see all registered providers. To register a custom provider, run 'assistant oauth providers register --help'.`,
           });
           process.exitCode = 1;
           return;
@@ -384,9 +384,9 @@ Examples:
       ) => {
         try {
           const row = registerProvider({
-            providerKey: opts.providerKey,
-            authUrl: opts.authUrl,
-            tokenUrl: opts.tokenUrl,
+            provider: opts.providerKey,
+            authorizeUrl: opts.authUrl,
+            tokenExchangeUrl: opts.tokenUrl,
             baseUrl: opts.baseUrl,
             userinfoUrl: opts.userinfoUrl,
             defaultScopes: opts.scopes ? opts.scopes.split(",") : [],
@@ -398,7 +398,7 @@ Examples:
               ? JSON.parse(opts.pingHeaders)
               : undefined,
             pingBody: opts.pingBody ? JSON.parse(opts.pingBody) : undefined,
-            displayName: opts.displayName,
+            displayLabel: opts.displayName,
             description: opts.description,
             dashboardUrl: opts.dashboardUrl,
             clientIdPlaceholder: opts.clientIdPlaceholder,
@@ -570,7 +570,7 @@ Examples:
     )
     .action(
       (
-        providerKey: string,
+        provider: string,
         opts: {
           authUrl?: string;
           tokenUrl?: string;
@@ -603,11 +603,11 @@ Examples:
       ) => {
         try {
           // Verify provider exists
-          const existing = getProvider(providerKey);
+          const existing = getProvider(provider);
           if (!existing) {
             writeOutput(cmd, {
               ok: false,
-              error: `Provider "${providerKey}" not found. Run 'assistant oauth providers list' to see all registered providers.`,
+              error: `Provider "${provider}" not found. Run 'assistant oauth providers list' to see all registered providers.`,
             });
             process.exitCode = 1;
             return;
@@ -616,17 +616,17 @@ Examples:
           if (!isProviderVisible(existing, loadConfig())) {
             writeOutput(cmd, {
               ok: false,
-              error: `Provider "${providerKey}" not found. Run 'assistant oauth providers list' to see all registered providers.`,
+              error: `Provider "${provider}" not found. Run 'assistant oauth providers list' to see all registered providers.`,
             });
             process.exitCode = 1;
             return;
           }
 
           // Block updates to built-in providers
-          if (SEEDED_PROVIDER_KEYS.has(providerKey)) {
+          if (SEEDED_PROVIDER_KEYS.has(provider)) {
             writeOutput(cmd, {
               ok: false,
-              error: `Cannot update built-in provider "${providerKey}". Built-in providers are managed by the system and reset on startup. To create a custom provider with different settings, use 'assistant oauth providers register --provider-key <your-custom-key> ...'`,
+              error: `Cannot update built-in provider "${provider}". Built-in providers are managed by the system and reset on startup. To create a custom provider with different settings, use 'assistant oauth providers register --provider-key <your-custom-key> ...'`,
             });
             process.exitCode = 1;
             return;
@@ -635,8 +635,9 @@ Examples:
           // Build params object from provided options, omitting undefined values
           const params: Record<string, unknown> = {};
 
-          if (opts.authUrl !== undefined) params.authUrl = opts.authUrl;
-          if (opts.tokenUrl !== undefined) params.tokenUrl = opts.tokenUrl;
+          if (opts.authUrl !== undefined) params.authorizeUrl = opts.authUrl;
+          if (opts.tokenUrl !== undefined)
+            params.tokenExchangeUrl = opts.tokenUrl;
           if (opts.baseUrl !== undefined) params.baseUrl = opts.baseUrl;
           if (opts.userinfoUrl !== undefined)
             params.userinfoUrl = opts.userinfoUrl;
@@ -652,7 +653,7 @@ Examples:
           if (opts.pingBody !== undefined)
             params.pingBody = JSON.parse(opts.pingBody);
           if (opts.displayName !== undefined)
-            params.displayName = opts.displayName;
+            params.displayLabel = opts.displayName;
           if (opts.description !== undefined)
             params.description = opts.description;
           if (opts.dashboardUrl !== undefined)
@@ -701,7 +702,7 @@ Examples:
             return;
           }
 
-          const row = updateProvider(providerKey, params);
+          const row = updateProvider(provider, params);
 
           writeOutput(cmd, parseProviderRow(row));
         } catch (err) {
@@ -747,53 +748,53 @@ Examples:
   $ assistant oauth providers delete custom-api --force --json`,
     )
     .action(
-      async (providerKey: string, opts: { force?: boolean }, cmd: Command) => {
+      async (provider: string, opts: { force?: boolean }, cmd: Command) => {
         try {
-          const provider = getProvider(providerKey);
-          if (!provider) {
+          const providerRow = getProvider(provider);
+          if (!providerRow) {
             writeOutput(cmd, {
               ok: false,
-              error: `Provider not found: "${providerKey}". Run 'assistant oauth providers list' to see all registered providers.`,
+              error: `Provider not found: "${provider}". Run 'assistant oauth providers list' to see all registered providers.`,
             });
             process.exitCode = 1;
             return;
           }
 
-          if (!isProviderVisible(provider, loadConfig())) {
+          if (!isProviderVisible(providerRow, loadConfig())) {
             writeOutput(cmd, {
               ok: false,
-              error: `Provider not found: "${providerKey}". Run 'assistant oauth providers list' to see all registered providers.`,
+              error: `Provider not found: "${provider}". Run 'assistant oauth providers list' to see all registered providers.`,
             });
             process.exitCode = 1;
             return;
           }
 
-          if (SEEDED_PROVIDER_KEYS.has(providerKey) && !opts.force) {
+          if (SEEDED_PROVIDER_KEYS.has(provider) && !opts.force) {
             log.info(
-              `Note: "${providerKey}" is a built-in provider and will be re-created on next startup.`,
+              `Note: "${provider}" is a built-in provider and will be re-created on next startup.`,
             );
           }
 
           const dependentApps = listApps().filter(
-            (a) => a.providerKey === providerKey,
+            (a) => a.provider === provider,
           );
-          const dependentConnections = listConnections(providerKey);
+          const dependentConnections = listConnections(provider);
           const appCount = dependentApps.length;
           const connCount = dependentConnections.length;
 
           if ((appCount > 0 || connCount > 0) && !opts.force) {
             writeOutput(cmd, {
               ok: false,
-              error: `Cannot delete provider "${providerKey}": ${appCount} app(s) and ${connCount} connection(s) depend on it. Use --force to cascade-delete all dependent apps and connections, or remove them manually first with 'assistant oauth apps delete' and 'assistant oauth disconnect'.`,
+              error: `Cannot delete provider "${provider}": ${appCount} app(s) and ${connCount} connection(s) depend on it. Use --force to cascade-delete all dependent apps and connections, or remove them manually first with 'assistant oauth apps delete' and 'assistant oauth disconnect'.`,
             });
             process.exitCode = 1;
             return;
           }
 
           // Warn about built-in providers when --force is used
-          if (SEEDED_PROVIDER_KEYS.has(providerKey) && opts.force) {
+          if (SEEDED_PROVIDER_KEYS.has(provider) && opts.force) {
             log.info(
-              `Note: "${providerKey}" is a built-in provider and will be re-created on next startup.`,
+              `Note: "${provider}" is a built-in provider and will be re-created on next startup.`,
             );
           }
 
@@ -802,7 +803,7 @@ Examples:
           // storage in addition to deleting the connection DB row.
           for (const conn of dependentConnections) {
             const result = await disconnectOAuthProvider(
-              providerKey,
+              provider,
               undefined,
               conn.id as string,
             );
@@ -816,10 +817,10 @@ Examples:
           for (const app of dependentApps) {
             await deleteApp(app.id);
           }
-          deleteProvider(providerKey);
+          deleteProvider(provider);
 
           if (!shouldOutputJson(cmd)) {
-            log.info(`Deleted provider: ${providerKey}`);
+            log.info(`Deleted provider: ${provider}`);
           }
 
           writeOutput(cmd, {

--- a/assistant/src/cli/commands/oauth/shared.ts
+++ b/assistant/src/cli/commands/oauth/shared.ts
@@ -30,9 +30,9 @@ export interface PlatformConnectionEntry {
  * lookup so that callers (e.g. `isManagedMode`, `mode.ts`) don't duplicate the
  * validation.
  */
-export function getManagedServiceConfigKey(providerKey: string): string | null {
-  const provider = getProvider(providerKey);
-  const managedKey = provider?.managedServiceConfigKey;
+export function getManagedServiceConfigKey(provider: string): string | null {
+  const providerRow = getProvider(provider);
+  const managedKey = providerRow?.managedServiceConfigKey;
   if (!managedKey || !(managedKey in ServicesSchema.shape)) return null;
   return managedKey;
 }
@@ -41,8 +41,8 @@ export function getManagedServiceConfigKey(providerKey: string): string | null {
  * Determine whether a provider is running in platform-managed mode.
  * Returns false if config is unavailable (e.g. in test environments).
  */
-export function isManagedMode(providerKey: string): boolean {
-  const managedKey = getManagedServiceConfigKey(providerKey);
+export function isManagedMode(provider: string): boolean {
+  const managedKey = getManagedServiceConfigKey(provider);
   if (!managedKey) return false;
   try {
     const services: Services = getConfig().services;

--- a/assistant/src/memory/schema/oauth.ts
+++ b/assistant/src/memory/schema/oauth.ts
@@ -7,21 +7,21 @@ import {
 } from "drizzle-orm/sqlite-core";
 
 export const oauthProviders = sqliteTable("oauth_providers", {
-  providerKey: text("provider_key").primaryKey(),
-  authUrl: text("auth_url").notNull(),
-  tokenUrl: text("token_url").notNull(),
+  provider: text("provider_key").primaryKey(),
+  authorizeUrl: text("auth_url").notNull(),
+  tokenExchangeUrl: text("token_url").notNull(),
   tokenEndpointAuthMethod: text("token_endpoint_auth_method"),
   userinfoUrl: text("userinfo_url"),
   baseUrl: text("base_url"),
   defaultScopes: text("default_scopes").notNull().default("[]"),
   scopePolicy: text("scope_policy").notNull().default("{}"),
-  extraParams: text("extra_params"),
+  authorizeParams: text("extra_params"),
   pingUrl: text("ping_url"),
   pingMethod: text("ping_method"),
   pingHeaders: text("ping_headers"),
   pingBody: text("ping_body"),
   managedServiceConfigKey: text("managed_service_config_key"),
-  displayName: text("display_name"),
+  displayLabel: text("display_name"),
   description: text("description"),
   dashboardUrl: text("dashboard_url"),
   clientIdPlaceholder: text("client_id_placeholder"),
@@ -46,9 +46,9 @@ export const oauthApps = sqliteTable(
   "oauth_apps",
   {
     id: text("id").primaryKey(),
-    providerKey: text("provider_key")
+    provider: text("provider_key")
       .notNull()
-      .references(() => oauthProviders.providerKey),
+      .references(() => oauthProviders.provider),
     clientId: text("client_id").notNull(),
     clientSecretCredentialPath: text("client_secret_credential_path").notNull(),
     createdAt: integer("created_at").notNull(),
@@ -56,7 +56,7 @@ export const oauthApps = sqliteTable(
   },
   (table) => [
     uniqueIndex("idx_oauth_apps_provider_client").on(
-      table.providerKey,
+      table.provider,
       table.clientId,
     ),
   ],
@@ -69,7 +69,7 @@ export const oauthConnections = sqliteTable(
     oauthAppId: text("oauth_app_id")
       .notNull()
       .references(() => oauthApps.id),
-    providerKey: text("provider_key").notNull(),
+    provider: text("provider_key").notNull(),
     accountInfo: text("account_info"),
     grantedScopes: text("granted_scopes").notNull().default("[]"),
     expiresAt: integer("expires_at"),
@@ -80,7 +80,5 @@ export const oauthConnections = sqliteTable(
     createdAt: integer("created_at").notNull(),
     updatedAt: integer("updated_at").notNull(),
   },
-  (table) => [
-    index("idx_oauth_connections_provider_key").on(table.providerKey),
-  ],
+  (table) => [index("idx_oauth_connections_provider_key").on(table.provider)],
 );

--- a/assistant/src/oauth/__tests__/identity-verifier.test.ts
+++ b/assistant/src/oauth/__tests__/identity-verifier.test.ts
@@ -24,26 +24,26 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 function makeProviderRow(
-  overrides: Partial<OAuthProviderRow> & { providerKey: string },
+  overrides: Partial<OAuthProviderRow> & { provider: string },
 ): OAuthProviderRow {
   const now = Date.now();
-  const { providerKey, ...rest } = overrides;
+  const { provider, ...rest } = overrides;
   return {
-    providerKey,
-    authUrl: "https://example.com/auth",
-    tokenUrl: "https://example.com/token",
+    provider,
+    authorizeUrl: "https://example.com/auth",
+    tokenExchangeUrl: "https://example.com/token",
     tokenEndpointAuthMethod: null,
     userinfoUrl: null,
     baseUrl: null,
     defaultScopes: "[]",
     scopePolicy: "{}",
-    extraParams: null,
+    authorizeParams: null,
     pingUrl: null,
     pingMethod: null,
     pingHeaders: null,
     pingBody: null,
     managedServiceConfigKey: null,
-    displayName: null,
+    displayLabel: null,
     description: null,
     dashboardUrl: null,
     clientIdPlaceholder: null,
@@ -82,7 +82,7 @@ describe("verifyIdentity", () => {
   // Missing identity URL
   // -----------------------------------------------------------------------
   test("returns undefined when identityUrl is null", async () => {
-    const row = makeProviderRow({ providerKey: "custom" });
+    const row = makeProviderRow({ provider: "custom" });
     const result = await verifyIdentity(row, "token-abc");
     expect(result).toBeUndefined();
     expect(mockFetch).not.toHaveBeenCalled();
@@ -93,7 +93,7 @@ describe("verifyIdentity", () => {
   // -----------------------------------------------------------------------
   describe("Google pattern", () => {
     const googleRow = makeProviderRow({
-      providerKey: "google",
+      provider: "google",
       identityUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
       identityResponsePaths: JSON.stringify(["email"]),
     });
@@ -127,7 +127,7 @@ describe("verifyIdentity", () => {
   // -----------------------------------------------------------------------
   describe("Slack pattern", () => {
     const slackRow = makeProviderRow({
-      providerKey: "slack",
+      provider: "slack",
       identityUrl: "https://slack.com/api/auth.test",
       identityOkField: "ok",
       identityResponsePaths: JSON.stringify(["user", "team"]),
@@ -176,7 +176,7 @@ describe("verifyIdentity", () => {
   // -----------------------------------------------------------------------
   describe("HubSpot pattern", () => {
     const hubspotRow = makeProviderRow({
-      providerKey: "hubspot",
+      provider: "hubspot",
       identityUrl:
         "https://api.hubapi.com/oauth/v1/access-tokens/${accessToken}",
       identityResponsePaths: JSON.stringify(["user", "hub_domain"]),
@@ -219,7 +219,7 @@ describe("verifyIdentity", () => {
   // -----------------------------------------------------------------------
   describe("Linear pattern", () => {
     const linearRow = makeProviderRow({
-      providerKey: "linear",
+      provider: "linear",
       identityUrl: "https://api.linear.app/graphql",
       identityMethod: "POST",
       identityHeaders: JSON.stringify({ "Content-Type": "application/json" }),
@@ -272,7 +272,7 @@ describe("verifyIdentity", () => {
   // -----------------------------------------------------------------------
   describe("Todoist pattern", () => {
     const todoistRow = makeProviderRow({
-      providerKey: "todoist",
+      provider: "todoist",
       identityUrl: "https://api.todoist.com/sync/v9/sync",
       identityMethod: "POST",
       identityHeaders: JSON.stringify({
@@ -317,7 +317,7 @@ describe("verifyIdentity", () => {
   // -----------------------------------------------------------------------
   describe("Twitter pattern", () => {
     const twitterRow = makeProviderRow({
-      providerKey: "twitter",
+      provider: "twitter",
       identityUrl: "https://api.x.com/2/users/me",
       identityResponsePaths: JSON.stringify(["data.username"]),
       identityFormat: "@${data.username}",
@@ -338,7 +338,7 @@ describe("verifyIdentity", () => {
   // -----------------------------------------------------------------------
   describe("GitHub pattern", () => {
     const githubRow = makeProviderRow({
-      providerKey: "github",
+      provider: "github",
       identityUrl: "https://api.github.com/user",
       identityResponsePaths: JSON.stringify(["login"]),
       identityFormat: "@${login}",
@@ -357,7 +357,7 @@ describe("verifyIdentity", () => {
   // -----------------------------------------------------------------------
   describe("Notion pattern", () => {
     const notionRow = makeProviderRow({
-      providerKey: "notion",
+      provider: "notion",
       identityUrl: "https://api.notion.com/v1/users/me",
       identityHeaders: JSON.stringify({ "Notion-Version": "2022-06-28" }),
       identityResponsePaths: JSON.stringify(["name", "person.email"]),
@@ -392,7 +392,7 @@ describe("verifyIdentity", () => {
   // -----------------------------------------------------------------------
   describe("error handling", () => {
     const googleRow = makeProviderRow({
-      providerKey: "google",
+      provider: "google",
       identityUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
       identityResponsePaths: JSON.stringify(["email"]),
     });
@@ -431,7 +431,7 @@ describe("verifyIdentity", () => {
   // -----------------------------------------------------------------------
   describe("Dropbox pattern", () => {
     const dropboxRow = makeProviderRow({
-      providerKey: "dropbox",
+      provider: "dropbox",
       identityUrl: "https://api.dropboxapi.com/2/users/get_current_account",
       identityMethod: "POST",
       identityResponsePaths: JSON.stringify(["name.display_name", "email"]),

--- a/assistant/src/oauth/byo-connection.test.ts
+++ b/assistant/src/oauth/byo-connection.test.ts
@@ -72,7 +72,7 @@ const mockConnections = new Map<
   string,
   {
     id: string;
-    providerKey: string;
+    provider: string;
     oauthAppId: string;
     expiresAt: number | null;
     grantedScopes?: string;
@@ -83,7 +83,7 @@ const mockApps = new Map<
   string,
   {
     id: string;
-    providerKey: string;
+    provider: string;
     clientId: string;
     clientSecretCredentialPath: string;
   }
@@ -92,7 +92,7 @@ const mockProviders = new Map<
   string,
   {
     key: string;
-    tokenUrl: string;
+    tokenExchangeUrl: string;
     tokenEndpointAuthMethod?: string;
     baseUrl?: string;
   }
@@ -192,7 +192,7 @@ async function setupCredential(
   const connId = `conn-${service}`;
   mockProviders.set(service, {
     key: service,
-    tokenUrl: "https://oauth2.googleapis.com/token",
+    tokenExchangeUrl: "https://oauth2.googleapis.com/token",
     // Only well-known providers (gmail) have a baseUrl; custom services don't
     baseUrl:
       service === "google"
@@ -201,13 +201,13 @@ async function setupCredential(
   });
   mockApps.set(appId, {
     id: appId,
-    providerKey: service,
+    provider: service,
     clientId: "test-client-id",
     clientSecretCredentialPath: `oauth_app/${appId}/client_secret`,
   });
   mockConnections.set(service, {
     id: connId,
-    providerKey: service,
+    provider: service,
     oauthAppId: appId,
     expiresAt: opts?.expiresAt ?? Date.now() + 3600 * 1000,
     grantedScopes: JSON.stringify(opts?.grantedScopes ?? ["read", "write"]),
@@ -233,7 +233,7 @@ async function setupCredential(
 function createConnection(service = "google"): BYOOAuthConnection {
   return new BYOOAuthConnection({
     id: `conn-${service}`,
-    providerKey: service,
+    provider: service,
     baseUrl: "https://gmail.googleapis.com/gmail/v1/users/me",
     accountInfo: null,
   });
@@ -497,7 +497,7 @@ describe("resolveOAuthConnection", () => {
     const conn = await resolveOAuthConnection("google");
 
     expect(conn).toBeInstanceOf(BYOOAuthConnection);
-    expect(conn.providerKey).toBe("google");
+    expect(conn.provider).toBe("google");
   });
 
   test("throws when no credential metadata exists", async () => {

--- a/assistant/src/oauth/byo-connection.ts
+++ b/assistant/src/oauth/byo-connection.ts
@@ -22,28 +22,28 @@ const REQUEST_TIMEOUT_MS = 30_000;
 
 export interface BYOOAuthConnectionOptions {
   id: string;
-  providerKey: string;
+  provider: string;
   baseUrl: string;
   accountInfo: string | null;
 }
 
 export class BYOOAuthConnection implements OAuthConnection {
   readonly id: string;
-  readonly providerKey: string;
+  readonly provider: string;
   readonly accountInfo: string | null;
 
   private readonly baseUrl: string;
 
   constructor(opts: BYOOAuthConnectionOptions) {
     this.id = opts.id;
-    this.providerKey = opts.providerKey;
+    this.provider = opts.provider;
     this.baseUrl = opts.baseUrl;
     this.accountInfo = opts.accountInfo;
   }
 
   async request(req: OAuthConnectionRequest): Promise<OAuthConnectionResponse> {
     return withValidToken(
-      this.providerKey,
+      this.provider,
       async (token) => {
         const effectiveBaseUrl = req.baseUrl ?? this.baseUrl;
         let fullUrl = `${effectiveBaseUrl}${req.path}`;
@@ -61,7 +61,7 @@ export class BYOOAuthConnection implements OAuthConnection {
         }
 
         log.debug(
-          { method: req.method, url: fullUrl, provider: this.providerKey },
+          { method: req.method, url: fullUrl, provider: this.provider },
           "Making authenticated request",
         );
 
@@ -88,7 +88,7 @@ export class BYOOAuthConnection implements OAuthConnection {
         if (resp.status === 401) {
           // Throw with a status property so withValidToken detects the 401
           // and triggers its refresh-and-retry logic.
-          const err = new Error(`HTTP 401 from ${this.providerKey}`);
+          const err = new Error(`HTTP 401 from ${this.provider}`);
           (err as Error & { status: number }).status = 401;
           throw err;
         }
@@ -100,7 +100,7 @@ export class BYOOAuthConnection implements OAuthConnection {
   }
 
   async withToken<T>(fn: (token: string) => Promise<T>): Promise<T> {
-    return withValidToken(this.providerKey, fn, {
+    return withValidToken(this.provider, fn, {
       connectionId: this.id,
     });
   }

--- a/assistant/src/oauth/connect-orchestrator.ts
+++ b/assistant/src/oauth/connect-orchestrator.ts
@@ -23,10 +23,7 @@
 import type { TokenEndpointAuthMethod } from "../security/oauth2.js";
 import { prepareOAuth2Flow, startOAuth2Flow } from "../security/oauth2.js";
 import { getLogger } from "../util/logger.js";
-import type {
-  OAuthConnectResult,
-  OAuthScopePolicy,
-} from "./connect-types.js";
+import type { OAuthConnectResult, OAuthScopePolicy } from "./connect-types.js";
 import { verifyIdentity } from "./identity-verifier.js";
 import { getProvider } from "./oauth-store.js";
 import { resolveScopes } from "./scope-policy.js";
@@ -98,7 +95,7 @@ export interface OAuthConnectOptions {
  *
  * Returns a discriminated result:
  * - Interactive success: `{ success: true, deferred: false, grantedScopes, accountInfo }`
- * - Deferred success:    `{ success: true, deferred: true, authUrl, state, service }`
+ * - Deferred success:    `{ success: true, deferred: true, authorizeUrl, state, service }`
  * - Error:               `{ success: false, error }`
  */
 export async function orchestrateOAuthConnect(
@@ -137,15 +134,15 @@ export async function orchestrateOAuthConnect(
       forbiddenScopes: [],
     },
   );
-  const dbExtraParams = safeJsonParse<Record<string, string> | undefined>(
-    providerRow.extraParams,
+  const dbAuthorizeParams = safeJsonParse<Record<string, string> | undefined>(
+    providerRow.authorizeParams,
     undefined,
   );
 
   // Resolve all protocol-level config from the DB
-  const authUrl = providerRow.authUrl;
-  const tokenUrl = providerRow.tokenUrl;
-  const extraParams = dbExtraParams;
+  const authorizeUrl = providerRow.authorizeUrl;
+  const tokenExchangeUrl = providerRow.tokenExchangeUrl;
+  const authorizeParams = dbAuthorizeParams;
   const userinfoUrl = providerRow.userinfoUrl ?? undefined;
   const tokenEndpointAuthMethod = providerRow.tokenEndpointAuthMethod as
     | TokenEndpointAuthMethod
@@ -173,14 +170,14 @@ export async function orchestrateOAuthConnect(
   }
   const finalScopes = scopeResult.scopes;
 
-  if (!authUrl) {
+  if (!authorizeUrl) {
     return {
       success: false,
       error: "auth_url is required (no well-known config for this service)",
       safeError: true,
     };
   }
-  if (!tokenUrl) {
+  if (!tokenExchangeUrl) {
     return {
       success: false,
       error: "token_url is required (no well-known config for this service)",
@@ -191,24 +188,24 @@ export async function orchestrateOAuthConnect(
   log.info(
     {
       service: options.service,
-      authUrl,
-      tokenUrl,
+      authorizeUrl,
+      tokenExchangeUrl,
       scopeCount: finalScopes.length,
       callbackTransport,
       loopbackPort,
-      hasClientSecret: !!options.clientSecret,
+      hasSecret: !!options.clientSecret,
       clientIdPrefix: options.clientId.substring(0, 12) + "…",
     },
     "orchestrateOAuthConnect: resolved provider config",
   );
 
   const oauthConfig = {
-    authUrl,
-    tokenUrl,
+    authorizeUrl,
+    tokenExchangeUrl,
     scopes: finalScopes,
     clientId: options.clientId,
     clientSecret: options.clientSecret,
-    extraParams,
+    authorizeParams,
     userinfoUrl,
     tokenEndpointAuthMethod,
   };
@@ -308,7 +305,7 @@ export async function orchestrateOAuthConnect(
       return {
         success: true,
         deferred: true,
-        authUrl: prepared.authUrl,
+        authorizeUrl: prepared.authorizeUrl,
         state: prepared.state,
         service: options.service,
       };
@@ -344,14 +341,18 @@ export async function orchestrateOAuthConnect(
             log.info("orchestrateOAuthConnect: using options.openUrl");
             options.openUrl(url);
           } else if (options.sendToClient) {
-            log.info("orchestrateOAuthConnect: using sendToClient with open_url event");
+            log.info(
+              "orchestrateOAuthConnect: using sendToClient with open_url event",
+            );
             options.sendToClient({
               type: "open_url",
               url,
               title: `Connect ${options.service}`,
             });
           } else {
-            log.warn("orchestrateOAuthConnect: no openUrl or sendToClient available — auth URL will not reach the user");
+            log.warn(
+              "orchestrateOAuthConnect: no openUrl or sendToClient available — auth URL will not reach the user",
+            );
           }
         },
       },

--- a/assistant/src/oauth/connect-types.ts
+++ b/assistant/src/oauth/connect-types.ts
@@ -4,8 +4,8 @@
  * These types are consumed by the token persistence module and the
  * credential vault orchestrator.
  *
- * All provider configuration — protocol-level OAuth config (authUrl,
- * tokenUrl, scopes, etc.) as well as behavioral config (identity
+ * All provider configuration — protocol-level OAuth config (authorizeUrl,
+ * tokenExchangeUrl, scopes, etc.) as well as behavioral config (identity
  * verification, injection templates, setup metadata) — is now stored
  * exclusively in the `oauth_providers` SQLite table and seeded on
  * startup via `seed-providers.ts`.
@@ -47,7 +47,7 @@ export interface OAuthConnectInteractiveResult {
 export interface OAuthConnectDeferredResult {
   success: true;
   deferred: true;
-  authUrl: string;
+  authorizeUrl: string;
   state: string;
   service: string;
 }

--- a/assistant/src/oauth/connection-resolver.test.ts
+++ b/assistant/src/oauth/connection-resolver.test.ts
@@ -79,13 +79,13 @@ function makeMockClient() {
 
 function setupDefaults(): void {
   mockProvider = {
-    providerKey: "google",
+    provider: "google",
     baseUrl: "https://gmail.googleapis.com/gmail/v1/users/me",
     managedServiceConfigKey: null,
   };
   mockConnection = {
     id: "conn-1",
-    providerKey: "google",
+    provider: "google",
     oauthAppId: "app-1",
     accountInfo: "user@example.com",
     grantedScopes: JSON.stringify(["scope-a", "scope-b"]),
@@ -125,7 +125,7 @@ describe("resolveOAuthConnection", () => {
     const result = await resolveOAuthConnection("google");
     expect(result).toBeInstanceOf(BYOOAuthConnection);
     expect(result.id).toBe("conn-1");
-    expect(result.providerKey).toBe("google");
+    expect(result.provider).toBe("google");
   });
 
   test("returns PlatformOAuthConnection when managed mode is active", async () => {
@@ -134,7 +134,7 @@ describe("resolveOAuthConnection", () => {
     const result = await resolveOAuthConnection("google");
     expect(result).toBeInstanceOf(PlatformOAuthConnection);
     expect(result.id).toBe("google");
-    expect(result.providerKey).toBe("google");
+    expect(result.provider).toBe("google");
     expect(result.accountInfo).toBeNull();
   });
 

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -29,7 +29,7 @@ export interface ResolveOAuthConnectionOptions {
  * BYO providers resolve from the local SQLite oauth-store and require an
  * active connection row and a stored access token.
  *
- * @param providerKey - Provider identifier (e.g. "google").
+ * @param provider - Provider identifier (e.g. "google").
  *   Maps to the `provider_key` primary key in the `oauth_providers` table.
  * @param options.clientId - Optional OAuth app client ID. When multiple BYO
  *   apps exist for the same provider, narrows the connection lookup to the
@@ -38,12 +38,12 @@ export interface ResolveOAuthConnectionOptions {
  *   multi-account connections.
  */
 export async function resolveOAuthConnection(
-  providerKey: string,
+  provider: string,
   options?: ResolveOAuthConnectionOptions,
 ): Promise<OAuthConnection> {
   const { clientId, account } = options ?? {};
-  const provider = getProvider(providerKey);
-  const managedKey = provider?.managedServiceConfigKey;
+  const providerRow = getProvider(provider);
+  const managedKey = providerRow?.managedServiceConfigKey;
 
   if (managedKey && managedKey in ServicesSchema.shape) {
     const services: Services = getConfig().services;
@@ -54,31 +54,31 @@ export async function resolveOAuthConnection(
           ? "missing platform prerequisites"
           : "missing assistant ID";
         throw new Error(
-          `Platform-managed connection for "${providerKey}" cannot be created: ${detail}. ` +
+          `Platform-managed connection for "${provider}" cannot be created: ${detail}. ` +
             `Log in to the Vellum platform or switch to using your own OAuth app.`,
         );
       }
 
       const connectionId = await resolvePlatformConnectionId({
         client,
-        provider: providerKey,
+        provider,
         account,
       });
 
       return new PlatformOAuthConnection({
-        id: providerKey,
-        providerKey,
-        externalId: providerKey,
+        id: provider,
+        provider,
+        externalId: provider,
         accountInfo: account ?? null,
         client,
         connectionId,
-        baseUrl: provider?.baseUrl ?? undefined,
+        baseUrl: providerRow?.baseUrl ?? undefined,
       });
     }
   }
 
   // BYO path — requires a local connection row, access token, and base URL.
-  const conn = getActiveConnection(providerKey, { clientId, account });
+  const conn = getActiveConnection(provider, { clientId, account });
   if (!conn) {
     const filters = [
       account && `account "${account}"`,
@@ -88,7 +88,7 @@ export async function resolveOAuthConnection(
       ? ` matching ${filters.join(" and ")}`
       : "";
     throw new Error(
-      `No active OAuth connection found for "${providerKey}"${qualifier}. Connect the service first with \`assistant oauth connect ${providerKey}\`.`,
+      `No active OAuth connection found for "${provider}"${qualifier}. Connect the service first with \`assistant oauth connect ${provider}\`.`,
     );
   }
 
@@ -97,20 +97,20 @@ export async function resolveOAuthConnection(
   );
   if (!accessToken) {
     throw new Error(
-      `OAuth connection for "${providerKey}" exists but has no access token. Re-authorize with \`assistant oauth connect ${providerKey}\`.`,
+      `OAuth connection for "${provider}" exists but has no access token. Re-authorize with \`assistant oauth connect ${provider}\`.`,
     );
   }
 
-  const baseUrl = provider?.baseUrl;
+  const baseUrl = providerRow?.baseUrl;
   if (!baseUrl) {
     throw new Error(
-      `OAuth provider "${providerKey}" has no base URL configured. Check provider setup.`,
+      `OAuth provider "${provider}" has no base URL configured. Check provider setup.`,
     );
   }
 
   return new BYOOAuthConnection({
     id: conn.id,
-    providerKey: conn.providerKey,
+    provider: conn.provider,
     baseUrl,
     accountInfo: conn.accountInfo,
   });

--- a/assistant/src/oauth/connection.ts
+++ b/assistant/src/oauth/connection.ts
@@ -32,6 +32,6 @@ export interface OAuthConnection {
   withToken<T>(fn: (token: string) => Promise<T>): Promise<T>;
 
   readonly id: string;
-  readonly providerKey: string;
+  readonly provider: string;
   readonly accountInfo: string | null;
 }

--- a/assistant/src/oauth/manual-token-connection.ts
+++ b/assistant/src/oauth/manual-token-connection.ts
@@ -25,14 +25,14 @@ const MANUAL_TOKEN_CLIENT_ID = "manual-config";
  * Ensure an active oauth_connection row exists for the given manual-token
  * provider. Creates the synthetic oauth_app row on first use.
  *
- * @param providerKey - The provider key (e.g. "slack_channel", "telegram")
+ * @param provider - The provider key (e.g. "slack_channel", "telegram")
  * @param accountInfo - Optional account info to store (e.g. team name, bot username)
  */
 export async function ensureManualTokenConnection(
-  providerKey: string,
+  provider: string,
   accountInfo?: string,
 ): Promise<void> {
-  const existing = getConnectionByProvider(providerKey);
+  const existing = getConnectionByProvider(provider);
   if (existing) {
     // Update account info if provided
     if (accountInfo !== undefined) {
@@ -42,11 +42,11 @@ export async function ensureManualTokenConnection(
   }
 
   // Create synthetic app + connection
-  const app = await upsertApp(providerKey, MANUAL_TOKEN_CLIENT_ID);
+  const app = await upsertApp(provider, MANUAL_TOKEN_CLIENT_ID);
 
   createConnection({
     oauthAppId: app.id,
-    providerKey,
+    provider,
     accountInfo,
     grantedScopes: [],
     hasRefreshToken: false,
@@ -59,8 +59,8 @@ export async function ensureManualTokenConnection(
  * Note: This only removes the oauth_connection row. The caller is still
  * responsible for deleting the stored credentials separately.
  */
-export function removeManualTokenConnection(providerKey: string): void {
-  const conn = getConnectionByProvider(providerKey);
+export function removeManualTokenConnection(provider: string): void {
+  const conn = getConnectionByProvider(provider);
   if (!conn) return;
   deleteConnection(conn.id);
 }
@@ -73,10 +73,10 @@ export function removeManualTokenConnection(providerKey: string): void {
  * keep connection status in sync without duplicating per-provider rules.
  */
 export async function syncManualTokenConnection(
-  providerKey: string,
+  provider: string,
   accountInfo?: string,
 ): Promise<void> {
-  switch (providerKey) {
+  switch (provider) {
     case "telegram": {
       const hasBotToken = !!(await getSecureKeyAsync(
         credentialKey("telegram", "bot_token"),
@@ -85,9 +85,9 @@ export async function syncManualTokenConnection(
         credentialKey("telegram", "webhook_secret"),
       ));
       if (hasBotToken && hasWebhookSecret) {
-        await ensureManualTokenConnection(providerKey, accountInfo);
+        await ensureManualTokenConnection(provider, accountInfo);
       } else {
-        removeManualTokenConnection(providerKey);
+        removeManualTokenConnection(provider);
       }
       return;
     }
@@ -100,9 +100,9 @@ export async function syncManualTokenConnection(
         credentialKey("slack_channel", "app_token"),
       ));
       if (hasBotToken && hasAppToken) {
-        await ensureManualTokenConnection(providerKey, accountInfo);
+        await ensureManualTokenConnection(provider, accountInfo);
       } else {
-        removeManualTokenConnection(providerKey);
+        removeManualTokenConnection(provider);
       }
       return;
     }

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -3,6 +3,11 @@
  *
  * Backed by Drizzle + SQLite. All JSON fields (default_scopes, scope_policy,
  * extra_params, granted_scopes, metadata) are stored as serialized JSON strings.
+ *
+ * Note: TS field names use camelCase from the platform's naming
+ * (provider, authorizeUrl, tokenExchangeUrl, displayLabel, authorizeParams),
+ * while underlying SQL columns retain their original snake_case names
+ * (provider_key, auth_url, token_url, display_name, extra_params).
  */
 
 import {
@@ -43,13 +48,13 @@ export type OAuthConnectionRow = typeof oauthConnections.$inferSelect;
 
 /**
  * Seed well-known provider profiles into the database. Uses INSERT … ON
- * CONFLICT DO UPDATE so that implementation fields (authUrl, tokenUrl,
- * tokenEndpointAuthMethod, userinfoUrl, extraParams,
+ * CONFLICT DO UPDATE so that implementation fields (authorizeUrl, tokenExchangeUrl,
+ * tokenEndpointAuthMethod, userinfoUrl, authorizeParams,
  * pingUrl, pingMethod, pingHeaders, pingBody, managedServiceConfigKey,
  * loopbackPort, injectionTemplates, appType, setupNotes,
  * identityUrl, identityMethod, identityHeaders, identityBody,
  * identityResponsePaths, identityFormat, identityOkField, featureFlag)
- * and display metadata (displayName, description, dashboardUrl,
+ * and display metadata (displayLabel, description, dashboardUrl,
  * clientIdPlaceholder, requiresClientSecret) propagate to existing
  * installations on every startup, while user-customizable fields
  * (defaultScopes, scopePolicy) are only written on the
@@ -59,9 +64,9 @@ export type OAuthConnectionRow = typeof oauthConnections.$inferSelect;
  */
 export function seedProviders(
   profiles: Array<{
-    providerKey: string;
-    authUrl: string;
-    tokenUrl: string;
+    provider: string;
+    authorizeUrl: string;
+    tokenExchangeUrl: string;
     tokenEndpointAuthMethod?: string;
     userinfoUrl?: string;
     pingUrl?: string;
@@ -71,9 +76,9 @@ export function seedProviders(
     baseUrl?: string;
     defaultScopes: string[];
     scopePolicy: Record<string, unknown>;
-    extraParams?: Record<string, string>;
+    authorizeParams?: Record<string, string>;
     managedServiceConfigKey?: string;
-    displayName?: string;
+    displayLabel?: string;
     description?: string;
     dashboardUrl?: string | null;
     clientIdPlaceholder?: string | null;
@@ -100,8 +105,8 @@ export function seedProviders(
   const db = getDb();
   const now = Date.now();
   for (const p of profiles) {
-    const authUrl = p.authUrl;
-    const tokenUrl = p.tokenUrl;
+    const authorizeUrl = p.authorizeUrl;
+    const tokenExchangeUrl = p.tokenExchangeUrl;
     const tokenEndpointAuthMethod = p.tokenEndpointAuthMethod ?? null;
     const userinfoUrl = p.userinfoUrl ?? null;
     const pingUrl = p.pingUrl ?? null;
@@ -112,9 +117,11 @@ export function seedProviders(
     const baseUrl = p.baseUrl ?? null;
     const defaultScopes = JSON.stringify(p.defaultScopes);
     const scopePolicy = JSON.stringify(p.scopePolicy);
-    const extraParams = p.extraParams ? JSON.stringify(p.extraParams) : null;
+    const authorizeParams = p.authorizeParams
+      ? JSON.stringify(p.authorizeParams)
+      : null;
     const managedServiceConfigKey = p.managedServiceConfigKey ?? null;
-    const displayName = p.displayName ?? null;
+    const displayLabel = p.displayLabel ?? null;
     const description = p.description ?? null;
     const dashboardUrl = p.dashboardUrl ?? null;
     const clientIdPlaceholder = p.clientIdPlaceholder ?? null;
@@ -141,21 +148,21 @@ export function seedProviders(
 
     db.insert(oauthProviders)
       .values({
-        providerKey: p.providerKey,
-        authUrl,
-        tokenUrl,
+        provider: p.provider,
+        authorizeUrl,
+        tokenExchangeUrl,
         tokenEndpointAuthMethod,
         userinfoUrl,
         baseUrl,
         defaultScopes,
         scopePolicy,
-        extraParams,
+        authorizeParams,
         pingUrl,
         pingMethod,
         pingHeaders,
         pingBody,
         managedServiceConfigKey,
-        displayName,
+        displayLabel,
         description,
         dashboardUrl,
         clientIdPlaceholder,
@@ -176,20 +183,20 @@ export function seedProviders(
         updatedAt: now,
       })
       .onConflictDoUpdate({
-        target: oauthProviders.providerKey,
+        target: oauthProviders.provider,
         set: {
-          authUrl,
-          tokenUrl,
+          authorizeUrl,
+          tokenExchangeUrl,
           tokenEndpointAuthMethod,
           userinfoUrl,
           baseUrl: sql`COALESCE(${oauthProviders.baseUrl}, ${baseUrl})`,
-          extraParams,
+          authorizeParams,
           pingUrl,
           pingMethod,
           pingHeaders,
           pingBody,
           managedServiceConfigKey,
-          displayName,
+          displayLabel,
           description,
           dashboardUrl,
           clientIdPlaceholder,
@@ -214,12 +221,12 @@ export function seedProviders(
 }
 
 /** Look up a provider by its primary key. */
-export function getProvider(providerKey: string): OAuthProviderRow | undefined {
+export function getProvider(provider: string): OAuthProviderRow | undefined {
   const db = getDb();
   return db
     .select()
     .from(oauthProviders)
-    .where(eq(oauthProviders.providerKey, providerKey))
+    .where(eq(oauthProviders.provider, provider))
     .get();
 }
 
@@ -234,9 +241,9 @@ export function listProviders(): OAuthProviderRow[] {
  * provider_key already exists.
  */
 export function registerProvider(params: {
-  providerKey: string;
-  authUrl: string;
-  tokenUrl: string;
+  provider: string;
+  authorizeUrl: string;
+  tokenExchangeUrl: string;
   tokenEndpointAuthMethod?: string;
   userinfoUrl?: string;
   pingUrl?: string;
@@ -246,9 +253,9 @@ export function registerProvider(params: {
   baseUrl?: string;
   defaultScopes: string[];
   scopePolicy: Record<string, unknown>;
-  extraParams?: Record<string, string>;
+  authorizeParams?: Record<string, string>;
   managedServiceConfigKey?: string;
-  displayName?: string;
+  displayLabel?: string;
   description?: string;
   dashboardUrl?: string;
   clientIdPlaceholder?: string;
@@ -274,28 +281,30 @@ export function registerProvider(params: {
   const db = getDb();
   const now = Date.now();
 
-  const existing = getProvider(params.providerKey);
+  const existing = getProvider(params.provider);
   if (existing) {
-    throw new Error(`OAuth provider already exists: ${params.providerKey}`);
+    throw new Error(`OAuth provider already exists: ${params.provider}`);
   }
 
   const row = {
-    providerKey: params.providerKey,
-    authUrl: params.authUrl,
-    tokenUrl: params.tokenUrl,
+    provider: params.provider,
+    authorizeUrl: params.authorizeUrl,
+    tokenExchangeUrl: params.tokenExchangeUrl,
     tokenEndpointAuthMethod: params.tokenEndpointAuthMethod ?? null,
     userinfoUrl: params.userinfoUrl ?? null,
     baseUrl: params.baseUrl ?? null,
     defaultScopes: JSON.stringify(params.defaultScopes),
     scopePolicy: JSON.stringify(params.scopePolicy),
-    extraParams: params.extraParams ? JSON.stringify(params.extraParams) : null,
+    authorizeParams: params.authorizeParams
+      ? JSON.stringify(params.authorizeParams)
+      : null,
     pingUrl: params.pingUrl ?? null,
     pingMethod: params.pingMethod ?? null,
     pingHeaders: params.pingHeaders ? JSON.stringify(params.pingHeaders) : null,
     pingBody:
       params.pingBody !== undefined ? JSON.stringify(params.pingBody) : null,
     managedServiceConfigKey: params.managedServiceConfigKey ?? null,
-    displayName: params.displayName ?? null,
+    displayLabel: params.displayLabel ?? null,
     description: params.description ?? null,
     dashboardUrl: params.dashboardUrl ?? null,
     clientIdPlaceholder: params.clientIdPlaceholder ?? null,
@@ -333,17 +342,17 @@ export function registerProvider(params: {
 /**
  * Update mutable fields on an existing provider. Only the fields explicitly
  * provided (not `undefined`) are written; everything else is left unchanged.
- * JSON fields (defaultScopes, scopePolicy, extraParams, pingHeaders, pingBody)
+ * JSON fields (defaultScopes, scopePolicy, authorizeParams, pingHeaders, pingBody)
  * are serialized with JSON.stringify before storage.
  *
  * Returns the updated provider row, or `undefined` if no provider with the
  * given key exists.
  */
 export function updateProvider(
-  providerKey: string,
+  provider: string,
   params: Partial<{
-    authUrl: string;
-    tokenUrl: string;
+    authorizeUrl: string;
+    tokenExchangeUrl: string;
     tokenEndpointAuthMethod: string;
     userinfoUrl: string;
     pingUrl: string;
@@ -353,8 +362,8 @@ export function updateProvider(
     baseUrl: string;
     defaultScopes: string[];
     scopePolicy: Record<string, unknown>;
-    extraParams: Record<string, string>;
-    displayName: string;
+    authorizeParams: Record<string, string>;
+    displayLabel: string;
     description: string;
     dashboardUrl: string;
     clientIdPlaceholder: string;
@@ -378,14 +387,15 @@ export function updateProvider(
     featureFlag: string;
   }>,
 ): OAuthProviderRow | undefined {
-  const existing = getProvider(providerKey);
+  const existing = getProvider(provider);
   if (!existing) return undefined;
 
   const db = getDb();
   const set: Record<string, unknown> = { updatedAt: Date.now() };
 
-  if (params.authUrl !== undefined) set.authUrl = params.authUrl;
-  if (params.tokenUrl !== undefined) set.tokenUrl = params.tokenUrl;
+  if (params.authorizeUrl !== undefined) set.authorizeUrl = params.authorizeUrl;
+  if (params.tokenExchangeUrl !== undefined)
+    set.tokenExchangeUrl = params.tokenExchangeUrl;
   if (params.tokenEndpointAuthMethod !== undefined)
     set.tokenEndpointAuthMethod = params.tokenEndpointAuthMethod;
   if (params.userinfoUrl !== undefined) set.userinfoUrl = params.userinfoUrl;
@@ -400,9 +410,9 @@ export function updateProvider(
     set.defaultScopes = JSON.stringify(params.defaultScopes);
   if (params.scopePolicy !== undefined)
     set.scopePolicy = JSON.stringify(params.scopePolicy);
-  if (params.extraParams !== undefined)
-    set.extraParams = JSON.stringify(params.extraParams);
-  if (params.displayName !== undefined) set.displayName = params.displayName;
+  if (params.authorizeParams !== undefined)
+    set.authorizeParams = JSON.stringify(params.authorizeParams);
+  if (params.displayLabel !== undefined) set.displayLabel = params.displayLabel;
   if (params.description !== undefined) set.description = params.description;
   if (params.dashboardUrl !== undefined) set.dashboardUrl = params.dashboardUrl;
   if (params.clientIdPlaceholder !== undefined)
@@ -432,10 +442,10 @@ export function updateProvider(
 
   db.update(oauthProviders)
     .set(set)
-    .where(eq(oauthProviders.providerKey, providerKey))
+    .where(eq(oauthProviders.provider, provider))
     .run();
 
-  return getProvider(providerKey);
+  return getProvider(provider);
 }
 
 /**
@@ -445,14 +455,12 @@ export function updateProvider(
  * Note: SQLite enforces the foreign-key constraint from `oauth_apps.provider_key`,
  * so deleting a provider that has existing apps will throw.
  */
-export function deleteProvider(providerKey: string): boolean {
-  const existing = getProvider(providerKey);
+export function deleteProvider(provider: string): boolean {
+  const existing = getProvider(provider);
   if (!existing) return false;
 
   const db = getDb();
-  db.delete(oauthProviders)
-    .where(eq(oauthProviders.providerKey, providerKey))
-    .run();
+  db.delete(oauthProviders).where(eq(oauthProviders.provider, provider)).run();
   return rawChanges() > 0;
 }
 
@@ -465,7 +473,7 @@ export function deleteProvider(providerKey: string): boolean {
  * Generates a UUID on insert.
  */
 export async function upsertApp(
-  providerKey: string,
+  provider: string,
   clientId: string,
   clientSecretOpts?: {
     clientSecretValue?: string;
@@ -499,10 +507,7 @@ export async function upsertApp(
     .select()
     .from(oauthApps)
     .where(
-      and(
-        eq(oauthApps.providerKey, providerKey),
-        eq(oauthApps.clientId, clientId),
-      ),
+      and(eq(oauthApps.provider, provider), eq(oauthApps.clientId, clientId)),
     )
     .get();
 
@@ -549,7 +554,7 @@ export async function upsertApp(
 
   const row = {
     id,
-    providerKey,
+    provider,
     clientId,
     clientSecretCredentialPath: credPath,
     createdAt: now,
@@ -597,7 +602,7 @@ export async function getAppClientSecret(
 
 /** Look up an app by (provider_key, client_id). */
 export function getAppByProviderAndClientId(
-  providerKey: string,
+  provider: string,
   clientId: string,
 ): OAuthAppRow | undefined {
   const db = getDb();
@@ -605,10 +610,7 @@ export function getAppByProviderAndClientId(
     .select()
     .from(oauthApps)
     .where(
-      and(
-        eq(oauthApps.providerKey, providerKey),
-        eq(oauthApps.clientId, clientId),
-      ),
+      and(eq(oauthApps.provider, provider), eq(oauthApps.clientId, clientId)),
     )
     .get();
 }
@@ -618,13 +620,13 @@ export function getAppByProviderAndClientId(
  * Returns undefined if no app exists for this provider.
  */
 export function getMostRecentAppByProvider(
-  providerKey: string,
+  provider: string,
 ): OAuthAppRow | undefined {
   const db = getDb();
   return db
     .select()
     .from(oauthApps)
-    .where(eq(oauthApps.providerKey, providerKey))
+    .where(eq(oauthApps.provider, provider))
     .orderBy(desc(oauthApps.createdAt))
     .limit(1)
     .get();
@@ -670,7 +672,7 @@ export async function deleteApp(id: string): Promise<boolean> {
  */
 export function createConnection(params: {
   oauthAppId: string;
-  providerKey: string;
+  provider: string;
   accountInfo?: string;
   grantedScopes: string[];
   expiresAt?: number;
@@ -687,7 +689,7 @@ export function createConnection(params: {
   const row = {
     id,
     oauthAppId: params.oauthAppId,
-    providerKey: params.providerKey,
+    provider: params.provider,
     accountInfo: params.accountInfo ?? null,
     grantedScopes: JSON.stringify(params.grantedScopes),
     expiresAt: params.expiresAt ?? null,
@@ -724,14 +726,14 @@ export function getConnection(id: string): OAuthConnectionRow | undefined {
  * Returns `undefined` when no matching active connection exists.
  */
 export function getActiveConnection(
-  providerKey: string,
+  provider: string,
   options?: { clientId?: string; account?: string },
 ): OAuthConnectionRow | undefined {
   const { clientId, account } = options ?? {};
   const db = getDb();
 
   const conditions = [
-    eq(oauthConnections.providerKey, providerKey),
+    eq(oauthConnections.provider, provider),
     eq(oauthConnections.status, "active"),
   ];
 
@@ -740,7 +742,7 @@ export function getActiveConnection(
   }
 
   if (clientId) {
-    const app = getAppByProviderAndClientId(providerKey, clientId);
+    const app = getAppByProviderAndClientId(provider, clientId);
     if (!app) return undefined;
     conditions.push(eq(oauthConnections.oauthAppId, app.id));
   }
@@ -756,26 +758,26 @@ export function getActiveConnection(
 
 /** @deprecated Use {@link getActiveConnection} instead. */
 export function getConnectionByProvider(
-  providerKey: string,
+  provider: string,
   clientId?: string,
 ): OAuthConnectionRow | undefined {
-  return getActiveConnection(providerKey, { clientId });
+  return getActiveConnection(provider, { clientId });
 }
 
 /** @deprecated Use {@link getActiveConnection} instead. */
 export function getConnectionByProviderAndAccount(
-  providerKey: string,
+  provider: string,
   accountInfo?: string,
   clientId?: string,
 ): OAuthConnectionRow | undefined {
-  return getActiveConnection(providerKey, { clientId, account: accountInfo });
+  return getActiveConnection(provider, { clientId, account: accountInfo });
 }
 
 /**
  * Get ALL active connections for a provider (supports multi-account).
  */
 export function listActiveConnectionsByProvider(
-  providerKey: string,
+  provider: string,
 ): OAuthConnectionRow[] {
   const db = getDb();
   return db
@@ -783,7 +785,7 @@ export function listActiveConnectionsByProvider(
     .from(oauthConnections)
     .where(
       and(
-        eq(oauthConnections.providerKey, providerKey),
+        eq(oauthConnections.provider, provider),
         eq(oauthConnections.status, "active"),
       ),
     )
@@ -799,10 +801,8 @@ export function listActiveConnectionsByProvider(
  * but the secure-key write for the access token failed, which would make
  * `resolveOAuthConnection()` throw at usage time.
  */
-export async function isProviderConnected(
-  providerKey: string,
-): Promise<boolean> {
-  const conn = getActiveConnection(providerKey);
+export async function isProviderConnected(provider: string): Promise<boolean> {
+  const conn = getActiveConnection(provider);
   if (!conn || conn.status !== "active") return false;
   return (
     (await getSecureKeyAsync(oauthConnectionAccessTokenPath(conn.id))) !==
@@ -853,24 +853,24 @@ export function updateConnection(
 
 /** List connections, optionally filtered by provider key and/or client ID. */
 export function listConnections(
-  providerKey?: string,
+  provider?: string,
   clientId?: string,
 ): OAuthConnectionRow[] {
   const db = getDb();
 
   let rows: OAuthConnectionRow[];
-  if (providerKey) {
+  if (provider) {
     rows = db
       .select()
       .from(oauthConnections)
-      .where(eq(oauthConnections.providerKey, providerKey))
-      .orderBy(oauthConnections.providerKey, oauthConnections.id)
+      .where(eq(oauthConnections.provider, provider))
+      .orderBy(oauthConnections.provider, oauthConnections.id)
       .all();
   } else {
     rows = db
       .select()
       .from(oauthConnections)
-      .orderBy(oauthConnections.providerKey, oauthConnections.id)
+      .orderBy(oauthConnections.provider, oauthConnections.id)
       .all();
   }
 
@@ -914,13 +914,13 @@ export function deleteConnection(id: string): boolean {
  * to avoid orphaning secrets).
  */
 export async function disconnectOAuthProvider(
-  providerKey: string,
+  provider: string,
   clientId?: string,
   connectionId?: string,
 ): Promise<"disconnected" | "not-found" | "error"> {
   const conn = connectionId
     ? getConnection(connectionId)
-    : getActiveConnection(providerKey, { clientId });
+    : getActiveConnection(provider, { clientId });
   if (!conn) return "not-found";
 
   // Wrap the assistant's secure-key functions into the SecureKeyBackend
@@ -945,7 +945,7 @@ export async function disconnectOAuthProvider(
     // way to surface the failure.
     log.warn(
       {
-        providerKey,
+        provider,
         connectionId: conn.id,
         accessTokenResult,
         refreshTokenResult,

--- a/assistant/src/oauth/platform-connection.test.ts
+++ b/assistant/src/oauth/platform-connection.test.ts
@@ -35,7 +35,7 @@ function makeMockClient(
 
 const DEFAULT_OPTIONS = {
   id: "conn-1",
-  providerKey: "google",
+  provider: "google",
   externalId: "ext-123",
   accountInfo: "user@example.com",
   client: makeMockClient(),
@@ -226,7 +226,7 @@ describe("PlatformOAuthConnection", () => {
     );
   });
 
-  test("uses connectionId in proxy URL regardless of providerKey format", async () => {
+  test("uses connectionId in proxy URL regardless of provider format", async () => {
     const client = makeMockClient(
       mock(async (url: string | URL | Request) => {
         expect(String(url)).toContain(
@@ -242,7 +242,7 @@ describe("PlatformOAuthConnection", () => {
     const conn = new PlatformOAuthConnection({
       ...DEFAULT_OPTIONS,
       client,
-      providerKey: "slack",
+      provider: "slack",
       connectionId: "slack-conn-456",
     });
     await conn.request({ method: "GET", path: "/test" });

--- a/assistant/src/oauth/platform-connection.ts
+++ b/assistant/src/oauth/platform-connection.ts
@@ -22,7 +22,7 @@ export class ProviderUnreachableError extends BackendError {
 
 export interface PlatformOAuthConnectionOptions {
   id: string;
-  providerKey: string;
+  provider: string;
   externalId: string;
   accountInfo: string | null;
   client: VellumPlatformClient;
@@ -35,7 +35,7 @@ export interface PlatformOAuthConnectionOptions {
 
 export class PlatformOAuthConnection implements OAuthConnection {
   readonly id: string;
-  readonly providerKey: string;
+  readonly provider: string;
   readonly externalId: string;
   readonly accountInfo: string | null;
 
@@ -46,13 +46,13 @@ export class PlatformOAuthConnection implements OAuthConnection {
   constructor(options: PlatformOAuthConnectionOptions) {
     if (!options.connectionId) {
       throw new BackendError(
-        `Platform-managed connection for "${options.providerKey}" cannot be created: missing connection ID. ` +
+        `Platform-managed connection for "${options.provider}" cannot be created: missing connection ID. ` +
           `Log in to the Vellum platform or switch to using your own OAuth app.`,
       );
     }
 
     this.id = options.id;
-    this.providerKey = options.providerKey;
+    this.provider = options.provider;
     this.externalId = options.externalId;
     this.accountInfo = options.accountInfo;
     this.client = options.client;

--- a/assistant/src/oauth/provider-serializer.ts
+++ b/assistant/src/oauth/provider-serializer.ts
@@ -60,7 +60,7 @@ function _serializeProvider(
 ) {
   return {
     ...row,
-    displayName: row.displayName ?? null,
+    displayLabel: row.displayLabel ?? null,
     description: row.description ?? null,
     dashboardUrl: row.dashboardUrl ?? null,
     clientIdPlaceholder: row.clientIdPlaceholder ?? null,
@@ -68,7 +68,9 @@ function _serializeProvider(
     supportsManagedMode: !!row.managedServiceConfigKey,
     defaultScopes: row.defaultScopes ? JSON.parse(row.defaultScopes) : [],
     scopePolicy: row.scopePolicy ? JSON.parse(row.scopePolicy) : {},
-    extraParams: row.extraParams ? JSON.parse(row.extraParams) : null,
+    authorizeParams: row.authorizeParams
+      ? JSON.parse(row.authorizeParams)
+      : null,
     pingHeaders: row.pingHeaders ? JSON.parse(row.pingHeaders) : null,
     pingBody: row.pingBody ? JSON.parse(row.pingBody) : null,
     loopbackPort: row.loopbackPort ?? null,
@@ -107,8 +109,8 @@ export function serializeProviderSummary(
 ): SerializedProviderSummary | null {
   if (!row) return null;
   return {
-    provider_key: row.providerKey,
-    display_name: row.displayName ?? null,
+    provider_key: row.provider,
+    display_name: row.displayLabel ?? null,
     description: row.description ?? null,
     dashboard_url: row.dashboardUrl ?? null,
     client_id_placeholder: row.clientIdPlaceholder ?? null,

--- a/assistant/src/oauth/provider-serializer.ts
+++ b/assistant/src/oauth/provider-serializer.ts
@@ -58,9 +58,26 @@ function _serializeProvider(
   row: OAuthProviderRow,
   options?: { redirectUri?: string | null },
 ) {
+  // Destructure the renamed Drizzle TS-side fields out of the row so they
+  // do not leak into the spread below. The wire format intentionally keeps
+  // the legacy camelCase keys (`providerKey`, `authUrl`, `tokenUrl`,
+  // `displayName`, `extraParams`) so existing CLI script consumers and any
+  // other clients that parse this output don't break. The renamed fields
+  // are emitted explicitly under their old names instead.
+  const {
+    provider,
+    authorizeUrl,
+    tokenExchangeUrl,
+    displayLabel,
+    authorizeParams,
+    ...rest
+  } = row;
   return {
-    ...row,
-    displayLabel: row.displayLabel ?? null,
+    ...rest,
+    providerKey: provider,
+    authUrl: authorizeUrl,
+    tokenUrl: tokenExchangeUrl,
+    displayName: displayLabel ?? null,
     description: row.description ?? null,
     dashboardUrl: row.dashboardUrl ?? null,
     clientIdPlaceholder: row.clientIdPlaceholder ?? null,
@@ -68,9 +85,7 @@ function _serializeProvider(
     supportsManagedMode: !!row.managedServiceConfigKey,
     defaultScopes: row.defaultScopes ? JSON.parse(row.defaultScopes) : [],
     scopePolicy: row.scopePolicy ? JSON.parse(row.scopePolicy) : {},
-    authorizeParams: row.authorizeParams
-      ? JSON.parse(row.authorizeParams)
-      : null,
+    extraParams: authorizeParams ? JSON.parse(authorizeParams) : null,
     pingHeaders: row.pingHeaders ? JSON.parse(row.pingHeaders) : null,
     pingBody: row.pingBody ? JSON.parse(row.pingBody) : null,
     loopbackPort: row.loopbackPort ?? null,

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -4,13 +4,13 @@ import { seedProviders } from "./oauth-store.js";
  * Protocol-level seed data for each well-known OAuth provider.
  *
  * These values are upserted into the `oauth_providers` SQLite table on
- * every startup. Only Vellum implementation fields (authUrl, tokenUrl,
- * tokenEndpointAuthMethod, userinfoUrl, extraParams,
+ * every startup. Only Vellum implementation fields (authorizeUrl, tokenExchangeUrl,
+ * tokenEndpointAuthMethod, userinfoUrl, authorizeParams,
  * pingUrl, pingMethod, pingHeaders, pingBody, managedServiceConfigKey,
  * loopbackPort, injectionTemplates, appType, setupNotes,
  * identityUrl, identityMethod, identityHeaders, identityBody,
  * identityResponsePaths, identityFormat, identityOkField, featureFlag)
- * and display metadata (displayName,
+ * and display metadata (displayLabel,
  * description, dashboardUrl, clientIdPlaceholder, requiresClientSecret)
  * are overwritten on subsequent startups — user-customizable
  * fields (defaultScopes, scopePolicy) are only
@@ -19,9 +19,9 @@ import { seedProviders } from "./oauth-store.js";
 const PROVIDER_SEED_DATA: Record<
   string,
   {
-    providerKey: string;
-    authUrl: string;
-    tokenUrl: string;
+    provider: string;
+    authorizeUrl: string;
+    tokenExchangeUrl: string;
     tokenEndpointAuthMethod?: string;
     userinfoUrl?: string;
     pingUrl?: string;
@@ -35,9 +35,9 @@ const PROVIDER_SEED_DATA: Record<
       allowedOptionalScopes: string[];
       forbiddenScopes: string[];
     };
-    extraParams?: Record<string, string>;
+    authorizeParams?: Record<string, string>;
     managedServiceConfigKey?: string;
-    displayName: string;
+    displayLabel: string;
     description: string;
     dashboardUrl: string | null;
     clientIdPlaceholder: string | null;
@@ -62,13 +62,13 @@ const PROVIDER_SEED_DATA: Record<
   }
 > = {
   google: {
-    providerKey: "google",
-    authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
-    tokenUrl: "https://oauth2.googleapis.com/token",
+    provider: "google",
+    authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+    tokenExchangeUrl: "https://oauth2.googleapis.com/token",
     userinfoUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
     pingUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
     baseUrl: "https://gmail.googleapis.com/gmail/v1/users/me",
-    displayName: "Google",
+    displayLabel: "Google",
     description: "Gmail, Calendar, and Contacts",
     dashboardUrl: "https://console.cloud.google.com/apis/credentials",
     clientIdPlaceholder: "123456789.apps.googleusercontent.com",
@@ -89,7 +89,7 @@ const PROVIDER_SEED_DATA: Record<
       ],
       forbiddenScopes: [],
     },
-    extraParams: { access_type: "offline", prompt: "consent" },
+    authorizeParams: { access_type: "offline", prompt: "consent" },
     loopbackPort: 17321,
     managedServiceConfigKey: "google-oauth",
     injectionTemplates: [
@@ -118,12 +118,12 @@ const PROVIDER_SEED_DATA: Record<
   },
 
   slack: {
-    providerKey: "slack",
-    authUrl: "https://slack.com/oauth/v2/authorize",
-    tokenUrl: "https://slack.com/api/oauth.v2.access",
+    provider: "slack",
+    authorizeUrl: "https://slack.com/oauth/v2/authorize",
+    tokenExchangeUrl: "https://slack.com/api/oauth.v2.access",
     pingUrl: "https://slack.com/api/auth.test",
     baseUrl: "https://slack.com/api",
-    displayName: "Slack",
+    displayLabel: "Slack",
     description: "Workspace messaging",
     dashboardUrl: "https://api.slack.com/apps",
     clientIdPlaceholder: null,
@@ -147,7 +147,7 @@ const PROVIDER_SEED_DATA: Record<
       allowedOptionalScopes: [],
       forbiddenScopes: [],
     },
-    extraParams: {
+    authorizeParams: {
       user_scope:
         "channels:read,channels:history,groups:read,groups:history,im:read,im:history,im:write,mpim:read,mpim:history,users:read,chat:write,search:read,reactions:write",
     },
@@ -168,13 +168,13 @@ const PROVIDER_SEED_DATA: Record<
   },
 
   notion: {
-    providerKey: "notion",
-    authUrl: "https://api.notion.com/v1/oauth/authorize",
-    tokenUrl: "https://api.notion.com/v1/oauth/token",
+    provider: "notion",
+    authorizeUrl: "https://api.notion.com/v1/oauth/authorize",
+    tokenExchangeUrl: "https://api.notion.com/v1/oauth/token",
     pingUrl: "https://api.notion.com/v1/users/me",
     pingHeaders: { "Notion-Version": "2022-06-28" },
     baseUrl: "https://api.notion.com",
-    displayName: "Notion",
+    displayLabel: "Notion",
     description: "Pages and databases",
     dashboardUrl: "https://www.notion.so/my-integrations",
     clientIdPlaceholder: null,
@@ -184,7 +184,7 @@ const PROVIDER_SEED_DATA: Record<
       allowedOptionalScopes: [],
       forbiddenScopes: [],
     },
-    extraParams: { owner: "user" },
+    authorizeParams: { owner: "user" },
     tokenEndpointAuthMethod: "client_secret_basic",
     loopbackPort: 17323,
     injectionTemplates: [
@@ -202,12 +202,12 @@ const PROVIDER_SEED_DATA: Record<
   },
 
   twitter: {
-    providerKey: "twitter",
-    authUrl: "https://twitter.com/i/oauth2/authorize",
-    tokenUrl: "https://api.x.com/2/oauth2/token",
+    provider: "twitter",
+    authorizeUrl: "https://twitter.com/i/oauth2/authorize",
+    tokenExchangeUrl: "https://api.x.com/2/oauth2/token",
     pingUrl: "https://api.x.com/2/users/me",
     baseUrl: "https://api.x.com",
-    displayName: "Twitter",
+    displayLabel: "Twitter",
     description: "Posts and direct messages",
     dashboardUrl: "https://developer.twitter.com/en/portal/dashboard",
     clientIdPlaceholder: null,
@@ -239,12 +239,12 @@ const PROVIDER_SEED_DATA: Record<
   },
 
   github: {
-    providerKey: "github",
-    authUrl: "https://github.com/login/oauth/authorize",
-    tokenUrl: "https://github.com/login/oauth/access_token",
+    provider: "github",
+    authorizeUrl: "https://github.com/login/oauth/authorize",
+    tokenExchangeUrl: "https://github.com/login/oauth/access_token",
     pingUrl: "https://api.github.com/user",
     baseUrl: "https://api.github.com",
-    displayName: "GitHub",
+    displayLabel: "GitHub",
     description: "Repositories and issues",
     dashboardUrl: "https://github.com/settings/developers",
     clientIdPlaceholder: null,
@@ -275,15 +275,15 @@ const PROVIDER_SEED_DATA: Record<
   },
 
   linear: {
-    providerKey: "linear",
-    authUrl: "https://linear.app/oauth/authorize",
-    tokenUrl: "https://api.linear.app/oauth/token",
+    provider: "linear",
+    authorizeUrl: "https://linear.app/oauth/authorize",
+    tokenExchangeUrl: "https://api.linear.app/oauth/token",
     pingUrl: "https://api.linear.app/graphql",
     pingMethod: "POST",
     pingHeaders: { "Content-Type": "application/json" },
     pingBody: { query: "{ viewer { id name email } }" },
     baseUrl: "https://api.linear.app",
-    displayName: "Linear",
+    displayLabel: "Linear",
     description: "Issues and projects",
     dashboardUrl: "https://linear.app/settings/api",
     clientIdPlaceholder: null,
@@ -293,7 +293,7 @@ const PROVIDER_SEED_DATA: Record<
       allowedOptionalScopes: [],
       forbiddenScopes: [],
     },
-    extraParams: { prompt: "consent" },
+    authorizeParams: { prompt: "consent" },
     loopbackPort: 17324,
     managedServiceConfigKey: "linear-oauth",
     injectionTemplates: [
@@ -313,12 +313,12 @@ const PROVIDER_SEED_DATA: Record<
   },
 
   spotify: {
-    providerKey: "spotify",
-    authUrl: "https://accounts.spotify.com/authorize",
-    tokenUrl: "https://accounts.spotify.com/api/token",
+    provider: "spotify",
+    authorizeUrl: "https://accounts.spotify.com/authorize",
+    tokenExchangeUrl: "https://accounts.spotify.com/api/token",
     pingUrl: "https://api.spotify.com/v1/me",
     baseUrl: "https://api.spotify.com/v1",
-    displayName: "Spotify",
+    displayLabel: "Spotify",
     description: "Music and playlists",
     dashboardUrl: "https://developer.spotify.com/dashboard",
     clientIdPlaceholder: null,
@@ -354,12 +354,12 @@ const PROVIDER_SEED_DATA: Record<
   },
 
   todoist: {
-    providerKey: "todoist",
-    authUrl: "https://todoist.com/oauth/authorize",
-    tokenUrl: "https://todoist.com/oauth/access_token",
+    provider: "todoist",
+    authorizeUrl: "https://todoist.com/oauth/authorize",
+    tokenExchangeUrl: "https://todoist.com/oauth/access_token",
     pingUrl: "https://api.todoist.com/rest/v2/projects",
     baseUrl: "https://api.todoist.com/rest/v2",
-    displayName: "Todoist",
+    displayLabel: "Todoist",
     description: "Tasks and projects",
     dashboardUrl: "https://developer.todoist.com/appconsole.html",
     clientIdPlaceholder: null,
@@ -387,12 +387,12 @@ const PROVIDER_SEED_DATA: Record<
   },
 
   discord: {
-    providerKey: "discord",
-    authUrl: "https://discord.com/oauth2/authorize",
-    tokenUrl: "https://discord.com/api/v10/oauth2/token",
+    provider: "discord",
+    authorizeUrl: "https://discord.com/oauth2/authorize",
+    tokenExchangeUrl: "https://discord.com/api/v10/oauth2/token",
     pingUrl: "https://discord.com/api/v10/users/@me",
     baseUrl: "https://discord.com/api/v10",
-    displayName: "Discord",
+    displayLabel: "Discord",
     description: "Servers and messages",
     dashboardUrl: "https://discord.com/developers/applications",
     clientIdPlaceholder: null,
@@ -422,13 +422,13 @@ const PROVIDER_SEED_DATA: Record<
   },
 
   dropbox: {
-    providerKey: "dropbox",
-    authUrl: "https://www.dropbox.com/oauth2/authorize",
-    tokenUrl: "https://api.dropboxapi.com/oauth2/token",
+    provider: "dropbox",
+    authorizeUrl: "https://www.dropbox.com/oauth2/authorize",
+    tokenExchangeUrl: "https://api.dropboxapi.com/oauth2/token",
     pingUrl: "https://api.dropboxapi.com/2/users/get_current_account",
     pingMethod: "POST",
     baseUrl: "https://api.dropboxapi.com/2",
-    displayName: "Dropbox",
+    displayLabel: "Dropbox",
     description: "Files and folders",
     dashboardUrl: "https://www.dropbox.com/developers/apps",
     clientIdPlaceholder: null,
@@ -443,7 +443,7 @@ const PROVIDER_SEED_DATA: Record<
       allowedOptionalScopes: [],
       forbiddenScopes: [],
     },
-    extraParams: { token_access_type: "offline" },
+    authorizeParams: { token_access_type: "offline" },
     loopbackPort: 17327,
     injectionTemplates: [
       {
@@ -466,12 +466,12 @@ const PROVIDER_SEED_DATA: Record<
   },
 
   asana: {
-    providerKey: "asana",
-    authUrl: "https://app.asana.com/-/oauth_authorize",
-    tokenUrl: "https://app.asana.com/-/oauth_token",
+    provider: "asana",
+    authorizeUrl: "https://app.asana.com/-/oauth_authorize",
+    tokenExchangeUrl: "https://app.asana.com/-/oauth_token",
     pingUrl: "https://app.asana.com/api/1.0/users/me",
     baseUrl: "https://app.asana.com/api/1.0",
-    displayName: "Asana",
+    displayLabel: "Asana",
     description: "Tasks and projects",
     dashboardUrl: "https://app.asana.com/0/my-apps",
     clientIdPlaceholder: null,
@@ -496,12 +496,12 @@ const PROVIDER_SEED_DATA: Record<
   },
 
   airtable: {
-    providerKey: "airtable",
-    authUrl: "https://airtable.com/oauth2/v1/authorize",
-    tokenUrl: "https://airtable.com/oauth2/v1/token",
+    provider: "airtable",
+    authorizeUrl: "https://airtable.com/oauth2/v1/authorize",
+    tokenExchangeUrl: "https://airtable.com/oauth2/v1/token",
     pingUrl: "https://api.airtable.com/v0/meta/whoami",
     baseUrl: "https://api.airtable.com/v0",
-    displayName: "Airtable",
+    displayLabel: "Airtable",
     description: "Bases and records",
     dashboardUrl: "https://airtable.com/create/tokens",
     clientIdPlaceholder: null,
@@ -531,12 +531,12 @@ const PROVIDER_SEED_DATA: Record<
   },
 
   hubspot: {
-    providerKey: "hubspot",
-    authUrl: "https://app.hubspot.com/oauth/authorize",
-    tokenUrl: "https://api.hubapi.com/oauth/v1/token",
+    provider: "hubspot",
+    authorizeUrl: "https://app.hubspot.com/oauth/authorize",
+    tokenExchangeUrl: "https://api.hubapi.com/oauth/v1/token",
     pingUrl: "https://api.hubapi.com/crm/v3/objects/contacts?limit=1",
     baseUrl: "https://api.hubapi.com",
-    displayName: "HubSpot",
+    displayLabel: "HubSpot",
     description: "CRM contacts and deals",
     dashboardUrl: "https://developers.hubspot.com/",
     clientIdPlaceholder: null,
@@ -570,12 +570,12 @@ const PROVIDER_SEED_DATA: Record<
   },
 
   figma: {
-    providerKey: "figma",
-    authUrl: "https://www.figma.com/oauth",
-    tokenUrl: "https://api.figma.com/v1/oauth/token",
+    provider: "figma",
+    authorizeUrl: "https://www.figma.com/oauth",
+    tokenExchangeUrl: "https://api.figma.com/v1/oauth/token",
     pingUrl: "https://api.figma.com/v1/me",
     baseUrl: "https://api.figma.com/v1",
-    displayName: "Figma",
+    displayLabel: "Figma",
     description: "Design files and comments",
     dashboardUrl: "https://www.figma.com/developers/apps",
     clientIdPlaceholder: null,
@@ -601,12 +601,14 @@ const PROVIDER_SEED_DATA: Record<
   },
 
   outlook: {
-    providerKey: "outlook",
-    authUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
-    tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+    provider: "outlook",
+    authorizeUrl:
+      "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+    tokenExchangeUrl:
+      "https://login.microsoftonline.com/common/oauth2/v2.0/token",
     pingUrl: "https://graph.microsoft.com/v1.0/me",
     baseUrl: "https://graph.microsoft.com",
-    displayName: "Outlook / Microsoft",
+    displayLabel: "Outlook / Microsoft",
     description: "Email and calendar",
     dashboardUrl:
       "https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade",
@@ -628,7 +630,7 @@ const PROVIDER_SEED_DATA: Record<
       allowedOptionalScopes: ["Contacts.Read", "Files.Read", "Tasks.ReadWrite"],
       forbiddenScopes: [],
     },
-    extraParams: { prompt: "consent" },
+    authorizeParams: { prompt: "consent" },
     tokenEndpointAuthMethod: "client_secret_post",
     loopbackPort: 17334,
     managedServiceConfigKey: "outlook-oauth",
@@ -647,14 +649,14 @@ const PROVIDER_SEED_DATA: Record<
 
   // Manual-token providers: these don't use OAuth2 flows but need provider
   // rows so that oauth_app and oauth_connection FK chains can reference them.
-  // The authUrl/tokenUrl values are placeholders — never used at runtime.
+  // The authorizeUrl/tokenExchangeUrl values are placeholders — never used at runtime.
   slack_channel: {
-    providerKey: "slack_channel",
-    authUrl: "urn:manual-token",
-    tokenUrl: "urn:manual-token",
+    provider: "slack_channel",
+    authorizeUrl: "urn:manual-token",
+    tokenExchangeUrl: "urn:manual-token",
     pingUrl: "https://slack.com/api/auth.test",
     baseUrl: "https://slack.com/api",
-    displayName: "Slack Channel",
+    displayLabel: "Slack Channel",
     description: "Channel bot token",
     dashboardUrl: null,
     clientIdPlaceholder: null,
@@ -668,11 +670,11 @@ const PROVIDER_SEED_DATA: Record<
   },
 
   telegram: {
-    providerKey: "telegram",
-    authUrl: "urn:manual-token",
-    tokenUrl: "urn:manual-token",
+    provider: "telegram",
+    authorizeUrl: "urn:manual-token",
+    tokenExchangeUrl: "urn:manual-token",
     baseUrl: "https://api.telegram.org",
-    displayName: "Telegram",
+    displayLabel: "Telegram",
     description: "Bot messaging",
     dashboardUrl: null,
     clientIdPlaceholder: null,

--- a/assistant/src/oauth/token-persistence.ts
+++ b/assistant/src/oauth/token-persistence.ts
@@ -188,7 +188,7 @@ export async function storeOAuth2Tokens(
   } else {
     const conn = createConnection({
       oauthAppId: app.id,
-      providerKey: service,
+      provider: service,
       accountInfo: resolvedAccountInfo,
       grantedScopes,
       expiresAt: expiresAt ?? undefined,

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -370,7 +370,7 @@ function buildCredentialSecuritySection(): string {
 }
 
 function buildIntegrationSection(): string {
-  let connections: { providerKey: string; accountInfo?: string | null }[];
+  let connections: { provider: string; accountInfo?: string | null }[];
   try {
     connections = listConnections().filter((c) => c.status === "active");
   } catch {
@@ -385,7 +385,7 @@ function buildIntegrationSection(): string {
     const state = conn.accountInfo
       ? `Connected (${conn.accountInfo})`
       : "Connected";
-    lines.push(`- **${conn.providerKey}**: ${state}`);
+    lines.push(`- **${conn.provider}**: ${state}`);
   }
 
   return lines.join("\n");

--- a/assistant/src/runtime/routes/oauth-apps.ts
+++ b/assistant/src/runtime/routes/oauth-apps.ts
@@ -60,8 +60,8 @@ export function oauthAppsRouteDefinitions(): RouteDefinition[] {
       endpoint: "oauth/apps",
       method: "GET",
       handler: ({ url }) => {
-        const providerKey = url.searchParams.get("provider_key");
-        if (!providerKey) {
+        const provider = url.searchParams.get("provider_key");
+        if (!provider) {
           return httpError(
             "BAD_REQUEST",
             "provider_key query parameter is required",
@@ -70,20 +70,18 @@ export function oauthAppsRouteDefinitions(): RouteDefinition[] {
         }
 
         const allApps = listApps();
-        const filtered = allApps.filter(
-          (row) => row.providerKey === providerKey,
-        );
+        const filtered = allApps.filter((row) => row.provider === provider);
 
-        const providerRow = getProvider(providerKey);
-        const provider = providerRow
+        const providerRow = getProvider(provider);
+        const providerSummary = providerRow
           ? serializeProviderSummary(providerRow)
           : null;
 
         return Response.json({
-          provider,
+          provider: providerSummary,
           apps: filtered.map((row) => ({
             id: row.id,
-            provider_key: row.providerKey,
+            provider_key: row.provider,
             client_id: row.clientId,
             created_at: row.createdAt,
             updated_at: row.updatedAt,
@@ -138,7 +136,7 @@ export function oauthAppsRouteDefinitions(): RouteDefinition[] {
           {
             app: {
               id: app.id,
-              provider_key: app.providerKey,
+              provider_key: app.provider,
               client_id: app.clientId,
               created_at: app.createdAt,
               updated_at: app.updatedAt,
@@ -165,9 +163,9 @@ export function oauthAppsRouteDefinitions(): RouteDefinition[] {
         }
 
         // Disconnect all connections for this app first to clean up tokens.
-        const connections = listConnections(app.providerKey, app.clientId);
+        const connections = listConnections(app.provider, app.clientId);
         for (const conn of connections) {
-          await disconnectOAuthProvider(app.providerKey, app.clientId, conn.id);
+          await disconnectOAuthProvider(app.provider, app.clientId, conn.id);
         }
 
         await deleteApp(params.id);
@@ -190,12 +188,12 @@ export function oauthAppsRouteDefinitions(): RouteDefinition[] {
           );
         }
 
-        const connections = listConnections(app.providerKey, app.clientId);
+        const connections = listConnections(app.provider, app.clientId);
 
         return Response.json({
           connections: connections.map((row) => ({
             id: row.id,
-            provider_key: row.providerKey,
+            provider_key: row.provider,
             account_info: row.accountInfo,
             granted_scopes: parseGrantedScopes(row.grantedScopes),
             status: row.status,
@@ -223,7 +221,7 @@ export function oauthAppsRouteDefinitions(): RouteDefinition[] {
         }
 
         const result = await disconnectOAuthProvider(
-          conn.providerKey,
+          conn.provider,
           undefined,
           conn.id,
         );
@@ -282,7 +280,7 @@ export function oauthAppsRouteDefinitions(): RouteDefinition[] {
         const clientSecret = await getAppClientSecret(app);
 
         const result = await orchestrateOAuthConnect({
-          service: app.providerKey,
+          service: app.provider,
           clientId: app.clientId,
           clientSecret,
           requestedScopes: body.scopes,
@@ -292,7 +290,7 @@ export function oauthAppsRouteDefinitions(): RouteDefinition[] {
 
         if (result.success && result.deferred) {
           return Response.json({
-            auth_url: result.authUrl,
+            auth_url: result.authorizeUrl,
             state: result.state,
           });
         }

--- a/assistant/src/runtime/routes/oauth-providers.ts
+++ b/assistant/src/runtime/routes/oauth-providers.ts
@@ -43,16 +43,20 @@ export function oauthProvidersRouteDefinitions(): RouteDefinition[] {
       },
     },
 
-    // GET /v1/oauth/providers/:provider — Get a single provider.
+    // GET /v1/oauth/providers/:providerKey — Get a single provider.
+    // The path parameter name `providerKey` is preserved for backward
+    // compatibility with the published OpenAPI spec (operationId
+    // `oauth_providers_by_providerKey_get`). The actual URL the client hits
+    // (`/v1/oauth/providers/google`) is unchanged either way.
     {
-      endpoint: "oauth/providers/:provider",
+      endpoint: "oauth/providers/:providerKey",
       method: "GET",
       handler: ({ params }) => {
-        const row = getProvider(params.provider);
+        const row = getProvider(params.providerKey);
         if (!row) {
           return httpError(
             "NOT_FOUND",
-            `No OAuth provider registered for "${params.provider}"`,
+            `No OAuth provider registered for "${params.providerKey}"`,
             404,
           );
         }
@@ -60,7 +64,7 @@ export function oauthProvidersRouteDefinitions(): RouteDefinition[] {
         if (!isProviderVisible(row, loadConfig())) {
           return httpError(
             "NOT_FOUND",
-            `No OAuth provider registered for "${params.provider}"`,
+            `No OAuth provider registered for "${params.providerKey}"`,
             404,
           );
         }

--- a/assistant/src/runtime/routes/oauth-providers.ts
+++ b/assistant/src/runtime/routes/oauth-providers.ts
@@ -43,16 +43,16 @@ export function oauthProvidersRouteDefinitions(): RouteDefinition[] {
       },
     },
 
-    // GET /v1/oauth/providers/:providerKey — Get a single provider.
+    // GET /v1/oauth/providers/:provider — Get a single provider.
     {
-      endpoint: "oauth/providers/:providerKey",
+      endpoint: "oauth/providers/:provider",
       method: "GET",
       handler: ({ params }) => {
-        const row = getProvider(params.providerKey);
+        const row = getProvider(params.provider);
         if (!row) {
           return httpError(
             "NOT_FOUND",
-            `No OAuth provider registered for "${params.providerKey}"`,
+            `No OAuth provider registered for "${params.provider}"`,
             404,
           );
         }
@@ -60,7 +60,7 @@ export function oauthProvidersRouteDefinitions(): RouteDefinition[] {
         if (!isProviderVisible(row, loadConfig())) {
           return httpError(
             "NOT_FOUND",
-            `No OAuth provider registered for "${params.providerKey}"`,
+            `No OAuth provider registered for "${params.provider}"`,
             404,
           );
         }

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -240,7 +240,7 @@ async function handleOAuthConnectStart(body: {
   try {
     // For HTTP, we cannot send `open_url` mid-request. The auth URL is
     // returned to the client to open.
-    let authUrl: string | undefined;
+    let authorizeUrl: string | undefined;
 
     const result = await orchestrateOAuthConnect({
       service,
@@ -250,7 +250,7 @@ async function handleOAuthConnectStart(body: {
       callbackTransport: "loopback",
       isInteractive: true,
       openUrl: (url: string) => {
-        authUrl = url;
+        authorizeUrl = url;
       },
       onDeferredComplete: (deferredResult) => {
         // Prefer accountInfo from oauth-store when available.
@@ -309,7 +309,7 @@ async function handleOAuthConnectStart(body: {
       return Response.json({
         ok: true,
         deferred: true,
-        authUrl: result.authUrl,
+        authorizeUrl: result.authorizeUrl,
       });
     }
 
@@ -326,7 +326,7 @@ async function handleOAuthConnectStart(body: {
       ok: true,
       grantedScopes: result.grantedScopes,
       accountInfo: responseAccountInfo,
-      ...(authUrl ? { authUrl } : {}),
+      ...(authorizeUrl ? { authorizeUrl } : {}),
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -309,7 +309,9 @@ async function handleOAuthConnectStart(body: {
       return Response.json({
         ok: true,
         deferred: true,
-        authorizeUrl: result.authorizeUrl,
+        // Wire key stays `authUrl` for backward compatibility with existing
+        // clients; the internal field on `result` is `authorizeUrl`.
+        authUrl: result.authorizeUrl,
       });
     }
 
@@ -326,7 +328,9 @@ async function handleOAuthConnectStart(body: {
       ok: true,
       grantedScopes: result.grantedScopes,
       accountInfo: responseAccountInfo,
-      ...(authorizeUrl ? { authorizeUrl } : {}),
+      // Wire key stays `authUrl` for backward compatibility with existing
+      // clients; the local variable was renamed to `authorizeUrl`.
+      ...(authorizeUrl ? { authUrl: authorizeUrl } : {}),
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -33,13 +33,13 @@ export type TokenEndpointAuthMethod =
   | "client_secret_post";
 
 export interface OAuth2Config {
-  authUrl: string;
-  tokenUrl: string;
+  authorizeUrl: string;
+  tokenExchangeUrl: string;
   scopes: string[];
   clientId: string;
   /** Client secret for providers that require it (e.g. Slack). PKCE is always used regardless. */
   clientSecret?: string;
-  extraParams?: Record<string, string>;
+  authorizeParams?: Record<string, string>;
   /** URL to fetch user identity info after OAuth. If omitted, account info is not fetched. */
   userinfoUrl?: string;
   /**
@@ -130,7 +130,7 @@ async function exchangeCodeForTokens(
     }
   }
 
-  const tokenResp = await fetch(config.tokenUrl, {
+  const tokenResp = await fetch(config.tokenExchangeUrl, {
     method: "POST",
     headers,
     body: new URLSearchParams(tokenBody),
@@ -228,7 +228,7 @@ async function runGatewayFlow(
   });
 
   const authParams = new URLSearchParams({
-    ...config.extraParams,
+    ...config.authorizeParams,
     client_id: config.clientId,
     redirect_uri: redirectUri,
     response_type: "code",
@@ -238,8 +238,8 @@ async function runGatewayFlow(
     code_challenge_method: "S256",
   });
 
-  const authUrl = `${config.authUrl}?${authParams}`;
-  callbacks.openUrl(authUrl);
+  const authorizeUrl = `${config.authorizeUrl}?${authParams}`;
+  callbacks.openUrl(authorizeUrl);
 
   const code = await codePromise;
 
@@ -401,7 +401,7 @@ function startLoopbackServerAndWaitForCode(
       );
 
       const authParams = new URLSearchParams({
-        ...config.extraParams,
+        ...config.authorizeParams,
         client_id: config.clientId,
         redirect_uri: boundRedirectUri,
         response_type: "code",
@@ -411,12 +411,12 @@ function startLoopbackServerAndWaitForCode(
         code_challenge_method: "S256",
       });
 
-      const authUrl = `${config.authUrl}?${authParams}`;
+      const authorizeUrl = `${config.authorizeUrl}?${authParams}`;
       log.info(
-        { authUrlLength: authUrl.length, state },
+        { authorizeUrlLength: authorizeUrl.length, state },
         "oauth2 loopback: built auth URL, calling openUrl callback",
       );
-      callbacks.openUrl(authUrl);
+      callbacks.openUrl(authorizeUrl);
       log.info("oauth2 loopback: openUrl callback returned");
     });
 
@@ -439,7 +439,7 @@ function startLoopbackServerAndWaitForCode(
 // ---------------------------------------------------------------------------
 
 export interface OAuth2PreparedFlow {
-  authUrl: string;
+  authorizeUrl: string;
   state: string;
   /** Resolves when the user completes authorization and tokens are exchanged. */
   completion: Promise<OAuth2FlowResult>;
@@ -493,7 +493,7 @@ export async function prepareOAuth2Flow(
   });
 
   const authParams = new URLSearchParams({
-    ...config.extraParams,
+    ...config.authorizeParams,
     client_id: config.clientId,
     redirect_uri: redirectUri,
     response_type: "code",
@@ -503,7 +503,7 @@ export async function prepareOAuth2Flow(
     code_challenge_method: "S256",
   });
 
-  const authUrl = `${config.authUrl}?${authParams}`;
+  const authorizeUrl = `${config.authorizeUrl}?${authParams}`;
 
   const completion = codePromise.then(async (code) => {
     return await exchangeCodeForTokens(config, code, redirectUri, codeVerifier);
@@ -511,7 +511,7 @@ export async function prepareOAuth2Flow(
 
   log.debug({ transport: "gateway", state }, "Prepared deferred OAuth2 flow");
 
-  return { authUrl, state, completion };
+  return { authorizeUrl, state, completion };
 }
 
 /**
@@ -533,7 +533,7 @@ async function prepareLoopbackFlow(
   );
 
   const authParams = new URLSearchParams({
-    ...config.extraParams,
+    ...config.authorizeParams,
     client_id: config.clientId,
     redirect_uri: redirectUri,
     response_type: "code",
@@ -543,7 +543,7 @@ async function prepareLoopbackFlow(
     code_challenge_method: "S256",
   });
 
-  const authUrl = `${config.authUrl}?${authParams}`;
+  const authorizeUrl = `${config.authorizeUrl}?${authParams}`;
 
   const completion = codePromise.then(async (code) => {
     return await exchangeCodeForTokens(config, code, redirectUri, codeVerifier);
@@ -554,7 +554,7 @@ async function prepareLoopbackFlow(
     "Prepared deferred OAuth2 flow (loopback)",
   );
 
-  return { authUrl, state, completion };
+  return { authorizeUrl, state, completion };
 }
 
 /**
@@ -763,7 +763,7 @@ export async function startOAuth2Flow(
  * Supports both PKCE (no secret) and client_secret flows.
  */
 export async function refreshOAuth2Token(
-  tokenUrl: string,
+  tokenExchangeUrl: string,
   clientId: string,
   refreshToken: string,
   clientSecret?: string,
@@ -792,7 +792,7 @@ export async function refreshOAuth2Token(
     }
   }
 
-  const resp = await fetch(tokenUrl, {
+  const resp = await fetch(tokenExchangeUrl, {
     method: "POST",
     headers,
     body: new URLSearchParams(body),

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -1,7 +1,7 @@
 /**
  * Token manager for OAuth2 credentials.
  *
- * Reads refresh configuration (tokenUrl, clientId, authMethod) exclusively
+ * Reads refresh configuration (tokenExchangeUrl, clientId, authMethod) exclusively
  * from the SQLite oauth-store (provider + app + connection rows). After a
  * successful refresh, writes tokens to new-format secure key paths and
  * updates the oauth_connection row.
@@ -90,7 +90,7 @@ const secureKeyBackend: SecureKeyBackend = {
 
 /** Shared shape for resolved refresh configuration. */
 interface RefreshConfig {
-  tokenUrl: string;
+  tokenExchangeUrl: string;
   clientId: string;
   /** OAuth client secret (optional — PKCE flows may omit it). */
   secret?: string;
@@ -102,7 +102,7 @@ interface RefreshConfig {
 /**
  * Resolve refresh configuration from the SQLite oauth-store.
  *
- * Looks up connection -> app -> provider to read tokenUrl, clientId, and
+ * Looks up connection -> app -> provider to read tokenExchangeUrl, clientId, and
  * authMethod. Throws `TokenExpiredError` if the connection is not found
  * or incomplete.
  */
@@ -126,7 +126,7 @@ async function resolveRefreshConfig(
     );
   }
 
-  const provider = getProvider(conn.providerKey);
+  const provider = getProvider(conn.provider);
   if (!provider) {
     throw new TokenExpiredError(
       service,
@@ -134,9 +134,9 @@ async function resolveRefreshConfig(
     );
   }
 
-  const tokenUrl = provider.tokenUrl;
+  const tokenExchangeUrl = provider.tokenExchangeUrl;
   const resolvedClientId = app.clientId;
-  if (!tokenUrl || !resolvedClientId) {
+  if (!tokenExchangeUrl || !resolvedClientId) {
     throw new TokenExpiredError(
       service,
       `Missing OAuth2 refresh config for "${service}".${recoveryHint(service)}`,
@@ -155,7 +155,7 @@ async function resolveRefreshConfig(
 
   return {
     connId: conn.id,
-    tokenUrl,
+    tokenExchangeUrl,
     clientId: resolvedClientId,
     secret,
     refreshToken,
@@ -175,7 +175,7 @@ async function resolveRefreshConfig(
 async function doRefresh(service: string, connId: string): Promise<string> {
   const refreshConfig = await resolveRefreshConfig(service, connId);
   const {
-    tokenUrl,
+    tokenExchangeUrl,
     clientId: resolvedClientId,
     secret,
     authMethod,
@@ -204,7 +204,7 @@ async function doRefresh(service: string, connId: string): Promise<string> {
   let result;
   try {
     result = await refreshOAuth2Token(
-      tokenUrl,
+      tokenExchangeUrl,
       resolvedClientId,
       refreshToken,
       secret,


### PR DESCRIPTION
## Summary
- Rename `providerKey`→`provider`, `displayName`→`displayLabel`, `authUrl`→`authorizeUrl`, `tokenUrl`→`tokenExchangeUrl`, `extraParams`→`authorizeParams` across the OAuth provider TS layer to match `vellum-assistant-platform`'s field naming.
- Pure compile-time refactor: SQL column names, HTTP API JSON keys, CLI flag names, and error message strings all unchanged. No new Drizzle migration.
- Drizzle schema rebinds TS field names to the same `text("...")` columns; storage and serialization layers updated accordingly.

Part of plan: oauth-field-renames.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
