### PR TITLE
fix(oauth): coerce empty-string scopeSeparator to default ' '

### DIFF
--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -456,6 +456,61 @@ describe("provider operations", () => {
       const fetched = getProvider("github");
       expect(fetched!.scopeSeparator).toBe(",");
     });
+
+    test("coerces empty-string scopeSeparator to default ' '", () => {
+      // An empty separator would join scopes into a single concatenated token
+      // (e.g. ["read","write"].join("") === "readwrite") which is never a
+      // valid OAuth authorize URL value. Coerce to the default.
+      seedProviders([
+        {
+          provider: "github",
+          authorizeUrl: "https://github.com/authorize",
+          tokenExchangeUrl: "https://github.com/token",
+          defaultScopes: ["repo"],
+          scopePolicy: {},
+          scopeSeparator: ",",
+        },
+      ]);
+
+      expect(getProvider("github")!.scopeSeparator).toBe(",");
+
+      const updated = updateProvider("github", { scopeSeparator: "" });
+      expect(updated).toBeDefined();
+      expect(updated!.scopeSeparator).toBe(" ");
+      expect(getProvider("github")!.scopeSeparator).toBe(" ");
+    });
+  });
+
+  describe("scopeSeparator empty-string coercion", () => {
+    test("seedProviders coerces empty-string scopeSeparator to ' '", () => {
+      seedProviders([
+        {
+          provider: "linear",
+          authorizeUrl: "https://linear.app/oauth/authorize",
+          tokenExchangeUrl: "https://api.linear.app/oauth/token",
+          defaultScopes: ["read"],
+          scopePolicy: {},
+          scopeSeparator: "",
+        },
+      ]);
+
+      const row = getProvider("linear");
+      expect(row!.scopeSeparator).toBe(" ");
+    });
+
+    test("registerProvider coerces empty-string scopeSeparator to ' '", () => {
+      registerProvider({
+        provider: "linear",
+        authorizeUrl: "https://linear.app/oauth/authorize",
+        tokenExchangeUrl: "https://api.linear.app/oauth/token",
+        defaultScopes: ["read"],
+        scopePolicy: {},
+        scopeSeparator: "",
+      });
+
+      const row = getProvider("linear");
+      expect(row!.scopeSeparator).toBe(" ");
+    });
   });
 });
 

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -119,7 +119,10 @@ export function seedProviders(
     const baseUrl = p.baseUrl ?? null;
     const defaultScopes = JSON.stringify(p.defaultScopes);
     const scopePolicy = JSON.stringify(p.scopePolicy);
-    const scopeSeparator = p.scopeSeparator ?? " ";
+    // Coerce empty string to the default space separator. An empty separator
+    // would join scopes into a single concatenated token (e.g. "readwrite"),
+    // which is never a valid OAuth authorize URL value.
+    const scopeSeparator = p.scopeSeparator || " ";
     const authorizeParams = p.authorizeParams
       ? JSON.stringify(p.authorizeParams)
       : null;
@@ -301,7 +304,8 @@ export function registerProvider(params: {
     baseUrl: params.baseUrl ?? null,
     defaultScopes: JSON.stringify(params.defaultScopes),
     scopePolicy: JSON.stringify(params.scopePolicy),
-    scopeSeparator: params.scopeSeparator ?? " ",
+    // Coerce empty string to the default space separator (see seedProviders).
+    scopeSeparator: params.scopeSeparator || " ",
     authorizeParams: params.authorizeParams
       ? JSON.stringify(params.authorizeParams)
       : null,
@@ -419,7 +423,8 @@ export function updateProvider(
   if (params.scopePolicy !== undefined)
     set.scopePolicy = JSON.stringify(params.scopePolicy);
   if (params.scopeSeparator !== undefined)
-    set.scopeSeparator = params.scopeSeparator;
+    // Coerce empty string to the default space separator (see seedProviders).
+    set.scopeSeparator = params.scopeSeparator || " ";
   if (params.authorizeParams !== undefined)
     set.authorizeParams = JSON.stringify(params.authorizeParams);
   if (params.displayLabel !== undefined) set.displayLabel = params.displayLabel;


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for scope-separator-support.md.

**Gap:** registerProvider/updateProvider/seedProviders accepted an empty string as a valid scopeSeparator (since `??` doesn't catch `""`). An empty separator would join scopes into a single concatenated token (e.g. `["read","write"].join("")` === `"readwrite"`), which is never a valid OAuth authorize URL value.

**Fix:** Use `||` instead of `??` to coerce empty strings to the default `' '` separator. Added regression tests in oauth-store.test.ts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
