### PR TITLE
fix: guard against late usage updates after terminal subagent status

### DIFF
--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -214,7 +214,8 @@ final class ChatActionHandler {
             if let index = vm.activeSubagents.firstIndex(where: { $0.id == msg.subagentId }) {
                 vm.activeSubagents[index].status = SubagentStatus(wire: msg.status)
                 vm.activeSubagents[index].error = msg.error
-                vm.subagentDetailStore.recordStatusChanged(subagentId: msg.subagentId, usage: msg.usage)
+                let status = SubagentStatus(wire: msg.status)
+                vm.subagentDetailStore.recordStatusChanged(subagentId: msg.subagentId, status: status, usage: msg.usage)
             }
 
         case .subagentEvent(let msg):

--- a/clients/shared/Features/Chat/SubagentDetailStore.swift
+++ b/clients/shared/Features/Chat/SubagentDetailStore.swift
@@ -96,6 +96,10 @@ public final class SubagentDetailStore {
     /// Staged usage stat updates accumulate here between flushes.
     @ObservationIgnored
     private var stagedUsage: [String: SubagentUsageStats] = [:]
+    /// Subagent IDs that have received a terminal status (completed/failed/aborted).
+    /// Late `.usageUpdate` deltas are skipped for these to prevent double-counting.
+    @ObservationIgnored
+    private var terminalSubagentIds: Set<String> = []
     /// The coalescing flush task; non-nil while a flush is scheduled.
     @ObservationIgnored
     private var flushTask: Task<Void, Never>?
@@ -230,7 +234,10 @@ public final class SubagentDetailStore {
     }
 
     /// Record a status change with optional usage stats.
-    public func recordStatusChanged(subagentId: String, usage: UsageStats?) {
+    public func recordStatusChanged(subagentId: String, status: SubagentStatus, usage: UsageStats?) {
+        if status.isTerminal {
+            terminalSubagentIds.insert(subagentId)
+        }
         if let usage {
             stagedUsage[subagentId] = SubagentUsageStats(
                 inputTokens: usage.inputTokens,
@@ -314,6 +321,9 @@ public final class SubagentDetailStore {
             #endif
 
         case .usageUpdate(let update):
+            // Skip late deltas after terminal status to avoid double-counting
+            // (recordStatusChanged already wrote cumulative stats).
+            guard !terminalSubagentIds.contains(subagentId) else { break }
             let current = stagedUsage[subagentId] ?? subagentStates[subagentId]?.usageStats ?? SubagentUsageStats()
             stagedUsage[subagentId] = SubagentUsageStats(
                 inputTokens: update.totalInputTokens,


### PR DESCRIPTION
Adds a guard to skip .usageUpdate processing when a subagent has already received a terminal status, preventing potential double-counting of estimatedCost. Addresses review feedback from PR #24160.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
