### PR TITLE
feat(macos): add centralized AppURLs module with docs base URL env var override

### DIFF
--- a/clients/macos/vellum-assistant/App/AppURLs.swift
+++ b/clients/macos/vellum-assistant/App/AppURLs.swift
@@ -15,11 +15,28 @@ public enum AppURLs {
     /// Base URL for Vellum docs. Honors `VELLUM_DOCS_BASE_URL` if set, otherwise
     /// returns `defaultDocsBaseURL`. Trailing slashes are stripped so callers can
     /// safely append paths with `/`.
+    ///
+    /// The env override is validated: it must parse as an absolute http(s) URL
+    /// with a non-nil host. Malformed values fall back to `defaultDocsBaseURL`
+    /// to prevent downstream force-unwraps in `docsURL(...)` from crashing.
     public static var docsBaseURL: String {
         let raw = ProcessInfo.processInfo.environment["VELLUM_DOCS_BASE_URL"]?
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        let base = (raw?.isEmpty == false ? raw! : defaultDocsBaseURL)
-        return base.hasSuffix("/") ? String(base.dropLast()) : base
+        guard let candidate = raw, !candidate.isEmpty else {
+            return defaultDocsBaseURL
+        }
+        let normalized = candidate.hasSuffix("/") ? String(candidate.dropLast()) : candidate
+        // Reject the override if it isn't a parseable absolute http(s) URL.
+        // This prevents downstream force-unwraps from crashing on malformed values.
+        guard
+            let url = URL(string: normalized),
+            let scheme = url.scheme?.lowercased(),
+            scheme == "http" || scheme == "https",
+            url.host != nil
+        else {
+            return defaultDocsBaseURL
+        }
+        return normalized
     }
 
     // MARK: - Concrete docs URLs

--- a/clients/macos/vellum-assistant/App/AppURLs.swift
+++ b/clients/macos/vellum-assistant/App/AppURLs.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// Centralized URLs the macOS app links out to.
+///
+/// The docs base URL can be overridden at runtime via the `VELLUM_DOCS_BASE_URL`
+/// environment variable (e.g. for staging or local docs servers). Falls back to
+/// the production docs site.
+///
+/// Pattern parallels the assistant's `src/config/env.ts` — a single source of
+/// truth, accessed via static getters rather than scattered string literals.
+public enum AppURLs {
+    /// Default base URL for Vellum docs. Used when no env var override is set.
+    public static let defaultDocsBaseURL = "https://www.vellum.ai/docs"
+
+    /// Base URL for Vellum docs. Honors `VELLUM_DOCS_BASE_URL` if set, otherwise
+    /// returns `defaultDocsBaseURL`. Trailing slashes are stripped so callers can
+    /// safely append paths with `/`.
+    public static var docsBaseURL: String {
+        let raw = ProcessInfo.processInfo.environment["VELLUM_DOCS_BASE_URL"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let base = (raw?.isEmpty == false ? raw! : defaultDocsBaseURL)
+        return base.hasSuffix("/") ? String(base.dropLast()) : base
+    }
+
+    // MARK: - Concrete docs URLs
+
+    /// Pricing docs page — linked from the Billing settings tab and the
+    /// Models & Services tab pricing banner.
+    public static var pricingDocs: URL {
+        docsURL(path: "/pricing")
+    }
+
+    /// Hosting options docs — linked from the API key onboarding step.
+    public static var hostingOptionsDocs: URL {
+        docsURL(path: "/hosting-options")
+    }
+
+    /// Terms of Use docs — linked from the onboarding ToS consent.
+    public static var termsOfUseDocs: URL {
+        docsURL(path: "/vellum-terms-of-use")
+    }
+
+    /// Privacy Policy docs — linked from the onboarding ToS consent.
+    public static var privacyPolicyDocs: URL {
+        docsURL(path: "/privacy-policy")
+    }
+
+    // MARK: - Helpers
+
+    /// Build a docs URL by appending a path to the (possibly env-overridden) base.
+    /// Force-unwrap is safe: `docsBaseURL` is always a valid URL string and `path`
+    /// is a literal path component supplied at the call site.
+    public static func docsURL(path: String) -> URL {
+        let normalizedPath = path.hasPrefix("/") ? path : "/\(path)"
+        return URL(string: "\(docsBaseURL)\(normalizedPath)")!
+    }
+
+    /// Build a docs URL with UTM tracking query parameters. Used by the Help menu
+    /// Documentation entry to attribute traffic to the macOS app.
+    public static func docsURL(
+        path: String = "",
+        utmSource: String,
+        utmMedium: String
+    ) -> URL {
+        let normalizedPath = path.isEmpty || path.hasPrefix("/") ? path : "/\(path)"
+        var components = URLComponents(string: "\(docsBaseURL)\(normalizedPath)")!
+        components.queryItems = [
+            URLQueryItem(name: "utm_source", value: utmSource),
+            URLQueryItem(name: "utm_medium", value: utmMedium),
+        ]
+        return components.url!
+    }
+}

--- a/clients/macos/vellum-assistantTests/AppURLsTests.swift
+++ b/clients/macos/vellum-assistantTests/AppURLsTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+@testable import vellum_assistant
+
+final class AppURLsTests: XCTestCase {
+    private var originalEnvValue: String?
+
+    override func setUp() {
+        super.setUp()
+        originalEnvValue = ProcessInfo.processInfo.environment["VELLUM_DOCS_BASE_URL"]
+        unsetenv("VELLUM_DOCS_BASE_URL")
+    }
+
+    override func tearDown() {
+        if let value = originalEnvValue {
+            setenv("VELLUM_DOCS_BASE_URL", value, 1)
+        } else {
+            unsetenv("VELLUM_DOCS_BASE_URL")
+        }
+        super.tearDown()
+    }
+
+    // MARK: - Base URL behavior
+
+    func testDocsBaseURLDefaultsToProduction() {
+        XCTAssertEqual(AppURLs.docsBaseURL, "https://www.vellum.ai/docs")
+    }
+
+    func testDocsBaseURLHonorsEnvOverride() {
+        setenv("VELLUM_DOCS_BASE_URL", "https://staging.vellum.ai/docs", 1)
+        XCTAssertEqual(AppURLs.docsBaseURL, "https://staging.vellum.ai/docs")
+    }
+
+    func testDocsBaseURLStripsTrailingSlash() {
+        setenv("VELLUM_DOCS_BASE_URL", "https://staging.vellum.ai/docs/", 1)
+        XCTAssertEqual(AppURLs.docsBaseURL, "https://staging.vellum.ai/docs")
+    }
+
+    func testDocsBaseURLEmptyEnvFallsBackToDefault() {
+        setenv("VELLUM_DOCS_BASE_URL", "  ", 1)
+        XCTAssertEqual(AppURLs.docsBaseURL, "https://www.vellum.ai/docs")
+    }
+
+    // MARK: - Concrete URL constructions
+
+    func testPricingDocsURLConstruction() {
+        XCTAssertEqual(AppURLs.pricingDocs.absoluteString, "https://www.vellum.ai/docs/pricing")
+    }
+
+    func testHostingOptionsDocsURLConstruction() {
+        XCTAssertEqual(AppURLs.hostingOptionsDocs.absoluteString, "https://www.vellum.ai/docs/hosting-options")
+    }
+
+    func testTermsOfUseDocsURLConstruction() {
+        XCTAssertEqual(AppURLs.termsOfUseDocs.absoluteString, "https://www.vellum.ai/docs/vellum-terms-of-use")
+    }
+
+    func testPrivacyPolicyDocsURLConstruction() {
+        XCTAssertEqual(AppURLs.privacyPolicyDocs.absoluteString, "https://www.vellum.ai/docs/privacy-policy")
+    }
+
+    // MARK: - Env override propagates to concrete URLs
+
+    func testConcreteURLsHonorEnvOverride() {
+        setenv("VELLUM_DOCS_BASE_URL", "https://staging.vellum.ai/docs", 1)
+        XCTAssertEqual(AppURLs.pricingDocs.absoluteString, "https://staging.vellum.ai/docs/pricing")
+        XCTAssertEqual(AppURLs.hostingOptionsDocs.absoluteString, "https://staging.vellum.ai/docs/hosting-options")
+        XCTAssertEqual(AppURLs.termsOfUseDocs.absoluteString, "https://staging.vellum.ai/docs/vellum-terms-of-use")
+        XCTAssertEqual(AppURLs.privacyPolicyDocs.absoluteString, "https://staging.vellum.ai/docs/privacy-policy")
+    }
+
+    // MARK: - UTM helper
+
+    func testUTMHelperBuildsBaseURLWithQueryParams() {
+        let url = AppURLs.docsURL(utmSource: "macos-app", utmMedium: "help-menu")
+        XCTAssertEqual(url.absoluteString, "https://www.vellum.ai/docs?utm_source=macos-app&utm_medium=help-menu")
+    }
+
+    func testUTMHelperWithPath() {
+        let url = AppURLs.docsURL(path: "/pricing", utmSource: "macos-app", utmMedium: "settings")
+        XCTAssertEqual(url.absoluteString, "https://www.vellum.ai/docs/pricing?utm_source=macos-app&utm_medium=settings")
+    }
+
+    func testUTMHelperHonorsEnvOverride() {
+        setenv("VELLUM_DOCS_BASE_URL", "https://staging.vellum.ai/docs", 1)
+        let url = AppURLs.docsURL(utmSource: "macos-app", utmMedium: "help-menu")
+        XCTAssertEqual(url.absoluteString, "https://staging.vellum.ai/docs?utm_source=macos-app&utm_medium=help-menu")
+    }
+
+    // MARK: - Path helper
+
+    func testDocsURLHelperNormalizesLeadingSlash() {
+        XCTAssertEqual(AppURLs.docsURL(path: "/pricing").absoluteString, "https://www.vellum.ai/docs/pricing")
+        XCTAssertEqual(AppURLs.docsURL(path: "pricing").absoluteString, "https://www.vellum.ai/docs/pricing")
+    }
+}

--- a/clients/macos/vellum-assistantTests/AppURLsTests.swift
+++ b/clients/macos/vellum-assistantTests/AppURLsTests.swift
@@ -40,6 +40,32 @@ final class AppURLsTests: XCTestCase {
         XCTAssertEqual(AppURLs.docsBaseURL, "https://www.vellum.ai/docs")
     }
 
+    func testDocsBaseURLRejectsMalformedURLAndFallsBack() {
+        setenv("VELLUM_DOCS_BASE_URL", "not a url", 1)
+        XCTAssertEqual(AppURLs.docsBaseURL, "https://www.vellum.ai/docs")
+    }
+
+    func testDocsBaseURLRejectsURLWithoutSchemeAndFallsBack() {
+        setenv("VELLUM_DOCS_BASE_URL", "vellum.ai/docs", 1)
+        XCTAssertEqual(AppURLs.docsBaseURL, "https://www.vellum.ai/docs")
+    }
+
+    func testDocsBaseURLRejectsNonHTTPSchemeAndFallsBack() {
+        setenv("VELLUM_DOCS_BASE_URL", "ftp://files.vellum.ai/docs", 1)
+        XCTAssertEqual(AppURLs.docsBaseURL, "https://www.vellum.ai/docs")
+    }
+
+    func testDocsBaseURLAcceptsHTTPScheme() {
+        setenv("VELLUM_DOCS_BASE_URL", "http://localhost:3000/docs", 1)
+        XCTAssertEqual(AppURLs.docsBaseURL, "http://localhost:3000/docs")
+    }
+
+    func testConcreteURLsFallBackOnMalformedEnv() {
+        setenv("VELLUM_DOCS_BASE_URL", "not a url", 1)
+        XCTAssertEqual(AppURLs.pricingDocs.absoluteString, "https://www.vellum.ai/docs/pricing")
+        XCTAssertEqual(AppURLs.hostingOptionsDocs.absoluteString, "https://www.vellum.ai/docs/hosting-options")
+    }
+
     // MARK: - Concrete URL constructions
 
     func testPricingDocsURLConstruction() {


### PR DESCRIPTION
## Summary
- Introduces a centralized `AppURLs` enum in the macOS app exposing the docs base URL with a `VELLUM_DOCS_BASE_URL` env var override (default: `https://www.vellum.ai/docs`).
- Provides concrete URL accessors for pricing, hosting options, terms of use, and privacy policy docs, plus a `docsURL(path:utmSource:utmMedium:)` helper for UTM-tagged links.
- Adds `AppURLsTests` covering env var override behavior, trailing-slash normalization, fallback semantics, and URL construction for every concrete constant.

Part of plan: docs-base-url-pricing-link.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
