### PR TITLE
fix: preserve user git identity in assistant workspaces

### DIFF
--- a/assistant/docker-entrypoint.sh
+++ b/assistant/docker-entrypoint.sh
@@ -6,6 +6,17 @@ if [ "$(id -u)" = "0" ] && [ "${VELLUM_WORKSPACE_DIR:-}" = "/workspace" ] && [ -
   git config --global --add safe.directory '/workspace/*' >/dev/null 2>&1 || true
 fi
 
+DEFAULT_GIT_NAME="${ASSISTANT_GIT_USER_NAME:-Vellum Assistant}"
+DEFAULT_GIT_EMAIL="${ASSISTANT_GIT_USER_EMAIL:-assistant@vellum.ai}"
+
+if ! git config --global --get user.name >/dev/null 2>&1; then
+  git config --global user.name "${DEFAULT_GIT_NAME}" >/dev/null 2>&1 || true
+fi
+
+if ! git config --global --get user.email >/dev/null 2>&1; then
+  git config --global user.email "${DEFAULT_GIT_EMAIL}" >/dev/null 2>&1 || true
+fi
+
 # ── Bun profiler bootstrap ──────────────────────────────────────────────
 # When VELLUM_PROFILER_RUN_ID and VELLUM_PROFILER_MODE are set, prepare the
 # run directory on the workspace volume and append the appropriate Bun

--- a/assistant/docs/architecture/memory.md
+++ b/assistant/docs/architecture/memory.md
@@ -303,16 +303,16 @@ stateDiagram-v2
 
 **Item extraction** uses LLM-powered extraction (with pattern-based fallback) to identify memorable information from conversation messages. Each extracted item belongs to one of eight kinds:
 
-| Kind         | Description                                                        | Base Lifetime |
-| ------------ | ------------------------------------------------------------------ | ------------- |
-| `identity`   | Personal info, facts, relationships                                | 6 months      |
-| `preference` | Likes, dislikes, preferred approaches/tools                        | 3 months      |
+| Kind         | Description                                                          | Base Lifetime |
+| ------------ | -------------------------------------------------------------------- | ------------- |
+| `identity`   | Personal info, facts, relationships                                  | 6 months      |
+| `preference` | Likes, dislikes, preferred approaches/tools                          | 3 months      |
 | `journal`    | Experiential reflections, journal-style notes, forward-looking items | 3 months      |
-| `constraint` | Rules, requirements, directives                                    | 1 month       |
-| `project`    | Project details, repos, tech stacks, action items                  | 2 weeks       |
-| `decision`   | Choices made, approaches selected                                  | 2 weeks       |
-| `event`      | Deadlines, milestones, meetings, dates                             | 3 days        |
-| `capability` | Skill catalog entries (system-generated, not LLM-extracted)        | never expires |
+| `constraint` | Rules, requirements, directives                                      | 1 month       |
+| `project`    | Project details, repos, tech stacks, action items                    | 2 weeks       |
+| `decision`   | Choices made, approaches selected                                    | 2 weeks       |
+| `event`      | Deadlines, milestones, meetings, dates                               | 3 days        |
+| `capability` | Skill catalog entries (system-generated, not LLM-extracted)          | never expires |
 
 **Supersession chains** replace the old conflict resolution system. When the LLM extracts a new item that updates an existing one, it sets `supersedes` to the old item's ID and `overrideConfidence` to one of three levels:
 
@@ -552,13 +552,13 @@ The Anthropic provider places `cache_control: { type: 'ephemeral' }` on the **la
 
 ### Key files
 
-| File                                                    | Role                                                                                                                                       |
-| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `assistant/src/workspace/top-level-scanner.ts`          | Synchronous directory scanner with `MAX_TOP_LEVEL_ENTRIES` cap                                                                             |
-| `assistant/src/workspace/top-level-renderer.ts`         | Renders `TopLevelSnapshot` to `<workspace>` XML block                                                                                      |
-| `assistant/src/daemon/conversation-runtime-assembly.ts` | Runtime injections and legacy-block strip helpers (`<workspace>`, `<turn_context>`, `<channel_onboarding_playbook>`, `<onboarding_mode>`)  |
-| `assistant/src/onboarding/onboarding-orchestrator.ts`   | Builds assistant-owned onboarding runtime guidance from channel playbook + transport metadata                                              |
-| `assistant/src/daemon/conversation-agent-loop.ts`       | Agent loop orchestration, runtime injection wiring, legacy-block strip chain                                                               |
+| File                                                    | Role                                                                                                                                      |
+| ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `assistant/src/workspace/top-level-scanner.ts`          | Synchronous directory scanner with `MAX_TOP_LEVEL_ENTRIES` cap                                                                            |
+| `assistant/src/workspace/top-level-renderer.ts`         | Renders `TopLevelSnapshot` to `<workspace>` XML block                                                                                     |
+| `assistant/src/daemon/conversation-runtime-assembly.ts` | Runtime injections and legacy-block strip helpers (`<workspace>`, `<turn_context>`, `<channel_onboarding_playbook>`, `<onboarding_mode>`) |
+| `assistant/src/onboarding/onboarding-orchestrator.ts`   | Builds assistant-owned onboarding runtime guidance from channel playbook + transport metadata                                             |
+| `assistant/src/daemon/conversation-agent-loop.ts`       | Agent loop orchestration, runtime injection wiring, legacy-block strip chain                                                              |
 
 ---
 
@@ -593,11 +593,11 @@ graph TB
 
 ### Key files
 
-| File                                                    | Role                                                                                                          |
-| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `assistant/src/daemon/date-context.ts`                  | `formatTurnTimestamp()` — generates the timestamp string used in `<turn_context>`                             |
-| `assistant/src/daemon/conversation-runtime-assembly.ts` | `buildUnifiedTurnContextBlock()` — constructs the unified `<turn_context>` block; legacy block strip helpers  |
-| `assistant/src/daemon/conversation-agent-loop.ts`       | Wiring: builds turn context, passes to `applyRuntimeInjections`                                               |
+| File                                                    | Role                                                                                                         |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `assistant/src/daemon/date-context.ts`                  | `formatTurnTimestamp()` — generates the timestamp string used in `<turn_context>`                            |
+| `assistant/src/daemon/conversation-runtime-assembly.ts` | `buildUnifiedTurnContextBlock()` — constructs the unified `<turn_context>` block; legacy block strip helpers |
+| `assistant/src/daemon/conversation-agent-loop.ts`       | Wiring: builds turn context, passes to `applyRuntimeInjections`                                              |
 
 ---
 
@@ -646,7 +646,7 @@ graph TB
 
 ### How it works
 
-1. **Lazy initialization**: The git repository is created on first use, not at workspace creation. When `ensureInitialized()` is called, it checks for a `.git` directory. If absent, it runs `git init`, creates a `.gitignore` (excluding `data/`, `logs/`, `*.log`, `*.sock`, `*.pid`, `session-token`), sets the git identity to "Vellum Assistant", and creates an initial baseline commit capturing any pre-existing files. The baseline commit is intentional — it makes `git log`, `git diff`, and `git revert` work cleanly from the start. Both new and existing workspaces get the same treatment. For existing repos (e.g. created by older versions or external tools), `.gitignore` rules and git identity are set idempotently on each init, ensuring proper configuration regardless of how the repo was originally created.
+1. **Lazy initialization**: The git repository is created on first use, not at workspace creation. When `ensureInitialized()` is called, it checks for a `.git` directory. If absent, it runs `git init`, creates a `.gitignore` (excluding `data/`, `logs/`, `*.log`, `*.sock`, `*.pid`, `session-token`), and creates an initial baseline commit capturing any pre-existing files. Assistant-managed commits pass the assistant identity explicitly at commit time instead of rewriting repo-local git config, so user-configured identities remain intact for interactive shell usage. The container entrypoint also seeds a global fallback identity only when `user.name` or `user.email` is missing, preventing Git from falling back to `root@<hostname>`. The baseline commit is intentional — it makes `git log`, `git diff`, and `git revert` work cleanly from the start. For existing repos (e.g. created by older versions or external tools), `.gitignore` rules are still normalized idempotently on each init.
 
 2. **Turn-boundary commits**: After each conversation turn (user message + assistant response cycle), `conversation.ts` commits workspace changes via `commitTurnChanges(workspaceDir, sessionId, turnNumber)`. The commit runs in the `finally` block of `runAgentLoop`, guarded by a `turnStarted` flag that is set once the agent loop begins executing. This guarantees a commit attempt even when post-processing (e.g. `resolveAssistantAttachments`) throws, or when the user cancels mid-turn. The commit is raced against a configurable timeout (`workspaceGit.turnCommitMaxWaitMs`, default 4s) via `Promise.race`. If the commit exceeds the timeout, the turn proceeds immediately while the commit continues in the background. Note: the background commit is NOT awaited before the next turn starts, so brief cross-turn file attribution windows are possible but accepted as a tradeoff for responsiveness. Commit outcomes are logged with structured fields (`sessionId`, `turnNumber`, `filesChanged`, `durationMs`) for observability.
 

--- a/assistant/src/__tests__/commit-message-enrichment-service.test.ts
+++ b/assistant/src/__tests__/commit-message-enrichment-service.test.ts
@@ -80,6 +80,10 @@ describe("CommitEnrichmentService", () => {
       "git",
       [
         "-c",
+        "user.name=Vellum Assistant",
+        "-c",
+        "user.email=assistant@vellum.ai",
+        "-c",
         "core.hooksPath=/dev/null",
         "commit",
         "--no-verify",

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -19,8 +19,8 @@ import {
   stripInjectionsForCompaction,
   stripNowScratchpad,
 } from "../daemon/conversation-runtime-assembly.js";
-import type { SubagentState } from "../subagent/types.js";
 import type { Message } from "../providers/types.js";
+import type { SubagentState } from "../subagent/types.js";
 
 // ---------------------------------------------------------------------------
 // resolveChannelCapabilities
@@ -1525,7 +1525,11 @@ function makeSubagentState(
     startedAt: overrides.startedAt ?? Date.now() - 55_000,
     completedAt: overrides.completedAt,
     error: overrides.error,
-    usage: overrides.usage ?? { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
+    usage: overrides.usage ?? {
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCost: 0,
+    },
   };
 }
 
@@ -1536,7 +1540,11 @@ describe("buildSubagentStatusBlock", () => {
 
   test("formats running subagent with elapsed time", () => {
     const children = [
-      makeSubagentState({ id: "abc-123", label: "research-auth", status: "running" }),
+      makeSubagentState({
+        id: "abc-123",
+        label: "research-auth",
+        status: "running",
+      }),
     ];
     const block = buildSubagentStatusBlock(children)!;
     expect(block).toContain("<active_subagents>");
@@ -1578,7 +1586,12 @@ describe("buildSubagentStatusBlock", () => {
     const children = [
       makeSubagentState({ id: "a", label: "researcher", status: "running" }),
       makeSubagentState({ id: "b", label: "coder", status: "completed" }),
-      makeSubagentState({ id: "c", label: "planner", status: "failed", error: "timeout" }),
+      makeSubagentState({
+        id: "c",
+        label: "planner",
+        status: "failed",
+        error: "timeout",
+      }),
     ];
     const block = buildSubagentStatusBlock(children)!;
     expect(block).toContain('"researcher"');
@@ -1593,11 +1606,14 @@ describe("injectSubagentStatus", () => {
       role: "user",
       content: [{ type: "text", text: "hello" }],
     };
-    const result = injectSubagentStatus(msg, "<active_subagents>\ntest\n</active_subagents>");
-    expect(result.content).toHaveLength(2);
-    expect((result.content[1] as { type: string; text: string }).text).toContain(
-      "<active_subagents>",
+    const result = injectSubagentStatus(
+      msg,
+      "<active_subagents>\ntest\n</active_subagents>",
     );
+    expect(result.content).toHaveLength(2);
+    expect(
+      (result.content[1] as { type: string; text: string }).text,
+    ).toContain("<active_subagents>");
   });
 });
 
@@ -1609,7 +1625,8 @@ describe("applyRuntimeInjections — subagent status", () => {
 
   test("includes subagent status in full mode", () => {
     const result = applyRuntimeInjections([userMsg], {
-      subagentStatusBlock: "<active_subagents>\n- [running] test\n</active_subagents>",
+      subagentStatusBlock:
+        "<active_subagents>\n- [running] test\n</active_subagents>",
       mode: "full",
     });
     const tail = result[result.length - 1];
@@ -1621,7 +1638,8 @@ describe("applyRuntimeInjections — subagent status", () => {
 
   test("skips subagent status in minimal mode", () => {
     const result = applyRuntimeInjections([userMsg], {
-      subagentStatusBlock: "<active_subagents>\n- [running] test\n</active_subagents>",
+      subagentStatusBlock:
+        "<active_subagents>\n- [running] test\n</active_subagents>",
       mode: "minimal",
     });
     const tail = result[result.length - 1];

--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -22,6 +22,25 @@ import {
   WorkspaceGitService,
 } from "../workspace/git-service.js";
 
+function getLocalGitConfig(cwd: string, key: string): string | null {
+  try {
+    return execFileSync("git", ["config", "--local", "--get", key], {
+      cwd,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function getHeadAuthor(cwd: string): string {
+  return execFileSync("git", ["log", "-1", "--format=%an <%ae>"], {
+    cwd,
+    encoding: "utf-8",
+  }).trim();
+}
+
 describe("WorkspaceGitService", () => {
   let testDir: string;
 
@@ -70,21 +89,15 @@ describe("WorkspaceGitService", () => {
       expect(content).toContain("session-token");
     });
 
-    test("sets git identity correctly", async () => {
+    test("creates commits with the assistant identity without writing local config", async () => {
       const service = new WorkspaceGitService(testDir);
       await service.ensureInitialized();
 
-      const userName = execFileSync("git", ["config", "user.name"], {
-        cwd: testDir,
-        encoding: "utf-8",
-      }).trim();
-      const userEmail = execFileSync("git", ["config", "user.email"], {
-        cwd: testDir,
-        encoding: "utf-8",
-      }).trim();
-
-      expect(userName).toBe("Vellum Assistant");
-      expect(userEmail).toBe("assistant@vellum.ai");
+      expect(getHeadAuthor(testDir)).toBe(
+        "Vellum Assistant <assistant@vellum.ai>",
+      );
+      expect(getLocalGitConfig(testDir, "user.name")).toBeNull();
+      expect(getLocalGitConfig(testDir, "user.email")).toBeNull();
     });
 
     test("multiple ensureInitialized calls are idempotent", async () => {
@@ -681,7 +694,7 @@ describe("WorkspaceGitService", () => {
       expect(contentAfter).toContain("*.sock");
     });
 
-    test("existing repo gets local identity set on init", async () => {
+    test("existing repo preserves local identity config on init", async () => {
       // Set up a pre-existing git repo with a different identity
       execFileSync("git", ["init", "-b", "main"], { cwd: testDir });
       execFileSync("git", ["config", "user.name", "Old Name"], {
@@ -698,17 +711,33 @@ describe("WorkspaceGitService", () => {
       const service = new WorkspaceGitService(testDir);
       await service.ensureInitialized();
 
-      const userName = execFileSync("git", ["config", "user.name"], {
-        cwd: testDir,
-        encoding: "utf-8",
-      }).trim();
-      const userEmail = execFileSync("git", ["config", "user.email"], {
-        cwd: testDir,
-        encoding: "utf-8",
-      }).trim();
+      expect(getLocalGitConfig(testDir, "user.name")).toBe("Old Name");
+      expect(getLocalGitConfig(testDir, "user.email")).toBe("old@example.com");
+    });
 
-      expect(userName).toBe("Vellum Assistant");
-      expect(userEmail).toBe("assistant@vellum.ai");
+    test("assistant-managed commits keep the assistant identity without overwriting local config", async () => {
+      execFileSync("git", ["init", "-b", "main"], { cwd: testDir });
+      execFileSync("git", ["config", "user.name", "Old Name"], {
+        cwd: testDir,
+      });
+      execFileSync("git", ["config", "user.email", "old@example.com"], {
+        cwd: testDir,
+      });
+      writeFileSync(join(testDir, "file.txt"), "content");
+      execFileSync("git", ["add", "-A"], { cwd: testDir });
+      execFileSync("git", ["commit", "-m", "init"], { cwd: testDir });
+
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      writeFileSync(join(testDir, "assistant.txt"), "assistant change");
+      await service.commitChanges("Assistant commit");
+
+      expect(getHeadAuthor(testDir)).toBe(
+        "Vellum Assistant <assistant@vellum.ai>",
+      );
+      expect(getLocalGitConfig(testDir, "user.name")).toBe("Old Name");
+      expect(getLocalGitConfig(testDir, "user.email")).toBe("old@example.com");
     });
 
     test("existing repo with correct config is idempotent", async () => {
@@ -740,10 +769,7 @@ describe("WorkspaceGitService", () => {
       const gitignoreAfter = readFileSync(join(testDir, ".gitignore"), "utf-8");
       expect(gitignoreAfter).toBe(gitignoreBefore);
 
-      const userName = execFileSync("git", ["config", "user.name"], {
-        cwd: testDir,
-        encoding: "utf-8",
-      }).trim();
+      const userName = getLocalGitConfig(testDir, "user.name");
       expect(userName).toBe("Vellum Assistant");
 
       const branch = execFileSync("git", ["symbolic-ref", "--short", "HEAD"], {

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -31,7 +31,6 @@ import {
   clearSentryConversationContext,
   setSentryConversationContext,
 } from "../instrument.js";
-import { getSubagentManager } from "../subagent/index.js";
 import { commitAppTurnChanges } from "../memory/app-git-service.js";
 import { getApp, listAppFiles, resolveAppDir } from "../memory/app-store.js";
 import {
@@ -59,6 +58,7 @@ import type { ContentBlock, Message } from "../providers/types.js";
 import type { Provider } from "../providers/types.js";
 import { resolveActorTrust } from "../runtime/actor-trust-resolver.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
+import { getSubagentManager } from "../subagent/index.js";
 import type { UsageActor } from "../usage/actors.js";
 import { getLogger } from "../util/logger.js";
 import { truncate } from "../util/truncate.js";
@@ -940,8 +940,12 @@ export async function runAgentLoopImpl(
         // value from injectionOpts to avoid duplicate injection.
         runMessages = applyRuntimeInjections(ctx.messages, {
           ...injectionOpts,
-          ...(step.compactionResult?.compacted && { pkbContext: currentPkbContent }),
-          ...(step.compactionResult?.compacted && { nowScratchpad: currentNowContent }),
+          ...(step.compactionResult?.compacted && {
+            pkbContext: currentPkbContent,
+          }),
+          ...(step.compactionResult?.compacted && {
+            nowScratchpad: currentNowContent,
+          }),
           workspaceTopLevelContext: shouldInjectWorkspace
             ? ctx.workspaceTopLevelContext
             : null,

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -1,10 +1,5 @@
 import { execFile, spawnSync } from "node:child_process";
-import {
-  existsSync,
-  readFileSync,
-  unlinkSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { promisify } from "node:util";
 
@@ -74,6 +69,16 @@ const WORKSPACE_GITIGNORE_RULES = [
   "vellum.pid",
   "session-token",
 ];
+
+const DEFAULT_ASSISTANT_GIT_NAME = "Vellum Assistant";
+const DEFAULT_ASSISTANT_GIT_EMAIL = "assistant@vellum.ai";
+
+function getAssistantGitIdentity(): { name: string; email: string } {
+  return {
+    name: process.env.ASSISTANT_GIT_USER_NAME || DEFAULT_ASSISTANT_GIT_NAME,
+    email: process.env.ASSISTANT_GIT_USER_EMAIL || DEFAULT_ASSISTANT_GIT_EMAIL,
+  };
+}
 
 /** Properties added by Node's child_process errors. */
 interface ExecError extends Error {
@@ -303,8 +308,7 @@ export class WorkspaceGitService {
    * If .git doesn't exist:
    * 1. Run git init -b main
    * 2. Create .gitignore
-   * 3. Set git identity
-   * 4. Stage all files and create initial commit
+   * 3. Stage all files and create initial commit
    *
    * The initial commit is created synchronously within the mutex lock
    * to prevent races with the first commitChanges() call.
@@ -431,7 +435,6 @@ export class WorkspaceGitService {
                 // These calls are OUTSIDE the rev-parse try/catch so that
                 // normalization errors are not misclassified as "no commits".
                 this.ensureGitignoreRulesLocked();
-                await this.ensureCommitIdentityLocked();
                 await this.ensureOnMainLocked();
                 this.initialized = true;
                 this.recordInitSuccess();
@@ -444,12 +447,11 @@ export class WorkspaceGitService {
           // Initialize new git repository
           await this.execGit(["init", "-b", "main"]);
 
-          // Run normalization (gitignore + identity + branch enforcement).
+          // Run normalization (gitignore + branch enforcement).
           // For fresh `git init -b main` the branch is already main, but
           // in the corruption-recovery path we fall through here after
           // removing .git, so branch enforcement is still useful.
           this.ensureGitignoreRulesLocked();
-          await this.ensureCommitIdentityLocked();
           await this.ensureOnMainLocked();
 
           // Create initial commit synchronously within the lock to prevent
@@ -759,19 +761,6 @@ export class WorkspaceGitService {
   }
 
   /**
-   * Ensure local git identity is configured for automated commits.
-   * Idempotent: git config set is a no-op if the value is already correct.
-   * Must be called with the mutex lock held.
-   */
-  private async ensureCommitIdentityLocked(): Promise<void> {
-    const gitName = process.env.ASSISTANT_GIT_USER_NAME || "Vellum Assistant";
-    const gitEmail =
-      process.env.ASSISTANT_GIT_USER_EMAIL || "assistant@vellum.ai";
-    await this.execGit(["config", "user.name", gitName]);
-    await this.execGit(["config", "user.email", gitEmail]);
-  }
-
-  /**
    * Ensure the workspace repo is on the `main` branch.
    * If on a different branch or in detached HEAD state, switches to main
    * (creating it if it doesn't exist).
@@ -882,13 +871,27 @@ export class WorkspaceGitService {
   }
 
   /**
-   * Build commit args that disable all git hook execution.
+   * Build commit args that disable hooks and use the assistant identity
+   * without mutating repo-local git config.
    *
    * Workspace contents are model-writable, so hooks in `.git/hooks` (or via
    * `core.hooksPath`) are untrusted. Auto-commit paths must not execute them.
+   * We pass the assistant identity via transient `-c` overrides so manual
+   * users can keep their own git config without the runtime rewriting it.
    */
   private buildSafeCommitArgs(args: string[]): string[] {
-    return ["-c", "core.hooksPath=/dev/null", "commit", "--no-verify", ...args];
+    const { name, email } = getAssistantGitIdentity();
+    return [
+      "-c",
+      "core.hooksPath=/dev/null",
+      "-c",
+      `user.name=${name}`,
+      "-c",
+      `user.email=${email}`,
+      "commit",
+      "--no-verify",
+      ...args,
+    ];
   }
 
   /**

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -880,18 +880,23 @@ export class WorkspaceGitService {
    * users can keep their own git config without the runtime rewriting it.
    */
   private buildSafeCommitArgs(args: string[]): string[] {
-    const { name, email } = getAssistantGitIdentity();
+    const identityArgs = this.buildAssistantIdentityConfigArgs();
     return [
+      ...identityArgs,
       "-c",
       "core.hooksPath=/dev/null",
-      "-c",
-      `user.name=${name}`,
-      "-c",
-      `user.email=${email}`,
       "commit",
       "--no-verify",
       ...args,
     ];
+  }
+
+  /**
+   * Build transient git config args for assistant-managed writes.
+   */
+  private buildAssistantIdentityConfigArgs(): string[] {
+    const { name, email } = getAssistantGitIdentity();
+    return ["-c", `user.name=${name}`, "-c", `user.email=${email}`];
   }
 
   /**
@@ -950,7 +955,16 @@ export class WorkspaceGitService {
   ): Promise<void> {
     await this.mutex.withLock(async () => {
       await this.execGit(
-        ["notes", "--ref=vellum", "add", "-f", "-m", noteContent, commitHash],
+        [
+          ...this.buildAssistantIdentityConfigArgs(),
+          "notes",
+          "--ref=vellum",
+          "add",
+          "-f",
+          "-m",
+          noteContent,
+          commitHash,
+        ],
         { signal },
       );
     });


### PR DESCRIPTION
## Summary
- pass the assistant git identity explicitly for assistant-managed commits instead of rewriting repo-local config
- seed a hostname-free global git fallback in managed containers only when user.name or user.email is missing
- cover preserved local config and assistant commit attribution in workspace git tests

## Original prompt
ok come up with a way of fixing the default git identity to vellum-assistant without the hostname, do not override the users identity if they set it when doing this
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
