### PR TITLE
fix: re-inject NOW.md and PKB after regular compaction

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -507,6 +507,7 @@ export async function runAgentLoopImpl(
 
     const isFirstMessage = ctx.messages.length === 1;
     let shouldInjectWorkspace = isFirstMessage;
+    let compactedThisTurn = false;
 
     const compactCheck = ctx.contextWindowManager.shouldCompact(ctx.messages);
     if (compactCheck.needed) {
@@ -562,6 +563,7 @@ export async function runAgentLoopImpl(
         collapseRawResponses(compacted.summaryRawResponses),
       );
       shouldInjectWorkspace = true;
+      compactedThisTurn = true;
     }
 
     const state = createEventHandlerState();
@@ -786,10 +788,11 @@ export async function runAgentLoopImpl(
     // compaction re-strips them).  Old injections persist in history and
     // are never stripped on normal turns — this preserves the cached prefix.
     const currentNowContent = readNowScratchpad();
-    const nowScratchpad = isFirstMessage ? currentNowContent : null;
+    const shouldInjectNowAndPkb = isFirstMessage || compactedThisTurn;
+    const nowScratchpad = shouldInjectNowAndPkb ? currentNowContent : null;
 
     const currentPkbContent = readPkbContext();
-    const pkbContext = isFirstMessage ? currentPkbContent : null;
+    const pkbContext = shouldInjectNowAndPkb ? currentPkbContent : null;
     const pkbActive = currentPkbContent !== null;
 
     // Subagent status injection — gives the parent LLM visibility into active/completed children.


### PR DESCRIPTION
Regular compaction could summarize away the first turn containing NOW.md/PKB injections. The isFirstMessage gate prevented re-injection on subsequent turns. Now re-inject after compaction, matching the pattern already used in preflight, mid-loop, and convergence paths.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
