### PR TITLE
feat(chrome-extension): bootstrap self-hosted capability token via native messaging

### DIFF
--- a/clients/chrome-extension/background/__tests__/self-hosted-auth.test.ts
+++ b/clients/chrome-extension/background/__tests__/self-hosted-auth.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Tests for the self-hosted capability-token bootstrap state machine.
+ *
+ * These tests mock `chrome.runtime.connectNative` and `chrome.storage.local`
+ * so they can run under bun:test without a real Chrome runtime. The fake
+ * native-messaging port is a tiny event emitter that lets the test drive
+ * `onMessage` / `onDisconnect` callbacks by hand.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+
+import {
+  getStoredLocalToken,
+  clearLocalToken,
+  bootstrapLocalToken,
+  type StoredLocalToken,
+} from '../self-hosted-auth.js';
+
+const STORAGE_KEY = 'vellum.localCapabilityToken';
+
+interface FakeStorage {
+  data: Record<string, unknown>;
+  get(key: string | string[]): Promise<Record<string, unknown>>;
+  set(items: Record<string, unknown>): Promise<void>;
+  remove(key: string | string[]): Promise<void>;
+}
+
+function createFakeStorage(): FakeStorage {
+  const data: Record<string, unknown> = {};
+  return {
+    data,
+    async get(key) {
+      const keys = Array.isArray(key) ? key : [key];
+      const result: Record<string, unknown> = {};
+      for (const k of keys) {
+        if (k in data) result[k] = data[k];
+      }
+      return result;
+    },
+    async set(items) {
+      Object.assign(data, items);
+    },
+    async remove(key) {
+      const keys = Array.isArray(key) ? key : [key];
+      for (const k of keys) delete data[k];
+    },
+  };
+}
+
+interface FakePort {
+  name: string;
+  onMessage: {
+    addListener(listener: (msg: unknown) => void): void;
+    removeListener(listener: (msg: unknown) => void): void;
+  };
+  onDisconnect: {
+    addListener(listener: (port: FakePort) => void): void;
+    removeListener(listener: (port: FakePort) => void): void;
+  };
+  postMessage(message: unknown): void;
+  disconnect(): void;
+
+  // Test handles
+  sent: unknown[];
+  disconnected: boolean;
+  emitMessage(msg: unknown): void;
+  emitDisconnect(): void;
+}
+
+interface FakeNativeRuntime {
+  lastError: { message?: string } | undefined;
+  connectNative(name: string): FakePort;
+  /** Set by the test to control how newly-created ports behave. */
+  onConnect?: (port: FakePort, application: string) => void;
+  /** The most recently created port, for convenience in tests. */
+  currentPort?: FakePort;
+  /** Log of application names passed to connectNative. */
+  connectCalls: string[];
+}
+
+function createFakePort(): FakePort {
+  const messageListeners: Array<(msg: unknown) => void> = [];
+  const disconnectListeners: Array<(port: FakePort) => void> = [];
+  const port: FakePort = {
+    name: 'com.vellum.daemon',
+    onMessage: {
+      addListener(listener) {
+        messageListeners.push(listener);
+      },
+      removeListener(listener) {
+        const idx = messageListeners.indexOf(listener);
+        if (idx >= 0) messageListeners.splice(idx, 1);
+      },
+    },
+    onDisconnect: {
+      addListener(listener) {
+        disconnectListeners.push(listener);
+      },
+      removeListener(listener) {
+        const idx = disconnectListeners.indexOf(listener);
+        if (idx >= 0) disconnectListeners.splice(idx, 1);
+      },
+    },
+    postMessage(message) {
+      port.sent.push(message);
+    },
+    disconnect() {
+      port.disconnected = true;
+    },
+    sent: [],
+    disconnected: false,
+    emitMessage(msg) {
+      for (const listener of messageListeners.slice()) listener(msg);
+    },
+    emitDisconnect() {
+      for (const listener of disconnectListeners.slice()) listener(port);
+    },
+  };
+  return port;
+}
+
+function createFakeRuntime(): FakeNativeRuntime {
+  const runtime: FakeNativeRuntime = {
+    lastError: undefined,
+    connectCalls: [],
+    connectNative(application: string) {
+      runtime.connectCalls.push(application);
+      const port = createFakePort();
+      runtime.currentPort = port;
+      if (runtime.onConnect) runtime.onConnect(port, application);
+      return port;
+    },
+  };
+  return runtime;
+}
+
+const originalChrome = (globalThis as { chrome?: unknown }).chrome;
+
+let fakeStorage: FakeStorage;
+let fakeRuntime: FakeNativeRuntime;
+
+beforeEach(() => {
+  fakeStorage = createFakeStorage();
+  fakeRuntime = createFakeRuntime();
+  (globalThis as { chrome?: unknown }).chrome = {
+    storage: {
+      local: fakeStorage,
+    },
+    runtime: fakeRuntime,
+  };
+});
+
+afterEach(() => {
+  (globalThis as { chrome?: unknown }).chrome = originalChrome;
+});
+
+describe('bootstrapLocalToken', () => {
+  test('happy path persists and returns the token', async () => {
+    const issuedAt = Date.now();
+    const expiresAtIso = new Date(issuedAt + 3_600_000).toISOString();
+
+    fakeRuntime.onConnect = (port) => {
+      // Drive the response asynchronously to mirror how Chrome delivers
+      // native-messaging frames in practice.
+      queueMicrotask(() => {
+        port.emitMessage({
+          type: 'token_response',
+          token: 'abc123',
+          expiresAt: expiresAtIso,
+          guardianId: 'g-42',
+        });
+      });
+    };
+
+    const result = await bootstrapLocalToken();
+    expect(result.token).toBe('abc123');
+    expect(result.guardianId).toBe('g-42');
+    expect(result.expiresAt).toBe(Date.parse(expiresAtIso));
+
+    // Port was told to request a token.
+    expect(fakeRuntime.connectCalls).toEqual(['com.vellum.daemon']);
+    expect(fakeRuntime.currentPort?.sent).toEqual([{ type: 'request_token' }]);
+
+    // Token was persisted.
+    expect(fakeStorage.data[STORAGE_KEY]).toEqual(result);
+
+    // Port was cleaned up.
+    expect(fakeRuntime.currentPort?.disconnected).toBe(true);
+  });
+
+  test('accepts numeric expiresAt for forward compatibility', async () => {
+    const expiresAt = Date.now() + 60_000;
+
+    fakeRuntime.onConnect = (port) => {
+      queueMicrotask(() => {
+        port.emitMessage({
+          type: 'token_response',
+          token: 'num-token',
+          expiresAt,
+          guardianId: 'g-1',
+        });
+      });
+    };
+
+    const result = await bootstrapLocalToken();
+    expect(result.expiresAt).toBe(expiresAt);
+  });
+
+  test('malformed token_response rejects and does not persist', async () => {
+    fakeRuntime.onConnect = (port) => {
+      queueMicrotask(() => {
+        port.emitMessage({
+          type: 'token_response',
+          token: 'abc',
+          // Missing expiresAt
+          guardianId: 'g-1',
+        });
+      });
+    };
+
+    await expect(bootstrapLocalToken()).rejects.toThrow('malformed token_response');
+    expect(fakeStorage.data[STORAGE_KEY]).toBeUndefined();
+    expect(fakeRuntime.currentPort?.disconnected).toBe(true);
+  });
+
+  test('error frame rejects with the helper message', async () => {
+    fakeRuntime.onConnect = (port) => {
+      queueMicrotask(() => {
+        port.emitMessage({ type: 'error', message: 'unauthorized_origin' });
+      });
+    };
+
+    await expect(bootstrapLocalToken()).rejects.toThrow('unauthorized_origin');
+    expect(fakeStorage.data[STORAGE_KEY]).toBeUndefined();
+    expect(fakeRuntime.currentPort?.disconnected).toBe(true);
+  });
+
+  test('error frame without message falls back to a default', async () => {
+    fakeRuntime.onConnect = (port) => {
+      queueMicrotask(() => {
+        port.emitMessage({ type: 'error' });
+      });
+    };
+
+    await expect(bootstrapLocalToken()).rejects.toThrow('native messaging error');
+  });
+
+  test('timeout rejects and disconnects the port', async () => {
+    // onConnect is a no-op — the helper never responds.
+    fakeRuntime.onConnect = () => {
+      // Intentionally silent.
+    };
+
+    await expect(bootstrapLocalToken({ timeoutMs: 20 })).rejects.toThrow(
+      'native messaging timeout',
+    );
+    expect(fakeStorage.data[STORAGE_KEY]).toBeUndefined();
+    expect(fakeRuntime.currentPort?.disconnected).toBe(true);
+  });
+
+  test('disconnect before response rejects with lastError message', async () => {
+    fakeRuntime.lastError = { message: 'Specified native messaging host not found.' };
+    fakeRuntime.onConnect = (port) => {
+      queueMicrotask(() => {
+        port.emitDisconnect();
+      });
+    };
+
+    await expect(bootstrapLocalToken()).rejects.toThrow(
+      'Specified native messaging host not found.',
+    );
+    expect(fakeStorage.data[STORAGE_KEY]).toBeUndefined();
+  });
+
+  test('disconnect with no lastError falls back to generic message', async () => {
+    fakeRuntime.onConnect = (port) => {
+      queueMicrotask(() => {
+        port.emitDisconnect();
+      });
+    };
+
+    await expect(bootstrapLocalToken()).rejects.toThrow(
+      'native messaging disconnected before response',
+    );
+  });
+
+  test('ignores unknown frame types until a recognised frame arrives', async () => {
+    const expiresAtIso = new Date(Date.now() + 60_000).toISOString();
+
+    fakeRuntime.onConnect = (port) => {
+      queueMicrotask(() => {
+        port.emitMessage({ type: 'some_future_type', payload: {} });
+        port.emitMessage(null);
+        port.emitMessage('not-an-object');
+        port.emitMessage({
+          type: 'token_response',
+          token: 'late',
+          expiresAt: expiresAtIso,
+          guardianId: 'g-late',
+        });
+      });
+    };
+
+    const result = await bootstrapLocalToken();
+    expect(result.token).toBe('late');
+  });
+});
+
+describe('getStoredLocalToken', () => {
+  test('returns null when nothing is stored', async () => {
+    expect(await getStoredLocalToken()).toBeNull();
+  });
+
+  test('returns the stored token when valid', async () => {
+    const token: StoredLocalToken = {
+      token: 'valid',
+      expiresAt: Date.now() + 60_000,
+      guardianId: 'g-1',
+    };
+    fakeStorage.data[STORAGE_KEY] = token;
+    expect(await getStoredLocalToken()).toEqual(token);
+  });
+
+  test('returns null when the token is expired', async () => {
+    fakeStorage.data[STORAGE_KEY] = {
+      token: 'expired',
+      expiresAt: Date.now() - 1_000,
+      guardianId: 'g-1',
+    } satisfies StoredLocalToken;
+    expect(await getStoredLocalToken()).toBeNull();
+  });
+
+  test('returns null when the stored value is malformed', async () => {
+    fakeStorage.data[STORAGE_KEY] = { token: 42, expiresAt: 'soon' };
+    expect(await getStoredLocalToken()).toBeNull();
+  });
+
+  test('returns null when guardianId is missing', async () => {
+    fakeStorage.data[STORAGE_KEY] = {
+      token: 'valid',
+      expiresAt: Date.now() + 60_000,
+    };
+    expect(await getStoredLocalToken()).toBeNull();
+  });
+});
+
+describe('clearLocalToken', () => {
+  test('removes the key from storage', async () => {
+    fakeStorage.data[STORAGE_KEY] = {
+      token: 'to-clear',
+      expiresAt: Date.now() + 60_000,
+      guardianId: 'g-1',
+    } satisfies StoredLocalToken;
+    await clearLocalToken();
+    expect(fakeStorage.data[STORAGE_KEY]).toBeUndefined();
+  });
+
+  test('is a no-op when nothing is stored', async () => {
+    await clearLocalToken();
+    expect(fakeStorage.data[STORAGE_KEY]).toBeUndefined();
+  });
+});

--- a/clients/chrome-extension/background/__tests__/self-hosted-auth.test.ts
+++ b/clients/chrome-extension/background/__tests__/self-hosted-auth.test.ts
@@ -20,6 +20,11 @@ const STORAGE_KEY = 'vellum.localCapabilityToken';
 
 interface FakeStorage {
   data: Record<string, unknown>;
+  /**
+   * When set, the next `set()` call rejects with this error (then the
+   * override is cleared). Used to exercise the storage-failure path.
+   */
+  nextSetError?: Error;
   get(key: string | string[]): Promise<Record<string, unknown>>;
   set(items: Record<string, unknown>): Promise<void>;
   remove(key: string | string[]): Promise<void>;
@@ -27,7 +32,7 @@ interface FakeStorage {
 
 function createFakeStorage(): FakeStorage {
   const data: Record<string, unknown> = {};
-  return {
+  const storage: FakeStorage = {
     data,
     async get(key) {
       const keys = Array.isArray(key) ? key : [key];
@@ -38,6 +43,11 @@ function createFakeStorage(): FakeStorage {
       return result;
     },
     async set(items) {
+      if (storage.nextSetError) {
+        const err = storage.nextSetError;
+        storage.nextSetError = undefined;
+        throw err;
+      }
       Object.assign(data, items);
     },
     async remove(key) {
@@ -45,6 +55,7 @@ function createFakeStorage(): FakeStorage {
       for (const k of keys) delete data[k];
     },
   };
+  return storage;
 }
 
 interface FakePort {
@@ -282,6 +293,72 @@ describe('bootstrapLocalToken', () => {
     await expect(bootstrapLocalToken()).rejects.toThrow(
       'native messaging disconnected before response',
     );
+  });
+
+  test('resolves with the in-memory token when chrome.storage.local.set fails', async () => {
+    const expiresAtIso = new Date(Date.now() + 60_000).toISOString();
+    fakeStorage.nextSetError = new Error('QuotaExceededError');
+
+    fakeRuntime.onConnect = (port) => {
+      queueMicrotask(() => {
+        port.emitMessage({
+          type: 'token_response',
+          token: 'persist-fail',
+          expiresAt: expiresAtIso,
+          guardianId: 'g-persist',
+        });
+      });
+    };
+
+    // The caller should still receive a usable token even though we
+    // failed to save it to chrome.storage.local. Persistence is
+    // best-effort from the pair flow's perspective — the in-memory
+    // token is still valid for the current session and the popup
+    // surfaces the same record to the user.
+    const result = await bootstrapLocalToken();
+    expect(result.token).toBe('persist-fail');
+    expect(result.guardianId).toBe('g-persist');
+    expect(result.expiresAt).toBe(Date.parse(expiresAtIso));
+
+    // But nothing was actually written to storage.
+    expect(fakeStorage.data[STORAGE_KEY]).toBeUndefined();
+
+    // And the port was torn down as part of marking the promise settled.
+    expect(fakeRuntime.currentPort?.disconnected).toBe(true);
+  });
+
+  test('ignores onDisconnect after a valid token_response (race)', async () => {
+    // Simulates the real-world race where the native helper writes its
+    // token_response frame and then immediately exits, causing Chrome
+    // to fire onDisconnect on the same turn as onMessage. Before the
+    // fix, `settled` was only flipped after the async storage write
+    // resolved, so a fast disconnect could win the race and reject a
+    // valid pairing. Now `settled` is set synchronously the moment the
+    // token frame is validated, so the subsequent disconnect is a no-op.
+    fakeRuntime.lastError = { message: 'port closed' };
+
+    const expiresAtIso = new Date(Date.now() + 60_000).toISOString();
+
+    fakeRuntime.onConnect = (port) => {
+      queueMicrotask(() => {
+        port.emitMessage({
+          type: 'token_response',
+          token: 'race-winner',
+          expiresAt: expiresAtIso,
+          guardianId: 'g-race',
+        });
+        // Emitted on the same microtask turn as the token frame, before
+        // the persistLocalToken promise has a chance to resolve. If the
+        // disconnect handler rejects here, the test fails.
+        port.emitDisconnect();
+      });
+    };
+
+    const result = await bootstrapLocalToken();
+    expect(result.token).toBe('race-winner');
+    expect(result.guardianId).toBe('g-race');
+    // Token was still persisted despite the racing disconnect.
+    expect(fakeStorage.data[STORAGE_KEY]).toEqual(result);
   });
 
   test('ignores unknown frame types until a recognised frame arrives', async () => {

--- a/clients/chrome-extension/background/self-hosted-auth.ts
+++ b/clients/chrome-extension/background/self-hosted-auth.ts
@@ -108,18 +108,33 @@ export async function bootstrapLocalToken(
 ): Promise<StoredLocalToken> {
   const timeoutMs = options.timeoutMs ?? DEFAULT_BOOTSTRAP_TIMEOUT_MS;
   return new Promise<StoredLocalToken>((resolve, reject) => {
+    // `settled` is flipped synchronously the moment we observe a decisive
+    // frame (token_response / error / timeout / disconnect) so that a
+    // racing onDisconnect — Chrome sometimes closes the native port the
+    // instant the helper exits, even if we've already received a valid
+    // token frame — can't win the race and reject a successful pairing.
+    //
+    // Critically, for the token_response happy path we mark `settled`
+    // BEFORE awaiting `persistLocalToken`. If we waited until the storage
+    // write resolved, an onDisconnect firing during that microtask would
+    // still see `settled === false` and reject the promise despite having
+    // a valid in-memory token.
     let settled = false;
     const port = chrome.runtime.connectNative(NATIVE_HOST_NAME);
 
-    const finish = (fn: () => void): void => {
-      if (settled) return;
-      settled = true;
+    const cleanup = (): void => {
       clearTimeout(timer);
       try {
         port.disconnect();
       } catch {
         // Chrome may have already torn the port down — ignore.
       }
+    };
+
+    const finish = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
       fn();
     };
 
@@ -155,14 +170,28 @@ export async function bootstrapLocalToken(
           expiresAt,
           guardianId: frame.guardianId,
         };
-        // Persist asynchronously but settle the promise with the stored
-        // record either way — a storage failure shouldn't block the caller
-        // from getting the token, but it should be surfaced as a rejection.
+
+        // Mark settled + tear down the port SYNCHRONOUSLY so a racing
+        // onDisconnect listener can't reject the promise after we've
+        // already received a valid token. The persistence write below
+        // is awaited afterwards, but it no longer gates `settled`.
+        settled = true;
+        cleanup();
+
+        // Persist asynchronously. If the storage write fails, we log
+        // the error and resolve with the in-memory token anyway — the
+        // caller can still use it for the current session even if we
+        // couldn't durably save it. This also matches the comment
+        // above: a storage failure shouldn't block the caller from
+        // getting a token they just successfully negotiated.
         persistLocalToken(stored).then(
-          () => finish(() => resolve(stored)),
+          () => resolve(stored),
           (err: unknown) => {
             const detail = err instanceof Error ? err.message : String(err);
-            finish(() => reject(new Error(`failed to persist token: ${detail}`)));
+            console.warn(
+              `[vellum-relay] failed to persist local capability token: ${detail}`,
+            );
+            resolve(stored);
           },
         );
         return;

--- a/clients/chrome-extension/background/self-hosted-auth.ts
+++ b/clients/chrome-extension/background/self-hosted-auth.ts
@@ -1,0 +1,193 @@
+/**
+ * Self-hosted capability-token bootstrap for the Vellum chrome extension.
+ *
+ * Spawns the native messaging helper registered under the host name
+ * `com.vellum.daemon`, asks it to exchange the calling extension's origin
+ * for a capability token via the assistant's `/v1/browser-extension-pair`
+ * endpoint, and persists the returned token in `chrome.storage.local`.
+ *
+ * This module is the self-hosted counterpart to `cloud-auth.ts`: cloud
+ * sign-in uses chrome.identity.launchWebAuthFlow against the Vellum
+ * gateway, while self-hosted pairing uses native messaging to talk to a
+ * locally running assistant without needing an external OAuth round-trip.
+ * Users with a local assistant can pair their extension entirely offline.
+ *
+ * The token is not yet wired into the relay WebSocket — that plumbing
+ * lands in PR 14 of the host-browser-proxy Phase 2 plan. This module is
+ * the storage + bootstrap state machine layer only.
+ *
+ * Wire format notes: the native helper sends
+ * `{ type: "token_response", token, expiresAt }` where `expiresAt` is an
+ * ISO 8601 string (per the /v1/browser-extension-pair response shape).
+ * We parse it into an epoch-millis number here so the in-memory and
+ * on-disk representation matches `StoredCloudToken` and downstream code
+ * can rely on a single numeric expiry type across both transports.
+ */
+
+export interface StoredLocalToken {
+  token: string;
+  expiresAt: number; // ms since epoch
+  guardianId: string;
+}
+
+const STORAGE_KEY = 'vellum.localCapabilityToken';
+const NATIVE_HOST_NAME = 'com.vellum.daemon';
+const DEFAULT_BOOTSTRAP_TIMEOUT_MS = 5_000;
+
+export interface BootstrapLocalTokenOptions {
+  /**
+   * Override the native-messaging timeout. Exposed primarily so tests can
+   * run the timeout path without having to wait five real seconds; callers
+   * in the extension itself should rely on the default.
+   */
+  timeoutMs?: number;
+}
+
+export async function getStoredLocalToken(): Promise<StoredLocalToken | null> {
+  const result = await chrome.storage.local.get(STORAGE_KEY);
+  const raw = result[STORAGE_KEY];
+  if (!raw || typeof raw !== 'object') return null;
+  const token = raw as StoredLocalToken;
+  if (
+    typeof token.token !== 'string' ||
+    typeof token.expiresAt !== 'number' ||
+    typeof token.guardianId !== 'string'
+  ) {
+    return null;
+  }
+  if (token.expiresAt <= Date.now()) return null;
+  return token;
+}
+
+export async function clearLocalToken(): Promise<void> {
+  await chrome.storage.local.remove(STORAGE_KEY);
+}
+
+async function persistLocalToken(token: StoredLocalToken): Promise<void> {
+  await chrome.storage.local.set({ [STORAGE_KEY]: token });
+}
+
+/**
+ * Parse the helper's `expiresAt` field into an epoch-millis number.
+ *
+ * The native helper echoes whatever the assistant's /v1/browser-extension-pair
+ * endpoint returned, which is an ISO 8601 string per PR 11. We tolerate a
+ * numeric value as well (belt and braces) so a future helper change that
+ * forwards a raw number doesn't break the extension.
+ */
+function parseExpiresAt(raw: unknown): number | null {
+  if (typeof raw === 'number' && Number.isFinite(raw) && raw > 0) {
+    return raw;
+  }
+  if (typeof raw === 'string' && raw.length > 0) {
+    const parsed = Date.parse(raw);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return null;
+}
+
+/**
+ * Spawns the native messaging helper via `chrome.runtime.connectNative`,
+ * posts a `request_token` frame, awaits the helper's `token_response`,
+ * and persists the returned capability token.
+ *
+ * Error handling:
+ * - If the helper emits `{ type: "error", message }`, rejects with that
+ *   message. The helper uses this shape for allowlist violations,
+ *   unreachable assistant, and malformed responses from the pair endpoint.
+ * - If the port disconnects before a response arrives, rejects with the
+ *   `chrome.runtime.lastError` message (Chrome surfaces native-messaging
+ *   spawn failures through this channel — e.g. the host manifest isn't
+ *   installed, or the binary exited non-zero before writing a frame).
+ * - If no frame arrives within `DEFAULT_BOOTSTRAP_TIMEOUT_MS`, rejects
+ *   with a timeout error and force-disconnects the port so the helper
+ *   process doesn't leak.
+ */
+export async function bootstrapLocalToken(
+  options: BootstrapLocalTokenOptions = {},
+): Promise<StoredLocalToken> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_BOOTSTRAP_TIMEOUT_MS;
+  return new Promise<StoredLocalToken>((resolve, reject) => {
+    let settled = false;
+    const port = chrome.runtime.connectNative(NATIVE_HOST_NAME);
+
+    const finish = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        port.disconnect();
+      } catch {
+        // Chrome may have already torn the port down — ignore.
+      }
+      fn();
+    };
+
+    const timer: ReturnType<typeof setTimeout> = setTimeout(() => {
+      finish(() => reject(new Error('native messaging timeout')));
+    }, timeoutMs);
+
+    port.onMessage.addListener((msg: unknown) => {
+      if (settled) return;
+      if (!msg || typeof msg !== 'object') return;
+      const frame = msg as {
+        type?: unknown;
+        token?: unknown;
+        expiresAt?: unknown;
+        guardianId?: unknown;
+        message?: unknown;
+      };
+
+      if (frame.type === 'token_response') {
+        const expiresAt = parseExpiresAt(frame.expiresAt);
+        if (
+          typeof frame.token !== 'string' ||
+          expiresAt === null ||
+          typeof frame.guardianId !== 'string'
+        ) {
+          finish(() =>
+            reject(new Error('native messaging returned malformed token_response')),
+          );
+          return;
+        }
+        const stored: StoredLocalToken = {
+          token: frame.token,
+          expiresAt,
+          guardianId: frame.guardianId,
+        };
+        // Persist asynchronously but settle the promise with the stored
+        // record either way — a storage failure shouldn't block the caller
+        // from getting the token, but it should be surfaced as a rejection.
+        persistLocalToken(stored).then(
+          () => finish(() => resolve(stored)),
+          (err: unknown) => {
+            const detail = err instanceof Error ? err.message : String(err);
+            finish(() => reject(new Error(`failed to persist token: ${detail}`)));
+          },
+        );
+        return;
+      }
+
+      if (frame.type === 'error') {
+        const message = typeof frame.message === 'string' ? frame.message : 'native messaging error';
+        finish(() => reject(new Error(message)));
+        return;
+      }
+
+      // Ignore any unrecognised frame types — the helper currently only
+      // emits `token_response` and `error`, but tolerating unknowns means
+      // a future protocol extension won't accidentally trip this path.
+    });
+
+    port.onDisconnect.addListener(() => {
+      if (settled) return;
+      const lastError = chrome.runtime.lastError;
+      const message = lastError?.message ?? 'native messaging disconnected before response';
+      // `finish` will call port.disconnect() again, but that's a no-op
+      // after Chrome has already torn the port down on its side.
+      finish(() => reject(new Error(message)));
+    });
+
+    port.postMessage({ type: 'request_token' });
+  });
+}

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -9,6 +9,10 @@
 import type { ExtensionCommand, ExtensionResponse, ExtensionHeartbeat } from '../../../assistant/src/browser-extension-relay/protocol.js';
 import { signInCloud, type CloudAuthConfig, type StoredCloudToken } from './cloud-auth.js';
 import {
+  bootstrapLocalToken,
+  type StoredLocalToken,
+} from './self-hosted-auth.js';
+import {
   createHostBrowserDispatcher,
   type HostBrowserDispatcher,
   type HostBrowserRequestEnvelope,
@@ -448,6 +452,17 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     };
     signInCloud(config)
       .then((stored: StoredCloudToken) => sendResponse({ ok: true, token: stored }))
+      .catch((err) => sendResponse({ ok: false, error: err instanceof Error ? err.message : String(err) }));
+    return true; // async
+  }
+  if (message.type === 'self-hosted-pair') {
+    // Mirror the cloud-auth-sign-in pattern: run the native-messaging
+    // bootstrap in the service worker so the popup closing mid-pair
+    // can't tear down the awaited promise before the token is persisted.
+    // chrome.runtime.connectNative also requires the "nativeMessaging"
+    // permission, which is declared in manifest.json.
+    bootstrapLocalToken()
+      .then((stored: StoredLocalToken) => sendResponse({ ok: true, token: stored }))
       .catch((err) => sendResponse({ ok: false, error: err instanceof Error ? err.message : String(err) }));
     return true; // async
   }

--- a/clients/chrome-extension/manifest.json
+++ b/clients/chrome-extension/manifest.json
@@ -9,6 +9,7 @@
     "cookies",
     "debugger",
     "identity",
+    "nativeMessaging",
     "scripting",
     "storage",
     "tabs"

--- a/clients/chrome-extension/popup/popup.html
+++ b/clients/chrome-extension/popup/popup.html
@@ -118,6 +118,14 @@
     }
     #btn-cloud-signin:hover:not(:disabled) { background: #1f2937; }
 
+    #btn-pair-local {
+      width: 100%;
+      background: #0f766e;
+      color: #fff;
+      margin-bottom: 8px;
+    }
+    #btn-pair-local:hover:not(:disabled) { background: #115e59; }
+
     .cloud-status {
       font-size: 12px;
       color: #4b5563;
@@ -125,6 +133,15 @@
       word-break: break-all;
     }
     .cloud-status.signed-in { color: #0f766e; }
+
+    .local-status {
+      font-size: 12px;
+      color: #4b5563;
+      margin-bottom: 4px;
+      word-break: break-all;
+    }
+    .local-status.paired { color: #0f766e; }
+    .local-status.error { color: #ef4444; }
 
     .beta-toggle {
       display: flex;
@@ -208,6 +225,12 @@
   </div>
 
   <p class="hint">Token is auto-fetched from the local gateway. Port defaults to 7830.</p>
+
+  <div class="divider"></div>
+
+  <p class="section-label">Local</p>
+  <p class="local-status" id="local-status">Not paired</p>
+  <button id="btn-pair-local" type="button">Pair with local assistant</button>
 
   <div class="divider"></div>
 

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -14,6 +14,11 @@
  */
 
 import { getStoredToken, type StoredCloudToken } from '../background/cloud-auth.js';
+import {
+  bootstrapLocalToken,
+  getStoredLocalToken,
+  type StoredLocalToken,
+} from '../background/self-hosted-auth.js';
 
 const DEFAULT_RELAY_PORT = 7830;
 
@@ -28,6 +33,8 @@ const manualToggle = document.getElementById('manual-toggle') as HTMLButtonEleme
 const tokenGroup = document.getElementById('token-group') as HTMLDivElement;
 const btnCloudSignIn = document.getElementById('btn-cloud-signin') as HTMLButtonElement;
 const cloudStatus = document.getElementById('cloud-status') as HTMLParagraphElement;
+const btnPairLocal = document.getElementById('btn-pair-local') as HTMLButtonElement;
+const localStatus = document.getElementById('local-status') as HTMLParagraphElement;
 const cdpProxyToggle = document.getElementById('cdp-proxy-toggle') as HTMLInputElement;
 
 const CDP_PROXY_ENABLED_KEY = 'vellum.cdpProxyEnabled';
@@ -158,6 +165,62 @@ btnDisconnect.addEventListener('click', () => {
     setConnected(false);
   });
 });
+
+// ── Self-hosted native-messaging pairing (new in Phase 2 PR 13) ─────
+//
+// Pairing runs the local native messaging helper (com.vellum.daemon),
+// which POSTs the extension's origin to the assistant's
+// `/v1/browser-extension-pair` endpoint and returns a capability token.
+// The token is persisted in chrome.storage.local under
+// `vellum.localCapabilityToken`. It is NOT yet used on any WebSocket —
+// PR 14 will read it when opening the relay connection in self-hosted
+// mode.
+
+function setLocalStatus(text: string, state: 'neutral' | 'paired' | 'error'): void {
+  localStatus.textContent = text;
+  localStatus.classList.remove('paired', 'error');
+  if (state !== 'neutral') localStatus.classList.add(state);
+}
+
+function formatLocalTokenStatus(token: StoredLocalToken): string {
+  const expiresDate = new Date(token.expiresAt);
+  const expiresStr = Number.isFinite(token.expiresAt)
+    ? expiresDate.toLocaleString()
+    : 'unknown';
+  return `Paired as guardian:${token.guardianId} (expires ${expiresStr})`;
+}
+
+async function refreshLocalStatus(): Promise<void> {
+  try {
+    const existing = await getStoredLocalToken();
+    if (existing) {
+      setLocalStatus(formatLocalTokenStatus(existing), 'paired');
+    } else {
+      setLocalStatus('Not paired', 'neutral');
+    }
+  } catch (err) {
+    setLocalStatus(
+      `Error: ${err instanceof Error ? err.message : String(err)}`,
+      'error',
+    );
+  }
+}
+
+btnPairLocal.addEventListener('click', async () => {
+  btnPairLocal.disabled = true;
+  setLocalStatus('Pairing…', 'neutral');
+  try {
+    const stored = await bootstrapLocalToken();
+    setLocalStatus(formatLocalTokenStatus(stored), 'paired');
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    setLocalStatus(`Pairing failed: ${detail}`, 'error');
+  } finally {
+    btnPairLocal.disabled = false;
+  }
+});
+
+refreshLocalStatus();
 
 // ── Cloud sign-in (new in Phase 2 PR 8) ────────────────────────────
 //

--- a/clients/chrome-extension/popup/popup.ts
+++ b/clients/chrome-extension/popup/popup.ts
@@ -15,7 +15,6 @@
 
 import { getStoredToken, type StoredCloudToken } from '../background/cloud-auth.js';
 import {
-  bootstrapLocalToken,
   getStoredLocalToken,
   type StoredLocalToken,
 } from '../background/self-hosted-auth.js';
@@ -206,18 +205,37 @@ async function refreshLocalStatus(): Promise<void> {
   }
 }
 
+interface LocalPairResponse {
+  ok: boolean;
+  token?: StoredLocalToken;
+  error?: string;
+}
+
+function requestLocalPair(): Promise<LocalPairResponse> {
+  return new Promise((resolve) => {
+    chrome.runtime.sendMessage({ type: 'self-hosted-pair' }, (response: LocalPairResponse) => {
+      if (chrome.runtime.lastError) {
+        resolve({ ok: false, error: chrome.runtime.lastError.message ?? 'Unknown error' });
+        return;
+      }
+      resolve(response ?? { ok: false, error: 'No response from service worker' });
+    });
+  });
+}
+
 btnPairLocal.addEventListener('click', async () => {
   btnPairLocal.disabled = true;
   setLocalStatus('Pairing…', 'neutral');
-  try {
-    const stored = await bootstrapLocalToken();
-    setLocalStatus(formatLocalTokenStatus(stored), 'paired');
-  } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
-    setLocalStatus(`Pairing failed: ${detail}`, 'error');
-  } finally {
-    btnPairLocal.disabled = false;
+  // Delegate to the service worker so the native-messaging bootstrap
+  // survives the popup teardown race — see the `self-hosted-pair`
+  // handler in worker.ts, and the matching cloud-auth-sign-in pattern.
+  const response = await requestLocalPair();
+  if (response.ok && response.token) {
+    setLocalStatus(formatLocalTokenStatus(response.token), 'paired');
+  } else {
+    setLocalStatus(`Pairing failed: ${response.error ?? 'Unknown error'}`, 'error');
   }
+  btnPairLocal.disabled = false;
 });
 
 refreshLocalStatus();

--- a/clients/chrome-extension/tsconfig.json
+++ b/clients/chrome-extension/tsconfig.json
@@ -18,6 +18,7 @@
     "background/cdp-proxy.ts",
     "background/cloud-auth.ts",
     "background/host-browser-dispatcher.ts",
+    "background/self-hosted-auth.ts",
     "background/__tests__/**/*.ts",
     "types/**/*.d.ts"
   ]

--- a/clients/chrome-extension/types/bun-test-shim.d.ts
+++ b/clients/chrome-extension/types/bun-test-shim.d.ts
@@ -3,7 +3,7 @@
  * can be type-checked without depending on bun-types being installed in
  * the chrome-extension's own node_modules. The full bun-types package is
  * available in assistant/node_modules and is the runtime source of truth;
- * this shim only declares the surface used by the cloud-auth tests.
+ * this shim only declares the surface used by the extension's unit tests.
  */
 
 declare module 'bun:test' {

--- a/clients/chrome-extension/types/chrome-globals.d.ts
+++ b/clients/chrome-extension/types/chrome-globals.d.ts
@@ -4,9 +4,10 @@
  * Minimal ambient declarations for the subset of the Chrome Extension API
  * surface used by the Vellum browser-relay extension's typed modules.
  *
- * This is intentionally narrow — it covers what's needed by background/cloud-auth.ts
- * and its tests. The full @types/chrome package is an option for the future if
- * we type-check more of the package.
+ * This is intentionally narrow — it covers what's needed by
+ * background/cloud-auth.ts, background/self-hosted-auth.ts, and their tests.
+ * The full @types/chrome package is an option for the future if we type-check
+ * more of the package.
  */
 
 declare namespace chrome {
@@ -29,5 +30,32 @@ declare namespace chrome {
     }
     function getRedirectURL(path?: string): string;
     function launchWebAuthFlow(details: WebAuthFlowDetails): Promise<string | undefined>;
+  }
+
+  namespace runtime {
+    interface LastError {
+      message?: string;
+    }
+    const lastError: LastError | undefined;
+
+    interface PortMessageEvent {
+      addListener(listener: (message: unknown) => void): void;
+      removeListener(listener: (message: unknown) => void): void;
+    }
+
+    interface PortDisconnectEvent {
+      addListener(listener: (port: Port) => void): void;
+      removeListener(listener: (port: Port) => void): void;
+    }
+
+    interface Port {
+      name: string;
+      onMessage: PortMessageEvent;
+      onDisconnect: PortDisconnectEvent;
+      postMessage(message: unknown): void;
+      disconnect(): void;
+    }
+
+    function connectNative(application: string): Port;
   }
 }


### PR DESCRIPTION
## Summary
- New self-hosted-auth.ts spawns the native helper via chrome.runtime.connectNative('com.vellum.daemon'), posts a request_token frame, and persists the returned capability token in chrome.storage.local
- Popup gets a 'Pair with local assistant' button that triggers the bootstrap flow and surfaces success/error inline
- Token is not yet used on any WebSocket — that wiring lands in PR 14

Part of plan: host-browser-proxy-phase-2.md (PR 13 of 16)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
