### PR TITLE
fix(macos): XML-escape VELLUM_DOCS_BASE_URL before embedding into Info.plist

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -793,6 +793,15 @@ if [ -n "${VELLUM_PLATFORM_URL:-}" ]; then
 fi
 if [ -n "${VELLUM_DOCS_BASE_URL:-}" ]; then
     DOCS_BASE_URL_OVERRIDE="${VELLUM_DOCS_BASE_URL%/}"
+    # XML-escape ampersand/lt/gt before embedding into Info.plist so a
+    # malformed override (e.g. one containing `&` in a URL path) cannot
+    # corrupt the entire plist and prevent the app from launching.
+    # Note: the sibling VELLUM_PLATFORM_URL / SENTRY_DSN_* blocks below
+    # have the same unescaped pattern; that's a pre-existing concern that
+    # should be addressed in a separate cleanup PR.
+    DOCS_BASE_URL_OVERRIDE="${DOCS_BASE_URL_OVERRIDE//&/&amp;}"
+    DOCS_BASE_URL_OVERRIDE="${DOCS_BASE_URL_OVERRIDE//</&lt;}"
+    DOCS_BASE_URL_OVERRIDE="${DOCS_BASE_URL_OVERRIDE//>/&gt;}"
     echo "Embedding app docs base URL override: $DOCS_BASE_URL_OVERRIDE"
     _LSE_ENTRIES+="
         <key>VELLUM_DOCS_BASE_URL</key>


### PR DESCRIPTION
## Summary
- Address Codex P2 on PR #24171: XML-escape \`\$DOCS_BASE_URL_OVERRIDE\` before embedding into the \`Info.plist\` \`LSEnvironment\` heredoc. Without escaping, an override containing \`&\`, \`<\`, or \`>\` would produce invalid XML and break LaunchServices' plist parse — preventing the app from launching with ANY of its embedded env vars.
- Uses bash pattern substitution (\`\${VAR//pattern/replacement}\`) to escape \`&\` first, then \`<\` and \`>\`. The order matters: escaping \`&\` first prevents double-escaping the \`&lt;\`/\`&gt;\` entity references introduced by the later substitutions.
- Adds a comment noting that the sibling \`VELLUM_PLATFORM_URL\` / \`SENTRY_DSN_*\` blocks have the same unescaped pattern. Those are pre-existing and intentionally left untouched — a future cleanup PR can apply the same fix consistently across all overrides.

Found by self-review during plan execution. Part of plan: docs-base-url-pricing-link.md (fix round 4).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
