### PR TITLE
fix(macos): anchor JSON tree viewer to top-left

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/JSONTreeView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/JSONTreeView.swift
@@ -288,19 +288,30 @@ struct JSONTreeView: View {
 
     @ViewBuilder
     private func treeContent(_ node: JSONNode) -> some View {
-        ScrollView([.vertical, .horizontal]) {
-            LazyVStack(alignment: .leading, spacing: 0) {
-                JSONNodeRow(
-                    node: node,
-                    key: nil,
-                    depth: 0,
-                    expandedPaths: $expandedPaths
+        // GeometryReader is used here so the inner content can claim at
+        // least the viewport's width and height. Without this, SwiftUI's
+        // bi-directional ScrollView visually centers content that is
+        // smaller than the viewport instead of anchoring it to the
+        // top-leading corner, which is the desired reading experience for
+        // a short JSON document like `install-meta.json`.
+        GeometryReader { proxy in
+            ScrollView([.vertical, .horizontal]) {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    JSONNodeRow(
+                        node: node,
+                        key: nil,
+                        depth: 0,
+                        expandedPaths: $expandedPaths
+                    )
+                }
+                .padding(VSpacing.md)
+                .frame(
+                    minWidth: proxy.size.width,
+                    minHeight: proxy.size.height,
+                    alignment: .topLeading
                 )
             }
-            .padding(VSpacing.md)
-            .frame(maxWidth: .infinity, alignment: .topLeading)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
     private func autoExpandInitial(_ node: JSONNode) {


### PR DESCRIPTION
## Summary
- Wrap the JSON tree `ScrollView` in a `GeometryReader` and apply `minWidth`/`minHeight` with `.topLeading` alignment so short JSON documents render in the top-left of the viewer instead of being visually centered.
- Fixes the issue where files like `install-meta.json` appeared floating in the middle of the file viewer's Preview tab.

## Original prompt
Fix the file viewer so that JSON file content is aligned to the top-left instead of centered. See the screenshot showing `install-meta.json` in the Preview tab — the JSON tree content is currently centered vertically and horizontally in the viewer, and should instead be biased toward the top-left corner.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/24184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
