### PR TITLE
feat(oauth): expose scopeSeparator in provider serializer and CLI

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -26,6 +26,11 @@ const disconnectOAuthProviderCalls: string[] = [];
 const disconnectOAuthProviderResult: "disconnected" | "not-found" | "error" =
   "not-found";
 
+// In-memory provider store used by registerProvider/updateProvider/getProvider
+// mocks below. Tests that exercise the providers register/update/get commands
+// can read and write through this map directly.
+const mockProviderStore = new Map<string, Record<string, unknown>>();
+
 // App upsert mock state
 let mockUpsertAppCalls: Array<{
   provider: string;
@@ -151,10 +156,91 @@ mock.module("../oauth/oauth-store.js", () => ({
     mockGetMostRecentAppByProvider(provider),
   listApps: () => [],
   deleteApp: async () => false,
-  getProvider: (provider: string) => mockGetProvider(provider),
+  getProvider: (provider: string) => {
+    // If the test has plugged in a custom mockGetProvider, prefer that.
+    const custom = mockGetProvider(provider);
+    if (custom !== undefined) return custom;
+    return mockProviderStore.get(provider);
+  },
   listProviders: () => mockListProviders(),
-  registerProvider: () => ({}),
-  updateProvider: () => undefined,
+  registerProvider: (params: Record<string, unknown>) => {
+    const now = Date.now();
+    const row: Record<string, unknown> = {
+      provider: params.provider,
+      authorizeUrl: params.authorizeUrl,
+      tokenExchangeUrl: params.tokenExchangeUrl,
+      tokenEndpointAuthMethod: params.tokenEndpointAuthMethod ?? null,
+      userinfoUrl: params.userinfoUrl ?? null,
+      baseUrl: params.baseUrl ?? null,
+      defaultScopes: JSON.stringify(params.defaultScopes ?? []),
+      scopePolicy: JSON.stringify(params.scopePolicy ?? {}),
+      scopeSeparator: (params.scopeSeparator as string | undefined) ?? " ",
+      authorizeParams: params.authorizeParams
+        ? JSON.stringify(params.authorizeParams)
+        : null,
+      pingUrl: params.pingUrl ?? null,
+      pingMethod: params.pingMethod ?? null,
+      pingHeaders: params.pingHeaders
+        ? JSON.stringify(params.pingHeaders)
+        : null,
+      pingBody:
+        params.pingBody !== undefined ? JSON.stringify(params.pingBody) : null,
+      managedServiceConfigKey: params.managedServiceConfigKey ?? null,
+      displayLabel: params.displayLabel ?? null,
+      description: params.description ?? null,
+      dashboardUrl: params.dashboardUrl ?? null,
+      clientIdPlaceholder: params.clientIdPlaceholder ?? null,
+      requiresClientSecret: params.requiresClientSecret ?? 1,
+      loopbackPort: params.loopbackPort ?? null,
+      injectionTemplates: params.injectionTemplates
+        ? JSON.stringify(params.injectionTemplates)
+        : null,
+      appType: params.appType ?? null,
+      setupNotes: params.setupNotes ? JSON.stringify(params.setupNotes) : null,
+      identityUrl: params.identityUrl ?? null,
+      identityMethod: params.identityMethod ?? null,
+      identityHeaders: params.identityHeaders
+        ? JSON.stringify(params.identityHeaders)
+        : null,
+      identityBody:
+        params.identityBody !== undefined
+          ? JSON.stringify(params.identityBody)
+          : null,
+      identityResponsePaths: params.identityResponsePaths
+        ? JSON.stringify(params.identityResponsePaths)
+        : null,
+      identityFormat: params.identityFormat ?? null,
+      identityOkField: params.identityOkField ?? null,
+      featureFlag: params.featureFlag ?? null,
+      createdAt: now,
+      updatedAt: now,
+    };
+    mockProviderStore.set(params.provider as string, row);
+    return row;
+  },
+  updateProvider: (provider: string, params: Record<string, unknown>) => {
+    const existing = mockProviderStore.get(provider);
+    if (!existing) return undefined;
+    const updated: Record<string, unknown> = { ...existing };
+    if (params.scopeSeparator !== undefined) {
+      updated.scopeSeparator = params.scopeSeparator;
+    }
+    if (params.authorizeUrl !== undefined) {
+      updated.authorizeUrl = params.authorizeUrl;
+    }
+    if (params.tokenExchangeUrl !== undefined) {
+      updated.tokenExchangeUrl = params.tokenExchangeUrl;
+    }
+    if (params.defaultScopes !== undefined) {
+      updated.defaultScopes = JSON.stringify(params.defaultScopes);
+    }
+    if (params.displayLabel !== undefined) {
+      updated.displayLabel = params.displayLabel;
+    }
+    updated.updatedAt = Date.now();
+    mockProviderStore.set(provider, updated);
+    return updated;
+  },
   deleteProvider: () => false,
   seedProviders: () => {},
   getActiveConnection: () => undefined,
@@ -1311,5 +1397,131 @@ describe("assistant oauth mode", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.provider).toBe("google");
     expect(parsed.mode).toBe("your-own");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// providers register / update / get — --scope-separator wiring
+// ---------------------------------------------------------------------------
+
+describe("assistant oauth providers --scope-separator", () => {
+  beforeEach(() => {
+    mockWithValidToken = async (_service, cb) => cb("mock-access-token-xyz");
+    mockProviderStore.clear();
+    // Default getProvider falls through to mockProviderStore via the
+    // oauth-store mock module. Tests in this describe block don't need
+    // a per-test mockGetProvider override.
+    mockGetProvider = () => undefined;
+    mockGetConfig = () => ({ services: {} });
+  });
+
+  afterEach(() => {
+    mockProviderStore.clear();
+    mockGetProvider = () => undefined;
+  });
+
+  test("providers register --scope-separator , stores ',' on the provider row", async () => {
+    const { exitCode } = await runCli([
+      "providers",
+      "register",
+      "--provider-key",
+      "custom-linear",
+      "--auth-url",
+      "https://linear.app/oauth/authorize",
+      "--token-url",
+      "https://api.linear.app/oauth/token",
+      "--scopes",
+      "read,write",
+      "--scope-separator",
+      ",",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const stored = mockProviderStore.get("custom-linear");
+    expect(stored).toBeDefined();
+    expect(stored?.scopeSeparator).toBe(",");
+  });
+
+  test("providers register without --scope-separator stores the default ' '", async () => {
+    const { exitCode } = await runCli([
+      "providers",
+      "register",
+      "--provider-key",
+      "custom-default-sep",
+      "--auth-url",
+      "https://example.com/oauth/authorize",
+      "--token-url",
+      "https://example.com/oauth/token",
+      "--scopes",
+      "read,write",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const stored = mockProviderStore.get("custom-default-sep");
+    expect(stored).toBeDefined();
+    expect(stored?.scopeSeparator).toBe(" ");
+  });
+
+  test("providers update --scope-separator , updates an existing custom provider", async () => {
+    // Seed the store with an existing custom provider that uses the default
+    // " " separator.
+    await runCli([
+      "providers",
+      "register",
+      "--provider-key",
+      "custom-update-target",
+      "--auth-url",
+      "https://example.com/oauth/authorize",
+      "--token-url",
+      "https://example.com/oauth/token",
+      "--scopes",
+      "read",
+      "--json",
+    ]);
+    expect(mockProviderStore.get("custom-update-target")?.scopeSeparator).toBe(
+      " ",
+    );
+
+    const { exitCode } = await runCli([
+      "providers",
+      "update",
+      "custom-update-target",
+      "--scope-separator",
+      ",",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(mockProviderStore.get("custom-update-target")?.scopeSeparator).toBe(
+      ",",
+    );
+  });
+
+  test("providers get <key> --json includes scopeSeparator from the serialized output", async () => {
+    // Seed the store with a custom provider that uses ',' as the separator.
+    await runCli([
+      "providers",
+      "register",
+      "--provider-key",
+      "custom-get-target",
+      "--auth-url",
+      "https://example.com/oauth/authorize",
+      "--token-url",
+      "https://example.com/oauth/token",
+      "--scopes",
+      "read,write",
+      "--scope-separator",
+      ",",
+      "--json",
+    ]);
+
+    const { exitCode, stdout } = await runCli([
+      "providers",
+      "get",
+      "custom-get-target",
+      "--json",
+    ]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.scopeSeparator).toBe(",");
   });
 });

--- a/assistant/src/__tests__/oauth-provider-serializer.test.ts
+++ b/assistant/src/__tests__/oauth-provider-serializer.test.ts
@@ -168,6 +168,18 @@ describe("serializeProvider", () => {
   test("returns null for null input", () => {
     expect(serializeProvider(null)).toBeNull();
   });
+
+  test("emits scopeSeparator from the row when set to ','", () => {
+    const row = makeRow({ scopeSeparator: "," });
+    const result = serializeProvider(row)!;
+    expect(result.scopeSeparator).toBe(",");
+  });
+
+  test("emits scopeSeparator default ' ' when row uses the default", () => {
+    const row = makeRow({ scopeSeparator: " " });
+    const result = serializeProvider(row)!;
+    expect(result.scopeSeparator).toBe(" ");
+  });
 });
 
 describe("serializeProviderSummary", () => {
@@ -230,5 +242,12 @@ describe("serializeProviderSummary", () => {
 
   test("returns null for undefined input", () => {
     expect(serializeProviderSummary(undefined)).toBeNull();
+  });
+
+  test("does NOT include scope_separator (intentionally omitted from the HTTP summary)", () => {
+    const row = makeRow({ scopeSeparator: "," });
+    const result = serializeProviderSummary(row)!;
+    expect(result).not.toHaveProperty("scope_separator");
+    expect(result).not.toHaveProperty("scopeSeparator");
   });
 });

--- a/assistant/src/cli/commands/oauth/providers.ts
+++ b/assistant/src/cli/commands/oauth/providers.ts
@@ -227,6 +227,10 @@ Examples:
       'Comma-separated default scopes (e.g. "read,write,profile")',
     )
     .option(
+      "--scope-separator <sep>",
+      'Separator used to join scopes in the authorize URL (default: " "). Use "," for providers like Linear that expect comma-separated scopes.',
+    )
+    .option(
       "--token-auth-method <method>",
       'How the client authenticates at the token endpoint: "client_secret_post" or "client_secret_basic"',
     )
@@ -341,6 +345,12 @@ Examples:
       --ping-method POST \\
       --ping-body '{"query":"{ viewer { id } }"}'
   $ assistant oauth providers register \\
+      --provider-key linear-custom \\
+      --auth-url https://linear.app/oauth/authorize \\
+      --token-url https://api.linear.app/oauth/token \\
+      --scopes read,write \\
+      --scope-separator ","
+  $ assistant oauth providers register \\
       --provider-key my-api \\
       --auth-url https://example.com/auth \\
       --token-url https://example.com/token \\
@@ -358,6 +368,7 @@ Examples:
           baseUrl?: string;
           userinfoUrl?: string;
           scopes?: string;
+          scopeSeparator?: string;
           tokenAuthMethod?: string;
           pingUrl?: string;
           pingMethod?: string;
@@ -391,6 +402,7 @@ Examples:
             userinfoUrl: opts.userinfoUrl,
             defaultScopes: opts.scopes ? opts.scopes.split(",") : [],
             scopePolicy: {},
+            scopeSeparator: opts.scopeSeparator,
             tokenEndpointAuthMethod: opts.tokenAuthMethod,
             pingUrl: opts.pingUrl,
             pingMethod: opts.pingMethod,
@@ -460,6 +472,10 @@ Examples:
     .option(
       "--scopes <scopes>",
       'Comma-separated default scopes (e.g. "read,write,profile")',
+    )
+    .option(
+      "--scope-separator <sep>",
+      'Separator used to join scopes in the authorize URL (default: " "). Use "," for providers like Linear that expect comma-separated scopes.',
     )
     .option(
       "--token-auth-method <method>",
@@ -562,6 +578,7 @@ Examples:
   $ assistant oauth providers update custom-api --display-name "My Custom API"
   $ assistant oauth providers update custom-api --scopes read,write --auth-url https://new.example.com/auth
   $ assistant oauth providers update custom-api --ping-url https://api.example.com/me --json
+  $ assistant oauth providers update custom-api --scope-separator ","
   $ assistant oauth providers update custom-api \\
       --identity-url https://api.example.com/me \\
       --identity-response-paths email,name
@@ -577,6 +594,7 @@ Examples:
           baseUrl?: string;
           userinfoUrl?: string;
           scopes?: string;
+          scopeSeparator?: string;
           tokenAuthMethod?: string;
           pingUrl?: string;
           pingMethod?: string;
@@ -643,6 +661,8 @@ Examples:
             params.userinfoUrl = opts.userinfoUrl;
           if (opts.scopes !== undefined)
             params.defaultScopes = opts.scopes.split(",");
+          if (opts.scopeSeparator !== undefined)
+            params.scopeSeparator = opts.scopeSeparator;
           if (opts.tokenAuthMethod !== undefined)
             params.tokenEndpointAuthMethod = opts.tokenAuthMethod;
           if (opts.pingUrl !== undefined) params.pingUrl = opts.pingUrl;

--- a/assistant/src/oauth/provider-serializer.ts
+++ b/assistant/src/oauth/provider-serializer.ts
@@ -85,6 +85,7 @@ function _serializeProvider(
     supportsManagedMode: !!row.managedServiceConfigKey,
     defaultScopes: row.defaultScopes ? JSON.parse(row.defaultScopes) : [],
     scopePolicy: row.scopePolicy ? JSON.parse(row.scopePolicy) : {},
+    scopeSeparator: row.scopeSeparator,
     extraParams: authorizeParams ? JSON.parse(authorizeParams) : null,
     pingHeaders: row.pingHeaders ? JSON.parse(row.pingHeaders) : null,
     pingBody: row.pingBody ? JSON.parse(row.pingBody) : null,


### PR DESCRIPTION
## Summary
- Emit scopeSeparator from the full provider serializer (not the HTTP summary)
- Add --scope-separator flag to providers register and providers update CLI commands
- Add serializer and CLI test coverage

Part of plan: scope-separator-support.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
