### PR TITLE
feat(runtime): add /v1/browser-extension-pair capability token endpoint

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -75,6 +75,11 @@ import {
   mintPairingBearerToken,
   resolveSigningKey,
 } from "../runtime/auth/token-service.js";
+import {
+  initCapabilityTokenSecret,
+  loadOrCreateCapabilityTokenSecret,
+  writeDaemonTokenFallback,
+} from "../runtime/capability-tokens.js";
 import { ensureVellumGuardianBinding } from "../runtime/guardian-vellum-migration.js";
 import { RuntimeHttpServer } from "../runtime/http-server.js";
 import { startScheduler } from "../schedule/scheduler.js";
@@ -270,6 +275,20 @@ export async function runDaemon(): Promise<void> {
     const signingKey = resolveSigningKey();
     initAuthSigningKey(signingKey);
 
+    // Load (or generate + persist) the capability-token HMAC secret used
+    // to mint scoped tokens for the chrome extension pair endpoint.
+    // Wrapped in try/catch so a disk failure here never blocks startup —
+    // tokens can still be minted using a lazy on-demand load inside the
+    // capability-tokens module.
+    try {
+      initCapabilityTokenSecret(loadOrCreateCapabilityTokenSecret());
+    } catch (err) {
+      log.warn(
+        { err },
+        "Failed to pre-load capability token secret — continuing startup (lazy load will handle subsequent calls)",
+      );
+    }
+
     // Pre-populate the feature flag cache from the gateway so all
     // subsequent sync isAssistantFeatureFlagEnabled() calls have data.
     // Fired non-blocking so a slow or unreachable gateway doesn't delay
@@ -432,12 +451,28 @@ export async function runDaemon(): Promise<void> {
 
       // Ensure a vellum guardian binding exists so the identity system works
       // without requiring a manual bootstrap step.
+      let localGuardianPrincipalId = "local";
       try {
-        ensureVellumGuardianBinding(DAEMON_INTERNAL_ASSISTANT_ID);
+        localGuardianPrincipalId = ensureVellumGuardianBinding(
+          DAEMON_INTERNAL_ASSISTANT_ID,
+        );
       } catch (err) {
         log.warn(
           { err },
           "Vellum guardian binding backfill failed — continuing startup",
+        );
+      }
+
+      // Write a dev-only fallback capability token to `~/.vellum/daemon-token`
+      // so developers can manually pair the chrome extension without the
+      // native messaging helper. Production pairing goes through
+      // `POST /v1/browser-extension-pair` via the native helper.
+      try {
+        writeDaemonTokenFallback(localGuardianPrincipalId);
+      } catch (err) {
+        log.warn(
+          { err },
+          "Failed to write dev daemon-token fallback — continuing startup",
         );
       }
 

--- a/assistant/src/runtime/__tests__/browser-extension-pair-routes.test.ts
+++ b/assistant/src/runtime/__tests__/browser-extension-pair-routes.test.ts
@@ -91,7 +91,9 @@ describe("handleBrowserExtensionPair", () => {
   test("rejects non-POST methods with 405", async () => {
     const req = buildRequest({
       method: "GET",
-      body: { extensionOrigin: "chrome-extension://fakedevid/" },
+      body: {
+        extensionOrigin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
+      },
     });
     const res = await handleBrowserExtensionPair(req, loopbackServer);
     expect(res.status).toBe(405);
@@ -99,7 +101,9 @@ describe("handleBrowserExtensionPair", () => {
 
   test("rejects non-loopback peer with 403", async () => {
     const req = buildRequest({
-      body: { extensionOrigin: "chrome-extension://fakedevid/" },
+      body: {
+        extensionOrigin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
+      },
     });
     const res = await handleBrowserExtensionPair(req, publicPeerServer);
     expect(res.status).toBe(403);
@@ -107,7 +111,9 @@ describe("handleBrowserExtensionPair", () => {
 
   test("rejects LAN peer (not loopback) with 403", async () => {
     const req = buildRequest({
-      body: { extensionOrigin: "chrome-extension://fakedevid/" },
+      body: {
+        extensionOrigin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
+      },
     });
     const res = await handleBrowserExtensionPair(req, lanPeerServer);
     expect(res.status).toBe(403);
@@ -115,7 +121,9 @@ describe("handleBrowserExtensionPair", () => {
 
   test("rejects request with non-loopback Host header", async () => {
     const req = buildRequest({
-      body: { extensionOrigin: "chrome-extension://fakedevid/" },
+      body: {
+        extensionOrigin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
+      },
       host: "vellum.example.com",
     });
     const res = await handleBrowserExtensionPair(req, loopbackServer);
@@ -124,7 +132,9 @@ describe("handleBrowserExtensionPair", () => {
 
   test("rejects request with x-forwarded-for header", async () => {
     const req = buildRequest({
-      body: { extensionOrigin: "chrome-extension://fakedevid/" },
+      body: {
+        extensionOrigin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
+      },
       forwardedFor: "1.2.3.4",
     });
     const res = await handleBrowserExtensionPair(req, loopbackServer);
@@ -171,7 +181,9 @@ describe("handleBrowserExtensionPair", () => {
 
   test("returns 200 with a valid token for the preferred extensionOrigin field", async () => {
     const req = buildRequest({
-      body: { extensionOrigin: "chrome-extension://fakedevid/" },
+      body: {
+        extensionOrigin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
+      },
     });
     const res = await handleBrowserExtensionPair(req, loopbackServer);
     expect(res.status).toBe(200);
@@ -210,7 +222,7 @@ describe("handleBrowserExtensionPair", () => {
 
   test("returns 200 using the legacy `origin` field for backwards compat", async () => {
     const req = buildRequest({
-      body: { origin: "chrome-extension://fakedevid/" },
+      body: { origin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/" },
     });
     const res = await handleBrowserExtensionPair(req, loopbackServer);
     expect(res.status).toBe(200);
@@ -227,7 +239,7 @@ describe("handleBrowserExtensionPair", () => {
     // request must succeed because we honor `extensionOrigin` first.
     const req = buildRequest({
       body: {
-        extensionOrigin: "chrome-extension://fakedevid/",
+        extensionOrigin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
         origin: "chrome-extension://not-allowed/",
       },
     });
@@ -248,7 +260,10 @@ describe("handleBrowserExtensionPair", () => {
     ];
     for (const host of variants) {
       const req = buildRequest({
-        body: { extensionOrigin: "chrome-extension://fakedevid/" },
+        body: {
+          extensionOrigin:
+            "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
+        },
         host,
       });
       const res = await handleBrowserExtensionPair(req, loopbackServer);
@@ -258,8 +273,25 @@ describe("handleBrowserExtensionPair", () => {
 
   test("rejects malformed bracketed Host header", async () => {
     const req = buildRequest({
-      body: { extensionOrigin: "chrome-extension://fakedevid/" },
+      body: {
+        extensionOrigin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
+      },
       host: "[::1", // missing closing bracket
+    });
+    const res = await handleBrowserExtensionPair(req, loopbackServer);
+    expect(res.status).toBe(403);
+  });
+
+  test("rejects bracketed Host header with junk after closing bracket", async () => {
+    // Defensive against `[::1]attacker.com`-style injection: the parser
+    // used to silently truncate at the first `]` and treat the rest as
+    // the hostname, which would let an attacker spoof a non-loopback
+    // host while still passing the loopback Host header check.
+    const req = buildRequest({
+      body: {
+        extensionOrigin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
+      },
+      host: "[::1]attacker.com",
     });
     const res = await handleBrowserExtensionPair(req, loopbackServer);
     expect(res.status).toBe(403);
@@ -267,7 +299,9 @@ describe("handleBrowserExtensionPair", () => {
 
   test("rejects non-loopback IPv6 Host header", async () => {
     const req = buildRequest({
-      body: { extensionOrigin: "chrome-extension://fakedevid/" },
+      body: {
+        extensionOrigin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
+      },
       host: "[2001:db8::1]:8765",
     });
     const res = await handleBrowserExtensionPair(req, loopbackServer);
@@ -284,11 +318,18 @@ describe("handleBrowserExtensionPair", () => {
     expect(parseHostHeader("[2001:db8::1]:443")).toBe("2001:db8::1");
     expect(parseHostHeader("[::1")).toBeNull();
     expect(parseHostHeader("")).toBeNull();
+    // Anything after the closing bracket that isn't an optional ":port"
+    // must be rejected — otherwise `[::1]attacker.com` would slip past
+    // the loopback check by parsing as `::1`.
+    expect(parseHostHeader("[::1]attacker.com")).toBeNull();
+    expect(parseHostHeader("[::1]extra")).toBeNull();
   });
 
   test("tampered tokens fail verification", async () => {
     const req = buildRequest({
-      body: { extensionOrigin: "chrome-extension://fakedevid/" },
+      body: {
+        extensionOrigin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
+      },
     });
     const res = await handleBrowserExtensionPair(req, loopbackServer);
     expect(res.status).toBe(200);
@@ -310,7 +351,9 @@ describe("handleBrowserExtensionPair", () => {
   test("tokens minted with a different secret fail verification", async () => {
     // Mint a token, then swap the secret — verification should fail.
     const req = buildRequest({
-      body: { extensionOrigin: "chrome-extension://fakedevid/" },
+      body: {
+        extensionOrigin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
+      },
     });
     const res = await handleBrowserExtensionPair(req, loopbackServer);
     expect(res.status).toBe(200);
@@ -323,7 +366,9 @@ describe("handleBrowserExtensionPair", () => {
 
   test("rejects tampered payload even with matching signature length", async () => {
     const req = buildRequest({
-      body: { extensionOrigin: "chrome-extension://fakedevid/" },
+      body: {
+        extensionOrigin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
+      },
     });
     const res = await handleBrowserExtensionPair(req, loopbackServer);
     expect(res.status).toBe(200);

--- a/assistant/src/runtime/__tests__/browser-extension-pair-routes.test.ts
+++ b/assistant/src/runtime/__tests__/browser-extension-pair-routes.test.ts
@@ -3,8 +3,13 @@
  *
  * Covers:
  *   - Method/host/origin enforcement (405, 403, 400, 401)
- *   - Successful mint on allowed origin (200)
- *   - Issued token round-trips through verifyHostBrowserCapability
+ *   - Successful mint on allowed origin (200) for both the preferred
+ *     `extensionOrigin` body field and the legacy `origin` alias
+ *   - `expiresAt` response field is an ISO 8601 string matching what the
+ *     native messaging helper validates
+ *   - IPv6 loopback `Host` header variants (bracketed and bare) are
+ *     accepted
+ *   - Issued token round-trips through `verifyHostBrowserCapability`
  *   - Tampered tokens fail verification
  */
 
@@ -16,7 +21,10 @@ import {
   setCapabilityTokenSecretForTests,
   verifyHostBrowserCapability,
 } from "../capability-tokens.js";
-import { handleBrowserExtensionPair } from "../routes/browser-extension-pair-routes.js";
+import {
+  handleBrowserExtensionPair,
+  parseHostHeader,
+} from "../routes/browser-extension-pair-routes.js";
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -83,7 +91,7 @@ describe("handleBrowserExtensionPair", () => {
   test("rejects non-POST methods with 405", async () => {
     const req = buildRequest({
       method: "GET",
-      body: { origin: "chrome-extension://fakedevid/" },
+      body: { extensionOrigin: "chrome-extension://fakedevid/" },
     });
     const res = await handleBrowserExtensionPair(req, loopbackServer);
     expect(res.status).toBe(405);
@@ -91,7 +99,7 @@ describe("handleBrowserExtensionPair", () => {
 
   test("rejects non-loopback peer with 403", async () => {
     const req = buildRequest({
-      body: { origin: "chrome-extension://fakedevid/" },
+      body: { extensionOrigin: "chrome-extension://fakedevid/" },
     });
     const res = await handleBrowserExtensionPair(req, publicPeerServer);
     expect(res.status).toBe(403);
@@ -99,7 +107,7 @@ describe("handleBrowserExtensionPair", () => {
 
   test("rejects LAN peer (not loopback) with 403", async () => {
     const req = buildRequest({
-      body: { origin: "chrome-extension://fakedevid/" },
+      body: { extensionOrigin: "chrome-extension://fakedevid/" },
     });
     const res = await handleBrowserExtensionPair(req, lanPeerServer);
     expect(res.status).toBe(403);
@@ -107,7 +115,7 @@ describe("handleBrowserExtensionPair", () => {
 
   test("rejects request with non-loopback Host header", async () => {
     const req = buildRequest({
-      body: { origin: "chrome-extension://fakedevid/" },
+      body: { extensionOrigin: "chrome-extension://fakedevid/" },
       host: "vellum.example.com",
     });
     const res = await handleBrowserExtensionPair(req, loopbackServer);
@@ -116,7 +124,7 @@ describe("handleBrowserExtensionPair", () => {
 
   test("rejects request with x-forwarded-for header", async () => {
     const req = buildRequest({
-      body: { origin: "chrome-extension://fakedevid/" },
+      body: { extensionOrigin: "chrome-extension://fakedevid/" },
       forwardedFor: "1.2.3.4",
     });
     const res = await handleBrowserExtensionPair(req, loopbackServer);
@@ -135,43 +143,59 @@ describe("handleBrowserExtensionPair", () => {
     expect(res.status).toBe(400);
   });
 
-  test("returns 400 when origin is missing", async () => {
+  test("returns 400 when extensionOrigin is missing", async () => {
     const req = buildRequest({ body: {} });
     const res = await handleBrowserExtensionPair(req, loopbackServer);
     expect(res.status).toBe(400);
   });
 
-  test("returns 400 when origin is not a string", async () => {
+  test("returns 400 when extensionOrigin is not a string", async () => {
+    const req = buildRequest({ body: { extensionOrigin: 42 } });
+    const res = await handleBrowserExtensionPair(req, loopbackServer);
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 400 when legacy origin field is not a string", async () => {
     const req = buildRequest({ body: { origin: 42 } });
     const res = await handleBrowserExtensionPair(req, loopbackServer);
     expect(res.status).toBe(400);
   });
 
-  test("returns 401 when origin is not on the allowlist", async () => {
+  test("returns 401 when extensionOrigin is not on the allowlist", async () => {
     const req = buildRequest({
-      body: { origin: "chrome-extension://not-allowed/" },
+      body: { extensionOrigin: "chrome-extension://not-allowed/" },
     });
     const res = await handleBrowserExtensionPair(req, loopbackServer);
     expect(res.status).toBe(401);
   });
 
-  test("returns 200 with a valid token for an allowed origin", async () => {
+  test("returns 200 with a valid token for the preferred extensionOrigin field", async () => {
     const req = buildRequest({
-      body: { origin: "chrome-extension://fakedevid/" },
+      body: { extensionOrigin: "chrome-extension://fakedevid/" },
     });
     const res = await handleBrowserExtensionPair(req, loopbackServer);
     expect(res.status).toBe(200);
 
     const payload = (await res.json()) as {
       token: string;
-      expiresAt: number;
+      expiresAt: string;
       guardianId: string;
     };
 
     expect(typeof payload.token).toBe("string");
     expect(payload.token.length).toBeGreaterThan(0);
-    expect(typeof payload.expiresAt).toBe("number");
-    expect(payload.expiresAt).toBeGreaterThan(Date.now());
+
+    // expiresAt must be an ISO 8601 string (matching what the
+    // chrome-extension-native-host helper validates) and must be in
+    // the future.
+    expect(typeof payload.expiresAt).toBe("string");
+    expect(payload.expiresAt).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+    );
+    const expiresAtMs = Date.parse(payload.expiresAt);
+    expect(Number.isNaN(expiresAtMs)).toBe(false);
+    expect(expiresAtMs).toBeGreaterThan(Date.now());
+
     expect(typeof payload.guardianId).toBe("string");
     expect(payload.guardianId.length).toBeGreaterThan(0);
 
@@ -180,7 +204,35 @@ describe("handleBrowserExtensionPair", () => {
     expect(claims).not.toBeNull();
     expect(claims?.capability).toBe("host_browser_command");
     expect(claims?.guardianId).toBe(payload.guardianId);
-    expect(claims?.expiresAt).toBe(payload.expiresAt);
+    // The numeric claim expiry should match the ISO response field.
+    expect(claims?.expiresAt).toBe(expiresAtMs);
+  });
+
+  test("returns 200 using the legacy `origin` field for backwards compat", async () => {
+    const req = buildRequest({
+      body: { origin: "chrome-extension://fakedevid/" },
+    });
+    const res = await handleBrowserExtensionPair(req, loopbackServer);
+    expect(res.status).toBe(200);
+    const payload = (await res.json()) as {
+      token: string;
+      expiresAt: string;
+    };
+    expect(typeof payload.token).toBe("string");
+    expect(typeof payload.expiresAt).toBe("string");
+  });
+
+  test("prefers extensionOrigin over legacy origin when both are provided", async () => {
+    // extensionOrigin is on the allowlist, `origin` is not — so the
+    // request must succeed because we honor `extensionOrigin` first.
+    const req = buildRequest({
+      body: {
+        extensionOrigin: "chrome-extension://fakedevid/",
+        origin: "chrome-extension://not-allowed/",
+      },
+    });
+    const res = await handleBrowserExtensionPair(req, loopbackServer);
+    expect(res.status).toBe(200);
   });
 
   test("accepts loopback Host header variants", async () => {
@@ -189,10 +241,14 @@ describe("handleBrowserExtensionPair", () => {
       "127.0.0.1:8765",
       "127.0.0.1",
       "localhost",
+      "127.1.2.3:8765",
+      "[::1]:8765",
+      "[::1]",
+      "::1",
     ];
     for (const host of variants) {
       const req = buildRequest({
-        body: { origin: "chrome-extension://fakedevid/" },
+        body: { extensionOrigin: "chrome-extension://fakedevid/" },
         host,
       });
       const res = await handleBrowserExtensionPair(req, loopbackServer);
@@ -200,9 +256,39 @@ describe("handleBrowserExtensionPair", () => {
     }
   });
 
+  test("rejects malformed bracketed Host header", async () => {
+    const req = buildRequest({
+      body: { extensionOrigin: "chrome-extension://fakedevid/" },
+      host: "[::1", // missing closing bracket
+    });
+    const res = await handleBrowserExtensionPair(req, loopbackServer);
+    expect(res.status).toBe(403);
+  });
+
+  test("rejects non-loopback IPv6 Host header", async () => {
+    const req = buildRequest({
+      body: { extensionOrigin: "chrome-extension://fakedevid/" },
+      host: "[2001:db8::1]:8765",
+    });
+    const res = await handleBrowserExtensionPair(req, loopbackServer);
+    expect(res.status).toBe(403);
+  });
+
+  test("parseHostHeader handles IPv4, IPv6, and bracketed forms", () => {
+    expect(parseHostHeader("localhost:8765")).toBe("localhost");
+    expect(parseHostHeader("127.0.0.1:8765")).toBe("127.0.0.1");
+    expect(parseHostHeader("127.0.0.1")).toBe("127.0.0.1");
+    expect(parseHostHeader("[::1]:8765")).toBe("::1");
+    expect(parseHostHeader("[::1]")).toBe("::1");
+    expect(parseHostHeader("::1")).toBe("::1");
+    expect(parseHostHeader("[2001:db8::1]:443")).toBe("2001:db8::1");
+    expect(parseHostHeader("[::1")).toBeNull();
+    expect(parseHostHeader("")).toBeNull();
+  });
+
   test("tampered tokens fail verification", async () => {
     const req = buildRequest({
-      body: { origin: "chrome-extension://fakedevid/" },
+      body: { extensionOrigin: "chrome-extension://fakedevid/" },
     });
     const res = await handleBrowserExtensionPair(req, loopbackServer);
     expect(res.status).toBe(200);
@@ -224,7 +310,7 @@ describe("handleBrowserExtensionPair", () => {
   test("tokens minted with a different secret fail verification", async () => {
     // Mint a token, then swap the secret — verification should fail.
     const req = buildRequest({
-      body: { origin: "chrome-extension://fakedevid/" },
+      body: { extensionOrigin: "chrome-extension://fakedevid/" },
     });
     const res = await handleBrowserExtensionPair(req, loopbackServer);
     expect(res.status).toBe(200);
@@ -237,7 +323,7 @@ describe("handleBrowserExtensionPair", () => {
 
   test("rejects tampered payload even with matching signature length", async () => {
     const req = buildRequest({
-      body: { origin: "chrome-extension://fakedevid/" },
+      body: { extensionOrigin: "chrome-extension://fakedevid/" },
     });
     const res = await handleBrowserExtensionPair(req, loopbackServer);
     expect(res.status).toBe(200);

--- a/assistant/src/runtime/__tests__/browser-extension-pair-routes.test.ts
+++ b/assistant/src/runtime/__tests__/browser-extension-pair-routes.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Tests for the /v1/browser-extension-pair capability-token pair endpoint.
+ *
+ * Covers:
+ *   - Method/host/origin enforcement (405, 403, 400, 401)
+ *   - Successful mint on allowed origin (200)
+ *   - Issued token round-trips through verifyHostBrowserCapability
+ *   - Tampered tokens fail verification
+ */
+
+import { randomBytes } from "node:crypto";
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  resetCapabilityTokenSecretForTests,
+  setCapabilityTokenSecretForTests,
+  verifyHostBrowserCapability,
+} from "../capability-tokens.js";
+import { handleBrowserExtensionPair } from "../routes/browser-extension-pair-routes.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+type ServerWithRequestIP = {
+  requestIP(
+    req: Request,
+  ): { address: string; family: string; port: number } | null;
+};
+
+function mockServer(address: string): ServerWithRequestIP {
+  return {
+    requestIP: () => ({ address, family: "IPv4", port: 0 }),
+  };
+}
+
+const loopbackServer = mockServer("127.0.0.1");
+const lanPeerServer = mockServer("192.168.1.10");
+const publicPeerServer = mockServer("203.0.113.50");
+
+function buildRequest(
+  options: {
+    method?: string;
+    body?: unknown;
+    host?: string | null;
+    origin?: string;
+    forwardedFor?: string;
+    rawBody?: string;
+  } = {},
+): Request {
+  const headers = new Headers();
+  if (options.host !== null) {
+    headers.set("host", options.host ?? "127.0.0.1:8765");
+  }
+  if (options.forwardedFor) {
+    headers.set("x-forwarded-for", options.forwardedFor);
+  }
+  let bodyStr: string | undefined;
+  if (options.rawBody !== undefined) {
+    bodyStr = options.rawBody;
+    headers.set("content-type", "application/json");
+  } else if (options.body !== undefined) {
+    bodyStr = JSON.stringify(options.body);
+    headers.set("content-type", "application/json");
+  }
+  return new Request("http://127.0.0.1:8765/v1/browser-extension-pair", {
+    method: options.method ?? "POST",
+    headers,
+    body: bodyStr,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("handleBrowserExtensionPair", () => {
+  beforeEach(() => {
+    resetCapabilityTokenSecretForTests();
+    setCapabilityTokenSecretForTests(randomBytes(32));
+  });
+
+  test("rejects non-POST methods with 405", async () => {
+    const req = buildRequest({
+      method: "GET",
+      body: { origin: "chrome-extension://fakedevid/" },
+    });
+    const res = await handleBrowserExtensionPair(req, loopbackServer);
+    expect(res.status).toBe(405);
+  });
+
+  test("rejects non-loopback peer with 403", async () => {
+    const req = buildRequest({
+      body: { origin: "chrome-extension://fakedevid/" },
+    });
+    const res = await handleBrowserExtensionPair(req, publicPeerServer);
+    expect(res.status).toBe(403);
+  });
+
+  test("rejects LAN peer (not loopback) with 403", async () => {
+    const req = buildRequest({
+      body: { origin: "chrome-extension://fakedevid/" },
+    });
+    const res = await handleBrowserExtensionPair(req, lanPeerServer);
+    expect(res.status).toBe(403);
+  });
+
+  test("rejects request with non-loopback Host header", async () => {
+    const req = buildRequest({
+      body: { origin: "chrome-extension://fakedevid/" },
+      host: "vellum.example.com",
+    });
+    const res = await handleBrowserExtensionPair(req, loopbackServer);
+    expect(res.status).toBe(403);
+  });
+
+  test("rejects request with x-forwarded-for header", async () => {
+    const req = buildRequest({
+      body: { origin: "chrome-extension://fakedevid/" },
+      forwardedFor: "1.2.3.4",
+    });
+    const res = await handleBrowserExtensionPair(req, loopbackServer);
+    expect(res.status).toBe(403);
+  });
+
+  test("returns 400 when body is missing", async () => {
+    const req = buildRequest({});
+    const res = await handleBrowserExtensionPair(req, loopbackServer);
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 400 when body is malformed JSON", async () => {
+    const req = buildRequest({ rawBody: "{not json" });
+    const res = await handleBrowserExtensionPair(req, loopbackServer);
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 400 when origin is missing", async () => {
+    const req = buildRequest({ body: {} });
+    const res = await handleBrowserExtensionPair(req, loopbackServer);
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 400 when origin is not a string", async () => {
+    const req = buildRequest({ body: { origin: 42 } });
+    const res = await handleBrowserExtensionPair(req, loopbackServer);
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 401 when origin is not on the allowlist", async () => {
+    const req = buildRequest({
+      body: { origin: "chrome-extension://not-allowed/" },
+    });
+    const res = await handleBrowserExtensionPair(req, loopbackServer);
+    expect(res.status).toBe(401);
+  });
+
+  test("returns 200 with a valid token for an allowed origin", async () => {
+    const req = buildRequest({
+      body: { origin: "chrome-extension://fakedevid/" },
+    });
+    const res = await handleBrowserExtensionPair(req, loopbackServer);
+    expect(res.status).toBe(200);
+
+    const payload = (await res.json()) as {
+      token: string;
+      expiresAt: number;
+      guardianId: string;
+    };
+
+    expect(typeof payload.token).toBe("string");
+    expect(payload.token.length).toBeGreaterThan(0);
+    expect(typeof payload.expiresAt).toBe("number");
+    expect(payload.expiresAt).toBeGreaterThan(Date.now());
+    expect(typeof payload.guardianId).toBe("string");
+    expect(payload.guardianId.length).toBeGreaterThan(0);
+
+    // Token should round-trip through verifyHostBrowserCapability.
+    const claims = verifyHostBrowserCapability(payload.token);
+    expect(claims).not.toBeNull();
+    expect(claims?.capability).toBe("host_browser_command");
+    expect(claims?.guardianId).toBe(payload.guardianId);
+    expect(claims?.expiresAt).toBe(payload.expiresAt);
+  });
+
+  test("accepts loopback Host header variants", async () => {
+    const variants = [
+      "localhost:8765",
+      "127.0.0.1:8765",
+      "127.0.0.1",
+      "localhost",
+    ];
+    for (const host of variants) {
+      const req = buildRequest({
+        body: { origin: "chrome-extension://fakedevid/" },
+        host,
+      });
+      const res = await handleBrowserExtensionPair(req, loopbackServer);
+      expect(res.status).toBe(200);
+    }
+  });
+
+  test("tampered tokens fail verification", async () => {
+    const req = buildRequest({
+      body: { origin: "chrome-extension://fakedevid/" },
+    });
+    const res = await handleBrowserExtensionPair(req, loopbackServer);
+    expect(res.status).toBe(200);
+
+    const payload = (await res.json()) as { token: string };
+    const originalToken = payload.token;
+
+    // Modify the signature: flip the last character.
+    const [head, sig] = originalToken.split(".");
+    const lastChar = sig.slice(-1);
+    const replacement = lastChar === "A" ? "B" : "A";
+    const tamperedToken = `${head}.${sig.slice(0, -1)}${replacement}`;
+
+    expect(verifyHostBrowserCapability(tamperedToken)).toBeNull();
+    // The original token should still verify.
+    expect(verifyHostBrowserCapability(originalToken)).not.toBeNull();
+  });
+
+  test("tokens minted with a different secret fail verification", async () => {
+    // Mint a token, then swap the secret — verification should fail.
+    const req = buildRequest({
+      body: { origin: "chrome-extension://fakedevid/" },
+    });
+    const res = await handleBrowserExtensionPair(req, loopbackServer);
+    expect(res.status).toBe(200);
+    const payload = (await res.json()) as { token: string };
+
+    // Swap secret and re-verify.
+    setCapabilityTokenSecretForTests(randomBytes(32));
+    expect(verifyHostBrowserCapability(payload.token)).toBeNull();
+  });
+
+  test("rejects tampered payload even with matching signature length", async () => {
+    const req = buildRequest({
+      body: { origin: "chrome-extension://fakedevid/" },
+    });
+    const res = await handleBrowserExtensionPair(req, loopbackServer);
+    expect(res.status).toBe(200);
+    const payload = (await res.json()) as { token: string };
+    const [head, sig] = payload.token.split(".");
+
+    // Swap the payload for a different base64url value of equivalent shape.
+    const bogusPayload = Buffer.from(
+      JSON.stringify({
+        capability: "host_browser_command",
+        guardianId: "attacker",
+        nonce: "00".repeat(16),
+        expiresAt: Date.now() + 60_000,
+      }),
+      "utf8",
+    )
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+
+    const tampered = `${bogusPayload}.${sig}`;
+    // Keep `head` referenced so the test reads naturally even though we
+    // do not use it after tampering.
+    expect(head).toBeTruthy();
+    expect(verifyHostBrowserCapability(tampered)).toBeNull();
+  });
+});

--- a/assistant/src/runtime/auth/__tests__/guard-tests.test.ts
+++ b/assistant/src/runtime/auth/__tests__/guard-tests.test.ts
@@ -63,6 +63,7 @@ describe("route policy coverage", () => {
     // excluded because they are handled before JWT auth and are not composed
     // into buildRouteTable().
     const PRE_AUTH_ROUTE_MODULES = new Set([
+      "browser-extension-pair-routes.ts",
       "guardian-bootstrap-routes.ts",
       "guardian-refresh-routes.ts",
     ]);

--- a/assistant/src/runtime/capability-tokens.ts
+++ b/assistant/src/runtime/capability-tokens.ts
@@ -6,8 +6,10 @@
  * Design:
  *   - Tokens are HMAC-SHA256 signed over a JSON claims payload.
  *   - Claims include a bound capability, guardian id, nonce, and expiry.
- *   - Signing uses a long-lived random secret persisted to the workspace
- *     data dir with 0600 permissions (mirrors `token-service.ts` pattern).
+ *   - Signing uses a long-lived random secret persisted to
+ *     `~/.vellum/protected/` with 0600 permissions. The protected
+ *     directory sits outside the workspace per AGENTS.md: workspace
+ *     directories must not hold security-sensitive material.
  *   - The secret is generated once on first launch and reused across
  *     subsequent daemon restarts so previously-minted tokens still verify.
  *   - Tests inject their own secret via `setCapabilityTokenSecretForTests`.
@@ -22,13 +24,14 @@ import {
   mkdirSync,
   readFileSync,
   renameSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
 import { getLogger } from "../util/logger.js";
-import { getDataDir } from "../util/platform.js";
+import { getDataDir, getProtectedDir } from "../util/platform.js";
 
 const log = getLogger("capability-tokens");
 
@@ -62,10 +65,24 @@ export interface CapabilityToken {
 let _secret: Buffer | undefined;
 
 /**
- * Returns the path where the capability-token secret is persisted.
- * Lives alongside other runtime-generated keys under workspace/data.
+ * Returns the canonical path where the capability-token secret is
+ * persisted: `~/.vellum/protected/capability-token-secret`. The protected
+ * directory is the canonical location for security-sensitive material
+ * and sits outside the workspace (which AGENTS.md forbids for secrets).
  */
 function getSecretPath(): string {
+  return join(getProtectedDir(), "capability-token-secret");
+}
+
+/**
+ * Legacy path under `workspace/data/` where earlier builds persisted the
+ * capability-token secret. We keep this as a read-only migration source
+ * so existing deployments don't regenerate their secret (and invalidate
+ * every outstanding token) on upgrade — the first launch after the
+ * upgrade copies the legacy file into `getProtectedDir()` and removes it
+ * from the workspace.
+ */
+function getLegacySecretPath(): string {
   return join(getDataDir(), "capability-token-secret");
 }
 
@@ -73,6 +90,10 @@ function getSecretPath(): string {
  * Load the capability-token secret from disk or generate and persist a new
  * one. Atomically writes with mode 0o600 so the secret is not readable by
  * other users on the same host.
+ *
+ * Migration: if the secret exists only at the legacy workspace path, copy
+ * it into the protected directory and delete the workspace copy so we do
+ * not leave security-sensitive material inside `workspace/`.
  */
 export function loadOrCreateCapabilityTokenSecret(): Buffer {
   const keyPath = getSecretPath();
@@ -94,13 +115,32 @@ export function loadOrCreateCapabilityTokenSecret(): Buffer {
     }
   }
 
+  // Attempt to migrate a legacy workspace-directory secret before we
+  // generate a fresh one. If this succeeds we end up with the legacy
+  // secret persisted at the protected path and the workspace copy
+  // removed, preserving every outstanding token across the upgrade.
+  const migrated = migrateLegacyCapabilityTokenSecret();
+  if (migrated) {
+    return migrated;
+  }
+
   const fresh = randomBytes(32);
+  writeSecretAtomic(keyPath, fresh);
+  log.info("Capability token secret generated and persisted");
+  return fresh;
+}
+
+/**
+ * Write `secret` to `keyPath` atomically with mode 0o600. Ensures the
+ * parent directory exists.
+ */
+function writeSecretAtomic(keyPath: string, secret: Buffer): void {
   const dir = dirname(keyPath);
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }
   const tmpPath = `${keyPath}.tmp.${process.pid}`;
-  writeFileSync(tmpPath, fresh, { mode: 0o600 });
+  writeFileSync(tmpPath, secret, { mode: 0o600 });
   renameSync(tmpPath, keyPath);
   try {
     chmodSync(keyPath, 0o600);
@@ -110,8 +150,50 @@ export function loadOrCreateCapabilityTokenSecret(): Buffer {
       "Failed to chmod capability token secret after write",
     );
   }
-  log.info("Capability token secret generated and persisted");
-  return fresh;
+}
+
+/**
+ * If a pre-migration capability token secret exists under the workspace
+ * data directory, copy it into the protected directory and remove the
+ * workspace copy. Returns the migrated secret if migration ran
+ * successfully, or `undefined` if there was nothing to migrate or the
+ * migration failed.
+ */
+function migrateLegacyCapabilityTokenSecret(): Buffer | undefined {
+  const legacyPath = getLegacySecretPath();
+  if (!existsSync(legacyPath)) {
+    return undefined;
+  }
+  try {
+    const raw = readFileSync(legacyPath);
+    if (raw.length !== 32) {
+      log.warn(
+        { legacyPath, length: raw.length },
+        "legacy capability token secret has unexpected length — ignoring",
+      );
+      return undefined;
+    }
+    writeSecretAtomic(getSecretPath(), raw);
+    try {
+      unlinkSync(legacyPath);
+    } catch (err) {
+      log.warn(
+        { err, legacyPath },
+        "Failed to remove legacy workspace capability token secret after migration",
+      );
+    }
+    log.info(
+      { from: legacyPath, to: getSecretPath() },
+      "Migrated capability token secret out of workspace into protected directory",
+    );
+    return raw;
+  } catch (err) {
+    log.warn(
+      { err, legacyPath },
+      "Failed to migrate legacy capability token secret — regenerating",
+    );
+    return undefined;
+  }
 }
 
 /**

--- a/assistant/src/runtime/capability-tokens.ts
+++ b/assistant/src/runtime/capability-tokens.ts
@@ -1,0 +1,300 @@
+/**
+ * Capability token minting and verification for scoped, short-lived tokens
+ * issued to the chrome extension (and other thin clients) so they can submit
+ * results back to the runtime without a full guardian-bound JWT.
+ *
+ * Design:
+ *   - Tokens are HMAC-SHA256 signed over a JSON claims payload.
+ *   - Claims include a bound capability, guardian id, nonce, and expiry.
+ *   - Signing uses a long-lived random secret persisted to the workspace
+ *     data dir with 0600 permissions (mirrors `token-service.ts` pattern).
+ *   - The secret is generated once on first launch and reused across
+ *     subsequent daemon restarts so previously-minted tokens still verify.
+ *   - Tests inject their own secret via `setCapabilityTokenSecretForTests`.
+ *
+ * The encoded token format is `<base64url(payload)>.<base64url(sig)>`.
+ */
+
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { getLogger } from "../util/logger.js";
+import { getDataDir } from "../util/platform.js";
+
+const log = getLogger("capability-tokens");
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Capability identifiers that can be bound to a capability token. */
+export type Capability = "host_browser_command";
+
+/** Claims encoded in the signed payload. */
+export interface CapabilityClaims {
+  capability: Capability;
+  guardianId: string;
+  /** 16-byte random nonce, hex-encoded. Prevents replay across fresh mints. */
+  nonce: string;
+  /** ms-since-epoch expiry. */
+  expiresAt: number;
+}
+
+/** A freshly-minted capability token and its absolute expiry. */
+export interface CapabilityToken {
+  token: string;
+  expiresAt: number;
+}
+
+// ---------------------------------------------------------------------------
+// Secret lifecycle
+// ---------------------------------------------------------------------------
+
+let _secret: Buffer | undefined;
+
+/**
+ * Returns the path where the capability-token secret is persisted.
+ * Lives alongside other runtime-generated keys under workspace/data.
+ */
+function getSecretPath(): string {
+  return join(getDataDir(), "capability-token-secret");
+}
+
+/**
+ * Load the capability-token secret from disk or generate and persist a new
+ * one. Atomically writes with mode 0o600 so the secret is not readable by
+ * other users on the same host.
+ */
+export function loadOrCreateCapabilityTokenSecret(): Buffer {
+  const keyPath = getSecretPath();
+  if (existsSync(keyPath)) {
+    try {
+      const raw = readFileSync(keyPath);
+      if (raw.length === 32) {
+        return raw;
+      }
+      log.warn(
+        { keyPath, length: raw.length },
+        "capability token secret has unexpected length — regenerating",
+      );
+    } catch (err) {
+      log.warn(
+        { err, keyPath },
+        "Failed to read capability token secret — regenerating",
+      );
+    }
+  }
+
+  const fresh = randomBytes(32);
+  const dir = dirname(keyPath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  const tmpPath = `${keyPath}.tmp.${process.pid}`;
+  writeFileSync(tmpPath, fresh, { mode: 0o600 });
+  renameSync(tmpPath, keyPath);
+  try {
+    chmodSync(keyPath, 0o600);
+  } catch (err) {
+    log.warn(
+      { err, keyPath },
+      "Failed to chmod capability token secret after write",
+    );
+  }
+  log.info("Capability token secret generated and persisted");
+  return fresh;
+}
+
+/**
+ * Initialize the module-level secret. Called once at daemon startup. Safe
+ * to call multiple times — subsequent calls overwrite the cached value
+ * (useful in tests that reset state).
+ */
+export function initCapabilityTokenSecret(secret: Buffer): void {
+  if (secret.length !== 32) {
+    throw new Error(
+      `capability token secret must be 32 bytes, got ${secret.length}`,
+    );
+  }
+  _secret = secret;
+}
+
+/**
+ * Test-only helper to inject a deterministic secret.
+ */
+export function setCapabilityTokenSecretForTests(secret: Buffer): void {
+  _secret = secret;
+}
+
+/**
+ * Reset the cached secret. Test-only — exposed so test isolation can
+ * force a reload from disk.
+ */
+export function resetCapabilityTokenSecretForTests(): void {
+  _secret = undefined;
+}
+
+function getSecret(): Buffer {
+  if (_secret) return _secret;
+  if (process.env.NODE_ENV === "test") {
+    _secret = randomBytes(32);
+    return _secret;
+  }
+  // Lazy load — daemon startup is expected to call
+  // `initCapabilityTokenSecret(loadOrCreateCapabilityTokenSecret())` but
+  // we fall back to a disk load here so unit tests and early call sites
+  // don't have to depend on startup ordering.
+  _secret = loadOrCreateCapabilityTokenSecret();
+  return _secret;
+}
+
+// ---------------------------------------------------------------------------
+// Mint / verify
+// ---------------------------------------------------------------------------
+
+const DEFAULT_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+function base64urlEncode(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function base64urlDecode(s: string): Buffer {
+  const pad = s.length % 4 === 0 ? 0 : 4 - (s.length % 4);
+  const b64 = s.replace(/-/g, "+").replace(/_/g, "/") + "=".repeat(pad);
+  return Buffer.from(b64, "base64");
+}
+
+function sign(payload: string, secret: Buffer): string {
+  return base64urlEncode(createHmac("sha256", secret).update(payload).digest());
+}
+
+/**
+ * Mint a capability token bound to the `host_browser_command` capability
+ * for the given guardian id. Default TTL is 30 minutes.
+ */
+export function mintHostBrowserCapability(
+  guardianId: string,
+  ttlMs: number = DEFAULT_TTL_MS,
+): CapabilityToken {
+  const expiresAt = Date.now() + ttlMs;
+  const nonce = randomBytes(16).toString("hex");
+  const claims: CapabilityClaims = {
+    capability: "host_browser_command",
+    guardianId,
+    nonce,
+    expiresAt,
+  };
+  const payload = base64urlEncode(Buffer.from(JSON.stringify(claims), "utf8"));
+  const sig = sign(payload, getSecret());
+  return { token: `${payload}.${sig}`, expiresAt };
+}
+
+/**
+ * Verify a capability token. Returns the decoded claims on success or null
+ * if the signature is invalid, the payload is malformed, the token has
+ * expired, or the bound capability is not `host_browser_command`.
+ *
+ * Signature comparison uses `timingSafeEqual` to avoid leaking the secret
+ * through timing side channels.
+ */
+export function verifyHostBrowserCapability(
+  token: string,
+): CapabilityClaims | null {
+  if (typeof token !== "string") return null;
+  const dot = token.indexOf(".");
+  if (dot < 0) return null;
+  const payload = token.slice(0, dot);
+  const sig = token.slice(dot + 1);
+  if (!payload || !sig) return null;
+
+  const expected = sign(payload, getSecret());
+  const a = Buffer.from(sig, "utf8");
+  const b = Buffer.from(expected, "utf8");
+  if (a.length !== b.length) return null;
+  if (!timingSafeEqual(a, b)) return null;
+
+  let claims: CapabilityClaims;
+  try {
+    claims = JSON.parse(
+      base64urlDecode(payload).toString("utf8"),
+    ) as CapabilityClaims;
+  } catch {
+    return null;
+  }
+
+  if (!claims || typeof claims !== "object") return null;
+  if (claims.capability !== "host_browser_command") return null;
+  if (typeof claims.guardianId !== "string" || claims.guardianId.length === 0) {
+    return null;
+  }
+  if (typeof claims.nonce !== "string" || claims.nonce.length === 0) {
+    return null;
+  }
+  if (typeof claims.expiresAt !== "number" || claims.expiresAt <= Date.now()) {
+    return null;
+  }
+  return claims;
+}
+
+// ---------------------------------------------------------------------------
+// Dev-only fallback token file
+// ---------------------------------------------------------------------------
+
+/**
+ * Path to the dev-pairing fallback token file. The runtime writes a freshly
+ * minted capability token to this location on daemon startup so developers
+ * can manually pair the chrome extension without wiring the native
+ * messaging helper. Production users should pair via the native helper
+ * (PRs 7/12/13).
+ */
+export function getDaemonTokenFilePath(): string {
+  // Always under `~/.vellum/` (not the configurable workspace dir) so the
+  // native messaging helper can find it at a fixed path regardless of
+  // workspace overrides. This is a dev-only convenience path — production
+  // pairing goes through the native messaging flow.
+  return join(homedir(), ".vellum", "daemon-token");
+}
+
+/**
+ * Write a freshly-minted capability token to `~/.vellum/daemon-token` with
+ * 0600 permissions. Swallows errors so a failure here never blocks daemon
+ * startup — this is a dev-convenience path, not a production auth
+ * requirement.
+ */
+export function writeDaemonTokenFallback(guardianId: string): void {
+  try {
+    const { token } = mintHostBrowserCapability(guardianId);
+    const filePath = getDaemonTokenFilePath();
+    const dir = dirname(filePath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    const tmpPath = `${filePath}.tmp.${process.pid}`;
+    writeFileSync(tmpPath, token, { mode: 0o600 });
+    renameSync(tmpPath, filePath);
+    try {
+      chmodSync(filePath, 0o600);
+    } catch {
+      // best-effort
+    }
+    log.info({ filePath }, "Dev capability token written to daemon-token file");
+  } catch (err) {
+    log.warn(
+      { err },
+      "Failed to write dev capability token file; manual pairing still available via /v1/browser-extension-pair",
+    );
+  }
+}

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -110,6 +110,7 @@ import { attachmentRouteDefinitions } from "./routes/attachment-routes.js";
 import { handleGetAudio } from "./routes/audio-routes.js";
 import { avatarRouteDefinitions } from "./routes/avatar-routes.js";
 import { brainGraphRouteDefinitions } from "./routes/brain-graph-routes.js";
+import { handleBrowserExtensionPair } from "./routes/browser-extension-pair-routes.js";
 import { btwRouteDefinitions } from "./routes/btw-routes.js";
 import { callRouteDefinitions } from "./routes/call-routes.js";
 import {
@@ -531,6 +532,13 @@ export class RuntimeHttpServer {
     }
     if (path === "/v1/pairing/status" && req.method === "GET") {
       return handlePairingStatus(url, this.pairingContext);
+    }
+
+    // Chrome extension capability-token pair endpoint — unauthenticated but
+    // restricted to loopback peers + an extension-id allowlist. Used by the
+    // native messaging helper to bootstrap a scoped token.
+    if (path === "/v1/browser-extension-pair") {
+      return await handleBrowserExtensionPair(req, server);
     }
 
     // Guardian bootstrap and refresh endpoints — before JWT auth because

--- a/assistant/src/runtime/routes/browser-extension-pair-routes.ts
+++ b/assistant/src/runtime/routes/browser-extension-pair-routes.ts
@@ -1,0 +1,160 @@
+/**
+ * Route handler for `POST /v1/browser-extension-pair`.
+ *
+ * Mints a short-lived, scoped `host_browser_command` capability token for a
+ * chrome extension that has proved (via the native messaging helper) it is
+ * running locally with an allowlisted extension id.
+ *
+ * Security properties:
+ *   - **Localhost-only**: enforced by both the TCP peer IP (via
+ *     `server.requestIP`) and the `Host` header. Non-localhost callers
+ *     receive a 403.
+ *   - **Origin allowlist**: the body must include `origin` matching a
+ *     hard-coded allowlist of known Vellum chrome extension ids. This is a
+ *     minimal check; real enforcement happens in the native messaging
+ *     helper which vets the extension id that spawned it (PR 7).
+ *   - **No auth header required**: the native messaging bootstrap flow
+ *     runs before the extension has any token. The localhost + origin
+ *     checks are the only gate.
+ *
+ * Returns `{ token, expiresAt, guardianId }` on success.
+ */
+
+import { findGuardianForChannel } from "../../contacts/contact-store.js";
+import { getLogger } from "../../util/logger.js";
+import { mintHostBrowserCapability } from "../capability-tokens.js";
+import { httpError } from "../http-errors.js";
+import { isLoopbackAddress } from "../middleware/auth.js";
+
+const log = getLogger("browser-extension-pair");
+
+/** Bun server shape needed for requestIP. */
+export type PairServerContext = {
+  requestIP(
+    req: Request,
+  ): { address: string; family: string; port: number } | null;
+};
+
+/**
+ * Hard-coded allowlist of chrome extension origins permitted to request a
+ * capability token. Mirrors the placeholder id used by PR 7's native
+ * messaging helper scaffold. Update in tandem with PR 7's
+ * `ALLOWED_EXTENSION_IDS` constant before release.
+ */
+export const ALLOWED_EXTENSION_ORIGINS: ReadonlySet<string> = new Set<string>([
+  // TODO: production chrome extension id
+  "chrome-extension://fakedevid/",
+]);
+
+/**
+ * Returns true if the Host header (if present) points at a loopback
+ * address. We accept a missing Host header because some HTTP clients
+ * (notably node test harnesses) omit it.
+ */
+function isLoopbackHostHeader(host: string | null): boolean {
+  if (!host) return true;
+  const hostname = host.split(":")[0]?.toLowerCase() ?? "";
+  if (hostname === "localhost") return true;
+  if (hostname === "127.0.0.1") return true;
+  if (hostname === "::1") return true;
+  if (hostname === "[::1]") return true;
+  if (hostname.startsWith("127.")) return true;
+  return false;
+}
+
+/**
+ * Resolve the guardian id to bind the capability token to. Phase 2 uses
+ * the local vellum guardian principal when one exists, falling back to
+ * the string `"local"` for fresh installs that haven't bootstrapped a
+ * guardian yet.
+ */
+function resolveLocalGuardianId(): string {
+  try {
+    const result = findGuardianForChannel("vellum");
+    if (result?.contact.principalId) {
+      return result.contact.principalId;
+    }
+  } catch (err) {
+    log.warn(
+      { err },
+      "Failed to look up local vellum guardian; falling back to 'local'",
+    );
+  }
+  return "local";
+}
+
+/**
+ * Handle POST /v1/browser-extension-pair.
+ *
+ * Body: { origin: string }
+ * Returns: { token, expiresAt, guardianId }
+ */
+export async function handleBrowserExtensionPair(
+  req: Request,
+  server: PairServerContext,
+): Promise<Response> {
+  if (req.method !== "POST") {
+    return new Response("method not allowed", {
+      status: 405,
+      headers: { Allow: "POST" },
+    });
+  }
+
+  // Enforce localhost-only via peer IP.
+  const peer = server.requestIP(req);
+  const peerIp = peer?.address ?? "";
+  if (!peerIp || !isLoopbackAddress(peerIp)) {
+    log.warn({ peerIp }, "Rejecting browser-extension-pair from non-loopback");
+    return httpError("FORBIDDEN", "endpoint is local-only", 403);
+  }
+
+  // Secondary check: Host header. Rejects requests that slip past the
+  // TCP-level check via proxies that rewrite the peer address.
+  const host = req.headers.get("host");
+  if (!isLoopbackHostHeader(host)) {
+    log.warn(
+      { host },
+      "Rejecting browser-extension-pair with non-loopback Host header",
+    );
+    return httpError("FORBIDDEN", "endpoint is local-only", 403);
+  }
+
+  // Any `x-forwarded-for` header indicates the request was proxied from a
+  // non-local client. Reject — the pair endpoint is strictly machine-local.
+  if (req.headers.get("x-forwarded-for")) {
+    return httpError("FORBIDDEN", "endpoint is local-only", 403);
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return httpError("BAD_REQUEST", "invalid JSON body", 400);
+  }
+
+  if (!body || typeof body !== "object") {
+    return httpError("BAD_REQUEST", "body must be an object", 400);
+  }
+  const origin = (body as { origin?: unknown }).origin;
+  if (typeof origin !== "string" || origin.length === 0) {
+    return httpError("BAD_REQUEST", "origin is required", 400);
+  }
+
+  if (!ALLOWED_EXTENSION_ORIGINS.has(origin)) {
+    log.warn(
+      { origin },
+      "Rejecting browser-extension-pair for disallowed origin",
+    );
+    return httpError("UNAUTHORIZED", "unauthorized origin", 401);
+  }
+
+  const guardianId = resolveLocalGuardianId();
+  const { token, expiresAt } = mintHostBrowserCapability(guardianId);
+
+  log.info(
+    { origin, guardianId, expiresAt },
+    "Issued chrome extension capability token",
+  );
+
+  return Response.json({ token, expiresAt, guardianId });
+}

--- a/assistant/src/runtime/routes/browser-extension-pair-routes.ts
+++ b/assistant/src/runtime/routes/browser-extension-pair-routes.ts
@@ -42,13 +42,15 @@ export type PairServerContext = {
 
 /**
  * Hard-coded allowlist of chrome extension origins permitted to request a
- * capability token. Mirrors the placeholder id used by PR 7's native
- * messaging helper scaffold. Update in tandem with PR 7's
- * `ALLOWED_EXTENSION_IDS` constant before release.
+ * capability token. Mirrors the placeholder id used by the native messaging
+ * helper at `clients/chrome-extension-native-host/src/index.ts`
+ * (`ALLOWED_EXTENSION_IDS`). Both lists must agree for the dev pair flow
+ * to work end-to-end — update them together before release.
  */
 export const ALLOWED_EXTENSION_ORIGINS: ReadonlySet<string> = new Set<string>([
-  // TODO: production chrome extension id
-  "chrome-extension://fakedevid/",
+  // Dev placeholder — replaced when the unpacked extension is loaded locally.
+  // TODO: production chrome extension id before release
+  "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/",
 ]);
 
 /**
@@ -57,7 +59,8 @@ export const ALLOWED_EXTENSION_ORIGINS: ReadonlySet<string> = new Set<string>([
  * Handles IPv6 bracket notation (`[::1]:8765`), unbracketed IPv6
  * (`::1`), hostname with port (`localhost:8765`), and bare hostnames
  * (`localhost`). Returns `null` when the header is malformed (e.g.
- * missing closing bracket).
+ * missing closing bracket, or content after the closing bracket that
+ * isn't an optional `:port`).
  *
  * Exported for testing.
  */
@@ -67,6 +70,11 @@ export function parseHostHeader(raw: string): string | null {
   if (raw.startsWith("[")) {
     const end = raw.indexOf("]");
     if (end < 0) return null;
+    // After the closing bracket only an optional ":port" is valid. Anything
+    // else (e.g. `[::1]attacker.com`) is a malformed Host header that an
+    // attacker could craft to slip a non-loopback hostname past the parser.
+    const after = raw.substring(end + 1);
+    if (after.length > 0 && !after.startsWith(":")) return null;
     return raw.substring(1, end);
   }
   // Bare IPv6 (no brackets) contains multiple colons and should be

--- a/assistant/src/runtime/routes/browser-extension-pair-routes.ts
+++ b/assistant/src/runtime/routes/browser-extension-pair-routes.ts
@@ -9,15 +9,20 @@
  *   - **Localhost-only**: enforced by both the TCP peer IP (via
  *     `server.requestIP`) and the `Host` header. Non-localhost callers
  *     receive a 403.
- *   - **Origin allowlist**: the body must include `origin` matching a
- *     hard-coded allowlist of known Vellum chrome extension ids. This is a
- *     minimal check; real enforcement happens in the native messaging
- *     helper which vets the extension id that spawned it (PR 7).
+ *   - **Origin allowlist**: the body must include `extensionOrigin`
+ *     matching a hard-coded allowlist of known Vellum chrome extension
+ *     ids. This is a minimal check; real enforcement happens in the
+ *     native messaging helper which vets the extension id that spawned
+ *     it (PR 7).
  *   - **No auth header required**: the native messaging bootstrap flow
  *     runs before the extension has any token. The localhost + origin
  *     checks are the only gate.
  *
- * Returns `{ token, expiresAt, guardianId }` on success.
+ * Request body:  `{ extensionOrigin: string }` (also accepts the legacy
+ *                 `{ origin: string }` for backwards compatibility).
+ * Response body: `{ token, expiresAt, guardianId }` — `expiresAt` is an
+ *                 ISO 8601 timestamp string matching what the native
+ *                 messaging helper validates.
  */
 
 import { findGuardianForChannel } from "../../contacts/contact-store.js";
@@ -47,18 +52,54 @@ export const ALLOWED_EXTENSION_ORIGINS: ReadonlySet<string> = new Set<string>([
 ]);
 
 /**
+ * Parse an HTTP `Host` header value and extract the hostname portion.
+ *
+ * Handles IPv6 bracket notation (`[::1]:8765`), unbracketed IPv6
+ * (`::1`), hostname with port (`localhost:8765`), and bare hostnames
+ * (`localhost`). Returns `null` when the header is malformed (e.g.
+ * missing closing bracket).
+ *
+ * Exported for testing.
+ */
+export function parseHostHeader(raw: string): string | null {
+  if (raw.length === 0) return null;
+  // IPv6 literal in brackets, e.g. `[::1]` or `[::1]:8765`.
+  if (raw.startsWith("[")) {
+    const end = raw.indexOf("]");
+    if (end < 0) return null;
+    return raw.substring(1, end);
+  }
+  // Bare IPv6 (no brackets) contains multiple colons and should be
+  // treated as a whole. Anything with a single colon is `host:port`.
+  const firstColon = raw.indexOf(":");
+  if (firstColon < 0) return raw;
+  const secondColon = raw.indexOf(":", firstColon + 1);
+  if (secondColon >= 0) {
+    // Multiple colons and no brackets — assume unbracketed IPv6.
+    return raw;
+  }
+  return raw.substring(0, firstColon);
+}
+
+/**
  * Returns true if the Host header (if present) points at a loopback
  * address. We accept a missing Host header because some HTTP clients
  * (notably node test harnesses) omit it.
  */
 function isLoopbackHostHeader(host: string | null): boolean {
   if (!host) return true;
-  const hostname = host.split(":")[0]?.toLowerCase() ?? "";
+  const parsed = parseHostHeader(host);
+  if (parsed === null) return false;
+  const hostname = parsed.toLowerCase();
   if (hostname === "localhost") return true;
   if (hostname === "127.0.0.1") return true;
   if (hostname === "::1") return true;
-  if (hostname === "[::1]") return true;
-  if (hostname.startsWith("127.")) return true;
+  if (hostname.startsWith("127.")) {
+    // Matches the 127.0.0.0/8 loopback range (e.g. 127.0.0.1, 127.1.2.3).
+    const parts = hostname.split(".");
+    if (parts.length !== 4) return false;
+    return parts.every((p) => /^\d+$/.test(p) && Number(p) <= 255);
+  }
   return false;
 }
 
@@ -86,8 +127,11 @@ function resolveLocalGuardianId(): string {
 /**
  * Handle POST /v1/browser-extension-pair.
  *
- * Body: { origin: string }
- * Returns: { token, expiresAt, guardianId }
+ * Body:    `{ extensionOrigin: string }` (also accepts legacy
+ *          `{ origin: string }` for backwards compatibility).
+ * Returns: `{ token, expiresAt, guardianId }` where `expiresAt` is an
+ *          ISO 8601 timestamp string that the native messaging helper
+ *          validates as a string.
  */
 export async function handleBrowserExtensionPair(
   req: Request,
@@ -135,14 +179,27 @@ export async function handleBrowserExtensionPair(
   if (!body || typeof body !== "object") {
     return httpError("BAD_REQUEST", "body must be an object", 400);
   }
-  const origin = (body as { origin?: unknown }).origin;
-  if (typeof origin !== "string" || origin.length === 0) {
-    return httpError("BAD_REQUEST", "origin is required", 400);
+
+  // Accept `extensionOrigin` (preferred, matches the native messaging
+  // helper) and fall back to `origin` (legacy, for any callers that
+  // haven't migrated yet).
+  const raw = body as {
+    extensionOrigin?: unknown;
+    origin?: unknown;
+  };
+  const extensionOrigin =
+    typeof raw.extensionOrigin === "string" && raw.extensionOrigin.length > 0
+      ? raw.extensionOrigin
+      : typeof raw.origin === "string" && raw.origin.length > 0
+        ? raw.origin
+        : null;
+  if (extensionOrigin === null) {
+    return httpError("BAD_REQUEST", "extensionOrigin is required", 400);
   }
 
-  if (!ALLOWED_EXTENSION_ORIGINS.has(origin)) {
+  if (!ALLOWED_EXTENSION_ORIGINS.has(extensionOrigin)) {
     log.warn(
-      { origin },
+      { extensionOrigin },
       "Rejecting browser-extension-pair for disallowed origin",
     );
     return httpError("UNAUTHORIZED", "unauthorized origin", 401);
@@ -150,11 +207,12 @@ export async function handleBrowserExtensionPair(
 
   const guardianId = resolveLocalGuardianId();
   const { token, expiresAt } = mintHostBrowserCapability(guardianId);
+  const expiresAtIso = new Date(expiresAt).toISOString();
 
   log.info(
-    { origin, guardianId, expiresAt },
+    { extensionOrigin, guardianId, expiresAt: expiresAtIso },
     "Issued chrome extension capability token",
   );
 
-  return Response.json({ token, expiresAt, guardianId });
+  return Response.json({ token, expiresAt: expiresAtIso, guardianId });
 }


### PR DESCRIPTION
## Summary
- Local pair endpoint mints scoped host_browser_command capability tokens over HMAC-SHA256
- Enforces localhost-only + origin allowlist; returns {token, expiresAt, guardianId}
- Persists a random capabilityTokenSecret on first launch and writes a dev fallback token to ~/.vellum/daemon-token

Part of plan: host-browser-proxy-phase-2.md (PR 11 of 16)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
