### PR TITLE
feat(macos): add 'Learn more about pricing' link to Billing tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -217,9 +217,14 @@ struct SettingsBillingTab: View {
     /// which honors the `VELLUM_DOCS_BASE_URL` env override.
     var addCreditsSubtitleAttributed: AttributedString? {
         guard let summary else { return nil }
-        let markdown = "Credits cost $1 each, with a maximum balance of \(formattedMaxBalance(summary)). Unused credits expire 12 months after purchase. [Learn more about pricing](\(AppURLs.pricingDocs.absoluteString))"
-        // swiftlint:disable:next force_try
-        var attributed = try! AttributedString(markdown: markdown)
+        let copy = "Credits cost $1 each, with a maximum balance of \(formattedMaxBalance(summary)). Unused credits expire 12 months after purchase."
+        let markdown = "\(copy) [Learn more about pricing](\(AppURLs.pricingDocs.absoluteString))"
+        // Use `try?` with a plain-text fallback so a markdown parse failure
+        // (e.g. unexpected interpolated content) degrades gracefully instead
+        // of crashing the Settings tab.
+        guard var attributed = try? AttributedString(markdown: markdown) else {
+            return AttributedString("\(copy) Learn more about pricing")
+        }
         for run in attributed.runs where run.link != nil {
             attributed[run.range].underlineStyle = .single
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -189,23 +189,41 @@ struct SettingsBillingTab: View {
     // MARK: - Add Credits Card
 
     private var addFundsCard: some View {
-        SettingsCard(title: "Add Credits", subtitle: addCreditsSubtitle) {
+        SettingsCard(
+            title: "Add Credits",
+            subtitleAttributed: addCreditsSubtitleAttributed
+        ) {
             topUpContent
         }
     }
 
-    private var addCreditsSubtitle: String? {
+    /// Formats the maximum balance from a billing summary as a thousands-grouped
+    /// integer string (e.g. `"1,000"`), falling back to the raw server value if
+    /// it can't be parsed as a positive number. Shared by `addCreditsSubtitleAttributed`
+    /// and `handleTopUp()` so the formatting stays consistent.
+    func formattedMaxBalance(_ summary: BillingSummaryResponse) -> String {
+        let value = Int(Double(summary.maximum_balance) ?? 0)
+        if value > 0 {
+            let formatter = NumberFormatter()
+            formatter.numberStyle = .decimal
+            return formatter.string(from: NSNumber(value: value)) ?? summary.maximum_balance
+        }
+        return summary.maximum_balance
+    }
+
+    /// Subtitle for the Add Credits card, rendered as an attributed string so the
+    /// trailing "Learn more about pricing" link is tappable. Returns nil while the
+    /// billing summary is still loading. The link target is `AppURLs.pricingDocs`,
+    /// which honors the `VELLUM_DOCS_BASE_URL` env override.
+    var addCreditsSubtitleAttributed: AttributedString? {
         guard let summary else { return nil }
-        let maxFormatted: String = {
-            let value = Int(Double(summary.maximum_balance) ?? 0)
-            if value > 0 {
-                let formatter = NumberFormatter()
-                formatter.numberStyle = .decimal
-                return formatter.string(from: NSNumber(value: value)) ?? summary.maximum_balance
-            }
-            return summary.maximum_balance
-        }()
-        return "Credits cost $1 each, with a maximum balance of \(maxFormatted). Unused credits expire 12 months after purchase."
+        let markdown = "Credits cost $1 each, with a maximum balance of \(formattedMaxBalance(summary)). Unused credits expire 12 months after purchase. [Learn more about pricing](\(AppURLs.pricingDocs.absoluteString))"
+        // swiftlint:disable:next force_try
+        var attributed = try! AttributedString(markdown: markdown)
+        for run in attributed.runs where run.link != nil {
+            attributed[run.range].underlineStyle = .single
+        }
+        return attributed
     }
 
     @ViewBuilder
@@ -311,15 +329,7 @@ struct SettingsBillingTab: View {
            let maxBalance = Double(summary.maximum_balance),
            let currentBalance = Double(summary.effective_balance),
            currentBalance + amount > maxBalance {
-            let maxFormatted: String = {
-                let value = Int(maxBalance)
-                if value > 0 {
-                    let formatter = NumberFormatter()
-                    formatter.numberStyle = .decimal
-                    return formatter.string(from: NSNumber(value: value)) ?? summary.maximum_balance
-                }
-                return summary.maximum_balance
-            }()
+            let maxFormatted = formattedMaxBalance(summary)
             topUpError = "This top-up would exceed the maximum credit balance of \(maxFormatted)."
             return
         }
@@ -336,5 +346,18 @@ struct SettingsBillingTab: View {
         } catch {
             self.topUpError = "Failed to create checkout session. Please try again."
         }
+    }
+}
+
+// MARK: - Test Support
+
+extension SettingsBillingTab {
+    /// Test-only convenience initializer that pre-populates the `summary` `@State`
+    /// without going through the `loadSummary()` async path. Used by
+    /// `SettingsBillingTabSubtitleTests` to exercise `addCreditsSubtitleAttributed`
+    /// against a known billing summary fixture.
+    init(authManager: AuthManager, initialSummary: BillingSummaryResponse?) {
+        self.authManager = authManager
+        self._summary = State(initialValue: initialSummary)
     }
 }

--- a/clients/macos/vellum-assistantTests/SettingsBillingTabSubtitleTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsBillingTabSubtitleTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+import SwiftUI
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Tests for the attributed subtitle on `SettingsBillingTab`'s Add Credits card.
+///
+/// Verifies:
+/// - The subtitle is `nil` while the billing summary is still loading.
+/// - When a summary is present, the subtitle ends with a tappable
+///   "Learn more about pricing" link pointing at `AppURLs.pricingDocs`.
+/// - The link target honors the `VELLUM_DOCS_BASE_URL` env var override so the
+///   docs base URL stays a single source of truth.
+@MainActor
+final class SettingsBillingTabSubtitleTests: XCTestCase {
+    private var originalEnvValue: String?
+
+    override func setUp() {
+        super.setUp()
+        originalEnvValue = ProcessInfo.processInfo.environment["VELLUM_DOCS_BASE_URL"]
+        unsetenv("VELLUM_DOCS_BASE_URL")
+    }
+
+    override func tearDown() {
+        if let value = originalEnvValue {
+            setenv("VELLUM_DOCS_BASE_URL", value, 1)
+        } else {
+            unsetenv("VELLUM_DOCS_BASE_URL")
+        }
+        super.tearDown()
+    }
+
+    // MARK: - Tests
+
+    func testSubtitleNilWhenSummaryNotLoaded() {
+        let view = SettingsBillingTab(authManager: AuthManager(), initialSummary: nil)
+        XCTAssertNil(view.addCreditsSubtitleAttributed)
+    }
+
+    func testSubtitleContainsPricingLink() {
+        let summary = makeSummary(maximumBalance: "1000")
+        let view = SettingsBillingTab(authManager: AuthManager(), initialSummary: summary)
+
+        let attributed = view.addCreditsSubtitleAttributed
+        XCTAssertNotNil(attributed)
+
+        let plain = String(attributed!.characters)
+        XCTAssertTrue(plain.contains("Learn more about pricing"))
+        XCTAssertTrue(plain.contains("Credits cost $1 each"))
+        XCTAssertTrue(plain.contains("maximum balance of 1,000"))
+
+        let linkRuns = attributed!.runs.filter { $0.link != nil }
+        XCTAssertEqual(linkRuns.count, 1, "Subtitle should contain exactly one link")
+        XCTAssertEqual(
+            linkRuns.first?.link?.absoluteString,
+            AppURLs.pricingDocs.absoluteString
+        )
+    }
+
+    func testSubtitleHonorsDocsBaseURLOverride() {
+        setenv("VELLUM_DOCS_BASE_URL", "https://staging.vellum.ai/docs", 1)
+        defer { unsetenv("VELLUM_DOCS_BASE_URL") }
+
+        let summary = makeSummary(maximumBalance: "1000")
+        let view = SettingsBillingTab(authManager: AuthManager(), initialSummary: summary)
+
+        let attributed = view.addCreditsSubtitleAttributed
+        let linkRun = attributed?.runs.first { $0.link != nil }
+        XCTAssertEqual(
+            linkRun?.link?.absoluteString,
+            "https://staging.vellum.ai/docs/pricing"
+        )
+    }
+
+    // MARK: - Fixture
+
+    /// Builds a `BillingSummaryResponse` with sensible defaults, parameterized
+    /// only on the fields the subtitle tests care about.
+    private func makeSummary(maximumBalance: String) -> BillingSummaryResponse {
+        BillingSummaryResponse(
+            settled_balance: "100.00",
+            pending_compute: "0.00",
+            effective_balance: "100.00",
+            minimum_top_up: "10.00",
+            maximum_top_up: "100.00",
+            maximum_balance: maximumBalance,
+            allowed_top_up_amounts: ["10.00", "25.00", "50.00"],
+            is_degraded: false
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Replaces the plain-string \`addCreditsSubtitle\` on the Billing settings tab with an attributed subtitle that ends with a tappable \"Learn more about pricing\" link pointing at \`AppURLs.pricingDocs\` (default: https://www.vellum.ai/docs/pricing, override via \`VELLUM_DOCS_BASE_URL\`).
- Extracts a shared \`formattedMaxBalance\` helper so the subtitle and \`handleTopUp\` no longer duplicate the maximum-balance number formatting.
- Adds \`SettingsBillingTabSubtitleTests\` covering the nil-summary case, the presence of the link in the rendered attributed string, and that \`VELLUM_DOCS_BASE_URL\` propagates into the link target.

Part of plan: docs-base-url-pricing-link.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
