### PR TITLE
feat(oauth): add refresh_url column and plumb through store + seed

### DIFF
--- a/assistant/src/__tests__/oauth-provider-serializer.test.ts
+++ b/assistant/src/__tests__/oauth-provider-serializer.test.ts
@@ -13,6 +13,7 @@ function makeRow(overrides: Partial<OAuthProviderRow> = {}): OAuthProviderRow {
     provider: "test-provider",
     authorizeUrl: "https://auth.example.com/authorize",
     tokenExchangeUrl: "https://auth.example.com/token",
+    refreshUrl: null,
     tokenEndpointAuthMethod: null,
     userinfoUrl: null,
     baseUrl: null,

--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -342,6 +342,72 @@ describe("provider operations", () => {
       const row = getProvider("linear");
       expect(row!.scopeSeparator).toBe(",");
     });
+
+    test("persists refreshUrl when provided", () => {
+      seedProviders([
+        {
+          provider: "test-provider",
+          authorizeUrl: "https://example.com/authorize",
+          tokenExchangeUrl: "https://example.com/token",
+          refreshUrl: "https://refresh.example.com/token",
+          defaultScopes: ["read"],
+          scopePolicy: {},
+        },
+      ]);
+
+      const row = getProvider("test-provider");
+      expect(row).toBeDefined();
+      expect(row!.refreshUrl).toBe("https://refresh.example.com/token");
+    });
+
+    test("refreshUrl defaults to null when omitted", () => {
+      seedProviders([
+        {
+          provider: "test-provider",
+          authorizeUrl: "https://example.com/authorize",
+          tokenExchangeUrl: "https://example.com/token",
+          defaultScopes: ["read"],
+          scopePolicy: {},
+        },
+      ]);
+
+      const row = getProvider("test-provider");
+      expect(row).toBeDefined();
+      expect(row!.refreshUrl).toBeNull();
+    });
+
+    test("re-seeding with a changed refreshUrl overwrites the stored value", () => {
+      seedProviders([
+        {
+          provider: "test-provider",
+          authorizeUrl: "https://example.com/authorize",
+          tokenExchangeUrl: "https://example.com/token",
+          refreshUrl: "https://refresh.example.com/token",
+          defaultScopes: ["read"],
+          scopePolicy: {},
+        },
+      ]);
+
+      const first = getProvider("test-provider");
+      expect(first!.refreshUrl).toBe("https://refresh.example.com/token");
+
+      // Re-seed with a different refreshUrl — it should be overwritten,
+      // proving refreshUrl is in the onConflictDoUpdate set clause (not
+      // preserved like defaultScopes).
+      seedProviders([
+        {
+          provider: "test-provider",
+          authorizeUrl: "https://example.com/authorize",
+          tokenExchangeUrl: "https://example.com/token",
+          refreshUrl: "https://refresh-v2.example.com/token",
+          defaultScopes: ["read"],
+          scopePolicy: {},
+        },
+      ]);
+
+      const row = getProvider("test-provider");
+      expect(row!.refreshUrl).toBe("https://refresh-v2.example.com/token");
+    });
   });
 
   describe("getProvider", () => {
@@ -432,6 +498,35 @@ describe("provider operations", () => {
       expect(fetched).toBeDefined();
       expect(fetched!.scopeSeparator).toBe(" ");
     });
+
+    test("persists refreshUrl and round-trips via getProvider", () => {
+      registerProvider({
+        provider: "linear",
+        authorizeUrl: "https://linear.app/oauth/authorize",
+        tokenExchangeUrl: "https://api.linear.app/oauth/token",
+        refreshUrl: "https://api.linear.app/oauth/refresh",
+        defaultScopes: ["read"],
+        scopePolicy: {},
+      });
+
+      const fetched = getProvider("linear");
+      expect(fetched).toBeDefined();
+      expect(fetched!.refreshUrl).toBe("https://api.linear.app/oauth/refresh");
+    });
+
+    test("refreshUrl defaults to null when omitted", () => {
+      registerProvider({
+        provider: "linear",
+        authorizeUrl: "https://linear.app/oauth/authorize",
+        tokenExchangeUrl: "https://api.linear.app/oauth/token",
+        defaultScopes: ["read"],
+        scopePolicy: {},
+      });
+
+      const fetched = getProvider("linear");
+      expect(fetched).toBeDefined();
+      expect(fetched!.refreshUrl).toBeNull();
+    });
   });
 
   describe("updateProvider", () => {
@@ -478,6 +573,61 @@ describe("provider operations", () => {
       expect(updated).toBeDefined();
       expect(updated!.scopeSeparator).toBe(" ");
       expect(getProvider("github")!.scopeSeparator).toBe(" ");
+    });
+
+    test("sets refreshUrl on an existing row where it was previously null", () => {
+      seedProviders([
+        {
+          provider: "github",
+          authorizeUrl: "https://github.com/authorize",
+          tokenExchangeUrl: "https://github.com/token",
+          defaultScopes: ["repo"],
+          scopePolicy: {},
+        },
+      ]);
+
+      const before = getProvider("github");
+      expect(before!.refreshUrl).toBeNull();
+
+      const updated = updateProvider("github", {
+        refreshUrl: "https://github.com/login/oauth/refresh",
+      });
+      expect(updated).toBeDefined();
+      expect(updated!.refreshUrl).toBe(
+        "https://github.com/login/oauth/refresh",
+      );
+
+      const fetched = getProvider("github");
+      expect(fetched!.refreshUrl).toBe(
+        "https://github.com/login/oauth/refresh",
+      );
+    });
+
+    test("leaves refreshUrl unchanged when not passed to updateProvider", () => {
+      seedProviders([
+        {
+          provider: "github",
+          authorizeUrl: "https://github.com/authorize",
+          tokenExchangeUrl: "https://github.com/token",
+          refreshUrl: "https://github.com/login/oauth/refresh",
+          defaultScopes: ["repo"],
+          scopePolicy: {},
+        },
+      ]);
+
+      expect(getProvider("github")!.refreshUrl).toBe(
+        "https://github.com/login/oauth/refresh",
+      );
+
+      // Update a different field — refreshUrl should be left alone.
+      const updated = updateProvider("github", {
+        displayLabel: "GitHub (updated)",
+      });
+      expect(updated).toBeDefined();
+      expect(updated!.refreshUrl).toBe(
+        "https://github.com/login/oauth/refresh",
+      );
+      expect(updated!.displayLabel).toBe("GitHub (updated)");
     });
   });
 

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -113,6 +113,7 @@ import {
   migrateOAuthProvidersManagedServiceConfigKey,
   migrateOAuthProvidersPingConfig,
   migrateOAuthProvidersPingUrl,
+  migrateOAuthProvidersRefreshUrl,
   migrateOAuthProvidersScopeSeparator,
   migrateReminderRoutingIntent,
   migrateRemindersToSchedules,
@@ -354,6 +355,7 @@ export function initializeDb(): void {
     migrateMemoryRecallLogsQueryContext,
     migrateLlmRequestLogsCreatedAtIndex,
     migrateOAuthProvidersScopeSeparator,
+    migrateOAuthProvidersRefreshUrl,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/214-oauth-providers-refresh-url.ts
+++ b/assistant/src/memory/migrations/214-oauth-providers-refresh-url.ts
@@ -1,0 +1,11 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+export function migrateOAuthProvidersRefreshUrl(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  try {
+    raw.exec(`ALTER TABLE oauth_providers ADD COLUMN refresh_url TEXT`);
+  } catch {
+    // Column already exists — nothing to do.
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -155,6 +155,7 @@ export { migrateScheduleReuseConversation } from "./210-schedule-reuse-conversat
 export { migrateMemoryRecallLogsQueryContext } from "./211-memory-recall-logs-query-context.js";
 export { migrateLlmRequestLogsCreatedAtIndex } from "./212-llm-request-logs-created-at-index.js";
 export { migrateOAuthProvidersScopeSeparator } from "./213-oauth-providers-scope-separator.js";
+export { migrateOAuthProvidersRefreshUrl } from "./214-oauth-providers-refresh-url.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/oauth.ts
+++ b/assistant/src/memory/schema/oauth.ts
@@ -10,6 +10,7 @@ export const oauthProviders = sqliteTable("oauth_providers", {
   provider: text("provider_key").primaryKey(),
   authorizeUrl: text("auth_url").notNull(),
   tokenExchangeUrl: text("token_url").notNull(),
+  refreshUrl: text("refresh_url"),
   tokenEndpointAuthMethod: text("token_endpoint_auth_method"),
   userinfoUrl: text("userinfo_url"),
   baseUrl: text("base_url"),

--- a/assistant/src/oauth/__tests__/identity-verifier.test.ts
+++ b/assistant/src/oauth/__tests__/identity-verifier.test.ts
@@ -32,6 +32,7 @@ function makeProviderRow(
     provider,
     authorizeUrl: "https://example.com/auth",
     tokenExchangeUrl: "https://example.com/token",
+    refreshUrl: null,
     tokenEndpointAuthMethod: null,
     userinfoUrl: null,
     baseUrl: null,

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -49,7 +49,7 @@ export type OAuthConnectionRow = typeof oauthConnections.$inferSelect;
 /**
  * Seed well-known provider profiles into the database. Uses INSERT … ON
  * CONFLICT DO UPDATE so that implementation fields (authorizeUrl, tokenExchangeUrl,
- * tokenEndpointAuthMethod, userinfoUrl, authorizeParams,
+ * refreshUrl, tokenEndpointAuthMethod, userinfoUrl, authorizeParams,
  * pingUrl, pingMethod, pingHeaders, pingBody, managedServiceConfigKey,
  * loopbackPort, injectionTemplates, appType, setupNotes,
  * identityUrl, identityMethod, identityHeaders, identityBody,
@@ -68,6 +68,7 @@ export function seedProviders(
     provider: string;
     authorizeUrl: string;
     tokenExchangeUrl: string;
+    refreshUrl?: string;
     tokenEndpointAuthMethod?: string;
     userinfoUrl?: string;
     pingUrl?: string;
@@ -109,6 +110,7 @@ export function seedProviders(
   for (const p of profiles) {
     const authorizeUrl = p.authorizeUrl;
     const tokenExchangeUrl = p.tokenExchangeUrl;
+    const refreshUrl = p.refreshUrl ?? null;
     const tokenEndpointAuthMethod = p.tokenEndpointAuthMethod ?? null;
     const userinfoUrl = p.userinfoUrl ?? null;
     const pingUrl = p.pingUrl ?? null;
@@ -157,6 +159,7 @@ export function seedProviders(
         provider: p.provider,
         authorizeUrl,
         tokenExchangeUrl,
+        refreshUrl,
         tokenEndpointAuthMethod,
         userinfoUrl,
         baseUrl,
@@ -194,6 +197,7 @@ export function seedProviders(
         set: {
           authorizeUrl,
           tokenExchangeUrl,
+          refreshUrl,
           tokenEndpointAuthMethod,
           userinfoUrl,
           baseUrl: sql`COALESCE(${oauthProviders.baseUrl}, ${baseUrl})`,
@@ -252,6 +256,7 @@ export function registerProvider(params: {
   provider: string;
   authorizeUrl: string;
   tokenExchangeUrl: string;
+  refreshUrl?: string;
   tokenEndpointAuthMethod?: string;
   userinfoUrl?: string;
   pingUrl?: string;
@@ -299,6 +304,7 @@ export function registerProvider(params: {
     provider: params.provider,
     authorizeUrl: params.authorizeUrl,
     tokenExchangeUrl: params.tokenExchangeUrl,
+    refreshUrl: params.refreshUrl ?? null,
     tokenEndpointAuthMethod: params.tokenEndpointAuthMethod ?? null,
     userinfoUrl: params.userinfoUrl ?? null,
     baseUrl: params.baseUrl ?? null,
@@ -364,6 +370,7 @@ export function updateProvider(
   params: Partial<{
     authorizeUrl: string;
     tokenExchangeUrl: string;
+    refreshUrl: string;
     tokenEndpointAuthMethod: string;
     userinfoUrl: string;
     pingUrl: string;
@@ -408,6 +415,7 @@ export function updateProvider(
   if (params.authorizeUrl !== undefined) set.authorizeUrl = params.authorizeUrl;
   if (params.tokenExchangeUrl !== undefined)
     set.tokenExchangeUrl = params.tokenExchangeUrl;
+  if (params.refreshUrl !== undefined) set.refreshUrl = params.refreshUrl;
   if (params.tokenEndpointAuthMethod !== undefined)
     set.tokenEndpointAuthMethod = params.tokenEndpointAuthMethod;
   if (params.userinfoUrl !== undefined) set.userinfoUrl = params.userinfoUrl;

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -5,7 +5,7 @@ import { seedProviders } from "./oauth-store.js";
  *
  * These values are upserted into the `oauth_providers` SQLite table on
  * every startup. Only Vellum implementation fields (authorizeUrl, tokenExchangeUrl,
- * tokenEndpointAuthMethod, userinfoUrl, authorizeParams,
+ * refreshUrl, tokenEndpointAuthMethod, userinfoUrl, authorizeParams,
  * pingUrl, pingMethod, pingHeaders, pingBody, managedServiceConfigKey,
  * loopbackPort, injectionTemplates, appType, setupNotes,
  * identityUrl, identityMethod, identityHeaders, identityBody,
@@ -23,6 +23,7 @@ const PROVIDER_SEED_DATA: Record<
     provider: string;
     authorizeUrl: string;
     tokenExchangeUrl: string;
+    refreshUrl?: string;
     tokenEndpointAuthMethod?: string;
     userinfoUrl?: string;
     pingUrl?: string;


### PR DESCRIPTION
## Summary
- Adds nullable `refresh_url` column to `oauth_providers` schema + migration 214
- Threads `refreshUrl` through `seedProviders`, `registerProvider`, and `updateProvider` using `?? null` (not the `|| " "` pattern used by scopeSeparator)
- Adds store tests covering seed/register/update round-trips and re-seed overwrite

Part of plan: refresh-url-parity.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
