### PR TITLE
fix: make overflow menu overlay alignment role-aware

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleOverflowMenu.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleOverflowMenu.swift
@@ -105,7 +105,7 @@ struct ChatBubbleOverflowMenu: View {
         if hasOverflowActions {
             Color.clear
                 .frame(height: Self.reservedRowHeight)
-                .overlay(alignment: .leading) {
+                .overlay(alignment: isUser ? .trailing : .leading) {
                     if showOverflowMenu {
                         menuContent
                             .transition(.opacity)


### PR DESCRIPTION
The overlay alignment was hardcoded to .leading, causing user message overflow menus to appear on the wrong side. Now uses isUser to select .trailing for user messages and .leading for assistant messages.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
