### PR TITLE
feat: inject active subagent status into parent agent context

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -6,17 +6,20 @@ import type {
 } from "../daemon/conversation-runtime-assembly.js";
 import {
   applyRuntimeInjections,
+  buildSubagentStatusBlock,
   buildUnifiedTurnContextBlock,
   findLastInjectedNowContent,
   injectChannelCapabilityContext,
   injectChannelCommandContext,
   injectNowScratchpad,
+  injectSubagentStatus,
   isGroupChatType,
   resolveChannelCapabilities,
   stripChannelCapabilityContext,
   stripInjectionsForCompaction,
   stripNowScratchpad,
 } from "../daemon/conversation-runtime-assembly.js";
+import type { SubagentState } from "../subagent/types.js";
 import type { Message } from "../providers/types.js";
 
 // ---------------------------------------------------------------------------
@@ -1498,5 +1501,156 @@ describe("findLastInjectedNowContent", () => {
     ];
 
     expect(findLastInjectedNowContent(messages)).toBe("User focus");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Subagent status injection
+// ---------------------------------------------------------------------------
+
+function makeSubagentState(
+  overrides: Partial<SubagentState> & { label: string; id: string },
+): SubagentState {
+  return {
+    config: {
+      id: overrides.id,
+      parentConversationId: "parent-conv",
+      label: overrides.label,
+      objective: "test objective",
+      ...overrides.config,
+    },
+    status: overrides.status ?? "running",
+    conversationId: `conv-${overrides.id}`,
+    createdAt: overrides.createdAt ?? Date.now() - 60_000,
+    startedAt: overrides.startedAt ?? Date.now() - 55_000,
+    completedAt: overrides.completedAt,
+    error: overrides.error,
+    usage: overrides.usage ?? { inputTokens: 0, outputTokens: 0, estimatedCost: 0 },
+  };
+}
+
+describe("buildSubagentStatusBlock", () => {
+  test("returns null for empty children array", () => {
+    expect(buildSubagentStatusBlock([])).toBeNull();
+  });
+
+  test("formats running subagent with elapsed time", () => {
+    const children = [
+      makeSubagentState({ id: "abc-123", label: "research-auth", status: "running" }),
+    ];
+    const block = buildSubagentStatusBlock(children)!;
+    expect(block).toContain("<active_subagents>");
+    expect(block).toContain("</active_subagents>");
+    expect(block).toContain('[running] "research-auth" (abc-123)');
+    expect(block).toContain("elapsed:");
+    expect(block).toContain("subagent_read");
+  });
+
+  test("formats pending subagent without elapsed time for terminal", () => {
+    const children = [
+      makeSubagentState({
+        id: "def-456",
+        label: "plan-feature",
+        status: "completed",
+        completedAt: Date.now(),
+      }),
+    ];
+    const block = buildSubagentStatusBlock(children)!;
+    expect(block).toContain('[completed] "plan-feature" (def-456)');
+    expect(block).not.toContain("elapsed:");
+  });
+
+  test("includes error for failed subagent", () => {
+    const children = [
+      makeSubagentState({
+        id: "ghi-789",
+        label: "run-tests",
+        status: "failed",
+        error: "Process exited with code 1",
+      }),
+    ];
+    const block = buildSubagentStatusBlock(children)!;
+    expect(block).toContain('[failed] "run-tests" (ghi-789)');
+    expect(block).toContain("error: Process exited with code 1");
+  });
+
+  test("includes both active and terminal subagents", () => {
+    const children = [
+      makeSubagentState({ id: "a", label: "researcher", status: "running" }),
+      makeSubagentState({ id: "b", label: "coder", status: "completed" }),
+      makeSubagentState({ id: "c", label: "planner", status: "failed", error: "timeout" }),
+    ];
+    const block = buildSubagentStatusBlock(children)!;
+    expect(block).toContain('"researcher"');
+    expect(block).toContain('"coder"');
+    expect(block).toContain('"planner"');
+  });
+});
+
+describe("injectSubagentStatus", () => {
+  test("appends status block to user message", () => {
+    const msg: Message = {
+      role: "user",
+      content: [{ type: "text", text: "hello" }],
+    };
+    const result = injectSubagentStatus(msg, "<active_subagents>\ntest\n</active_subagents>");
+    expect(result.content).toHaveLength(2);
+    expect((result.content[1] as { type: string; text: string }).text).toContain(
+      "<active_subagents>",
+    );
+  });
+});
+
+describe("applyRuntimeInjections — subagent status", () => {
+  const userMsg: Message = {
+    role: "user",
+    content: [{ type: "text", text: "user message" }],
+  };
+
+  test("includes subagent status in full mode", () => {
+    const result = applyRuntimeInjections([userMsg], {
+      subagentStatusBlock: "<active_subagents>\n- [running] test\n</active_subagents>",
+      mode: "full",
+    });
+    const tail = result[result.length - 1];
+    const texts = tail.content
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text);
+    expect(texts.some((t) => t.includes("<active_subagents>"))).toBe(true);
+  });
+
+  test("skips subagent status in minimal mode", () => {
+    const result = applyRuntimeInjections([userMsg], {
+      subagentStatusBlock: "<active_subagents>\n- [running] test\n</active_subagents>",
+      mode: "minimal",
+    });
+    const tail = result[result.length - 1];
+    const texts = tail.content
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text);
+    expect(texts.some((t) => t.includes("<active_subagents>"))).toBe(false);
+  });
+});
+
+describe("stripInjectionsForCompaction — subagent status", () => {
+  test("strips <active_subagents> blocks", () => {
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "hello" },
+          {
+            type: "text",
+            text: '<active_subagents>\n- [running] "test" (id)\n</active_subagents>',
+          },
+        ],
+      },
+    ];
+    const result = stripInjectionsForCompaction(messages);
+    const texts = result[0].content
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text);
+    expect(texts.some((t) => t.includes("<active_subagents>"))).toBe(false);
+    expect(texts).toContain("hello");
   });
 });

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -31,6 +31,7 @@ import {
   clearSentryConversationContext,
   setSentryConversationContext,
 } from "../instrument.js";
+import { getSubagentManager } from "../subagent/index.js";
 import { commitAppTurnChanges } from "../memory/app-git-service.js";
 import { getApp, listAppFiles, resolveAppDir } from "../memory/app-store.js";
 import {
@@ -100,6 +101,7 @@ import type {
 } from "./conversation-runtime-assembly.js";
 import {
   applyRuntimeInjections,
+  buildSubagentStatusBlock,
   buildUnifiedTurnContextBlock,
   findLastInjectedNowContent,
   inboundActorContextFromTrust,
@@ -261,6 +263,8 @@ export interface AgentLoopConversationContext {
   lastAttachmentWarnings: string[];
 
   hasNoClient: boolean;
+  /** True when this conversation is itself a subagent (suppresses subagent status injection). */
+  isSubagent?: boolean;
   headlessLock?: boolean;
   readonly streamThinking: boolean;
   readonly prompter: PermissionPrompter;
@@ -788,6 +792,14 @@ export async function runAgentLoopImpl(
     const pkbContext = isFirstMessage ? currentPkbContent : null;
     const pkbActive = currentPkbContent !== null;
 
+    // Subagent status injection — gives the parent LLM visibility into active/completed children.
+    // Skipped when this conversation IS a subagent (no nesting) or has no children.
+    const subagentStatusBlock = ctx.isSubagent
+      ? null
+      : buildSubagentStatusBlock(
+          getSubagentManager().getChildrenOf(ctx.conversationId),
+        );
+
     // Shared injection options — reused whenever we need to re-inject after reduction.
     const injectionOpts = {
       activeSurface,
@@ -803,6 +815,7 @@ export async function runAgentLoopImpl(
       voiceCallControlPrompt: ctx.voiceCallControlPrompt ?? null,
       transportHints: ctx.transportHints ?? null,
       isNonInteractive: !isInteractiveResolved,
+      subagentStatusBlock,
     } as const;
 
     let currentInjectionMode: InjectionMode = "full";

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -13,6 +13,8 @@ import { getAppDirPath, listAppFiles } from "../memory/app-store.js";
 import type { Message } from "../providers/types.js";
 import type { ActorTrustContext } from "../runtime/actor-trust-resolver.js";
 import { channelStatusToMemberStatus } from "../runtime/routes/inbound-stages/acl-enforcement.js";
+import type { SubagentState } from "../subagent/types.js";
+import { TERMINAL_STATUSES } from "../subagent/types.js";
 import { getWorkspaceDir, getWorkspacePromptPath } from "../util/platform.js";
 import { stripCommentLines } from "../util/strip-comment-lines.js";
 
@@ -439,6 +441,58 @@ export function injectActiveSurfaceContext(
   return {
     ...message,
     content: [{ type: "text", text: block }, ...message.content],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Subagent status injection
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the `<active_subagents>` injection block from the current child states.
+ * Returns null if there are no children (zero overhead for non-subagent parents).
+ */
+export function buildSubagentStatusBlock(
+  children: SubagentState[],
+): string | null {
+  if (children.length === 0) return null;
+
+  const now = Date.now();
+  const lines: string[] = ["<active_subagents>"];
+  for (const child of children) {
+    const elapsed = child.startedAt
+      ? `${Math.round((now - child.startedAt) / 1000)}s`
+      : "pending";
+    const parts = [
+      `- [${child.status}] "${child.config.label}" (${child.config.id})`,
+    ];
+    if (!TERMINAL_STATUSES.has(child.status)) {
+      parts.push(`elapsed: ${elapsed}`);
+    }
+    if (child.status === "failed" && child.error) {
+      parts.push(`error: ${child.error}`);
+    }
+    lines.push(parts.join(" | "));
+  }
+  lines.push(
+    "",
+    "Use subagent_read to retrieve output from completed/failed subagents.",
+    "</active_subagents>",
+  );
+  return lines.join("\n");
+}
+
+/** Append a subagent status block to the last user message. */
+export function injectSubagentStatus(
+  message: Message,
+  statusBlock: string,
+): Message {
+  return {
+    ...message,
+    content: [
+      ...message.content,
+      { type: "text" as const, text: statusBlock },
+    ],
   };
 }
 
@@ -1077,6 +1131,7 @@ const RUNTIME_INJECTION_PREFIXES = [
   // NOTE: <workspace> is intentionally NOT stripped — workspace context
   // persists in history so the assistant retains workspace grounding.
   "<temporal_context>\nToday:", // backward-compat: strip legacy temporal blocks
+  "<active_subagents>",
   "<active_workspace>",
   "<active_dynamic_page>",
   "<non_interactive_context>",
@@ -1149,6 +1204,7 @@ export function applyRuntimeInjections(
     pkbContext?: string | null;
     pkbActive?: boolean;
     nowScratchpad?: string | null;
+    subagentStatusBlock?: string | null;
     isNonInteractive?: boolean;
     transportHints?: string[] | null;
     mode?: InjectionMode;
@@ -1252,6 +1308,16 @@ export function applyRuntimeInjections(
       result = [
         ...result.slice(0, -1),
         injectChannelCommandContext(userTail, options.channelCommandContext),
+      ];
+    }
+  }
+
+  if (mode === "full" && options.subagentStatusBlock) {
+    const userTail = result[result.length - 1];
+    if (userTail && userTail.role === "user") {
+      result = [
+        ...result.slice(0, -1),
+        injectSubagentStatus(userTail, options.subagentStatusBlock),
       ];
     }
   }


### PR DESCRIPTION
## Summary
- Adds `buildSubagentStatusBlock()` and `injectSubagentStatus()` to runtime assembly, producing a concise `<active_subagents>` tagged block with each child's status, label, ID, elapsed time, and errors
- Wires the injection into `conversation-agent-loop.ts` via `injectionOpts` — applied on every turn in full mode, skipped for subagent conversations and minimal mode
- Registers `<active_subagents>` in `RUNTIME_INJECTION_PREFIXES` for compaction stripping (not stripped between turns, preserving prefix cache)

## Original prompt
Inject active subagent status into parent agent context so the parent LLM is always aware of what subagents are running.

## Test plan
- [x] `buildSubagentStatusBlock` returns null for empty children array
- [x] `buildSubagentStatusBlock` formats running/completed/failed subagents correctly
- [x] `injectSubagentStatus` appends block to user tail
- [x] `applyRuntimeInjections` includes block in full mode, skips in minimal
- [x] `stripInjectionsForCompaction` strips `<active_subagents>` blocks
- [x] Full type-check passes (`bunx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)