### PR TITLE
feat(lockfile): allow multiple managed entries when multi-platform-assistant is enabled

### DIFF
--- a/clients/macos/vellum-assistant/App/ManagedAssistantConnectionCoordinator.swift
+++ b/clients/macos/vellum-assistant/App/ManagedAssistantConnectionCoordinator.swift
@@ -105,6 +105,7 @@ final class ManagedAssistantConnectionCoordinator {
             assistantId: assistant.id,
             runtimeUrl: runtimeURL,
             hatchedAt: hatchedAt,
+            allowMultipleManaged: AssistantFeatureFlagResolver.isEnabled("multi-platform-assistant"),
             lockfilePath: lockfilePath
         )
 

--- a/clients/macos/vellum-assistantTests/LockfileAssistantManagedTests.swift
+++ b/clients/macos/vellum-assistantTests/LockfileAssistantManagedTests.swift
@@ -339,12 +339,14 @@ final class LockfileAssistantManagedTests: XCTestCase {
             assistantId: "assistant-1",
             runtimeUrl: "https://platform.vellum.ai",
             hatchedAt: "2024-01-01T00:00:00Z",
+            allowMultipleManaged: true,
             lockfilePath: lockfilePath
         )
         LockfileAssistant.ensureManagedEntry(
             assistantId: "assistant-2",
             runtimeUrl: "https://platform.vellum.ai",
             hatchedAt: "2024-02-01T00:00:00Z",
+            allowMultipleManaged: true,
             lockfilePath: lockfilePath
         )
 
@@ -354,5 +356,119 @@ final class LockfileAssistantManagedTests: XCTestCase {
         XCTAssertEqual(assistants.count, 2)
         XCTAssertEqual(assistants[0]["assistantId"] as? String, "assistant-1")
         XCTAssertEqual(assistants[1]["assistantId"] as? String, "assistant-2")
+    }
+
+    // MARK: - allowMultipleManaged flag
+
+    func testEnsureReplacesExistingManagedWhenSingleMode() {
+        // Flag-off regression guard: inserting a different managed assistant
+        // replaces the existing managed entry so only one coexists.
+        LockfileAssistant.ensureManagedEntry(
+            assistantId: "old-managed",
+            runtimeUrl: "https://platform.vellum.ai",
+            hatchedAt: "2024-01-01T00:00:00Z",
+            lockfilePath: lockfilePath
+        )
+        LockfileAssistant.ensureManagedEntry(
+            assistantId: "new-managed",
+            runtimeUrl: "https://platform.vellum.ai",
+            hatchedAt: "2024-06-01T00:00:00Z",
+            lockfilePath: lockfilePath
+        )
+
+        let data = try! Data(contentsOf: URL(fileURLWithPath: lockfilePath))
+        let json = try! JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let assistants = json["assistants"] as! [[String: Any]]
+        let managed = assistants.filter { ($0["cloud"] as? String) == "vellum" }
+        XCTAssertEqual(managed.count, 1, "Only one managed entry should exist in single-managed mode")
+        XCTAssertEqual(managed[0]["assistantId"] as? String, "new-managed")
+    }
+
+    func testEnsureAppendsNewManagedWhenMultiModeEnabled() {
+        LockfileAssistant.ensureManagedEntry(
+            assistantId: "first-managed",
+            runtimeUrl: "https://platform.vellum.ai",
+            hatchedAt: "2024-01-01T00:00:00Z",
+            allowMultipleManaged: true,
+            lockfilePath: lockfilePath
+        )
+        LockfileAssistant.ensureManagedEntry(
+            assistantId: "second-managed",
+            runtimeUrl: "https://platform.vellum.ai",
+            hatchedAt: "2024-06-01T00:00:00Z",
+            allowMultipleManaged: true,
+            lockfilePath: lockfilePath
+        )
+
+        let data = try! Data(contentsOf: URL(fileURLWithPath: lockfilePath))
+        let json = try! JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let assistants = json["assistants"] as! [[String: Any]]
+        let managed = assistants.filter { ($0["cloud"] as? String) == "vellum" }
+        XCTAssertEqual(managed.count, 2, "Both managed entries should coexist in multi-managed mode")
+        XCTAssertTrue(managed.contains(where: { ($0["assistantId"] as? String) == "first-managed" }))
+        XCTAssertTrue(managed.contains(where: { ($0["assistantId"] as? String) == "second-managed" }))
+    }
+
+    func testEnsureUpdatesInPlaceWhenIdMatchesInBothModes() {
+        // Flag-off: same ID updates runtimeUrl in place.
+        LockfileAssistant.ensureManagedEntry(
+            assistantId: "same-id",
+            runtimeUrl: "https://old.example.com",
+            hatchedAt: "2024-01-01T00:00:00Z",
+            lockfilePath: lockfilePath
+        )
+        LockfileAssistant.ensureManagedEntry(
+            assistantId: "same-id",
+            runtimeUrl: "https://new.example.com",
+            hatchedAt: "2024-01-01T00:00:00Z",
+            lockfilePath: lockfilePath
+        )
+
+        var data = try! Data(contentsOf: URL(fileURLWithPath: lockfilePath))
+        var json = try! JSONSerialization.jsonObject(with: data) as! [String: Any]
+        var assistants = json["assistants"] as! [[String: Any]]
+        XCTAssertEqual(assistants.count, 1)
+        XCTAssertEqual(assistants[0]["runtimeUrl"] as? String, "https://new.example.com")
+
+        // Flag-on: same ID also updates in place.
+        LockfileAssistant.ensureManagedEntry(
+            assistantId: "same-id",
+            runtimeUrl: "https://newer.example.com",
+            hatchedAt: "2024-01-01T00:00:00Z",
+            allowMultipleManaged: true,
+            lockfilePath: lockfilePath
+        )
+
+        data = try! Data(contentsOf: URL(fileURLWithPath: lockfilePath))
+        json = try! JSONSerialization.jsonObject(with: data) as! [String: Any]
+        assistants = json["assistants"] as! [[String: Any]]
+        XCTAssertEqual(assistants.count, 1)
+        XCTAssertEqual(assistants[0]["runtimeUrl"] as? String, "https://newer.example.com")
+    }
+
+    func testActiveAssistantIdSurvivesAddingSecondManagedEntry() {
+        LockfileAssistant.ensureManagedEntry(
+            assistantId: "managed-1",
+            runtimeUrl: "https://platform.vellum.ai",
+            hatchedAt: "2024-01-01T00:00:00Z",
+            allowMultipleManaged: true,
+            lockfilePath: lockfilePath
+        )
+        LockfileAssistant.setActiveAssistantId("managed-1", lockfilePath: lockfilePath)
+
+        LockfileAssistant.ensureManagedEntry(
+            assistantId: "managed-2",
+            runtimeUrl: "https://platform.vellum.ai",
+            hatchedAt: "2024-06-01T00:00:00Z",
+            allowMultipleManaged: true,
+            lockfilePath: lockfilePath
+        )
+
+        let data = try! Data(contentsOf: URL(fileURLWithPath: lockfilePath))
+        let json = try! JSONSerialization.jsonObject(with: data) as! [String: Any]
+        XCTAssertEqual(json["activeAssistant"] as? String, "managed-1",
+                       "Adding a new managed entry must not change activeAssistantId")
+        let assistants = json["assistants"] as! [[String: Any]]
+        XCTAssertEqual(assistants.count, 2)
     }
 }

--- a/clients/shared/Network/LockfileAssistant.swift
+++ b/clients/shared/Network/LockfileAssistant.swift
@@ -444,12 +444,20 @@ public struct LockfileAssistant {
     ///   - assistantId: The platform-assigned assistant UUID string.
     ///   - runtimeUrl: The platform base URL used for managed transport.
     ///   - hatchedAt: ISO-8601 timestamp of when the assistant was created.
+    ///   - allowMultipleManaged: When `false` (default), enforces the single-
+    ///     managed-assistant invariant: any other existing `cloud == "vellum"`
+    ///     entries are removed before inserting a new entry. When `true`
+    ///     (gated by the `multi-platform-assistant` feature flag), a new
+    ///     managed entry is appended without disturbing existing managed
+    ///     entries. In both modes, if an entry with a matching `assistantId`
+    ///     already exists it is updated in place.
     ///   - lockfilePath: Override for tests; defaults to `LockfilePaths.primaryPath`.
     @discardableResult
     public static func ensureManagedEntry(
         assistantId: String,
         runtimeUrl: String,
         hatchedAt: String,
+        allowMultipleManaged: Bool = false,
         lockfilePath: String? = nil
     ) -> Bool {
         let path = lockfilePath ?? LockfilePaths.primaryPath
@@ -497,6 +505,18 @@ public struct LockfileAssistant {
 
             assistants[existingIndex] = existingEntry
         } else {
+            // Single-managed mode: remove any pre-existing managed entries
+            // so only one `cloud == "vellum"` entry can exist at a time.
+            // Multi-managed mode (flag-gated): leave existing managed entries
+            // untouched and simply append the new one.
+            if !allowMultipleManaged {
+                assistants.removeAll { entry in
+                    let cloud = (entry["cloud"] as? String)?
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                        .lowercased()
+                    return cloud == "vellum" || cloud == "platform"
+                }
+            }
             let newEntry: [String: Any] = [
                 "assistantId": assistantId,
                 "runtimeUrl": runtimeUrl,


### PR DESCRIPTION
## Summary
- Adds `allowMultipleManaged: Bool = false` to `LockfileAssistant.ensureManagedEntry()`. Flag-off enforces the single-managed-assistant invariant (replaces any existing `cloud: vellum` entry); flag-on appends without disturbing existing managed entries or `activeAssistantId`.
- Wires `ManagedAssistantConnectionCoordinator` to pass `AssistantFeatureFlagResolver.isEnabled("multi-platform-assistant")`.
- Extends `LockfileAssistantManagedTests` with four new tests covering both flag modes. Updated the pre-existing `testEnsureMultipleDifferentAssistants` to opt into multi-mode since single-mode now enforces one managed entry (single-mode is being deprecated in favor of multi-mode).

iOS path untouched — `LockfileAssistant` remains `#if os(macOS)` only.

## Test plan
- [ ] `LockfileAssistantManagedTests` passes (all existing + 4 new tests)
- [ ] With flag off: connecting a new managed assistant replaces the prior managed entry
- [ ] With flag on: connecting a new managed assistant appends alongside existing ones; `activeAssistantId` is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
