### PR TITLE
fix(macos): correct AppURLsTests import and reject query/fragment in docs base URL

### DIFF
--- a/clients/macos/vellum-assistant/App/AppURLs.swift
+++ b/clients/macos/vellum-assistant/App/AppURLs.swift
@@ -26,13 +26,18 @@ public enum AppURLs {
             return defaultDocsBaseURL
         }
         let normalized = candidate.hasSuffix("/") ? String(candidate.dropLast()) : candidate
-        // Reject the override if it isn't a parseable absolute http(s) URL.
+        // Reject the override if it isn't a parseable absolute http(s) URL, or if
+        // it contains a query string or fragment. The contract is "base URL must
+        // be scheme://host[/path]" — a query or fragment would be silently
+        // clobbered or pasted into the middle of the URL by the docsURL helpers.
         // This prevents downstream force-unwraps from crashing on malformed values.
         guard
             let url = URL(string: normalized),
             let scheme = url.scheme?.lowercased(),
             scheme == "http" || scheme == "https",
-            url.host != nil
+            url.host != nil,
+            url.query == nil,
+            url.fragment == nil
         else {
             return defaultDocsBaseURL
         }

--- a/clients/macos/vellum-assistantTests/AppURLsTests.swift
+++ b/clients/macos/vellum-assistantTests/AppURLsTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import vellum_assistant
+@testable import VellumAssistantLib
 
 final class AppURLsTests: XCTestCase {
     private var originalEnvValue: String?
@@ -58,6 +58,16 @@ final class AppURLsTests: XCTestCase {
     func testDocsBaseURLAcceptsHTTPScheme() {
         setenv("VELLUM_DOCS_BASE_URL", "http://localhost:3000/docs", 1)
         XCTAssertEqual(AppURLs.docsBaseURL, "http://localhost:3000/docs")
+    }
+
+    func testDocsBaseURLRejectsBaseWithQueryAndFallsBack() {
+        setenv("VELLUM_DOCS_BASE_URL", "https://example.com/docs?build=123", 1)
+        XCTAssertEqual(AppURLs.docsBaseURL, "https://www.vellum.ai/docs")
+    }
+
+    func testDocsBaseURLRejectsBaseWithFragmentAndFallsBack() {
+        setenv("VELLUM_DOCS_BASE_URL", "https://example.com/docs#section", 1)
+        XCTAssertEqual(AppURLs.docsBaseURL, "https://www.vellum.ai/docs")
     }
 
     func testConcreteURLsFallBackOnMalformedEnv() {


### PR DESCRIPTION
## Summary
- Fixes a compile error in `AppURLsTests.swift` that would only surface on full CI: the test target imported `vellum_assistant`, an executable module the test target does not depend on. Changed to `@testable import VellumAssistantLib` to match the convention used by 40+ sibling tests.
- Tightens `AppURLs.docsBaseURL` validation so a `VELLUM_DOCS_BASE_URL` containing a query (`?build=123`) or fragment (`#section`) is rejected and falls back to the default — prevents the path/UTM helpers from silently producing semantically broken URLs.
- Adds test coverage for both query and fragment rejection.

Found by self-review during plan execution. Part of plan: docs-base-url-pricing-link.md (fix round 1).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
