### PR TITLE
feat(oauth): add scope_separator column and plumb through store + seed

### DIFF
--- a/assistant/src/__tests__/oauth-provider-serializer.test.ts
+++ b/assistant/src/__tests__/oauth-provider-serializer.test.ts
@@ -18,6 +18,7 @@ function makeRow(overrides: Partial<OAuthProviderRow> = {}): OAuthProviderRow {
     baseUrl: null,
     defaultScopes: "[]",
     scopePolicy: "{}",
+    scopeSeparator: " ",
     authorizeParams: null,
     pingUrl: null,
     pingMethod: null,

--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -43,6 +43,7 @@ import {
   registerProvider,
   seedProviders,
   updateConnection,
+  updateProvider,
   upsertApp,
 } from "../oauth/oauth-store.js";
 
@@ -276,6 +277,71 @@ describe("provider operations", () => {
       expect(JSON.parse(row!.authorizeParams!)).toEqual({ prompt: "login" });
       expect(row!.pingUrl).toBe("https://api.github.com/user-v2");
     });
+
+    test("persists custom scopeSeparator when provided", () => {
+      seedProviders([
+        {
+          provider: "test-provider",
+          authorizeUrl: "https://example.com/authorize",
+          tokenExchangeUrl: "https://example.com/token",
+          defaultScopes: ["read", "write"],
+          scopePolicy: {},
+          scopeSeparator: ",",
+        },
+      ]);
+
+      const row = getProvider("test-provider");
+      expect(row).toBeDefined();
+      expect(row!.scopeSeparator).toBe(",");
+    });
+
+    test("scopeSeparator defaults to ' ' when omitted", () => {
+      seedProviders([
+        {
+          provider: "github",
+          authorizeUrl: "https://github.com/authorize",
+          tokenExchangeUrl: "https://github.com/token",
+          defaultScopes: ["repo"],
+          scopePolicy: {},
+        },
+      ]);
+
+      const row = getProvider("github");
+      expect(row).toBeDefined();
+      expect(row!.scopeSeparator).toBe(" ");
+    });
+
+    test("re-seeding with a changed scopeSeparator overwrites the stored value", () => {
+      seedProviders([
+        {
+          provider: "linear",
+          authorizeUrl: "https://linear.app/oauth/authorize",
+          tokenExchangeUrl: "https://api.linear.app/oauth/token",
+          defaultScopes: ["read"],
+          scopePolicy: {},
+          scopeSeparator: " ",
+        },
+      ]);
+
+      const first = getProvider("linear");
+      expect(first!.scopeSeparator).toBe(" ");
+
+      // Re-seed with a different separator — it should be overwritten,
+      // proving scopeSeparator is in the onConflictDoUpdate set clause.
+      seedProviders([
+        {
+          provider: "linear",
+          authorizeUrl: "https://linear.app/oauth/authorize",
+          tokenExchangeUrl: "https://api.linear.app/oauth/token",
+          defaultScopes: ["read"],
+          scopePolicy: {},
+          scopeSeparator: ",",
+        },
+      ]);
+
+      const row = getProvider("linear");
+      expect(row!.scopeSeparator).toBe(",");
+    });
   });
 
   describe("getProvider", () => {
@@ -336,6 +402,59 @@ describe("provider operations", () => {
           scopePolicy: {},
         }),
       ).toThrow(/already exists.*linear/);
+    });
+
+    test("persists scopeSeparator and round-trips via getProvider", () => {
+      registerProvider({
+        provider: "linear",
+        authorizeUrl: "https://linear.app/oauth/authorize",
+        tokenExchangeUrl: "https://api.linear.app/oauth/token",
+        defaultScopes: ["read"],
+        scopePolicy: {},
+        scopeSeparator: ";",
+      });
+
+      const fetched = getProvider("linear");
+      expect(fetched).toBeDefined();
+      expect(fetched!.scopeSeparator).toBe(";");
+    });
+
+    test("scopeSeparator defaults to ' ' when omitted", () => {
+      registerProvider({
+        provider: "linear",
+        authorizeUrl: "https://linear.app/oauth/authorize",
+        tokenExchangeUrl: "https://api.linear.app/oauth/token",
+        defaultScopes: ["read"],
+        scopePolicy: {},
+      });
+
+      const fetched = getProvider("linear");
+      expect(fetched).toBeDefined();
+      expect(fetched!.scopeSeparator).toBe(" ");
+    });
+  });
+
+  describe("updateProvider", () => {
+    test("updates scopeSeparator on an existing row", () => {
+      seedProviders([
+        {
+          provider: "github",
+          authorizeUrl: "https://github.com/authorize",
+          tokenExchangeUrl: "https://github.com/token",
+          defaultScopes: ["repo"],
+          scopePolicy: {},
+        },
+      ]);
+
+      const before = getProvider("github");
+      expect(before!.scopeSeparator).toBe(" ");
+
+      const updated = updateProvider("github", { scopeSeparator: "," });
+      expect(updated).toBeDefined();
+      expect(updated!.scopeSeparator).toBe(",");
+
+      const fetched = getProvider("github");
+      expect(fetched!.scopeSeparator).toBe(",");
     });
   });
 });

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -113,6 +113,7 @@ import {
   migrateOAuthProvidersManagedServiceConfigKey,
   migrateOAuthProvidersPingConfig,
   migrateOAuthProvidersPingUrl,
+  migrateOAuthProvidersScopeSeparator,
   migrateReminderRoutingIntent,
   migrateRemindersToSchedules,
   migrateRenameConversationTypeColumn,
@@ -352,6 +353,7 @@ export function initializeDb(): void {
     migrateScheduleReuseConversation,
     migrateMemoryRecallLogsQueryContext,
     migrateLlmRequestLogsCreatedAtIndex,
+    migrateOAuthProvidersScopeSeparator,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/213-oauth-providers-scope-separator.ts
+++ b/assistant/src/memory/migrations/213-oauth-providers-scope-separator.ts
@@ -1,0 +1,13 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+export function migrateOAuthProvidersScopeSeparator(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  try {
+    raw.exec(
+      `ALTER TABLE oauth_providers ADD COLUMN scope_separator TEXT NOT NULL DEFAULT ' '`,
+    );
+  } catch {
+    // Column already exists — nothing to do.
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -154,6 +154,7 @@ export { migrateStripThinkingFromConsolidated } from "./209-strip-thinking-from-
 export { migrateScheduleReuseConversation } from "./210-schedule-reuse-conversation.js";
 export { migrateMemoryRecallLogsQueryContext } from "./211-memory-recall-logs-query-context.js";
 export { migrateLlmRequestLogsCreatedAtIndex } from "./212-llm-request-logs-created-at-index.js";
+export { migrateOAuthProvidersScopeSeparator } from "./213-oauth-providers-scope-separator.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/oauth.ts
+++ b/assistant/src/memory/schema/oauth.ts
@@ -15,6 +15,7 @@ export const oauthProviders = sqliteTable("oauth_providers", {
   baseUrl: text("base_url"),
   defaultScopes: text("default_scopes").notNull().default("[]"),
   scopePolicy: text("scope_policy").notNull().default("{}"),
+  scopeSeparator: text("scope_separator").notNull().default(" "),
   authorizeParams: text("extra_params"),
   pingUrl: text("ping_url"),
   pingMethod: text("ping_method"),

--- a/assistant/src/oauth/__tests__/identity-verifier.test.ts
+++ b/assistant/src/oauth/__tests__/identity-verifier.test.ts
@@ -37,6 +37,7 @@ function makeProviderRow(
     baseUrl: null,
     defaultScopes: "[]",
     scopePolicy: "{}",
+    scopeSeparator: " ",
     authorizeParams: null,
     pingUrl: null,
     pingMethod: null,

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -53,7 +53,8 @@ export type OAuthConnectionRow = typeof oauthConnections.$inferSelect;
  * pingUrl, pingMethod, pingHeaders, pingBody, managedServiceConfigKey,
  * loopbackPort, injectionTemplates, appType, setupNotes,
  * identityUrl, identityMethod, identityHeaders, identityBody,
- * identityResponsePaths, identityFormat, identityOkField, featureFlag)
+ * identityResponsePaths, identityFormat, identityOkField, featureFlag,
+ * scopeSeparator)
  * and display metadata (displayLabel, description, dashboardUrl,
  * clientIdPlaceholder, requiresClientSecret) propagate to existing
  * installations on every startup, while user-customizable fields
@@ -76,6 +77,7 @@ export function seedProviders(
     baseUrl?: string;
     defaultScopes: string[];
     scopePolicy: Record<string, unknown>;
+    scopeSeparator?: string;
     authorizeParams?: Record<string, string>;
     managedServiceConfigKey?: string;
     displayLabel?: string;
@@ -117,6 +119,7 @@ export function seedProviders(
     const baseUrl = p.baseUrl ?? null;
     const defaultScopes = JSON.stringify(p.defaultScopes);
     const scopePolicy = JSON.stringify(p.scopePolicy);
+    const scopeSeparator = p.scopeSeparator ?? " ";
     const authorizeParams = p.authorizeParams
       ? JSON.stringify(p.authorizeParams)
       : null;
@@ -156,6 +159,7 @@ export function seedProviders(
         baseUrl,
         defaultScopes,
         scopePolicy,
+        scopeSeparator,
         authorizeParams,
         pingUrl,
         pingMethod,
@@ -190,6 +194,7 @@ export function seedProviders(
           tokenEndpointAuthMethod,
           userinfoUrl,
           baseUrl: sql`COALESCE(${oauthProviders.baseUrl}, ${baseUrl})`,
+          scopeSeparator,
           authorizeParams,
           pingUrl,
           pingMethod,
@@ -253,6 +258,7 @@ export function registerProvider(params: {
   baseUrl?: string;
   defaultScopes: string[];
   scopePolicy: Record<string, unknown>;
+  scopeSeparator?: string;
   authorizeParams?: Record<string, string>;
   managedServiceConfigKey?: string;
   displayLabel?: string;
@@ -295,6 +301,7 @@ export function registerProvider(params: {
     baseUrl: params.baseUrl ?? null,
     defaultScopes: JSON.stringify(params.defaultScopes),
     scopePolicy: JSON.stringify(params.scopePolicy),
+    scopeSeparator: params.scopeSeparator ?? " ",
     authorizeParams: params.authorizeParams
       ? JSON.stringify(params.authorizeParams)
       : null,
@@ -362,6 +369,7 @@ export function updateProvider(
     baseUrl: string;
     defaultScopes: string[];
     scopePolicy: Record<string, unknown>;
+    scopeSeparator: string;
     authorizeParams: Record<string, string>;
     displayLabel: string;
     description: string;
@@ -410,6 +418,8 @@ export function updateProvider(
     set.defaultScopes = JSON.stringify(params.defaultScopes);
   if (params.scopePolicy !== undefined)
     set.scopePolicy = JSON.stringify(params.scopePolicy);
+  if (params.scopeSeparator !== undefined)
+    set.scopeSeparator = params.scopeSeparator;
   if (params.authorizeParams !== undefined)
     set.authorizeParams = JSON.stringify(params.authorizeParams);
   if (params.displayLabel !== undefined) set.displayLabel = params.displayLabel;

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -9,7 +9,8 @@ import { seedProviders } from "./oauth-store.js";
  * pingUrl, pingMethod, pingHeaders, pingBody, managedServiceConfigKey,
  * loopbackPort, injectionTemplates, appType, setupNotes,
  * identityUrl, identityMethod, identityHeaders, identityBody,
- * identityResponsePaths, identityFormat, identityOkField, featureFlag)
+ * identityResponsePaths, identityFormat, identityOkField, featureFlag,
+ * scopeSeparator)
  * and display metadata (displayLabel,
  * description, dashboardUrl, clientIdPlaceholder, requiresClientSecret)
  * are overwritten on subsequent startups — user-customizable
@@ -35,6 +36,7 @@ const PROVIDER_SEED_DATA: Record<
       allowedOptionalScopes: string[];
       forbiddenScopes: string[];
     };
+    scopeSeparator?: string;
     authorizeParams?: Record<string, string>;
     managedServiceConfigKey?: string;
     displayLabel: string;
@@ -293,6 +295,7 @@ const PROVIDER_SEED_DATA: Record<
       allowedOptionalScopes: [],
       forbiddenScopes: [],
     },
+    scopeSeparator: ",",
     authorizeParams: { prompt: "consent" },
     loopbackPort: 17324,
     managedServiceConfigKey: "linear-oauth",


### PR DESCRIPTION
## Summary
- Add scope_separator column to oauth_providers schema with default ' ' and a migration
- Plumb scopeSeparator through seedProviders, registerProvider, updateProvider
- Set Linear's separator to ',' to match the platform

Part of plan: scope-separator-support.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
