### PR TITLE
fix(skills): collapse file viewer folders by default

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillDetailView.swift
@@ -69,21 +69,18 @@ struct SkillDetailView: View {
                 }
             }
 
-            // 3. On the first fetch for this skill view, expand every directory in
-            //    the tree so nested files are visible by default — this preserves
-            //    the pre-tree flat-list behavior where all files were immediately
-            //    visible. On subsequent refetches (e.g. files re-fetched after an
-            //    edit, a refresh button, or a file watcher), the `didSeedExpandedPaths`
-            //    flag prevents re-seeding so manual collapses aren't clobbered —
-            //    even if the user has collapsed every directory (which would defeat
-            //    a naive `expandedPaths.isEmpty` predicate). `didSeedExpandedPaths`
-            //    is reset in `.onDisappear` alongside `expandedPaths`, so navigating
+            // 3. On the first fetch for this skill view, start with all folders
+            //    collapsed. Only expand the ancestor chain of the auto-selected
+            //    file so that file remains visible in the tree — for the common
+            //    case where SKILL.md lives at the root, this is a no-op and every
+            //    folder stays collapsed. On subsequent refetches (e.g. files
+            //    re-fetched after an edit, a refresh button, or a file watcher),
+            //    the `didSeedExpandedPaths` flag prevents re-seeding so manual
+            //    expansions/collapses aren't clobbered. `didSeedExpandedPaths` is
+            //    reset in `.onDisappear` alongside `expandedPaths`, so navigating
             //    to a different skill re-triggers the initial seeding.
-            //    Compute `allDirectoryPaths` from the filtered text files (not the
-            //    raw file list) so directories that only contain binaries — which
-            //    don't appear in the tree — don't leak into `expandedPaths`.
             if !didSeedExpandedPaths && !textFiles.isEmpty {
-                var newExpanded = Self.allDirectoryPaths(in: textFiles)
+                var newExpanded: Set<String> = []
                 if let selectedPath = expandedFilePath {
                     newExpanded.formUnion(Self.ancestorPaths(of: selectedPath))
                 }
@@ -119,21 +116,6 @@ struct SkillDetailView: View {
         var result: Set<String> = []
         for i in 1..<components.count {
             result.insert(components[0..<i].joined(separator: "/"))
-        }
-        return result
-    }
-
-    /// Returns every directory path present in a flat list of skill files.
-    /// E.g. a file `external/asana/asana.md` contributes `external` and
-    /// `external/asana` to the resulting set.
-    private static func allDirectoryPaths(in files: [SkillFileEntry]) -> Set<String> {
-        var result: Set<String> = []
-        for file in files {
-            let components = file.path.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
-            guard components.count > 1 else { continue }
-            for i in 1..<components.count {
-                result.insert(components[0..<i].joined(separator: "/"))
-            }
         }
         return result
     }


### PR DESCRIPTION
## Summary
- On first load of a Skills detail page, seed `expandedPaths` with an empty set instead of every directory so the file viewer opens with all folders collapsed.
- Kept the ancestor-chain expansion for the auto-selected file so a deeply nested initial selection still remains visible (a no-op for the common `SKILL.md`-at-root case).
- Removed the now-unused `allDirectoryPaths` helper.

## Original prompt
In the Skills detail page, within the file viewer, make all folders collapsed by default instead of expanded.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
