### PR TITLE
fix: guard against limit:0 unbounded query in memory graph retriever

### DIFF
--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -549,12 +549,15 @@ export async function loadContextMemory(
   // SQLite — no Qdrant vectors needed — so capabilities surface even on
   // fresh assistants whose embedding jobs haven't completed yet.
   const capabilityReserve = ctxLoadCfg.capabilityReserve;
-  const rawCapabilityNodes = queryNodes({
-    scopeId: opts.scopeId,
-    types: ["procedural"],
-    fidelityNot: ["gone"],
-    limit: capabilityReserve * 4,
-  });
+  const rawCapabilityNodes =
+    capabilityReserve > 0
+      ? queryNodes({
+          scopeId: opts.scopeId,
+          types: ["procedural"],
+          fidelityNot: ["gone"],
+          limit: capabilityReserve * 4,
+        })
+      : [];
 
   // Dedup: both seeding systems may create nodes for the same capability.
   // Extract capability ID from content and keep only the first node per ID.
@@ -1035,6 +1038,7 @@ export async function retrieveForTurn(
   // Sort and apply threshold — pull a wider pool for dedup, then trim
   scored.sort((a, b) => b.score - a.score);
   const INJECTION_THRESHOLD = 0.3;
+  // Hard cap on candidates fed to the dedup LLM — effectively caps maxNodes
   const PRE_DEDUP_POOL = 20;
   const maxGeneralNodes = Math.max(
     0,

--- a/assistant/src/memory/graph/store.ts
+++ b/assistant/src/memory/graph/store.ts
@@ -351,7 +351,7 @@ export function queryNodes(filters: NodeQueryFilters): MemoryNode[] {
     .where(conditions.length > 0 ? and(...conditions) : undefined)
     .orderBy(sql`${memoryGraphNodes.significance} DESC`);
 
-  if (filters.limit) {
+  if (filters.limit != null) {
     query = query.limit(filters.limit) as typeof query;
   }
 


### PR DESCRIPTION
## Summary
- When `capabilityReserve` is configured to `0`, `queryNodes` was called with `limit: 0`. Since the limit check in `store.ts` uses `if (filters.limit)` which treats `0` as falsy, this triggered an unbounded full procedural-node scan.
- **Primary fix**: Early return in retriever — skip the `queryNodes` call entirely when `capabilityReserve` is 0.
- **Defense in depth**: Fix the limit check in `store.ts` to use `!= null` instead of truthiness, so `limit: 0` correctly applies a zero-row limit.
- **Secondary**: Added comment noting that `PRE_DEDUP_POOL = 20` hard-caps the effective `maxNodes` for per-turn injection.

## Test plan
- [ ] Verify that setting `capabilityReserve: 0` no longer triggers a full table scan
- [ ] Verify that `queryNodes({ limit: 0 })` returns an empty result set
- [ ] Verify normal retrieval with default `capabilityReserve` is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24164" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
