### PR TITLE
feat(installer): write Chrome native messaging host manifest on macOS install

### DIFF
--- a/clients/chrome-extension-native-host/README.md
+++ b/clients/chrome-extension-native-host/README.md
@@ -6,10 +6,15 @@ exists so the extension can bootstrap a scoped capability token for the
 self-hosted (local-assistant) transport without ever shipping a long-lived
 secret in the extension package itself.
 
-This package is **scaffolding only** in this PR. It is not yet wired into
-the extension or the macOS installer — those land in PR 12 (manifest +
-installer) and PR 13 (extension self-hosted bootstrap flow). The runtime
-HTTP endpoint it talks to (`/v1/browser-extension-pair`) lands in PR 11.
+The macOS installer wiring landed in PR 12: the helper is now bundled
+into the Mac `.app` under `Contents/MacOS/vellum-chrome-native-host`
+via `clients/macos/build.sh` (see the "Bundling into the macOS app"
+section below), and `NativeMessagingInstaller` writes the
+`com.vellum.daemon.json` manifest into Chrome's per-user
+`NativeMessagingHosts` directory at launch time. The extension-side
+bootstrap flow that actually spawns this helper lands in PR 13, and the
+runtime HTTP endpoint it talks to (`/v1/browser-extension-pair`) lands
+in PR 11.
 
 [cnm]: https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging
 
@@ -139,7 +144,59 @@ bun run build       # produces dist/index.js
 
 `bun run build` is a thin wrapper around `tsc -p tsconfig.json`. The
 output is a single ES module file under `dist/` that can be invoked
-directly with `node dist/index.js`.
+directly with `node dist/index.js`. This form is convenient for local
+development and unit tests.
+
+## Bundling into the macOS app
+
+The production macOS `.app` does **not** ship the `dist/index.js` form
+— Chrome's native messaging `path` field must point at a runnable
+executable, and we do not want to assume that the user has `node` on
+their `$PATH`. Instead, `clients/macos/build.sh` uses
+`bun build --compile` (via its shared `build_bun_binary` helper) to
+produce a self-contained single-file binary named
+`vellum-chrome-native-host`, writes it to
+`$SCRIPT_DIR/native-host-bin/`, and then copies it into the app bundle
+at `Contents/MacOS/vellum-chrome-native-host` alongside the other
+compiled Bun binaries (`vellum-daemon`, `vellum-cli`,
+`vellum-gateway`, `vellum-assistant`).
+
+At first launch, the Swift-side `NativeMessagingInstaller` (see
+`clients/macos/vellum-assistant/Features/Installer/NativeMessagingInstaller.swift`)
+resolves the bundled binary via
+`Bundle.main.url(forAuxiliaryExecutable: "vellum-chrome-native-host")`
+and writes `com.vellum.daemon.json` pointing `path` at that absolute
+location. Because the manifest is regenerated on every launch, moving
+or upgrading the `.app` bundle automatically repoints Chrome at the
+new helper location without a manual re-pair step.
+
+### Why Bun single-file compile (not `node dist/index.js`)
+
+The plan initially considered shipping `dist/index.js` plus a wrapper
+shell script. That approach was dropped because:
+
+1. Chrome's native messaging host `path` must be executable — it does
+   not support shell interpretation of script shebangs beyond the OS's
+   own `execve`, which means we would still need a compiled wrapper.
+2. Every other binary the macOS app ships (daemon, CLI, gateway) uses
+   `bun build --compile` into a native single-file binary. Reusing
+   that same pipeline keeps the build/signing steps uniform and avoids
+   depending on the user having `node` installed.
+3. The compiled binary participates in the app's codesign chain and
+   notarization pipeline the same way as the other helpers, which
+   keeps macOS Gatekeeper happy.
+
+### Manifest template
+
+The canonical manifest shape is checked in at
+`clients/chrome-extension-native-host/com.vellum.daemon.json.template`.
+`NativeMessagingInstaller` rebuilds the same structure in-memory via
+`JSONSerialization` and overwrites the on-disk file on every launch
+(idempotent) so that upgrading the app bundle automatically updates the
+`path` and `allowed_origins` entries. The `__HELPER_BINARY_PATH__` and
+`__VELLUM_EXTENSION_ID__` placeholders in the template are for
+humans reading the checked-in file — the actual install never
+performs template substitution.
 
 ## Testing
 

--- a/clients/chrome-extension-native-host/com.vellum.daemon.json.template
+++ b/clients/chrome-extension-native-host/com.vellum.daemon.json.template
@@ -1,0 +1,9 @@
+{
+  "name": "com.vellum.daemon",
+  "description": "Vellum assistant native messaging host",
+  "path": "__HELPER_BINARY_PATH__",
+  "type": "stdio",
+  "allowed_origins": [
+    "chrome-extension://__VELLUM_EXTENSION_ID__/"
+  ]
+}

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -643,7 +643,7 @@ if [ "${SKIP_BUN_REBUILD:-}" != "1" ] && [ -d "$NATIVE_HOST_SRC_DIR/src" ] && co
     elif [ -n "$(find "$NATIVE_HOST_SRC_DIR/src" -name '*.ts' -newer "$SCRIPT_DIR/native-host-bin/vellum-chrome-native-host" -print -quit 2>/dev/null)" ]; then
         NATIVE_HOST_BIN_NEEDS_BUILD=true
     elif [ "$NATIVE_HOST_SRC_DIR/package.json" -nt "$SCRIPT_DIR/native-host-bin/vellum-chrome-native-host" ] || \
-         [ -f "$NATIVE_HOST_SRC_DIR/bun.lock" ] && [ "$NATIVE_HOST_SRC_DIR/bun.lock" -nt "$SCRIPT_DIR/native-host-bin/vellum-chrome-native-host" ]; then
+         { [ -f "$NATIVE_HOST_SRC_DIR/bun.lock" ] && [ "$NATIVE_HOST_SRC_DIR/bun.lock" -nt "$SCRIPT_DIR/native-host-bin/vellum-chrome-native-host" ]; }; then
         NATIVE_HOST_BIN_NEEDS_BUILD=true
     fi
 fi

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -213,6 +213,7 @@ export SIGN_IDENTITY
 ASSISTANT_SRC_DIR="$SCRIPT_DIR/../../assistant"
 CLI_SRC_DIR="$SCRIPT_DIR/../../cli"
 GATEWAY_SRC_DIR="$SCRIPT_DIR/../../gateway"
+NATIVE_HOST_SRC_DIR="$SCRIPT_DIR/../chrome-extension-native-host"
 
 # Packages that must stay external in compiled Bun binaries.
 # playwright-core has optional requires (electron, chromium-bidi) that cannot
@@ -278,6 +279,9 @@ build_binaries() {
     (cd "$ASSISTANT_SRC_DIR" && bun install --frozen-lockfile 2>/dev/null || bun install)
     (cd "$CLI_SRC_DIR" && bun install --frozen-lockfile 2>/dev/null || bun install)
     (cd "$GATEWAY_SRC_DIR" && bun install --frozen-lockfile 2>/dev/null || bun install)
+    if [ -d "$NATIVE_HOST_SRC_DIR/src" ]; then
+        (cd "$NATIVE_HOST_SRC_DIR" && bun install --frozen-lockfile 2>/dev/null || bun install)
+    fi
 
     # Shared flags for daemon and assistant CLI
     local daemon_flags=("${BUN_EXTERNAL_FLAGS[@]}")
@@ -317,6 +321,12 @@ build_binaries() {
     SKIP_BUN_INSTALL=1 build_bun_binary "$GATEWAY_SRC_DIR" "$GATEWAY_SRC_DIR/src/index.ts" \
         "$SCRIPT_DIR/gateway-bin" "vellum-gateway" &
     pids+=($!)
+
+    if [ -d "$NATIVE_HOST_SRC_DIR/src" ]; then
+        SKIP_BUN_INSTALL=1 build_bun_binary "$NATIVE_HOST_SRC_DIR" "$NATIVE_HOST_SRC_DIR/src/index.ts" \
+            "$SCRIPT_DIR/native-host-bin" "vellum-chrome-native-host" &
+        pids+=($!)
+    fi
 
     for pid in "${pids[@]}"; do
         wait "$pid" || failures=$((failures + 1))
@@ -388,7 +398,7 @@ case "$CMD" in
     clean)
         echo "Cleaning..."
         rm -rf "$SCRIPT_DIR/dist" "$SCRIPT_DIR/../.build"
-        rm -rf "$SCRIPT_DIR/daemon-bin" "$SCRIPT_DIR/assistant-bin" "$SCRIPT_DIR/cli-bin" "$SCRIPT_DIR/gateway-bin"
+        rm -rf "$SCRIPT_DIR/daemon-bin" "$SCRIPT_DIR/assistant-bin" "$SCRIPT_DIR/cli-bin" "$SCRIPT_DIR/gateway-bin" "$SCRIPT_DIR/native-host-bin"
         rm -rf "$SPM_MODULE_CACHE"
         echo "Done."
         exit 0
@@ -433,7 +443,7 @@ if [ "$CMD" = "release" ] || [ "$CMD" = "release-application" ]; then
         # (e.g. arm64 binaries from a previous build being bundled into an x86_64 release).
         # Skip when SKIP_BUN_REBUILD=1, since pre-built binaries are intentionally provided.
         if [ "${SKIP_BUN_REBUILD:-}" != "1" ]; then
-            rm -rf "$SCRIPT_DIR/daemon-bin" "$SCRIPT_DIR/assistant-bin" "$SCRIPT_DIR/cli-bin" "$SCRIPT_DIR/gateway-bin"
+            rm -rf "$SCRIPT_DIR/daemon-bin" "$SCRIPT_DIR/assistant-bin" "$SCRIPT_DIR/cli-bin" "$SCRIPT_DIR/gateway-bin" "$SCRIPT_DIR/native-host-bin"
         fi
     fi
 fi
@@ -620,6 +630,35 @@ if [ -f "$SCRIPT_DIR/gateway-bin/vellum-gateway" ]; then
     fi
 fi
 
+# Auto-build Chrome native messaging helper binary if missing or stale
+# and bun is available. This is the binary Chrome spawns via
+# chrome.runtime.connectNative("com.vellum.daemon") — see
+# clients/chrome-extension-native-host/ for the source and
+# clients/macos/vellum-assistant/Features/Installer/NativeMessagingInstaller.swift
+# for the manifest that points at the bundled copy.
+NATIVE_HOST_BIN_NEEDS_BUILD=false
+if [ "${SKIP_BUN_REBUILD:-}" != "1" ] && [ -d "$NATIVE_HOST_SRC_DIR/src" ] && command -v bun &>/dev/null; then
+    if [ ! -f "$SCRIPT_DIR/native-host-bin/vellum-chrome-native-host" ]; then
+        NATIVE_HOST_BIN_NEEDS_BUILD=true
+    elif [ -n "$(find "$NATIVE_HOST_SRC_DIR/src" -name '*.ts' -newer "$SCRIPT_DIR/native-host-bin/vellum-chrome-native-host" -print -quit 2>/dev/null)" ]; then
+        NATIVE_HOST_BIN_NEEDS_BUILD=true
+    elif [ "$NATIVE_HOST_SRC_DIR/package.json" -nt "$SCRIPT_DIR/native-host-bin/vellum-chrome-native-host" ] || \
+         [ -f "$NATIVE_HOST_SRC_DIR/bun.lock" ] && [ "$NATIVE_HOST_SRC_DIR/bun.lock" -nt "$SCRIPT_DIR/native-host-bin/vellum-chrome-native-host" ]; then
+        NATIVE_HOST_BIN_NEEDS_BUILD=true
+    fi
+fi
+if [ "$NATIVE_HOST_BIN_NEEDS_BUILD" = true ]; then
+    build_bun_binary "$NATIVE_HOST_SRC_DIR" "$NATIVE_HOST_SRC_DIR/src/index.ts" \
+        "$SCRIPT_DIR/native-host-bin" "vellum-chrome-native-host"
+fi
+
+# Also rebuild if native host binary changed or newly added
+if [ -f "$SCRIPT_DIR/native-host-bin/vellum-chrome-native-host" ]; then
+    if [ ! -f "$MACOS_DIR/vellum-chrome-native-host" ] || [ "$SCRIPT_DIR/native-host-bin/vellum-chrome-native-host" -nt "$MACOS_DIR/vellum-chrome-native-host" ]; then
+        NEEDS_REBUILD=true
+    fi
+fi
+
 # Ensure .app bundle structure exists
 mkdir -p "$MACOS_DIR" "$RESOURCES_DIR" "$FRAMEWORKS_DIR"
 
@@ -674,6 +713,19 @@ if [ "$NEEDS_REBUILD" = true ]; then
         chmod +x "$MACOS_DIR/vellum-gateway"
     else
         echo "No gateway binary at $GATEWAY_BIN — skipping (dev mode)"
+    fi
+
+    # Copy bundled Chrome native messaging helper binary (if available).
+    # This is an auxiliary executable under Contents/MacOS/ that Chrome
+    # spawns via the com.vellum.daemon.json manifest written by
+    # NativeMessagingInstaller at first launch.
+    NATIVE_HOST_BIN="$SCRIPT_DIR/native-host-bin/vellum-chrome-native-host"
+    if [ -f "$NATIVE_HOST_BIN" ]; then
+        echo "Bundling Chrome native messaging helper binary..."
+        cp "$NATIVE_HOST_BIN" "$MACOS_DIR/vellum-chrome-native-host"
+        chmod +x "$MACOS_DIR/vellum-chrome-native-host"
+    else
+        echo "No Chrome native messaging helper binary at $NATIVE_HOST_BIN — skipping (dev mode)"
     fi
 
 else
@@ -1124,6 +1176,16 @@ if [ -f "$MACOS_DIR/vellum-gateway" ]; then
     echo "Gateway binary signed"
 fi
 
+# Sign Chrome native messaging helper binary
+if [ -f "$MACOS_DIR/vellum-chrome-native-host" ]; then
+    NATIVE_HOST_SIGN_FLAGS=(--force --sign "$SIGN_IDENTITY")
+    if [ "$CONFIG" = "release" ] && [ "$SIGN_IDENTITY" != "-" ]; then
+        NATIVE_HOST_SIGN_FLAGS+=(--timestamp --options runtime)
+    fi
+    codesign "${NATIVE_HOST_SIGN_FLAGS[@]}" "$MACOS_DIR/vellum-chrome-native-host"
+    echo "Chrome native messaging helper binary signed"
+fi
+
 # Embedding runtime node_modules are no longer bundled (downloaded post-hatch).
 
 # Sign any additional regular files directly under Contents/MacOS.
@@ -1138,6 +1200,7 @@ if [ -d "$MACOS_DIR" ]; then
         ! -name "vellum-daemon" \
         ! -name "vellum-cli" \
         ! -name "vellum-gateway" \
+        ! -name "vellum-chrome-native-host" \
         -exec codesign "${EXTRA_FILE_SIGN_FLAGS[@]}" {} \;
 fi
 

--- a/clients/macos/vellum-assistant/App/AppDelegate+NativeMessaging.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+NativeMessaging.swift
@@ -1,0 +1,110 @@
+import AppKit
+import Foundation
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "AppDelegate+NativeMessaging")
+
+/// Install-time hook for the Chrome native messaging host manifest.
+///
+/// See `NativeMessagingInstaller` and
+/// `clients/chrome-extension-native-host/` for the full flow:
+/// this extension is responsible for (1) locating the bundled
+/// `vellum-chrome-native-host` helper binary inside the `.app`
+/// bundle at launch time, and (2) writing the
+/// `com.vellum.daemon.json` manifest into Chrome's well-known
+/// `~/Library/Application Support/Google/Chrome/NativeMessagingHosts/`
+/// directory so Chrome will spawn that helper when the Vellum
+/// extension calls `chrome.runtime.connectNative("com.vellum.daemon")`.
+///
+/// This runs off the main thread from `applicationDidFinishLaunching`
+/// because writing to `~/Library` involves disk I/O and we do not
+/// want to block app launch if the directory has unusual permissions.
+/// It also runs unconditionally on every launch (cheap, idempotent)
+/// so that upgrading the app bundle automatically repoints the
+/// manifest at the newer helper binary path.
+extension AppDelegate {
+
+    /// Installs the Chrome native messaging host manifest for the
+    /// Vellum chrome extension. Idempotent — safe to call on every
+    /// launch. Runs off the main thread.
+    ///
+    /// This method is deliberately non-`@MainActor`: it touches no
+    /// app state, does pure file I/O under `~/Library`, and follows
+    /// the same off-main-thread pattern as `installCLISymlinkIfNeeded`.
+    nonisolated static func installChromeNativeMessagingHostIfNeeded() {
+        guard let helperBinaryUrl = resolveBundledNativeMessagingHelper() else {
+            // Normal for dev builds where the helper binary hasn't
+            // been built yet (see `clients/chrome-extension-native-host`
+            // and the build.sh wiring). Not an error — the self-hosted
+            // Chrome extension pairing flow (PR 13) is optional, and
+            // everything else in the assistant continues to work.
+            log.info("vellum-chrome-native-host helper not bundled — skipping Chrome manifest install (dev build?)")
+            return
+        }
+
+        do {
+            try NativeMessagingInstaller.installChromeManifest(
+                helperBinaryPath: helperBinaryUrl,
+                extensionId: ChromeExtensionAllowlist.devPlaceholderId
+            )
+        } catch {
+            // Best-effort: a failing manifest install must not crash
+            // the app. Log at warning so it shows up in diagnostics
+            // but does not spam the error channel.
+            log.warning(
+                "Failed to install Chrome native messaging manifest: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    /// Resolves the absolute URL of the bundled
+    /// `vellum-chrome-native-host` helper binary inside the running
+    /// app bundle, or `nil` if it is not present (dev builds that
+    /// haven't run the helper's `bun run build` yet).
+    ///
+    /// Tries `Bundle.main.url(forAuxiliaryExecutable:)` first — which
+    /// is the Apple-recommended way to look up secondary binaries
+    /// inside `Contents/MacOS/` — and falls back to a direct path
+    /// computation for builds that package the binary at a
+    /// non-standard location.
+    nonisolated static func resolveBundledNativeMessagingHelper() -> URL? {
+        let binaryName = "vellum-chrome-native-host"
+
+        if let url = Bundle.main.url(forAuxiliaryExecutable: binaryName) {
+            return url
+        }
+
+        // Fallback: compute the path directly against the bundle's
+        // executable URL. This matches how `installCLISymlinkIfNeeded`
+        // discovers the `vellum-cli` sibling binary.
+        if let execURL = Bundle.main.executableURL {
+            let candidate = execURL
+                .deletingLastPathComponent()
+                .appendingPathComponent(binaryName)
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                return candidate
+            }
+        }
+
+        return nil
+    }
+}
+
+/// Hard-coded allowlist of Chrome extension IDs the installer pins
+/// into the manifest's `allowed_origins`. Must stay in lockstep with
+/// `ALLOWED_EXTENSION_IDS` in
+/// `clients/chrome-extension-native-host/src/index.ts` (PR 7) and the
+/// allowlist the assistant's `/v1/browser-extension-pair` endpoint
+/// checks (PR 11).
+///
+/// Kept in a standalone enum so unit tests can reference it without
+/// instantiating `AppDelegate`.
+enum ChromeExtensionAllowlist {
+    /// Dev placeholder id. Matches the single entry currently present
+    /// in the helper binary's allowlist in PR 7. Replaced before
+    /// release with the production extension id — see the
+    /// `TODO: production id before release` comment in
+    /// `clients/chrome-extension-native-host/src/index.ts`.
+    static let devPlaceholderId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -527,6 +527,16 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             Self.installCLISymlinkIfNeeded(isDevMode: isDevMode)
         }
 
+        // Install the Chrome native messaging host manifest so the
+        // Vellum Chrome extension can spawn the bundled helper binary
+        // via `chrome.runtime.connectNative("com.vellum.daemon")`.
+        // Best-effort and idempotent — see
+        // `AppDelegate+NativeMessaging.swift` for details. Runs off
+        // the main thread because it touches `~/Library` on disk.
+        Task.detached(priority: .utility) {
+            Self.installChromeNativeMessagingHostIfNeeded()
+        }
+
         let hasAssistants = lockfileHasAssistants()
         log.info("[appLaunch] skipOnboarding=\(skipOnboarding) hasAssistants=\(hasAssistants)")
 

--- a/clients/macos/vellum-assistant/Features/Installer/NativeMessagingInstaller.swift
+++ b/clients/macos/vellum-assistant/Features/Installer/NativeMessagingInstaller.swift
@@ -41,13 +41,21 @@ public enum NativeMessagingInstaller {
     /// the manifest install fails, and the Chrome extension's
     /// self-hosted pairing flow (PR 13) will simply not work until it
     /// is resolved.
-    public enum InstallError: Error, CustomStringConvertible {
+    ///
+    /// Conforms to `LocalizedError` (rather than only
+    /// `CustomStringConvertible`) so that `error.localizedDescription`
+    /// returns the human-readable string below instead of Foundation's
+    /// generic "The operation couldn't be completed (… error 0.)"
+    /// fallback. This matches the convention used by other error types
+    /// in this app (see `RecorderError`, `CaptureError`,
+    /// `ExecutorError`, etc.).
+    public enum InstallError: Error, LocalizedError {
         case helperBinaryMissing(URL)
 
-        public var description: String {
+        public var errorDescription: String? {
             switch self {
             case .helperBinaryMissing(let url):
-                return "helper binary not found at \(url.path)"
+                return "Native messaging helper binary not found at \(url.path)"
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Installer/NativeMessagingInstaller.swift
+++ b/clients/macos/vellum-assistant/Features/Installer/NativeMessagingInstaller.swift
@@ -1,0 +1,174 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "NativeMessagingInstaller")
+
+/// Installs and removes the Chrome Native Messaging host manifest that
+/// points at the bundled `vellum-chrome-native-host` helper binary.
+///
+/// Chrome looks for per-user native messaging host manifests in
+/// `~/Library/Application Support/Google/Chrome/NativeMessagingHosts/`.
+/// When the Vellum Chrome extension calls
+/// `chrome.runtime.connectNative("com.vellum.daemon")`, Chrome reads
+/// `com.vellum.daemon.json` from that directory, verifies that the
+/// calling extension's ID is on the manifest's `allowed_origins`
+/// list, and spawns the binary referenced by `path`.
+///
+/// See `clients/chrome-extension-native-host/` (PR 7) for the helper
+/// binary and `clients/chrome-extension-native-host/com.vellum.daemon.json.template`
+/// for the shape of the manifest this installer writes.
+///
+/// This helper intentionally carries **no** app state so it can run
+/// safely off the main thread from `applicationDidFinishLaunching`
+/// without `@MainActor` isolation, matching the pattern used by
+/// `AppDelegate.installCLISymlinkIfNeeded(isDevMode:)`.
+public enum NativeMessagingInstaller {
+
+    /// Canonical Chrome native messaging host name for the Vellum helper.
+    /// Intentionally left as `com.vellum.daemon` because it is a technical
+    /// identifier baked into Chrome's manifest lookup — not user-facing —
+    /// and must match `chrome.runtime.connectNative("com.vellum.daemon")`
+    /// in the extension (see PR 13).
+    public static let hostName = "com.vellum.daemon"
+
+    /// Human-readable description written into the manifest's
+    /// `description` field. Per `clients/AGENTS.md` the user-facing
+    /// wording prefers "assistant" over "daemon".
+    public static let hostDescription = "Vellum assistant native messaging host"
+
+    /// Errors surfaced by the installer. Rendered to the app log rather
+    /// than bubbled to the UI — the assistant continues to run even if
+    /// the manifest install fails, and the Chrome extension's
+    /// self-hosted pairing flow (PR 13) will simply not work until it
+    /// is resolved.
+    public enum InstallError: Error, CustomStringConvertible {
+        case helperBinaryMissing(URL)
+
+        public var description: String {
+            switch self {
+            case .helperBinaryMissing(let url):
+                return "helper binary not found at \(url.path)"
+            }
+        }
+    }
+
+    // MARK: - Public API
+
+    /// Writes the `com.vellum.daemon.json` manifest under the current
+    /// user's Chrome native messaging hosts directory. Overwrites any
+    /// existing manifest so upgrades cleanly repoint at the new helper
+    /// binary path.
+    ///
+    /// - Parameters:
+    ///   - helperBinaryPath: Absolute path to the bundled native
+    ///     messaging helper binary (e.g.
+    ///     `…/Contents/MacOS/vellum-chrome-native-host`). Must exist —
+    ///     Chrome refuses to spawn a host whose `path` is missing.
+    ///   - extensionId: The Chrome extension ID to pin in
+    ///     `allowed_origins`. Must match the allowlist enforced by the
+    ///     helper binary itself (PR 7 `ALLOWED_EXTENSION_IDS`) and the
+    ///     runtime pair endpoint's allowlist (PR 11).
+    public static func installChromeManifest(
+        helperBinaryPath: URL,
+        extensionId: String
+    ) throws {
+        try installChromeManifest(
+            helperBinaryPath: helperBinaryPath,
+            extensionId: extensionId,
+            homeDirectory: FileManager.default.homeDirectoryForCurrentUser,
+            fileManager: FileManager.default
+        )
+    }
+
+    /// Removes the `com.vellum.daemon.json` manifest if present. Safe to
+    /// call when the manifest does not exist — returns without error.
+    public static func uninstallChromeManifest() throws {
+        try uninstallChromeManifest(
+            homeDirectory: FileManager.default.homeDirectoryForCurrentUser,
+            fileManager: FileManager.default
+        )
+    }
+
+    // MARK: - Testable overloads
+
+    /// Test-only overload that allows injecting a mock home directory so
+    /// the installer can be exercised without touching the real Chrome
+    /// directory under the tester's home folder.
+    internal static func installChromeManifest(
+        helperBinaryPath: URL,
+        extensionId: String,
+        homeDirectory: URL,
+        fileManager: FileManager
+    ) throws {
+        guard fileManager.fileExists(atPath: helperBinaryPath.path) else {
+            throw InstallError.helperBinaryMissing(helperBinaryPath)
+        }
+
+        let targetDir = manifestDirectory(under: homeDirectory)
+        try fileManager.createDirectory(
+            at: targetDir,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+
+        let manifestUrl = targetDir.appendingPathComponent("\(hostName).json")
+
+        // JSONSerialization is used (rather than a Codable struct) so the
+        // field order matches the Chrome-expected shape and so the
+        // structure lines up 1:1 with the .template file checked into
+        // the chrome-extension-native-host package.
+        //
+        // Swift dictionaries are unordered, but Chrome doesn't care about
+        // field order — it just parses the object — so we prioritize
+        // clarity here.
+        let manifest: [String: Any] = [
+            "name": hostName,
+            "description": hostDescription,
+            "path": helperBinaryPath.path,
+            "type": "stdio",
+            "allowed_origins": ["chrome-extension://\(extensionId)/"],
+        ]
+
+        let data = try JSONSerialization.data(
+            withJSONObject: manifest,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        try data.write(to: manifestUrl, options: .atomic)
+
+        // Chrome requires the manifest to be readable by the user; 0o644
+        // is what Google's own documentation for macOS native messaging
+        // host manifests uses and it matches the DMG/installer patterns
+        // used elsewhere in this app.
+        try fileManager.setAttributes(
+            [.posixPermissions: NSNumber(value: 0o644)],
+            ofItemAtPath: manifestUrl.path
+        )
+
+        log.info("Installed Chrome native messaging manifest at \(manifestUrl.path, privacy: .public)")
+    }
+
+    internal static func uninstallChromeManifest(
+        homeDirectory: URL,
+        fileManager: FileManager
+    ) throws {
+        let manifestUrl = manifestDirectory(under: homeDirectory)
+            .appendingPathComponent("\(hostName).json")
+        if fileManager.fileExists(atPath: manifestUrl.path) {
+            try fileManager.removeItem(at: manifestUrl)
+            log.info("Removed Chrome native messaging manifest at \(manifestUrl.path, privacy: .public)")
+        }
+    }
+
+    /// Resolves the directory where Chrome looks up per-user native
+    /// messaging host manifests, given a home directory. Exposed so
+    /// tests can build the expected path without duplicating the
+    /// constant string.
+    internal static func manifestDirectory(under homeDirectory: URL) -> URL {
+        homeDirectory
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("Google", isDirectory: true)
+            .appendingPathComponent("Chrome", isDirectory: true)
+            .appendingPathComponent("NativeMessagingHosts", isDirectory: true)
+    }
+}

--- a/clients/macos/vellum-assistantTests/NativeMessagingInstallerTests.swift
+++ b/clients/macos/vellum-assistantTests/NativeMessagingInstallerTests.swift
@@ -1,0 +1,253 @@
+import Foundation
+import XCTest
+@testable import VellumAssistantLib
+
+/// Tests for `NativeMessagingInstaller` — the macOS install-time
+/// helper that writes the Chrome native messaging host manifest
+/// (`com.vellum.daemon.json`) into Chrome's well-known per-user
+/// `NativeMessagingHosts/` directory.
+///
+/// These tests use an injected mock `homeDirectory` so the installer
+/// writes under a fresh `temporaryDirectory` rather than the real
+/// tester's `~/Library/Application Support/Google/Chrome/`. The
+/// production public entry points (`installChromeManifest(...)`,
+/// `uninstallChromeManifest()`) use `FileManager.default`; the tests
+/// exercise the internal testable overloads that accept both the
+/// home directory and the file manager explicitly.
+final class NativeMessagingInstallerTests: XCTestCase {
+    private var tempDir: URL!
+    private var mockHome: URL!
+    private var helperBinaryUrl: URL!
+
+    override func setUp() {
+        super.setUp()
+
+        // A fresh scratch root per test, isolated to the test bundle
+        // so parallel test runs can't collide.
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("NativeMessagingInstallerTests-\(UUID().uuidString)", isDirectory: true)
+        try! FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+        // Simulate ~/ under tempDir so the installer computes
+        // ~/Library/Application Support/Google/Chrome/NativeMessagingHosts
+        // relative to a controlled root.
+        mockHome = tempDir.appendingPathComponent("home", isDirectory: true)
+        try! FileManager.default.createDirectory(at: mockHome, withIntermediateDirectories: true)
+
+        // Stand in for the bundled `vellum-chrome-native-host` binary.
+        // The installer only verifies existence via
+        // `fileExists(atPath:)`, so a placeholder file is sufficient.
+        helperBinaryUrl = tempDir.appendingPathComponent("vellum-chrome-native-host")
+        FileManager.default.createFile(
+            atPath: helperBinaryUrl.path,
+            contents: Data("#!/bin/sh\nexit 0\n".utf8),
+            attributes: [.posixPermissions: NSNumber(value: 0o755)]
+        )
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    // MARK: - install
+
+    func testInstallWritesManifestWithExpectedStructure() throws {
+        try NativeMessagingInstaller.installChromeManifest(
+            helperBinaryPath: helperBinaryUrl,
+            extensionId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            homeDirectory: mockHome,
+            fileManager: .default
+        )
+
+        let manifestUrl = NativeMessagingInstaller
+            .manifestDirectory(under: mockHome)
+            .appendingPathComponent("com.vellum.daemon.json")
+
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: manifestUrl.path),
+            "manifest should exist at expected path"
+        )
+
+        let data = try Data(contentsOf: manifestUrl)
+        let parsed = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+
+        XCTAssertEqual(parsed["name"] as? String, "com.vellum.daemon")
+        XCTAssertEqual(parsed["description"] as? String, "Vellum assistant native messaging host")
+        XCTAssertEqual(parsed["type"] as? String, "stdio")
+        XCTAssertEqual(parsed["path"] as? String, helperBinaryUrl.path)
+
+        let origins = try XCTUnwrap(parsed["allowed_origins"] as? [String])
+        XCTAssertEqual(origins, ["chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/"])
+    }
+
+    func testInstallSetsManifestPermissionsTo0o644() throws {
+        try NativeMessagingInstaller.installChromeManifest(
+            helperBinaryPath: helperBinaryUrl,
+            extensionId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            homeDirectory: mockHome,
+            fileManager: .default
+        )
+
+        let manifestUrl = NativeMessagingInstaller
+            .manifestDirectory(under: mockHome)
+            .appendingPathComponent("com.vellum.daemon.json")
+
+        let attrs = try FileManager.default.attributesOfItem(atPath: manifestUrl.path)
+        let perms = try XCTUnwrap(attrs[.posixPermissions] as? NSNumber)
+        XCTAssertEqual(perms.intValue, 0o644)
+    }
+
+    func testInstallCreatesIntermediateNativeMessagingHostsDirectory() throws {
+        // Sanity: the mock home starts without a Chrome subtree.
+        let expectedDir = NativeMessagingInstaller.manifestDirectory(under: mockHome)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: expectedDir.path),
+            "precondition: NativeMessagingHosts directory should not yet exist"
+        )
+
+        try NativeMessagingInstaller.installChromeManifest(
+            helperBinaryPath: helperBinaryUrl,
+            extensionId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            homeDirectory: mockHome,
+            fileManager: .default
+        )
+
+        var isDir: ObjCBool = false
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: expectedDir.path, isDirectory: &isDir),
+            "NativeMessagingHosts directory should have been created"
+        )
+        XCTAssertTrue(isDir.boolValue, "NativeMessagingHosts should be a directory")
+    }
+
+    func testInstallOverwritesExistingManifest() throws {
+        // First install with a stale helper path/extension id.
+        let staleBinary = tempDir.appendingPathComponent("stale-binary")
+        FileManager.default.createFile(
+            atPath: staleBinary.path,
+            contents: Data("old\n".utf8),
+            attributes: nil
+        )
+        try NativeMessagingInstaller.installChromeManifest(
+            helperBinaryPath: staleBinary,
+            extensionId: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            homeDirectory: mockHome,
+            fileManager: .default
+        )
+
+        // Re-install with the canonical helper binary and placeholder id.
+        try NativeMessagingInstaller.installChromeManifest(
+            helperBinaryPath: helperBinaryUrl,
+            extensionId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            homeDirectory: mockHome,
+            fileManager: .default
+        )
+
+        let manifestUrl = NativeMessagingInstaller
+            .manifestDirectory(under: mockHome)
+            .appendingPathComponent("com.vellum.daemon.json")
+        let data = try Data(contentsOf: manifestUrl)
+        let parsed = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+
+        XCTAssertEqual(
+            parsed["path"] as? String,
+            helperBinaryUrl.path,
+            "second install should overwrite the stale path"
+        )
+        XCTAssertEqual(
+            parsed["allowed_origins"] as? [String],
+            ["chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/"],
+            "second install should overwrite the stale allowed_origins"
+        )
+    }
+
+    func testInstallRejectsMissingHelperBinary() {
+        let missingBinary = tempDir.appendingPathComponent("does-not-exist")
+
+        XCTAssertThrowsError(
+            try NativeMessagingInstaller.installChromeManifest(
+                helperBinaryPath: missingBinary,
+                extensionId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                homeDirectory: mockHome,
+                fileManager: .default
+            )
+        ) { error in
+            guard case NativeMessagingInstaller.InstallError.helperBinaryMissing(let url) = error else {
+                XCTFail("expected helperBinaryMissing, got \(error)")
+                return
+            }
+            XCTAssertEqual(url.path, missingBinary.path)
+        }
+
+        // The installer must not leave behind a partial manifest when
+        // the helper is missing.
+        let manifestUrl = NativeMessagingInstaller
+            .manifestDirectory(under: mockHome)
+            .appendingPathComponent("com.vellum.daemon.json")
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: manifestUrl.path),
+            "manifest must not be written when helper is missing"
+        )
+    }
+
+    // MARK: - uninstall
+
+    func testUninstallRemovesManifest() throws {
+        try NativeMessagingInstaller.installChromeManifest(
+            helperBinaryPath: helperBinaryUrl,
+            extensionId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            homeDirectory: mockHome,
+            fileManager: .default
+        )
+
+        let manifestUrl = NativeMessagingInstaller
+            .manifestDirectory(under: mockHome)
+            .appendingPathComponent("com.vellum.daemon.json")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: manifestUrl.path))
+
+        try NativeMessagingInstaller.uninstallChromeManifest(
+            homeDirectory: mockHome,
+            fileManager: .default
+        )
+
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: manifestUrl.path),
+            "manifest should be removed after uninstall"
+        )
+    }
+
+    func testUninstallIsNoOpWhenManifestMissing() {
+        // Precondition: no install happened, so no manifest on disk.
+        let manifestUrl = NativeMessagingInstaller
+            .manifestDirectory(under: mockHome)
+            .appendingPathComponent("com.vellum.daemon.json")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: manifestUrl.path))
+
+        XCTAssertNoThrow(
+            try NativeMessagingInstaller.uninstallChromeManifest(
+                homeDirectory: mockHome,
+                fileManager: .default
+            )
+        )
+    }
+
+    // MARK: - manifestDirectory
+
+    func testManifestDirectoryMatchesChromeExpectedLayout() {
+        let dir = NativeMessagingInstaller.manifestDirectory(under: mockHome)
+        let relative = dir.path.replacingOccurrences(of: mockHome.path, with: "")
+
+        // Chrome's documented location for per-user native messaging
+        // host manifests on macOS. Any drift from this layout will
+        // break `chrome.runtime.connectNative("com.vellum.daemon")`.
+        XCTAssertEqual(
+            relative,
+            "/Library/Application Support/Google/Chrome/NativeMessagingHosts"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Ships the Chrome native messaging host manifest (com.vellum.daemon.json) at macOS install time with allowed_origins pinned to Vellum's extension id
- Bundles the PR 7 native helper binary into the Mac app and points the manifest at its auxiliary executable path
- New NativeMessagingInstaller.swift with install + uninstall helpers and tempdir-based unit tests

Part of plan: host-browser-proxy-phase-2.md (PR 12 of 16)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
