### PR TITLE
fix(macos): embed VELLUM_DOCS_BASE_URL into Info.plist LSEnvironment

### DIFF
--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -96,6 +96,14 @@ To point managed sign-in at a specific platform host for a local run:
 VELLUM_PLATFORM_URL=https://platform.vellum.ai ./build.sh run
 ```
 
+To point in-app docs links at a staging or local docs server for a local run:
+
+```bash
+VELLUM_DOCS_BASE_URL=https://staging.vellum.ai/docs ./build.sh run
+```
+
+Defaults to `https://www.vellum.ai/docs`. The override must be a parseable absolute http(s) URL with no query or fragment, otherwise it's ignored and the default is used.
+
 This builds a debug `.app` bundle, codesigns it, and launches it immediately.
 
 ---

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -23,6 +23,7 @@ set -euo pipefail
 #   BUILD_VERSION     Override CFBundleVersion (default: 1)
 #   SIGN_IDENTITY     Override code signing identity
 #   VELLUM_PLATFORM_URL  Override managed sign-in platform URL for app launches
+#   VELLUM_DOCS_BASE_URL Override docs base URL for in-app docs links (e.g. staging)
 #   SKIP_BUN_REBUILD    Set to 1 to skip Bun binary staleness checks (use pre-built binaries as-is)
 #   SENTRY_DSN_MACOS     Sentry DSN for the macOS app project (omit to disable)
 #   SENTRY_DSN_ASSISTANT Sentry DSN for the assistant/daemon project (omit to disable)
@@ -789,6 +790,13 @@ if [ -n "${VELLUM_PLATFORM_URL:-}" ]; then
     _LSE_ENTRIES+="
         <key>VELLUM_PLATFORM_URL</key>
         <string>$PLATFORM_URL_OVERRIDE</string>"
+fi
+if [ -n "${VELLUM_DOCS_BASE_URL:-}" ]; then
+    DOCS_BASE_URL_OVERRIDE="${VELLUM_DOCS_BASE_URL%/}"
+    echo "Embedding app docs base URL override: $DOCS_BASE_URL_OVERRIDE"
+    _LSE_ENTRIES+="
+        <key>VELLUM_DOCS_BASE_URL</key>
+        <string>$DOCS_BASE_URL_OVERRIDE</string>"
 fi
 if [ "$CONFIG" = "debug" ]; then
     echo "Embedding VELLUM_FLAG_PLATFORM_HOSTED_ENABLED for debug build"


### PR DESCRIPTION
## Summary
- The plan introduces `VELLUM_DOCS_BASE_URL` as a runtime override for the docs base URL, but the macOS `./build.sh run` workflow launches the app via `open` (LaunchServices), which does NOT propagate the parent shell's environment to the launched GUI app. Without an `LSEnvironment` entry, `ProcessInfo.processInfo.environment` in the launched app cannot see the override and `AppURLs.docsBaseURL` falls back to the production default — the documented workflow is silently a no-op.
- Mirrors the existing `VELLUM_PLATFORM_URL` embedding pattern in `build.sh` (around the existing `_LSE_ENTRIES+=` block) so the documented `VELLUM_DOCS_BASE_URL=https://staging.vellum.ai/docs ./build.sh run` workflow now actually exercises the override end-to-end.
- Documents `VELLUM_DOCS_BASE_URL` in `clients/macos/README.md` alongside the sibling `VELLUM_PLATFORM_URL` example so devs discover it.

Found by self-review during plan execution. Part of plan: docs-base-url-pricing-link.md (fix round 3).