### PR TITLE
feat(macos): allow SettingsCard subtitle to render markdown links

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsCard.swift
@@ -6,6 +6,7 @@ import VellumAssistantShared
 struct SettingsCard<Content: View, Accessory: View>: View {
     let title: String
     var subtitle: String? = nil
+    var subtitleAttributed: AttributedString? = nil
     var showBorder: Bool = true
     @ViewBuilder let accessory: () -> Accessory
     @ViewBuilder let content: () -> Content
@@ -17,7 +18,16 @@ struct SettingsCard<Content: View, Accessory: View>: View {
                     Text(title)
                         .font(VFont.titleSmall)
                         .foregroundStyle(VColor.contentEmphasized)
-                    if let subtitle {
+                    if let subtitleAttributed {
+                        Text(subtitleAttributed)
+                            .font(VFont.bodyMediumDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                            .tint(VColor.primaryBase)
+                            .environment(\.openURL, OpenURLAction { url in
+                                NSWorkspace.shared.open(url)
+                                return .handled
+                            })
+                    } else if let subtitle {
                         Text(subtitle)
                             .font(VFont.bodyMediumDefault)
                             .foregroundStyle(VColor.contentTertiary)
@@ -35,9 +45,16 @@ struct SettingsCard<Content: View, Accessory: View>: View {
 }
 
 extension SettingsCard where Accessory == EmptyView {
-    init(title: String, subtitle: String? = nil, showBorder: Bool = true, @ViewBuilder content: @escaping () -> Content) {
+    init(
+        title: String,
+        subtitle: String? = nil,
+        subtitleAttributed: AttributedString? = nil,
+        showBorder: Bool = true,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
         self.title = title
         self.subtitle = subtitle
+        self.subtitleAttributed = subtitleAttributed
         self.showBorder = showBorder
         self.accessory = { EmptyView() }
         self.content = content


### PR DESCRIPTION
## Summary
- Adds an optional `subtitleAttributed: AttributedString?` property to `SettingsCard` so subtitles can contain tappable markdown links.
- When set, the body renders it via SwiftUI's `Text(_:AttributedString)` initializer with primary tint and an `OpenURLAction` that opens links via `NSWorkspace`.
- Purely additive — every existing `SettingsCard` call site continues to compile and behave identically because both subtitle props default to `nil`.

Part of plan: docs-base-url-pricing-link.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
