### PR TITLE
fix: gate NOW/PKB reinjection on actual summarization, not truncation-only compaction

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -563,7 +563,9 @@ export async function runAgentLoopImpl(
         collapseRawResponses(compacted.summaryRawResponses),
       );
       shouldInjectWorkspace = true;
-      compactedThisTurn = true;
+      if (compacted.compactedPersistedMessages > 0) {
+        compactedThisTurn = true;
+      }
     }
 
     const state = createEventHandlerState();


### PR DESCRIPTION
Refines the compactedThisTurn flag to only trigger NOW.md/PKB re-injection when messages were actually summarized, not during truncation-only compaction passes. Prevents unnecessary duplicate content in the context window. Addresses review feedback from PR #24167.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
