### PR TITLE
fix: parenthesize OR in edge query and filter gone-node triggers

### DIFF
--- a/assistant/src/memory/graph/store.ts
+++ b/assistant/src/memory/graph/store.ts
@@ -2,7 +2,7 @@
 // Memory Graph — Data access layer
 // ---------------------------------------------------------------------------
 
-import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, or, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "../db.js";
@@ -409,7 +409,7 @@ export function getEdgesForNode(
       ? eq(memoryGraphEdges.sourceNodeId, nodeId)
       : direction === "incoming"
         ? eq(memoryGraphEdges.targetNodeId, nodeId)
-        : sql`${memoryGraphEdges.sourceNodeId} = ${nodeId} OR ${memoryGraphEdges.targetNodeId} = ${nodeId}`;
+        : or(eq(memoryGraphEdges.sourceNodeId, nodeId), eq(memoryGraphEdges.targetNodeId, nodeId));
 
   // Exclude edges where either endpoint has fidelity='gone' (soft-deleted)
   const condition = and(
@@ -527,12 +527,23 @@ export function getActiveTriggersByType(
     return rows.map((r) => rowToTrigger(r.trigger));
   }
 
-  return db
-    .select()
+  const rows = db
+    .select({
+      trigger: memoryGraphTriggers,
+    })
     .from(memoryGraphTriggers)
-    .where(and(...conditions))
-    .all()
-    .map(rowToTrigger);
+    .innerJoin(
+      memoryGraphNodes,
+      eq(memoryGraphTriggers.nodeId, memoryGraphNodes.id),
+    )
+    .where(
+      and(
+        ...conditions,
+        sql`${memoryGraphNodes.fidelity} != 'gone'`,
+      ),
+    )
+    .all();
+  return rows.map((r) => rowToTrigger(r.trigger));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fix SQL operator precedence in getEdgesForNode where OR wasn't parenthesized, allowing rows to bypass NOT EXISTS gone-node checks. Also add gone-node filter to non-scoped branch of getActiveTriggersByType.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
