### PR TITLE
fix: conditional insertion for chat bubble overflow menu

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleOverflowMenu.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleOverflowMenu.swift
@@ -18,6 +18,8 @@ final class ChatBubbleHoverState {
 /// Owns volatile @State (copy confirmation, audio player, popover) so that
 /// changes only re-evaluate this small view, not the full ChatBubble body.
 struct ChatBubbleOverflowMenu: View {
+    private static let reservedRowHeight: CGFloat = 24
+
     let message: ChatMessage
     let hoverState: ChatBubbleHoverState
     let isTTSEnabled: Bool
@@ -99,14 +101,16 @@ struct ChatBubbleOverflowMenu: View {
 
     // MARK: - Body
 
-    // The opacity approach constructs buttons even when hidden, but the
-    // ChatEquatableButton firewall prevents body re-evaluation during
-    // unrelated parent cascades. This preserves the fade animation while
-    // eliminating the primary performance cost (repeated VButton body work).
     var body: some View {
         if hasOverflowActions {
-            menuContent
-                .opacity(showOverflowMenu ? 1 : 0)
+            Color.clear
+                .frame(height: Self.reservedRowHeight)
+                .overlay(alignment: .leading) {
+                    if showOverflowMenu {
+                        menuContent
+                            .transition(.opacity)
+                    }
+                }
                 .animation(VAnimation.fast, value: showOverflowMenu)
         }
     }
@@ -116,7 +120,7 @@ struct ChatBubbleOverflowMenu: View {
             Text(formattedTimestamp)
                 .font(VFont.labelDefault)
                 .foregroundStyle(VColor.contentTertiary)
-                .help(detailedTimestamp)
+                .nativeTooltip(detailedTimestamp)
             if hasCopyableText {
                 ChatEquatableButton(
                     label: showCopyConfirmation ? "Copied" : "Copy message",


### PR DESCRIPTION
## Summary
- Replace opacity-based overflow menu visibility with conditional insertion via `Color.clear` overlay, avoiding unnecessary view construction when hidden
- Switch timestamp tooltip from `.help()` to `.nativeTooltip()` for consistency with other tooltips