### PR TITLE
refactor(macos): route existing hardcoded vellum.ai/docs URLs through AppURLs

### DIFF
--- a/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
+++ b/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
@@ -64,7 +64,7 @@ struct VellumAssistantApp: App {
             }
             CommandGroup(replacing: .help) {
                 Button("Documentation") {
-                    NSWorkspace.shared.open(URL(string: "https://vellum.ai/docs?utm_source=macos-app&utm_medium=help-menu")!)
+                    NSWorkspace.shared.open(AppURLs.docsURL(utmSource: "macos-app", utmMedium: "help-menu"))
                 }
                 Button("Discord Community") {
                     NSWorkspace.shared.open(URL(string: "https://www.vellum.ai/community?utm_source=macos-app&utm_medium=help-menu")!)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -434,7 +434,7 @@ struct SettingsPanel: View {
                     .foregroundStyle(VColor.contentSecondary)
 
                 Button {
-                    NSWorkspace.shared.open(URL(string: "https://vellum.ai/docs/pricing")!)
+                    NSWorkspace.shared.open(AppURLs.pricingDocs)
                 } label: {
                     HStack(spacing: VSpacing.xs) {
                         Text("View pricing")

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -112,7 +112,7 @@ struct APIKeyStepView: View {
                 }
 
                 VButton(label: "Need help deciding?", style: .ghost) {
-                    NSWorkspace.shared.open(URL(string: "https://vellum.ai/docs/hosting-options")!)
+                    NSWorkspace.shared.open(AppURLs.hostingOptionsDocs)
                 }
 
                 if !isAuthenticated {

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -135,10 +135,9 @@ struct ImproveExperienceStepView: View {
     }
 
     private var tosAttributedString: AttributedString {
+        let markdown = "I agree to the [Terms of Service](\(AppURLs.termsOfUseDocs.absoluteString)) and [Privacy Policy](\(AppURLs.privacyPolicyDocs.absoluteString))"
         // swiftlint:disable:next force_try
-        var str = try! AttributedString(
-            markdown: "I agree to the [Terms of Service](https://www.vellum.ai/docs/vellum-terms-of-use) and [Privacy Policy](https://www.vellum.ai/docs/privacy-policy)"
-        )
+        var str = try! AttributedString(markdown: markdown)
         for run in str.runs where run.link != nil {
             str[run.range].underlineStyle = .single
         }


### PR DESCRIPTION
## Summary
- Migrates the four remaining hardcoded \`vellum.ai/docs\` URLs in the macOS app to use the \`AppURLs\` constants introduced earlier in this plan, so the docs base URL has a single source of truth across the codebase.
- Touches the Models & Services pricing banner, the API key onboarding 'Need help deciding?' link, the ToS / Privacy Policy markdown links in the onboarding consent step, and the Help menu Documentation item.
- Verified \`grep -rn 'vellum.ai/docs' clients/macos --include='*.swift' | grep -v Tests\` returns zero matches in non-test source files. The Discord Community URL is intentionally untouched (not a docs link).

Part of plan: docs-base-url-pricing-link.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
