### PR TITLE
fix(outlook): add Connection Setup section to skill for auto-detect parity

### DIFF
--- a/assistant/src/config/bundled-skills/outlook/SKILL.md
+++ b/assistant/src/config/bundled-skills/outlook/SKILL.md
@@ -35,6 +35,13 @@ When the user mentions "email" - sending, reading, checking, decluttering, draft
 
 Do not offer AgentMail as an option or mention it unless the user specifically asks. If Outlook is not connected, guide them through Outlook setup - do not suggest AgentMail as an alternative.
 
+## Connection Setup
+
+### Outlook
+
+1. **Try connecting directly first.** Run `assistant oauth status outlook`. This will show whether or not the user had previously connected their Outlook/Microsoft account. If so, they are ready to go.
+2. **If no connections are found:** Call `skill_load` with `skill: "vellum-oauth-integrations"`. The skill will evaluate whether managed or your-own mode is appropriate and guide the user accordingly.
+
 ## Communication Style
 
 - **Be action-oriented.** When the user asks to do something ("declutter", "check my email"), start doing it immediately. Don't ask for permission to read their inbox - that's obviously what they want.


### PR DESCRIPTION
## Summary
- The Outlook bundled skill was missing a **Connection Setup** section (Gmail's is at `gmail/SKILL.md:26-31`). With no instructions, when Outlook wasn't connected the model improvised a raw \`Sign in with Microsoft →\` markdown link and asked the user to manually confirm — bypassing the polling path entirely.
- The CLI polling in `assistant/src/cli/commands/oauth/connect.ts:254-282` is already provider-agnostic and works for Outlook; it just was never getting invoked because the skill never told the assistant to run `assistant oauth connect outlook` (via `vellum-oauth-integrations`).
- Added a Connection Setup section to `outlook/SKILL.md` mirroring Gmail's, so the assistant now checks `assistant oauth status outlook` first and falls back to loading `vellum-oauth-integrations`.

## Test plan
- [ ] In a fresh conversation with no Outlook connection, ask the assistant to connect Outlook and confirm it runs `assistant oauth status outlook` → loads `vellum-oauth-integrations` → auto-detects the connection after sign-in (no "let me know once you're done" prompt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
