### PR TITLE
feat: encourage aggressive subagent delegation

### DIFF
--- a/assistant/src/config/bundled-skills/subagent/SKILL.md
+++ b/assistant/src/config/bundled-skills/subagent/SKILL.md
@@ -71,3 +71,6 @@ Set `send_result_to_user: false` when spawning a subagent whose result is for in
 - Use `notify_parent` for interim findings instead of waiting for completion. This lets the parent act on partial results early.
 - Use `subagent_message` to send follow-up instructions to a running subagent.
 - Use `subagent_abort` to cancel a subagent that is no longer needed.
+- Default to spawning subagents for any task that involves web research, multi-file exploration, or independent coding work. Serial execution should be the exception, not the rule.
+- When a user request has both an information-gathering component and an action component, spawn a researcher immediately rather than doing the research inline yourself.
+- Prefer spawning 2-3 focused subagents over one large general-purpose subagent. Smaller scopes finish faster and fail more gracefully.

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -431,6 +431,8 @@ function buildParallelToolCallsSection(): string {
   return [
     "<use_parallel_tool_calls>",
     "For maximum efficiency, whenever you perform multiple independent operations, invoke all relevant tools simultaneously rather than sequentially. Prioritize calling tools in parallel whenever possible. For example, when reading 3 files, run 3 tool calls in parallel to read all 3 files into context at the same time. When running multiple read-only commands like `ls` or `list_dir`, always run all of the commands in parallel. Err on the side of maximizing parallel tool calls rather than running too many tools sequentially.",
+    "",
+    "For non-trivial independent workstreams — research, coding tasks, multi-step investigations — aggressively delegate to subagents (load the `subagent` skill for tools and instructions). Spawn subagents early and often; the cost of an unnecessary subagent is far lower than the cost of serializing work you could have parallelized.",
     "</use_parallel_tool_calls>",
   ].join("\n");
 }


### PR DESCRIPTION
## Summary

- Add a paragraph to the static `<use_parallel_tool_calls>` system prompt section directing the assistant to aggressively delegate non-trivial independent workstreams to subagents, with an explicit reference to the `subagent` skill so the model knows to load it
- Add three proactivity-oriented tips to the subagent SKILL.md reinforcing default-to-delegation behavior with concrete patterns

## Original prompt
I want the assistant to use subagents more aggressively and proactively. I think this could be worth a line in the static section of the system prompt, but if you see another approach I'm open to that as well.