### PR TITLE
fix: remove per-block scroll capping in message inspector code views

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorMemoryTab.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorMemoryTab.swift
@@ -347,10 +347,11 @@ struct MessageInspectorMemoryTab: View {
                     text: .constant(model.queryContext ?? ""),
                     language: .plain,
                     isEditable: false,
-                    isActivelyEditing: .constant(false)
+                    isActivelyEditing: .constant(false),
+                    allowsVerticalScrolling: false
                 )
                 .frame(maxWidth: .infinity)
-                .frame(minHeight: 80, maxHeight: 300)
+                .frame(minHeight: 80)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             }
         }
@@ -377,10 +378,11 @@ struct MessageInspectorMemoryTab: View {
                     text: .constant(model.injectedText ?? ""),
                     language: .plain,
                     isEditable: false,
-                    isActivelyEditing: .constant(false)
+                    isActivelyEditing: .constant(false),
+                    allowsVerticalScrolling: false
                 )
                 .frame(maxWidth: .infinity)
-                .frame(minHeight: 120, maxHeight: 400)
+                .frame(minHeight: 120)
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             }
         }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorPromptTab.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorPromptTab.swift
@@ -115,10 +115,11 @@ struct MessageInspectorPromptTab: View {
                 text: .constant(section.displayText),
                 language: section.syntaxLanguage,
                 isEditable: false,
-                isActivelyEditing: .constant(false)
+                isActivelyEditing: .constant(false),
+                allowsVerticalScrolling: false
             )
             .frame(maxWidth: .infinity)
-            .frame(minHeight: 120, maxHeight: 260)
+            .frame(minHeight: 120)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/HighlightedTextView.swift
@@ -17,6 +17,7 @@ struct HighlightedTextView: View {
     let isEditable: Bool
     @Binding var isActivelyEditing: Bool
     var onTextChange: ((String) -> Void)?
+    var allowsVerticalScrolling: Bool = true
 
     @State private var isSearchVisible = false
     @State private var searchQuery = ""
@@ -82,6 +83,24 @@ struct HighlightedTextView: View {
     private var editableView: some View {
         let lineCount = cachedLineCount
         let gutterWidth = gutterWidth(for: lineCount)
+        let content = HStack(alignment: .top, spacing: 0) {
+            lineNumberGutter(lineCount: lineCount, width: gutterWidth)
+
+            CodeTextView(
+                text: $text,
+                onTextChange: onTextChange,
+                onEscape: {
+                    if isSearchVisible {
+                        dismissSearch()
+                    } else {
+                        isActivelyEditing = false
+                    }
+                },
+                onCommandF: { isSearchVisible = true }
+            )
+            .frame(maxWidth: .infinity)
+        }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
 
         return VStack(spacing: 0) {
             if isSearchVisible {
@@ -93,25 +112,14 @@ struct HighlightedTextView: View {
                 )
             }
 
-            ScrollView([.vertical]) {
-                HStack(alignment: .top, spacing: 0) {
-                    lineNumberGutter(lineCount: lineCount, width: gutterWidth)
-
-                    CodeTextView(
-                        text: $text,
-                        onTextChange: onTextChange,
-                        onEscape: {
-                            if isSearchVisible {
-                                dismissSearch()
-                            } else {
-                                isActivelyEditing = false
-                            }
-                        },
-                        onCommandF: { isSearchVisible = true }
-                    )
-                    .frame(maxWidth: .infinity)
+            Group {
+                if allowsVerticalScrolling {
+                    ScrollView([.vertical]) {
+                        content
+                    }
+                } else {
+                    content
                 }
-                .frame(maxWidth: .infinity, alignment: .topLeading)
             }
             .background(Self.editorBackground)
         }
@@ -157,7 +165,8 @@ struct HighlightedTextView: View {
                 SyntaxTheme.highlightNS(text, language: language, paragraphStyle: paragraphStyle)
             },
             highlightVersion: highlightVersion,
-            onContentClick: onContentClick
+            onContentClick: onContentClick,
+            allowsVerticalScrolling: allowsVerticalScrolling
         )
         .onChange(of: text) { _, _ in
             highlightVersion &+= 1

--- a/clients/shared/DesignSystem/Components/Display/VCodeView.swift
+++ b/clients/shared/DesignSystem/Components/Display/VCodeView.swift
@@ -39,6 +39,10 @@ public struct VCodeView: View {
     /// that would block text selection or steal clicks from child controls.
     public var onContentClick: (() -> Void)?
 
+    /// When false, renders the full code block height and relies on an
+    /// ancestor scroll view for vertical scrolling.
+    public var allowsVerticalScrolling: Bool = true
+
     @State private var isSearchVisible = false
     @State private var searchQuery = ""
     @State private var currentMatchIndex = 0
@@ -48,12 +52,14 @@ public struct VCodeView: View {
         text: String,
         highlighter: ((String, NSParagraphStyle?) -> NSAttributedString)? = nil,
         highlightVersion: UInt64 = 0,
-        onContentClick: (() -> Void)? = nil
+        onContentClick: (() -> Void)? = nil,
+        allowsVerticalScrolling: Bool = true
     ) {
         self.text = text
         self.highlighter = highlighter
         self.highlightVersion = highlightVersion
         self.onContentClick = onContentClick
+        self.allowsVerticalScrolling = allowsVerticalScrolling
     }
 
     public var body: some View {
@@ -108,24 +114,31 @@ public struct VCodeView: View {
     private var editorContent: some View {
         let lineCount = cachedLineCount
         let gutterWidth = gutterWidth(for: lineCount)
+        let content = HStack(alignment: .top, spacing: 0) {
+            lineNumberGutter(lineCount: lineCount, width: gutterWidth)
 
-        return ScrollView([.vertical]) {
-            HStack(alignment: .top, spacing: 0) {
-                lineNumberGutter(lineCount: lineCount, width: gutterWidth)
+            VCodeTextView(
+                text: text,
+                highlighter: highlighter,
+                highlightVersion: highlightVersion,
+                searchQuery: searchQuery,
+                currentMatchIndex: currentMatchIndex,
+                matchRanges: isSearchVisible
+                    ? Self.findMatchRanges(in: text, query: searchQuery) : [],
+                onContentClick: onContentClick
+            )
+            .frame(maxWidth: .infinity)
+        }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
 
-                VCodeTextView(
-                    text: text,
-                    highlighter: highlighter,
-                    highlightVersion: highlightVersion,
-                    searchQuery: searchQuery,
-                    currentMatchIndex: currentMatchIndex,
-                    matchRanges: isSearchVisible
-                        ? Self.findMatchRanges(in: text, query: searchQuery) : [],
-                    onContentClick: onContentClick
-                )
-                .frame(maxWidth: .infinity)
+        return Group {
+            if allowsVerticalScrolling {
+                ScrollView([.vertical]) {
+                    content
+                }
+            } else {
+                content
             }
-            .frame(maxWidth: .infinity, alignment: .topLeading)
         }
         .background(Self.editorBackground)
     }


### PR DESCRIPTION
## Summary
- Add `allowsVerticalScrolling` parameter to `VCodeView` and `HighlightedTextView` (defaults to `true` for backwards compatibility)
- When `false`, the code block renders at full intrinsic height without its own `ScrollView`, relying on the ancestor scroll view
- Inspector memory and prompt tabs pass `allowsVerticalScrolling: false` and remove `maxHeight` constraints so code blocks expand fully