### PR TITLE
feat(settings): flag-gated per-assistant settings scoping with one-time migration

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -91,10 +91,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     let computerUseClient: any ComputerUseClientProtocol = ComputerUseClient()
     let appsClient: any AppsClientProtocol = AppsClient()
     let toolConfirmationNotificationService = ToolConfirmationNotificationService()
-    /// Shared feature flag store — caches resolved flags in memory so that
-    /// hot paths (e.g. `SoundManager.play()`) avoid synchronous file I/O on
-    /// the main thread.
-    let featureFlagStore = AssistantFeatureFlagStore()
+    /// Shared feature flag store — owned by `AppServices` so `SettingsStore`
+    /// can depend on the same instance; forwarded here for backwards
+    /// compatibility with existing call sites.
+    var featureFlagStore: AssistantFeatureFlagStore { services.featureFlagStore }
 
     lazy var recordingManager: RecordingManager = RecordingManager(connectionManager: connectionManager)
     var recordingPickerWindow: RecordingSourcePickerWindow?

--- a/clients/macos/vellum-assistant/App/AppServices.swift
+++ b/clients/macos/vellum-assistant/App/AppServices.swift
@@ -12,10 +12,16 @@ public final class AppServices {
     let secretPromptManager = SecretPromptManager()
     let zoomManager = ZoomManager()
 
+    /// Shared feature flag store — caches resolved flags in memory so that
+    /// hot paths (e.g. `SoundManager.play()`) avoid synchronous file I/O on
+    /// the main thread.
+    let featureFlagStore = AssistantFeatureFlagStore()
+
     /// Shared settings state consumed by SettingsPanel and its tab views.
     public lazy var settingsStore: SettingsStore = SettingsStore(
         connectionManager: connectionManager,
-        eventStreamClient: connectionManager.eventStreamClient
+        eventStreamClient: connectionManager.eventStreamClient,
+        featureFlagStore: featureFlagStore
     )
 
     /// Reconfigure the connection for a new assistant.

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -317,6 +317,81 @@ public final class SettingsStore: ObservableObject {
     private let pairingClient: PairingClientProtocol
     private var cancellables = Set<AnyCancellable>()
     private let configPath: String?
+    private let featureFlagStore: AssistantFeatureFlagStore?
+
+    /// Factory for a scoped defaults accessor bound to a specific assistant id.
+    /// See ``ScopedDefaults`` for the key-prefixing contract.
+    static func scoped(for assistantId: String) -> ScopedDefaults {
+        ScopedDefaults(assistantId: assistantId)
+    }
+
+    private func isMultiPlatformAssistantEnabled() -> Bool {
+        featureFlagStore?.isEnabled(SettingsStoreScopedMigration.featureFlagKey) ?? false
+    }
+
+    /// Read a per-assistant key. Returns the scoped value when the flag is on
+    /// and a cached assistant id is available; otherwise falls back to the
+    /// legacy unscoped key on `UserDefaults.standard`.
+    private func readPerAssistantObject(_ key: String) -> Any? {
+        if isMultiPlatformAssistantEnabled(), let id = cachedAssistantId {
+            return Self.scoped(for: id).object(forKey: key)
+        }
+        return UserDefaults.standard.object(forKey: key)
+    }
+
+    private func readPerAssistantString(_ key: String) -> String? {
+        if isMultiPlatformAssistantEnabled(), let id = cachedAssistantId {
+            return Self.scoped(for: id).string(forKey: key)
+        }
+        return UserDefaults.standard.string(forKey: key)
+    }
+
+    /// Write a per-assistant key. Writes to scoped storage when the flag is on
+    /// and a cached assistant id is available; otherwise writes to the legacy
+    /// unscoped key. Legacy keys are never touched by the on-path, so flag-off
+    /// behavior is byte-for-byte unchanged.
+    /// Re-reads per-assistant @Published properties from their (possibly
+    /// scoped) backing store. Called on `activeAssistantDidChange` after the
+    /// cached assistant id is updated and the migration helper has copied
+    /// legacy values into the new scope. Assigning to `@Published` properties
+    /// automatically triggers `objectWillChange` so SwiftUI rebinds to the
+    /// freshly-scoped values.
+    private func reloadPerAssistantPublishedValues() {
+        if let stored = readPerAssistantString("selectedImageGenModel"),
+           Self.availableImageGenModels.contains(stored) {
+            selectedImageGenModel = stored
+        }
+        cmdEnterToSend = readPerAssistantObject("cmdEnterToSend") as? Bool ?? false
+
+        globalHotkeyShortcut = readPerAssistantObject("globalHotkeyShortcut") == nil
+            ? "cmd+shift+g"
+            : (readPerAssistantString("globalHotkeyShortcut") ?? "")
+        quickInputHotkeyShortcut = readPerAssistantObject("quickInputHotkeyShortcut") == nil
+            ? "cmd+shift+/"
+            : (readPerAssistantString("quickInputHotkeyShortcut") ?? "")
+        quickInputHotkeyKeyCode =
+            (readPerAssistantObject("quickInputHotkeyKeyCode") as? Int) ?? kVK_ANSI_Slash
+        sidebarToggleShortcut = readPerAssistantObject("sidebarToggleShortcut") == nil
+            ? "cmd+\\"
+            : (readPerAssistantString("sidebarToggleShortcut") ?? "")
+        newChatShortcut = readPerAssistantObject("newChatShortcut") == nil
+            ? "cmd+n"
+            : (readPerAssistantString("newChatShortcut") ?? "")
+        currentConversationShortcut = readPerAssistantObject("currentConversationShortcut") == nil
+            ? "cmd+shift+n"
+            : (readPerAssistantString("currentConversationShortcut") ?? "")
+        popOutShortcut = readPerAssistantObject("popOutShortcut") == nil
+            ? "cmd+p"
+            : (readPerAssistantString("popOutShortcut") ?? "")
+    }
+
+    private func writePerAssistant(_ value: Any?, forKey key: String) {
+        if isMultiPlatformAssistantEnabled(), let id = cachedAssistantId {
+            Self.scoped(for: id).set(value, forKey: key)
+            return
+        }
+        UserDefaults.standard.set(value, forKey: key)
+    }
 
     /// In-memory cache of the active assistant ID to avoid repeated
     /// lockfile I/O on every access. Seeded once in `init` and
@@ -377,6 +452,7 @@ public final class SettingsStore: ObservableObject {
         integrationClient: IntegrationClientProtocol = IntegrationClient(),
         settingsClient: SettingsClientProtocol = SettingsClient(),
         pairingClient: PairingClientProtocol = PairingClient(),
+        featureFlagStore: AssistantFeatureFlagStore? = nil,
         configPath: String? = nil,
         verificationSessionTimeoutDuration: TimeInterval = 12,
         verificationStatusPollInterval: TimeInterval = 2,
@@ -388,6 +464,7 @@ public final class SettingsStore: ObservableObject {
         self.integrationClient = integrationClient
         self.settingsClient = settingsClient
         self.pairingClient = pairingClient
+        self.featureFlagStore = featureFlagStore
         self.configPath = configPath
         self.verificationSessionTimeoutDuration = max(0.05, verificationSessionTimeoutDuration)
         self.verificationStatusPollInterval = max(0.05, verificationStatusPollInterval)
@@ -406,44 +483,73 @@ public final class SettingsStore: ObservableObject {
         // user's selection survives restarts even if the daemon is unreachable.
         // loadServiceModes() will override with the daemon's authoritative
         // value once it connects.
-        let storedImageGenModel = UserDefaults.standard.string(forKey: "selectedImageGenModel")
+        // Run the one-time per-assistant settings migration before reading
+        // per-assistant values so scoped storage is populated on first read.
+        // No-op when the feature flag is off or the sentinel is already set.
+        if let featureFlagStore, let activeAssistantId = self.cachedAssistantId {
+            SettingsStoreScopedMigration.migratePerAssistantKeysIfNeeded(
+                activeAssistantId: activeAssistantId,
+                featureFlagStore: featureFlagStore
+            )
+        }
+
+        // Local read helpers that branch on the multi-platform assistant flag.
+        // Flag off ⇒ legacy unscoped key. Flag on + known assistant id ⇒
+        // scoped key. Flag on + nil assistant id ⇒ fall back to legacy.
+        let isMPAEnabled = featureFlagStore?
+            .isEnabled(SettingsStoreScopedMigration.featureFlagKey) ?? false
+        let activeAssistantIdForInit = self.cachedAssistantId
+        func readObject(_ key: String) -> Any? {
+            if isMPAEnabled, let id = activeAssistantIdForInit {
+                return ScopedDefaults(assistantId: id).object(forKey: key)
+            }
+            return UserDefaults.standard.object(forKey: key)
+        }
+        func readString(_ key: String) -> String? {
+            if isMPAEnabled, let id = activeAssistantIdForInit {
+                return ScopedDefaults(assistantId: id).string(forKey: key)
+            }
+            return UserDefaults.standard.string(forKey: key)
+        }
+
+        let storedImageGenModel = readString("selectedImageGenModel")
         if let storedImageGenModel, Self.availableImageGenModels.contains(storedImageGenModel) {
             self.selectedImageGenModel = storedImageGenModel
         }
 
-        self.cmdEnterToSend = UserDefaults.standard.object(forKey: "cmdEnterToSend") as? Bool ?? false
+        self.cmdEnterToSend = readObject("cmdEnterToSend") as? Bool ?? false
 
-        if UserDefaults.standard.object(forKey: "globalHotkeyShortcut") == nil {
+        if readObject("globalHotkeyShortcut") == nil {
             self.globalHotkeyShortcut = "cmd+shift+g"
         } else {
-            self.globalHotkeyShortcut = UserDefaults.standard.string(forKey: "globalHotkeyShortcut") ?? ""
+            self.globalHotkeyShortcut = readString("globalHotkeyShortcut") ?? ""
         }
-        if UserDefaults.standard.object(forKey: "quickInputHotkeyShortcut") == nil {
+        if readObject("quickInputHotkeyShortcut") == nil {
             self.quickInputHotkeyShortcut = "cmd+shift+/"
         } else {
-            self.quickInputHotkeyShortcut = UserDefaults.standard.string(forKey: "quickInputHotkeyShortcut") ?? ""
+            self.quickInputHotkeyShortcut = readString("quickInputHotkeyShortcut") ?? ""
         }
-        let storedQIKeyCode = UserDefaults.standard.object(forKey: "quickInputHotkeyKeyCode") as? Int
+        let storedQIKeyCode = readObject("quickInputHotkeyKeyCode") as? Int
         self.quickInputHotkeyKeyCode = storedQIKeyCode ?? kVK_ANSI_Slash
-        if UserDefaults.standard.object(forKey: "sidebarToggleShortcut") == nil {
+        if readObject("sidebarToggleShortcut") == nil {
             self.sidebarToggleShortcut = "cmd+\\"
         } else {
-            self.sidebarToggleShortcut = UserDefaults.standard.string(forKey: "sidebarToggleShortcut") ?? ""
+            self.sidebarToggleShortcut = readString("sidebarToggleShortcut") ?? ""
         }
-        if UserDefaults.standard.object(forKey: "newChatShortcut") == nil {
+        if readObject("newChatShortcut") == nil {
             self.newChatShortcut = "cmd+n"
         } else {
-            self.newChatShortcut = UserDefaults.standard.string(forKey: "newChatShortcut") ?? ""
+            self.newChatShortcut = readString("newChatShortcut") ?? ""
         }
-        if UserDefaults.standard.object(forKey: "currentConversationShortcut") == nil {
+        if readObject("currentConversationShortcut") == nil {
             self.currentConversationShortcut = "cmd+shift+n"
         } else {
-            self.currentConversationShortcut = UserDefaults.standard.string(forKey: "currentConversationShortcut") ?? ""
+            self.currentConversationShortcut = readString("currentConversationShortcut") ?? ""
         }
-        if UserDefaults.standard.object(forKey: "popOutShortcut") == nil {
+        if readObject("popOutShortcut") == nil {
             self.popOutShortcut = "cmd+p"
         } else {
-            self.popOutShortcut = UserDefaults.standard.string(forKey: "popOutShortcut") ?? ""
+            self.popOutShortcut = readString("popOutShortcut") ?? ""
         }
 
         // Use defaults for config-dependent properties; the daemon will
@@ -480,7 +586,7 @@ public final class SettingsStore: ObservableObject {
         $cmdEnterToSend
             .dropFirst()
             .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
-            .sink { value in UserDefaults.standard.set(value, forKey: "cmdEnterToSend") }
+            .sink { [weak self] value in self?.writePerAssistant(value, forKey: "cmdEnterToSend") }
             .store(in: &cancellables)
 
         $sendDiagnostics
@@ -505,37 +611,37 @@ public final class SettingsStore: ObservableObject {
         // Persist shortcut changes immediately so the hotkey re-registers without delay
         $globalHotkeyShortcut
             .dropFirst()
-            .sink { value in UserDefaults.standard.set(value, forKey: "globalHotkeyShortcut") }
+            .sink { [weak self] value in self?.writePerAssistant(value, forKey: "globalHotkeyShortcut") }
             .store(in: &cancellables)
 
         $quickInputHotkeyShortcut
             .dropFirst()
-            .sink { value in UserDefaults.standard.set(value, forKey: "quickInputHotkeyShortcut") }
+            .sink { [weak self] value in self?.writePerAssistant(value, forKey: "quickInputHotkeyShortcut") }
             .store(in: &cancellables)
 
         $quickInputHotkeyKeyCode
             .dropFirst()
-            .sink { value in UserDefaults.standard.set(value, forKey: "quickInputHotkeyKeyCode") }
+            .sink { [weak self] value in self?.writePerAssistant(value, forKey: "quickInputHotkeyKeyCode") }
             .store(in: &cancellables)
 
         $sidebarToggleShortcut
             .dropFirst()
-            .sink { value in UserDefaults.standard.set(value, forKey: "sidebarToggleShortcut") }
+            .sink { [weak self] value in self?.writePerAssistant(value, forKey: "sidebarToggleShortcut") }
             .store(in: &cancellables)
 
         $newChatShortcut
             .dropFirst()
-            .sink { value in UserDefaults.standard.set(value, forKey: "newChatShortcut") }
+            .sink { [weak self] value in self?.writePerAssistant(value, forKey: "newChatShortcut") }
             .store(in: &cancellables)
 
         $currentConversationShortcut
             .dropFirst()
-            .sink { value in UserDefaults.standard.set(value, forKey: "currentConversationShortcut") }
+            .sink { [weak self] value in self?.writePerAssistant(value, forKey: "currentConversationShortcut") }
             .store(in: &cancellables)
 
         $popOutShortcut
             .dropFirst()
-            .sink { value in UserDefaults.standard.set(value, forKey: "popOutShortcut") }
+            .sink { [weak self] value in self?.writePerAssistant(value, forKey: "popOutShortcut") }
             .store(in: &cancellables)
 
         // Re-resolve lockfile-derived state whenever the connected assistant changes
@@ -543,8 +649,21 @@ public final class SettingsStore: ObservableObject {
         NotificationCenter.default.publisher(for: LockfileAssistant.activeAssistantDidChange)
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
-                self?.cachedAssistantId = LockfileAssistant.loadActiveAssistantId()
-                self?.refreshLockfileState()
+                guard let self else { return }
+                self.cachedAssistantId = LockfileAssistant.loadActiveAssistantId()
+                // Run the one-time per-assistant migration for the newly
+                // active assistant (no-op when flag off or sentinel already set),
+                // then rebind per-assistant @Published values from scoped storage
+                // so SwiftUI views pick up the new assistant's settings.
+                if let featureFlagStore = self.featureFlagStore,
+                   let activeId = self.cachedAssistantId {
+                    SettingsStoreScopedMigration.migratePerAssistantKeysIfNeeded(
+                        activeAssistantId: activeId,
+                        featureFlagStore: featureFlagStore
+                    )
+                }
+                self.reloadPerAssistantPublishedValues()
+                self.refreshLockfileState()
                 Task { await IdentityInfo.refreshCache() }
             }
             .store(in: &cancellables)
@@ -899,7 +1018,7 @@ public final class SettingsStore: ObservableObject {
 
     func setImageGenModel(_ model: String) {
         selectedImageGenModel = model
-        UserDefaults.standard.set(model, forKey: "selectedImageGenModel")
+        writePerAssistant(model, forKey: "selectedImageGenModel")
         Task {
             _ = await settingsClient.setImageGenModel(modelId: model)
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStoreScopedKeys.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStoreScopedKeys.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Thin wrapper over `UserDefaults.standard` that namespaces every key under
+/// a per-assistant prefix (`"<assistantId>.<key>"`). Stateless — owns no
+/// identity of its own; the caller supplies the assistant id at construction.
+///
+/// The lockfile (`LockfileAssistant`) remains the source of truth for
+/// assistant identity; `UserDefaults` remains the backing store for settings,
+/// namespaced here so two assistants on the same host can carry independent
+/// values for the same logical key.
+@MainActor
+struct ScopedDefaults {
+    let assistantId: String
+    private let defaults: UserDefaults
+
+    init(assistantId: String, defaults: UserDefaults = .standard) {
+        self.assistantId = assistantId
+        self.defaults = defaults
+    }
+
+    private func scopedKey(_ key: String) -> String {
+        "\(assistantId).\(key)"
+    }
+
+    func string(forKey key: String) -> String? {
+        defaults.string(forKey: scopedKey(key))
+    }
+
+    func bool(forKey key: String) -> Bool {
+        defaults.bool(forKey: scopedKey(key))
+    }
+
+    func integer(forKey key: String) -> Int {
+        defaults.integer(forKey: scopedKey(key))
+    }
+
+    func object(forKey key: String) -> Any? {
+        defaults.object(forKey: scopedKey(key))
+    }
+
+    func set(_ value: Any?, forKey key: String) {
+        defaults.set(value, forKey: scopedKey(key))
+    }
+}
+

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStoreScopedMigration.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStoreScopedMigration.swift
@@ -1,0 +1,82 @@
+import Foundation
+import os
+import VellumAssistantShared
+
+private let migrationLog = Logger(
+    subsystem: Bundle.appBundleIdentifier,
+    category: "SettingsStoreScopedMigration"
+)
+
+enum SettingsStoreScopedMigration {
+    /// Canonical list of UserDefaults keys that are per-assistant and should
+    /// be copied into scoped storage the first time the multi-platform
+    /// assistant flag flips on for a given assistant id.
+    ///
+    /// The migration helper iterates this list directly — there is no
+    /// separate documentation block; this array is the spec.
+    ///
+    /// Install-global keys (e.g. `sendDiagnostics`, `collectUsageData`)
+    /// are intentionally absent.
+    static let perAssistantKeys: [String] = [
+        "selectedImageGenModel",
+        "cmdEnterToSend",
+        "globalHotkeyShortcut",
+        "quickInputHotkeyShortcut",
+        "quickInputHotkeyKeyCode",
+        "sidebarToggleShortcut",
+        "newChatShortcut",
+        "currentConversationShortcut",
+        "popOutShortcut",
+    ]
+
+    /// Name of the feature flag that gates the entire multi-platform assistant
+    /// migration. When false, settings reads and writes continue to use the
+    /// legacy unscoped keys — byte-for-byte today's behavior.
+    static let featureFlagKey = "multi-platform-assistant"
+
+    /// Suffix for the idempotency sentinel stored alongside the scoped keys.
+    /// A value of `true` means this assistant's legacy keys have already been
+    /// copied into scope once.
+    static let sentinelSuffix = "__settings_migrated_v1"
+
+    /// One-time, idempotent, flag-gated copy of legacy per-assistant settings
+    /// into `"<assistantId>.<key>"` scoped storage. Mirrors the guard / copy /
+    /// sentinel pattern in
+    /// `AppDelegate+ConnectionSetup.migrateConnectedAssistantIdToLockfile()`.
+    ///
+    /// - Returns: `true` if a copy pass ran for this call, `false` if it was
+    ///   skipped (flag off or sentinel already set). Exposed primarily for
+    ///   tests.
+    @MainActor
+    @discardableResult
+    static func migratePerAssistantKeysIfNeeded(
+        activeAssistantId: String,
+        featureFlagStore: AssistantFeatureFlagStore,
+        defaults: UserDefaults = .standard
+    ) -> Bool {
+        guard featureFlagStore.isEnabled(featureFlagKey) else {
+            return false
+        }
+
+        let sentinelKey = "\(activeAssistantId).\(sentinelSuffix)"
+        if defaults.bool(forKey: sentinelKey) {
+            return false
+        }
+
+        let scoped = ScopedDefaults(assistantId: activeAssistantId, defaults: defaults)
+        var copiedCount = 0
+        for key in perAssistantKeys {
+            guard let legacyValue = defaults.object(forKey: key) else { continue }
+            // Never delete the legacy key — cleanup lives in a separate
+            // post-bake PR once this migration has baked across all installs.
+            scoped.set(legacyValue, forKey: key)
+            copiedCount += 1
+        }
+
+        defaults.set(true, forKey: sentinelKey)
+        migrationLog.info(
+            "Migrated per-assistant settings into scope '\(activeAssistantId, privacy: .public)' (\(copiedCount, privacy: .public) keys)"
+        )
+        return true
+    }
+}

--- a/clients/macos/vellum-assistantTests/SettingsStoreScopingTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreScopingTests.swift
@@ -1,0 +1,247 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+final class SettingsStoreScopingTests: XCTestCase {
+    private let flagKey = "multi-platform-assistant"
+
+    // Every per-assistant key this PR scopes.
+    private let perAssistantKeys: [String] = [
+        "selectedImageGenModel",
+        "cmdEnterToSend",
+        "globalHotkeyShortcut",
+        "quickInputHotkeyShortcut",
+        "quickInputHotkeyKeyCode",
+        "sidebarToggleShortcut",
+        "newChatShortcut",
+        "currentConversationShortcut",
+        "popOutShortcut",
+    ]
+
+    private let assistantAId = "scoping-test-assistant-A"
+    private let assistantBId = "scoping-test-assistant-B"
+
+    override func setUp() {
+        super.setUp()
+        clearAll()
+    }
+
+    override func tearDown() {
+        clearAll()
+        super.tearDown()
+    }
+
+    private func clearAll() {
+        let defaults = UserDefaults.standard
+        for key in perAssistantKeys {
+            defaults.removeObject(forKey: key)
+            defaults.removeObject(forKey: "\(assistantAId).\(key)")
+            defaults.removeObject(forKey: "\(assistantBId).\(key)")
+        }
+        defaults.removeObject(forKey: "\(assistantAId).__settings_migrated_v1")
+        defaults.removeObject(forKey: "\(assistantBId).__settings_migrated_v1")
+        defaults.removeObject(forKey: "sendDiagnostics")
+        defaults.removeObject(forKey: "collectUsageData")
+        AssistantFeatureFlagResolver.clearCachedFlags()
+    }
+
+    private func makeFlagStore(enabled: Bool) -> AssistantFeatureFlagStore {
+        AssistantFeatureFlagResolver.mergeCachedFlag(key: flagKey, enabled: enabled)
+        return AssistantFeatureFlagStore()
+    }
+
+    // MARK: - ScopedDefaults wrapper
+
+    func testScopedDefaultsKeyPrefixing() {
+        let scoped = ScopedDefaults(assistantId: assistantAId)
+        scoped.set("hello", forKey: "myKey")
+
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "\(assistantAId).myKey"),
+            "hello",
+            "ScopedDefaults should write with '<assistantId>.<key>' prefix"
+        )
+        XCTAssertEqual(scoped.string(forKey: "myKey"), "hello")
+        XCTAssertNil(
+            UserDefaults.standard.object(forKey: "myKey"),
+            "Legacy unscoped key must be left untouched"
+        )
+
+        // Cleanup
+        UserDefaults.standard.removeObject(forKey: "\(assistantAId).myKey")
+    }
+
+    func testScopedDefaultsTwoAssistantsDoNotCollide() {
+        let a = ScopedDefaults(assistantId: assistantAId)
+        let b = ScopedDefaults(assistantId: assistantBId)
+
+        a.set("alpha", forKey: "shared")
+        b.set("beta", forKey: "shared")
+
+        XCTAssertEqual(a.string(forKey: "shared"), "alpha")
+        XCTAssertEqual(b.string(forKey: "shared"), "beta")
+
+        UserDefaults.standard.removeObject(forKey: "\(assistantAId).shared")
+        UserDefaults.standard.removeObject(forKey: "\(assistantBId).shared")
+    }
+
+    // MARK: - Migration helper
+
+    func testMigrationNoOpWhenFlagOff() {
+        UserDefaults.standard.set("cmd+shift+g", forKey: "globalHotkeyShortcut")
+        let store = makeFlagStore(enabled: false)
+
+        let ran = SettingsStoreScopedMigration.migratePerAssistantKeysIfNeeded(
+            activeAssistantId: assistantAId,
+            featureFlagStore: store
+        )
+        XCTAssertFalse(ran)
+        XCTAssertNil(UserDefaults.standard.object(forKey: "\(assistantAId).globalHotkeyShortcut"))
+        XCTAssertFalse(UserDefaults.standard.bool(forKey: "\(assistantAId).__settings_migrated_v1"))
+    }
+
+    func testMigrationCopiesLegacyKeysAndLeavesLegacyIntact() {
+        UserDefaults.standard.set("cmd+shift+g", forKey: "globalHotkeyShortcut")
+        UserDefaults.standard.set(true, forKey: "cmdEnterToSend")
+        UserDefaults.standard.set(42, forKey: "quickInputHotkeyKeyCode")
+        let store = makeFlagStore(enabled: true)
+
+        let ran = SettingsStoreScopedMigration.migratePerAssistantKeysIfNeeded(
+            activeAssistantId: assistantAId,
+            featureFlagStore: store
+        )
+        XCTAssertTrue(ran)
+
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "\(assistantAId).globalHotkeyShortcut"),
+            "cmd+shift+g"
+        )
+        XCTAssertEqual(
+            UserDefaults.standard.object(forKey: "\(assistantAId).cmdEnterToSend") as? Bool,
+            true
+        )
+        XCTAssertEqual(
+            UserDefaults.standard.object(forKey: "\(assistantAId).quickInputHotkeyKeyCode") as? Int,
+            42
+        )
+
+        // Legacy keys preserved.
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "globalHotkeyShortcut"), "cmd+shift+g")
+        XCTAssertEqual(UserDefaults.standard.object(forKey: "cmdEnterToSend") as? Bool, true)
+        XCTAssertEqual(UserDefaults.standard.object(forKey: "quickInputHotkeyKeyCode") as? Int, 42)
+
+        // Sentinel set.
+        XCTAssertTrue(UserDefaults.standard.bool(forKey: "\(assistantAId).__settings_migrated_v1"))
+    }
+
+    func testMigrationIsIdempotent() {
+        UserDefaults.standard.set("cmd+shift+g", forKey: "globalHotkeyShortcut")
+        let store = makeFlagStore(enabled: true)
+
+        XCTAssertTrue(SettingsStoreScopedMigration.migratePerAssistantKeysIfNeeded(
+            activeAssistantId: assistantAId,
+            featureFlagStore: store
+        ))
+        // Second run: sentinel blocks re-copy.
+        XCTAssertFalse(SettingsStoreScopedMigration.migratePerAssistantKeysIfNeeded(
+            activeAssistantId: assistantAId,
+            featureFlagStore: store
+        ))
+
+        // Mutating legacy after the fact must not leak into scope.
+        UserDefaults.standard.set("cmd+shift+h", forKey: "globalHotkeyShortcut")
+        XCTAssertFalse(SettingsStoreScopedMigration.migratePerAssistantKeysIfNeeded(
+            activeAssistantId: assistantAId,
+            featureFlagStore: store
+        ))
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "\(assistantAId).globalHotkeyShortcut"),
+            "cmd+shift+g",
+            "Idempotent migration must not re-copy after sentinel is set"
+        )
+    }
+
+    func testMigrationTwoAssistantsIndependent() {
+        UserDefaults.standard.set("cmd+shift+g", forKey: "globalHotkeyShortcut")
+        let store = makeFlagStore(enabled: true)
+
+        XCTAssertTrue(SettingsStoreScopedMigration.migratePerAssistantKeysIfNeeded(
+            activeAssistantId: assistantAId,
+            featureFlagStore: store
+        ))
+        XCTAssertTrue(SettingsStoreScopedMigration.migratePerAssistantKeysIfNeeded(
+            activeAssistantId: assistantBId,
+            featureFlagStore: store
+        ))
+
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "\(assistantAId).globalHotkeyShortcut"),
+            "cmd+shift+g"
+        )
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "\(assistantBId).globalHotkeyShortcut"),
+            "cmd+shift+g"
+        )
+    }
+
+    // MARK: - Install-global guard
+
+    func testInstallGlobalKeysStayOnLegacyRegardlessOfFlag() {
+        // Seed legacy values.
+        UserDefaults.standard.set(false, forKey: "sendDiagnostics")
+        UserDefaults.standard.set(false, forKey: "collectUsageData")
+
+        for enabled in [false, true] {
+            let store = makeFlagStore(enabled: enabled)
+            _ = SettingsStoreScopedMigration.migratePerAssistantKeysIfNeeded(
+                activeAssistantId: assistantAId,
+                featureFlagStore: store
+            )
+            XCTAssertNil(
+                UserDefaults.standard.object(forKey: "\(assistantAId).sendDiagnostics"),
+                "sendDiagnostics must never be migrated into a scoped key"
+            )
+            XCTAssertNil(
+                UserDefaults.standard.object(forKey: "\(assistantAId).collectUsageData"),
+                "collectUsageData must never be migrated into a scoped key"
+            )
+            UserDefaults.standard.removeObject(forKey: "\(assistantAId).__settings_migrated_v1")
+        }
+    }
+
+    // MARK: - SettingsStore property routing
+
+    func testFlagOffRegressionWritesLegacyKey() {
+        let flagStore = makeFlagStore(enabled: false)
+        let store = SettingsStore(featureFlagStore: flagStore)
+
+        store.globalHotkeyShortcut = "cmd+shift+x"
+        // Sink is synchronous (no debounce) for hotkeys.
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "globalHotkeyShortcut"),
+            "cmd+shift+x",
+            "Flag off must write to the legacy unscoped key — byte-for-byte today's behavior"
+        )
+        XCTAssertNil(
+            UserDefaults.standard.object(forKey: "\(assistantAId).globalHotkeyShortcut")
+        )
+    }
+
+    func testFlagOnNilAssistantIdFallsBackToLegacy() {
+        // Ensure no active assistant id is cached — the lockfile helper
+        // returns nil when no lockfile is present in the test environment
+        // for this random assistant id.
+        let flagStore = makeFlagStore(enabled: true)
+        let store = SettingsStore(featureFlagStore: flagStore)
+
+        // If there is no cached assistant id, writes fall back to legacy.
+        if LockfileAssistant.loadActiveAssistantId() == nil {
+            store.globalHotkeyShortcut = "cmd+shift+y"
+            XCTAssertEqual(
+                UserDefaults.standard.string(forKey: "globalHotkeyShortcut"),
+                "cmd+shift+y"
+            )
+        }
+    }
+}

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -290,6 +290,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "multi-platform-assistant",
+      "scope": "macos",
+      "key": "multi-platform-assistant",
+      "label": "Multi-Platform Assistant",
+      "description": "Scope per-assistant settings (hotkeys, UI preferences) under the active assistant id in UserDefaults so two assistants on one host carry independent values. Off = legacy unscoped behavior.",
+      "defaultEnabled": false
+    },
+    {
       "id": "apple-container",
       "scope": "macos",
       "key": "apple-container",


### PR DESCRIPTION
## Summary

- Introduce `ScopedDefaults` — a pure key-prefixing wrapper over `UserDefaults.standard` that namespaces per-assistant settings under `"<assistantId>.<key>"`.
- Add `SettingsStoreScopedMigration.migratePerAssistantKeysIfNeeded`, a one-time idempotent sentinel-guarded copy of legacy per-assistant keys into the scoped namespace. Mirrors the guard / copy / sentinel pattern in `AppDelegate+ConnectionSetup.migrateConnectedAssistantIdToLockfile`. Legacy keys are never deleted — cleanup lives in a separate post-bake PR.
- Route `SettingsStore` reads/writes for the per-assistant hotkey & UI keys (`globalHotkeyShortcut`, `quickInputHotkeyShortcut`, `quickInputHotkeyKeyCode`, `sidebarToggleShortcut`, `newChatShortcut`, `currentConversationShortcut`, `popOutShortcut`, `cmdEnterToSend`, `selectedImageGenModel`) through a single `multi-platform-assistant` feature flag. Flag off = today's behavior, byte-for-byte. Flag on = scoped storage + migration. On `LockfileAssistant.activeAssistantDidChange` the migration runs for the newly-active assistant and `@Published` properties rebind from the new scope so SwiftUI picks up the switch.
- Install-global keys (`sendDiagnostics`, `collectUsageData`) deliberately stay on legacy unscoped storage regardless of flag state.
- Move `AssistantFeatureFlagStore` ownership from `AppDelegate` onto `AppServices` so `SettingsStore` can depend on the same instance; `AppDelegate.featureFlagStore` is kept as a forwarding property.
- Add the `multi-platform-assistant` macOS-scope flag (`defaultEnabled: false`) and re-run the bundled-copies sync.
- Add `SettingsStoreScopingTests` — 9 tests covering the `ScopedDefaults` wrapper (key prefixing, two-assistant isolation, legacy untouched), the migration helper (no-op flag off, sentinel idempotency, key-by-key copy preserving legacy, two-assistant independence), install-global guard (`sendDiagnostics`/`collectUsageData` never scoped), and `SettingsStore` property routing (flag-off regression guard, flag-on + nil assistant id fall-back).

### Out of scope (deliberately deferred)

- `connectedOrganizationId` scoping — although listed in the plan, multiple consumers (`LogExporter`, `SentryDeviceInfo`, `ManagedAssistantConnectionCoordinator`) read/write this key directly on `UserDefaults.standard` and the KVO publisher `SettingsStore` uses can't observe scoped keys without further refactoring. Deferred to a follow-up.
- iOS (`clients/ios` / shared iOS UserDefaults path) — unchanged; `LockfileAssistant` remains `#if os(macOS)` only.
- Post-bake cleanup of legacy UserDefaults keys — separate PR.

## Test plan

- [x] `swift build --target VellumAssistantLib` — clean build
- [x] `swift build --target vellum-assistantTests` — clean build
- [x] `swift test --filter SettingsStoreScopingTests` — 9/9 passing

### Manual test plan

- [ ] Launch with `multi-platform-assistant` flag off. Change `globalHotkeyShortcut` and `cmdEnterToSend` in Settings. Quit and relaunch — verify values persisted via legacy unscoped keys.
- [ ] Flip the flag on via Developer Settings. Verify existing hotkey values still load (one-time migration copies legacy → `<assistantId>.globalHotkeyShortcut`) and the sentinel `<assistantId>.__settings_migrated_v1` is set.
- [ ] Switch to a second assistant. Verify hotkeys reset to defaults for the new assistant scope.
- [ ] Set different hotkeys for the second assistant. Switch back to the original assistant. Verify the original hotkeys are restored.
- [ ] Flip the flag off. Verify SettingsStore reverts to reading/writing legacy keys — original values still present.

## Original prompt

Implement PR 1 of the multi-host-assistant plan: flag-gated per-assistant settings scoping with one-time migration. Per-key classification and acceptance criteria from the plan were followed; `connectedOrganizationId` was deferred as noted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
