### PR TITLE
fix(macos): fall back to plain text if onboarding ToS markdown fails to parse

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -136,8 +136,12 @@ struct ImproveExperienceStepView: View {
 
     private var tosAttributedString: AttributedString {
         let markdown = "I agree to the [Terms of Service](\(AppURLs.termsOfUseDocs.absoluteString)) and [Privacy Policy](\(AppURLs.privacyPolicyDocs.absoluteString))"
-        // swiftlint:disable:next force_try
-        var str = try! AttributedString(markdown: markdown)
+        // Use `try?` with a plain-text fallback so a markdown parse failure
+        // (e.g. unexpected interpolated content from VELLUM_DOCS_BASE_URL) degrades
+        // gracefully instead of crashing the onboarding flow.
+        guard var str = try? AttributedString(markdown: markdown) else {
+            return AttributedString("I agree to the Terms of Service and Privacy Policy")
+        }
         for run in str.runs where run.link != nil {
             str[run.range].underlineStyle = .single
         }


### PR DESCRIPTION
## Summary
- Mirrors the \`try?\` + plain-text fallback pattern already applied to \`SettingsBillingTab.addCreditsSubtitleAttributed\` so the onboarding ToS markdown parser also degrades gracefully on failure instead of crashing the flow.
- The risk is real after the URL migration in PR 4: the markdown now interpolates \`AppURLs.termsOfUseDocs\` and \`AppURLs.privacyPolicyDocs\`, which honor the \`VELLUM_DOCS_BASE_URL\` env var and could in theory contain markdown-breaking characters.
- Removes the \`swiftlint:disable:next force_try\` directive that's no longer needed.

Found by self-review during plan execution. Part of plan: docs-base-url-pricing-link.md (fix round 1).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
