### PR TITLE
feat(oauth): use provider scopeSeparator when joining and splitting scopes

### DIFF
--- a/assistant/src/__tests__/oauth-connect-orchestrator.test.ts
+++ b/assistant/src/__tests__/oauth-connect-orchestrator.test.ts
@@ -94,6 +94,7 @@ type ProviderRow = {
   baseUrl: string | null;
   defaultScopes: string;
   scopePolicy: string;
+  scopeSeparator: string;
   authorizeParams: string | null;
   pingUrl: string | null;
   pingMethod: string | null;
@@ -169,6 +170,7 @@ function makeProviderRow(
     defaultScopes: '["openid","email"]',
     scopePolicy:
       '{"allowAdditionalScopes":false,"allowedOptionalScopes":[],"forbiddenScopes":[]}',
+    scopeSeparator: " ",
     authorizeParams: null,
     pingUrl: null,
     pingMethod: null,
@@ -706,6 +708,88 @@ describe("orchestrateOAuthConnect — transport selection", () => {
         callbackTransport: "loopback",
         loopbackPort: undefined,
       });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Scope separator propagation
+  // -------------------------------------------------------------------------
+
+  describe("scope separator propagation", () => {
+    test("comma separator from providerRow propagates to oauthConfig (deferred)", async () => {
+      mockProviderStore["linear"] = makeProviderRow({
+        provider: "linear",
+        scopeSeparator: ",",
+      });
+
+      await orchestrateOAuthConnect({
+        service: "linear",
+        clientId: "client-id",
+        isInteractive: false,
+        callbackTransport: "loopback",
+      });
+
+      expect(lastPrepareArgs).not.toBeNull();
+      const capturedConfig = lastPrepareArgs!.config as {
+        scopeSeparator: string;
+      };
+      expect(capturedConfig.scopeSeparator).toBe(",");
+    });
+
+    test("space separator (default) from providerRow propagates to oauthConfig (deferred)", async () => {
+      mockProviderStore["google"] = GOOGLE_PROVIDER;
+
+      await orchestrateOAuthConnect({
+        service: "google",
+        clientId: "client-id",
+        isInteractive: false,
+        callbackTransport: "loopback",
+      });
+
+      expect(lastPrepareArgs).not.toBeNull();
+      const capturedConfig = lastPrepareArgs!.config as {
+        scopeSeparator: string;
+      };
+      expect(capturedConfig.scopeSeparator).toBe(" ");
+    });
+
+    test("comma separator from providerRow propagates to oauthConfig (interactive)", async () => {
+      mockProviderStore["linear"] = makeProviderRow({
+        provider: "linear",
+        scopeSeparator: ",",
+      });
+
+      await orchestrateOAuthConnect({
+        service: "linear",
+        clientId: "client-id",
+        isInteractive: true,
+        callbackTransport: "loopback",
+        openUrl: () => {},
+      });
+
+      expect(lastStartArgs).not.toBeNull();
+      const capturedConfig = lastStartArgs!.config as {
+        scopeSeparator: string;
+      };
+      expect(capturedConfig.scopeSeparator).toBe(",");
+    });
+
+    test("space separator from providerRow propagates to oauthConfig (interactive)", async () => {
+      mockProviderStore["google"] = GOOGLE_PROVIDER;
+
+      await orchestrateOAuthConnect({
+        service: "google",
+        clientId: "client-id",
+        isInteractive: true,
+        callbackTransport: "loopback",
+        openUrl: () => {},
+      });
+
+      expect(lastStartArgs).not.toBeNull();
+      const capturedConfig = lastStartArgs!.config as {
+        scopeSeparator: string;
+      };
+      expect(capturedConfig.scopeSeparator).toBe(" ");
     });
   });
 });

--- a/assistant/src/__tests__/oauth2-gateway-transport.test.ts
+++ b/assistant/src/__tests__/oauth2-gateway-transport.test.ts
@@ -672,8 +672,8 @@ describe("OAuth2 gateway transport", () => {
 
       await new Promise((r) => setTimeout(r, 10));
 
-      // Space-encoded scopes
-      expect(capturedAuthUrl).toContain("scope=read%20write");
+      // URLSearchParams encodes spaces as '+' in query strings (application/x-www-form-urlencoded)
+      expect(capturedAuthUrl).toContain("scope=read+write");
 
       const entries = Array.from(pendingCallbacks.entries());
       entries[0][1].resolve("space-separator-code");

--- a/assistant/src/__tests__/oauth2-gateway-transport.test.ts
+++ b/assistant/src/__tests__/oauth2-gateway-transport.test.ts
@@ -776,5 +776,72 @@ describe("OAuth2 gateway transport", () => {
       const result = await flowPromise;
       expect(result.grantedScopes).toEqual(["read", "write"]);
     });
+
+    test("default-space provider still parses comma-separated token response scopes (GitHub/Slack compat)", async () => {
+      // Providers like GitHub and Slack use space as their authorize-URL
+      // separator but return comma-separated scopes in token responses.
+      // The defensive split MUST tolerate that without requiring providers
+      // to opt into scopeSeparator: ",".
+      mockPublicBaseUrl = "https://gw.example.com";
+      mockTokenResponse = {
+        ok: true,
+        status: 200,
+        body: {
+          access_token: "test-access-token",
+          refresh_token: "test-refresh-token",
+          expires_in: 3600,
+          scope: "repo,read:user,notifications",
+          token_type: "Bearer",
+        },
+      };
+
+      // BASE_OAUTH_CONFIG uses the default " " separator.
+      const flowPromise = startOAuth2Flow(
+        BASE_OAUTH_CONFIG,
+        { openUrl: () => {} },
+        { callbackTransport: "gateway" },
+      );
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      const entries = Array.from(pendingCallbacks.entries());
+      entries[0][1].resolve("github-style-code");
+
+      const result = await flowPromise;
+      expect(result.grantedScopes).toEqual([
+        "repo",
+        "read:user",
+        "notifications",
+      ]);
+    });
+
+    test("default-space provider parses space-separated token response scopes", async () => {
+      mockPublicBaseUrl = "https://gw.example.com";
+      mockTokenResponse = {
+        ok: true,
+        status: 200,
+        body: {
+          access_token: "test-access-token",
+          refresh_token: "test-refresh-token",
+          expires_in: 3600,
+          scope: "read write admin",
+          token_type: "Bearer",
+        },
+      };
+
+      const flowPromise = startOAuth2Flow(
+        BASE_OAUTH_CONFIG,
+        { openUrl: () => {} },
+        { callbackTransport: "gateway" },
+      );
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      const entries = Array.from(pendingCallbacks.entries());
+      entries[0][1].resolve("space-token-code");
+
+      const result = await flowPromise;
+      expect(result.grantedScopes).toEqual(["read", "write", "admin"]);
+    });
   });
 });

--- a/assistant/src/__tests__/oauth2-gateway-transport.test.ts
+++ b/assistant/src/__tests__/oauth2-gateway-transport.test.ts
@@ -142,6 +142,7 @@ const BASE_OAUTH_CONFIG: OAuth2Config = {
   tokenExchangeUrl: "https://provider.example.com/token",
   scopes: ["read", "write"],
   clientId: "test-client-id",
+  scopeSeparator: " ",
 };
 
 beforeEach(() => {
@@ -651,6 +652,129 @@ describe("OAuth2 gateway transport", () => {
       expect(lastTokenRequestBody).not.toBeNull();
       expect(lastTokenRequestBody!.get("client_id")).toBe("test-client-id");
       expect(lastTokenRequestBody!.has("client_secret")).toBe(false);
+    });
+  });
+
+  describe("scope separator", () => {
+    test("authorize URL joins scopes with space when scopeSeparator is ' '", async () => {
+      mockPublicBaseUrl = "https://gw.example.com";
+
+      let capturedAuthUrl = "";
+      const flowPromise = startOAuth2Flow(
+        BASE_OAUTH_CONFIG,
+        {
+          openUrl: (url) => {
+            capturedAuthUrl = url;
+          },
+        },
+        { callbackTransport: "gateway" },
+      );
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      // Space-encoded scopes
+      expect(capturedAuthUrl).toContain("scope=read%20write");
+
+      const entries = Array.from(pendingCallbacks.entries());
+      entries[0][1].resolve("space-separator-code");
+      await flowPromise;
+    });
+
+    test("authorize URL joins scopes with comma when scopeSeparator is ','", async () => {
+      mockPublicBaseUrl = "https://gw.example.com";
+
+      const commaConfig: OAuth2Config = {
+        ...BASE_OAUTH_CONFIG,
+        scopeSeparator: ",",
+      };
+
+      let capturedAuthUrl = "";
+      const flowPromise = startOAuth2Flow(
+        commaConfig,
+        {
+          openUrl: (url) => {
+            capturedAuthUrl = url;
+          },
+        },
+        { callbackTransport: "gateway" },
+      );
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      // Comma-encoded scopes
+      expect(capturedAuthUrl).toContain("scope=read%2Cwrite");
+
+      const entries = Array.from(pendingCallbacks.entries());
+      entries[0][1].resolve("comma-separator-code");
+      await flowPromise;
+    });
+
+    test("token response with comma-separated scope splits into individual scopes when scopeSeparator is ','", async () => {
+      mockPublicBaseUrl = "https://gw.example.com";
+      mockTokenResponse = {
+        ok: true,
+        status: 200,
+        body: {
+          access_token: "test-access-token",
+          refresh_token: "test-refresh-token",
+          expires_in: 3600,
+          scope: "read,write,issues:create",
+          token_type: "Bearer",
+        },
+      };
+
+      const commaConfig: OAuth2Config = {
+        ...BASE_OAUTH_CONFIG,
+        scopeSeparator: ",",
+      };
+
+      const flowPromise = startOAuth2Flow(
+        commaConfig,
+        { openUrl: () => {} },
+        { callbackTransport: "gateway" },
+      );
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      const entries = Array.from(pendingCallbacks.entries());
+      entries[0][1].resolve("comma-token-code");
+
+      const result = await flowPromise;
+      expect(result.grantedScopes).toEqual(["read", "write", "issues:create"]);
+    });
+
+    test("token response with whitespace around comma separators is trimmed", async () => {
+      mockPublicBaseUrl = "https://gw.example.com";
+      mockTokenResponse = {
+        ok: true,
+        status: 200,
+        body: {
+          access_token: "test-access-token",
+          refresh_token: "test-refresh-token",
+          expires_in: 3600,
+          scope: " read , write ",
+          token_type: "Bearer",
+        },
+      };
+
+      const commaConfig: OAuth2Config = {
+        ...BASE_OAUTH_CONFIG,
+        scopeSeparator: ",",
+      };
+
+      const flowPromise = startOAuth2Flow(
+        commaConfig,
+        { openUrl: () => {} },
+        { callbackTransport: "gateway" },
+      );
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      const entries = Array.from(pendingCallbacks.entries());
+      entries[0][1].resolve("comma-whitespace-code");
+
+      const result = await flowPromise;
+      expect(result.grantedScopes).toEqual(["read", "write"]);
     });
   });
 });

--- a/assistant/src/oauth/connect-orchestrator.ts
+++ b/assistant/src/oauth/connect-orchestrator.ts
@@ -203,6 +203,7 @@ export async function orchestrateOAuthConnect(
     authorizeUrl,
     tokenExchangeUrl,
     scopes: finalScopes,
+    scopeSeparator: providerRow.scopeSeparator,
     clientId: options.clientId,
     clientSecret: options.clientSecret,
     authorizeParams,

--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -194,10 +194,17 @@ async function exchangeCodeForTokens(
       (tokenData.token_type as string | undefined),
   };
 
+  // Defensive split: providers (e.g. GitHub, Slack) may return comma-separated
+  // scopes in token responses regardless of the scope_separator used to join
+  // outbound authorize URLs, so we tolerate both spaces and commas here. When
+  // a provider explicitly configures a non-default separator (e.g. Linear uses
+  // ","), we honor that to keep symmetric round-tripping of configured scopes.
+  const splitPattern =
+    config.scopeSeparator === " " ? /[ ,]/ : config.scopeSeparator;
   const grantedScopes =
     typeof tokens.scope === "string"
       ? tokens.scope
-          .split(config.scopeSeparator)
+          .split(splitPattern)
           .map((s) => s.trim())
           .filter(Boolean)
       : [...config.scopes];

--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -49,6 +49,13 @@ export interface OAuth2Config {
    * Defaults to `client_secret_post`.
    */
   tokenEndpointAuthMethod?: TokenEndpointAuthMethod;
+  /**
+   * Separator used to join scopes in the authorize URL and split the
+   * granted-scope string returned by the token endpoint. Defaults to
+   * `" "` (space) per the OAuth 2.0 spec, but providers like Linear
+   * use `","` (comma).
+   */
+  scopeSeparator: string;
 }
 
 export interface OAuth2TokenResult {
@@ -189,7 +196,10 @@ async function exchangeCodeForTokens(
 
   const grantedScopes =
     typeof tokens.scope === "string"
-      ? tokens.scope.split(/[ ,]/).filter(Boolean)
+      ? tokens.scope
+          .split(config.scopeSeparator)
+          .map((s) => s.trim())
+          .filter(Boolean)
       : [...config.scopes];
 
   return { tokens, grantedScopes, rawTokenResponse: tokenData };
@@ -232,7 +242,7 @@ async function runGatewayFlow(
     client_id: config.clientId,
     redirect_uri: redirectUri,
     response_type: "code",
-    scope: config.scopes.join(" "),
+    scope: config.scopes.join(config.scopeSeparator),
     state,
     code_challenge: codeChallenge,
     code_challenge_method: "S256",
@@ -405,7 +415,7 @@ function startLoopbackServerAndWaitForCode(
         client_id: config.clientId,
         redirect_uri: boundRedirectUri,
         response_type: "code",
-        scope: config.scopes.join(" "),
+        scope: config.scopes.join(config.scopeSeparator),
         state,
         code_challenge: codeChallenge,
         code_challenge_method: "S256",
@@ -497,7 +507,7 @@ export async function prepareOAuth2Flow(
     client_id: config.clientId,
     redirect_uri: redirectUri,
     response_type: "code",
-    scope: config.scopes.join(" "),
+    scope: config.scopes.join(config.scopeSeparator),
     state,
     code_challenge: codeChallenge,
     code_challenge_method: "S256",
@@ -537,7 +547,7 @@ async function prepareLoopbackFlow(
     client_id: config.clientId,
     redirect_uri: redirectUri,
     response_type: "code",
-    scope: config.scopes.join(" "),
+    scope: config.scopes.join(config.scopeSeparator),
     state,
     code_challenge: codeChallenge,
     code_challenge_method: "S256",


### PR DESCRIPTION
## Summary
- Add required scopeSeparator field to OAuth2Config
- Replace the four hardcoded scopes.join(" ") sites with config.scopeSeparator
- Replace the token-response split regex with split(config.scopeSeparator) + trim
- Propagate providerRow.scopeSeparator through connect-orchestrator

Part of plan: scope-separator-support.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
