### PR TITLE
feat: update subagent usage stats incrementally during execution

### DIFF
--- a/clients/shared/Features/Chat/SubagentDetailStore.swift
+++ b/clients/shared/Features/Chat/SubagentDetailStore.swift
@@ -313,6 +313,18 @@ public final class SubagentDetailStore {
             trackMutation()
             #endif
 
+        case .usageUpdate(let update):
+            let current = stagedUsage[subagentId] ?? subagentStates[subagentId]?.usageStats ?? SubagentUsageStats()
+            stagedUsage[subagentId] = SubagentUsageStats(
+                inputTokens: update.totalInputTokens,
+                outputTokens: update.totalOutputTokens,
+                estimatedCost: current.estimatedCost + update.estimatedCost
+            )
+            scheduleFlush()
+            #if DEBUG
+            trackMutation()
+            #endif
+
         default:
             break
         }


### PR DESCRIPTION
## Summary
- Add `.usageUpdate` case to `SubagentDetailStore.handleEvent()` so the SubagentDetailPanel shows Input Tokens / Output Tokens / Cost as each LLM call completes, rather than only at subagent completion
- Uses cumulative `totalInputTokens`/`totalOutputTokens` from the server directly; accumulates incremental `estimatedCost`
- No server changes needed — the plumbing already sends `usage_update` inside `subagent_event`

## Original prompt
When using subagents, we should update the Inputs Tokens / Output Tokens / Cost as the subagent progresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
